### PR TITLE
[Flutter GPU] Make ShaderLibrary.fromAsset asynchronous

### DIFF
--- a/engine/src/flutter/impeller/fixtures/dart_tests.dart
+++ b/engine/src/flutter/impeller/fixtures/dart_tests.dart
@@ -26,16 +26,16 @@ void instantiateDefaultContext() {
 }
 
 @pragma('vm:entry-point')
-void canCreateShaderLibrary() {
-  final gpu.ShaderLibrary? library = gpu.ShaderLibrary.fromAsset('playground');
+Future<void> canCreateShaderLibrary() async {
+  final gpu.ShaderLibrary? library = await gpu.ShaderLibrary.fromAsset('playground');
   assert(library != null);
   final gpu.Shader? shader = library!['UnlitVertex'];
   assert(shader != null);
 }
 
 @pragma('vm:entry-point')
-void canReflectUniformStructs() {
-  final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+Future<void> canReflectUniformStructs() async {
+  final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
 
   final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
   assert(vertInfo.uniformName == 'VertInfo');
@@ -50,8 +50,8 @@ void canReflectUniformStructs() {
   assert(colorOffset! == 64);
 }
 
-gpu.RenderPipeline createUnlitRenderPipeline() {
-  final gpu.ShaderLibrary? library = gpu.ShaderLibrary.fromAsset('playground');
+Future<gpu.RenderPipeline> createUnlitRenderPipeline() async {
+  final gpu.ShaderLibrary? library = await gpu.ShaderLibrary.fromAsset('playground');
   assert(library != null);
   final gpu.Shader? vertex = library!['UnlitVertex'];
   assert(vertex != null);
@@ -65,7 +65,7 @@ ByteData float32(List<double> values) {
 }
 
 @pragma('vm:entry-point')
-void canCreateRenderPassAndSubmit(int width, int height) {
+Future<void> canCreateRenderPassAndSubmit(int width, int height) async {
   final gpu.Texture renderTexture = gpu.gpuContext.createTexture(
     gpu.StorageMode.devicePrivate,
     width,
@@ -77,7 +77,7 @@ void canCreateRenderPassAndSubmit(int width, int height) {
   final renderTarget = gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: renderTexture));
   final gpu.RenderPass encoder = commandBuffer.createRenderPass(renderTarget);
 
-  final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+  final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
   encoder.bindPipeline(pipeline);
 
   // Configure blending with defaults (just to test the bindings).

--- a/engine/src/flutter/impeller/renderer/renderer_dart_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_dart_unittests.cc
@@ -27,6 +27,7 @@
 
 #include "gtest/gtest.h"
 #include "third_party/imgui/imgui.h"
+#include "third_party/tonic/dart_microtask_queue.h"
 
 namespace impeller {
 namespace testing {
@@ -37,6 +38,20 @@ static void InstantiateTestShaderLibrary(Context::BackendType backend_type) {
   auto library = flutter::gpu::ShaderLibrary::MakeFromFlatbuffer(
       backend_type, std::move(fixture));
   flutter::gpu::ShaderLibrary::SetOverride(library);
+}
+
+// Drains the microtask queue so async Dart entry points run to completion.
+// Returns false if a microtask produced an unhandled error. Must be called
+// inside an isolate scope. The fixture entry points are now async (shader
+// loading returns a Future), and on native everything they await is already
+// available, so the work finishes as microtasks with no message loop needed.
+static bool DrainMicrotasks() {
+  auto* queue = tonic::DartMicrotaskQueue::GetForCurrentThread();
+  if (queue == nullptr) {
+    return true;
+  }
+  queue->RunMicrotasks();
+  return queue->GetLastError() == tonic::kNoError;
 }
 
 class RendererDartTest : public PlaygroundTest,
@@ -94,7 +109,7 @@ class RendererDartTest : public PlaygroundTest,
                                 tonic::ToDart(dart_function_name), 2, args))) {
             return false;
           }
-          return true;
+          return DrainMicrotasks();
         });
     if (!success) {
       FML_LOG(ERROR) << "Failed to invoke dart test function:"
@@ -120,7 +135,7 @@ class RendererDartTest : public PlaygroundTest,
                             tonic::ToDart(dart_function_name), 0, nullptr))) {
         return false;
       }
-      return true;
+      return DrainMicrotasks();
     });
   }
 
