### PR TITLE
[Android] [a11y] make text field floating label a separated semantics node in android

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1716,6 +1716,7 @@ class _RenderDecoration extends RenderBox
       _InputDecoratorState._kPrefixIconSemanticsTag,
       _InputDecoratorState._kSuffixSemanticsTag,
       _InputDecoratorState._kSuffixIconSemanticsTag,
+      if (defaultTargetPlatform == TargetPlatform.android) _InputDecoratorState._kLabelSemanticsTag,
     };
 
     for (final childConfig in childConfigs) {
@@ -2018,6 +2019,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   static const SemanticsTag _kSuffixIconSemanticsTag = SemanticsTag(
     '_InputDecoratorState.suffixIcon',
   );
+  static const SemanticsTag _kLabelSemanticsTag = SemanticsTag('_InputDecoratorState.label');
 
   @override
   void initState() {
@@ -2406,6 +2408,9 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
           ),
         ),
       );
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        label = Semantics(tagForChildren: _kLabelSemanticsTag, child: label);
+      }
     }
 
     final bool hasPrefix = decoration.prefix != null || decoration.prefixText != null;

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import '../widgets/semantics_tester.dart';
 
 const Duration kTransitionDuration = Duration(milliseconds: 167);
 
@@ -15769,5 +15770,129 @@ void main() {
       ),
     );
     expect(tester.getSize(find.byType(InputDecorator)), Size.zero);
+  });
+
+  testWidgets('TextField label semantics is split on Android, merged on iOS', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    addTearDown(semantics.dispose);
+
+    // 1. Android - Split Label Semantics
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.android),
+        home: Scaffold(
+          body: TextField(
+            decoration: const InputDecoration(labelText: 'Label Text'),
+            controller: TextEditingController(text: 'Input Text'),
+          ),
+        ),
+      ),
+    );
+
+    // Verify that 'Label Text' and 'Input Text' are in separate semantics nodes.
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              children: <TestSemantics>[
+                TestSemantics(
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                      children: <TestSemantics>[
+                        TestSemantics(label: 'Label Text', textDirection: TextDirection.ltr),
+                        TestSemantics(
+                          value: 'Input Text',
+                          textDirection: TextDirection.ltr,
+                          inputType: SemanticsInputType.text,
+                          currentValueLength: 10,
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.isTextField,
+                            SemanticsFlag.isFocusable,
+                            SemanticsFlag.hasEnabledState,
+                            SemanticsFlag.isEnabled,
+                          ],
+                          actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+        ignoreId: true,
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
+
+    // 2. iOS - Merged Label Semantics
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.iOS),
+        home: Scaffold(
+          body: TextField(
+            decoration: const InputDecoration(labelText: 'Label Text'),
+            controller: TextEditingController(text: 'Input Text'),
+          ),
+        ),
+      ),
+    );
+
+    // On iOS, they are merged into one node.
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              children: <TestSemantics>[
+                TestSemantics(
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                      children: <TestSemantics>[
+                        TestSemantics(
+                          label: 'Label Text',
+                          value: 'Input Text',
+                          textDirection: TextDirection.ltr,
+                          inputType: SemanticsInputType.text,
+                          currentValueLength: 10,
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.isTextField,
+                            SemanticsFlag.isFocusable,
+                            SemanticsFlag.hasEnabledState,
+                            SemanticsFlag.isEnabled,
+                          ],
+                          actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+        ignoreId: true,
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
+
+    semantics.dispose();
+    debugDefaultTargetPlatformOverride = null;
   });
 }


### PR DESCRIPTION
fix: https://github.com/flutter/flutter/issues/185266  
The issue is the floating text label for text field is visible but not announced.
flutter uses setHintText in ANI to set the floating label text.
And Android assumes that hint text is only visible when there's no value.
so Android only announces the hinttext when value is null, when value is not null, android omit the hint text announcement.
I tested on Android and iOS, when label text and value are both visible. android textfield is actually 2 a11y nodes, iOS textfiels is only a11y node.
I think the solution on the flutter requires changes in the framework.
we should produce two semantics node for android and one semantics node for iOS.




## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
