### PR TITLE
Reland (framework): Support linux-arm64 host for Android gen_snapshot artifact download

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -511,9 +511,8 @@ class CachedArtifacts implements Artifacts {
       case Artifact.genSnapshotX64:
         assert(mode != BuildMode.debug, 'Artifact $artifact only available in non-debug mode.');
 
-        // TODO(cbracken): Build Android gen_snapshot as Arm64 binary to run
-        // natively on Apple Silicon. See:
-        // https://github.com/flutter/flutter/issues/152281
+        // macOS gen_snapshot ships as a universal binary under the darwin-x64
+        // directory name, so remap darwin-arm64 to darwin-x64 for path resolution.
         HostPlatform hostPlatform = getCurrentHostPlatform();
         if (hostPlatform == HostPlatform.darwin_arm64) {
           hostPlatform = HostPlatform.darwin_x64;

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -386,10 +386,11 @@ class AndroidGenSnapshotArtifacts extends EngineCachedArtifact {
 
   @override
   List<List<String>> getBinaryDirs() {
+    final String linuxArch = cache.getHostPlatformArchName();
     return <List<String>>[
       if (cache.includeAllPlatforms) ...<List<String>>[
         ..._osxBinaryDirs,
-        ..._linuxBinaryDirs,
+        ..._linuxBinaryDirs(linuxArch),
         ..._windowsBinaryDirs,
         ..._dartSdks,
       ] else if (_platform.isWindows)
@@ -397,7 +398,7 @@ class AndroidGenSnapshotArtifacts extends EngineCachedArtifact {
       else if (_platform.isMacOS)
         ..._osxBinaryDirs
       else if (_platform.isLinux)
-        ..._linuxBinaryDirs,
+        ..._linuxBinaryDirs(linuxArch),
     ];
   }
 
@@ -902,13 +903,13 @@ const _osxBinaryDirs = <List<String>>[
   <String>['android-x64-release/darwin-x64', 'android-x64-release/darwin-x64.zip'],
 ];
 
-const _linuxBinaryDirs = <List<String>>[
-  <String>['android-arm-profile/linux-x64', 'android-arm-profile/linux-x64.zip'],
-  <String>['android-arm-release/linux-x64', 'android-arm-release/linux-x64.zip'],
-  <String>['android-arm64-profile/linux-x64', 'android-arm64-profile/linux-x64.zip'],
-  <String>['android-arm64-release/linux-x64', 'android-arm64-release/linux-x64.zip'],
-  <String>['android-x64-profile/linux-x64', 'android-x64-profile/linux-x64.zip'],
-  <String>['android-x64-release/linux-x64', 'android-x64-release/linux-x64.zip'],
+List<List<String>> _linuxBinaryDirs(String arch) => <List<String>>[
+  <String>['android-arm-profile/linux-$arch', 'android-arm-profile/linux-$arch.zip'],
+  <String>['android-arm-release/linux-$arch', 'android-arm-release/linux-$arch.zip'],
+  <String>['android-arm64-profile/linux-$arch', 'android-arm64-profile/linux-$arch.zip'],
+  <String>['android-arm64-release/linux-$arch', 'android-arm64-release/linux-$arch.zip'],
+  <String>['android-x64-profile/linux-$arch', 'android-x64-profile/linux-$arch.zip'],
+  <String>['android-x64-release/linux-$arch', 'android-x64-release/linux-$arch.zip'],
 ];
 
 const _windowsBinaryDirs = <List<String>>[

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -6,6 +6,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -161,6 +162,52 @@ void main() {
           'bin',
           'snapshots',
           'frontend_server_aot.dart.snapshot',
+        ),
+      );
+    });
+
+    testWithoutContext('getArtifactPath resolves gen_snapshot to linux-x64 on x64 Linux host', () {
+      expect(
+        artifacts.getArtifactPath(
+          Artifact.genSnapshot,
+          platform: TargetPlatform.android_arm64,
+          mode: BuildMode.release,
+        ),
+        fileSystem.path.join(
+          'root',
+          'bin',
+          'cache',
+          'artifacts',
+          'engine',
+          'android-arm64-release',
+          'linux-x64',
+          'gen_snapshot',
+        ),
+      );
+    });
+
+    testWithoutContext('getArtifactPath resolves gen_snapshot to linux-arm64 on arm64 Linux host', () {
+      final arm64Artifacts = CachedArtifacts(
+        fileSystem: fileSystem,
+        cache: cache,
+        platform: platform,
+        operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.linux_arm64),
+      );
+      expect(
+        arm64Artifacts.getArtifactPath(
+          Artifact.genSnapshot,
+          platform: TargetPlatform.android_arm64,
+          mode: BuildMode.release,
+        ),
+        fileSystem.path.join(
+          'root',
+          'bin',
+          'cache',
+          'artifacts',
+          'engine',
+          'android-arm64-release',
+          'linux-arm64',
+          'gen_snapshot',
         ),
       );
     });

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -1289,6 +1289,38 @@ void main() {
     ]);
   });
 
