### PR TITLE
[Impeller] Reland: Allow attaching specific texture mip levels and slices

### DIFF
--- a/engine/src/flutter/impeller/core/formats.cc
+++ b/engine/src/flutter/impeller/core/formats.cc
@@ -29,6 +29,20 @@ bool Attachment::IsValid() const {
     return false;
   }
 
+  const TextureDescriptor& desc = texture->GetTextureDescriptor();
+  if (mip_level >= desc.mip_count) {
+    VALIDATION_LOG << "Attachment mip_level " << mip_level
+                   << " is out of range; the texture has " << desc.mip_count
+                   << " mip levels.";
+    return false;
+  }
+  const uint32_t slice_count = desc.type == TextureType::kTextureCube ? 6u : 1u;
+  if (slice >= slice_count) {
+    VALIDATION_LOG << "Attachment slice " << slice
+                   << " is out of range for the texture type.";
+    return false;
+  }
+
   if (StoreActionNeedsResolveTexture(store_action)) {
     if (!resolve_texture || !resolve_texture->IsValid()) {
       VALIDATION_LOG << "Store action needs resolve but no valid resolve "

--- a/engine/src/flutter/impeller/core/formats.h
+++ b/engine/src/flutter/impeller/core/formats.h
@@ -921,6 +921,12 @@ struct Attachment {
   std::shared_ptr<Texture> resolve_texture;
   LoadAction load_action = LoadAction::kDontCare;
   StoreAction store_action = StoreAction::kStore;
+  // The mip level of `texture` to render into. Must be < the texture's
+  // mip_count.
+  uint32_t mip_level = 0;
+  // The slice (cube map face or array layer) of `texture` to render into.
+  // Must be < the slice count implied by the texture's type.
+  uint32_t slice = 0;
 
   bool IsValid() const;
 };

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -51,6 +51,9 @@ static const constexpr char* kTextureCompressionAstcOesExt =
 static const constexpr char* kTextureCompressionAstcHdrExt =
     "GL_KHR_texture_compression_astc_hdr";
 
+// https://registry.khronos.org/OpenGL/extensions/OES/OES_fbo_render_mipmap.txt
+static const constexpr char* kFboRenderMipmapExt = "GL_OES_fbo_render_mipmap";
+
 CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   {
     GLint value = 0;
@@ -190,10 +193,20 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
       desc->HasExtension(kTextureCompressionAstcOesExt);
   supports_texture_compression_etc2_ =
       desc->IsES() && desc->GetGlVersion().major_version >= 3;
+
+  // Non-zero mip levels are renderable on desktop GL, ES 3.0+, or ES 2.0 with
+  // GL_OES_fbo_render_mipmap.
+  supports_fbo_render_mipmap_ = !desc->IsES() ||
+                                desc->GetGlVersion().major_version >= 3 ||
+                                desc->HasExtension(kFboRenderMipmapExt);
 }
 
 bool CapabilitiesGLES::IsES() const {
   return is_es_;
+}
+
+bool CapabilitiesGLES::SupportsFramebufferRenderMipmap() const {
+  return supports_fbo_render_mipmap_;
 }
 
 size_t CapabilitiesGLES::GetMaxTextureUnits(ShaderStage stage) const {

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
@@ -80,6 +80,11 @@ class CapabilitiesGLES final
   /// @brief Whether this is an ES GL variant or (if false) desktop GL.
   bool IsES() const;
 
+  /// @brief Whether a non-zero mip level of a texture can be attached to a
+  ///        framebuffer. Core ES 2.0 only allows mip level 0; ES 3.0+ and the
+  ///        GL_OES_fbo_render_mipmap extension lift that restriction.
+  bool SupportsFramebufferRenderMipmap() const;
+
   // |Capabilities|
   bool SupportsOffscreenMSAA() const override;
 
@@ -154,6 +159,7 @@ class CapabilitiesGLES final
   bool supports_offscreen_msaa_ = false;
   bool supports_implicit_msaa_ = false;
   bool supports_32bit_primitive_indices_ = false;
+  bool supports_fbo_render_mipmap_ = false;
   bool is_angle_ = false;
   bool is_es_ = false;
   bool supports_texture_compression_bc_ = false;

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -134,6 +134,14 @@ struct RenderPassData {
   std::shared_ptr<Texture> depth_attachment;
   std::shared_ptr<Texture> stencil_attachment;
 
+  // The subresource of each attachment to render into.
+  uint32_t color_mip_level = 0u;
+  uint32_t color_slice = 0u;
+  uint32_t depth_mip_level = 0u;
+  uint32_t depth_slice = 0u;
+  uint32_t stencil_mip_level = 0u;
+  uint32_t stencil_slice = 0u;
+
   bool clear_color_attachment = true;
   bool clear_depth_attachment = true;
   bool clear_stencil_attachment = true;
@@ -260,38 +268,43 @@ static void EncodeViewport(const ProcTableGLES& gl,
       gl.BindFramebuffer(GL_FRAMEBUFFER, *color_gles.GetFBO());
     }
   } else {
-    // Create and bind an offscreen FBO.
-    if (!color_gles.GetCachedFBO().IsDead()) {
-      fbo = reactor.GetGLHandle(color_gles.GetCachedFBO());
-      if (!fbo.has_value()) {
-        return false;
-      }
-      gl.BindFramebuffer(GL_FRAMEBUFFER, fbo.value());
-    } else {
-      HandleGLES cached_fbo =
-          reactor.CreateUntrackedHandle(HandleType::kFrameBuffer);
-      color_gles.SetCachedFBO(cached_fbo);
-      fbo = reactor.GetGLHandle(cached_fbo);
-      if (!fbo.has_value()) {
-        return false;
-      }
-      gl.BindFramebuffer(GL_FRAMEBUFFER, fbo.value());
+    // Create (once) and bind an offscreen FBO. The cached FBO remembers which
+    // subresource it is bound to, so it is re-attached only when freshly
+    // created or when rendering into a different mip level or slice of the
+    // same texture.
+    bool needs_attachment = false;
+    if (color_gles.GetCachedFBO().IsDead()) {
+      color_gles.SetCachedFBO(
+          reactor.CreateUntrackedHandle(HandleType::kFrameBuffer));
+      needs_attachment = true;
+    }
+    fbo = reactor.GetGLHandle(color_gles.GetCachedFBO());
+    if (!fbo.has_value()) {
+      return false;
+    }
+    gl.BindFramebuffer(GL_FRAMEBUFFER, fbo.value());
 
+    if (needs_attachment ||
+        !color_gles.CachedFBOMatchesSubresource(pass_data.color_mip_level,
+                                                pass_data.color_slice)) {
       if (!color_gles.SetAsFramebufferAttachment(
-              GL_FRAMEBUFFER, TextureGLES::AttachmentType::kColor0)) {
+              GL_FRAMEBUFFER, TextureGLES::AttachmentType::kColor0,
+              pass_data.color_mip_level, pass_data.color_slice)) {
         return false;
       }
 
       if (auto depth = TextureGLES::Cast(pass_data.depth_attachment.get())) {
         if (!depth->SetAsFramebufferAttachment(
-                GL_FRAMEBUFFER, TextureGLES::AttachmentType::kDepth)) {
+                GL_FRAMEBUFFER, TextureGLES::AttachmentType::kDepth,
+                pass_data.depth_mip_level, pass_data.depth_slice)) {
           return false;
         }
       }
       if (auto stencil =
               TextureGLES::Cast(pass_data.stencil_attachment.get())) {
         if (!stencil->SetAsFramebufferAttachment(
-                GL_FRAMEBUFFER, TextureGLES::AttachmentType::kStencil)) {
+                GL_FRAMEBUFFER, TextureGLES::AttachmentType::kStencil,
+                pass_data.stencil_mip_level, pass_data.stencil_slice)) {
           return false;
         }
       }
@@ -302,6 +315,8 @@ static void EncodeViewport(const ProcTableGLES& gl,
                        << DebugToFramebufferError(status);
         return false;
       }
+      color_gles.SetCachedFBOSubresource(pass_data.color_mip_level,
+                                         pass_data.color_slice);
     }
   }
 
@@ -768,6 +783,8 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
   ///
   pass_data->color_attachment = color0.texture;
   pass_data->resolve_attachment = color0.resolve_texture;
+  pass_data->color_mip_level = color0.mip_level;
+  pass_data->color_slice = color0.slice;
   pass_data->clear_color = color0.clear_color;
   pass_data->clear_color_attachment = CanClearAttachment(color0.load_action);
   pass_data->discard_color_attachment =
@@ -789,6 +806,8 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
   ///
   if (depth0.has_value()) {
     pass_data->depth_attachment = depth0->texture;
+    pass_data->depth_mip_level = depth0->mip_level;
+    pass_data->depth_slice = depth0->slice;
     pass_data->clear_depth = depth0->clear_depth;
     pass_data->clear_depth_attachment = CanClearAttachment(depth0->load_action);
     pass_data->discard_depth_attachment =
@@ -800,6 +819,8 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
   ///
   if (stencil0.has_value()) {
     pass_data->stencil_attachment = stencil0->texture;
+    pass_data->stencil_mip_level = stencil0->mip_level;
+    pass_data->stencil_slice = stencil0->slice;
     pass_data->clear_stencil = stencil0->clear_stencil;
     pass_data->clear_stencil_attachment =
         CanClearAttachment(stencil0->load_action);

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -643,34 +643,92 @@ static GLenum ToAttachmentType(TextureGLES::AttachmentType point) {
   }
 }
 
-bool TextureGLES::SetAsFramebufferAttachment(GLenum target,
-                                             AttachmentType attachment_type) {
-  if (!IsValid()) {
-    return false;
+bool TextureGLES::EnsureSliceMipLevelStorage(size_t slice, size_t mip_level) {
+  if (IsSliceMipLevelInitialized(slice, mip_level)) {
+    return true;
   }
-  InitializeContentsIfNecessary();
+  // Renderbuffers and multisampled textures only have their single level
+  // allocated at init; only sampled 2D and cube textures allocate per-level.
+  if (type_ != Type::kTexture) {
+    return true;
+  }
   auto handle = GetGLHandle();
   if (!handle.has_value()) {
     return false;
   }
   const auto& gl = reactor_->GetProcTable();
+  const auto& desc = GetTextureDescriptor();
+  std::optional<PixelFormatGLES> gles_format = ToPixelFormatGLES(
+      desc.format,
+      gl.GetDescription()->HasExtension("GL_EXT_texture_format_BGRA8888"));
+  if (!gles_format.has_value()) {
+    return false;
+  }
+  ISize size = GetSize();
+  bool is_cube = desc.type == TextureType::kTextureCube;
+  GLenum image_target =
+      is_cube ? GL_TEXTURE_CUBE_MAP_POSITIVE_X + slice : GL_TEXTURE_2D;
+  gl.BindTexture(is_cube ? GL_TEXTURE_CUBE_MAP : GL_TEXTURE_2D, handle.value());
+  gl.TexImage2D(image_target,                                    // target
+                static_cast<GLint>(mip_level),                   // LOD level
+                gles_format->internal_format,                    // internal
+                std::max<int64_t>(1, size.width >> mip_level),   // width
+                std::max<int64_t>(1, size.height >> mip_level),  // height
+                0u,                                              // border
+                gles_format->external_format,                    // format
+                gles_format->type,                               // type
+                nullptr                                          // data
+  );
+  MarkSliceMipLevelInitialized(slice, mip_level);
+  return true;
+}
+
+bool TextureGLES::SetAsFramebufferAttachment(GLenum target,
+                                             AttachmentType attachment_type,
+                                             uint32_t mip_level,
+                                             uint32_t slice) {
+  if (!IsValid()) {
+    return false;
+  }
+  InitializeContentsIfNecessary();
+  const auto& gl = reactor_->GetProcTable();
+  if (mip_level > 0 &&
+      !gl.GetCapabilities()->SupportsFramebufferRenderMipmap()) {
+    VALIDATION_LOG << "Attaching a non-zero mip level requires OpenGL ES 3.0 "
+                      "or the GL_OES_fbo_render_mipmap extension.";
+    return false;
+  }
+  if (!EnsureSliceMipLevelStorage(slice, mip_level)) {
+    return false;
+  }
+  auto handle = GetGLHandle();
+  if (!handle.has_value()) {
+    return false;
+  }
+  const GLint level = static_cast<GLint>(mip_level);
 
   switch (ComputeTypeForBinding(target)) {
-    case Type::kTexture:
+    case Type::kTexture: {
+      // Cube maps attach a specific face; 2D textures attach the 2D target.
+      GLenum textarget =
+          GetTextureDescriptor().type == TextureType::kTextureCube
+              ? GL_TEXTURE_CUBE_MAP_POSITIVE_X + slice
+              : GL_TEXTURE_2D;
       gl.FramebufferTexture2D(target,                             // target
                               ToAttachmentType(attachment_type),  // attachment
-                              GL_TEXTURE_2D,                      // textarget
+                              textarget,                          // textarget
                               handle.value(),                     // texture
-                              0                                   // level
+                              level                               // level
       );
       break;
+    }
     case Type::kTextureMultisampled:
       gl.FramebufferTexture2DMultisampleEXT(
           target,                             // target
           ToAttachmentType(attachment_type),  // attachment
           GL_TEXTURE_2D,                      // textarget
           handle.value(),                     // texture
-          0,                                  // level
+          level,                              // level
           4                                   // samples
       );
       break;
@@ -712,6 +770,16 @@ void TextureGLES::SetCachedFBO(HandleGLES fbo) {
 
 const HandleGLES& TextureGLES::GetCachedFBO() const {
   return cached_fbo_.Get();
+}
+
+void TextureGLES::SetCachedFBOSubresource(uint32_t mip_level, uint32_t slice) {
+  cached_fbo_mip_level_ = mip_level;
+  cached_fbo_slice_ = slice;
+}
+
+bool TextureGLES::CachedFBOMatchesSubresource(uint32_t mip_level,
+                                              uint32_t slice) const {
+  return cached_fbo_mip_level_ == mip_level && cached_fbo_slice_ == slice;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -669,15 +669,17 @@ bool TextureGLES::EnsureSliceMipLevelStorage(size_t slice, size_t mip_level) {
   GLenum image_target =
       is_cube ? GL_TEXTURE_CUBE_MAP_POSITIVE_X + slice : GL_TEXTURE_2D;
   gl.BindTexture(is_cube ? GL_TEXTURE_CUBE_MAP : GL_TEXTURE_2D, handle.value());
-  gl.TexImage2D(image_target,                                    // target
-                static_cast<GLint>(mip_level),                   // LOD level
-                gles_format->internal_format,                    // internal
-                std::max<int64_t>(1, size.width >> mip_level),   // width
-                std::max<int64_t>(1, size.height >> mip_level),  // height
-                0u,                                              // border
-                gles_format->external_format,                    // format
-                gles_format->type,                               // type
-                nullptr                                          // data
+  gl.TexImage2D(image_target,                   // target
+                static_cast<GLint>(mip_level),  // LOD level
+                gles_format->internal_format,   // internal
+                static_cast<GLsizei>(
+                    std::max<int64_t>(1, size.width >> mip_level)),  // width
+                static_cast<GLsizei>(
+                    std::max<int64_t>(1, size.height >> mip_level)),  // height
+                0u,                                                   // border
+                gles_format->external_format,                         // format
+                gles_format->type,                                    // type
+                nullptr                                               // data
   );
   MarkSliceMipLevelInitialized(slice, mip_level);
   return true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.h
@@ -96,7 +96,9 @@ class TextureGLES final : public Texture,
     kStencil,
   };
   [[nodiscard]] bool SetAsFramebufferAttachment(GLenum target,
-                                                AttachmentType attachment_type);
+                                                AttachmentType attachment_type,
+                                                uint32_t mip_level = 0,
+                                                uint32_t slice = 0);
 
   Type GetType() const;
 
@@ -162,6 +164,13 @@ class TextureGLES final : public Texture,
   /// Retrieve the cached FBO object, or a dead handle if there is no object.
   const HandleGLES& GetCachedFBO() const;
 
+  /// Records the subresource the cached FBO is currently bound to.
+  void SetCachedFBOSubresource(uint32_t mip_level, uint32_t slice);
+
+  /// Whether the cached FBO is currently bound to `(mip_level, slice)`. When
+  /// false, the FBO must be re-attached before use.
+  bool CachedFBOMatchesSubresource(uint32_t mip_level, uint32_t slice) const;
+
   // Visible for testing.
   std::optional<HandleGLES> GetSyncFence() const;
 
@@ -186,6 +195,8 @@ class TextureGLES final : public Texture,
   const bool is_wrapped_;
   const std::optional<GLuint> wrapped_fbo_;
   UniqueHandleGLES cached_fbo_;
+  uint32_t cached_fbo_mip_level_ = 0;
+  uint32_t cached_fbo_slice_ = 0;
   bool is_valid_ = false;
 
   TextureGLES(std::shared_ptr<ReactorGLES> reactor,
@@ -213,6 +224,11 @@ class TextureGLES final : public Texture,
   ISize GetSize() const override;
 
   void InitializeContentsIfNecessary();
+
+  // Allocates storage for `(slice, mip_level)` if it has not been allocated
+  // yet, so the subresource can be attached to a framebuffer. Returns false on
+  // failure.
+  bool EnsureSliceMipLevelStorage(size_t slice, size_t mip_level);
 
   TextureGLES(const TextureGLES&) = delete;
 

--- a/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -64,6 +64,10 @@ static bool ConfigureAttachment(const Attachment& desc,
   attachment.texture = TextureMTL::Cast(*desc.texture).GetMTLTexture();
   attachment.loadAction = ToMTLLoadAction(desc.load_action);
   attachment.storeAction = ToMTLStoreAction(desc.store_action);
+  // mip_level/slice select the subresource of the primary texture. The
+  // resolve texture, if any, resolves into its own level 0 / slice 0.
+  attachment.level = desc.mip_level;
+  attachment.slice = desc.slice;
 
   if (!ConfigureResolveTextureAttachment(desc, attachment)) {
     return false;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -398,18 +398,37 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
                      << vk::to_string(result);
       return;
     }
-    // Create a specialized view for render target attachments.
+    // Create one 2D attachment view per (mip level, array layer) so a
+    // specific subresource can be rendered into. Render targets are usually a
+    // single 2D mip (one view); cube and mipmapped render targets get the
+    // full set. Non-render-target textures only need the base view.
+    view_info.viewType = vk::ImageViewType::e2D;
     view_info.subresourceRange.levelCount = 1u;
-    auto [rt_result, rt_image_view] = device.createImageViewUnique(view_info);
-    if (rt_result != vk::Result::eSuccess) {
-      VALIDATION_LOG << "Unable to create an image view for allocation: "
-                     << vk::to_string(rt_result);
-      return;
+    view_info.subresourceRange.layerCount = 1u;
+    const bool is_render_target = !!(desc.usage & TextureUsage::kRenderTarget);
+    const uint32_t rt_mip_count = is_render_target ? image_info.mipLevels : 1u;
+    const uint32_t rt_layer_count =
+        is_render_target ? ToArrayLayerCount(desc.type) : 1u;
+    std::vector<vk::UniqueImageView> rt_image_views;
+    rt_image_views.reserve(rt_mip_count * rt_layer_count);
+    for (uint32_t mip = 0; mip < rt_mip_count; mip++) {
+      for (uint32_t layer = 0; layer < rt_layer_count; layer++) {
+        view_info.subresourceRange.baseMipLevel = mip;
+        view_info.subresourceRange.baseArrayLayer = layer;
+        auto [rt_result, rt_image_view] =
+            device.createImageViewUnique(view_info);
+        if (rt_result != vk::Result::eSuccess) {
+          VALIDATION_LOG << "Unable to create a render target image view: "
+                         << vk::to_string(rt_result);
+          return;
+        }
+        rt_image_views.push_back(std::move(rt_image_view));
+      }
     }
 
     resource_.Swap(ImageResource(
         ImageVMA{allocator, allocation, image}, std::move(image_view),
-        std::move(rt_image_view), context.GetResourceAllocator(),
+        std::move(rt_image_views), context.GetResourceAllocator(),
         context.GetDeviceHolder()));
     is_valid_ = true;
   }
@@ -424,8 +443,16 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
     return resource_->image_view.get();
   }
 
-  vk::ImageView GetRenderTargetView() const override {
-    return resource_->rt_image_view.get();
+  vk::ImageView GetRenderTargetView(uint32_t mip_level,
+                                    uint32_t array_layer) const override {
+    const auto& views = resource_->rt_image_views;
+    if (views.empty()) {
+      return VK_NULL_HANDLE;
+    }
+    const uint32_t layer_count = ToArrayLayerCount(GetTextureDescriptor().type);
+    const size_t index =
+        static_cast<size_t>(mip_level) * layer_count + array_layer;
+    return index < views.size() ? views[index].get() : views[0].get();
   }
 
   bool IsSwapchainImage() const override { return false; }
@@ -436,20 +463,21 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
     std::shared_ptr<Allocator> allocator;
     UniqueImageVMA image;
     vk::UniqueImageView image_view;
-    vk::UniqueImageView rt_image_view;
+    // One attachment view per (mip level, array layer), row-major by mip.
+    std::vector<vk::UniqueImageView> rt_image_views;
 
     ImageResource() = default;
 
     ImageResource(ImageVMA p_image,
                   vk::UniqueImageView p_image_view,
-                  vk::UniqueImageView p_rt_image_view,
+                  std::vector<vk::UniqueImageView> p_rt_image_views,
                   std::shared_ptr<Allocator> allocator,
                   std::shared_ptr<DeviceHolderVK> device_holder)
         : device_holder(std::move(device_holder)),
           allocator(std::move(allocator)),
           image(p_image),
           image_view(std::move(p_image_view)),
-          rt_image_view(std::move(p_rt_image_view)) {}
+          rt_image_views(std::move(p_rt_image_views)) {}
 
     ImageResource(ImageResource&& o) = default;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
@@ -308,7 +308,10 @@ vk::ImageView AHBTextureSourceVK::GetImageView() const {
 }
 
 // |TextureSourceVK|
-vk::ImageView AHBTextureSourceVK::GetRenderTargetView() const {
+vk::ImageView AHBTextureSourceVK::GetRenderTargetView(
+    uint32_t mip_level,
+    uint32_t array_layer) const {
+  // Hardware buffer textures are always a single 2D mip and layer.
   return image_view_.get();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
@@ -49,7 +49,8 @@ class AHBTextureSourceVK final : public TextureSourceVK {
   vk::ImageView GetImageView() const override;
 
   // |TextureSourceVK|
-  vk::ImageView GetRenderTargetView() const override;
+  vk::ImageView GetRenderTargetView(uint32_t mip_level,
+                                    uint32_t array_layer) const override;
 
   bool IsValid() const;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -165,15 +165,17 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   bool is_swapchain = false;
   SampleCount sample_count =
       color_image_vk_->GetTextureDescriptor().sample_count;
-  if (resolve_image_vk_) {
-    frame_data =
-        TextureVK::Cast(*resolve_image_vk_).GetCachedFrameData(sample_count);
-    is_swapchain = TextureVK::Cast(*resolve_image_vk_).IsSwapchainImage();
-  } else {
-    frame_data =
-        TextureVK::Cast(*color_image_vk_).GetCachedFrameData(sample_count);
-    is_swapchain = TextureVK::Cast(*color_image_vk_).IsSwapchainImage();
-  }
+  // The framebuffer references attachment views bound to a specific
+  // subresource, so the cache is keyed on color0's (mip_level, slice) as
+  // well as sample count. Caller-side invariants on the rest of the
+  // attachment set are the same as before.
+  const uint32_t cache_mip_level = color0.mip_level;
+  const uint32_t cache_slice = color0.slice;
+  TextureVK& frame_data_texture = TextureVK::Cast(
+      resolve_image_vk_ ? *resolve_image_vk_ : *color_image_vk_);
+  is_swapchain = frame_data_texture.IsSwapchainImage();
+  frame_data = frame_data_texture.GetCachedFrameData(
+      sample_count, cache_mip_level, cache_slice);
 
   const auto& target_size = render_target_.GetRenderTargetSize();
 
@@ -203,13 +205,8 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   frame_data.framebuffer = framebuffer;
   frame_data.render_pass = render_pass_;
 
-  if (resolve_image_vk_) {
-    TextureVK::Cast(*resolve_image_vk_)
-        .SetCachedFrameData(frame_data, sample_count);
-  } else {
-    TextureVK::Cast(*color_image_vk_)
-        .SetCachedFrameData(frame_data, sample_count);
-  }
+  frame_data_texture.SetCachedFrameData(frame_data, sample_count,
+                                        cache_mip_level, cache_slice);
 
   // If the resolve image exists and has mipmaps, transition mip levels besides
   // the base to shader read only in preparation for mipmap generation.
@@ -320,8 +317,10 @@ SharedHandleVK<vk::Framebuffer> RenderPassVK::CreateVKFramebuffer(
         // The bind point doesn't matter here since that information is present
         // in the render pass.
         attachments[count++] =
-            TextureVK::Cast(*attachment.texture).GetRenderTargetView();
+            TextureVK::Cast(*attachment.texture)
+                .GetRenderTargetView(attachment.mip_level, attachment.slice);
         if (attachment.resolve_texture) {
+          // The resolve texture resolves into its own base level/layer.
           attachments[count++] = TextureVK::Cast(*attachment.resolve_texture)
                                      .GetRenderTargetView();
         }
@@ -330,11 +329,13 @@ SharedHandleVK<vk::Framebuffer> RenderPassVK::CreateVKFramebuffer(
 
   if (auto depth = render_target_.GetDepthAttachment(); depth.has_value()) {
     attachments[count++] =
-        TextureVK::Cast(*depth->texture).GetRenderTargetView();
+        TextureVK::Cast(*depth->texture)
+            .GetRenderTargetView(depth->mip_level, depth->slice);
   } else if (auto stencil = render_target_.GetStencilAttachment();
              stencil.has_value()) {
     attachments[count++] =
-        TextureVK::Cast(*stencil->texture).GetRenderTargetView();
+        TextureVK::Cast(*stencil->texture)
+            .GetRenderTargetView(stencil->mip_level, stencil->slice);
   }
 
   fb_info.setPAttachments(attachments.data());

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_image_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_image_vk.cc
@@ -46,7 +46,10 @@ vk::ImageView KHRSwapchainImageVK::GetImageView() const {
 }
 
 // |TextureSourceVK|
-vk::ImageView KHRSwapchainImageVK::GetRenderTargetView() const {
+vk::ImageView KHRSwapchainImageVK::GetRenderTargetView(
+    uint32_t mip_level,
+    uint32_t array_layer) const {
+  // Swapchain images are always a single 2D mip and layer.
   return image_view_.get();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_image_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_image_vk.h
@@ -30,7 +30,8 @@ class KHRSwapchainImageVK final : public TextureSourceVK {
   vk::ImageView GetImageView() const override;
 
   // |TextureSourceVK|
-  vk::ImageView GetRenderTargetView() const override;
+  vk::ImageView GetRenderTargetView(uint32_t mip_level,
+                                    uint32_t array_layer) const override;
 
   // |TextureSourceVK|
   bool IsSwapchainImage() const override;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
@@ -59,13 +59,30 @@ fml::Status TextureSourceVK::SetLayout(const BarrierVK& barrier) const {
 }
 
 void TextureSourceVK::SetCachedFrameData(const FramebufferAndRenderPass& data,
-                                         SampleCount sample_count) {
-  frame_data_[static_cast<int>(sample_count) / 4] = data;
+                                         SampleCount sample_count,
+                                         uint32_t mip_level,
+                                         uint32_t slice) {
+  for (auto& entry : frame_data_) {
+    if (entry.sample_count == sample_count && entry.mip_level == mip_level &&
+        entry.slice == slice) {
+      entry.data = data;
+      return;
+    }
+  }
+  frame_data_.push_back({sample_count, mip_level, slice, data});
 }
 
-const FramebufferAndRenderPass& TextureSourceVK::GetCachedFrameData(
-    SampleCount sample_count) const {
-  return frame_data_[static_cast<int>(sample_count) / 4];
+FramebufferAndRenderPass TextureSourceVK::GetCachedFrameData(
+    SampleCount sample_count,
+    uint32_t mip_level,
+    uint32_t slice) const {
+  for (const auto& entry : frame_data_) {
+    if (entry.sample_count == sample_count && entry.mip_level == mip_level &&
+        entry.slice == slice) {
+      return entry.data;
+    }
+  }
+  return {};
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
@@ -5,6 +5,9 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_TEXTURE_SOURCE_VK_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_TEXTURE_SOURCE_VK_H_
 
+#include <cstdint>
+#include <vector>
+
 #include "flutter/fml/status.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
@@ -65,17 +68,20 @@ class TextureSourceVK {
   virtual vk::ImageView GetImageView() const = 0;
 
   //----------------------------------------------------------------------------
-  /// @brief      Retrieve the image view used for render target attachments
-  ///             with this texture source.
+  /// @brief      Retrieve the image view used to attach a specific
+  ///             subresource of this texture as a render target.
   ///
-  ///             ImageViews used as render target attachments cannot have any
-  ///             mip levels. In cases where we want to generate mipmaps with
-  ///             the result of this texture, we need to create multiple image
-  ///             views.
+  ///             The returned view covers a single mip level and a single
+  ///             array layer (or cube map face), since attachment views cannot
+  ///             span multiple levels or layers.
+  ///
+  /// @param[in]  mip_level    The mip level to attach.
+  /// @param[in]  array_layer  The array layer or cube map face to attach.
   ///
   /// @return     The render target view.
   ///
-  virtual vk::ImageView GetRenderTargetView() const = 0;
+  virtual vk::ImageView GetRenderTargetView(uint32_t mip_level,
+                                            uint32_t array_layer) const = 0;
 
   //----------------------------------------------------------------------------
   /// @brief      Encodes the layout transition `barrier` to
@@ -132,21 +138,27 @@ class TextureSourceVK {
 
   // These methods should only be used by render_pass_vk.h
 
-  /// Store the last framebuffer and render pass object used with this texture.
+  /// Store the framebuffer and render pass last used to render into the
+  /// `(sample_count, mip_level, slice)` subresource of this texture.
   ///
-  /// This method is only called if this texture is used as the resolve texture
-  /// of a render pass. By construction, this framebuffer should be compatible
-  /// with any future render passes.
+  /// This is only called when this texture is being used as the resolve (or
+  /// non-MSAA color) target of a render pass. By construction, the cached
+  /// objects are compatible with any future render pass that targets the
+  /// same subresource.
   void SetCachedFrameData(const FramebufferAndRenderPass& data,
-                          SampleCount sample_count);
+                          SampleCount sample_count,
+                          uint32_t mip_level = 0u,
+                          uint32_t slice = 0u);
 
-  /// Retrieve the last framebuffer and render pass object used with this
-  /// texture for a given sample count.
+  /// Retrieve the cached framebuffer and render pass for the given
+  /// `(sample_count, mip_level, slice)` subresource.
   ///
-  /// An empty FramebufferAndRenderPass is returned if there is no cached data
-  /// for a particular sample count.
-  const FramebufferAndRenderPass& GetCachedFrameData(
-      SampleCount sample_count) const;
+  /// An empty `FramebufferAndRenderPass` is returned when no cached entry
+  /// exists for that key. Entries are populated lazily on first use and
+  /// live for the lifetime of the texture.
+  FramebufferAndRenderPass GetCachedFrameData(SampleCount sample_count,
+                                              uint32_t mip_level = 0u,
+                                              uint32_t slice = 0u) const;
 
  protected:
   const TextureDescriptor desc_;
@@ -154,7 +166,17 @@ class TextureSourceVK {
   explicit TextureSourceVK(TextureDescriptor desc);
 
  private:
-  std::array<FramebufferAndRenderPass, 2> frame_data_;
+  struct CachedFrameDataEntry {
+    SampleCount sample_count;
+    uint32_t mip_level;
+    uint32_t slice;
+    FramebufferAndRenderPass data;
+  };
+  // Linear-scanned because N is typically 1 and bounded by
+  // `sample_counts * mip_count * layer_count` for the rare textures that
+  // are rendered to across many subresources (e.g. a fully populated cube
+  // mip chain).
+  std::vector<CachedFrameDataEntry> frame_data_;
   mutable vk::ImageLayout layout_ = vk::ImageLayout::eUndefined;
 };
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -193,18 +193,22 @@ vk::ImageLayout TextureVK::GetLayout() const {
   return source_ ? source_->GetLayout() : vk::ImageLayout::eUndefined;
 }
 
-vk::ImageView TextureVK::GetRenderTargetView() const {
-  return source_->GetRenderTargetView();
+vk::ImageView TextureVK::GetRenderTargetView(uint32_t mip_level,
+                                             uint32_t array_layer) const {
+  return source_->GetRenderTargetView(mip_level, array_layer);
 }
 
 void TextureVK::SetCachedFrameData(const FramebufferAndRenderPass& data,
-                                   SampleCount sample_count) {
-  source_->SetCachedFrameData(data, sample_count);
+                                   SampleCount sample_count,
+                                   uint32_t mip_level,
+                                   uint32_t slice) {
+  source_->SetCachedFrameData(data, sample_count, mip_level, slice);
 }
 
-const FramebufferAndRenderPass& TextureVK::GetCachedFrameData(
-    SampleCount sample_count) const {
-  return source_->GetCachedFrameData(sample_count);
+FramebufferAndRenderPass TextureVK::GetCachedFrameData(SampleCount sample_count,
+                                                       uint32_t mip_level,
+                                                       uint32_t slice) const {
+  return source_->GetCachedFrameData(sample_count, mip_level, slice);
 }
 
 void TextureVK::SetMipMapGenerated() {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
@@ -29,7 +29,8 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
 
   vk::ImageView GetImageView() const;
 
-  vk::ImageView GetRenderTargetView() const;
+  vk::ImageView GetRenderTargetView(uint32_t mip_level = 0,
+                                    uint32_t array_layer = 0) const;
 
   bool SetLayout(const BarrierVK& barrier) const;
 
@@ -49,21 +50,22 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
   std::shared_ptr<SamplerVK> GetImmutableSamplerVariant(
       const SamplerVK& sampler) const;
 
-  /// Store the last framebuffer and render pass object used with this texture.
+  /// Store the framebuffer and render pass last used to render into the
+  /// `(sample_count, mip_level, slice)` subresource of this texture.
   ///
-  /// This method is only called if this texture is used as the resolve texture
-  /// of a render pass. By construction, this framebuffer should be compatible
-  /// with any future render passes.
+  /// Only called when this texture is being used as the resolve (or
+  /// non-MSAA color) target of a render pass.
   void SetCachedFrameData(const FramebufferAndRenderPass& data,
-                          SampleCount sample_count);
+                          SampleCount sample_count,
+                          uint32_t mip_level = 0u,
+                          uint32_t slice = 0u);
 
-  /// Retrieve the last framebuffer and render pass object used with this
-  /// texture.
-  ///
-  /// An empty FramebufferAndRenderPass is returned if there is no cached data
-  /// for a particular sample count.
-  const FramebufferAndRenderPass& GetCachedFrameData(
-      SampleCount sample_count) const;
+  /// Retrieve the cached framebuffer and render pass for the given
+  /// `(sample_count, mip_level, slice)` subresource. Returns an empty
+  /// `FramebufferAndRenderPass` if no entry exists.
+  FramebufferAndRenderPass GetCachedFrameData(SampleCount sample_count,
+                                              uint32_t mip_level = 0u,
+                                              uint32_t slice = 0u) const;
 
  private:
   std::weak_ptr<Context> context_;

--- a/engine/src/flutter/impeller/renderer/render_target.cc
+++ b/engine/src/flutter/impeller/renderer/render_target.cc
@@ -16,6 +16,18 @@
 
 namespace impeller {
 
+// The dimensions of `texture` at `mip_level`, clamped to a minimum of 1x1.
+// Rendering into a mip level uses that level's size, not the base size.
+static ISize SizeForMipLevel(const std::shared_ptr<Texture>& texture,
+                             uint32_t mip_level) {
+  ISize size = texture->GetSize();
+  // Any real texture reaches 1x1 well before this; clamping the shift also
+  // avoids undefined behavior for absurd mip levels.
+  uint32_t shift = std::min(mip_level, 31u);
+  return ISize{std::max<int64_t>(1, size.width >> shift),
+               std::max<int64_t>(1, size.height >> shift)};
+}
+
 RenderTarget::RenderTarget() = default;
 
 RenderTarget::~RenderTarget() = default;
@@ -34,10 +46,12 @@ bool RenderTarget::IsValid() const {
     std::optional<ISize> size;
     bool sizes_are_same = true;
     auto iterator = [&](const Attachment& attachment) -> bool {
+      ISize attachment_size =
+          SizeForMipLevel(attachment.texture, attachment.mip_level);
       if (!size.has_value()) {
-        size = attachment.texture->GetSize();
+        size = attachment_size;
       }
-      if (size != attachment.texture->GetSize()) {
+      if (size != attachment_size) {
         sizes_are_same = false;
         return false;
       }
@@ -155,7 +169,8 @@ bool RenderTarget::HasColorAttachment(size_t index) const {
 std::optional<ISize> RenderTarget::GetColorAttachmentSize(size_t index) const {
   if (index == 0u) {
     if (color0_.has_value()) {
-      return color0_.value().texture->GetSize();
+      return SizeForMipLevel(color0_.value().texture,
+                             color0_.value().mip_level);
     }
     return std::nullopt;
   }
@@ -165,7 +180,7 @@ std::optional<ISize> RenderTarget::GetColorAttachmentSize(size_t index) const {
     return std::nullopt;
   }
 
-  return found->second.texture->GetSize();
+  return SizeForMipLevel(found->second.texture, found->second.mip_level);
 }
 
 ISize RenderTarget::GetRenderTargetSize() const {

--- a/engine/src/flutter/impeller/renderer/renderer_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/time/time_point.h"
+#include "impeller/base/validation.h"
 #include "impeller/core/device_buffer_descriptor.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/host_buffer.h"
@@ -1585,6 +1586,107 @@ TEST_P(RendererTest, BindingNullTexturesDoesNotCrash) {
 
   auto pass = command_buffer->CreateRenderPass(target);
   EXPECT_FALSE(FS::BindContents2(*pass, nullptr, sampler));
+}
+
+// Clears a single cube map face by attaching it as a render target slice.
+// Rendering to cube faces is portable down to OpenGL ES 2.0, so this runs on
+// every backend.
+TEST_P(RendererTest, CanRenderToTextureSlice) {
+  auto context = GetContext();
+  ASSERT_TRUE(context);
+
+  TextureDescriptor desc;
+  desc.storage_mode = StorageMode::kDevicePrivate;
+  desc.type = TextureType::kTextureCube;
+  desc.format = PixelFormat::kR8G8B8A8UNormInt;
+  desc.size = {100, 100};
+  desc.usage = TextureUsage::kRenderTarget | TextureUsage::kShaderRead;
+  auto texture = context->GetResourceAllocator()->CreateTexture(desc);
+  ASSERT_TRUE(texture);
+
+  ColorAttachment color0;
+  color0.texture = texture;
+  color0.slice = 3u;  // +Y face.
+  color0.load_action = LoadAction::kClear;
+  color0.store_action = StoreAction::kStore;
+  color0.clear_color = Color::Green();
+  RenderTarget target;
+  target.SetColorAttachment(color0, 0u);
+
+  auto buffer = context->CreateCommandBuffer();
+  auto pass = buffer->CreateRenderPass(target);
+  ASSERT_TRUE(pass && pass->IsValid());
+  pass->EncodeCommands();
+  EXPECT_TRUE(context->GetCommandQueue()->Submit({buffer}).ok());
+}
+
+// Clears mip level 1 of a texture by attaching it as a render target. Skipped
+// on OpenGL ES, where rendering to non-zero mip levels needs ES 3.0 or
+// GL_OES_fbo_render_mipmap.
+TEST_P(RendererTest, CanRenderToMipLevel) {
+  if (GetBackend() == PlaygroundBackend::kOpenGLES) {
+    GTEST_SKIP() << "Rendering to non-zero mip levels is gated on a GLES "
+                    "capability; covered by the Metal and Vulkan backends.";
+  }
+  auto context = GetContext();
+  ASSERT_TRUE(context);
+
+  TextureDescriptor desc;
+  desc.storage_mode = StorageMode::kDevicePrivate;
+  desc.format = PixelFormat::kR8G8B8A8UNormInt;
+  desc.size = {100, 100};
+  desc.mip_count = 2u;
+  desc.usage = TextureUsage::kRenderTarget | TextureUsage::kShaderRead;
+  auto texture = context->GetResourceAllocator()->CreateTexture(desc);
+  ASSERT_TRUE(texture);
+
+  ColorAttachment color0;
+  color0.texture = texture;
+  color0.mip_level = 1u;
+  color0.load_action = LoadAction::kClear;
+  color0.store_action = StoreAction::kStore;
+  color0.clear_color = Color::Green();
+  RenderTarget target;
+  target.SetColorAttachment(color0, 0u);
+  // The render area follows the mip level dimensions.
+  EXPECT_EQ(target.GetRenderTargetSize(), ISize(50, 50));
+
+  auto buffer = context->CreateCommandBuffer();
+  auto pass = buffer->CreateRenderPass(target);
+  ASSERT_TRUE(pass && pass->IsValid());
+  pass->EncodeCommands();
+  EXPECT_TRUE(context->GetCommandQueue()->Submit({buffer}).ok());
+}
+
+// Attachment validation rejects out-of-range mip levels and slices.
+TEST_P(RendererTest, AttachmentRejectsOutOfRangeSubresource) {
+  auto context = GetContext();
+  ASSERT_TRUE(context);
+
+  TextureDescriptor desc;
+  desc.storage_mode = StorageMode::kDevicePrivate;
+  desc.format = PixelFormat::kR8G8B8A8UNormInt;
+  desc.size = {100, 100};
+  desc.mip_count = 2u;
+  desc.usage = TextureUsage::kRenderTarget;
+  auto texture = context->GetResourceAllocator()->CreateTexture(desc);
+  ASSERT_TRUE(texture);
+
+  ColorAttachment color0;
+  color0.texture = texture;
+  color0.load_action = LoadAction::kClear;
+  color0.store_action = StoreAction::kStore;
+  EXPECT_TRUE(color0.IsValid());
+
+  // The out-of-range cases log validation errors on purpose.
+  ScopedValidationDisable disable_validation;
+
+  color0.mip_level = 2u;  // Only levels 0 and 1 exist.
+  EXPECT_FALSE(color0.IsValid());
+
+  color0.mip_level = 0u;
+  color0.slice = 1u;  // A 2D texture has a single slice.
+  EXPECT_FALSE(color0.IsValid());
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/renderer_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_unittests.cc
@@ -1624,7 +1624,8 @@ TEST_P(RendererTest, CanRenderToTextureSlice) {
 // on OpenGL ES, where rendering to non-zero mip levels needs ES 3.0 or
 // GL_OES_fbo_render_mipmap.
 TEST_P(RendererTest, CanRenderToMipLevel) {
-  if (GetBackend() == PlaygroundBackend::kOpenGLES) {
+  if (GetBackend() == PlaygroundBackend::kOpenGLES ||
+      GetBackend() == PlaygroundBackend::kOpenGLESSDF) {
     GTEST_SKIP() << "Rendering to non-zero mip levels is gated on a GLES "
                     "capability; covered by the Metal and Vulkan backends.";
   }

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -40,7 +40,10 @@ class WrappedTextureSourceVK : public impeller::TextureSourceVK {
     return image_view_.get();
   }
 
-  impeller::vk::ImageView GetRenderTargetView() const override {
+  impeller::vk::ImageView GetRenderTargetView(
+      uint32_t mip_level,
+      uint32_t array_layer) const override {
+    // Swapchain images are always a single 2D mip and layer.
     return image_view_.get();
   }
 


### PR DESCRIPTION
Relands #187066, reverted in #187445.

The original PR passed every pre-submit check and merged cleanly, but broke post-submit on Mac and Linux because a concurrent change (#187246, `b4e5291940c` "add sdf golden variants for OpenGL") added a `kOpenGLESSDF` variant to `PlaygroundBackend` that was not present when this PR's CI last ran. `CanRenderToMipLevel` only skipped `kOpenGLES`, so on the post-submit master it ran on `kOpenGLESSDF` and aborted with SIGABRT because the GLES test backend does not support rendering into non-zero mip levels. This reland is identical to #187066 plus the missing `kOpenGLESSDF` skip in `CanRenderToMipLevel`, matching the skip pattern that every other GLES-skipping test in `renderer_unittests.cc` already uses after #187246.

Failing test seen post-submit (Mac mac_unopt build 12910, Linux linux_unopt build 18302): `Play/RendererTest.CanRenderToMipLevel/OpenGLESSDF` returned/aborted with exit code -6.

---

Fixes flutter/flutter#145014 (the attachment half; uploading specific mip levels and slices already landed).

Impeller could only attach the base mip level and slice of a texture as a render target. This adds `mip_level` and `slice` to the HAL `Attachment` struct so a render pass can target a specific mip level, cube map face, or array layer. The render target size follows the selected mip level.

- Metal: sets the attachment descriptor's level and slice.
- Vulkan: creates one 2D attachment view per mip level and layer, and the framebuffer cache is keyed on `(sample_count, mip_level, slice)` so non-base subresources reuse cached framebuffers.
- OpenGL ES: attaches the cube face target and mip level, allocates the subresource on demand, and gates non-zero mip levels on ES 3.0 or `GL_OES_fbo_render_mipmap`. Rendering to cube faces works down to ES 2.0.

Tests cover attachment validation and cross-backend rendering to a slice and to a mip level.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
