### PR TITLE
Fix AppBar title route announcements on iOS and macOS

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1068,17 +1068,7 @@ class _AppBarState extends State<AppBar> {
     if (title != null) {
       title = _AppBarTitleBox(child: title);
       if (!widget.excludeHeaderSemantics) {
-        title = Semantics(
-          namesRoute: switch (defaultTargetPlatform) {
-            TargetPlatform.android ||
-            TargetPlatform.fuchsia ||
-            TargetPlatform.linux ||
-            TargetPlatform.windows => true,
-            TargetPlatform.iOS || TargetPlatform.macOS => null,
-          },
-          header: true,
-          child: title,
-        );
+        title = Semantics(namesRoute: true, header: true, child: title);
       }
 
       title = DefaultTextStyle(

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1493,77 +1493,9 @@ void main() {
     semantics.dispose();
   });
 
-  // Regression test for https://github.com/flutter/flutter/issues/176566
   testWidgets(
-    'AppBar title Semantics.namesRoute flag should be null on iOS/macOS platforms regardless of theme platform',
+    'AppBar title Semantics.namesRoute flag should be non-null on all platforms regardless of theme platform',
     (WidgetTester tester) async {
-      // Regression test for VoiceOver accessibility when theme platform differs from device platform.
-      // When someone sets theme.platform to TargetPlatform.android on an iOS/macOS device,
-      // VoiceOver should still work correctly by not having a namesRoute flag in the title's semantics.
-      final semantics = SemanticsTester(tester);
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
-          home: AppBar(title: const Text('Title')),
-        ),
-      );
-
-      final expectedFlags = <SemanticsFlag>[SemanticsFlag.isHeader];
-
-      expect(
-        semantics,
-        hasSemantics(
-          TestSemantics.root(
-            children: <TestSemantics>[
-              TestSemantics(
-                id: 1,
-                textDirection: TextDirection.ltr,
-                children: <TestSemantics>[
-                  TestSemantics(
-                    id: 2,
-                    children: <TestSemantics>[
-                      TestSemantics(
-                        id: 3,
-                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
-                        children: <TestSemantics>[
-                          TestSemantics(
-                            id: 4,
-                            children: <TestSemantics>[
-                              TestSemantics(
-                                id: 5,
-                                flags: expectedFlags,
-                                label: 'Title',
-                                textDirection: TextDirection.ltr,
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-          ignoreRect: true,
-          ignoreTransform: true,
-        ),
-      );
-
-      semantics.dispose();
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.iOS,
-      TargetPlatform.macOS,
-    }),
-  );
-
-  // Regression test for https://github.com/flutter/flutter/issues/176566
-  testWidgets(
-    'AppBar title Semantics.namesRoute flag should be non-null on Android/Fuchsia/Linux/Windows platforms regardless of theme platform',
-    (WidgetTester tester) async {
-      // When someone sets theme.platform to TargetPlatform.iOS on an Android device,
-      // TalkBack should still work correctly by having a namesRoute flag in the title's semantics.
       final semantics = SemanticsTester(tester);
       await tester.pumpWidget(
         MaterialApp(
@@ -1616,12 +1548,7 @@ void main() {
 
       semantics.dispose();
     },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.android,
-      TargetPlatform.fuchsia,
-      TargetPlatform.linux,
-      TargetPlatform.windows,
-    }),
+    variant: TargetPlatformVariant.all(),
   );
 
   testWidgets('Material3 - AppBar draws a light system bar for a dark background', (


### PR DESCRIPTION

Fix: https://github.com/flutter/flutter/issues/185894 

see discussion in  https://github.com/flutter/flutter/issues/185894  

Previously, from PR https://github.com/flutter/flutter/pull/16081 (from April 2018) `namesRoute` on `AppBar.title`'s `Semantics` widget was set to `null` on iOS and macOS to follow iOS conventions. 

This PR sets `namesRoute` to `true` on the `AppBar`'s title semantics across all platforms, matching standard WCAG 2.4.2 page-titled guidelines.



## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
