### PR TITLE
Rename Dart_LoadELF2 back to Dart_LoadELF.

### DIFF
--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -1740,11 +1740,11 @@ FlutterEngineResult FlutterEngineCreateAOTData(
       Dart_LoadedElf* loaded_elf = nullptr;
 #else
       Dart_LoadedElf* loaded_elf =
-          Dart_LoadELF2(source->elf_path,             // file path
-                        0,                            // file offset
-                        &error,                       // error (out)
-                        &aot_data->vm_isolate_data,   // vm isolate data (out)
-                        &aot_data->vm_isolate_instrs  // vm isolate instr (out)
+          Dart_LoadELF(source->elf_path,             // file path
+                       0,                            // file offset
+                       &error,                       // error (out)
+                       &aot_data->vm_isolate_data,   // vm isolate data (out)
+                       &aot_data->vm_isolate_instrs  // vm isolate instr (out)
           );
       if (loaded_elf != nullptr) {
         aot_data->vm_snapshot_data = aot_data->vm_isolate_data;

--- a/engine/src/flutter/testing/elf_loader.cc
+++ b/engine/src/flutter/testing/elf_loader.cc
@@ -39,11 +39,11 @@ ELFAOTSymbols LoadELFSymbolFromFixturesIfNeccessary(std::string elf_filename) {
   const char* error = nullptr;
 
   auto loaded_elf =
-      Dart_LoadELF2(elf_path.c_str(),           // file path
-                    0,                          // file offset
-                    &error,                     // error (out)
-                    &symbols.vm_isolate_data,   // vm isolate data (out)
-                    &symbols.vm_isolate_instrs  // vm isolate instr (out)
+      Dart_LoadELF(elf_path.c_str(),           // file path
+                   0,                          // file offset
+                   &error,                     // error (out)
+                   &symbols.vm_isolate_data,   // vm isolate data (out)
+                   &symbols.vm_isolate_instrs  // vm isolate instr (out)
       );
   if (loaded_elf != nullptr) {
     symbols.vm_snapshot_data = symbols.vm_isolate_data;
@@ -91,11 +91,11 @@ ELFAOTSymbols LoadELFSplitSymbolFromFixturesIfNeccessary(
   const char* error = nullptr;
 
   auto loaded_elf =
-      Dart_LoadELF2(elf_path.c_str(),           // file path
-                    0,                          // file offset
-                    &error,                     // error (out)
-                    &symbols.vm_isolate_data,   // vm isolate data (out)
-                    &symbols.vm_isolate_instrs  // vm isolate instr (out)
+      Dart_LoadELF(elf_path.c_str(),           // file path
+                   0,                          // file offset
+                   &error,                     // error (out)
+                   &symbols.vm_isolate_data,   // vm isolate data (out)
+                   &symbols.vm_isolate_instrs  // vm isolate instr (out)
       );
   if (loaded_elf != nullptr) {
     symbols.vm_snapshot_data = symbols.vm_isolate_data;


### PR DESCRIPTION
The unsuffixed name now has the new signature.
 