### PR TITLE
[Flutter GPU] Document the formats.dart enums

### DIFF
--- a/engine/src/flutter/lib/gpu/lib/src/formats.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/formats.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: public_member_api_docs
-
 part of flutter_gpu;
 
 // ATTENTION! ATTENTION! ATTENTION!
@@ -33,23 +31,85 @@ enum StorageMode {
   deviceTransient,
 }
 
+/// The memory layout of the texels in a [Texture].
+///
+/// Each name spells out the texture's components in order, the bit width of
+/// each component, and how those bits are interpreted. For example,
+/// [r8g8b8a8UNormInt] is a 32 bit per pixel format with four 8 bit components
+/// ordered red, green, blue, alpha, each stored as an unsigned normalized
+/// integer.
+///
+/// Component key:
+///
+///  * `r`, `g`, `b`: the red, green, and blue color components.
+///  * `a`: the alpha component.
+///  * `d`: the depth component.
+///  * `s`: the stencil component.
+///  * `UNorm`: an unsigned integer that is mapped from the range
+///    `[0, 2^bits - 1]` onto the floating point range `[0.0, 1.0]` when read.
+///  * `UInt`: an unsigned integer that is read without normalization.
+///  * `Float`: an IEEE 754 floating point value.
+///  * `SRGB`: the color components are stored in the sRGB color space and are
+///    converted to and from linear space when read and written.
+///
+/// The block-compressed formats are named after their compression scheme (BC,
+/// ETC2, or ASTC) and block dimensions. See [PixelFormatProperties] for block
+/// geometry and [TextureCompressionFamily] for how hardware support is
+/// grouped.
 enum PixelFormat {
+  /// An invalid or unspecified format.
+  ///
+  /// Used as a placeholder and never as the format of a real texture.
   unknown,
+
+  /// A single 8 bit alpha component, stored as an unsigned normalized integer.
   a8UNormInt,
+
+  /// A single 8 bit red component, stored as an unsigned normalized integer.
   r8UNormInt,
+
+  /// Two 8 bit components (red, green), stored as unsigned normalized integers.
   r8g8UNormInt,
+
+  /// Four 8 bit components (red, green, blue, alpha), stored as unsigned
+  /// normalized integers.
+  ///
+  /// This is the most common 32 bit per pixel color format and the default for
+  /// [GpuContext.createTexture].
   r8g8b8a8UNormInt,
+
+  /// Like [r8g8b8a8UNormInt], but the color components are stored in the sRGB
+  /// color space.
   r8g8b8a8UNormIntSRGB,
+
+  /// Four 8 bit components ordered blue, green, red, alpha, stored as unsigned
+  /// normalized integers.
   b8g8r8a8UNormInt,
+
+  /// Like [b8g8r8a8UNormInt], but the color components are stored in the sRGB
+  /// color space.
   b8g8r8a8UNormIntSRGB,
+
+  /// Four 32 bit floating point components (red, green, blue, alpha), for a
+  /// total of 128 bits per pixel.
   r32g32b32a32Float,
+
+  /// Four 16 bit (half precision) floating point components (red, green, blue,
+  /// alpha), for a total of 64 bits per pixel.
   r16g16b16a16Float,
 
   /// A single-channel 32-bit floating-point pixel format.
   r32Float,
   // Depth and stencil formats.
+  /// A single 8 bit stencil component, stored as an unsigned integer.
   s8UInt,
+
+  /// A 24 bit depth component stored as an unsigned normalized integer, packed
+  /// together with an 8 bit unsigned integer stencil component.
   d24UnormS8Uint,
+
+  /// A 32 bit floating point depth component, packed together with an 8 bit
+  /// unsigned integer stencil component.
   d32FloatS8UInt,
   // Block-compressed formats. These are sample-only: they cannot be used as
   // render targets, with storage modes other than `hostVisible`/`devicePrivate`,
@@ -247,6 +307,8 @@ extension PixelFormatProperties on PixelFormat {
   }
 }
 