@@ -139,7 +154,7 @@ class RendererDartTest : public PlaygroundTest,
                                 tonic::ToDart(dart_function_name), 2, args))) {
             return false;
           }
-          return true;
+          return DrainMicrotasks();
         });
   }
 

--- a/engine/src/flutter/lib/gpu/lib/src/shader_library.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/shader_library.dart
@@ -7,7 +7,19 @@
 part of flutter_gpu;
 
 base class ShaderLibrary extends NativeFieldWrapperClass1 {
-  static ShaderLibrary? fromAsset(String assetName) {
+  /// Loads the shader bundle at [assetName] and returns its [ShaderLibrary],
+  /// or `null` if the bundle could not be parsed.
+  ///
+  /// This is async so it can work on every platform. Some platforms can only
+  /// read assets asynchronously, so loading is async everywhere for a
+  /// consistent API. On platforms that can read synchronously the returned
+  /// [Future] still completes in the same turn. A load failure is reported
+  /// through the [Future] rather than thrown synchronously.
+  ///
+  /// The library is cached by [assetName], so repeated loads of the same
+  /// asset return the same instance. The cache also backs hot reload (see
+  /// [reinitialize]), which looks the library up by asset path.
+  static Future<ShaderLibrary?> fromAsset(String assetName) async {
     final cached = _registry[assetName];
     if (cached != null) {
       return cached;

--- a/engine/src/flutter/testing/dart/gpu_shader_reload_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_shader_reload_test.dart
@@ -78,10 +78,19 @@ void main() {
   // `reinitializeShaderLibrary` service extension looks the library up by
   // asset path and reloads into the existing instance.
   test('ShaderLibrary.fromAsset caches by asset path', () async {
-    final gpu.ShaderLibrary? a = gpu.ShaderLibrary.fromAsset('test.shaderbundle');
-    final gpu.ShaderLibrary? b = gpu.ShaderLibrary.fromAsset('test.shaderbundle');
+    final gpu.ShaderLibrary? a = await gpu.ShaderLibrary.fromAsset('test.shaderbundle');
+    final gpu.ShaderLibrary? b = await gpu.ShaderLibrary.fromAsset('test.shaderbundle');
     expect(a, isNotNull);
     expect(identical(a, b), isTrue);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  // A load failure comes back through the returned Future rather than as a
+  // synchronous throw, so callers can uniformly `await` the loader.
+  test('ShaderLibrary.fromAsset surfaces load failure through the Future', () async {
+    final Future<gpu.ShaderLibrary?> future = gpu.ShaderLibrary.fromAsset(
+      'does_not_exist.shaderbundle',
+    );
+    await expectLater(future, throwsA(isA<Exception>()));
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   // `reinitialize` with an asset that hasn't been loaded yet must no-op.
@@ -98,7 +107,7 @@ void main() {
   // a pipeline clears the bit. Uses test_alt.shaderbundle, which no other
   // test in this file loads, so the bit reflects a fresh load.
   test('shaders start dirty and are cleaned by registration', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test_alt.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test_alt.shaderbundle'))!;
     final gpu.Shader vertex = library['UnlitVertex']!;
     final gpu.Shader fragment = library['UnlitFragment']!;
     expect(vertex.debugIsDirty, isTrue, reason: 'freshly parsed shaders start dirty');
@@ -114,7 +123,7 @@ void main() {
   // comparison so unchanged shaders stay clean across reload. Reloading
   // identical bytes must leave every shader clean.
   test('reinitialize with unchanged bytes leaves shaders clean', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test.shaderbundle'))!;
     final gpu.Shader vertex = library['UnlitVertex']!;
     final gpu.Shader fragment = library['UnlitFragment']!;
     // Force registration so the dirty bit is observable as false before reload.
@@ -133,7 +142,7 @@ void main() {
   // clean, changed shaders flip dirty so the next pipeline build evicts and
   // re-registers them.
   test('reinitialize marks only changed shaders dirty', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test.shaderbundle'))!;
     final gpu.Shader vertex = library['UnlitVertex']!;
     final gpu.Shader fragment = library['UnlitFragment']!;
     gpu.gpuContext.createRenderPipeline(vertex, fragment);
@@ -156,7 +165,7 @@ void main() {
   // function runs `UnregisterFunction` + `RemovePipelinesWithEntryPoint`
   // before re-registering.
   test('reinitialize evicts and re-registers shader functions cleanly', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test.shaderbundle'))!;
     final gpu.Shader vertex = library['UnlitVertex']!;
     final gpu.Shader fragment = library['UnlitFragment']!;
 

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -63,8 +63,8 @@ Future<ByteData> readTextureBytes(gpu.Texture texture) async {
   return bytes!;
 }
 
-gpu.RenderPipeline createUnlitRenderPipeline() {
-  final gpu.ShaderLibrary? library = gpu.ShaderLibrary.fromAsset('test.shaderbundle');
+Future<gpu.RenderPipeline> createUnlitRenderPipeline() async {
+  final gpu.ShaderLibrary? library = await gpu.ShaderLibrary.fromAsset('test.shaderbundle');
   assert(library != null);
   final gpu.Shader? vertex = library!['UnlitVertex'];
   assert(vertex != null);
@@ -73,8 +73,8 @@ gpu.RenderPipeline createUnlitRenderPipeline() {
   return gpu.gpuContext.createRenderPipeline(vertex!, fragment!);
 }
 
-gpu.RenderPipeline createTextureRenderPipeline() {
-  final gpu.ShaderLibrary? library = gpu.ShaderLibrary.fromAsset('test.shaderbundle');
+Future<gpu.RenderPipeline> createTextureRenderPipeline() async {
+  final gpu.ShaderLibrary? library = await gpu.ShaderLibrary.fromAsset('test.shaderbundle');
   assert(library != null);
   final gpu.Shader? vertex = library!['TextureVertex'];
   assert(vertex != null);
@@ -164,8 +164,8 @@ RenderPassState createSimpleRenderPassWithMSAA() {
   return RenderPassState(resolveTexture, commandBuffer, renderPass);
 }
 
-void drawTriangle(RenderPassState state, Vector4 color) {
-  final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+Future<void> drawTriangle(RenderPassState state, Vector4 color) async {
+  final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
 
   state.renderPass.bindPipeline(pipeline);
 
@@ -991,7 +991,7 @@ void main() async {
   test('RenderPass.bindTexture throws for deviceTransient Textures', () async {
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     // Although this is a non-texture uniform slot, it'll work fine for the
     // purposes of testing this error.
     final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
@@ -1131,7 +1131,7 @@ void main() async {
   test('Can bind uniforms in range', () async {
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
 
     final ByteData vertInfoData = float32(<double>[
@@ -1165,7 +1165,7 @@ void main() async {
   // Renders a green triangle pointing downwards.
   test('Can render triangle', () async {
     final RenderPassState state = createSimpleRenderPass();
-    drawTriangle(state, Colors.lime);
+    await drawTriangle(state, Colors.lime);
     state.commandBuffer.submit();
 
     final ui.Image image = state.renderTexture.asImage();
@@ -1176,7 +1176,7 @@ void main() async {
   // walking a 3-entry index buffer with drawIndexed.
   test('Can render triangle with drawIndexed', () async {
     final RenderPassState state = createSimpleRenderPass();
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
@@ -1254,7 +1254,7 @@ void main() async {
     texture.overwrite(mip1.buffer.asByteData(), mipLevel: 1);
 
     final RenderPassState state = createSimpleRenderPass();
-    final gpu.RenderPipeline pipeline = createTextureRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createTextureRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     // A fullscreen quad. Each vertex is position (vec3), texture_coords (vec2),
@@ -1285,7 +1285,7 @@ void main() async {
 
   test('drawIndexed throws when no index buffer is bound', () async {
     final RenderPassState state = createSimpleRenderPass();
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
@@ -1320,7 +1320,7 @@ void main() async {
   test('Uniform block with non-conforming instance name binds on all backends', () async {
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test.shaderbundle'))!;
     final gpu.RenderPipeline pipeline = gpu.gpuContext.createRenderPipeline(
       library['UnlitVertex']!,
       library['UnlitFragmentAltInstance']!,
@@ -1387,7 +1387,7 @@ void main() async {
   test('Can render triangle with explicit VertexLayout', () async {
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test.shaderbundle'))!;
     final gpu.RenderPipeline pipeline = gpu.gpuContext.createRenderPipeline(
       library['UnlitVertex']!,
       library['UnlitFragment']!,
@@ -1423,7 +1423,7 @@ void main() async {
     const triangleInstanceCount = 4;
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test.shaderbundle'))!;
     final gpu.RenderPipeline pipeline = gpu.gpuContext.createRenderPipeline(
       library['InstancedVertex']!,
       library['InstancedFragment']!,
@@ -1480,7 +1480,7 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('createRenderPipeline rejects VertexLayout with wrong attribute format', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test.shaderbundle'))!;
     try {
       gpu.gpuContext.createRenderPipeline(
         library['UnlitVertex']!,
@@ -1512,7 +1512,7 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('createRenderPipeline rejects VertexAttribute that overruns stride', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test.shaderbundle'))!;
     try {
       gpu.gpuContext.createRenderPipeline(
         library['UnlitVertex']!,
@@ -1540,7 +1540,7 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('createRenderPipeline rejects VertexLayout with overlapping attributes', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test.shaderbundle'))!;
     try {
       gpu.gpuContext.createRenderPipeline(
         library['UnlitVertex']!,
@@ -1571,7 +1571,7 @@ void main() async {
 
   test('bindVertexBuffer throws RangeError for out-of-range slot', () async {
     final RenderPassState state = createSimpleRenderPass();
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
@@ -1585,7 +1585,7 @@ void main() async {
 
   test('draw throws StateError on sparse vertex buffer bindings', () async {
     final RenderPassState state = createSimpleRenderPass();
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
@@ -1611,7 +1611,7 @@ void main() async {
 
   test('draw calls reject negative instanceCount', () async {
     final RenderPassState state = createSimpleRenderPass();
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
@@ -1626,7 +1626,7 @@ void main() async {
 
   test('draw calls with zero count or instanceCount are no-ops', () async {
     final RenderPassState state = createSimpleRenderPass();
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     state.renderPass.draw(0);
@@ -1636,7 +1636,7 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('createRenderPipeline rejects VertexAttribute with unknown name', () async {
-    final gpu.ShaderLibrary library = gpu.ShaderLibrary.fromAsset('test.shaderbundle')!;
+    final gpu.ShaderLibrary library = (await gpu.ShaderLibrary.fromAsset('test.shaderbundle'))!;
     try {
       gpu.gpuContext.createRenderPipeline(
         library['UnlitVertex']!,
@@ -1664,6 +1664,22 @@ void main() async {
     }
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
+  // The awaited library exposes the bundle's shaders and can drive a pipeline.
+  test('ShaderLibrary.fromAsset loads a usable library', () async {
+    final gpu.ShaderLibrary? library = await gpu.ShaderLibrary.fromAsset('test.shaderbundle');
+    expect(library, isNotNull);
+
+    final gpu.Shader? vertex = library!['UnlitVertex'];
+    final gpu.Shader? fragment = library['UnlitFragment'];
+    expect(vertex, isNotNull);
+    expect(fragment, isNotNull);
+
+    // The shaders are real enough to build a pipeline from.
+    final gpu.RenderPipeline pipeline = gpu.gpuContext.createRenderPipeline(vertex!, fragment!);
+    expect(pipeline.vertexShader, vertex);
+    expect(pipeline.fragmentShader, fragment);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
   // Two distinct shader bundles can ship the same entrypoint names without
   // colliding in the shared shader registry. `test.shaderbundle` and
   // `test_alt.shaderbundle` both export `UnlitFragment` and `UnlitVertex`
@@ -1672,8 +1688,8 @@ void main() async {
   // namespacing the asset paths (the bundle library_ids) make the keys
   // distinct, so both bundles can be loaded and used in the same process.
   test('Two shader bundles with the same entrypoint names do not collide', () async {
-    final gpu.ShaderLibrary? libraryA = gpu.ShaderLibrary.fromAsset('test.shaderbundle');
-    final gpu.ShaderLibrary? libraryB = gpu.ShaderLibrary.fromAsset('test_alt.shaderbundle');
+    final gpu.ShaderLibrary? libraryA = await gpu.ShaderLibrary.fromAsset('test.shaderbundle');
+    final gpu.ShaderLibrary? libraryB = await gpu.ShaderLibrary.fromAsset('test_alt.shaderbundle');
     expect(libraryA, isNotNull);
     expect(libraryB, isNotNull);
 
@@ -1725,7 +1741,7 @@ void main() async {
   test('Can render triangle with polygon mode line.', () async {
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     // Configure blending with defaults (just to test the bindings).
@@ -1767,7 +1783,7 @@ void main() async {
   // Renders a green triangle pointing downwards, with 4xMSAA.
   test('Can render triangle with MSAA', () async {
     final RenderPassState state = createSimpleRenderPassWithMSAA();
-    drawTriangle(state, Colors.lime);
+    await drawTriangle(state, Colors.lime);
     state.commandBuffer.submit();
 
     final ui.Image image = state.renderTexture.asImage();
@@ -1777,7 +1793,7 @@ void main() async {
   test('Rendering with MSAA throws exception when offscreen MSAA is not supported', () async {
     try {
       final RenderPassState state = createSimpleRenderPassWithMSAA();
-      drawTriangle(state, Colors.lime);
+      await drawTriangle(state, Colors.lime);
       state.commandBuffer.submit();
       fail('Exception not thrown when offscreen MSAA is not supported.');
     } catch (e) {
@@ -1794,7 +1810,7 @@ void main() async {
   test('Can render hollowed out triangle using stencil ops', () async {
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     // Configure blending with defaults (just to test the bindings).
@@ -1870,7 +1886,7 @@ void main() async {
   test('Drawing respects cull mode', () async {
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     state.renderPass.setColorBlendEnable(true);
@@ -1921,7 +1937,7 @@ void main() async {
   test('Can render hollow hexagon using line strip primitive type', () async {
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     // Configure blending with defaults (just to test the bindings).
@@ -1960,7 +1976,7 @@ void main() async {
   test('Can render portion of the triangle using scissor', () async {
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     // Configure blending with defaults (just to test the bindings).
@@ -2052,7 +2068,7 @@ void main() async {
   test('Can render portion of the triangle using viewport', () async {
     final RenderPassState state = createSimpleRenderPass();
 
-    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
     state.renderPass.bindPipeline(pipeline);
 
     // Configure blending with defaults (just to test the bindings).


### PR DESCRIPTION
`ShaderLibrary.fromAsset` now returns a `Future<ShaderLibrary?>` instead of loading synchronously.

Asset reads can only be asynchronous on some platforms, so a synchronous loader cannot work everywhere. Making the single loader async gives every platform one consistent entry point and removes the need for downstream code to keep a separate async loading path. flutter_gpu is experimental, so this breaking change is cheap to make now.

On platforms that read synchronously the returned Future still completes in the same turn, and the library is still cached by asset path, so hot reload is unaffected.

The engine Dart tests and the renderer fixture harness are updated to await the loader. The fixture harness drains the microtask queue after invoking an entry point so the now-async fixtures run to completion.

This is a breaking change to an experimental API, so no `flutter/tests` migration guide is needed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