+  testWithoutContext('Android gen_snapshot artifacts on x64 linux host include linux-x64 archives', () {
+    fakeProcessManager.addCommand(unameCommandForX64);
+
+    final Cache cache = createCache(FakePlatform());
+    final artifacts = AndroidGenSnapshotArtifacts(cache, platform: FakePlatform());
+
+    expect(artifacts.getBinaryDirs(), <List<String>>[
+      <String>['android-arm-profile/linux-x64', 'android-arm-profile/linux-x64.zip'],
+      <String>['android-arm-release/linux-x64', 'android-arm-release/linux-x64.zip'],
+      <String>['android-arm64-profile/linux-x64', 'android-arm64-profile/linux-x64.zip'],
+      <String>['android-arm64-release/linux-x64', 'android-arm64-release/linux-x64.zip'],
+      <String>['android-x64-profile/linux-x64', 'android-x64-profile/linux-x64.zip'],
+      <String>['android-x64-release/linux-x64', 'android-x64-release/linux-x64.zip'],
+    ]);
+  });
+
+  testWithoutContext('Android gen_snapshot artifacts on arm64 linux host include linux-arm64 archives', () {
+    fakeProcessManager.addCommand(unameCommandForArm64);
+
+    final Cache cache = createCache(FakePlatform());
+    final artifacts = AndroidGenSnapshotArtifacts(cache, platform: FakePlatform());
+
+    expect(artifacts.getBinaryDirs(), <List<String>>[
+      <String>['android-arm-profile/linux-arm64', 'android-arm-profile/linux-arm64.zip'],
+      <String>['android-arm-release/linux-arm64', 'android-arm-release/linux-arm64.zip'],
+      <String>['android-arm64-profile/linux-arm64', 'android-arm64-profile/linux-arm64.zip'],
+      <String>['android-arm64-release/linux-arm64', 'android-arm64-release/linux-arm64.zip'],
+      <String>['android-x64-profile/linux-arm64', 'android-x64-profile/linux-arm64.zip'],
+      <String>['android-x64-release/linux-arm64', 'android-x64-release/linux-arm64.zip'],
+    ]);
+  });
+
   testWithoutContext('Cache can delete stampfiles of artifacts', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final artifactSet = FakeIosUsbArtifacts();


### PR DESCRIPTION
## Summary

Framework half of the reland of #182552. Opened as a **draft** for code review in parallel with #187591 (engine reland). **Do not merge until both gates clear:**

1. #187591 (engine reland) has landed.
2. The new `linux_arm64_android_aot_engine` builder has produced `linux-arm64.zip` to GCS for at least one engine SHA after merge.

The original PR #182552 landed both halves together, which is why the revert #186693 broke `flutter precache --all`: framework code advertised paths that didn't yet exist on GCS. This time, framework lands only after the artifacts are confirmed present. A scheduled job is watching for the two conditions and will flip this PR from draft → ready for review when both are met.

### Changes

- `packages/flutter_tools/lib/src/flutter_cache.dart`: convert the hardcoded `_linuxBinaryDirs` const list into a function parameterized by host architecture, using the existing `cache.getHostPlatformArchName()` pattern from `LinuxEngineArtifacts`.
- `packages/flutter_tools/lib/src/artifacts.dart`: replace a stale TODO comment with an accurate explanation of why `darwin-arm64` is remapped to `darwin-x64` (universal binary). No Linux remapping needed since Linux ships native binaries per host architecture.
- `packages/flutter_tools/test/general.shard/cache_test.dart`: new tests covering both x64 and arm64 host artifact resolution, following the existing `LinuxEngineArtifacts` test pattern.
- `packages/flutter_tools/test/general.shard/artifacts_test.dart`: same for `getArtifactPath` resolving `gen_snapshot` paths.

Related #75864
Related #168980

### Why open this before #187591 lands?

To get code review on the framework half in parallel rather than serially. The actual sequencing-dependency (artifacts must exist before framework manifests them) is enforced by **keeping this in draft**, not by waiting to open the PR. Reviewers can verify the framework changes are correct without taking on the merge-timing risk.

## Pre-launch Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview).
- [x] I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) wiki page.
- [x] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md).
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
