### PR TITLE
Fix selection handles triggering Android system back gesture near screen edges

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -439,6 +439,7 @@ class TextSelectionOverlay {
   /// Defaults to false.
   bool get handlesVisible => _handlesVisible;
   bool _handlesVisible = false;
+
   set handlesVisible(bool visible) {
     if (_handlesVisible == visible) {
       return;
@@ -1209,6 +1210,7 @@ class SelectionOverlay {
   /// Changing the value while the handles are visible causes them to rebuild.
   TextSelectionHandleType get startHandleType => _startHandleType;
   TextSelectionHandleType _startHandleType;
+
   set startHandleType(TextSelectionHandleType value) {
     if (_startHandleType == value) {
       return;
@@ -1224,6 +1226,7 @@ class SelectionOverlay {
   /// Changing the value while the handles are visible causes them to rebuild.
   double get lineHeightAtStart => _lineHeightAtStart;
   double _lineHeightAtStart;
+
   set lineHeightAtStart(double value) {
     if (_lineHeightAtStart == value) {
       return;
@@ -1330,6 +1333,7 @@ class SelectionOverlay {
   /// Changing the value while the handles are visible causes them to rebuild.
   TextSelectionHandleType get endHandleType => _endHandleType;
   TextSelectionHandleType _endHandleType;
+
   set endHandleType(TextSelectionHandleType value) {
     if (_endHandleType == value) {
       return;
@@ -1345,6 +1349,7 @@ class SelectionOverlay {
   /// Changing the value while the handles are visible causes them to rebuild.
   double get lineHeightAtEnd => _lineHeightAtEnd;
   double _lineHeightAtEnd;
+
   set lineHeightAtEnd(double value) {
     if (_lineHeightAtEnd == value) {
       return;
@@ -1457,6 +1462,7 @@ class SelectionOverlay {
   /// The text selection positions of selection start and end.
   List<TextSelectionPoint> get selectionEndpoints => _selectionEndpoints;
   List<TextSelectionPoint> _selectionEndpoints;
+
   set selectionEndpoints(List<TextSelectionPoint> value) {
     if (!listEquals(_selectionEndpoints, value)) {
       markNeedsBuild();
@@ -1561,6 +1567,7 @@ class SelectionOverlay {
   )
   Offset? get toolbarLocation => _toolbarLocation;
   Offset? _toolbarLocation;
+
   set toolbarLocation(Offset? value) {
     if (_toolbarLocation == value) {
       return;
@@ -1583,6 +1590,43 @@ class SelectionOverlay {
   final ContextMenuController _contextMenuController = ContextMenuController();
 
   final ContextMenuController _spellCheckToolbarController = ContextMenuController();
+
+  /// Updates the Android system gesture exclusion rects to cover the current
+  /// handle positions, preventing the system back gesture from intercepting
+  /// handle drags near screen edges.
+  void _updateSystemGestureExclusionRects() {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return;
+    }
+    if (_handles == null) {
+      SystemChannels.platform.invokeMethod<void>(
+        'SystemChrome.setSystemGestureExclusionRects',
+        <Map<String, int>>[],
+      );
+      return;
+    }
+    final renderBox = context.findRenderObject() as RenderBox?;
+    if (renderBox == null) {
+      return;
+    }
+    final rects = <Map<String, int>>[];
+    for (final TextSelectionPoint endpoint in _selectionEndpoints) {
+      final Offset global = renderBox.localToGlobal(endpoint.point);
+      final double dpr = WidgetsBinding.instance.window.devicePixelRatio;
+      const handleWidth = 20.0;
+      const handleHeight = 20.0;
+      rects.add(<String, int>{
+        'left': ((global.dx - handleWidth) * dpr).round(),
+        'top': (global.dy * dpr).round(),
+        'right': ((global.dx + handleWidth) * dpr).round(),
+        'bottom': ((global.dy + handleHeight) * dpr).round(),
+      });
+    }
+    SystemChannels.platform.invokeMethod<void>(
+      'SystemChrome.setSystemGestureExclusionRects',
+      rects,
+    );
+  }
 
   /// {@template flutter.widgets.SelectionOverlay.showHandles}
   /// Builds the handles by inserting them into the [context]'s overlay.
@@ -1616,6 +1660,7 @@ class SelectionOverlay {
       ),
     );
     overlay.insertAll(<OverlayEntry>[_handles!.start, _handles!.end]);
+    _updateSystemGestureExclusionRects();
   }
 
   /// {@template flutter.widgets.SelectionOverlay.hideHandles}
@@ -1628,6 +1673,7 @@ class SelectionOverlay {
       _handles!.end.remove();
       _handles!.end.dispose();
       _handles = null;
+      _updateSystemGestureExclusionRects();
     }
   }
 
@@ -1715,6 +1761,7 @@ class SelectionOverlay {
       if (_handles != null) {
         _handles!.start.markNeedsBuild();
         _handles!.end.markNeedsBuild();
+        _updateSystemGestureExclusionRects();
       }
       _toolbar?.markNeedsBuild();
       if (_contextMenuController.isShown) {
@@ -1920,6 +1967,7 @@ class _SelectionToolbarWrapper extends StatefulWidget {
 class _SelectionToolbarWrapperState extends State<_SelectionToolbarWrapper>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
+
   Animation<double> get _opacity => _controller.view;
 
   @override
@@ -2014,6 +2062,7 @@ class _SelectionHandleOverlay extends StatefulWidget {
 class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
+
   Animation<double> get _opacity => _controller.view;
 
   @override

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -16,6 +16,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
+import '../../cupertino.dart';
 import 'basic.dart';
 import 'binding.dart';
 import 'constants.dart';
@@ -1605,14 +1606,17 @@ class SelectionOverlay {
       );
       return;
     }
+    if (!context.mounted) {
+      return;
+    }
     final renderBox = context.findRenderObject() as RenderBox?;
     if (renderBox == null) {
       return;
     }
     final rects = <Map<String, int>>[];
+    final double dpr = View.of(context).devicePixelRatio;
     for (final TextSelectionPoint endpoint in _selectionEndpoints) {
       final Offset global = renderBox.localToGlobal(endpoint.point);
-      final double dpr = WidgetsBinding.instance.window.devicePixelRatio;
       const handleWidth = 20.0;
       const handleHeight = 20.0;
       rects.add(<String, int>{

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1397,7 +1397,56 @@ void main() {
       selectionOverlay.dispose();
       await tester.pumpAndSettle();
     });
+    testWidgets(
+      'sends system gesture exclusion rects on Android when handles shown and hidden',
+      (WidgetTester tester) async {
+        final List<MethodCall> log = <MethodCall>[];
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (
+          MethodCall call,
+        ) async {
+          log.add(call);
+          return null;
+        });
+        addTearDown(() {
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            SystemChannels.platform,
+            null,
+          );
+        });
 
+        final spy = TextSelectionControlsSpy();
+        final SelectionOverlay selectionOverlay = await pumpApp(tester, selectionControls: spy);
+        selectionOverlay
+          ..startHandleType = TextSelectionHandleType.left
+          ..endHandleType = TextSelectionHandleType.right
+          ..selectionEndpoints = const <TextSelectionPoint>[
+            TextSelectionPoint(Offset(10, 10), TextDirection.ltr),
+            TextSelectionPoint(Offset(20, 20), TextDirection.ltr),
+          ];
+
+        log.clear();
+        selectionOverlay.showHandles();
+        await tester.pump();
+
+        expect(
+          log.where((MethodCall c) => c.method == 'SystemChrome.setSystemGestureExclusionRects'),
+          isNotEmpty,
+        );
+
+        log.clear();
+        selectionOverlay.hideHandles();
+        await tester.pump();
+
+        final Iterable<MethodCall> hideCalls = log.where(
+          (MethodCall c) => c.method == 'SystemChrome.setSystemGestureExclusionRects',
+        );
+        expect(hideCalls, isNotEmpty);
+        expect((hideCalls.last.arguments as List<dynamic>), isEmpty);
+
+        selectionOverlay.dispose();
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
     testWidgets('only paints one collapsed handle', (WidgetTester tester) async {
       final spy = TextSelectionControlsSpy();
       final SelectionOverlay selectionOverlay = await pumpApp(tester, selectionControls: spy);
@@ -1990,6 +2039,7 @@ class FakeEditableTextState extends EditableTextState {
 
 class FakeEditable extends LeafRenderObjectWidget {
   const FakeEditable(this.delegate, {super.key});
+
   final EditableTextState delegate;
 
   @override
@@ -2020,6 +2070,7 @@ class FakeRenderEditable extends RenderEditable {
   ViewportOffset _offset;
 
   bool selectWordsInRangeCalled = false;
+
   @override
   void selectWordsInRange({
     required Offset from,
@@ -2032,6 +2083,7 @@ class FakeRenderEditable extends RenderEditable {
   }
 
   bool selectWordEdgeCalled = false;
+
   @override
   void selectWordEdge({required SelectionChangedCause cause}) {
     selectWordEdgeCalled = true;
@@ -2042,6 +2094,7 @@ class FakeRenderEditable extends RenderEditable {
   bool selectPositionAtCalled = false;
   Offset? selectPositionAtFrom;
   Offset? selectPositionAtTo;
+
   @override
   void selectPositionAt({required Offset from, Offset? to, required SelectionChangedCause cause}) {
     selectPositionAtCalled = true;
@@ -2052,6 +2105,7 @@ class FakeRenderEditable extends RenderEditable {
   }
 
   bool selectPositionCalled = false;
+
   @override
   void selectPosition({required SelectionChangedCause cause}) {
     selectPositionCalled = true;
@@ -2060,6 +2114,7 @@ class FakeRenderEditable extends RenderEditable {
   }
 
   bool selectWordCalled = false;
+
   @override
   void selectWord({required SelectionChangedCause cause}) {
     selectWordCalled = true;
@@ -2132,6 +2187,7 @@ class FakeClipboardStatusNotifier extends ClipboardStatusNotifier {
   FakeClipboardStatusNotifier() : super(value: ClipboardStatus.unknown);
 
   bool updateCalled = false;
+
   @override
   Future<void> update() async {
     updateCalled = true;


### PR DESCRIPTION
When text selection handles are positioned near the left or right screen edges on Android with gesture navigation enabled, dragging a handle triggers the Android system back gesture instead of continuing the drag. This happens because Flutter never calls View.setSystemGestureExclusionRects() to exclude handle areas from system gesture detection, unlike native Android EditText which does this automatically.
This PR fixes the issue by calling View.setSystemGestureExclusionRects() via the platform channel whenever selection handles are shown, updated, or hidden in SelectionOverlay. The exclusion rects are cleared when handles are hidden.
The engine-side changes (PlatformChannel.java, PlatformPlugin.java) will follow in a separate flutter/engine PR.
Fixes #187647