+/// The orientation of the coordinate system used to address the texels of a
+/// [Texture].
 enum TextureCoordinateSystem {
   /// Alternative coordinate system used when uploading texture data from the
   /// host.
@@ -258,58 +320,255 @@ enum TextureCoordinateSystem {
   renderToTexture,
 }
 
+/// A coefficient that scales one input to the blend equation.
+///
+/// When blending is enabled for a color attachment, the new (source) color
+/// produced by the fragment shader is combined with the existing (destination)
+/// color already in the attachment. Each side is first multiplied by a
+/// [BlendFactor] and then combined by a [BlendOperation]:
+///
+/// ```
+/// result.rgb = (sourceColorFactor * source.rgb) <op> (destinationColorFactor * destination.rgb);
+/// result.a   = (sourceAlphaFactor * source.a)   <op> (destinationAlphaFactor * destination.a);
+/// ```
+///
+/// The "blend color" referenced by some factors is a separate constant color
+/// supplied to the blend equation, distinct from the source and destination
+/// colors.
 enum BlendFactor {
+  /// Multiplies the input by zero, dropping it from the blend.
   zero,
+
+  /// Multiplies the input by one, leaving it unchanged.
   one,
+
+  /// Multiplies the input by the source color, component by component.
   sourceColor,
+
+  /// Multiplies the input by one minus the source color, component by
+  /// component.
   oneMinusSourceColor,
+
+  /// Multiplies the input by the source alpha.
   sourceAlpha,
+
+  /// Multiplies the input by one minus the source alpha.
   oneMinusSourceAlpha,
+
+  /// Multiplies the input by the destination color, component by component.
   destinationColor,
+
+  /// Multiplies the input by one minus the destination color, component by
+  /// component.
   oneMinusDestinationColor,
+
+  /// Multiplies the input by the destination alpha.
   destinationAlpha,
+
+  /// Multiplies the input by one minus the destination alpha.
   oneMinusDestinationAlpha,
+
+  /// Multiplies the input by `min(sourceAlpha, 1 - destinationAlpha)`.
   sourceAlphaSaturated,
+
+  /// Multiplies the input by the constant blend color, component by component.
   blendColor,
+
+  /// Multiplies the input by one minus the constant blend color, component by
+  /// component.
   oneMinusBlendColor,
+
+  /// Multiplies the input by the alpha of the constant blend color.
   blendAlpha,
+
+  /// Multiplies the input by one minus the alpha of the constant blend color.
   oneMinusBlendAlpha,
 }
 
-enum BlendOperation { add, subtract, reverseSubtract }
+/// The operator that combines the scaled source and destination values in the
+/// blend equation.
+///
+/// Each operand is first scaled by a [BlendFactor] before this operation is
+/// applied.
+enum BlendOperation {
+  /// Adds the source and destination values: `source + destination`.
+  add,
 
-enum LoadAction { dontCare, load, clear }
+  /// Subtracts the destination from the source: `source - destination`.
+  subtract,
 
-enum StoreAction {
+  /// Subtracts the source from the destination: `destination - source`.
+  reverseSubtract,
+}
+
+/// What happens to the contents of an attachment's [Texture] when a render
+/// pass begins.
+enum LoadAction {
+  /// The existing contents are not preserved and may be left undefined.
+  ///
+  /// Use this when the entire attachment will be drawn over during the pass.
   dontCare,
+
+  /// The existing contents of the texture are loaded so that the render pass
+  /// draws on top of them.
+  load,
+
+  /// The texture is cleared to the attachment's clear value before drawing.
+  clear,
+}
+
+/// What happens to the contents of an attachment's [Texture] when a render
+/// pass ends.
+enum StoreAction {
+  /// The results are not guaranteed to be stored and may be discarded.
+  ///
+  /// Use this for transient attachments that are not read after the pass, such
+  /// as a depth or stencil buffer used only during rendering.
+  dontCare,
+
+  /// The results are written back to the texture so they can be read later.
   store,
+
+  /// The multisampled results are resolved into the attachment's resolve
+  /// texture. The multisampled texture itself is not stored.
   multisampleResolve,
+
+  /// The multisampled results are both stored and resolved into the
+  /// attachment's resolve texture.
   storeAndMultisampleResolve,
 }
 
-enum ShaderStage { vertex, fragment }
+/// A programmable stage of the render pipeline that a [Shader] runs in.
+enum ShaderStage {
+  /// The vertex stage, which runs once per input vertex.
+  vertex,
 
-enum MinMagFilter { nearest, linear }
+  /// The fragment stage, which runs once per rasterized fragment.
+  fragment,
+}
 
-enum MipFilter { nearest, linear }
+/// How a [Texture] is sampled when it is minified or magnified to fit the area
+/// being drawn.
+enum MinMagFilter {
+  /// Uses the value of the single texel nearest to the sample point.
+  ///
+  /// This is the most widely supported filter.
+  nearest,
 
-enum SamplerAddressMode { clampToEdge, repeat, mirror }
+  /// Linearly interpolates between the texels nearest to the sample point.
+  linear,
+}
 
-enum IndexType { int16, int32 }
+/// How samples are selected and filtered between the mipmap levels of a
+/// [Texture].
+enum MipFilter {
+  /// Samples from the single nearest mipmap level.
+  nearest,
 
-enum PrimitiveType { triangle, triangleStrip, line, lineStrip, point }
+  /// Samples from the two nearest mipmap levels and linearly interpolates
+  /// between them.
+  linear,
+}
 
-enum CullMode { none, frontFace, backFace }
+/// How texture coordinates outside the range `[0, 1]` are mapped back onto a
+/// [Texture] when sampling.
+enum SamplerAddressMode {
+  /// Coordinates are clamped to the edge of the texture, so sampling outside
+  /// the texture repeats its border texels.
+  clampToEdge,
 
-enum WindingOrder { clockwise, counterClockwise }
+  /// The texture is tiled by wrapping coordinates around, keeping only their
+  /// fractional part.
+  repeat,
 
-enum PolygonMode { fill, line }
+  /// The texture is tiled by mirroring it at every integer coordinate
+  /// boundary.
+  mirror,
+}
 
+/// The width of each element in an index buffer.
+///
+/// See [RenderPass.bindIndexBuffer].
+enum IndexType {
+  /// Each index is a 16 bit unsigned integer.
+  int16,
+
+  /// Each index is a 32 bit unsigned integer.
+  int32,
+}
+
+/// How a sequence of vertices is assembled into primitives to be rasterized.
+enum PrimitiveType {
+  /// Draws a separate triangle for each group of three vertices.
+  ///
+  /// Vertices `[A, B, C, D, E, F]` produce triangles `[ABC, DEF]`.
+  triangle,
+
+  /// Draws a connected strip of triangles, adding one triangle for each vertex
+  /// after the first two.
+  ///
+  /// Vertices `[A, B, C, D, E, F]` produce triangles
+  /// `[ABC, BCD, CDE, DEF]`.
+  triangleStrip,
+
+  /// Draws a separate line segment for each pair of vertices.
+  ///
+  /// Vertices `[A, B, C, D]` produce line segments `[AB, CD]`.
+  line,
+
+  /// Draws a single connected line that passes through every vertex in order.
+  ///
+  /// Vertices `[A, B, C]` produce one connected line `[ABC]`.
+  lineStrip,
+
+  /// Draws a point at each vertex.
+  point,
+}
+
+/// Which triangle faces, if any, are discarded before rasterization.
+///
+/// A triangle's facing is determined by its [WindingOrder].
+enum CullMode {
+  /// No triangles are culled. Both front and back faces are drawn.
+  none,
+
+  /// Front facing triangles are culled.
+  frontFace,
+
+  /// Back facing triangles are culled.
+  backFace,
+}
+
+/// The vertex winding direction that defines the front face of a triangle.
+///
+/// Used together with [CullMode] to decide which triangles are discarded.
+enum WindingOrder {
+  /// Triangles whose vertices appear in clockwise order are front facing.
+  clockwise,
+
+  /// Triangles whose vertices appear in counter clockwise order are front
+  /// facing.
+  counterClockwise,
+}
+
+/// How triangles are rasterized: as filled areas or as outlines.
+enum PolygonMode {
+  /// Triangles are filled.
+  fill,
+
+  /// Only the edges of triangles are drawn, producing a wireframe.
+  line,
+}
+
+/// The comparison applied between a new value and the value already stored in
+/// the depth or stencil buffer.
+///
+/// The test passes when the comparison evaluates to true.
 enum CompareFunction {
   /// Comparison test never passes.
   never,
 
-  /// Comparison test passes always passes.
+  /// Comparison test always passes.
   always,
 
   /// Comparison test passes if new_value < current_value.
@@ -331,6 +590,10 @@ enum CompareFunction {
   greaterEqual,
 }
 
+/// The operation performed on the value in the stencil buffer based on the
+/// outcome of the stencil and depth tests.
+///
+/// See [StencilConfig].
 enum StencilOperation {
   /// Don't modify the current stencil value.
   keep,
@@ -357,6 +620,8 @@ enum StencilOperation {
   decrementWrap,
 }
 
+/// The kind of a [Texture], which determines its dimensionality and how it is
+/// sampled.
 enum TextureType {
   /// A 2-dimensional texture.
   texture2D,


### PR DESCRIPTION
Works toward flutter/flutter#143893.

Adds dartdoc comments to every enum and enum value in `lib/gpu/lib/src/formats.dart`, and removes the `// ignore_for_file: public_member_api_docs` suppression so the `public_member_api_docs` lint keeps the file fully documented from here on.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests. (Documentation-only change; test-exempt.)
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/flutter/blob/main/engine/src/flutter/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/blob/main/docs/engine/testing/Testing-the-engine.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md

