### PR TITLE
[MenuAnchor] fix: MenuAnchor submenu topStart alignment overlapping parent menu

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -3451,11 +3451,21 @@ class _MenuLayout extends SingleChildLayoutDelegate {
       desiredPosition += directionalOffset;
       x = desiredPosition.dx;
       y = desiredPosition.dy;
-      switch (textDirection) {
-        case TextDirection.rtl:
+      if (parentOrientation == orientation) {
+        // For same-axis submenus (e.g. vertical→vertical), the alignment
+        // determines which side the submenu opens on. If the resolved
+        // alignment points to the left side, the submenu should grow
+        // leftward (place its right edge at the anchor point).
+        final Alignment resolvedAlignment = alignment.resolve(textDirection);
+        if (resolvedAlignment.x < 0) {
           x -= childSize.width;
-        case TextDirection.ltr:
-          break;
+        }
+      } else {
+        // For cross-axis menus (e.g. MenuBar→dropdown), use text direction
+        // to determine the growth direction.
+        if (textDirection == TextDirection.rtl) {
+          x -= childSize.width;
+        }
       }
     } else {
       final Offset adjustedPosition = menuPosition! + anchorRect.topLeft;

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -898,6 +898,145 @@ void main() {
       );
     });
 
+    testWidgets('submenu with topStart alignment opens to the left in LTR', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/181895.
+      // A SubmenuButton inside a vertical menu with topStart alignment should
+      // position the submenu to the left of the parent menu, not overlapping it.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: Material(
+            child: Center(
+              child: MenuAnchor(
+                menuChildren: <Widget>[
+                  const MenuItemButton(child: Text('Item A')),
+                  SubmenuButton(
+                    menuStyle: const MenuStyle(
+                      alignment: AlignmentDirectional.topStart,
+                    ),
+                    menuChildren: const <Widget>[
+                      MenuItemButton(child: Text('Sub 1')),
+                      MenuItemButton(child: Text('Sub 2')),
+                    ],
+                    child: const Text('Group'),
+                  ),
+                  const MenuItemButton(child: Text('Item B')),
+                ],
+                builder: (BuildContext context, MenuController controller, Widget? child) {
+                  return FilledButton(
+                    onPressed: () {
+                      if (controller.isOpen) {
+                        controller.close();
+                      } else {
+                        controller.open();
+                      }
+                    },
+                    child: const Text('Open'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Open the parent menu.
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+
+      // Hover over the submenu button to open the submenu.
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.moveTo(tester.getCenter(find.text('Group')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final Rect parentMenuRect = tester.getRect(
+        find.ancestor(of: find.text('Item A'), matching: find.byType(FocusScope)).first,
+      );
+      final Rect submenuRect = tester.getRect(
+        find.ancestor(of: find.text('Sub 1'), matching: find.byType(FocusScope)).first,
+      );
+
+      // The submenu's right edge should be at or to the left of the parent
+      // menu's left edge (opens to the left, no overlap).
+      expect(
+        submenuRect.right,
+        lessThanOrEqualTo(parentMenuRect.left),
+        reason: 'Submenu with topStart alignment should open to the left of the parent menu',
+      );
+    });
+
+    testWidgets('submenu with topStart alignment opens to the right in RTL', (WidgetTester tester) async {
+      // In RTL, topStart resolves to the right side, so the submenu should
+      // open to the right of the parent menu.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Material(
+              child: Center(
+                child: MenuAnchor(
+                  menuChildren: <Widget>[
+                    const MenuItemButton(child: Text('Item A')),
+                    SubmenuButton(
+                      menuStyle: const MenuStyle(
+                        alignment: AlignmentDirectional.topStart,
+                      ),
+                      menuChildren: const <Widget>[
+                        MenuItemButton(child: Text('Sub 1')),
+                        MenuItemButton(child: Text('Sub 2')),
+                      ],
+                      child: const Text('Group'),
+                    ),
+                    const MenuItemButton(child: Text('Item B')),
+                  ],
+                  builder: (BuildContext context, MenuController controller, Widget? child) {
+                    return FilledButton(
+                      onPressed: () {
+                        if (controller.isOpen) {
+                          controller.close();
+                        } else {
+                          controller.open();
+                        }
+                      },
+                      child: const Text('Open'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Open the parent menu.
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+
+      // Hover over the submenu button to open the submenu.
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.moveTo(tester.getCenter(find.text('Group')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final Rect parentMenuRect = tester.getRect(
+        find.ancestor(of: find.text('Item A'), matching: find.byType(FocusScope)).first,
+      );
+      final Rect submenuRect = tester.getRect(
+        find.ancestor(of: find.text('Sub 1'), matching: find.byType(FocusScope)).first,
+      );
+
+      // In RTL, topStart means the right side, so submenu should open to the
+      // right. The submenu's left edge should be at or to the right of the
+      // parent menu's right edge.
+      expect(
+        submenuRect.left,
+        greaterThanOrEqualTo(parentMenuRect.right),
+        reason: 'Submenu with topStart alignment in RTL should open to the right of the parent menu',
+      );
+    });
+
     testWidgets('menu position in LTR', (WidgetTester tester) async {
       await tester.pumpWidget(buildTestApp(alignmentOffset: const Offset(100, 50)));
 


### PR DESCRIPTION
## Description

When a `SubmenuButton` inside a vertical menu uses `AlignmentDirectional.topStart` in its `menuStyle`, the submenu should open to the **left** of the parent menu (in LTR). Previously, it overlapped the parent menu because the x-position adjustment in `_MenuLayout._positionChild()` only considered RTL text direction, not the resolved alignment direction for same-axis submenus.

### Before (bug)
The submenu's top-left corner was placed at the parent menu item's top-left corner, causing the submenu to overlap the parent menu

https://github.com/user-attachments/assets/3ebe02be-8098-498f-88d7-fc963c62dad1



### After (fix)
The submenu's top-right edge aligns with the parent menu item's left edge, opening the submenu to the left as expected.

https://github.com/user-attachments/assets/b72f2d08-7250-4420-8282-5b53899c3b0e


### What changed
In `_positionChild()`, the x-position adjustment now distinguishes between:
- **Same-axis submenus** (e.g., vertical→vertical): Uses the resolved alignment's x component to determine growth direction. If `resolvedAlignment.x < 0`, the submenu grows leftward.
- **Cross-axis menus** (e.g., MenuBar→dropdown): Keeps the existing RTL-based adjustment unchanged.

Fixes https://github.com/flutter/flutter/issues/181895

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md