### PR TITLE
[Impeller] Wait for the Vulkan device to become idle before destroying Vulkan objects in the AHBSwapchainImplVK destructor

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
@@ -10,6 +10,7 @@
 
 namespace impeller::android::testing {
 
+using impeller::testing::GetMockVulkanFunctions;
 using impeller::testing::MockVulkanContextBuilder;
 
 const std::vector<std::string> kAndroidDeviceExtensions = {
@@ -54,6 +55,22 @@ TEST(AndroidAHBSwapchainTest,
 
   ahb_swapchain->AcquireNextDrawable();
   EXPECT_FALSE(wait_for_fences_called);
+}
+
+TEST(AndroidAHBSwapchainTest, AHBSwapchainDtorCallsWaitIdle) {
+  auto const context = MockVulkanContextBuilder()
+                           .SetDeviceExtensions(kAndroidDeviceExtensions)
+                           .Build();
+
+  auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
+      context, std::make_shared<FakeSurfaceControl>(), {}, {100, 100}, false));
+
+  ahb_swapchain.reset();
+
+  auto called_functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_NE(std::find(called_functions->begin(), called_functions->end(),
+                      "vkDeviceWaitIdle"),
+            called_functions->end());
 }
 
 }  // namespace impeller::android::testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
@@ -58,7 +58,7 @@ TEST(AndroidAHBSwapchainTest,
 }
 
 TEST(AndroidAHBSwapchainTest, AHBSwapchainDtorCallsWaitIdle) {
-  auto const context = MockVulkanContextBuilder()
+  const auto context = MockVulkanContextBuilder()
                            .SetDeviceExtensions(kAndroidDeviceExtensions)
                            .Build();
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -105,7 +105,11 @@ AHBSwapchainImplVK::AHBSwapchainImplVK(
   is_valid_ = control && control->IsValid();
 }
 
-AHBSwapchainImplVK::~AHBSwapchainImplVK() = default;
+AHBSwapchainImplVK::~AHBSwapchainImplVK() {
+  // Ensure that the Vulkan device is idle before destroying objects that the
+  // device may have been using.
+  WaitIdle();
+}
 
 const ISize& AHBSwapchainImplVK::GetSize() const {
   return desc_.size;
@@ -118,6 +122,15 @@ bool AHBSwapchainImplVK::IsValid() const {
 const android::HardwareBufferDescriptor& AHBSwapchainImplVK::GetDescriptor()
     const {
   return desc_;
+}
+
+void AHBSwapchainImplVK::WaitIdle() const {
+  if (transients_) {
+    if (auto context = transients_->GetContext().lock()) {
+      [[maybe_unused]] auto result =
+          ContextVK::Cast(*context).GetDevice().waitIdle();
+    }
+  }
 }
 
 std::unique_ptr<Surface> AHBSwapchainImplVK::AcquireNextDrawable() {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -127,8 +127,10 @@ const android::HardwareBufferDescriptor& AHBSwapchainImplVK::GetDescriptor()
 void AHBSwapchainImplVK::WaitIdle() const {
   if (transients_) {
     if (auto context = transients_->GetContext().lock()) {
-      [[maybe_unused]] auto result =
-          ContextVK::Cast(*context).GetDevice().waitIdle();
+      auto result = ContextVK::Cast(*context).GetDevice().waitIdle();
+      if (result != vk::Result::eSuccess) {
+        FML_LOG(INFO) << "Device waitIdle failed: " << vk::to_string(result);
+      }
     }
   }
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.h
@@ -141,6 +141,8 @@ class AHBSwapchainImplVK final
 
   bool Present(const std::shared_ptr<AHBTextureSourceVK>& texture);
 
+  void WaitIdle() const;
+
   vk::UniqueSemaphore CreateRenderReadySemaphore(
       const std::shared_ptr<fml::UniqueFD>& fd) const;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.h
@@ -14,9 +14,10 @@
 namespace impeller {
 
 namespace android::testing {
+FML_TEST_CLASS(AndroidAHBSwapchainTest, AHBSwapchainDtorCallsWaitIdle);
 FML_TEST_CLASS(AndroidAHBSwapchainTest,
                AHBSwapchainNoFenceWaitAfterAcquireNextImageFailure);
-}
+}  // namespace android::testing
 
 using CreateTransactionCB = std::function<android::SurfaceTransaction()>;
 
@@ -60,6 +61,8 @@ class AHBSwapchainVK final : public SwapchainVK {
 
  private:
   friend class SwapchainVK;
+  FML_FRIEND_TEST(android::testing::AndroidAHBSwapchainTest,
+                  AHBSwapchainDtorCallsWaitIdle);
   FML_FRIEND_TEST(android::testing::AndroidAHBSwapchainTest,
                   AHBSwapchainNoFenceWaitAfterAcquireNextImageFailure);
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -467,6 +467,12 @@ VkResult vkCreateGraphicsPipelines(
   return VK_SUCCESS;
 }
 
+VkResult vkDeviceWaitIdle(VkDevice device) {
+  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  mock_device->AddCalledFunction("vkDeviceWaitIdle");
+  return VK_SUCCESS;
+}
+
 void vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
   MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
   mock_device->AddCalledFunction("vkDestroyDevice");
@@ -960,6 +966,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreatePipelineLayout);
   } else if (strcmp("vkCreateGraphicsPipelines", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateGraphicsPipelines);
+  } else if (strcmp("vkDeviceWaitIdle", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkDeviceWaitIdle);
   } else if (strcmp("vkDestroyDevice", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDevice);
   } else if (strcmp("vkDestroyInstance", pName) == 0) {


### PR DESCRIPTION
AHBSwapchainImplVK holds Vulkan objects such as fences that may be used by operations submitted to the Vulkan device.  The AHBSwapchainImplVK destructor must wait until the device is no longer using these objects before destroying them.

Fixes https://github.com/flutter/flutter/issues/187237