### PR TITLE
[flutter_tools] Fix `flutter create` crash with SDK packages in bin/cache/pkg

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -1403,13 +1403,16 @@ List<String> gatherSdkPackageDependencies(Directory directory) {
   // So it is safe to access it here.
   final String flutterRoot = Cache.flutterRoot!;
   for (final sdkPackage in sdkPackages) {
+    final Directory? packageDir = _resolveSdkPackageDir(fs, flutterRoot, sdkPackage);
+    if (packageDir == null) {
+      // This resolves the same locations as pub's FlutterSdk.packagePath, so a
+      // package we cannot find here is one pub cannot find either, and the
+      // `pub get` that runs next reports it. Skipping avoids turning that case
+      // (such as a mistyped SDK dependency) into an unhandled crash here.
+      continue;
+    }
     final pubspecYaml =
-        loadYaml(
-              fs
-                  .file(fs.path.join(flutterRoot, 'packages', sdkPackage, 'pubspec.yaml'))
-                  .readAsStringSync(),
-            )
-            as YamlMap;
+        loadYaml(packageDir.childFile('pubspec.yaml').readAsStringSync()) as YamlMap;
     for (final MapEntry<dynamic, dynamic> dependency
         in (pubspecYaml['dependencies'] as YamlMap).entries) {
       final descriptor = dependency.value as Object?;
@@ -1421,4 +1424,26 @@ List<String> gatherSdkPackageDependencies(Directory directory) {
     }
   }
   return result.toList();
+}
+
+/// Returns the directory of the `sdk: flutter` package [packageName], or null
+/// if it is not present under [flutterRoot].
+///
+/// Such packages live in one of two locations, searched here in the same order
+/// as pub's `FlutterSdk.packagePath`
+/// (third_party/pkg/pub/lib/src/sdk/flutter.dart), the source of truth for how
+/// `sdk: flutter` dependencies are resolved: in-tree under
+/// `<flutter_root>/packages`, or shipped with the engine artifact under
+/// `<flutter_root>/bin/cache/pkg` (for example, `flutter_gpu`).
+Directory? _resolveSdkPackageDir(FileSystem fs, String flutterRoot, String packageName) {
+  final candidates = <Directory>[
+    fs.directory(fs.path.join(flutterRoot, 'packages', packageName)),
+    fs.directory(fs.path.join(flutterRoot, 'bin', 'cache', 'pkg', packageName)),
+  ];
+  for (final candidate in candidates) {
+    if (candidate.childFile('pubspec.yaml').existsSync()) {
+      return candidate;
+    }
+  }
+  return null;
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/create_pubspec_lock_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/create_pubspec_lock_test.dart
@@ -1,0 +1,85 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/create.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  late FileSystem fileSystem;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    Cache.flutterRoot = '/flutter';
+  });
+
+  // Writes a minimal SDK package pubspec with a single hosted dependency.
+  void writeSdkPackagePubspec(String path, String name) {
+    fileSystem.file(path)
+      ..createSync(recursive: true)
+      ..writeAsStringSync('name: $name\ndependencies:\n  vector_math: 2.1.4\n');
+  }
+
+  Directory writeProject(String pubspec) {
+    final Directory projectDir = fileSystem.directory('/project')..createSync();
+    projectDir.childFile('pubspec.yaml').writeAsStringSync(pubspec);
+    return projectDir;
+  }
+
+  testWithoutContext('resolves SDK packages vendored under bin/cache/pkg', () {
+    // `flutter` lives under packages/, while `flutter_gpu` is vendored into
+    // bin/cache/pkg. Both must be resolved without throwing.
+    writeSdkPackagePubspec('/flutter/packages/flutter/pubspec.yaml', 'flutter');
+    writeSdkPackagePubspec('/flutter/bin/cache/pkg/flutter_gpu/pubspec.yaml', 'flutter_gpu');
+
+    final Directory projectDir = writeProject(
+      'name: my_app\n'
+      'dependencies:\n'
+      '  flutter:\n'
+      '    sdk: flutter\n'
+      '  flutter_gpu:\n'
+      '    sdk: flutter\n',
+    );
+
+    expect(() => gatherSdkPackageDependencies(projectDir), returnsNormally);
+    expect(gatherSdkPackageDependencies(projectDir), contains('vector_math'));
+  });
+
+  testWithoutContext('skips an SDK package whose pubspec cannot be found', () {
+    writeSdkPackagePubspec('/flutter/packages/flutter/pubspec.yaml', 'flutter');
+
+    final Directory projectDir = writeProject(
+      'name: my_app\n'
+      'dependencies:\n'
+      '  flutter:\n'
+      '    sdk: flutter\n'
+      '  not_a_real_sdk_package:\n'
+      '    sdk: flutter\n',
+    );
+
+    expect(() => gatherSdkPackageDependencies(projectDir), returnsNormally);
+    expect(gatherSdkPackageDependencies(projectDir), contains('vector_math'));
+  });
+
+  testWithoutContext('skips an SDK package whose directory exists but has no pubspec', () {
+    writeSdkPackagePubspec('/flutter/packages/flutter/pubspec.yaml', 'flutter');
+    // The package directory exists, but does not contain a pubspec.yaml.
+    fileSystem.directory('/flutter/bin/cache/pkg/empty_pkg').createSync(recursive: true);
+
+    final Directory projectDir = writeProject(
+      'name: my_app\n'
+      'dependencies:\n'
+      '  flutter:\n'
+      '    sdk: flutter\n'
+      '  empty_pkg:\n'
+      '    sdk: flutter\n',
+    );
+
+    expect(() => gatherSdkPackageDependencies(projectDir), returnsNormally);
+    expect(gatherSdkPackageDependencies(projectDir), contains('vector_math'));
+  });
+}


### PR DESCRIPTION
Fixes flutter/flutter#187652

`flutter create` crashes with a `PathNotFoundException` when the project depended on an SDK package vendored in `bin/cache/pkg` (such as `flutter_gpu`), because `gatherSdkPackageDependencies` only looked for SDK package pubspecs under `<flutter_root>/packages`. It now resolves the directory the same way pub's `FlutterSdk.packagePath` does, searching both `packages/` and `bin/cache/pkg/`, and skips a package instead of crashing when its pubspec is missing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
