### PR TITLE
issue fixed -> TabController animateTo() unexpected behaivour

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -186,11 +186,29 @@ class TabController extends ChangeNotifier {
   Animation<double>? get animation => _animationController?.view;
   AnimationController? _animationController;
 
-  /// Controls the duration of TabController and TabBarView animations.
+  /// Controls the default duration of [TabController] and [TabBarView]
+  /// animations.
   ///
   /// Defaults to kTabScrollDuration.
+  ///
+  /// This is the duration that's used when [animateTo] is called without
+  /// an explicit `duration`. To find the duration of the animation that's
+  /// currently changing [index], use [currentAnimationDuration] instead,
+  /// since that reflects any `duration` override passed to [animateTo].
   Duration get animationDuration => _animationDuration;
   final Duration _animationDuration;
+
+  /// The duration of the animation that's currently changing [index], as
+  /// requested by the most recent call to [animateTo].
+  ///
+  /// [TabBarView] uses this value, instead of [animationDuration], to keep
+  /// its content animation in sync with the [TabBar]'s selected tab
+  /// indicator animation, even when [animateTo] is called with a `duration`
+  /// that's different from [animationDuration].
+  ///
+  /// Defaults to [animationDuration].
+  Duration get currentAnimationDuration => _currentAnimationDuration ?? _animationDuration;
+  Duration? _currentAnimationDuration;
 
   /// The total number of tabs.
   ///
@@ -208,6 +226,7 @@ class TabController extends ChangeNotifier {
     _previousIndex = index;
     _index = value;
     if (duration != null && duration > Duration.zero) {
+      _currentAnimationDuration = duration;
       _indexIsChangingCount += 1;
       notifyListeners(); // Because the value of indexIsChanging may have changed.
       _animationController!

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -2396,9 +2396,9 @@ class _TabBarViewState extends State<TabBarView> {
 
     final adjacentDestination = (_currentIndex! - _controller!.previousIndex).abs() == 1;
     if (adjacentDestination) {
-      _warpToAdjacentTab(_controller!.animationDuration);
+      _warpToAdjacentTab(_controller!.currentAnimationDuration);
     } else {
-      _warpToNonAdjacentTab(_controller!.animationDuration);
+      _warpToNonAdjacentTab(_controller!.currentAnimationDuration);
     }
   }
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1733,6 +1733,65 @@ void main() {
     expect(position.pixels, 800);
   });
 
+  testWidgets('TabBarView animates using the duration passed to TabController.animateTo', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/166519.
+    const controllerAnimationDuration = Duration(milliseconds: 100);
+    const animateToDuration = Duration(seconds: 1);
+    final tabs = <String>['A', 'B', 'C'];
+
+    final TabController tabController = createTabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+      animationDuration: controllerAnimationDuration,
+    );
+    await tester.pumpWidget(
+      boilerplate(
+        child: Column(
+          children: <Widget>[
+            TabBar(
+              tabs: tabs.map<Widget>((String tab) => Tab(text: tab)).toList(),
+              controller: tabController,
+            ),
+            SizedBox.square(
+              dimension: 400.0,
+              child: TabBarView(
+                controller: tabController,
+                children: const <Widget>[
+                  Center(child: Text('0')),
+                  Center(child: Text('1')),
+                  Center(child: Text('2')),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final PageView pageView = tester.widget(find.byType(PageView));
+    final PageController pageController = pageView.controller!;
+    final ScrollPosition position = pageController.position;
+
+    expect(position.pixels, 0.0);
+
+    // Animate to an adjacent tab using a duration that's much longer than
+    // the TabController's default animationDuration.
+    tabController.animateTo(1, duration: animateToDuration);
+    await tester.pump();
+
+    // The TabBarView must keep animating for animateToDuration -- to remain
+    // in sync with the TabBar's selected tab indicator -- instead of
+    // finishing after the controller's default animationDuration.
+    await tester.pump(controllerAnimationDuration);
+    expect(position.pixels, greaterThan(0.0));
+    expect(position.pixels, lessThan(400.0));
+
+    await tester.pump(animateToDuration - controllerAnimationDuration);
+    expect(position.pixels, 400.0);
+  });
+
   testWidgets('TabBarView animation can be interrupted', (WidgetTester tester) async {
     const animationDuration = Duration(seconds: 2);
     final tabs = <String>['A', 'B', 'C'];


### PR DESCRIPTION
Expected results
When calling animateTo() method I expect both TabBar and TabBarView to animate with given time duration.

Actual results
TabBar is animated 10 seconds, TabBarView content is animated 2 seconds.

I dived into TabBarView code and it looks like it only respects inital animation duration.