### PR TITLE
feat: Implement Windows platform view plugin lifecycle

### DIFF
--- a/engine/src/flutter/shell/platform/windows/BUILD.gn
+++ b/engine/src/flutter/shell/platform/windows/BUILD.gn
@@ -238,6 +238,7 @@ executable("flutter_windows_unittests") {
     "keyboard_unittests.cc",
     "keyboard_utils_unittests.cc",
     "platform_handler_unittests.cc",
+    "platform_view_plugin_unittests.cc",
     "sequential_id_generator_unittests.cc",
     "settings_plugin_unittests.cc",
     "system_utils_unittests.cc",

--- a/engine/src/flutter/shell/platform/windows/flutter_windows.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows.cc
@@ -300,8 +300,12 @@ void FlutterDesktopEngineRegisterPlatformViewType(
     FlutterDesktopEngineRef engine,
     const char* view_type_name,
     FlutterPlatformViewTypeEntry view_type) {
-  // TODO(schectman): forward to platform view manager.
-  // https://github.com/flutter/flutter/issues/143375
+  if (engine == nullptr || view_type_name == nullptr ||
+      view_type.factory == nullptr) {
+    return;
+  }
+
+  EngineFromHandle(engine)->RegisterPlatformViewType(view_type_name, view_type);
 }
 
 FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
@@ -423,10 +423,7 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
 
   args.custom_task_runners = &custom_task_runners;
 
-  if (!platform_view_plugin_) {
-    platform_view_plugin_ = std::make_unique<PlatformViewPlugin>(
-        messenger_wrapper_.get(), task_runner_.get());
-  }
+  GetOrCreatePlatformViewPlugin();
   if (egl_manager_) {
     auto resolver = [](const char* name) -> void* {
       return reinterpret_cast<void*>(::eglGetProcAddress(name));
@@ -710,6 +707,20 @@ FlutterWindowsView* FlutterWindowsEngine::view(FlutterViewId view_id) const {
 // Returns the currently configured Plugin Registrar.
 FlutterDesktopPluginRegistrarRef FlutterWindowsEngine::GetRegistrar() {
   return plugin_registrar_.get();
+}
+
+void FlutterWindowsEngine::RegisterPlatformViewType(
+    std::string_view type_name,
+    const FlutterPlatformViewTypeEntry& type) {
+  GetOrCreatePlatformViewPlugin()->RegisterPlatformViewType(type_name, type);
+}
+
+PlatformViewPlugin* FlutterWindowsEngine::GetOrCreatePlatformViewPlugin() {
+  if (!platform_view_plugin_) {
+    platform_view_plugin_ = std::make_unique<PlatformViewPlugin>(
+        messenger_wrapper_.get(), task_runner_.get());
+  }
+  return platform_view_plugin_.get();
 }
 
 void FlutterWindowsEngine::AddPluginRegistrarDestructionCallback(

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
@@ -178,6 +178,10 @@ class FlutterWindowsEngine {
     return texture_registrar_.get();
   }
 
+  // Registers a Windows platform view type with the engine.
+  void RegisterPlatformViewType(std::string_view type_name,
+                                const FlutterPlatformViewTypeEntry& type);
+
   // The EGL manager object. If this is nullptr, then we are
   // rendering using software instead of OpenGL.
   egl::Manager* egl_manager() const { return egl_manager_.get(); }
@@ -528,6 +532,8 @@ class FlutterWindowsEngine {
   std::shared_ptr<egl::ProcTable> gl_;
 
   std::unique_ptr<PlatformViewPlugin> platform_view_plugin_;
+
+  PlatformViewPlugin* GetOrCreatePlatformViewPlugin();
 
   // Handles display-related window messages.
   bool HandleDisplayMonitorMessage(HWND hwnd,

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -2,13 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <thread>
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
+
+#include <optional>
+#include <string>
+#include <thread>
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
+#include "flutter/shell/platform/windows/flutter_windows_internal.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 #include "flutter/shell/platform/windows/testing/egl/mock_manager.h"
@@ -1411,6 +1415,48 @@ TEST_F(FlutterWindowsEngineTest, ReceivePlatformViewMessage) {
   while (!received_call) {
     engine->task_runner()->ProcessTasks();
   }
+}
+
+TEST_F(FlutterWindowsEngineTest, RegisterPlatformViewTypeForwardsToPlugin) {
+  FlutterWindowsEngineBuilder builder{GetContext()};
+  auto engine = builder.Build();
+  EngineModifier modifier{engine.get()};
+
+  struct FactoryCallState {
+    int calls = 0;
+    HWND hwnd = reinterpret_cast<HWND>(0x1234);
+    PlatformViewId id = -1;
+    std::string type;
+  };
+  FactoryCallState state;
+
+  FlutterPlatformViewTypeEntry entry = {};
+  entry.struct_size = sizeof(FlutterPlatformViewTypeEntry);
+  entry.user_data = &state;
+  entry.factory = [](const FlutterPlatformViewCreationParameters* params) {
+    auto state = static_cast<FactoryCallState*>(params->user_data);
+    state->calls++;
+    state->id = params->platform_view_id;
+    state->type = params->platform_view_type;
+    return state->hwnd;
+  };
+
+  FlutterDesktopEngineRegisterPlatformViewType(
+      reinterpret_cast<FlutterDesktopEngineRef>(engine.get()), "test_view",
+      entry);
+
+  PlatformViewPlugin* plugin = modifier.platform_view_plugin();
+  ASSERT_NE(plugin, nullptr);
+  ASSERT_TRUE(plugin->AddPlatformView(42, "test_view"));
+
+  EXPECT_TRUE(plugin->InstantiatePlatformView(42, nullptr));
+
+  EXPECT_EQ(state.calls, 1);
+  EXPECT_EQ(state.id, 42);
+  EXPECT_EQ(state.type, "test_view");
+  std::optional<HWND> handle = plugin->GetNativeHandleForId(42);
+  ASSERT_TRUE(handle.has_value());
+  EXPECT_EQ(handle.value(), state.hwnd);
 }
 
 TEST_F(FlutterWindowsEngineTest, AddViewFailureDoesNotHang) {

--- a/engine/src/flutter/shell/platform/windows/platform_view_plugin.cc
+++ b/engine/src/flutter/shell/platform/windows/platform_view_plugin.cc
@@ -12,36 +12,101 @@ PlatformViewPlugin::PlatformViewPlugin(BinaryMessenger* messenger,
 
 PlatformViewPlugin::~PlatformViewPlugin() {}
 
-// TODO(schectman): Impelement platform view lookup.
-// https://github.com/flutter/flutter/issues/143375
 std::optional<HWND> PlatformViewPlugin::GetNativeHandleForId(
     PlatformViewId id) const {
-  return std::nullopt;
+  auto view = platform_views_.find(id);
+  if (view == platform_views_.end()) {
+    return std::nullopt;
+  }
+  return view->second;
 }
 
-// TODO(schectman): Impelement platform view type registration.
-// https://github.com/flutter/flutter/issues/143375
 void PlatformViewPlugin::RegisterPlatformViewType(
     std::string_view type_name,
-    const FlutterPlatformViewTypeEntry& type) {}
+    const FlutterPlatformViewTypeEntry& type) {
+  if (type_name.empty() || type.factory == nullptr) {
+    return;
+  }
+  platform_view_types_[std::string(type_name)] = type;
+}
 
-// TODO(schectman): Impelement platform view instantiation.
-// https://github.com/flutter/flutter/issues/143375
-void PlatformViewPlugin::InstantiatePlatformView(PlatformViewId id) {}
+bool PlatformViewPlugin::InstantiatePlatformView(PlatformViewId id,
+                                                 HWND parent_window) {
+  if (platform_views_.find(id) != platform_views_.end()) {
+    return true;
+  }
 
-// TODO(schectman): Impelement platform view addition.
-// https://github.com/flutter/flutter/issues/143375
-bool PlatformViewPlugin::AddPlatformView(PlatformViewId id,
-                                         std::string_view type_name) {
+  auto pending_view = pending_platform_views_.find(id);
+  if (pending_view == pending_platform_views_.end()) {
+    return false;
+  }
+
+  auto instantiate = [this, id, parent_window]() {
+    if (platform_views_.find(id) != platform_views_.end()) {
+      return;
+    }
+
+    auto pending_view = pending_platform_views_.find(id);
+    if (pending_view == pending_platform_views_.end()) {
+      return;
+    }
+
+    HWND hwnd = pending_view->second(parent_window);
+    if (hwnd == nullptr) {
+      return;
+    }
+
+    platform_views_[id] = hwnd;
+    pending_platform_views_.erase(pending_view);
+  };
+
+  task_runner_->RunNowOrPostTask(std::move(instantiate));
   return true;
 }
 
-// TODO(schectman): Impelement platform view focus request.
-// https://github.com/flutter/flutter/issues/143375
+bool PlatformViewPlugin::AddPlatformView(PlatformViewId id,
+                                         std::string_view type_name) {
+  auto type = platform_view_types_.find(std::string(type_name));
+  if (type == platform_view_types_.end()) {
+    return false;
+  }
+
+  if (platform_views_.find(id) != platform_views_.end() ||
+      pending_platform_views_.find(id) != pending_platform_views_.end()) {
+    return false;
+  }
+
+  auto type_name_string = std::string(type_name);
+  FlutterPlatformViewTypeEntry type_entry = type->second;
+  pending_platform_views_[id] = [id,
+                                 type_name_string = std::move(type_name_string),
+                                 type_entry](HWND parent_window) {
+    FlutterPlatformViewCreationParameters params = {};
+    params.struct_size = sizeof(FlutterPlatformViewCreationParameters);
+    params.parent_window = parent_window;
+    params.platform_view_type = type_name_string.c_str();
+    params.user_data = type_entry.user_data;
+    params.platform_view_id = id;
+    return type_entry.factory(&params);
+  };
+  return true;
+}
+
 bool PlatformViewPlugin::FocusPlatformView(PlatformViewId id,
                                            FocusChangeDirection direction,
                                            bool focus) {
-  return true;
+  (void)direction;
+
+  auto view = platform_views_.find(id);
+  if (view == platform_views_.end()) {
+    return false;
+  }
+
+  if (!focus) {
+    return true;
+  }
+
+  return ::SetFocus(view->second) == view->second;
 }
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/platform_view_plugin.h
+++ b/engine/src/flutter/shell/platform/windows/platform_view_plugin.h
@@ -40,7 +40,9 @@ class PlatformViewPlugin : public PlatformViewManager {
   // AddPlatformView.
   // This method will create the platform view within a task queued to the
   // engine's TaskRunner, which will run on the UI thread.
-  void InstantiatePlatformView(PlatformViewId id);
+  // Returns false if id does not correspond to a pending or created platform
+  // view.
+  bool InstantiatePlatformView(PlatformViewId id, HWND parent_window = nullptr);
 
   // | PlatformViewManager |
   // id must correspond to an identifier that has already been added with
@@ -55,7 +57,7 @@ class PlatformViewPlugin : public PlatformViewManager {
 
   std::unordered_map<PlatformViewId, HWND> platform_views_;
 
-  std::unordered_map<PlatformViewId, std::function<HWND()>>
+  std::unordered_map<PlatformViewId, std::function<HWND(HWND)>>
       pending_platform_views_;
 
   // Pointer to the task runner of the associated engine.

--- a/engine/src/flutter/shell/platform/windows/platform_view_plugin_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/platform_view_plugin_unittests.cc
@@ -1,0 +1,128 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/platform_view_plugin.h"
+
+#include <optional>
+#include <string>
+
+#include "flutter/shell/platform/windows/testing/test_binary_messenger.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+namespace {
+
+constexpr char kPlatformViewType[] = "test_view";
+constexpr PlatformViewId kPlatformViewId = 42;
+
+uint64_t TestGetCurrentTime() {
+  return 0;
+}
+
+struct FactoryCallState {
+  int calls = 0;
+  HWND hwnd = reinterpret_cast<HWND>(0x1234);
+  HWND parent = nullptr;
+  std::string type;
+  PlatformViewId id = -1;
+};
+
+HWND TestPlatformViewFactory(
+    const FlutterPlatformViewCreationParameters* params) {
+  auto state = static_cast<FactoryCallState*>(params->user_data);
+  state->calls++;
+  state->parent = params->parent_window;
+  state->type = params->platform_view_type;
+  state->id = params->platform_view_id;
+  return state->hwnd;
+}
+
+class PlatformViewPluginTest : public ::testing::Test {
+ public:
+  PlatformViewPluginTest()
+      : task_runner_(TestGetCurrentTime, [](const FlutterTask*) {}),
+        plugin_(&messenger_, &task_runner_) {}
+
+ protected:
+  FlutterPlatformViewTypeEntry MakeTypeEntry(FactoryCallState* state) {
+    FlutterPlatformViewTypeEntry entry = {};
+    entry.struct_size = sizeof(FlutterPlatformViewTypeEntry);
+    entry.factory = TestPlatformViewFactory;
+    entry.user_data = state;
+    return entry;
+  }
+
+  TestBinaryMessenger messenger_;
+  TaskRunner task_runner_;
+  PlatformViewPlugin plugin_;
+};
+
+TEST_F(PlatformViewPluginTest, AddPlatformViewQueuesViewForInstantiation) {
+  FactoryCallState state;
+  plugin_.RegisterPlatformViewType(kPlatformViewType, MakeTypeEntry(&state));
+
+  EXPECT_TRUE(plugin_.AddPlatformView(kPlatformViewId, kPlatformViewType));
+
+  EXPECT_EQ(state.calls, 0);
+  EXPECT_EQ(plugin_.GetNativeHandleForId(kPlatformViewId), std::nullopt);
+}
+
+TEST_F(PlatformViewPluginTest, InstantiatePlatformViewCreatesHwndOnce) {
+  FactoryCallState state;
+  HWND parent = reinterpret_cast<HWND>(0x5678);
+  plugin_.RegisterPlatformViewType(kPlatformViewType, MakeTypeEntry(&state));
+  ASSERT_TRUE(plugin_.AddPlatformView(kPlatformViewId, kPlatformViewType));
+
+  EXPECT_TRUE(plugin_.InstantiatePlatformView(kPlatformViewId, parent));
+
+  EXPECT_EQ(state.calls, 1);
+  EXPECT_EQ(state.parent, parent);
+  EXPECT_EQ(state.type, kPlatformViewType);
+  EXPECT_EQ(state.id, kPlatformViewId);
+  std::optional<HWND> handle = plugin_.GetNativeHandleForId(kPlatformViewId);
+  ASSERT_TRUE(handle.has_value());
+  EXPECT_EQ(handle.value(), state.hwnd);
+
+  EXPECT_TRUE(plugin_.InstantiatePlatformView(kPlatformViewId, parent));
+  EXPECT_EQ(state.calls, 1);
+}
+
+TEST_F(PlatformViewPluginTest, AddPlatformViewRejectsUnknownType) {
+  EXPECT_FALSE(plugin_.AddPlatformView(kPlatformViewId, kPlatformViewType));
+  EXPECT_EQ(plugin_.GetNativeHandleForId(kPlatformViewId), std::nullopt);
+}
+
+TEST_F(PlatformViewPluginTest, AddPlatformViewRejectsDuplicateId) {
+  FactoryCallState state;
+  plugin_.RegisterPlatformViewType(kPlatformViewType, MakeTypeEntry(&state));
+
+  EXPECT_TRUE(plugin_.AddPlatformView(kPlatformViewId, kPlatformViewType));
+  EXPECT_FALSE(plugin_.AddPlatformView(kPlatformViewId, kPlatformViewType));
+
+  EXPECT_TRUE(plugin_.InstantiatePlatformView(kPlatformViewId, nullptr));
+  EXPECT_FALSE(plugin_.AddPlatformView(kPlatformViewId, kPlatformViewType));
+}
+
+TEST_F(PlatformViewPluginTest, InstantiateUnknownPlatformViewDoesNothing) {
+  EXPECT_FALSE(plugin_.InstantiatePlatformView(kPlatformViewId, nullptr));
+
+  EXPECT_EQ(plugin_.GetNativeHandleForId(kPlatformViewId), std::nullopt);
+}
+
+TEST_F(PlatformViewPluginTest, FocusPlatformViewFailsBeforeInstantiation) {
+  FactoryCallState state;
+  plugin_.RegisterPlatformViewType(kPlatformViewType, MakeTypeEntry(&state));
+
+  EXPECT_FALSE(plugin_.FocusPlatformView(
+      kPlatformViewId, FocusChangeDirection::kProgrammatic, true));
+
+  ASSERT_TRUE(plugin_.AddPlatformView(kPlatformViewId, kPlatformViewType));
+  EXPECT_FALSE(plugin_.FocusPlatformView(
+      kPlatformViewId, FocusChangeDirection::kProgrammatic, true));
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/testing/engine_modifier.h
+++ b/engine/src/flutter/shell/platform/windows/testing/engine_modifier.h
@@ -87,6 +87,10 @@ class EngineModifier {
     engine_->platform_view_plugin_ = std::move(manager);
   }
 
+  PlatformViewPlugin* platform_view_plugin() {
+    return engine_->platform_view_plugin_.get();
+  }
+
   void OnViewFocusChangeRequest(const FlutterViewFocusChangeRequest* request) {
     engine_->OnViewFocusChangeRequest(request);
   }


### PR DESCRIPTION
This PR introduces groundwork for windows platform views, it doesn't yet make a full `PlatformView` render on Windows by itself (We still need compositor level changes) but engine level platform view plugin lifecycle is properly handled now.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.