### PR TITLE
[material] Fix DropdownMenuFormField leadingIcon not rendered (regression since 3.38)

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1240,6 +1240,12 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
             suffixIcon: _buildDefaultSuffixIcon(context, controller),
           );
         }
+        // Mirror the suffixIcon fallback: apply leadingIcon as prefixIcon when
+        // the decorationBuilder did not set one (e.g. DropdownMenuFormField's
+        // effectiveDecorationBuilder, which only injects label/hint/helper/error).
+        if (decoration.prefixIcon == null && widget.leadingIcon != null) {
+          decoration = decoration.copyWith(prefixIcon: widget.leadingIcon);
+        }
         final InputDecoration effectiveDecoration = decoration.applyDefaults(
           effectiveInputDecorationTheme,
         );

--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -175,6 +175,35 @@ void main() {
     expect(dropdownMenu.leadingIcon, leadingIcon);
   });
 
+  testWidgets('leadingIcon is applied to the InputDecoration', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/185416
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenuFormField<MenuItem>(dropdownMenuEntries: menuEntries),
+        ),
+      ),
+    );
+
+    TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.prefixIcon, isNull);
+
+    const Widget leadingIcon = Icon(Icons.abc);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenuFormField<MenuItem>(
+            leadingIcon: leadingIcon,
+            dropdownMenuEntries: menuEntries,
+          ),
+        ),
+      ),
+    );
+
+    textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.prefixIcon, isNotNull);
+  });
+
   testWidgets('Passes trailingIcon to underlying DropdownMenu', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -4894,6 +4894,50 @@ void main() {
       },
     );
 
+    testWidgets(
+      'leadingIcon is applied as prefixIcon when decorationBuilder does not set one',
+      (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/185416
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: DropdownMenu<TestMenu>(
+                leadingIcon: const Icon(Icons.search),
+                dropdownMenuEntries: menuChildren,
+                decorationBuilder: buildDecoration,
+              ),
+            ),
+          ),
+        );
+
+        final TextField textField = tester.widget(find.byType(TextField));
+        expect(textField.decoration?.prefixIcon, isNotNull);
+      },
+    );
+
+    testWidgets(
+      'decorationBuilder prefixIcon takes precedence over leadingIcon',
+      (WidgetTester tester) async {
+        final Key customIconKey = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: DropdownMenu<TestMenu>(
+                leadingIcon: const Icon(Icons.abc),
+                dropdownMenuEntries: menuChildren,
+                decorationBuilder: (BuildContext context, MenuController controller) {
+                  return InputDecoration(prefixIcon: Icon(Icons.search, key: customIconKey));
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byKey(customIconKey), findsOneWidget);
+        expect(find.byIcon(Icons.abc), findsNothing);
+      },
+    );
+
     testWidgets('Passing label and decorationBuilder throws', (WidgetTester tester) async {
       final menuController = MenuController();
       await expectLater(() async {


### PR DESCRIPTION
## Description

Fixes #185416.

`DropdownMenuFormField` always passes its own `effectiveDecorationBuilder` as the `decorationBuilder` argument to the underlying `DropdownMenu`. This bypassed `_buildDefaultDecoration` — the only code path that applied `widget.leadingIcon` as `InputDecoration.prefixIcon`. As a result, any `leadingIcon` passed to `DropdownMenuFormField` was silently ignored during rendering.

## Fix

Added a fallback in `DropdownMenu.build` that mirrors the existing `suffixIcon` fallback (already present since the `decorationBuilder` API was introduced):

```dart
// If no prefixIcon is provided, fall back to widget.leadingIcon.
if (decoration.prefixIcon == null && widget.leadingIcon != null) {
  decoration = decoration.copyWith(prefixIcon: widget.leadingIcon);
}
```

This runs after the `decorationBuilder` is called and before `applyDefaults`, so:
- A custom `decorationBuilder` that explicitly sets `prefixIcon` is respected (it wins).
- `_buildDefaultDecoration` is unaffected (it already sets `prefixIcon`, so the fallback never fires on the default path).
- All callers of `DropdownMenu` with a custom `decorationBuilder` benefit, not just `DropdownMenuFormField`.

**Bonus fixes:** the same gap was causing `_RenderDropdownMenuBody` to miscalculate the dropdown's preferred width (used in layout), and `refreshLeadingPadding` to measure a width of 0 (causing text misalignment when a leading icon was present). Both are now correct.

## Tests

- **`dropdown_menu_form_field_test.dart`**: Added `'leadingIcon is applied to the InputDecoration'` — regression test that checks `TextField.decoration?.prefixIcon` is non-null when `leadingIcon` is set on `DropdownMenuFormField`.
- **`dropdown_menu_test.dart`** (in `DropdownMenu.decorationBuilder` group):
  - `'leadingIcon is applied as prefixIcon when decorationBuilder does not set one'` — covers `DropdownMenu` directly with a custom `decorationBuilder`.
  - `'decorationBuilder prefixIcon takes precedence over leadingIcon'` — confirms a user's explicit `prefixIcon` in their `decorationBuilder` is not overridden.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/