### PR TITLE
[Impeller] Submit a Vulkan command buffer only if its fence was successfully added to the FenceWaiterVK

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -27,6 +27,7 @@ impeller_component("vulkan_unittests") {
     "blit_pass_vk_unittests.cc",
     "command_encoder_vk_unittests.cc",
     "command_pool_vk_unittests.cc",
+    "command_queue_vk_unittests.cc",
     "context_vk_unittests.cc",
     "descriptor_pool_vk_unittests.cc",
     "driver_info_vk_unittests.cc",

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
@@ -83,7 +83,8 @@ fml::Status CommandQueueVK::Submit(
   if (status != vk::Result::eSuccess) {
     context->GetFenceWaiter()->RemoveFence(raw_fence);
     VALIDATION_LOG << "Failed to submit queue: " << vk::to_string(status);
-    return fml::Status(fml::StatusCode::kCancelled, "Failed to submit queue: ");
+    return fml::Status(fml::StatusCode::kCancelled,
+                       "Failed to submit queue: " + vk::to_string(status));
   }
 
   reset.Release();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
@@ -60,16 +60,9 @@ fml::Status CommandQueueVK::Submit(
     return fml::Status(fml::StatusCode::kCancelled, "Failed to create fence.");
   }
 
-  vk::SubmitInfo submit_info;
-  submit_info.setCommandBuffers(vk_buffers);
-  auto status = context->GetGraphicsQueue()->Submit(submit_info, *fence);
-  if (status != vk::Result::eSuccess) {
-    VALIDATION_LOG << "Failed to submit queue: " << vk::to_string(status);
-    return fml::Status(fml::StatusCode::kCancelled, "Failed to submit queue: ");
-  }
-
   // Submit will proceed, call callback with true when it is done and do not
   // call when `reset` is collected.
+  vk::Fence raw_fence = fence.get();
   auto added_fence = context->GetFenceWaiter()->AddFence(
       std::move(fence), [completion_callback, tracked_objects = std::move(
                                                   tracked_objects)]() mutable {
@@ -83,6 +76,16 @@ fml::Status CommandQueueVK::Submit(
   if (!added_fence) {
     return fml::Status(fml::StatusCode::kCancelled, "Failed to add fence.");
   }
+
+  vk::SubmitInfo submit_info;
+  submit_info.setCommandBuffers(vk_buffers);
+  auto status = context->GetGraphicsQueue()->Submit(submit_info, raw_fence);
+  if (status != vk::Result::eSuccess) {
+    context->GetFenceWaiter()->RemoveFence(raw_fence);
+    VALIDATION_LOG << "Failed to submit queue: " << vk::to_string(status);
+    return fml::Status(fml::StatusCode::kCancelled, "Failed to submit queue: ");
+  }
+
   reset.Release();
   return fml::Status();
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
@@ -18,7 +18,7 @@ TEST(CommandQueueVKTest, SubmitAfterFenceWaiterTerminated) {
   auto buffer = context->CreateCommandBuffer();
   context->GetFenceWaiter()->Terminate();
   auto status = context->GetCommandQueue()->Submit({buffer});
-  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), fml::StatusCode::kCancelled);
 
   // The command buffer should not be submitted to the Vulkan queue if the
   // fence waiter has been terminated.

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
@@ -17,7 +17,8 @@ TEST(CommandQueueVKTest, SubmitAfterFenceWaiterTerminated) {
   const auto context = MockVulkanContextBuilder().Build();
   auto buffer = context->CreateCommandBuffer();
   context->GetFenceWaiter()->Terminate();
-  context->GetCommandQueue()->Submit({buffer});
+  auto status = context->GetCommandQueue()->Submit({buffer});
+  EXPECT_FALSE(status.ok());
 
   // The command buffer should not be submitted to the Vulkan queue if the
   // fence waiter has been terminated.

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <algorithm>
+
+#include "flutter/testing/testing.h"
+#include "gtest/gtest.h"
+#include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/renderer/backend/vulkan/fence_waiter_vk.h"
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(CommandQueueVKTest, SubmitAfterFenceWaiterTerminated) {
+  const auto context = MockVulkanContextBuilder().Build();
+  auto buffer = context->CreateCommandBuffer();
+  context->GetFenceWaiter()->Terminate();
+  context->GetCommandQueue()->Submit({buffer});
+
+  // The command buffer should not be submitted to the Vulkan queue if the
+  // fence waiter has been terminated.
+  const auto called = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_EQ(std::find(called->begin(), called->end(), "vkQueueSubmit"),
+            called->end());
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -78,6 +78,14 @@ bool FenceWaiterVK::AddFence(vk::UniqueFence fence,
   return true;
 }
 
+void FenceWaiterVK::RemoveFence(vk::Fence fence) {
+  std::scoped_lock lock(wait_set_mutex_);
+  auto match = [fence](const std::shared_ptr<WaitSetEntry>& entry) {
+    return entry->GetFence() == fence;
+  };
+  std::erase_if(wait_set_, match);
+}
+
 static std::vector<vk::Fence> GetFencesForWaitSet(const WaitSet& set) {
   std::vector<vk::Fence> fences;
   for (const auto& entry : set) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -81,7 +81,7 @@ bool FenceWaiterVK::AddFence(vk::UniqueFence fence,
 void FenceWaiterVK::RemoveFence(vk::Fence fence) {
   std::scoped_lock lock(wait_set_mutex_);
   auto match = [fence](const std::shared_ptr<WaitSetEntry>& entry) {
-    return entry->GetFence() == fence;
+    return entry && entry->GetFence() == fence;
   };
   std::erase_if(wait_set_, match);
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.h
@@ -30,6 +30,8 @@ class FenceWaiterVK {
 
   bool AddFence(vk::UniqueFence fence, const fml::closure& callback);
 
+  void RemoveFence(vk::Fence fence);
+
  private:
   friend class ContextVK;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -38,6 +38,8 @@ class MockQueue {
   MockDevice& device() const { return device_; }
 
  private:
+  // The MockDevice owns the MockQueues, and each MockQueue holds a reference
+  // to its parent device.
   MockDevice& device_;
 };
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -20,6 +20,8 @@ namespace testing {
 
 namespace {
 
+class MockDevice;
+
 struct MockCommandBuffer {
   explicit MockCommandBuffer(
       std::shared_ptr<std::vector<std::string>> called_functions)
@@ -27,6 +29,16 @@ struct MockCommandBuffer {
   std::shared_ptr<std::vector<std::string>> called_functions_;
   std::vector<VkImageMemoryBarrier> image_memory_barriers_;
   std::vector<VkViewport> recorded_viewports_;
+};
+
+class MockQueue {
+ public:
+  MockQueue(MockDevice& device) : device_(device) {}
+
+  MockDevice& device() const { return device_; }
+
+ private:
+  MockDevice& device_;
 };
 
 struct MockQueryPool {};
@@ -52,7 +64,8 @@ static ISize currentImageSize = ISize{1, 1};
 
 class MockDevice final {
  public:
-  explicit MockDevice() : called_functions_(new std::vector<std::string>()) {}
+  explicit MockDevice()
+      : called_functions_(new std::vector<std::string>()), queue_(*this) {}
 
   MockCommandBuffer* NewCommandBuffer() {
     auto buffer = std::make_unique<MockCommandBuffer>(called_functions_);
@@ -90,6 +103,8 @@ class MockDevice final {
     called_functions_->push_back(function);
   }
 
+  const MockQueue& GetQueue() const { return queue_; }
+
  private:
   MockDevice(const MockDevice&) = delete;
 
@@ -106,6 +121,8 @@ class MockDevice final {
   Mutex commmand_pools_mutex_;
   std::vector<std::unique_ptr<MockCommandPool>> command_pools_
       IPLR_GUARDED_BY(commmand_pools_mutex_);
+
+  const MockQueue queue_;
 };
 
 struct MockVulkanState {
@@ -619,10 +636,21 @@ VkResult vkDestroyFence(VkDevice device,
   return VK_SUCCESS;
 }
 
+void vkGetDeviceQueue(VkDevice device,
+                      uint32_t queueFamilyIndex,
+                      uint32_t queueIndex,
+                      VkQueue* pQueue) {
+  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  *pQueue = reinterpret_cast<VkQueue>(
+      const_cast<MockQueue*>(&mock_device->GetQueue()));
+}
+
 VkResult vkQueueSubmit(VkQueue queue,
                        uint32_t submitCount,
                        const VkSubmitInfo* pSubmits,
                        VkFence fence) {
+  const MockQueue* mock_queue = reinterpret_cast<const MockQueue*>(queue);
+  mock_queue->device().AddCalledFunction("vkQueueSubmit");
   return VK_SUCCESS;
 }
 
@@ -1000,6 +1028,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateFence);
   } else if (strcmp("vkDestroyFence", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyFence);
+  } else if (strcmp("vkGetDeviceQueue", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkGetDeviceQueue);
   } else if (strcmp("vkQueueSubmit", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkQueueSubmit);
   } else if (strcmp("vkWaitForFences", pName) == 0) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -103,7 +103,7 @@ class MockDevice final {
     called_functions_->push_back(function);
   }
 
-  const MockQueue& GetQueue() const { return queue_; }
+  MockQueue& GetQueue() { return queue_; }
 
  private:
   MockDevice(const MockDevice&) = delete;
@@ -122,7 +122,7 @@ class MockDevice final {
   std::vector<std::unique_ptr<MockCommandPool>> command_pools_
       IPLR_GUARDED_BY(commmand_pools_mutex_);
 
-  const MockQueue queue_;
+  MockQueue queue_;
 };
 
 struct MockVulkanState {
@@ -641,8 +641,7 @@ void vkGetDeviceQueue(VkDevice device,
                       uint32_t queueIndex,
                       VkQueue* pQueue) {
   MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
-  *pQueue = reinterpret_cast<VkQueue>(
-      const_cast<MockQueue*>(&mock_device->GetQueue()));
+  *pQueue = reinterpret_cast<VkQueue>(&mock_device->GetQueue());
 }
 
 VkResult vkQueueSubmit(VkQueue queue,


### PR DESCRIPTION
The FenceWaiterVK may be in a state where it is unable to add a new fence.  This could happen if the FenceWaiterVK has been terminated during engine shutdown.

If FenceWaiterVK::AddFence fails, then CommandQueueVK::Submit should not submit the command buffer.

Prior to this PR, CommandQueueVK::Submit was submitting the command buffer to the queue with the fence before calling AddFence.  If AddFence failed, then the fence would be destroyed even though the Vulkan driver still holds its handle.  That could cause a crash when the command completes and the Vulkan driver tries to signal the fence.

Fixes https://github.com/flutter/flutter/issues/187703