### PR TITLE
Fix unintentionally joined path contours

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_path_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_path_unittests.cc
@@ -983,6 +983,32 @@ TEST_P(AiksTest, TwoContourPathWithSinglePointContour) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(AiksTest, TwoContourPathWithConnectingLines) {
+  DisplayListBuilder builder;
+
+  DlPaint paint;
+  paint.setColor(DlColor::kRed());
+  paint.setDrawStyle(DlDrawStyle::kStroke);
+  paint.setStrokeWidth(15.0);
+
+  builder.Translate(100, 0);
+  for (auto join : std::vector<DlStrokeJoin>{
+           DlStrokeJoin::kMiter, DlStrokeJoin::kRound, DlStrokeJoin::kBevel}) {
+    builder.Translate(0, 100);
+    paint.setStrokeJoin(join);
+
+    DlPathBuilder path_builder;
+    path_builder.MoveTo(DlPoint(0, 0));
+    path_builder.LineTo(DlPoint(50, 50));
+    path_builder.MoveTo(DlPoint(50, 50));
+    path_builder.LineTo(DlPoint(100, 0));
+
+    builder.DrawPath(path_builder.TakePath(), paint);
+  }
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 TEST_P(AiksTest, StrokeCapsAndJoins) {
   DisplayListBuilder builder;
   builder.Scale(GetContentScale().x, GetContentScale().y);

--- a/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
@@ -810,7 +810,7 @@ TEST(EntityGeometryTest, TwoLineSegmentsRightTurnStrokeVerticesBevelJoin) {
       Point(30, 25),
       Point(30, 15),
 
-      // The points for the second segment (120, 20) -> (130, 20)
+      // The points for the second segment (30, 20) -> (30, 30)
       Point(25, 20),
       Point(35, 20),
       Point(25, 30),
@@ -844,11 +844,58 @@ TEST(EntityGeometryTest, TwoLineSegmentsLeftTurnStrokeVerticesBevelJoin) {
       Point(30, 25),
       Point(30, 15),
 
-      // The points for the second segment (120, 20) -> (130, 20)
+      // The points for the second segment (30, 20) -> (30, 10)
       Point(35, 20),
       Point(25, 20),
       Point(35, 10),
       Point(25, 10),
+  };
+
+  EXPECT_EQ(points, expected);
+}
+
+TEST(EntityGeometryTest, TwoLineSegmentsInDifferentContoursAreNotJoined) {
+  flutter::DlPathBuilder path_builder;
+  // First contour with a single line.
+  path_builder.MoveTo({20, 20});
+  path_builder.LineTo({30, 20});
+  // Starts a new contour with a MoveTo command. The start of the new contour is
+  // specified to be the same as the end of the previous contour.
+  path_builder.MoveTo({30, 20});
+  // Add a line in the second contour.
+  path_builder.LineTo({30, 30});
+  flutter::DlPath path = path_builder.TakePath();
+
+  auto points = ImpellerEntityUnitTestAccessor::GenerateSolidStrokeVertices(
+      path,
+      {
+          .width = 10.0f,
+          .cap = Cap::kButt,
+          .join = Join::kBevel,
+          .miter_limit = 4.0f,
+      },
+      1.0f);
+
+  std::vector<Point> expected = {
+      // The points for the first segment (20, 20) -> (30, 20)
+      Point(20, 25),
+      Point(20, 15),
+      Point(30, 25),
+      Point(30, 15),
+
+      // The glue points that allow us to "pick up the pen" between segments.
+      // This prevents segments in different contours from being unintentionally
+      // joined with a bevel.
+      Point(30, 20),
+      Point(30, 20),
+      Point(30, 20),
+      Point(30, 20),
+
+      // The points for the second segment (30, 20) -> (30, 30)
+      Point(25, 20),
+      Point(35, 20),
+      Point(25, 30),
+      Point(35, 30),
   };
 
   EXPECT_EQ(points, expected);

--- a/engine/src/flutter/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/stroke_path_geometry.cc
@@ -155,7 +155,7 @@ class StrokePathSegmentReceiver : public PathAndArcSegmentReceiver {
  protected:
   // |SegmentReceiver|
   void BeginContour(Point origin, bool will_be_closed) override {
-    if (has_prior_contour_ && origin != last_point_) {
+    if (has_prior_contour_) {
       // We only append these extra points if we have had a prior contour.
       vtx_builder_.AppendVertex(last_point_);
       vtx_builder_.AppendVertex(last_point_);


### PR DESCRIPTION
Fixes a bug where neighboring path contours are incorrectly bevel joined when the end point of one contour coincides with the start point of the next contour.

`StrokePathSegmentReceiver::BeginContour` has logic to keep contours separate by adding extra vertices between neighboring contours (referred to as "glue points" in the unit tests). This existing logic does not add these points if the new contour starts at the same point as the end of the old contour (if `origin == last_point_`). This check is incorrect, and we still need these "glue points" when the new contour starts at the end of the old contour.

Fixes https://github.com/flutter/flutter/issues/186942

### Screenshots, using the sample app in https://github.com/flutter/flutter/issues/186942
#### Before:
<img width="912" height="744" alt="Screenshot 2026-06-02 at 4 57 35 PM" src="https://github.com/user-attachments/assets/5c0d03c9-e46e-4985-ba37-5704444fe85e" />

The blue paths (consisting of one line followed by another line added with a subpath) are incorrectly bevel joined.

#### After:
<img width="912" height="744" alt="Screenshot 2026-06-02 at 5 01 03 PM" src="https://github.com/user-attachments/assets/0611e43a-6d59-4ccb-8313-7da522db48f8" />

The two line segments of the blue paths are not connected with a join. Expected behavior.

### Geometry:
#### Before:
<img width="564" height="628" alt="Screenshot 2026-06-02 at 4 59 44 PM" src="https://github.com/user-attachments/assets/bded7ff0-8657-48d8-8480-1257d3521937" />

#### After:
<img width="588" height="692" alt="Screenshot 2026-06-02 at 4 53 29 PM" src="https://github.com/user-attachments/assets/4e63c6ba-897d-4c47-8b03-26f068d4415e" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
