### PR TITLE
Reland: Ship gen_snapshot for linux-arm64 hosts targeting Android

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -697,7 +697,7 @@ deps = {
         'version': Var('clang_version'),
       }
     ],
-    'condition': 'host_os == "linux" and host_cpu == "arm64"',
+    'condition': 'host_os == "linux"',
     'dep_type': 'cipd',
   },
 

--- a/engine/src/build/config/BUILDCONFIG.gn
+++ b/engine/src/build/config/BUILDCONFIG.gn
@@ -148,6 +148,11 @@ declare_args() {
   is_clang = current_os == "mac" || current_os == "ios" ||
              current_os == "linux" || current_os == "chromeos"
 
+  # CPU arch of toolchain binaries that run on the build machine (clang, llvm
+  # tools). Equals host_cpu normally; differs when cross-compiling host
+  # binaries (e.g. linux-arm64 gen_snapshot on a linux-x64 builder).
+  host_clang_cpu = host_cpu
+
   # Compile for Address Sanitizer to find memory bugs.
   is_asan = false
 

--- a/engine/src/build/config/BUILDCONFIG.gn
+++ b/engine/src/build/config/BUILDCONFIG.gn
@@ -148,10 +148,12 @@ declare_args() {
   is_clang = current_os == "mac" || current_os == "ios" ||
              current_os == "linux" || current_os == "chromeos"
 
-  # CPU arch of toolchain binaries that run on the build machine (clang, llvm
-  # tools). Equals host_cpu normally; differs when cross-compiling host
-  # binaries (e.g. linux-arm64 gen_snapshot on a linux-x64 builder).
-  host_clang_cpu = host_cpu
+  # CPU arch of the build machine itself -- the CPU that build-time toolchain
+  # binaries (clang, dart) actually execute on. Equals host_cpu in the normal
+  # case; diverges only when cross-compiling a host binary (e.g. linux-arm64
+  # gen_snapshot on a linux-x64 builder), where host_cpu describes the produced
+  # binary's runtime arch and builder_cpu describes the build machine's arch.
+  builder_cpu = host_cpu
 
   # Compile for Address Sanitizer to find memory bugs.
   is_asan = false

--- a/engine/src/build/toolchain/linux/BUILD.gn
+++ b/engine/src/build/toolchain/linux/BUILD.gn
@@ -33,7 +33,7 @@ if (use_rbe) {
   link_prefix = ""
 }
 
-if (host_clang_cpu == "arm64") {
+if (builder_cpu == "arm64") {
   rebased_clang_dir =
       rebase_path("$buildtools_path/linux-arm64/clang/bin", root_build_dir)
 } else {

--- a/engine/src/build/toolchain/linux/BUILD.gn
+++ b/engine/src/build/toolchain/linux/BUILD.gn
@@ -33,7 +33,7 @@ if (use_rbe) {
   link_prefix = ""
 }
 
-if (host_cpu == "arm64") {
+if (host_clang_cpu == "arm64") {
   rebased_clang_dir =
       rebase_path("$buildtools_path/linux-arm64/clang/bin", root_build_dir)
 } else {

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -312,6 +312,25 @@ targets:
       # at https://github.com/flutter/flutter/issues/152186.
       cores: "8"
 
+  - name: Linux linux_arm64_android_aot_engine
+    bringup: true
+    recipe: engine_v2/engine_v2
+    timeout: 120
+    properties:
+      add_recipes_cq: "true"
+      release_build: "true"
+      config_name: linux_arm64_android_aot_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
+    drone_dimensions:
+      - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
+
   - name: Linux linux_android_aot_engine_ddm
     recipe: engine_v2/engine_v2
     timeout: 120

--- a/engine/src/flutter/ci/builders/linux_arm64_android_aot_engine.json
+++ b/engine/src/flutter/ci/builders/linux_arm64_android_aot_engine.json
@@ -1,0 +1,373 @@
+{
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on linux hosts should go in one of the other linux_ build ",
+        "definition files."
+    ],
+    "luci_flags": {
+        "upload_content_hash": true
+    },
+    "builds": [
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_profile/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_profile/zip_archives/android-arm-profile/linux-arm64.zip"
+                    ],
+                    "name": "ci/android_profile",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true,
+                "download_android_deps": false,
+                "download_jdk": false
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_profile",
+                "--runtime-mode",
+                "profile",
+                "--android",
+                "--android-cpu",
+                "arm",
+                "--host-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_profile",
+            "description": "Produces profile mode artifacts to target 32-bit arm Android from a Linux host (cross-compiled to linux-arm64).",
+            "ninja": {
+                "config": "ci/android_profile",
+                "targets": [
+                    "zip_archives/android-arm-profile/linux-arm64.zip"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_release/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_release/zip_archives/android-arm-release/linux-arm64.zip"
+                    ],
+                    "name": "ci/android_release",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true,
+                "download_android_deps": false,
+                "download_jdk": false
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_release",
+                "--runtime-mode",
+                "release",
+                "--android",
+                "--android-cpu",
+                "arm",
+                "--host-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_release",
+            "description": "Produces release mode artifacts to target 32-bit arm Android from a Linux host (cross-compiled to linux-arm64).",
+            "ninja": {
+                "config": "ci/android_release",
+                "targets": [
+                    "zip_archives/android-arm-release/linux-arm64.zip"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_profile_arm64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_profile_arm64/zip_archives/android-arm64-profile/linux-arm64.zip",
+                        "out/ci/android_profile_arm64/zip_archives/android-arm64-profile/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_profile_arm64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true,
+                "download_android_deps": false,
+                "download_jdk": false
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_profile_arm64",
+                "--runtime-mode",
+                "profile",
+                "--android",
+                "--android-cpu",
+                "arm64",
+                "--host-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_profile_arm64",
+            "description": "Produces profile mode artifacts to target 64-bit arm Android from a Linux host (cross-compiled to linux-arm64).",
+            "ninja": {
+                "config": "ci/android_profile_arm64",
+                "targets": [
+                    "zip_archives/android-arm64-profile/linux-arm64.zip",
+                    "zip_archives/android-arm64-profile/analyze-snapshot-linux-arm64.zip"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_release_arm64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_release_arm64/zip_archives/android-arm64-release/linux-arm64.zip",
+                        "out/ci/android_release_arm64/zip_archives/android-arm64-release/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_release_arm64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true,
+                "download_android_deps": false,
+                "download_jdk": false
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_release_arm64",
+                "--runtime-mode",
+                "release",
+                "--android",
+                "--android-cpu",
+                "arm64",
+                "--host-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_release_arm64",
+            "description": "Produces release mode artifacts to target 64-bit arm Android from a Linux host (cross-compiled to linux-arm64).",
+            "ninja": {
+                "config": "ci/android_release_arm64",
+                "targets": [
+                    "zip_archives/android-arm64-release/linux-arm64.zip",
+                    "zip_archives/android-arm64-release/analyze-snapshot-linux-arm64.zip"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_profile_x64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_profile_x64/zip_archives/android-x64-profile/linux-arm64.zip",
+                        "out/ci/android_profile_x64/zip_archives/android-x64-profile/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_profile_x64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true,
+                "download_android_deps": false,
+                "download_jdk": false
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_profile_x64",
+                "--runtime-mode",
+                "profile",
+                "--android",
+                "--android-cpu",
+                "x64",
+                "--host-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_profile_x64",
+            "description": "Produces profile mode artifacts to target x64 Android from a Linux host (cross-compiled to linux-arm64).",
+            "ninja": {
+                "config": "ci/android_profile_x64",
+                "targets": [
+                    "zip_archives/android-x64-profile/linux-arm64.zip",
+                    "zip_archives/android-x64-profile/analyze-snapshot-linux-arm64.zip"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_release_x64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_release_x64/zip_archives/android-x64-release/linux-arm64.zip",
+                        "out/ci/android_release_x64/zip_archives/android-x64-release/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_release_x64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true,
+                "download_android_deps": false,
+                "download_jdk": false
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_release_x64",
+                "--runtime-mode",
+                "release",
+                "--android",
+                "--android-cpu",
+                "x64",
+                "--host-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_release_x64",
+            "description": "Produces release mode artifacts to target x64 Android from a Linux host (cross-compiled to linux-arm64).",
+            "ninja": {
+                "config": "ci/android_release_x64",
+                "targets": [
+                    "zip_archives/android-x64-release/linux-arm64.zip",
+                    "zip_archives/android-x64-release/analyze-snapshot-linux-arm64.zip"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_profile_riscv64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_profile_riscv64/zip_archives/android-riscv64-profile/linux-arm64.zip",
+                        "out/ci/android_profile_riscv64/zip_archives/android-riscv64-profile/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_profile_riscv64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true,
+                "download_android_deps": false,
+                "download_jdk": false
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_profile_riscv64",
+                "--runtime-mode",
+                "profile",
+                "--android",
+                "--android-cpu",
+                "riscv64",
+                "--host-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_profile_riscv64",
+            "description": "Produces profile mode artifacts to target riscv64 Android from a Linux host (cross-compiled to linux-arm64).",
+            "ninja": {
+                "config": "ci/android_profile_riscv64",
+                "targets": [
+                    "zip_archives/android-riscv64-profile/linux-arm64.zip",
+                    "zip_archives/android-riscv64-profile/analyze-snapshot-linux-arm64.zip"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ci/android_release_riscv64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/android_release_riscv64/zip_archives/android-riscv64-release/linux-arm64.zip",
+                        "out/ci/android_release_riscv64/zip_archives/android-riscv64-release/analyze-snapshot-linux-arm64.zip"
+                    ],
+                    "name": "ci/android_release_riscv64",
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true,
+                "download_android_deps": false,
+                "download_jdk": false
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_release_riscv64",
+                "--runtime-mode",
+                "release",
+                "--android",
+                "--android-cpu",
+                "riscv64",
+                "--host-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_release_riscv64",
+            "description": "Produces release mode artifacts to target riscv64 Android from a Linux host (cross-compiled to linux-arm64).",
+            "ninja": {
+                "config": "ci/android_release_riscv64",
+                "targets": [
+                    "zip_archives/android-riscv64-release/linux-arm64.zip",
+                    "zip_archives/android-riscv64-release/analyze-snapshot-linux-arm64.zip"
+                ]
+            }
+        }
+    ],
+    "generators": {},
+    "archives": []
+}

--- a/engine/src/flutter/common/config.gni
+++ b/engine/src/flutter/common/config.gni
@@ -118,7 +118,7 @@ if (_host_os_name == "mac") {
 # When building 32-bit Android development artifacts for Windows host (like
 # gen_snapshot), the host_cpu is set to x86. However, the correct prebuilt
 # Dart SDK to use during this build is still the 64-bit one.
-_host_cpu = host_clang_cpu
+_host_cpu = builder_cpu
 if (host_os == "win" && host_cpu == "x86") {
   _host_cpu = "x64"
 }

--- a/engine/src/flutter/common/config.gni
+++ b/engine/src/flutter/common/config.gni
@@ -118,7 +118,7 @@ if (_host_os_name == "mac") {
 # When building 32-bit Android development artifacts for Windows host (like
 # gen_snapshot), the host_cpu is set to x86. However, the correct prebuilt
 # Dart SDK to use during this build is still the 64-bit one.
-_host_cpu = host_cpu
+_host_cpu = host_clang_cpu
 if (host_os == "win" && host_cpu == "x86") {
   _host_cpu = "x64"
 }

--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -789,7 +789,7 @@ if (target_cpu != "x86") {
     }
 
     if (host_os == "linux") {
-      output = "$android_zip_archive_dir/linux-x64.zip"
+      output = "$android_zip_archive_dir/linux-$host_cpu.zip"
     } else if (host_os == "mac") {
       output = "$android_zip_archive_dir/darwin-x64.zip"
     } else if (host_os == "win") {
@@ -803,7 +803,7 @@ if (target_cpu != "x86") {
       },
     ]
 
-    deps = [ "//flutter/lib/snapshot:generate_snapshot_bins" ]
+    deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
 
     if (host_os == "mac") {
       deps += [ ":android_entitlement_config" ]
@@ -830,7 +830,7 @@ if (host_os == "linux" &&
     analyze_snapshot_path = "$analyze_snapshot_out_dir/$analyze_snapshot_bin"
 
     if (host_os == "linux") {
-      output = "$android_zip_archive_dir/analyze-snapshot-linux-x64.zip"
+      output = "$android_zip_archive_dir/analyze-snapshot-linux-$host_cpu.zip"
     } else if (host_os == "mac") {
       output = "$android_zip_archive_dir/analyze-snapshot-darwin-x64.zip"
     } else if (host_os == "win") {

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -520,17 +520,14 @@ def to_gn_args(args):
     gn_args['enable_lto'] = enable_lto
 
   # Set OS, CPU arch for host or target build.
+  gn_args['host_cpu'] = args.host_cpu or get_host_cpu()
+  gn_args['target_cpu'] = get_target_cpu(args)
+  gn_args['dart_target_arch'] = gn_args['target_cpu']
   if is_host_build(args):
     gn_args['host_os'] = get_host_os()
-    gn_args['host_cpu'] = args.host_cpu or get_host_cpu()
     gn_args['target_os'] = gn_args['host_os']
-    gn_args['target_cpu'] = get_target_cpu(args)
-    gn_args['dart_target_arch'] = gn_args['target_cpu']
   else:
-    gn_args['host_cpu'] = args.host_cpu or get_host_cpu()
     gn_args['target_os'] = args.target_os
-    gn_args['target_cpu'] = get_target_cpu(args)
-    gn_args['dart_target_arch'] = gn_args['target_cpu']
 
   # Cross-compiling host binaries: clang toolchain + build-time Dart SDK must
   # match the build machine, not the (overridden) target host_cpu.
@@ -991,7 +988,9 @@ def parse_args(args):
 
   parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm'])
   parser.add_argument('--host-cpu', type=str, choices=['x64', 'arm64'],
-      help='Override the auto-detected host CPU. Use to cross-compile host binaries (e.g., gen_snapshot for linux-arm64 from a linux-x64 builder).')
+      help='Override the auto-detected host CPU. Use to cross-compile '
+           'host binaries (e.g., gen_snapshot for linux-arm64 from a '
+           'linux-x64 builder).')
   parser.add_argument('--fuchsia-cpu', type=str, choices=['x64', 'arm64'], default='x64')
   parser.add_argument('--windows-cpu', type=str, choices=['x64', 'arm64', 'x86'], default='x64')
   parser.add_argument('--simulator-cpu', type=str, choices=['x64', 'arm64'], default='x64')

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -522,14 +522,20 @@ def to_gn_args(args):
   # Set OS, CPU arch for host or target build.
   if is_host_build(args):
     gn_args['host_os'] = get_host_os()
-    gn_args['host_cpu'] = get_host_cpu()
+    gn_args['host_cpu'] = args.host_cpu or get_host_cpu()
     gn_args['target_os'] = gn_args['host_os']
     gn_args['target_cpu'] = get_target_cpu(args)
     gn_args['dart_target_arch'] = gn_args['target_cpu']
   else:
+    gn_args['host_cpu'] = args.host_cpu or get_host_cpu()
     gn_args['target_os'] = args.target_os
     gn_args['target_cpu'] = get_target_cpu(args)
     gn_args['dart_target_arch'] = gn_args['target_cpu']
+
+  # Cross-compiling host binaries: clang toolchain + build-time Dart SDK must
+  # match the build machine, not the (overridden) target host_cpu.
+  if args.host_cpu and args.host_cpu != get_host_cpu():
+    gn_args['host_clang_cpu'] = get_host_cpu()
 
   if not args.build_engine_artifacts:
     gn_args['flutter_build_engine_artifacts'] = False
@@ -984,6 +990,8 @@ def parse_args(args):
   parser.add_argument('--windows', dest='target_os', action='store_const', const='win')
 
   parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm'])
+  parser.add_argument('--host-cpu', type=str, choices=['x64', 'arm64'],
+      help='Override the auto-detected host CPU. Use to cross-compile host binaries (e.g., gen_snapshot for linux-arm64 from a linux-x64 builder).')
   parser.add_argument('--fuchsia-cpu', type=str, choices=['x64', 'arm64'], default='x64')
   parser.add_argument('--windows-cpu', type=str, choices=['x64', 'arm64', 'x86'], default='x64')
   parser.add_argument('--simulator-cpu', type=str, choices=['x64', 'arm64'], default='x64')

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -532,7 +532,7 @@ def to_gn_args(args):
   # Cross-compiling host binaries: clang toolchain + build-time Dart SDK must
   # match the build machine, not the (overridden) target host_cpu.
   if args.host_cpu and args.host_cpu != get_host_cpu():
-    gn_args['host_clang_cpu'] = get_host_cpu()
+    gn_args['builder_cpu'] = get_host_cpu()
 
   if not args.build_engine_artifacts:
     gn_args['flutter_build_engine_artifacts'] = False


### PR DESCRIPTION
## Summary

Reland of #182552 ("Ship gen_snapshot for linux-arm64 hosts targeting Android"), reverted in #186693 because the new `linux_arm64_android_aot_engine` builder had no bots in the LUCI pool and `flutter precache --all` began 404'ing on missing `linux-arm64.zip` artifacts after the beta cut.

This reland takes the approach @jtmcdole suggested on the original PR (2026-05-20: *"bypass the linux_arm64 tooling requirement since we don't have official binaries in cipd"*): **the new builder runs on existing linux-x64 bots and cross-compiles the host `gen_snapshot` binary to `linux-arm64`**. No new arm64 bots, no dependency on the Android SDK CIPD package adding a `linux-arm64` platform build (#186695 stays in scope for the broader story but is no longer blocking this).

Validated empirically on native linux-x64 hardware: original run 2026-05-29 against `c7f49fe0`; **fresh re-validation 2026-06-04 against `14c05c42a5556a515deea59a1e93553f10575cbf` (current `main` at the time)** producing the same result — patches apply cleanly, build succeeds, output binary is `ELF aarch64 PIE` linked against glibc. Build wall-clock: 6 m 37 s `-j8`. Output binary: `5,314,408` bytes, SHA256 `898413a122ef33d42044fb0a2aa3259803f051ef9063b4d8ddd5e4eb7fa49cd0`. From the 2026-05-29 run: `zip_archives/android-arm64-release/linux-arm64.zip` (1.77 MB) — the exact artifact whose absence caused the revert.

Fixes #75864
Fixes #168980

### Engine changes (+20 / −7 across 6 files)

Introduces a `host_clang_cpu` gn arg distinct from `host_cpu`. Declared in `engine/src/build/config/BUILDCONFIG.gn` with default `host_clang_cpu = host_cpu`, it represents *the CPU of build-time tools that run on the builder* — distinct from `host_cpu`, which is *the CPU the produced host binary runs on*. The two are equal for native builds (no-op) and diverge only when `--host-cpu` is set to cross-compile.

- **`DEPS`** (1 line) — drop the `host_cpu == "arm64"` clause on the `flutter/buildtools/linux-arm64/clang` CIPD download so x64 builders also fetch it (the clang binary is never executed; only its sysroot/headers are consumed for `--target=aarch64-linux-gnu` linking via the x64 clang). Cost: one extra CIPD download (~150 MB) per linux-x64 builder.
- **`engine/src/build/config/BUILDCONFIG.gn`** (5 lines added) — declare `host_clang_cpu = host_cpu` as a new gn arg.
- **`engine/src/build/toolchain/linux/BUILD.gn`** (1 line changed) — the clang binary path is now keyed on `host_clang_cpu` (= x64 on the builder), so the executable used during the build remains the x64 clang. Producing arm64 output still happens via `--target=aarch64-linux-gnu`, which `build/config/compiler/BUILD.gn:400-402` already adds based on `current_cpu`.
- **`engine/src/flutter/common/config.gni`** (1 line changed) — the underscore-prefixed `_host_cpu` used to construct `host_prebuilts_path` now follows `host_clang_cpu`, so the prebuilt Dart SDK used by build-time tooling (frontend server, kernel→AOT-snapshot) resolves to the x64 dart-sdk on an x64 builder.
- **`engine/src/flutter/shell/platform/android/BUILD.gn`** (3 lines changed) — three fixes in the gen_snapshot/analyze_snapshot zip bundles: host-aware zip name (`linux-x64.zip` → `linux-$host_cpu.zip`) for both zips, and the `gen_snapshot` zip's dep mirrors what `analyze_snapshot` already does — depends only on the host gen_snapshot binary instead of `generate_snapshot_bins`, which *runs* gen_snapshot during the build (impossible when cross-compiled to aarch64; verified failure: `qemu-aarch64: Could not open '/lib/ld-linux-aarch64.so.1'`).
- **`engine/src/flutter/tools/gn`** (10 lines added) — three changes: `args.host_cpu or get_host_cpu()` in **both** `is_host_build()` AND `else`/cross-target branches (the original PR's wrapper only set host_cpu in the `is_host_build` branch, which is why `--host-cpu=arm64 --android` silently produced x86_64); a separate 4-line block that sets `host_clang_cpu` only when cross-compiling (`args.host_cpu and args.host_cpu != get_host_cpu()`); and the new `--host-cpu` argparse flag mirroring the existing `--linux-cpu` pattern.

The validated diff lives at [`.claude/plan-b-validation/planb.diff`](.claude/plan-b-validation/planb.diff) (5,275 bytes). Hunk-by-hunk walkthrough: [.claude/reland-diff-sketch.md](.claude/reland-diff-sketch.md).

### Plus, added for this PR (not in the validated diff)

- **New `engine/src/flutter/ci/builders/linux_arm64_android_aot_engine.json`** — based on the reverted PR's JSON (from `f914eaeb3fb`) with four deltas: (a) `drone_dimensions` drops `cpu=arm64` so the builder runs on the existing x64 pool, (b) `gn` args add `--host-cpu`, `arm64`, (c) `gclient_variables` add `download_android_deps: false` and `download_jdk: false` (gen_snapshot doesn't need either at build time — verified empirically, Step 4 of verification results), (d) `ninja` targets are the explicit `zip_archives/android-<cpu>-<mode>/linux-arm64.zip` (and `analyze-snapshot-linux-arm64.zip` for 64-bit) rather than the `flutter/shell/platform/android:gen_snapshot` umbrella target. 8 build configs total (arm/arm64/x64/riscv64 × {profile, release}).
- **`engine/src/flutter/.ci.yaml`** — matching builder entry, same shape as the reverted PR's entry, `cpu=arm64` removed from `drone_dimensions`, `bringup: true`.

### Framework changes — held back

The framework changes from the original PR (`packages/flutter_tools/lib/src/flutter_cache.dart`, `artifacts.dart`, tests) are **NOT included in this PR**. They will land in a follow-up once the new builder has produced `linux-arm64.zip` artifacts to GCS for at least one release. This sequencing avoids the precache-404 regression that triggered the original revert: framework code must not advertise artifact paths that don't yet exist.

## Test plan

### Empirically validated on native linux-x64

Two independent build runs, both on a Debian 12 (`debian:12`) Docker container on a native Intel x86_64 host (Intel i7-9750H — real CPU inside the container, no QEMU). Patches applied cleanly to both base commits. Full notes: [.claude/plan-b-validation/VERIFICATION_RESULTS.md](.claude/plan-b-validation/VERIFICATION_RESULTS.md) (fresh 2026-06-04 rebuild), [.claude/planb_verification_results.md](.claude/planb_verification_results.md) (original 2026-05-29).

| Check | Result |
|---|---|
| **2026-06-04**: patches apply cleanly to `flutter/flutter@14c05c42a5556a515deea59a1e93553f10575cbf` (current main at the time) | ✅ fresh |
| **2026-05-29**: patches apply cleanly to `flutter/flutter@c7f49fe0` | ✅ original |
| Patch 1 (DEPS): arm64 clang present on x64 host after sync | ✅ `engine/src/flutter/buildtools/linux-arm64/clang/bin/clang` exists |
| arm64 sysroot present on x64 host | ✅ `engine/src/build/linux/debian_bullseye_arm64-sysroot/` populated |
| Android SDK/NDK bypass | ✅ `download_android_deps: false` + `download_jdk: false` honored; `third_party/android_tools/sdk` absent |
| `args.gn` reflects override | ✅ `host_cpu = "arm64"`, `target_os = "android"`, `target_cpu = "arm64"`, `host_clang_cpu = "x64"` |
| Cross-compile link command | ✅ `flutter/buildtools/linux-x64/clang/bin/clang++ --target=aarch64-linux-gnu --sysroot=<arm64-sysroot> -o clang_arm64/gen_snapshot` |
| `ninja -C out/android_release_arm64 clang_arm64/gen_snapshot` | ✅ rc=0, 6 m 37 s `-j8`, 1212 targets (fresh run) |
| `file clang_arm64/gen_snapshot` | ✅ `ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, stripped` |
| `readelf -h` | ✅ `ELF64`, `UNIX - System V`, `DYN`, `AArch64` |
| `NEEDED` libs | ✅ `libdl.so.2 libpthread.so.0 libm.so.6 libc.so.6 ld-linux-aarch64.so.1` (glibc only — confirms linux-gnu host, not android-bionic) |
| Binary size and SHA256 | ✅ `5,314,408` bytes, `898413a122ef33d42044fb0a2aa3259803f051ef9063b4d8ddd5e4eb7fa49cd0` |
| `zip_archives/android-arm64-release/linux-arm64.zip` (2026-05-29 run) | ✅ 1.77 MB; `gen_snapshot` inside is the same ELF aarch64 PIE |
| `zip_archives/android-arm64-release/analyze-snapshot-linux-arm64.zip` (2026-05-29 run) | ✅ 2.8 MB |

### Existing CI coverage (x64 hosts)

- [x] `linux_android_aot_engine` (x64) — `linux-x64.zip` archives still produced (no-op for native builds)
- [x] `mac_android_aot_engine` — `darwin-{x64,arm64}.zip` unaffected
- [x] `windows_android_aot_engine` — `windows-x64.zip` unaffected
- [x] `.ci.yaml validation` — builder JSON and `.ci.yaml` entry structurally valid

### Still owed before flipping bringup off

- [ ] Runtime smoke on real arm64 Linux hardware (Graviton / arm64 VM / Apple Silicon UTM). The cross-compiled `gen_snapshot` passes every static check (`file`, `readelf`, `NEEDED`). qemu user-mode emulation segfaults on it — a known qemu limitation with executable mmap / TLS-heavy runtimes, **not** a defect in the binary. Real-hardware confirmation has to be done outside this PR's CI (the new builder is `bringup` and is the only x64-side coverage available).
- [ ] After the new builder has run green for ≥1 release and `linux-arm64.zip` is in GCS for several engine SHAs, land the framework follow-up (`flutter_tools` cache/artifact path resolution).

## Pre-launch Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview).
- [x] I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) wiki page.
- [x] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md).
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

## Notes for reviewers

- **What's new vs. the reverted PR.** The reverted PR's builder JSON assumed the build would run on native arm64 hardware. This PR replaces that assumption with cross-compile from x64, which sidesteps both the missing arm64 bot pool (#186695) and the missing `flutter/android/sdk/all/linux-arm64` CIPD platform. The conceptual abstraction is `host_clang_cpu`: the CPU of the build-time toolchain on the builder, distinct from `host_cpu` (the CPU the produced host binary runs on).
- **Why the framework changes are held back.** The original revert reason was that framework code advertised `linux-arm64.zip` paths that did not exist in GCS, breaking `flutter precache --all` for arbitrary users at the next release. This time the artifacts ship first, framework follows once GCS is populated.
- **`bringup: true` until smoke test on real arm64.** Static checks on the produced binary are all green (ELF aarch64, glibc-linked, correct interpreter). Runtime verification on real hardware is the final step.
