### PR TITLE
[Test cross_imports] Check cross imports in flutter_test/**

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -54,10 +54,17 @@ void main(List<String> args) {
   }
 
   const FileSystem filesystem = LocalFileSystem();
-  final Directory tests = filesystem.directory(parsedArgs['test']! as String);
+  final Directory flutterSlashTestDirectory = filesystem.directory(parsedArgs['test']! as String);
   final Directory flutterRoot = filesystem.directory(parsedArgs['flutter-root']! as String);
+  final Directory flutterTestLibraryDirectory = flutterRoot
+      .childDirectory('packages')
+      .childDirectory('flutter_test');
 
-  final checker = TestsCrossImportChecker(testsDirectory: tests, flutterRoot: flutterRoot);
+  final checker = TestsCrossImportChecker(
+    flutterSlashTestDirectory: flutterSlashTestDirectory,
+    flutterTestLibraryDirectory: flutterTestLibraryDirectory,
+    flutterRoot: flutterRoot,
+  );
 
   if (!checker.check()) {
     reportErrorsAndExit('Some errors were found in the framework test imports.');
@@ -88,12 +95,14 @@ void main(List<String> args) {
 ///  - Libraries that do not have anything to do with Cupertino or Material should never import them.
 class TestsCrossImportChecker {
   TestsCrossImportChecker({
-    required this.testsDirectory,
+    required this.flutterSlashTestDirectory,
+    required this.flutterTestLibraryDirectory,
     required this.flutterRoot,
     this.filesystem = const LocalFileSystem(),
   });
 
-  final Directory testsDirectory;
+  final Directory flutterSlashTestDirectory;
+  final Directory flutterTestLibraryDirectory;
   final Directory flutterRoot;
   final FileSystem filesystem;
 
@@ -174,7 +183,17 @@ class TestsCrossImportChecker {
   // See https://github.com/flutter/flutter/issues/177028.
   static final Set<String> knownFlutterSlashTestCrossImports = <String>{};
 
+  /// These tests are known to have cross imports. These cross imports
+  /// should all eventually be resolved, but until they are we allow them, so
+  /// that we can catch any new cross imports that are added.
+  ///
+  /// The files in this set belong to `packages/flutter_test`, or one of its subdirectories.
+  // TODO(justinmc): Fix all of these tests so there are no cross imports.
+  // See https://github.com/flutter/flutter/issues/177028.
+  static final Set<String> knownFlutterTestLibraryCrossImports = <String>{};
+
   static final Set<String> _knownCrossImports = {
+    ...knownFlutterTestLibraryCrossImports,
     ...knownFlutterSlashTestCrossImports,
     ...knownWidgetsCrossImports,
     ...knownAnimationCrossImports,
@@ -192,7 +211,8 @@ class TestsCrossImportChecker {
     ...knownServicesCrossImports,
   };
 
-  static final RegExp _flutterTestPrefix = RegExp(r'packages[/\\]flutter[/\\]test');
+  // This matches both `packages/flutter/test` and `packages/flutter_test`.
+  static final RegExp _flutterTestPrefix = RegExp(r'packages[/\\]flutter[/\\_]test');
 
   /// Returns the [Set] of paths in [knownPaths] that are not in [files].
   static Set<String> _differencePaths(Set<String> knownPaths, Set<File> files) {
@@ -279,13 +299,14 @@ class TestsCrossImportChecker {
   /// Get a list of all the filenames that end in ".dart", grouped by library.
   Map<_Library, Set<File>> _getTestFiles() {
     final dartFilePattern = RegExp(r'\.dart$');
-    const _Library flutterTest = _OtherLibrary('packages/flutter/test');
-    final Map<_Library, Set<File>> mapping = {flutterTest: {}};
+    const _Library flutterSlashTest = _OtherLibrary('packages/flutter/test');
+    const _Library flutterTestLibrary = _OtherLibrary('packages/flutter_test');
+    final Map<_Library, Set<File>> mapping = {flutterSlashTest: {}, flutterTestLibrary: {}};
 
     // List the files directly under `packages/flutter/test` and then walk the subdirectories.
-    for (final FileSystemEntity fileOrDirectory in testsDirectory.listSync()) {
+    for (final FileSystemEntity fileOrDirectory in flutterSlashTestDirectory.listSync()) {
       if (fileOrDirectory is File && fileOrDirectory.absolute.path.contains(dartFilePattern)) {
-        mapping[flutterTest]?.add(fileOrDirectory);
+        mapping[flutterSlashTest]?.add(fileOrDirectory);
 
         continue;
       }
@@ -297,6 +318,16 @@ class TestsCrossImportChecker {
             if (file.absolute.path.contains(dartFilePattern)) file,
         };
       }
+    }
+
+    // List the files directly under `packages/flutter_test` and then walk the subdirectories.
+    for (final File file
+        in flutterTestLibraryDirectory.listSync(recursive: true).whereType<File>()) {
+      if (!file.absolute.path.contains(dartFilePattern)) {
+        continue;
+      }
+
+      mapping[flutterTestLibrary]?.add(file);
     }
 
     return mapping;
@@ -446,6 +477,7 @@ sealed class _Library {
   /// This is used for reporting mismatched cross imports.
   String get crossImportsListSymbolName {
     return switch (name) {
+      'packages/flutter_test' => 'knownFlutterTestLibraryCrossImports',
       'packages/flutter/test' => 'knownFlutterSlashTestCrossImports',
       'packages/flutter/test/animation' => 'knownAnimationCrossImports',
       'packages/flutter/test/cupertino' => 'knownCupertinoCrossImports',
@@ -476,6 +508,8 @@ sealed class _Library {
     }
 
     return switch (crossImportsListSymbolName) {
+      'knownFlutterTestLibraryCrossImports' =>
+        TestsCrossImportChecker.knownFlutterTestLibraryCrossImports,
       'knownFlutterSlashTestCrossImports' =>
         TestsCrossImportChecker.knownFlutterSlashTestCrossImports,
       'knownAnimationCrossImports' => TestsCrossImportChecker.knownAnimationCrossImports,

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -191,7 +191,6 @@ class TestsCrossImportChecker {
   // TODO(justinmc): Fix all of these tests so there are no cross imports.
   // See https://github.com/flutter/flutter/issues/177028.
   static final Set<String> knownFlutterTestLibraryCrossImports = <String>{
-    'packages/flutter_test/lib/src/test_text_input_key_handler.dart',
     'packages/flutter_test/lib/src/widget_tester.dart',
     'packages/flutter_test/lib/src/finders.dart',
     'packages/flutter_test/lib/src/matchers.dart',

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -190,7 +190,32 @@ class TestsCrossImportChecker {
   /// The files in this set belong to `packages/flutter_test`, or one of its subdirectories.
   // TODO(justinmc): Fix all of these tests so there are no cross imports.
   // See https://github.com/flutter/flutter/issues/177028.
-  static final Set<String> knownFlutterTestLibraryCrossImports = <String>{};
+  static final Set<String> knownFlutterTestLibraryCrossImports = <String>{
+    'packages/flutter_test/lib/src/test_text_input_key_handler.dart',
+    'packages/flutter_test/lib/src/widget_tester.dart',
+    'packages/flutter_test/lib/src/finders.dart',
+    'packages/flutter_test/lib/src/matchers.dart',
+    'packages/flutter_test/test_fixes/flutter_test/animation_sheet_builder.dart',
+    'packages/flutter_test/test_fixes/flutter_test/matchers.dart',
+    'packages/flutter_test/test/navigator_test.dart',
+    'packages/flutter_test/test/mock_canvas_test.dart',
+    'packages/flutter_test/test/semantics_finder_test.dart',
+    'packages/flutter_test/test/accessibility_window_test.dart',
+    'packages/flutter_test/test/widget_tester_live_device_test.dart',
+    'packages/flutter_test/test/all_elements_test.dart',
+    'packages/flutter_test/test/utils/memory_leak_tests.dart',
+    'packages/flutter_test/test/widget_tester_test.dart',
+    'packages/flutter_test/test/display_test.dart',
+    'packages/flutter_test/test/bindings_test.dart',
+    'packages/flutter_test/test/live_widget_controller_test.dart',
+    'packages/flutter_test/test/live_binding_test.dart',
+    'packages/flutter_test/test/accessibility_test.dart',
+    'packages/flutter_test/test/finders_test.dart',
+    'packages/flutter_test/test/controller_test.dart',
+    'packages/flutter_test/test/recording_canvas_test.dart',
+    'packages/flutter_test/test/test_text_input_test.dart',
+    'packages/flutter_test/test/multi_view_accessibility_test.dart',
+  };
 
   static final Set<String> _knownCrossImports = {
     ...knownFlutterTestLibraryCrossImports,

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -345,13 +345,28 @@ class TestsCrossImportChecker {
     }
 
     // List the files directly under `packages/flutter_test` and then walk the subdirectories.
-    for (final File file
-        in flutterTestLibraryDirectory.listSync(recursive: true).whereType<File>()) {
-      if (!file.absolute.path.contains(dartFilePattern)) {
+    // Since packages/flutter_test is a library in itself,
+    // exclude generated directories like `packages/flutter_test/build` and `packages/flutter_test/.dart_tool`.
+    for (final FileSystemEntity fileSystemEntity in flutterTestLibraryDirectory.listSync()) {
+      if (fileSystemEntity is File && fileSystemEntity.absolute.path.contains(dartFilePattern)) {
+        mapping[flutterTestLibrary]?.add(fileSystemEntity);
+
         continue;
       }
 
-      mapping[flutterTestLibrary]?.add(file);
+      if (fileSystemEntity is Directory) {
+        final String directoryName = path.basename(fileSystemEntity.absolute.path);
+
+        if (directoryName == 'build' || directoryName == '.dart_tool') {
+          continue;
+        }
+
+        for (final File file in fileSystemEntity.listSync(recursive: true).whereType<File>()) {
+          if (file.absolute.path.contains(dartFilePattern)) {
+            mapping[flutterTestLibrary]?.add(file);
+          }
+        }
+      }
     }
 
     return mapping;

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -18,7 +18,8 @@ void main() {
 
   void buildKnownCrossImportTestFiles({Set<String> excludes = const <String>{}}) {
     final Map<Directory, Set<String>> knownFiles = checkerDirectories.getKnownFiles(
-      checker.testsDirectory,
+      flutterSlashTestDirectory: checker.flutterSlashTestDirectory,
+      flutterTestLibraryDirectory: checker.flutterTestLibraryDirectory,
     );
 
     for (final MapEntry<Directory, Set<String>>(key: Directory directory, value: Set<String> files)
@@ -43,18 +44,26 @@ void main() {
     )..createSync(recursive: true);
     fs.currentDirectory = flutterRoot;
 
-    final Directory testsDirectory =
+    final Directory flutterSlashTestDirectory =
         flutterRoot.childDirectory('packages').childDirectory('flutter').childDirectory('test')
           ..createSync(recursive: true);
-    testsDirectory.childDirectory('material').createSync(recursive: true);
+    flutterSlashTestDirectory.childDirectory('material').createSync(recursive: true);
+
+    final Directory flutterTestLibraryDirectory =
+        flutterRoot.childDirectory('packages').childDirectory('flutter_test')
+          ..createSync(recursive: true);
 
     checker = TestsCrossImportChecker(
-      testsDirectory: testsDirectory,
+      flutterSlashTestDirectory: flutterSlashTestDirectory,
+      flutterTestLibraryDirectory: flutterTestLibraryDirectory,
       flutterRoot: flutterRoot,
       filesystem: fs,
     );
-    checkerDirectories = _CrossImportsTestDirectories(testsDirectory)
-      ..createTestDirectories(testsDirectory);
+    checkerDirectories = _CrossImportsTestDirectories(flutterSlashTestDirectory)
+      ..createTestDirectories(
+        flutterSlashTestDirectory: flutterSlashTestDirectory,
+        flutterTestLibraryDirectory: flutterTestLibraryDirectory,
+      );
   });
 
   test('when only all knowns have cross imports', () async {
@@ -70,7 +79,7 @@ void main() {
   test('non-Dart files are ignored', () async {
     buildKnownCrossImportTestFiles();
 
-    checker.testsDirectory.childFile('README.md')
+    checker.flutterSlashTestDirectory.childFile('README.md')
       ..createSync()
       ..writeAsStringSync("import 'package:flutter/material.dart';");
 
@@ -80,7 +89,7 @@ void main() {
   test('non-Dart files with .dart in the filename are ignored', () async {
     buildKnownCrossImportTestFiles();
 
-    checker.testsDirectory.childFile('foo.dart.md')
+    checker.flutterSlashTestDirectory.childFile('foo.dart.md')
       ..createSync()
       ..writeAsStringSync("import 'package:flutter/material.dart';");
 
@@ -119,7 +128,8 @@ void main() {
 
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
-        checker.testsDirectory,
+        flutterSlashTestDirectory: checker.flutterSlashTestDirectory,
+        flutterTestLibraryDirectory: checker.flutterTestLibraryDirectory,
       );
 
       buildKnownCrossImportTestFiles();
@@ -145,7 +155,8 @@ void main() {
 
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
-        checker.testsDirectory,
+        flutterSlashTestDirectory: checker.flutterSlashTestDirectory,
+        flutterTestLibraryDirectory: checker.flutterTestLibraryDirectory,
       );
 
       buildKnownCrossImportTestFiles();
@@ -171,7 +182,8 @@ void main() {
 
       final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
         libraryName,
-        checker.testsDirectory,
+        flutterSlashTestDirectory: checker.flutterSlashTestDirectory,
+        flutterTestLibraryDirectory: checker.flutterTestLibraryDirectory,
       );
 
       buildKnownCrossImportTestFiles();
@@ -197,7 +209,8 @@ void main() {
         final testDartFile = '$libraryName/foo_test.dart';
         final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
           libraryName,
-          checker.testsDirectory,
+          flutterSlashTestDirectory: checker.flutterSlashTestDirectory,
+          flutterTestLibraryDirectory: checker.flutterTestLibraryDirectory,
         );
 
         buildKnownCrossImportTestFiles();
@@ -231,7 +244,8 @@ void main() {
 
         final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
           libraryName,
-          checker.testsDirectory,
+          flutterSlashTestDirectory: checker.flutterSlashTestDirectory,
+          flutterTestLibraryDirectory: checker.flutterTestLibraryDirectory,
         );
 
         buildKnownCrossImportTestFiles();
@@ -264,7 +278,8 @@ void main() {
         final testDartFile = '$libraryName/foo_utils.dart';
         final Directory testFilesDirectory = checkerDirectories.testFilesDirectoryFor(
           libraryName,
-          checker.testsDirectory,
+          flutterSlashTestDirectory: checker.flutterSlashTestDirectory,
+          flutterTestLibraryDirectory: checker.flutterTestLibraryDirectory,
         );
 
         buildKnownCrossImportTestFiles();
@@ -415,12 +430,24 @@ class _CrossImportsTestDirectories {
   final Directory testServicesDirectory;
   final Directory testWidgetsDirectory;
 
-  /// A mapping of the `flutter/test/xyz` directories,
-  /// to their corresponding known imports list in `check_tests_cross_imports.dart`,
-  /// including `flutter/test` itself.
-  Map<Directory, Set<String>> getKnownFiles(Directory flutterTestDirectory) {
+  /// A mapping of the Flutter framework `packages/**` directories - that are related to tests -
+  /// to their corresponding known imports list in `check_tests_cross_imports.dart`.
+  ///
+  /// This list includes:
+  ///  - `packages/flutter/test` itself
+  ///  - all of the `packages/flutter/test/*` subdirectories
+  ///  - `packages/flutter_test/**`
+  ///
+  /// For the purpose (and the short livedness) of the cross imports checker,
+  /// the `packages/flutter_test` known files list is one entry,
+  /// as cross importing will be impossible post Material and Cupertino split.
+  Map<Directory, Set<String>> getKnownFiles({
+    required Directory flutterSlashTestDirectory,
+    required Directory flutterTestLibraryDirectory,
+  }) {
     return <Directory, Set<String>>{
-      flutterTestDirectory: TestsCrossImportChecker.knownFlutterSlashTestCrossImports,
+      flutterTestLibraryDirectory: TestsCrossImportChecker.knownFlutterTestLibraryCrossImports,
+      flutterSlashTestDirectory: TestsCrossImportChecker.knownFlutterSlashTestCrossImports,
       testCupertinoDirectory: TestsCrossImportChecker.knownCupertinoCrossImports,
       testAnimationDirectory: TestsCrossImportChecker.knownAnimationCrossImports,
       testDartDirectory: TestsCrossImportChecker.knownDartCrossImports,
@@ -438,12 +465,18 @@ class _CrossImportsTestDirectories {
     };
   }
 
-  void createTestDirectories(Directory flutterTestDirectory) {
-    final Map<Directory, Set<String>> knownFiles = getKnownFiles(flutterTestDirectory);
+  void createTestDirectories({
+    required Directory flutterSlashTestDirectory,
+    required Directory flutterTestLibraryDirectory,
+  }) {
+    final Map<Directory, Set<String>> knownFiles = getKnownFiles(
+      flutterSlashTestDirectory: flutterSlashTestDirectory,
+      flutterTestLibraryDirectory: flutterTestLibraryDirectory,
+    );
 
     for (final Directory directory in knownFiles.keys) {
-      // The `flutter/test` directory is created in `setUp()`.
-      if (directory == flutterTestDirectory) {
+      // The `packages/flutter/test` and `packages/flutter_test` directories are created in `setUp()`.
+      if (directory == flutterSlashTestDirectory || directory == flutterTestLibraryDirectory) {
         continue;
       }
 
@@ -451,9 +484,13 @@ class _CrossImportsTestDirectories {
     }
   }
 
-  Directory testFilesDirectoryFor(String libraryName, Directory flutterTestDirectory) {
+  Directory testFilesDirectoryFor(
+    String libraryName, {
+    required Directory flutterSlashTestDirectory,
+    required Directory flutterTestLibraryDirectory,
+  }) {
     return switch (libraryName) {
-      'packages/flutter/test' => flutterTestDirectory,
+      'packages/flutter/test' => flutterSlashTestDirectory,
       'packages/flutter/test/animation' => testAnimationDirectory,
       'packages/flutter/test/cupertino' => testCupertinoDirectory,
       'packages/flutter/test/dart' => testDartDirectory,
@@ -468,6 +505,7 @@ class _CrossImportsTestDirectories {
       'packages/flutter/test/semantics' => testSemanticsDirectory,
       'packages/flutter/test/services' => testServicesDirectory,
       'packages/flutter/test/widgets' => testWidgetsDirectory,
+      'packages/flutter_test' => flutterTestLibraryDirectory,
       _ => throw ArgumentError('Unknown library name: $libraryName'),
     };
   }
@@ -496,5 +534,6 @@ final crossImportsTestCases = <(String, String, Set<String>)>[
   ('packages/flutter/test/semantics', 'knownSemanticsCrossImports', TestsCrossImportChecker.knownSemanticsCrossImports),
   ('packages/flutter/test/services', 'knownServicesCrossImports', TestsCrossImportChecker.knownServicesCrossImports),
   ('packages/flutter/test/widgets', 'knownWidgetsCrossImports', TestsCrossImportChecker.knownWidgetsCrossImports),
+  ('packages/flutter_test', 'knownFlutterTestLibraryCrossImports', TestsCrossImportChecker.knownFlutterTestLibraryCrossImports),
 ];
 // dart format on

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -96,6 +96,31 @@ void main() {
     expect(checker.check(), isTrue);
   });
 
+  test('files under packages/flutter_test/build are ignored', () async {
+    buildKnownCrossImportTestFiles();
+
+    final Directory buildDirectory = checker.flutterTestLibraryDirectory.childDirectory('build')
+      ..createSync();
+    buildDirectory.childFile('foo_test.dart')
+      ..createSync()
+      ..writeAsStringSync("import 'package:flutter/material.dart';");
+
+    expect(checker.check(), isTrue);
+  });
+
+  test('files under packages/flutter_test/.dart_tool are ignored', () async {
+    buildKnownCrossImportTestFiles();
+
+    final Directory dartToolDirectory = checker.flutterTestLibraryDirectory.childDirectory(
+      '.dart_tool',
+    )..createSync();
+    dartToolDirectory.childFile('foo_test.dart')
+      ..createSync()
+      ..writeAsStringSync("import 'package:flutter/material.dart';");
+
+    expect(checker.check(), isTrue);
+  });
+
   for (final (String libraryName, String knownCrossImportsListName, Set<String> knownCrossImports)
       in crossImportsTestCases) {
     test(

--- a/dev/bots/test/check_tests_cross_imports_test.dart
+++ b/dev/bots/test/check_tests_cross_imports_test.dart
@@ -344,7 +344,11 @@ bool isCupertino(String libraryName) => libraryName == 'packages/flutter/test/cu
 File getFile(String filepath, Directory directory) {
   final String platformFilepath = filepath.replaceAll('/', Platform.pathSeparator);
   final String searchPattern = directory.basename + Platform.pathSeparator;
-  final int overlapIndex = platformFilepath.lastIndexOf(searchPattern);
+  // Don't use `lastIndexOf`, as for files in test fixes
+  // i.e. `packages/flutter_test/test_fixes/flutter_test/matchers.dart`
+  // the overlap index could appear multiple times.
+  // Only take the first one.
+  final int overlapIndex = platformFilepath.indexOf(searchPattern);
 
   if (overlapIndex < 0) {
     throw ArgumentError('filepath $filepath must be located in directory ${directory.path}.');

--- a/packages/flutter_test/lib/src/test_text_input_key_handler.dart
+++ b/packages/flutter_test/lib/src/test_text_input_key_handler.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart' show SingleActivator;
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart' show SingleActivator;
 
 import 'binding.dart';
 


### PR DESCRIPTION
This PR updates the cross imports checker to also check in `packages/flutter_test` and its subdirectories.

Since `flutter_test` is testing related, I figured it is a good candidate to be put in the existing check.

To dry run the new check, I fixed one of the violations, along with updating the relevant test.

Fixes https://github.com/flutter/flutter/issues/187528

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
