### PR TITLE
[Impeller] Move queue submission into a callback that is invoked by FenceWaiterVK::AddFence only if it can accept the fence

### DIFF
--- a/engine/src/flutter/fml/closure.h
+++ b/engine/src/flutter/fml/closure.h
@@ -45,6 +45,9 @@ class ScopedCleanupClosure final {
   explicit ScopedCleanupClosure(const fml::closure& closure)
       : closure_(closure) {}
 
+  explicit ScopedCleanupClosure(fml::closure&& closure)
+      : closure_(std::move(closure)) {}
+
   ~ScopedCleanupClosure() { Reset(); }
 
   explicit operator bool() const { return static_cast<bool>(closure_); }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -27,6 +27,7 @@ impeller_component("vulkan_unittests") {
     "blit_pass_vk_unittests.cc",
     "command_encoder_vk_unittests.cc",
     "command_pool_vk_unittests.cc",
+    "command_queue_vk_unittests.cc",
     "context_vk_unittests.cc",
     "descriptor_pool_vk_unittests.cc",
     "driver_info_vk_unittests.cc",

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
@@ -60,19 +60,26 @@ fml::Status CommandQueueVK::Submit(
     return fml::Status(fml::StatusCode::kCancelled, "Failed to create fence.");
   }
 
-  vk::SubmitInfo submit_info;
-  submit_info.setCommandBuffers(vk_buffers);
-  auto status = context->GetGraphicsQueue()->Submit(submit_info, *fence);
-  if (status != vk::Result::eSuccess) {
-    VALIDATION_LOG << "Failed to submit queue: " << vk::to_string(status);
-    return fml::Status(fml::StatusCode::kCancelled, "Failed to submit queue: ");
-  }
+  auto submit_callback = [&](vk::Fence submit_fence) {
+    vk::SubmitInfo submit_info;
+    submit_info.setCommandBuffers(vk_buffers);
+    auto status =
+        context->GetGraphicsQueue()->Submit(submit_info, submit_fence);
+    if (status != vk::Result::eSuccess) {
+      std::string submit_error =
+          "Failed to submit command: " + vk::to_string(status);
+      VALIDATION_LOG << submit_error;
+      return fml::Status(fml::StatusCode::kCancelled, submit_error);
+    }
+    return fml::Status();
+  };
 
   // Submit will proceed, call callback with true when it is done and do not
   // call when `reset` is collected.
-  auto added_fence = context->GetFenceWaiter()->AddFence(
-      std::move(fence), [completion_callback, tracked_objects = std::move(
-                                                  tracked_objects)]() mutable {
+  auto fence_status = context->GetFenceWaiter()->AddFence(
+      std::move(fence), submit_callback,
+      [completion_callback,
+       tracked_objects = std::move(tracked_objects)]() mutable {
         // Ensure tracked objects are destructed before calling any final
         // callbacks.
         tracked_objects.clear();
@@ -80,8 +87,8 @@ fml::Status CommandQueueVK::Submit(
           completion_callback(CommandBuffer::Status::kCompleted);
         }
       });
-  if (!added_fence) {
-    return fml::Status(fml::StatusCode::kCancelled, "Failed to add fence.");
+  if (!fence_status.ok()) {
+    return fence_status;
   }
   reset.Release();
   return fml::Status();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
@@ -90,8 +90,7 @@ fml::Status CommandQueueVK::Submit(
   // Submit will proceed, call callback with true when it is done and do not
   // call when `reset` is collected.
   auto fence_status = context->GetFenceWaiter()->AddFence(
-      std::move(fence), std::move(submit_callback),
-      std::move(fence_complete_callback));
+      std::move(fence), submit_callback, std::move(fence_complete_callback));
   if (!fence_status.ok()) {
     return fence_status;
   }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
@@ -60,7 +60,8 @@ fml::Status CommandQueueVK::Submit(
     return fml::Status(fml::StatusCode::kCancelled, "Failed to create fence.");
   }
 
-  auto submit_callback = [&](vk::Fence submit_fence) {
+  // This will be called immediately by FenceWaiterVK::AddFence.
+  auto submit_callback = [&context, &vk_buffers](vk::Fence submit_fence) {
     vk::SubmitInfo submit_info;
     submit_info.setCommandBuffers(vk_buffers);
     auto status =
@@ -74,19 +75,23 @@ fml::Status CommandQueueVK::Submit(
     return fml::Status();
   };
 
+  // This will be called later when the command completes.
+  auto fence_complete_callback = [completion_callback,
+                                  tracked_objects =
+                                      std::move(tracked_objects)]() mutable {
+    // Ensure tracked objects are destructed before calling any final
+    // callbacks.
+    tracked_objects.clear();
+    if (completion_callback) {
+      completion_callback(CommandBuffer::Status::kCompleted);
+    }
+  };
+
   // Submit will proceed, call callback with true when it is done and do not
   // call when `reset` is collected.
   auto fence_status = context->GetFenceWaiter()->AddFence(
-      std::move(fence), submit_callback,
-      [completion_callback,
-       tracked_objects = std::move(tracked_objects)]() mutable {
-        // Ensure tracked objects are destructed before calling any final
-        // callbacks.
-        tracked_objects.clear();
-        if (completion_callback) {
-          completion_callback(CommandBuffer::Status::kCompleted);
-        }
-      });
+      std::move(fence), std::move(submit_callback),
+      std::move(fence_complete_callback));
   if (!fence_status.ok()) {
     return fence_status;
   }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <algorithm>
+
+#include "flutter/testing/testing.h"
+#include "gtest/gtest.h"
+#include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/renderer/backend/vulkan/fence_waiter_vk.h"
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(CommandQueueVKTest, SubmitAfterFenceWaiterTerminated) {
+  const auto context = MockVulkanContextBuilder().Build();
+  auto buffer = context->CreateCommandBuffer();
+  context->GetFenceWaiter()->Terminate();
+  auto status = context->GetCommandQueue()->Submit({buffer});
+  EXPECT_EQ(status.code(), fml::StatusCode::kCancelled);
+
+  // The command buffer should not be submitted to the Vulkan queue if the
+  // fence waiter has been terminated.
+  const auto called = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_EQ(std::find(called->begin(), called->end(), "vkQueueSubmit"),
+            called->end());
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
@@ -13,6 +13,17 @@
 namespace impeller {
 namespace testing {
 
+TEST(CommandQueueVKTest, QueueSubmit) {
+  const auto context = MockVulkanContextBuilder().Build();
+  auto buffer = context->CreateCommandBuffer();
+  auto status = context->GetCommandQueue()->Submit({buffer});
+  EXPECT_TRUE(status.ok());
+
+  const auto called = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_NE(std::find(called->begin(), called->end(), "vkQueueSubmit"),
+            called->end());
+}
+
 TEST(CommandQueueVKTest, SubmitAfterFenceWaiterTerminated) {
   const auto context = MockVulkanContextBuilder().Build();
   auto buffer = context->CreateCommandBuffer();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -18,9 +18,9 @@ namespace impeller {
 class WaitSetEntry {
  public:
   static std::shared_ptr<WaitSetEntry> Create(vk::UniqueFence p_fence,
-                                              const fml::closure& p_callback) {
+                                              fml::closure p_callback) {
     return std::shared_ptr<WaitSetEntry>(
-        new WaitSetEntry(std::move(p_fence), p_callback));
+        new WaitSetEntry(std::move(p_fence), std::move(p_callback)));
   }
 
   void UpdateSignalledStatus(const vk::Device& device) {
@@ -39,9 +39,8 @@ class WaitSetEntry {
   fml::ScopedCleanupClosure callback_;
   bool is_signalled_ = false;
 
-  WaitSetEntry(vk::UniqueFence p_fence, const fml::closure& p_callback)
-      : fence_(std::move(p_fence)),
-        callback_(fml::ScopedCleanupClosure{p_callback}) {}
+  WaitSetEntry(vk::UniqueFence p_fence, fml::closure p_callback)
+      : fence_(std::move(p_fence)), callback_(std::move(p_callback)) {}
 
   WaitSetEntry(const WaitSetEntry&) = delete;
 
@@ -63,7 +62,7 @@ FenceWaiterVK::~FenceWaiterVK() {
 
 fml::Status FenceWaiterVK::AddFence(
     vk::UniqueFence fence,
-    std::function<fml::Status(vk::Fence)> submit_callback,
+    const std::function<fml::Status(vk::Fence)>& submit_callback,
     fml::closure completion_callback) {
   if (!fence || !submit_callback || !completion_callback) {
     return fml::Status(fml::StatusCode::kInvalidArgument, "Invalid arguments");

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -64,7 +64,7 @@ FenceWaiterVK::~FenceWaiterVK() {
 fml::Status FenceWaiterVK::AddFence(
     vk::UniqueFence fence,
     std::function<fml::Status(vk::Fence)> submit_callback,
-    const fml::closure& completion_callback) {
+    fml::closure completion_callback) {
   if (!fence || !submit_callback || !completion_callback) {
     return fml::Status(fml::StatusCode::kInvalidArgument, "Invalid arguments");
   }
@@ -80,7 +80,7 @@ fml::Status FenceWaiterVK::AddFence(
       return submit_status;
     }
     wait_set_.emplace_back(
-        WaitSetEntry::Create(std::move(fence), completion_callback));
+        WaitSetEntry::Create(std::move(fence), std::move(completion_callback)));
   }
   wait_set_cv_.notify_one();
   return fml::Status();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -61,21 +61,29 @@ FenceWaiterVK::~FenceWaiterVK() {
   Terminate();
 }
 
-bool FenceWaiterVK::AddFence(vk::UniqueFence fence,
-                             const fml::closure& callback) {
-  if (!fence || !callback) {
-    return false;
+fml::Status FenceWaiterVK::AddFence(
+    vk::UniqueFence fence,
+    std::function<fml::Status(vk::Fence)> submit_callback,
+    const fml::closure& completion_callback) {
+  if (!fence || !submit_callback || !completion_callback) {
+    return fml::Status(fml::StatusCode::kInvalidArgument, "Invalid arguments");
   }
   {
     // Maintain the invariant that terminate_ is accessed only under the lock.
     std::scoped_lock lock(wait_set_mutex_);
     if (terminate_) {
-      return false;
+      return fml::Status(fml::StatusCode::kCancelled,
+                         "Fence waiter is terminated");
     }
-    wait_set_.emplace_back(WaitSetEntry::Create(std::move(fence), callback));
+    auto submit_status = submit_callback(fence.get());
+    if (!submit_status.ok()) {
+      return submit_status;
+    }
+    wait_set_.emplace_back(
+        WaitSetEntry::Create(std::move(fence), completion_callback));
   }
   wait_set_cv_.notify_one();
-  return true;
+  return fml::Status();
 }
 
 static std::vector<vk::Fence> GetFencesForWaitSet(const WaitSet& set) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_FENCE_WAITER_VK_H_
 
 #include <condition_variable>
+#include <functional>
 #include <memory>
 #include <thread>
 #include <vector>

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.h
@@ -30,12 +30,13 @@ class FenceWaiterVK {
 
   void Terminate();
 
-  /// @brief Invokes the [submit_callback] and adds the fence to the wait set
-  ///        if it succeeds.  The [completion_callback] will be called when
-  ///        the submitted command completes and the fence is signaled.
+  /// @brief Invokes the [submit_callback] synchronously and adds the fence to
+  ///        the wait set if it succeeds.  The [completion_callback] will be
+  ///        called when the submitted command completes and the fence is
+  ///        signaled.
   fml::Status AddFence(vk::UniqueFence fence,
                        std::function<fml::Status(vk::Fence)> submit_callback,
-                       const fml::closure& completion_callback);
+                       fml::closure completion_callback);
 
  private:
   friend class ContextVK;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.h
@@ -34,9 +34,10 @@ class FenceWaiterVK {
   ///        the wait set if it succeeds.  The [completion_callback] will be
   ///        called when the submitted command completes and the fence is
   ///        signaled.
-  fml::Status AddFence(vk::UniqueFence fence,
-                       std::function<fml::Status(vk::Fence)> submit_callback,
-                       fml::closure completion_callback);
+  fml::Status AddFence(
+      vk::UniqueFence fence,
+      const std::function<fml::Status(vk::Fence)>& submit_callback,
+      fml::closure completion_callback);
 
  private:
   friend class ContextVK;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "flutter/fml/closure.h"
+#include "flutter/fml/status.h"
 #include "impeller/renderer/backend/vulkan/device_holder_vk.h"
 
 namespace impeller {
@@ -28,7 +29,12 @@ class FenceWaiterVK {
 
   void Terminate();
 
-  bool AddFence(vk::UniqueFence fence, const fml::closure& callback);
+  /// @brief Invokes the [submit_callback] and adds the fence to the wait set
+  ///        if it succeeds.  The [completion_callback] will be called when
+  ///        the submitted command completes and the fence is signaled.
+  fml::Status AddFence(vk::UniqueFence fence,
+                       std::function<fml::Status(vk::Fence)> submit_callback,
+                       const fml::closure& completion_callback);
 
  private:
   friend class ContextVK;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk_unittests.cc
@@ -10,7 +10,7 @@
 namespace impeller {
 namespace testing {
 
-auto default_submit_callback = [](vk::Fence) { return fml::Status(); };
+const auto default_submit_callback = [](vk::Fence) { return fml::Status(); };
 
 TEST(FenceWaiterVKTest, IgnoresNullFence) {
   auto const context = MockVulkanContextBuilder().Build();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk_unittests.cc
@@ -10,14 +10,16 @@
 namespace impeller {
 namespace testing {
 
-const auto default_submit_callback = [](vk::Fence) { return fml::Status(); };
+namespace {
+auto default_submit_callback = [](vk::Fence) { return fml::Status(); };
+}  // namespace
 
 TEST(FenceWaiterVKTest, IgnoresNullFence) {
   auto const context = MockVulkanContextBuilder().Build();
   auto const waiter = context->GetFenceWaiter();
   const auto add_status =
       waiter->AddFence(vk::UniqueFence(), default_submit_callback, []() {});
-  EXPECT_FALSE(add_status.ok());
+  EXPECT_EQ(add_status.code(), fml::StatusCode::kInvalidArgument);
 }
 
 TEST(FenceWaiterVKTest, IgnoresNullCallback) {
@@ -28,7 +30,7 @@ TEST(FenceWaiterVKTest, IgnoresNullCallback) {
   auto fence = device.createFenceUnique({}).value;
   const auto add_status =
       waiter->AddFence(std::move(fence), default_submit_callback, nullptr);
-  EXPECT_FALSE(add_status.ok());
+  EXPECT_EQ(add_status.code(), fml::StatusCode::kInvalidArgument);
 }
 
 TEST(FenceWaiterVKTest, ReturnsSubmitError) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk_unittests.cc
@@ -10,10 +10,14 @@
 namespace impeller {
 namespace testing {
 
+auto default_submit_callback = [](vk::Fence) { return fml::Status(); };
+
 TEST(FenceWaiterVKTest, IgnoresNullFence) {
   auto const context = MockVulkanContextBuilder().Build();
   auto const waiter = context->GetFenceWaiter();
-  EXPECT_FALSE(waiter->AddFence(vk::UniqueFence(), []() {}));
+  const auto add_status =
+      waiter->AddFence(vk::UniqueFence(), default_submit_callback, []() {});
+  EXPECT_FALSE(add_status.ok());
 }
 
 TEST(FenceWaiterVKTest, IgnoresNullCallback) {
@@ -22,7 +26,24 @@ TEST(FenceWaiterVKTest, IgnoresNullCallback) {
   auto const waiter = context->GetFenceWaiter();
 
   auto fence = device.createFenceUnique({}).value;
-  EXPECT_FALSE(waiter->AddFence(std::move(fence), nullptr));
+  const auto add_status =
+      waiter->AddFence(std::move(fence), default_submit_callback, nullptr);
+  EXPECT_FALSE(add_status.ok());
+}
+
+TEST(FenceWaiterVKTest, ReturnsSubmitError) {
+  auto const context = MockVulkanContextBuilder().Build();
+  auto const device = context->GetDevice();
+  auto const waiter = context->GetFenceWaiter();
+
+  auto submit_callback = [&](vk::Fence) {
+    return fml::Status(fml::StatusCode::kCancelled, "Submit failed");
+  };
+
+  auto fence = device.createFenceUnique({}).value;
+  const auto add_status =
+      waiter->AddFence(std::move(fence), submit_callback, []() {});
+  EXPECT_EQ(add_status.code(), fml::StatusCode::kCancelled);
 }
 
 TEST(FenceWaiterVKTest, ExecutesFenceCallback) {
@@ -30,9 +51,17 @@ TEST(FenceWaiterVKTest, ExecutesFenceCallback) {
   auto const device = context->GetDevice();
   auto const waiter = context->GetFenceWaiter();
 
+  bool submit_called = false;
+  auto submit_callback = [&](vk::Fence) {
+    submit_called = true;
+    return fml::Status();
+  };
+
   auto signal = fml::ManualResetWaitableEvent();
   auto fence = device.createFenceUnique({}).value;
-  waiter->AddFence(std::move(fence), [&signal]() { signal.Signal(); });
+  waiter->AddFence(std::move(fence), submit_callback,
+                   [&signal]() { signal.Signal(); });
+  EXPECT_TRUE(submit_called);
 
   signal.Wait();
 }
@@ -44,11 +73,13 @@ TEST(FenceWaiterVKTest, ExecutesFenceCallbackX2) {
 
   auto signal = fml::ManualResetWaitableEvent();
   auto fence = device.createFenceUnique({}).value;
-  waiter->AddFence(std::move(fence), [&signal]() { signal.Signal(); });
+  waiter->AddFence(std::move(fence), default_submit_callback,
+                   [&signal]() { signal.Signal(); });
 
   auto signal2 = fml::ManualResetWaitableEvent();
   auto fence2 = device.createFenceUnique({}).value;
-  waiter->AddFence(std::move(fence2), [&signal2]() { signal2.Signal(); });
+  waiter->AddFence(std::move(fence2), default_submit_callback,
+                   [&signal2]() { signal2.Signal(); });
 
   signal.Wait();
   signal2.Wait();
@@ -63,7 +94,8 @@ TEST(FenceWaiterVKTest, ExecutesNewFenceThenOldFence) {
   auto fence = device.createFenceUnique({}).value;
   MockFence::SetStatus(fence, vk::Result::eNotReady);
   auto raw_fence = MockFence::GetRawPointer(fence);
-  waiter->AddFence(std::move(fence), [&signal]() { signal.Signal(); });
+  waiter->AddFence(std::move(fence), default_submit_callback,
+                   [&signal]() { signal.Signal(); });
 
   // The easiest way to verify that the callback was _not_ called is to wait
   // for a timeout, but that could introduce flakiness. Instead, we'll add a
@@ -72,7 +104,8 @@ TEST(FenceWaiterVKTest, ExecutesNewFenceThenOldFence) {
     auto signal2 = fml::ManualResetWaitableEvent();
     auto fence2 = device.createFenceUnique({}).value;
     MockFence::SetStatus(fence2, vk::Result::eSuccess);
-    waiter->AddFence(std::move(fence2), [&signal2]() { signal2.Signal(); });
+    waiter->AddFence(std::move(fence2), default_submit_callback,
+                     [&signal2]() { signal2.Signal(); });
     signal2.Wait();
   }
 
@@ -93,7 +126,8 @@ TEST(FenceWaiterVKTest, AddFenceDoesNothingIfTerminating) {
     waiter->Terminate();
 
     auto fence = device.createFenceUnique({}).value;
-    waiter->AddFence(std::move(fence), [&signal]() { signal.Signal(); });
+    waiter->AddFence(std::move(fence), default_submit_callback,
+                     [&signal]() { signal.Signal(); });
   }
 
   // Ensure the fence did _not_ signal.
@@ -114,7 +148,8 @@ TEST(FenceWaiterVKTest, InProgressFencesStillWaitIfTerminated) {
   // Even if the fence is eSuccess, it's not guaranteed to be called in time.
   MockFence::SetStatus(fence, vk::Result::eNotReady);
   raw_fence = MockFence::GetRawPointer(fence);
-  waiter->AddFence(std::move(fence), [&signal]() { signal.Signal(); });
+  waiter->AddFence(std::move(fence), default_submit_callback,
+                   [&signal]() { signal.Signal(); });
 
   // Signal the fence after a delay.
   std::thread thread([&]() {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -20,6 +20,8 @@ namespace testing {
 
 namespace {
 
+class MockDevice;
+
 struct MockCommandBuffer {
   explicit MockCommandBuffer(
       std::shared_ptr<std::vector<std::string>> called_functions)
@@ -27,6 +29,18 @@ struct MockCommandBuffer {
   std::shared_ptr<std::vector<std::string>> called_functions_;
   std::vector<VkImageMemoryBarrier> image_memory_barriers_;
   std::vector<VkViewport> recorded_viewports_;
+};
+
+class MockQueue {
+ public:
+  MockQueue(MockDevice& device) : device_(device) {}
+
+  MockDevice& device() const { return device_; }
+
+ private:
+  // The MockDevice owns the MockQueues, and each MockQueue holds a reference
+  // to its parent device.
+  MockDevice& device_;
 };
 
 struct MockQueryPool {};
@@ -52,7 +66,8 @@ static ISize currentImageSize = ISize{1, 1};
 
 class MockDevice final {
  public:
-  explicit MockDevice() : called_functions_(new std::vector<std::string>()) {}
+  explicit MockDevice()
+      : called_functions_(new std::vector<std::string>()), queue_(*this) {}
 
   MockCommandBuffer* NewCommandBuffer() {
     auto buffer = std::make_unique<MockCommandBuffer>(called_functions_);
@@ -90,6 +105,8 @@ class MockDevice final {
     called_functions_->push_back(function);
   }
 
+  MockQueue& GetQueue() { return queue_; }
+
  private:
   MockDevice(const MockDevice&) = delete;
 
@@ -106,6 +123,8 @@ class MockDevice final {
   Mutex commmand_pools_mutex_;
   std::vector<std::unique_ptr<MockCommandPool>> command_pools_
       IPLR_GUARDED_BY(commmand_pools_mutex_);
+
+  MockQueue queue_;
 };
 
 struct MockVulkanState {
@@ -619,10 +638,20 @@ VkResult vkDestroyFence(VkDevice device,
   return VK_SUCCESS;
 }
 
+void vkGetDeviceQueue(VkDevice device,
+                      uint32_t queueFamilyIndex,
+                      uint32_t queueIndex,
+                      VkQueue* pQueue) {
+  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  *pQueue = reinterpret_cast<VkQueue>(&mock_device->GetQueue());
+}
+
 VkResult vkQueueSubmit(VkQueue queue,
                        uint32_t submitCount,
                        const VkSubmitInfo* pSubmits,
                        VkFence fence) {
+  const MockQueue* mock_queue = reinterpret_cast<const MockQueue*>(queue);
+  mock_queue->device().AddCalledFunction("vkQueueSubmit");
   return VK_SUCCESS;
 }
 
@@ -1000,6 +1029,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateFence);
   } else if (strcmp("vkDestroyFence", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyFence);
+  } else if (strcmp("vkGetDeviceQueue", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkGetDeviceQueue);
   } else if (strcmp("vkQueueSubmit", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkQueueSubmit);
   } else if (strcmp("vkWaitForFences", pName) == 0) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -33,7 +33,7 @@ struct MockCommandBuffer {
 
 class MockQueue {
  public:
-  MockQueue(MockDevice& device) : device_(device) {}
+  explicit MockQueue(MockDevice& device) : device_(device) {}
 
   MockDevice& device() const { return device_; }
 


### PR DESCRIPTION
The FenceWaiterVK owns the lifetime of the fences that signal completion of a Vulkan command buffer submitted through vkQueueSubmit.

Prior to this PR, CommandQueueVK::Submit was submitting the command buffer to the queue with a fence before calling
FenceWaiterVK::AddFence.  If AddFence failed, then the fence would be destroyed even though the Vulkan driver still holds its handle.  That could cause a crash when the command completes and the Vulkan driver tries to signal the fence.

With this PR, the vkQueueSubmit call is moved into a callback that will be invoked by FenceWaiterVK::AddFence only if the FenceWaiterVK can take ownership of the fence.  If the FenceWaiterVK has been terminated, then AddFence will skip the submit and destroy the fence.

Fixes https://github.com/flutter/flutter/issues/187703