### PR TITLE
Remove many absolute paths from build commands.

### DIFF
--- a/engine/src/build/toolchain/rbe.gni
+++ b/engine/src/build/toolchain/rbe.gni
@@ -19,7 +19,7 @@ declare_args() {
   # If use_rbe is false, this property is ignored.
   create_xcode_symlinks = false
 
-  rbe_exec_root = rebase_path("//")
+  rbe_exec_root = rebase_path("//", root_build_dir)
 
   rbe_server_address = ""
 
@@ -33,10 +33,13 @@ declare_args() {
 
   rbe_platform = ""
 
-  rbe_dir = rebase_path("$buildtools_path/linux-x64/reclient")
+  rbe_dir = "$buildtools_path/linux-x64/reclient"
 
-  rbe_cfg = rebase_path("//flutter/build/rbe/rewrapper-linux.cfg")
+  rbe_cfg = "//flutter/build/rbe/rewrapper-linux.cfg"
 }
+
+rbe_dir = rebase_path(rbe_dir, root_build_dir)
+rbe_cfg = rebase_path(rbe_cfg, root_build_dir)
 
 rewrapper_command = [
   "$rbe_dir/rewrapper",

--- a/engine/src/flutter/build/bin_to_obj.gni
+++ b/engine/src/flutter/build/bin_to_obj.gni
@@ -19,9 +19,9 @@ template("bin_to_assembly") {
     output = "$target_gen_dir/${invoker.input}.S"
     args = [
       "--input",
-      rebase_path(invoker.input),
+      rebase_path(invoker.input, root_build_dir),
       "--output",
-      rebase_path(output),
+      rebase_path(output, root_build_dir),
       "--symbol_name",
       invoker.symbol,
       "--target_os",
@@ -63,9 +63,9 @@ template("bin_to_coff") {
     output = "$target_gen_dir/${invoker.input}.o"
     args = [
       "--input",
-      rebase_path(invoker.input),
+      rebase_path(invoker.input, root_build_dir),
       "--output",
-      rebase_path(output),
+      rebase_path(output, root_build_dir),
       "--symbol_name",
       invoker.symbol,
     ]

--- a/engine/src/flutter/build/dart/internal/application_snapshot.gni
+++ b/engine/src/flutter/build/dart/internal/application_snapshot.gni
@@ -49,7 +49,8 @@ template("application_snapshot") {
     # As we move towards a single pub workspace for the engine, this will be
     # the correct package config to use, as we will no longer have a per-package
     # .dart_tool/package_config.json.
-    package_config = rebase_path("//flutter/.dart_tool/package_config.json")
+    package_config =
+        rebase_path("//flutter/.dart_tool/package_config.json", root_build_dir)
   }
 
   extra_deps = []
@@ -66,15 +67,11 @@ template("application_snapshot") {
   }
 
   depfile = output + ".d"
-  abs_depfile = rebase_path(depfile)
-  abs_output = rebase_path(output)
-  rel_output = rebase_path(output, root_build_dir)
   snapshot_vm_args = [
     "--deterministic",
     "--packages=$package_config",
-    "--snapshot=$abs_output",
-    "--snapshot-depfile=$abs_depfile",
-    "--depfile-output-filename=$rel_output",
+    "--snapshot=" + rebase_path(output, root_build_dir),
+    "--snapshot-depfile=" + rebase_path(depfile, root_build_dir),
   ]
   if (defined(invoker.vm_args)) {
     snapshot_vm_args += invoker.vm_args
@@ -124,7 +121,7 @@ template("application_snapshot") {
 
       args = [ dart ]
       args += snapshot_vm_args
-      args += [ rebase_path(main_dart) ]
+      args += [ rebase_path(main_dart, root_build_dir) ]
       args += training_args
     }
   } else {

--- a/engine/src/flutter/build/dart/internal/flutter_frontend_server.gni
+++ b/engine/src/flutter/build/dart/internal/flutter_frontend_server.gni
@@ -52,7 +52,8 @@ template("flutter_frontend_server") {
     # As we move towards a single pub workspace for the engine, this will be
     # the correct package config to use, as we will no longer have a per-package
     # .dart_tool/package_config.json.
-    package_config = rebase_path("//flutter/.dart_tool/package_config.json")
+    package_config =
+        rebase_path("//flutter/.dart_tool/package_config.json", root_build_dir)
   }
   packages_args += [
     "--packages",
@@ -97,7 +98,8 @@ template("flutter_frontend_server") {
       dart = rebase_path("$host_prebuilt_dart_sdk/bin/dartaotruntime$ext",
                          root_out_dir)
       frontend_server =
-          rebase_path("$root_gen_dir/frontend_server_aot.dart.snapshot")
+          rebase_path("$root_gen_dir/frontend_server_aot.dart.snapshot",
+                      root_build_dir)
 
       args = [ dart ] + [ frontend_server ] + common_args
     }

--- a/engine/src/flutter/build/dart/internal/flutter_snapshot.gni
+++ b/engine/src/flutter/build/dart/internal/flutter_snapshot.gni
@@ -99,7 +99,7 @@ template("flutter_snapshot") {
         outputs += [ snapshot_assembly ]
         args += [
           "--snapshot_kind=app-aot-assembly",
-          "--assembly=" + rebase_path(snapshot_assembly),
+          "--assembly=" + rebase_path(snapshot_assembly, root_build_dir),
         ]
       } else if (is_android) {
         if (defined(invoker.output_aot_lib)) {
@@ -111,7 +111,7 @@ template("flutter_snapshot") {
         outputs += [ libapp ]
         args += [
           "--snapshot_kind=app-aot-elf",
-          "--elf=" + rebase_path(libapp),
+          "--elf=" + rebase_path(libapp, root_build_dir),
         ]
       } else {
         assert(false)
@@ -135,12 +135,13 @@ template("flutter_snapshot") {
       ]
       args += [
         "--snapshot_kind=app",
-        "--snapshot_data=" + rebase_path(isolate_snapshot_data),
-        "--snapshot_text=" + rebase_path(isolate_snapshot_instructions),
+        "--snapshot_data=" + rebase_path(isolate_snapshot_data, root_build_dir),
+        "--snapshot_text=" +
+            rebase_path(isolate_snapshot_instructions, root_build_dir),
       ]
     }
 
-    args += [ rebase_path(kernel_output) ]
+    args += [ rebase_path(kernel_output, root_build_dir) ]
   }
 
   group(target_name) {

--- a/engine/src/flutter/build/zip_bundle.gni
+++ b/engine/src/flutter/build/zip_bundle.gni
@@ -77,15 +77,15 @@ template("zip_bundle") {
 
     args = [
       "-o",
-      rebase_path(outputs[0]),
+      rebase_path(outputs[0], root_build_dir),
       "-i",
-      rebase_path(license_readme),
+      rebase_path(license_readme, root_build_dir),
       "LICENSE.$target_name.md",
     ]
     foreach(input, invoker.files) {
       args += [
         "-i",
-        rebase_path(input.source),
+        rebase_path(input.source, root_build_dir),
         input.destination,
       ]
       sources += [ input.source ]
@@ -132,9 +132,9 @@ template("zip_bundle_from_file") {
     write_file(location_source_path, invoker.files, "json")
     args = [
       "-o",
-      rebase_path(outputs[0]),
+      rebase_path(outputs[0], root_build_dir),
       "-f",
-      rebase_path(location_source_path),
+      rebase_path(location_source_path, root_build_dir),
     ]
   }
 }

--- a/engine/src/flutter/impeller/tools/compiler.gni
+++ b/engine/src/flutter/impeller/tools/compiler.gni
@@ -107,7 +107,8 @@ template("impellerc") {
       generated_dir = "$target_gen_dir"
     }
 
-    shader_lib_dir = rebase_path("//flutter/impeller/compiler/shader_lib")
+    shader_lib_dir =
+        rebase_path("//flutter/impeller/compiler/shader_lib", root_build_dir)
     args = [ "--include=$shader_lib_dir" ] + shader_target_flags
 
     # When we're in single invocation mode, we can't use source enumeration.

--- a/engine/src/flutter/impeller/tools/embed_blob.gni
+++ b/engine/src/flutter/impeller/tools/embed_blob.gni
@@ -22,11 +22,11 @@ template("embed_blob") {
       "--symbol-name",
       invoker.symbol_name,
       "--output-header",
-      rebase_path(invoker.hdr),
+      rebase_path(invoker.hdr, root_build_dir),
       "--output-source",
-      rebase_path(invoker.cc),
+      rebase_path(invoker.cc, root_build_dir),
       "--source",
-      rebase_path(invoker.blob),
+      rebase_path(invoker.blob, root_build_dir),
     ]
     script = "//flutter/impeller/tools/xxd.py"
     deps = invoker.deps

--- a/engine/src/flutter/lib/snapshot/BUILD.gn
+++ b/engine/src/flutter/lib/snapshot/BUILD.gn
@@ -109,8 +109,9 @@ compiled_action("generate_snapshot_bin") {
   args = [
     "--snapshot_kind=core",
     "--enable_mirrors=false",
-    "--snapshot_data=" + rebase_path(isolate_snapshot_data),
-    "--snapshot_text=" + rebase_path(isolate_snapshot_instructions),
+    "--snapshot_data=" + rebase_path(isolate_snapshot_data, root_build_dir),
+    "--snapshot_text=" +
+        rebase_path(isolate_snapshot_instructions, root_build_dir),
   ]
 
   if (is_debug && flutter_runtime_mode != "profile" &&
@@ -119,7 +120,7 @@ compiled_action("generate_snapshot_bin") {
     args += [ "--enable_asserts" ]
   }
 
-  args += [ rebase_path(platform_kernel) ]
+  args += [ rebase_path(platform_kernel, root_build_dir) ]
 
   metadata = {
     entitlement_file_path = [ "gen_snapshot" ]
@@ -200,9 +201,11 @@ if (host_os == "mac" &&
       output_dir = get_label_info(gen_snapshot_target, "root_out_dir")
 
       args = [
-        rebase_path("${output_dir}/${gen_snapshot_target_name}"),
+        rebase_path("${output_dir}/${gen_snapshot_target_name}",
+                    root_build_dir),
         rebase_path(
-            "${root_out_dir}/artifacts_$host_cpu/gen_snapshot${gen_snapshot_suffix}"),
+            "${root_out_dir}/artifacts_$host_cpu/gen_snapshot${gen_snapshot_suffix}",
+            root_build_dir),
       ]
       outputs = [ "${root_out_dir}/artifacts_$host_cpu/gen_snapshot${gen_snapshot_suffix}" ]
       deps = [ gen_snapshot_target ]
@@ -237,12 +240,14 @@ if (host_os == "mac" &&
     args = [
       "--in-arm64",
       rebase_path(
-          "${root_out_dir}/artifacts_arm64/gen_snapshot${gen_snapshot_suffix}"),
+          "${root_out_dir}/artifacts_arm64/gen_snapshot${gen_snapshot_suffix}",
+          root_build_dir),
       "--in-x64",
       rebase_path(
-          "${root_out_dir}/artifacts_x64/gen_snapshot${gen_snapshot_suffix}"),
+          "${root_out_dir}/artifacts_x64/gen_snapshot${gen_snapshot_suffix}",
+          root_build_dir),
       "--out",
-      rebase_path(universal_output_path),
+      rebase_path(universal_output_path, root_build_dir),
     ]
     deps = [
       ":create_macos_gen_snapshot_arm64${gen_snapshot_suffix}",
@@ -266,7 +271,7 @@ source_set("snapshot") {
 # Compiles the Dart/Flutter core libraries to kernel bytecode.
 compile_platform("strong_platform") {
   single_root_scheme = "org-dartlang-sdk"
-  single_root_base = rebase_path("../../../")
+  single_root_base = rebase_path("../../../", root_build_dir)
   libraries_specification_uri =
       "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
 

--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -204,7 +204,7 @@ action("gen_android_build_config_java") {
 
   args = [
     "--out",
-    rebase_path(build_config_java),
+    rebase_path(build_config_java, root_build_dir),
     "--runtime-mode",
     flutter_runtime_mode,
   ]
@@ -441,9 +441,9 @@ action("check_imports") {
 
   args = [
            "--stamp",
-           rebase_path(stamp_file),
+           rebase_path(stamp_file, root_build_dir),
            "--files",
-         ] + rebase_path(android_java_sources)
+         ] + rebase_path(android_java_sources, root_build_dir)
 }
 
 action("flutter_shell_java") {
@@ -471,7 +471,7 @@ action("flutter_shell_java") {
              lambda_jar,
            ] + embedding_dependencies_jars
 
-  _rebased_current_path = rebase_path(".")
+  _rebased_current_path = rebase_path(".", root_build_dir)
   _rebased_jar_path = rebase_path(jar_path, root_build_dir)
   _rebased_source_jar_path = rebase_path(source_jar_path, root_build_dir)
   _rebased_depfile = rebase_path(depfile, root_build_dir)
@@ -620,7 +620,7 @@ action("pom_libflutter") {
 
   args = [
     "--destination",
-    rebase_path(root_build_dir),
+    rebase_path(root_build_dir, root_build_dir),
     "--engine-version",
     engine_version,
     "--engine-artifact-id",
@@ -644,7 +644,7 @@ action("pom_content_hash_libflutter") {
 
   args = [
     "--destination",
-    rebase_path(hash_dir),
+    rebase_path(hash_dir, root_build_dir),
     "--engine-version",
     content_hash,
     "--engine-artifact-id",
@@ -666,7 +666,7 @@ action("pom_embedding") {
 
   args = [
     "--destination",
-    rebase_path(root_build_dir),
+    rebase_path(root_build_dir, root_build_dir),
     "--engine-version",
     engine_version,
     "--engine-artifact-id",
@@ -691,7 +691,7 @@ action("pom_content_hash_embedding") {
 
   args = [
     "--destination",
-    rebase_path(hash_dir),
+    rebase_path(hash_dir, root_build_dir),
     "--engine-version",
     content_hash,
     "--engine-artifact-id",
@@ -737,13 +737,13 @@ action("gen_android_javadoc") {
   outputs = [ "$target_gen_dir/javadocs" ]
   args = [
     "--out-dir",
-    rebase_path(outputs[0]),
+    rebase_path(outputs[0], root_build_dir),
     "--android-source-root",
-    rebase_path("."),
+    rebase_path(".", root_build_dir),
     "--build-config-path",
-    rebase_path(target_gen_dir),
+    rebase_path(target_gen_dir, root_build_dir),
     "--src-dir",
-    rebase_path("//"),
+    rebase_path("//", root_build_dir),
     "--quiet",
   ]
 
@@ -782,9 +782,9 @@ if (target_cpu != "x86") {
     gen_snapshot_dest = "gen_snapshot"
 
     if (host_os == "mac") {
-      gen_snapshot_src = rebase_path("$root_out_dir/universal/gen_snapshot")
+      gen_snapshot_src = "$root_out_dir/universal/gen_snapshot"
     } else if (host_os == "win") {
-      gen_snapshot_src = rebase_path("$root_out_dir/gen_snapshot.exe")
+      gen_snapshot_src = "$root_out_dir/gen_snapshot.exe"
       gen_snapshot_dest = "gen_snapshot.exe"
     }
 
@@ -827,8 +827,7 @@ if (host_os == "linux" &&
         get_label_info(
             "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)",
             "root_out_dir")
-    analyze_snapshot_path =
-        rebase_path("$analyze_snapshot_out_dir/$analyze_snapshot_bin")
+    analyze_snapshot_path = "$analyze_snapshot_out_dir/$analyze_snapshot_bin"
 
     if (host_os == "linux") {
       output = "$android_zip_archive_dir/analyze-snapshot-linux-x64.zip"
@@ -837,7 +836,7 @@ if (host_os == "linux" &&
     } else if (host_os == "win") {
       output = "$android_zip_archive_dir/analyze-snapshot-windows-x64.zip"
       analyze_snapshot_bin = "analyze-snapshot.exe"
-      analyze_snapshot_path = rebase_path("$root_out_dir/$analyze_snapshot_bin")
+      analyze_snapshot_path = "$root_out_dir/$analyze_snapshot_bin"
     }
 
     files = [
@@ -897,17 +896,17 @@ action("embedding_jars") {
       args += [
         "-i",
         "${name}.jar",
-        rebase_path("${base_name}.jar"),
+        rebase_path("${base_name}.jar", root_build_dir),
         "-i",
         "${name}-sources.jar",
-        rebase_path("${base_name}-sources.jar"),
+        rebase_path("${base_name}-sources.jar", root_build_dir),
       ]
     } else {
       outputs += [ "${base_name}.${extension}" ]
       args += [
         "-i",
-        rebase_path(source),
-        rebase_path("${base_name}.${extension}"),
+        rebase_path(source, root_build_dir),
+        rebase_path("${base_name}.${extension}", root_build_dir),
       ]
     }
   }
@@ -931,17 +930,17 @@ action("embedding_jars") {
       args += [
         "-i",
         "${name}.jar",
-        rebase_path("${hash_base_name}.jar"),
+        rebase_path("${hash_base_name}.jar", root_build_dir),
         "-i",
         "${name}-sources.jar",
-        rebase_path("${hash_base_name}-sources.jar"),
+        rebase_path("${hash_base_name}-sources.jar", root_build_dir),
       ]
     } else {
       outputs += [ "${hash_base_name}.${extension}" ]
       args += [
         "-i",
-        rebase_path(source),
-        rebase_path("${hash_base_name}.${extension}"),
+        rebase_path(source, root_build_dir),
+        rebase_path("${hash_base_name}.${extension}", root_build_dir),
       ]
     }
   }
@@ -980,8 +979,8 @@ action("abi_jars") {
     outputs += [ "${base_name}.${extension}" ]
     args += [
       "-i",
-      rebase_path(source),
-      rebase_path("${base_name}.${extension}"),
+      rebase_path(source, root_build_dir),
+      rebase_path("${base_name}.${extension}", root_build_dir),
     ]
   }
 
@@ -999,8 +998,8 @@ action("abi_jars") {
     outputs += [ "${hash_base_name}.${extension}" ]
     args += [
       "-i",
-      rebase_path(source),
-      rebase_path("${hash_base_name}.${extension}"),
+      rebase_path(source, root_build_dir),
+      rebase_path("${hash_base_name}.${extension}", root_build_dir),
     ]
   }
 }

--- a/engine/src/flutter/shell/platform/embedder/BUILD.gn
+++ b/engine/src/flutter/shell/platform/embedder/BUILD.gn
@@ -460,7 +460,8 @@ shared_library("flutter_engine_library") {
     ldflags += [ "-Wl,-install_name,@rpath/FlutterEmbedder.framework/$_framework_binary_subpath" ]
   }
   if (is_linux) {
-    ldflags += [ "-Wl,--version-script=" + rebase_path("embedder_exports.lst") ]
+    ldflags += [ "-Wl,--version-script=" +
+                 rebase_path("embedder_exports.lst", root_build_dir) ]
   }
 
   deps = [ ":embedder" ]

--- a/engine/src/flutter/shell/platform/fuchsia/dart/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart/BUILD.gn
@@ -10,7 +10,7 @@ application_snapshot("kernel_compiler") {
 
   deps = [ "../flutter/kernel:kernel_platform_files($host_toolchain)" ]
 
-  package_config = rebase_path("$dart_src/.dart_tool/package_config.json")
+  package_config = "$dart_src/.dart_tool/package_config.json"
 
   training_args = [
     "--train",
@@ -38,7 +38,7 @@ application_snapshot("_list_libraries_kernel") {
   visibility = [ ":*" ]
   snapshot_kind = "kernel"
   main_dart = "$dart_src/pkg/vm/bin/list_libraries.dart"
-  package_config = rebase_path("$dart_src/.dart_tool/package_config.json")
+  package_config = "$dart_src/.dart_tool/package_config.json"
   training_args = []
   output = "$target_gen_dir/list_libraries.dart.dill"
 }
@@ -46,10 +46,10 @@ application_snapshot("_list_libraries_kernel") {
 application_snapshot("list_libraries") {
   deps = [ ":_list_libraries_kernel" ]
   main_dart = "$dart_src/pkg/vm/bin/list_libraries.dart"
-  package_config = rebase_path("$dart_src/.dart_tool/package_config.json")
+  package_config = "$dart_src/.dart_tool/package_config.json"
   training_args = [
     # train against the dill file which is generated for this snapshot.
-    rebase_path("$target_gen_dir/list_libraries.dart.dill"),
+    rebase_path("$target_gen_dir/list_libraries.dart.dill", root_build_dir),
   ]
 }
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -81,7 +81,7 @@ template("create_kernel_core_snapshot") {
     if (!invoker.product && (is_debug || flutter_runtime_mode == "debug")) {
       args += [ "--enable_asserts" ]
     }
-    args += [ rebase_path(platform_dill) ]
+    args += [ rebase_path(platform_dill, root_build_dir) ]
   }
 }
 
@@ -129,7 +129,7 @@ template("create_ffi_callback_stub") {
     if (!invoker.product && (is_debug || flutter_runtime_mode == "debug")) {
       args += [ "--enable_asserts" ]
     }
-    args += [ rebase_path(platform_dill) ]
+    args += [ rebase_path(platform_dill, root_build_dir) ]
   }
 }
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -59,7 +59,7 @@ template("aot_snapshot") {
     args = [
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
-      "--elf=" + rebase_path(snapshot_path),
+      "--elf=" + rebase_path(snapshot_path, root_build_dir),
     ]
 
     # No asserts in debug or release product.
@@ -69,7 +69,7 @@ template("aot_snapshot") {
       args += [ "--enable_asserts" ]
     }
 
-    args += [ rebase_path(shim_kernel) ]
+    args += [ rebase_path(shim_kernel, root_build_dir) ]
   }
 }
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -85,7 +85,7 @@ template("core_snapshot") {
     if (!invoker.product && (is_debug || flutter_runtime_mode == "debug")) {
       args += [ "--enable_asserts" ]
     }
-    args += [ rebase_path(platform_dill) ]
+    args += [ rebase_path(platform_dill, root_build_dir) ]
   }
 }
 
@@ -132,7 +132,7 @@ template("ffi_callback_stub") {
     if (!invoker.product && (is_debug || flutter_runtime_mode == "debug")) {
       args += [ "--enable_asserts" ]
     }
-    args += [ rebase_path(platform_dill) ]
+    args += [ rebase_path(platform_dill, root_build_dir) ]
   }
 }
 

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols/BUILD.gn
@@ -20,15 +20,16 @@ template("generate_dart_profiler_symbols") {
 
     script = "dart_profiler_symbols.dart"
 
-    packages = rebase_path("$dart_src/.dart_tool/package_config.json")
+    packages = "$dart_src/.dart_tool/package_config.json"
 
     args = [
       "--nm",
-      rebase_path("$buildtools_path/${host_os}-${host_cpu}/clang/bin/llvm-nm"),
+      rebase_path("$buildtools_path/${host_os}-${host_cpu}/clang/bin/llvm-nm",
+                  root_build_dir),
       "--binary",
-      rebase_path(invoker.library_path),
+      rebase_path(invoker.library_path, root_build_dir),
       "--output",
-      rebase_path(invoker.output),
+      rebase_path(invoker.output, root_build_dir),
     ]
   }
 }

--- a/engine/src/flutter/sky/dist/BUILD.gn
+++ b/engine/src/flutter/sky/dist/BUILD.gn
@@ -15,9 +15,9 @@ if (is_android) {
 
     args = [
       "--source",
-      rebase_path(source),
+      rebase_path(source, root_build_dir),
       "--dest",
-      rebase_path(dest),
+      rebase_path(dest, root_build_dir),
     ]
 
     deps = [ "//flutter/sky/packages/sky_engine" ]

--- a/engine/src/flutter/sky/packages/sky_engine/BUILD.gn
+++ b/engine/src/flutter/sky/packages/sky_engine/BUILD.gn
@@ -287,7 +287,7 @@ generated_file("_embedder_yaml") {
 
 action("sky_engine") {
   package_name = "sky_engine"
-  pkg_directory = rebase_path("$root_gen_dir/dart-pkg")
+  pkg_directory = rebase_path("$root_gen_dir/dart-pkg", root_build_dir)
   stamp_file = "$root_gen_dir/dart-pkg/${package_name}.stamp"
 
   sources = [
@@ -320,19 +320,20 @@ action("sky_engine") {
 
   script = rebase_path("//flutter/build/dart/tools/dart_pkg.py", ".", "//")
 
-  inputs = [ script ] + rebase_path(sources)
+  inputs = [ script ] + sources
 
-  args = [
-           "--package-name",
-           package_name,
-           "--dart-sdk",
-           rebase_path(dart_sdk_root),
-           "--pkg-directory",
-           pkg_directory,
-           "--stamp-file",
-           rebase_path(stamp_file),
-           "--package-sources",
-         ] + rebase_path(sources) + [ "--sdk-ext-directories" ] +
-         rebase_path(sdk_ext_directory) + [ "--sdk-ext-files" ] +
-         rebase_path(sdk_ext_files) + [ "--sdk-ext-mappings" ]
+  args =
+      [
+        "--package-name",
+        package_name,
+        "--dart-sdk",
+        rebase_path(dart_sdk_root, root_build_dir),
+        "--pkg-directory",
+        pkg_directory,
+        "--stamp-file",
+        rebase_path(stamp_file, root_build_dir),
+        "--package-sources",
+      ] + rebase_path(sources, root_build_dir) + [ "--sdk-ext-directories" ] +
+      rebase_path(sdk_ext_directory, root_build_dir) + [ "--sdk-ext-files" ] +
+      rebase_path(sdk_ext_files, root_build_dir) + [ "--sdk-ext-mappings" ]
 }

--- a/engine/src/flutter/sky/tools/create_macos_binary.py
+++ b/engine/src/flutter/sky/tools/create_macos_binary.py
@@ -10,16 +10,6 @@ import subprocess
 import sys
 
 
-def canonical_path(path):
-  """Returns the canonical path for the input path.
-  If the input path is not absolute, it is treated as relative to the engine
-  source tree's buildroot directory."""
-  if os.path.isabs(path):
-    return path
-  buildroot_dir = os.path.abspath(os.path.join(os.path.realpath(__file__), '..', '..', '..', '..'))
-  return os.path.join(buildroot_dir, path)
-
-
 def assert_file_exists(binary_path, arch):
   if not os.path.isfile(binary_path):
     print('Cannot find macOS %s binary at %s' % (arch, binary_path))
@@ -39,9 +29,9 @@ def main():
   parser.add_argument('--out', type=str, required=True)
   args = parser.parse_args()
 
-  in_arm64 = canonical_path(args.in_arm64)
-  in_x64 = canonical_path(args.in_x64)
-  out = canonical_path(args.out)
+  in_arm64 = args.in_arm64
+  in_x64 = args.in_x64
+  out = args.out
 
   assert_file_exists(in_arm64, 'arm64')
   assert_file_exists(in_x64, 'x64')

--- a/engine/src/flutter/testing/testing.gni
+++ b/engine/src/flutter/testing/testing.gni
@@ -129,9 +129,10 @@ template("dart_snapshot_aot") {
     args = [
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
-      "--loading_unit_manifest=" + rebase_path(loading_unit_manifest),
-      "--elf=" + rebase_path(elf_object),
-      rebase_path(invoker.dart_kernel),
+      "--loading_unit_manifest=" +
+          rebase_path(loading_unit_manifest, root_build_dir),
+      "--elf=" + rebase_path(elf_object, root_build_dir),
+      rebase_path(invoker.dart_kernel, root_build_dir),
     ]
 
     forward_variables_from(invoker, [ "deps" ])

--- a/engine/src/flutter/tools/fuchsia/fuchsia_debug_symbols.gni
+++ b/engine/src/flutter/tools/fuchsia/fuchsia_debug_symbols.gni
@@ -30,12 +30,13 @@ template("_copy_debug_symbols") {
       "--executable-name",
       target_name,
       "--executable-path",
-      rebase_path(binary_path),
+      rebase_path(binary_path, root_build_dir),
       "--destination-base",
-      rebase_path(_dest_base),
+      rebase_path(_dest_base, root_build_dir),
       "--read-elf",
       rebase_path(
-          "$buildtools_path/${host_os}-${host_cpu}/clang/bin/llvm-readelf"),
+          "$buildtools_path/${host_os}-${host_cpu}/clang/bin/llvm-readelf",
+          root_build_dir),
     ]
 
     if (unstripped) {
@@ -53,7 +54,7 @@ template("fuchsia_debug_symbols") {
 
   _copy_debug_symbols("_${target_name}_stripped") {
     forward_variables_from(invoker, "*")
-    binary_path = rebase_path("${root_out_dir}/$binary")
+    binary_path = "${root_out_dir}/$binary"
     unstripped = false
   }
 

--- a/engine/src/flutter/web_sdk/web_sdk.gni
+++ b/engine/src/flutter/web_sdk/web_sdk.gni
@@ -32,16 +32,16 @@ template("sdk_rewriter") {
       invoker.output_dir,
     ]
 
-    build_dir = rebase_path(root_out_dir)
-    input_dir = rebase_path(invoker.input_dir)
-    output_dir = rebase_path(invoker.output_dir)
+    build_dir = rebase_path(root_out_dir, root_build_dir)
+    input_dir = rebase_path(invoker.input_dir, root_build_dir)
+    output_dir = rebase_path(invoker.output_dir, root_build_dir)
 
     args = [
       "--build-dir=$build_dir",
       "--output-dir=$output_dir",
       "--input-dir=$input_dir",
       "--depfile",
-      rebase_path(depfile),
+      rebase_path(depfile, root_build_dir),
       "--stamp",
       rebase_path(stamp_location, root_build_dir),
     ]
@@ -61,7 +61,7 @@ template("sdk_rewriter") {
       args += [ "--ui" ]
     } else {
       library_name = invoker.library_name
-      api_file = rebase_path(invoker.api_file)
+      api_file = rebase_path(invoker.api_file, root_build_dir)
       args += [
         "--library-name=$library_name",
         "--api-file=$api_file",


### PR DESCRIPTION
Relative paths are preferred for reproducible builds.

They are also needed for remote build steps. The current RBE steps (only clang compiles) are already free of absolute paths, but it is easier to verify the whole build.


