### PR TITLE
Fix stale _entries and pointer tracking in OneSequenceGestureRecognizer.rejectGesture

### DIFF
--- a/packages/flutter/lib/src/gestures/force_press.dart
+++ b/packages/flutter/lib/src/gestures/force_press.dart
@@ -350,9 +350,11 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   @override
+  @mustCallSuper
   void rejectGesture(int pointer) {
     stopTrackingPointer(pointer);
     didStopTrackingLastPointer(pointer);
+    super.rejectGesture(pointer);
   }
 
   static double _inverseLerp(double min, double max, double t) {

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -745,7 +745,9 @@ sealed class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   @override
+  @mustCallSuper
   void rejectGesture(int pointer) {
+    super.rejectGesture(pointer);
     _giveUpPointer(pointer);
   }
 

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -448,7 +448,11 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
   void acceptGesture(int pointer) {}
 
   @override
-  void rejectGesture(int pointer) {}
+  @mustCallSuper
+  void rejectGesture(int pointer) {
+    stopTrackingPointer(pointer);
+    _entries.remove(pointer);
+  }
 
   /// Called when the number of pointers this recognizer is tracking changes from one to zero.
   ///
@@ -775,11 +779,13 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
   }
 
   @override
+  @mustCallSuper
   void rejectGesture(int pointer) {
     if (pointer == primaryPointer && state == GestureRecognizerState.possible) {
       _stopTimer();
       _state = GestureRecognizerState.defunct;
     }
+    super.rejectGesture(pointer);
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -827,11 +827,13 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   @override
+  @mustCallSuper
   void rejectGesture(int pointer) {
     _pointerPanZooms.remove(pointer);
     _pointerLocations.remove(pointer);
     _pointerQueue.remove(pointer);
     stopTrackingPointer(pointer);
+    super.rejectGesture(pointer);
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/tap_and_drag.dart
+++ b/packages/flutter/lib/src/gestures/tap_and_drag.dart
@@ -551,6 +551,7 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
   @override
   void rejectGesture(int pointer) {
     _tapTrackerReset();
+    super.rejectGesture(pointer);
   }
 
   @override
@@ -1128,6 +1129,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
   }
 
   @override
+  @mustCallSuper
   void rejectGesture(int pointer) {
     if (pointer != _primaryPointer) {
       return;

--- a/packages/flutter/test/gestures/recognizer_test.dart
+++ b/packages/flutter/test/gestures/recognizer_test.dart
@@ -117,10 +117,9 @@ void main() {
       tester.async.flushMicrotasks();
       tester.route(down);
       tester.route(move);
-      expect(rejecting.state, GestureRecognizerState.defunct);
+      expect(rejecting.state, GestureRecognizerState.ready);
       expect(rejecting.primaryPointer, 5);
-      expect(rejecting.initialPosition!.global, down.position);
-      expect(rejecting.initialPosition!.local, down.localPosition);
+      expect(rejecting.initialPosition, isNull);
       expect(resolutions, <String>['rejected']);
 
       tester.route(up);

--- a/packages/flutter/test/gestures/team_test.dart
+++ b/packages/flutter/test/gestures/team_test.dart
@@ -115,6 +115,35 @@ void main() {
     tap.dispose();
     captain.dispose();
   });
+
+  testGesture('losing team member cleans up per-pointer state', (GestureTester tester) {
+    final team = GestureArenaTeam();
+    final first = _TrackingCleanupRecognizer()..team = team;
+    final second = _TrackingCleanupRecognizer()..team = team;
+    addTearDown(first.dispose);
+    addTearDown(second.dispose);
+
+    const PointerDownEvent down = PointerDownEvent(pointer: 5, position: Offset(10, 10));
+    first.addPointer(down);
+    second.addPointer(down);
+
+    // Both recognizers are tracking pointer 5.
+    expect(first.didStopTracking, false);
+    expect(second.didStopTracking, false);
+
+    // Close the arena. With no other competitors, the team combiner is the sole
+    // member. The microtask resolves by default: the combiner wins and picks
+    // the first member as winner. The second member is rejected.
+    tester.closeArena(5);
+    tester.async.flushMicrotasks();
+
+    // The winning recognizer (first) was not rejected — its state is intact.
+    expect(first.didStopTracking, false);
+    // The losing recognizer (second) was rejected by the combiner. Its
+    // rejectGesture should have called stopTrackingPointer, which in turn
+    // calls didStopTrackingLastPointer.
+    expect(second.didStopTracking, true);
+  });
 }
 
 typedef GestureAcceptedCallback = void Function();
@@ -146,7 +175,24 @@ class PassiveGestureRecognizer extends OneSequenceGestureRecognizer {
   void acceptGesture(int pointer) {
     onGestureAccepted?.call();
   }
+}
+
+class _TrackingCleanupRecognizer extends OneSequenceGestureRecognizer {
+  bool didStopTracking = false;
 
   @override
-  void rejectGesture(int pointer) {}
+  void addPointer(PointerDownEvent event) {
+    startTrackingPointer(event.pointer);
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {
+    didStopTracking = true;
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {}
+
+  @override
+  String get debugDescription => 'TrackingCleanup';
 }


### PR DESCRIPTION
## Summary

`OneSequenceGestureRecognizer.rejectGesture` was a no-op (`{}`), leaving stale `_entries` and tracked pointers when a recognizer lost the gesture arena. This caused pointer route leaks and particularly affected `GestureArenaTeam` scenarios where losing team members retained per-pointer state indefinitely.

Fixes https://github.com/flutter/flutter/issues/187475
Related https://github.com/flutter/flutter/issues/117356

## Changes

- `OneSequenceGestureRecognizer.rejectGesture`: now calls `stopTrackingPointer` + removes `_entries`, marked `@mustCallSuper`
- `PrimaryPointerGestureRecognizer.rejectGesture`: added `super.rejectGesture(pointer)` + `@mustCallSuper`
- `DragGestureRecognizer.rejectGesture`: added `super.rejectGesture(pointer)` + `@mustCallSuper`
- `ForcePressGestureRecognizer.rejectGesture`: added `super.rejectGesture(pointer)` + `@mustCallSuper`
- `ScaleGestureRecognizer.rejectGesture`: added `super.rejectGesture(pointer)` + `@mustCallSuper`
- `_TapStatusTrackerMixin.rejectGesture`: added `super.rejectGesture(pointer)` to ensure chain reaches base
- `BaseTapAndDragGestureRecognizer.rejectGesture`: added `@mustCallSuper`
- `PassiveGestureRecognizer` (test helper): removed unnecessary override
- `PrimaryPointerGestureRecognizer`: state now transitions to `ready` via `didStopTrackingLastPointer` after rejection
- New test: `losing team member cleans up per-pointer state` in `team_test.dart`
- Updated test: `PrimaryPointerGestureRecognizer` state expectations in `recognizer_test.dart`

## Tests

All 344 gesture tests pass.