### PR TITLE
Fix RenderSliverPadding padding setter assertion

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -340,7 +340,7 @@ class RenderSliverPadding extends RenderSliverEdgeInsetsPadding {
   EdgeInsetsGeometry get padding => _padding;
   EdgeInsetsGeometry _padding;
   set padding(EdgeInsetsGeometry value) {
-    assert(padding.isNonNegative);
+    assert(value.isNonNegative);
     if (_padding == value) {
       return;
     }

--- a/packages/flutter/test/rendering/sliver_cache_test.dart
+++ b/packages/flutter/test/rendering/sliver_cache_test.dart
@@ -498,6 +498,12 @@ void main() {
     expect(children.sublist(42, 60).every((RenderBox r) => r.attached), true);
   });
 
+  test('RenderSliverPadding setter asserts for negative padding', () {
+    final RenderSliverPadding renderSliverPadding = RenderSliverPadding(padding: EdgeInsets.zero);
+
+    expect(() => renderSliverPadding.padding = const EdgeInsets.all(-1.0), throwsAssertionError);
+  });
+
   test('RenderSliverPadding calculates correct geometry', () {
     // Viewport is 800x600, each item is 100px high with 50px before and after = 200px
 

--- a/packages/flutter/test/rendering/sliver_cache_test.dart
+++ b/packages/flutter/test/rendering/sliver_cache_test.dart
@@ -498,12 +498,6 @@ void main() {
     expect(children.sublist(42, 60).every((RenderBox r) => r.attached), true);
   });
 
-  test('RenderSliverPadding setter asserts for negative padding', () {
-    final RenderSliverPadding renderSliverPadding = RenderSliverPadding(padding: EdgeInsets.zero);
-
-    expect(() => renderSliverPadding.padding = const EdgeInsets.all(-1.0), throwsAssertionError);
-  });
-
   test('RenderSliverPadding calculates correct geometry', () {
     // Viewport is 800x600, each item is 100px high with 50px before and after = 200px
 

--- a/packages/flutter/test/widgets/slivers_padding_test.dart
+++ b/packages/flutter/test/widgets/slivers_padding_test.dart
@@ -408,10 +408,8 @@ void main() {
 
     await tester.pumpWidget(buildApp(EdgeInsets.zero));
 
-    await expectLater(
-      () => tester.pumpWidget(buildApp(const EdgeInsets.all(-1.0))),
-      throwsAssertionError,
-    );
+    await tester.pumpWidget(buildApp(const EdgeInsets.all(-1.0)));
+    expect(tester.takeException(), isAssertionError);
   });
 
   testWidgets('Viewport+SliverPadding changing direction', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/slivers_padding_test.dart
+++ b/packages/flutter/test/widgets/slivers_padding_test.dart
@@ -390,6 +390,27 @@ void main() {
     );
   });
 
+  testWidgets('Viewport+SliverPadding changing padding to negative asserts', (
+    WidgetTester tester,
+  ) async {
+    final offset = ViewportOffset.fixed(0.0);
+    addTearDown(offset.dispose);
+
+    Widget buildApp(EdgeInsetsGeometry padding) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Viewport(
+          offset: offset,
+          slivers: <Widget>[SliverPadding(padding: padding)],
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(EdgeInsets.zero));
+
+    expect(() => tester.pumpWidget(buildApp(const EdgeInsets.all(-1.0))), throwsAssertionError);
+  });
+
   testWidgets('Viewport+SliverPadding changing direction', (WidgetTester tester) async {
     final offset1 = ViewportOffset.fixed(0.0);
     addTearDown(offset1.dispose);

--- a/packages/flutter/test/widgets/slivers_padding_test.dart
+++ b/packages/flutter/test/widgets/slivers_padding_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 class _MockRenderSliver extends RenderSliver {
   @override
@@ -390,27 +391,30 @@ void main() {
     );
   });
 
-  testWidgets('Viewport+SliverPadding changing padding to negative asserts', (
-    WidgetTester tester,
-  ) async {
-    final offset = ViewportOffset.fixed(0.0);
-    addTearDown(offset.dispose);
+  testWidgets(
+    'Viewport+SliverPadding changing padding to negative asserts',
+    experimentalLeakTesting: LeakTesting.settings
+        .withIgnoredAll(), // leaking by design because of exception
+    (WidgetTester tester) async {
+      final offset = ViewportOffset.fixed(0.0);
+      addTearDown(offset.dispose);
 
-    Widget buildApp(EdgeInsetsGeometry padding) {
-      return Directionality(
-        textDirection: TextDirection.ltr,
-        child: Viewport(
-          offset: offset,
-          slivers: <Widget>[SliverPadding(padding: padding)],
-        ),
-      );
-    }
+      Widget buildApp(EdgeInsetsGeometry padding) {
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: Viewport(
+            offset: offset,
+            slivers: <Widget>[SliverPadding(padding: padding)],
+          ),
+        );
+      }
 
-    await tester.pumpWidget(buildApp(EdgeInsets.zero));
+      await tester.pumpWidget(buildApp(EdgeInsets.zero));
 
-    await tester.pumpWidget(buildApp(const EdgeInsets.all(-1.0)));
-    expect(tester.takeException(), isAssertionError);
-  });
+      await tester.pumpWidget(buildApp(const EdgeInsets.all(-1.0)));
+      expect(tester.takeException(), isAssertionError);
+    },
+  );
 
   testWidgets('Viewport+SliverPadding changing direction', (WidgetTester tester) async {
     final offset1 = ViewportOffset.fixed(0.0);

--- a/packages/flutter/test/widgets/slivers_padding_test.dart
+++ b/packages/flutter/test/widgets/slivers_padding_test.dart
@@ -408,7 +408,10 @@ void main() {
 
     await tester.pumpWidget(buildApp(EdgeInsets.zero));
 
-    expect(() => tester.pumpWidget(buildApp(const EdgeInsets.all(-1.0))), throwsAssertionError);
+    await expectLater(
+      () => tester.pumpWidget(buildApp(const EdgeInsets.all(-1.0))),
+      throwsAssertionError,
+    );
   });
 
   testWidgets('Viewport+SliverPadding changing direction', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes #187527.

The `RenderSliverPadding.padding` setter asserted against the old padding value instead of the incoming value. Updating it to validate `value.isNonNegative` makes runtime padding updates enforce the same invariant as the constructor.

This also adds a widget regression test that pumps a `SliverPadding` with valid padding, updates it to negative padding, and verifies the assertion is reported.

Tests:
`./bin/flutter test packages/flutter/test/widgets/slivers_padding_test.dart --plain-name "Viewport+SliverPadding changing padding to negative asserts"`