### PR TITLE
Remove references to 'good first issue'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,12 +95,16 @@ for how to set up your development environment, or ask in #hackers-test on Disco
 Developing for Flutter
 ----------------------
 
-If you prefer to write code, consider starting with the list of good
-first issues for [Flutter][flutter-gfi] or for [Flutter DevTools][devtools-gfi].
+If you prefer to write code, find an issue that interests
+you in [Flutter][flutter-issues] or [Flutter DevTools][devtools-issues].
 Reference the respective sections below for further instructions.
 
-[flutter-gfi]: https://github.com/flutter/flutter/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
-[devtools-gfi]: https://github.com/flutter/devtools/labels/good%20first%20issue
+If you are looking for guidance on good starter issues in a
+specific component, consider asking in the #hackers-new
+[Discord channel](./docs/contributing/Chat.md).
+
+[flutter-issues]: https://github.com/flutter/flutter/issues
+[devtools-issues]: https://github.com/flutter/devtools/issues
 
 ### Framework and Engine
 

--- a/docs/contributing/issue_hygiene/README.md
+++ b/docs/contributing/issue_hygiene/README.md
@@ -285,9 +285,6 @@ careers.
 
 The `blocked` label can be used to indicate that a particular issue is unable to make progress until some other problem is resolved. This is particularly useful if you use your own list of assigned issues to drive your work.
 
-The `good first issue` label should be used on issues that seem like friendly introductions to contributing to Flutter. They should be relatively well-understood issues that are not controversial, do not require a design doc, and do not require a deep understanding of our stack, but are sufficiently involved that they at least require a basic test to be added.
-
-
 ## Milestones
 
 We do not use GitHub milestones to track work.


### PR DESCRIPTION
Removes docs references to the `good first issue` label, which no longer exists since it now overwhelmingly attracts agent-driven PRs that, in many cases, do not follow our AI contribution guidelines. Instead, suggest that new developers find an issue that interests them, or start a discussion in Discord.