### PR TITLE
[fuchsia] use non-blocking InjectEvents

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate.cc
@@ -19,7 +19,6 @@ using fup_PointerSample = fuchsia::ui::pointerinjector::PointerSample;
 using fup_Target = fuchsia::ui::pointerinjector::Target;
 using fup_Viewport = fuchsia::ui::pointerinjector::Viewport;
 using fuv_ViewRef = fuchsia::ui::views::ViewRef;
-const auto fup_MAX_INJECT = fuchsia::ui::pointerinjector::MAX_INJECT;
 
 namespace {
 
@@ -187,58 +186,11 @@ void PointerInjectorDelegate::PointerInjectorEndpoint::InjectEvent(
 
   auto event = ExtractPointerEvent(std::move(request));
 
-  // Add the event to |injector_events_| and dispatch it to the view.
-  EnqueueEvent(std::move(event));
+  FML_CHECK(device_.is_bound());
 
-  DispatchPendingEvents();
-}
-
-void PointerInjectorDelegate::PointerInjectorEndpoint::DispatchPendingEvents() {
-  // Return if there is already a |fuchsia.ui.pointerinjector.Device.Inject|
-  // call in flight. The new pointer events will be dispatched once the
-  // in-progress call terminates.
-  if (injection_in_flight_) {
-    return;
-  }
-
-  // Dispatch the events present in |injector_events_|. Note that we recursively
-  // call |DispatchPendingEvents| in the callback passed to the
-  // |f.u.p.Device.Inject| call. This ensures that there is only one
-  // |f.u.p.Device.Inject| call at a time. If a new pointer event comes when
-  // there is a |f.u.p.Device.Inject| call in progress, it gets buffered in
-  // |injector_events_| and is picked up later.
-  if (!injector_events_.empty()) {
-    auto events = std::move(injector_events_.front());
-    injector_events_.pop();
-    injection_in_flight_ = true;
-
-    FML_CHECK(device_.is_bound());
-    FML_CHECK(events.size() <= fup_MAX_INJECT);
-
-    device_->Inject(std::move(events), [weak = weak_factory_.GetWeakPtr()] {
-      if (!weak) {
-        FML_LOG(WARNING) << "Use after free attempted.";
-        return;
-      }
-      weak->injection_in_flight_ = false;
-      weak->DispatchPendingEvents();
-    });
-  }
-}
-
-void PointerInjectorDelegate::PointerInjectorEndpoint::EnqueueEvent(
-    fup_Event event) {
-  // Add |event| in |injector_events_| keeping in mind that the vector size does
-  // not exceed |fup_MAX_INJECT|.
-  if (!injector_events_.empty() &&
-      injector_events_.back().size() < fup_MAX_INJECT) {
-    injector_events_.back().push_back(std::move(event));
-  } else {
-    std::vector<fup_Event> vec;
-    vec.reserve(fup_MAX_INJECT);
-    vec.push_back(std::move(event));
-    injector_events_.push(std::move(vec));
-  }
+  std::vector<fup_Event> events;
+  events.push_back(std::move(event));
+  device_->InjectEvents(std::move(events));
 }
 
 void PointerInjectorDelegate::PointerInjectorEndpoint::RegisterInjector(
@@ -282,9 +234,7 @@ void PointerInjectorDelegate::PointerInjectorEndpoint::RegisterInjector(
 }
 
 void PointerInjectorDelegate::PointerInjectorEndpoint::Reset() {
-  injection_in_flight_ = false;
   registered_ = false;
-  injector_events_ = {};
 }
 
 }  // namespace flutter_runner

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/pointer_injector_delegate.h
@@ -8,7 +8,6 @@
 #include <fuchsia/ui/pointerinjector/cpp/fidl.h>
 #include <fuchsia/ui/views/cpp/fidl.h>
 
-#include <queue>
 #include <unordered_map>
 #include <vector>
 
@@ -100,15 +99,15 @@ class PointerInjectorDelegate {
               return;
             }
 
-            // Clear all the stale pointer events in |injector_events_| and
-            // reset the state of |weak| so that any future calls do not inject
-            // any stale pointer events.
+            // Reset the state of |weak| so that any future calls re-register
+            // the pointer injector.
             weak->Reset();
           });
     }
 
     // Registers |device_| if it has not been registered and calls
-    // |DispatchPendingEvents()| to dispatch |request| to the view.
+    // |fuchsia.ui.pointerinjector.Device.InjectEvents| to dispatch |request|
+    // to the view.
     void InjectEvent(PointerInjectorRequest request);
 
    private:
@@ -120,22 +119,8 @@ class PointerInjectorDelegate {
     // injected into the channel while registration is pending ("feed forward").
     void RegisterInjector(const PointerInjectorRequest& request);
 
-    // Recursively calls |fuchsia.ui.pointerinjector.Device.Inject| to dispatch
-    // the pointer events in |injector_events_| to the view.
-    void DispatchPendingEvents();
-
-    void EnqueueEvent(fuchsia::ui::pointerinjector::Event event);
-
-    // Resets |registered_|, |injection_in_flight_| and |injector_events_| so
-    // that |device_| can be re-registered and future calls to
-    // |fuchsia.ui.pointerinjector.Device.Inject| do not include any stale
-    // pointer events.
+    // Resets |registered_| so that |device_| can be re-registered.
     void Reset();
-
-    // Set to true if there is a |fuchsia.ui.pointerinjector.Device.Inject| call
-    // in progress. If true, the |fuchsia.ui.pointerinjector.Event| is buffered
-    // in |injector_events_|.
-    bool injection_in_flight_ = false;
 
     // Set to true if |device_| has been registered using
     // |fuchsia.ui.pointerinjector.Registry.Register|. False otherwise.
@@ -151,13 +136,6 @@ class PointerInjectorDelegate {
     std::optional<fuchsia::ui::views::ViewRef> view_ref_;
 
     fuchsia::ui::pointerinjector::DevicePtr device_;
-
-    // A queue containing all the pending |fuchsia.ui.pointerinjector.Event|s
-    // which have to be dispatched to the view.
-    // Note: The size of a vector inside |injector_events_| should not exceed
-    // |fuchsia.ui.pointerinjector.MAX_INJECT|.
-    std::queue<std::vector<fuchsia::ui::pointerinjector::Event>>
-        injector_events_;
 
     fml::WeakPtrFactory<PointerInjectorEndpoint>
         weak_factory_;  // Must be the last member.

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/mock_injector_registry.h
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/mock_injector_registry.h
@@ -39,16 +39,14 @@ class MockInjectorRegistry : public fuchsia::ui::pointerinjector::Registry,
     callback();
   }
 
-  // |fuchsia.ui.pointerinjector.Device.Inject|.
-  void Inject(std::vector<fuchsia::ui::pointerinjector::Event> events,
-              InjectCallback callback) override {
+  // |fuchsia.ui.pointerinjector.Device.InjectEvents|.
+  void InjectEvents(
+      std::vector<fuchsia::ui::pointerinjector::Event> events) override {
     num_events_received_ += events.size();
 
     for (auto& event : events) {
       events_.push_back(std::move(event));
     }
-
-    callback();
   }
 
   void ClearBindings() { bindings_.clear(); }


### PR DESCRIPTION
`fuchsia.ui.pointerinjector.Device.Inject()` is deprecated, change flutter to use new API.

Bug: b/465472227

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
