### PR TITLE
Don't trigger predictive back transition on a route covered by a drag…

### DIFF
--- a/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
+++ b/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
@@ -76,11 +76,8 @@ class PredictiveBackPageTransitionsBuilder extends PageTransitionsBuilder {
             PredictiveBackEvent? startBackEvent,
             PredictiveBackEvent? currentBackEvent,
           ) {
-            // Only do a predictive back transition when the user is performing a
-            // pop gesture. Otherwise, for things like button presses or other
-            // programmatic navigation, fall back to
-            // FadeForwardsPageTransitionsBuilder.
-            if (route.popGestureInProgress) {
+            // Only use the predictive back transition during an active back gesture.
+            if (phase != _PredictiveBackPhase.idle) {
               return _PredictiveBackSharedElementPageTransition(
                 isDelegatedTransition: true,
                 animation: animation,
@@ -156,10 +153,8 @@ class PredictiveBackFullscreenPageTransitionsBuilder extends PageTransitionsBuil
             PredictiveBackEvent? startBackEvent,
             PredictiveBackEvent? currentBackEvent,
           ) {
-            // Only do a predictive back transition when the user is performing a
-            // pop gesture. Otherwise, for things like button presses or other
-            // programmatic navigation, fall back to ZoomPageTransitionsBuilder.
-            if (route.popGestureInProgress) {
+            // Only use the predictive back transition during an active back gesture.
+            if (phase != _PredictiveBackPhase.idle) {
               return _PredictiveBackFullscreenPageTransition(
                 animation: animation,
                 secondaryAnimation: secondaryAnimation,

--- a/packages/flutter/test/material/predictive_back_page_transitions_builder_test.dart
+++ b/packages/flutter/test/material/predictive_back_page_transitions_builder_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart' show CupertinoPageScaffold, showCupertinoSheet;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -776,6 +777,77 @@ void main() {
       await tester.pumpAndSettle();
     },
     variant: TargetPlatformVariant.all(),
+  );
+
+  for (final builder in <PageTransitionsBuilder>[
+    const PredictiveBackPageTransitionsBuilder(),
+    const PredictiveBackFullscreenPageTransitionsBuilder(),
+  ]) {
+    testWidgets(
+      'route covered by a CupertinoSheet does not switch to the predictive back '
+      'transition while the sheet is dragged (${builder.runtimeType})',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              pageTransitionsTheme: PageTransitionsTheme(
+                builders: <TargetPlatform, PageTransitionsBuilder>{
+                  for (final TargetPlatform platform in TargetPlatform.values)
+                    platform: builder,
+                },
+              ),
+            ),
+            home: Builder(
+              builder: (BuildContext context) {
+                return Scaffold(
+                  body: Center(
+                    child: TextButton(
+                      onPressed: () {
+                        showCupertinoSheet<void>(
+                          context: context,
+                          scrollableBuilder: _sheetContent,
+                        );
+                      },
+                      child: const Text('open sheet'),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open sheet'));
+        await tester.pumpAndSettle();
+
+        expect(_findPredictiveBackPageTransition(builder), findsNothing);
+        expect(_findFallbackPageTransition(builder), findsOneWidget);
+
+        final TestGesture gesture = await tester.startGesture(const Offset(100, 300));
+        // A small drag first to win the gesture arena, then a larger one.
+        await gesture.moveBy(const Offset(0, 30));
+        await gesture.moveBy(const Offset(0, 100));
+        await tester.pump();
+
+        expect(_findPredictiveBackPageTransition(builder), findsNothing);
+        expect(_findFallbackPageTransition(builder), findsOneWidget);
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+      },
+    );
+  }
+}
+
+Widget _sheetContent(BuildContext context, ScrollController controller) {
+  return CupertinoPageScaffold(
+    child: ListView.builder(
+      controller: controller,
+      itemCount: 30,
+      itemBuilder: (BuildContext context, int index) {
+        return SizedBox(height: 56.0, child: Text('item $index'));
+      },
+    ),
   );
 }
 


### PR DESCRIPTION
Fixes #187492

This fixes an issue where covered routes could incorrectly enter the predictive back transition during unrelated navigator user gestures, causing their corners to snap to the display corner radius when dragging a CupertinoSheet.

PredictiveBackPageTransitionsBuilder and PredictiveBackFullscreenPageTransitionsBuilder previously used route.popGestureInProgress to decide whether to show the predictive back transition. However, route.popGestureInProgress is based on navigator.userGestureInProgress, which is true for any user gesture in the navigator, including dragging a CupertinoSheet above the route.

As a result, the covered route could incorrectly switch to the predictive back transition and be clipped to the display corner radius while the sheet was being dragged. This issue is visible on physical Android devices that report display corner radii. On emulators or devices that do not report display corner radii, the value is null and falls back to BorderRadius.zero, so no visible jump occurs. This issue also does not occur on iOS because it uses CupertinoPageTransitionsBuilder.

This changes the condition to use the predictive back phase instead, which is only non-idle while an actual predictive back gesture is in progress.

## Tests

```bash
flutter test packages/flutter/test/material/predictive_back_page_transitions_builder_test.dart
dart analyze packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
packages/flutter/test/material/predictive_back_page_transitions_builder_test.dart
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

## Videos

Before this PR:


https://github.com/user-attachments/assets/c849f238-aab9-4c60-afb2-8aa35474cb0d



After this PR:


https://github.com/user-attachments/assets/576a9562-29a7-4716-aabb-ab52df72138d



Android emulator：


https://github.com/user-attachments/assets/8fb24efb-a5a0-4193-85c1-b9792357ebe1