### PR TITLE
Start iOS Simulator log reader before launch

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -488,8 +488,12 @@ class IOSSimulator extends Device {
 
     ProtocolDiscovery? vmServiceDiscovery;
     if (debuggingOptions.debuggingEnabled) {
+      final DeviceLogReader logReader = getLogReader(app: package);
+      if (logReader is _IOSSimulatorLogReader) {
+        await logReader.start();
+      }
       vmServiceDiscovery = ProtocolDiscovery.vmService(
-        getLogReader(app: package),
+        logReader,
         ipv6: debuggingOptions.ipv6,
         hostPort: debuggingOptions.hostVmServicePort,
         devicePort: debuggingOptions.deviceVmServicePort,
@@ -831,7 +835,7 @@ class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
   final String? _appName;
 
   late final _linesController = StreamController<String>.broadcast(
-    onListen: _start,
+    onListen: start,
     onCancel: _stop,
   );
 
@@ -848,6 +852,12 @@ class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
 
   @override
   String get name => device.name;
+
+  Future<void>? _startFuture;
+
+  Future<void> start() {
+    return _startFuture ??= _start();
+  }
 
   Future<void> _start() async {
     // Unified logging iOS 11 and greater (introduced in iOS 10).

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwarder.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/application_package.dart';
+import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
@@ -1509,6 +1510,82 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
     );
 
     testUsingContext(
+      'startApp starts the simulator log reader before launching in debug mode',
+      () async {
+        const logPredicate =
+            'eventType = logEvent AND processImagePath ENDSWITH "name" AND '
+            '(senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" '
+            'OR processImageUUID == senderImageUUID OR eventMessage CONTAINS "`UIScene` lifecycle '
+            'will soon be required" OR eventMessage CONTAINS "This process does not adopt UIScene '
+            'lifecycle.") AND NOT(eventMessage CONTAINS ": could not find icon '
+            'for representation -> com.apple.") AND NOT(eventMessage BEGINSWITH "assertion failed: ") '
+            'AND NOT(eventMessage CONTAINS " libxpc.dylib ")';
+        final fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <Pattern>[
+              'xcrun',
+              'simctl',
+              'spawn',
+              'x',
+              'log',
+              'stream',
+              '--style',
+              'json',
+              '--predicate',
+              logPredicate,
+            ],
+          ),
+        ]);
+        final device = IOSSimulator(
+          'x',
+          name: 'iPhone SE',
+          simulatorCategory: 'iOS 11.2',
+          simControl: simControl,
+          logger: logger,
+        );
+        testPlistParser.setProperty('CFBundleIdentifier', 'correct');
+
+        final Directory mockDir = globals.fs.currentDirectory;
+        final IOSApp package = PrebuiltIOSApp(
+          projectBundleId: 'correct',
+          bundleName: 'name',
+          uncompressedBundle: mockDir,
+          applicationPackage: mockDir,
+        );
+        final logReader = device.getLogReader(app: package) as SharedIOSDeviceLogReader;
+
+        const mockInfo = BuildInfo(
+          BuildMode.debug,
+          'flavor',
+          treeShakeIcons: false,
+          packageConfigPath: '.dart_tool/package_config.json',
+        );
+        final mockOptions = DebuggingOptions.enabled(mockInfo);
+        simControl.onLaunch = () {
+          expect(fakeProcessManager, hasNoRemainingExpectations);
+          logReader.linesController.add(
+            'The Dart VM Service is listening on http://127.0.0.1:12345/abc=/',
+          );
+        };
+
+        final LaunchResult result = await device.startApp(
+          package,
+          prebuiltApplication: true,
+          debuggingOptions: mockOptions,
+        );
+
+        expect(result.started, isTrue);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+      },
+      overrides: <Type, Generator>{
+        PlistParser: () => testPlistParser,
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Xcode: () => xcode,
+      },
+    );
+
+    testUsingContext(
       'startApp using route',
       () async {
         final device = IOSSimulator(
@@ -1666,6 +1743,7 @@ class FakeIosProject extends Fake implements IosProject {
 
 class FakeSimControl extends Fake implements SimControl {
   final requests = <LaunchRequest>[];
+  void Function()? onLaunch;
 
   @override
   Future<RunResult> launch(
@@ -1673,6 +1751,7 @@ class FakeSimControl extends Fake implements SimControl {
     String appIdentifier, [
     List<String>? launchArgs,
   ]) async {
+    onLaunch?.call();
     requests.add(LaunchRequest(appIdentifier, launchArgs));
     return RunResult(ProcessResult(0, 0, '', ''), <String>['test']);
   }


### PR DESCRIPTION
My agent observed some issues when implementing https://github.com/fzyzcjy/flutter_rust_bridge/pull/3188 in flutter_rust_bridge, thinks it is a racing condition, and proposed this solution. (see details in the PR description there, which is generated by that agent)

I only glanced the PR and the shape looks not bad, but do not personally have time to check in detail. Therefore, I let agents make this PR, mainly to FYI about this information.