### PR TITLE
Ensure that directory names are typed as strings in the CIPD package YAML file generated by merge_and_upload_debug_symbols.py

### DIFF
--- a/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
+++ b/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
@@ -45,7 +45,7 @@ data:
 """ % (target_arch, target_arch)
   for symbol_dir in symbol_dirs:
     symbol_dir_name = os.path.basename(os.path.normpath(symbol_dir))
-    data = '\n  - dir: %s' % (symbol_dir_name)
+    data = '\n  - dir: "%s"' % (symbol_dir_name)
     pkg_def = pkg_def + data
   return pkg_def
 


### PR DESCRIPTION
This script is writing a YAML file that is used to create a CIPD package containing Fuchsia debug symbols.  The YAML spec references subdirectories in Fuchsia's .build-id directory.

.build-id contains binaries indexed by the binary's hash.  The name of each subdirectory in .build-id is the first two hex digits of the hash.

If the subdirectory name contains two digits starting with a zero, then the YAML entry will look like "dir: 01".  YAML will interpret the value as the integer 1, which will not match the actual directory name of "01".  CIPD will thus fail to create the package.

This PR fixes the YAML so that the directory names are quoted as strings.

See https://github.com/flutter/flutter/issues/187806