### PR TITLE
fix: SearchAnchor.bar respects SearchBarThemeData.padding

### DIFF
--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1276,6 +1276,7 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
          viewOnClose: onClose,
          viewOnOpen: onOpen,
          builder: (BuildContext context, SearchController controller) {
+           final SearchBarThemeData searchBarTheme = SearchBarTheme.of(context);
            return SearchBar(
              constraints: constraints,
              controller: controller,
@@ -1295,8 +1296,8 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
              overlayColor: barOverlayColor,
              side: barSide,
              shape: barShape,
-             padding:
-                 barPadding ??
+             padding: barPadding ??
+                 searchBarTheme.padding ??
                  const MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.symmetric(horizontal: 16.0)),
              leading: barLeading ?? const Icon(Icons.search),
              trailing: barTrailing,

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -701,6 +701,69 @@ void main() {
     expect(trailingRect.right, barRect.right - 16.0);
   });
 
+  testWidgets('SearchAnchor.bar respects SearchBarThemeData.padding', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: Material(
+            child: SearchBarTheme(
+              data: const SearchBarThemeData(
+                padding: MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.all(30.0)),
+              ),
+              child: SearchAnchor.bar(
+                suggestionsBuilder: (BuildContext context, SearchController controller) {
+                  return <Widget>[];
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Rect barRect = tester.getRect(find.byType(SearchBar));
+    final Rect leadingRect = tester.getRect(find.byIcon(Icons.search));
+    final Rect textFieldRect = tester.getRect(find.byType(TextField));
+
+    // outer padding (30) separates bar edge from leading icon
+    expect(barRect.left, leadingRect.left - 30.0);
+    // inner padding (30) separates leading icon from text field
+    expect(leadingRect.right, textFieldRect.left - 30.0);
+    // right side: outer (30) + inner (30) = 60 between text field right and bar right
+    expect(barRect.right, textFieldRect.right + 60.0);
+  });
+
+  testWidgets('SearchAnchor.bar.barPadding overrides SearchBarThemeData.padding', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: Material(
+            child: SearchBarTheme(
+              data: const SearchBarThemeData(
+                padding: MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.all(30.0)),
+              ),
+              child: SearchAnchor.bar(
+                barPadding: const MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.all(10.0)),
+                suggestionsBuilder: (BuildContext context, SearchController controller) {
+                  return <Widget>[];
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Rect barRect = tester.getRect(find.byType(SearchBar));
+    final Rect leadingRect = tester.getRect(find.byIcon(Icons.search));
+    final Rect textFieldRect = tester.getRect(find.byType(TextField));
+
+    expect(barRect.left, leadingRect.left - 10.0);
+    expect(leadingRect.right, textFieldRect.left - 10.0);
+    // right side: outer (10) + inner (10) = 20
+    expect(barRect.right, textFieldRect.right + 20.0);
+  });
+
   testWidgets('SearchBar respects hintStyle property', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -708,7 +708,7 @@ void main() {
           child: Material(
             child: SearchBarTheme(
               data: const SearchBarThemeData(
-                padding: MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.all(30.0)),
+                padding: WidgetStatePropertyAll<EdgeInsets>(EdgeInsets.all(30.0)),
               ),
               child: SearchAnchor.bar(
                 suggestionsBuilder: (BuildContext context, SearchController controller) {
@@ -740,10 +740,10 @@ void main() {
           child: Material(
             child: SearchBarTheme(
               data: const SearchBarThemeData(
-                padding: MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.all(30.0)),
+                padding: WidgetStatePropertyAll<EdgeInsets>(EdgeInsets.all(30.0)),
               ),
               child: SearchAnchor.bar(
-                barPadding: const MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.all(10.0)),
+                barPadding: const WidgetStatePropertyAll<EdgeInsets>(EdgeInsets.all(10.0)),
                 suggestionsBuilder: (BuildContext context, SearchController controller) {
                   return <Widget>[];
                 },


### PR DESCRIPTION
## Description

Fixes #185889

`SearchAnchor.bar()` builds its anchor widget using a `SearchBar` inside a builder closure. When `barPadding` was not explicitly provided, the code fell back to a hardcoded `EdgeInsets.symmetric(horizontal: 16.0)`, which completely bypassed `SearchBarThemeData.padding`. A standalone `SearchBar` correctly walked the 3-tier resolution chain (`widget.padding → SearchBarThemeData.padding → M3 defaults`), making `SearchAnchor.bar` inconsistent with the rest of the theming system.

## Changes

**`packages/flutter/lib/src/material/search_anchor.dart`**

In `_SearchAnchorWithSearchBar`'s builder closure, read `SearchBarTheme.of(context)` and apply a 3-tier resolution for padding:

```dart
padding: barPadding ??
    searchBarTheme.padding ??
    const MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.symmetric(horizontal: 16.0)),
```

This:
1. Uses explicit `barPadding` if provided (unchanged)
2. Falls back to `SearchBarThemeData.padding` when set (the bug fix)
3. Falls back to the original `horizontal: 16.0` default (backward compatible — no visual regression for existing apps)

**`packages/flutter/test/material/search_anchor_test.dart`**

Added two regression tests:
- `SearchAnchor.bar respects SearchBarThemeData.padding` — wraps in `SearchBarTheme` with custom padding and verifies the layout reflects it
- `SearchAnchor.bar.barPadding overrides SearchBarThemeData.padding` — verifies widget-level `barPadding` takes precedence over the theme

## Test plan

- [x] `flutter test packages/flutter/test/material/search_anchor_test.dart` — all 127 tests pass
- [x] Two new regression tests added and passing
- [x] No existing tests changed