### PR TITLE
Add vector_math to package issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/08_first_party_packages.yml
+++ b/.github/ISSUE_TEMPLATE/08_first_party_packages.yml
@@ -65,6 +65,7 @@ body:
         - two_dimensional_scrollables
         - url_launcher
         - vector_graphics
+        - vector_math
         - video_player
         - web_benchmarks
         - webview_flutter


### PR DESCRIPTION
Adds `vector_math` to the options for 1P packages in the issue template now that it's been moved into flutter/core-packages