### PR TITLE
Use workspace resolution for the meta package in dev/integration_tests/record_use_test_package

### DIFF
--- a/dev/integration_tests/record_use_test_package/pubspec.yaml
+++ b/dev/integration_tests/record_use_test_package/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   hooks: ^2.0.0
   data_assets: ^0.20.0
   record_use: 0.6.0
-  meta: 1.18.2
+  meta: any
 
 dev_dependencies:
   flutter_test:
@@ -23,4 +23,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: gl7kb7
+# PUBSPEC CHECKSUM: ka5c8a


### PR DESCRIPTION
This fixes a packages_autoroller breakage.

(see https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8679521293759852737/+/u/run_roll-packages_script/stdout)