### PR TITLE
Add alternative input method for RangeSlider in NavigationMode.directional

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -472,6 +472,11 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
   // effect when using traditional navigation.
   bool _isEditingInDirectionalMode = false;
 
+  // Cached here so build() doesn't have to read it (and re-pick a shortcut map)
+  // every pass. didChangeDependencies is the right place to depend on the
+  // MediaQuery.
+  NavigationMode _navigationMode = NavigationMode.traditional;
+
   // Keyboard mapping for a focused range slider.
   static const Map<ShortcutActivator, Intent> _traditionalNavShortcutMap =
       <ShortcutActivator, Intent>{
@@ -585,6 +590,12 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       vsync: this,
       value: _unlerp(widget.values.end),
     );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _navigationMode = MediaQuery.navigationModeOf(context);
   }
 
   @override
@@ -876,9 +887,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       result = Padding(padding: padding, child: result);
     }
 
-    final Map<ShortcutActivator, Intent> shortcutMap = switch (MediaQuery.navigationModeOf(
-      context,
-    )) {
+    final Map<ShortcutActivator, Intent> shortcutMap = switch (_navigationMode) {
       NavigationMode.directional =>
         _isEditingInDirectionalMode
             ? _directionalNavEditingShortcutMap

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -879,9 +879,10 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     final Map<ShortcutActivator, Intent> shortcutMap = switch (MediaQuery.navigationModeOf(
       context,
     )) {
-      NavigationMode.directional => _isEditingInDirectionalMode
-          ? _directionalNavEditingShortcutMap
-          : _directionalNavShortcutMap,
+      NavigationMode.directional =>
+        _isEditingInDirectionalMode
+            ? _directionalNavEditingShortcutMap
+            : _directionalNavShortcutMap,
       NavigationMode.traditional => _traditionalNavShortcutMap,
     };
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -21,6 +21,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart' show timeDilation;
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'color_scheme.dart';
@@ -462,6 +463,50 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
   final FocusNode startFocusNode = FocusNode();
   final FocusNode endFocusNode = FocusNode();
 
+  final GlobalKey _renderObjectKey = GlobalKey();
+
+  // Whether the slider is currently in the value adjustment mode while using
+  // directional navigation (e.g. a TV remote or D-pad). When false, arrow keys
+  // are left unhandled so they can move the focus between views; when true,
+  // arrow keys adjust the slider value. Toggled by the enter key. This has no
+  // effect when using traditional navigation.
+  bool _isEditingInDirectionalMode = false;
+
+  // Keyboard mapping for a focused range slider.
+  static const Map<ShortcutActivator, Intent> _traditionalNavShortcutMap =
+      <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.arrowUp): _AdjustSliderIntent.up(),
+        SingleActivator(LogicalKeyboardKey.arrowDown): _AdjustSliderIntent.down(),
+        SingleActivator(LogicalKeyboardKey.arrowLeft): _AdjustSliderIntent.left(),
+        SingleActivator(LogicalKeyboardKey.arrowRight): _AdjustSliderIntent.right(),
+      };
+
+  // Keyboard mapping for a focused range slider when using directional
+  // navigation and not in the value adjustment mode. Only the enter key is
+  // handled, to enter the value adjustment mode. The arrow keys are left
+  // unhandled so they can move the focus between views.
+  static const Map<ShortcutActivator, Intent> _directionalNavShortcutMap =
+      <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.enter): _ToggleRangeSliderEditModeIntent(),
+      };
+
+  // Keyboard mapping for a focused range slider when using directional
+  // navigation and in the value adjustment mode. The horizontal inputs adjust
+  // the value and the enter key exits the value adjustment mode. The vertical
+  // inputs are not handled to allow navigating out of the slider.
+  static const Map<ShortcutActivator, Intent> _directionalNavEditingShortcutMap =
+      <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.arrowLeft): _AdjustSliderIntent.left(),
+        SingleActivator(LogicalKeyboardKey.arrowRight): _AdjustSliderIntent.right(),
+        SingleActivator(LogicalKeyboardKey.enter): _ToggleRangeSliderEditModeIntent(),
+      };
+
+  // Action mapping for the start thumb.
+  late Map<Type, Action<Intent>> _startActionMap;
+
+  // Action mapping for the end thumb.
+  late Map<Type, Action<Intent>> _endActionMap;
+
   // Animation controller that is run when the overlay (a.k.a radial reaction)
   // changes visibility in response to user interaction.
   late AnimationController overlayController;
@@ -504,6 +549,22 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
   @override
   void initState() {
     super.initState();
+    _startActionMap = <Type, Action<Intent>>{
+      _AdjustSliderIntent: CallbackAction<_AdjustSliderIntent>(
+        onInvoke: (_AdjustSliderIntent intent) => _actionHandler(intent, Thumb.start),
+      ),
+      _ToggleRangeSliderEditModeIntent: CallbackAction<_ToggleRangeSliderEditModeIntent>(
+        onInvoke: (_ToggleRangeSliderEditModeIntent intent) => _toggleEditMode(),
+      ),
+    };
+    _endActionMap = <Type, Action<Intent>>{
+      _AdjustSliderIntent: CallbackAction<_AdjustSliderIntent>(
+        onInvoke: (_AdjustSliderIntent intent) => _actionHandler(intent, Thumb.end),
+      ),
+      _ToggleRangeSliderEditModeIntent: CallbackAction<_ToggleRangeSliderEditModeIntent>(
+        onInvoke: (_ToggleRangeSliderEditModeIntent intent) => _toggleEditMode(),
+      ),
+    };
     overlayController = AnimationController(duration: kRadialReactionDuration, vsync: this);
     valueIndicatorController = AnimationController(
       duration: valueIndicatorAnimationDuration,
@@ -562,6 +623,41 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     final RangeValues lerpValues = _lerpRangeValues(values);
     if (lerpValues != widget.values) {
       widget.onChanged!(lerpValues);
+    }
+  }
+
+  void _actionHandler(_AdjustSliderIntent intent, Thumb thumb) {
+    final slider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderRangeSlider;
+    final TextDirection directionality = Directionality.of(_renderObjectKey.currentContext!);
+    final bool increase = switch (intent.type) {
+      _SliderAdjustmentType.up => true,
+      _SliderAdjustmentType.down => false,
+      _SliderAdjustmentType.left => directionality == TextDirection.rtl,
+      _SliderAdjustmentType.right => directionality == TextDirection.ltr,
+    };
+    switch (thumb) {
+      case Thumb.start:
+        increase ? slider.increaseStartAction() : slider.decreaseStartAction();
+      case Thumb.end:
+        increase ? slider.increaseEndAction() : slider.decreaseEndAction();
+    }
+  }
+
+  // Toggles the value adjustment mode used by directional navigation. Entered
+  // and exited by pressing the enter key on a focused thumb.
+  void _toggleEditMode() {
+    setState(() {
+      _isEditingInDirectionalMode = !_isEditingInDirectionalMode;
+    });
+  }
+
+  // Exits the value adjustment mode when a thumb loses focus, so the slider
+  // does not stay in the editing state after the user navigates away.
+  void _handleFocusChanged(bool hasFocus) {
+    if (!hasFocus && _isEditingInDirectionalMode) {
+      setState(() {
+        _isEditingInDirectionalMode = false;
+      });
     }
   }
 
@@ -758,6 +854,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
           return _buildValueIndicator(sliderTheme.showValueIndicator!);
         },
         child: _RangeSliderRenderObjectWidget(
+          key: _renderObjectKey,
           values: _unlerpRangeValues(widget.values),
           divisions: widget.divisions,
           labels: widget.labels,
@@ -779,18 +876,42 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       result = Padding(padding: padding, child: result);
     }
 
+    final Map<ShortcutActivator, Intent> shortcutMap = switch (MediaQuery.navigationModeOf(
+      context,
+    )) {
+      NavigationMode.directional => _isEditingInDirectionalMode
+          ? _directionalNavEditingShortcutMap
+          : _directionalNavShortcutMap,
+      NavigationMode.traditional => _traditionalNavShortcutMap,
+    };
+
     return Stack(
       children: <Widget>[
         // Adds two invisible focus nodes to the range slider for its two thumbs.
-        Row(
-          children: <Widget>[
-            Focus(
-              focusNode: startFocusNode,
-              includeSemantics: false,
-              child: const SizedBox.shrink(),
-            ),
-            Focus(focusNode: endFocusNode, includeSemantics: false, child: const SizedBox.shrink()),
-          ],
+        Shortcuts(
+          shortcuts: shortcutMap,
+          child: Row(
+            children: <Widget>[
+              Actions(
+                actions: _startActionMap,
+                child: Focus(
+                  focusNode: startFocusNode,
+                  includeSemantics: false,
+                  onFocusChange: _handleFocusChanged,
+                  child: const SizedBox.shrink(),
+                ),
+              ),
+              Actions(
+                actions: _endActionMap,
+                child: Focus(
+                  focusNode: endFocusNode,
+                  includeSemantics: false,
+                  onFocusChange: _handleFocusChanged,
+                  child: const SizedBox.shrink(),
+                ),
+              ),
+            ],
+          ),
         ),
         MouseRegion(
           onEnter: (_) => _handleHoverChanged(true),
@@ -823,6 +944,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
 
 class _RangeSliderRenderObjectWidget extends LeafRenderObjectWidget {
   const _RangeSliderRenderObjectWidget({
+    super.key,
     required this.values,
     required this.divisions,
     required this.labels,
@@ -1915,16 +2037,16 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       values.start,
       _increasedStartValue,
       _decreasedStartValue,
-      _increaseStartAction,
-      _decreaseStartAction,
+      increaseStartAction,
+      decreaseStartAction,
       focused: _state.startFocusNode.hasFocus,
     );
     final SemanticsConfiguration endSemanticsConfiguration = _createSemanticsConfiguration(
       values.end,
       _increasedEndValue,
       _decreasedEndValue,
-      _increaseEndAction,
-      _decreaseEndAction,
+      increaseEndAction,
+      decreaseEndAction,
       focused: _state.endFocusNode.hasFocus,
     );
 
@@ -1975,25 +2097,25 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
 
   double get _semanticActionUnit => divisions != null ? 1.0 / divisions! : _adjustmentUnit;
 
-  void _increaseStartAction() {
+  void increaseStartAction() {
     if (isEnabled) {
       onChanged!(RangeValues(_increasedStartValue, values.end));
     }
   }
 
-  void _decreaseStartAction() {
+  void decreaseStartAction() {
     if (isEnabled) {
       onChanged!(RangeValues(_decreasedStartValue, values.end));
     }
   }
 
-  void _increaseEndAction() {
+  void increaseEndAction() {
     if (isEnabled) {
       onChanged!(RangeValues(values.start, _increasedEndValue));
     }
   }
 
-  void _decreaseEndAction() {
+  void decreaseEndAction() {
     if (isEnabled) {
       onChanged!(RangeValues(values.start, _decreasedEndValue));
     }
@@ -2162,6 +2284,28 @@ class _RangeSliderDefaultsM2 extends SliderThemeData {
 
   @override
   double? get minThumbSeparation => 8;
+}
+
+class _AdjustSliderIntent extends Intent {
+  const _AdjustSliderIntent({required this.type});
+
+  const _AdjustSliderIntent.right() : type = _SliderAdjustmentType.right;
+
+  const _AdjustSliderIntent.left() : type = _SliderAdjustmentType.left;
+
+  const _AdjustSliderIntent.up() : type = _SliderAdjustmentType.up;
+
+  const _AdjustSliderIntent.down() : type = _SliderAdjustmentType.down;
+
+  final _SliderAdjustmentType type;
+}
+
+enum _SliderAdjustmentType { right, left, up, down }
+
+// Toggles the value adjustment mode used by directional navigation, so the
+// thumb that has focus enters or exits the editing state.
+class _ToggleRangeSliderEditModeIntent extends Intent {
+  const _ToggleRangeSliderEditModeIntent();
 }
 
 // BEGIN GENERATED TOKEN PROPERTIES - RangeSlider

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2704,6 +2704,187 @@ void main() {
     expect(FocusManager.instance.primaryFocus, endFocusNode);
   });
 
+  group('RangeSlider keyboard with NavigationMode.directional', () {
+    // Builds a RangeSlider whose ambient navigation mode can be toggled, and
+    // exposes the latest values through the returned [ValueGetter].
+    Future<ValueGetter<RangeValues>> buildFrame(
+      WidgetTester tester, {
+      required NavigationMode navigationMode,
+    }) async {
+      var values = const RangeValues(40, 80);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return MediaQuery(
+                    data: MediaQueryData(navigationMode: navigationMode),
+                    child: Center(
+                      child: RangeSlider(
+                        values: values,
+                        max: 100,
+                        onChanged: (RangeValues newValues) {
+                          setState(() {
+                            values = newValues;
+                          });
+                        },
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      return () => values;
+    }
+
+    FocusNode startFocusNodeOf(WidgetTester tester) =>
+        (tester.firstState(find.byType(RangeSlider)) as dynamic).startFocusNode as FocusNode;
+
+    testWidgets('arrow keys do not change the value when not in editing mode', (
+      WidgetTester tester,
+    ) async {
+      final ValueGetter<RangeValues> values = await buildFrame(
+        tester,
+        navigationMode: NavigationMode.directional,
+      );
+      startFocusNodeOf(tester).requestFocus();
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+      expect(
+        values(),
+        const RangeValues(40, 80),
+        reason: 'arrowRight should move focus, not change the value, outside editing mode',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pumpAndSettle();
+      expect(
+        values(),
+        const RangeValues(40, 80),
+        reason: 'arrowLeft should move focus, not change the value, outside editing mode',
+      );
+    });
+
+    testWidgets('pressing enter enters editing mode so arrow keys change the value', (
+      WidgetTester tester,
+    ) async {
+      final ValueGetter<RangeValues> values = await buildFrame(
+        tester,
+        navigationMode: NavigationMode.directional,
+      );
+      startFocusNodeOf(tester).requestFocus();
+      await tester.pumpAndSettle();
+
+      // Enter editing mode.
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      // Now the arrow keys adjust the focused (start) thumb.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+      expect(values().start, greaterThan(40));
+      expect(values().end, 80);
+    });
+
+    testWidgets('in editing mode, arrow keys change the value', (WidgetTester tester) async {
+      final ValueGetter<RangeValues> values = await buildFrame(
+        tester,
+        navigationMode: NavigationMode.directional,
+      );
+      startFocusNodeOf(tester).requestFocus();
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+      final double increasedStart = values().start;
+      expect(increasedStart, greaterThan(40));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pumpAndSettle();
+      expect(values().start, lessThan(increasedStart));
+    });
+
+    testWidgets('pressing enter again exits editing mode', (WidgetTester tester) async {
+      final ValueGetter<RangeValues> values = await buildFrame(
+        tester,
+        navigationMode: NavigationMode.directional,
+      );
+      startFocusNodeOf(tester).requestFocus();
+      await tester.pumpAndSettle();
+
+      // Enter then exit editing mode.
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      // Arrow keys no longer adjust the value.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+      expect(
+        values(),
+        const RangeValues(40, 80),
+        reason: 'arrow keys should not change the value after exiting editing mode',
+      );
+    });
+
+    testWidgets('losing focus exits editing mode', (WidgetTester tester) async {
+      final ValueGetter<RangeValues> values = await buildFrame(
+        tester,
+        navigationMode: NavigationMode.directional,
+      );
+      final FocusNode startFocusNode = startFocusNodeOf(tester);
+      startFocusNode.requestFocus();
+      await tester.pumpAndSettle();
+
+      // Enter editing mode.
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      // Losing focus should reset the editing mode.
+      startFocusNode.unfocus();
+      await tester.pumpAndSettle();
+
+      // Re-focus and verify arrow keys no longer adjust the value, proving the
+      // editing mode was reset when focus was lost.
+      startFocusNode.requestFocus();
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+      expect(
+        values(),
+        const RangeValues(40, 80),
+        reason: 'editing mode should be reset after the slider lost focus',
+      );
+    });
+
+    testWidgets('arrow keys change the value directly in traditional navigation mode', (
+      WidgetTester tester,
+    ) async {
+      final ValueGetter<RangeValues> values = await buildFrame(
+        tester,
+        navigationMode: NavigationMode.traditional,
+      );
+      startFocusNodeOf(tester).requestFocus();
+      await tester.pumpAndSettle();
+
+      // No need to enter an editing mode in traditional navigation.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+      expect(values().start, greaterThan(40));
+      expect(values().end, 80);
+    });
+  });
+
   testWidgets('Keyboard focus also changes semantics focus', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2705,13 +2705,16 @@ void main() {
   });
 
   group('RangeSlider keyboard with NavigationMode.directional', () {
-    // Builds a RangeSlider whose ambient navigation mode can be toggled, and
-    // exposes the latest values through the returned [ValueGetter].
-    Future<ValueGetter<RangeValues>> buildFrame(
+    // Pumps a RangeSlider in the given navigation mode. Read the live values
+    // back through [sliderKey] with [valuesOf]; [initialValues] is where the
+    // slider starts.
+    Future<void> pumpRangeSlider(
       WidgetTester tester, {
       required NavigationMode navigationMode,
+      required GlobalKey sliderKey,
+      required RangeValues initialValues,
     }) async {
-      var values = const RangeValues(40, 80);
+      var values = initialValues;
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
@@ -2723,6 +2726,7 @@ void main() {
                     data: MediaQueryData(navigationMode: navigationMode),
                     child: Center(
                       child: RangeSlider(
+                        key: sliderKey,
                         values: values,
                         max: 100,
                         onChanged: (RangeValues newValues) {
@@ -2739,8 +2743,9 @@ void main() {
           ),
         ),
       );
-      return () => values;
     }
+
+    RangeValues valuesOf(GlobalKey sliderKey) => (sliderKey.currentWidget! as RangeSlider).values;
 
     FocusNode startFocusNodeOf(WidgetTester tester) =>
         (tester.firstState(find.byType(RangeSlider)) as dynamic).startFocusNode as FocusNode;
@@ -2748,9 +2753,12 @@ void main() {
     testWidgets('arrow keys do not change the value when not in editing mode', (
       WidgetTester tester,
     ) async {
-      final ValueGetter<RangeValues> values = await buildFrame(
+      final GlobalKey sliderKey = GlobalKey();
+      await pumpRangeSlider(
         tester,
         navigationMode: NavigationMode.directional,
+        sliderKey: sliderKey,
+        initialValues: const RangeValues(40, 80),
       );
       startFocusNodeOf(tester).requestFocus();
       await tester.pumpAndSettle();
@@ -2758,7 +2766,7 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pumpAndSettle();
       expect(
-        values(),
+        valuesOf(sliderKey),
         const RangeValues(40, 80),
         reason: 'arrowRight should move focus, not change the value, outside editing mode',
       );
@@ -2766,18 +2774,21 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.pumpAndSettle();
       expect(
-        values(),
+        valuesOf(sliderKey),
         const RangeValues(40, 80),
         reason: 'arrowLeft should move focus, not change the value, outside editing mode',
       );
     });
 
-    testWidgets('pressing enter enters editing mode so arrow keys change the value', (
+    testWidgets('pressing enter enters editing mode and arrow keys adjust the value', (
       WidgetTester tester,
     ) async {
-      final ValueGetter<RangeValues> values = await buildFrame(
+      final GlobalKey sliderKey = GlobalKey();
+      await pumpRangeSlider(
         tester,
         navigationMode: NavigationMode.directional,
+        sliderKey: sliderKey,
+        initialValues: const RangeValues(40, 80),
       );
       startFocusNodeOf(tester).requestFocus();
       await tester.pumpAndSettle();
@@ -2786,37 +2797,27 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pumpAndSettle();
 
-      // Now the arrow keys adjust the focused (start) thumb.
+      // In LTR, the right arrow increases the focused (start) thumb...
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pumpAndSettle();
-      expect(values().start, greaterThan(40));
-      expect(values().end, 80);
-    });
-
-    testWidgets('in editing mode, arrow keys change the value', (WidgetTester tester) async {
-      final ValueGetter<RangeValues> values = await buildFrame(
-        tester,
-        navigationMode: NavigationMode.directional,
-      );
-      startFocusNodeOf(tester).requestFocus();
-      await tester.pumpAndSettle();
-      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-      await tester.pumpAndSettle();
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-      await tester.pumpAndSettle();
-      final double increasedStart = values().start;
+      final double increasedStart = valuesOf(sliderKey).start;
       expect(increasedStart, greaterThan(40));
+      expect(valuesOf(sliderKey).end, 80);
 
+      // ...and the left arrow decreases it.
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.pumpAndSettle();
-      expect(values().start, lessThan(increasedStart));
+      expect(valuesOf(sliderKey).start, lessThan(increasedStart));
+      expect(valuesOf(sliderKey).end, 80);
     });
 
     testWidgets('pressing enter again exits editing mode', (WidgetTester tester) async {
-      final ValueGetter<RangeValues> values = await buildFrame(
+      final GlobalKey sliderKey = GlobalKey();
+      await pumpRangeSlider(
         tester,
         navigationMode: NavigationMode.directional,
+        sliderKey: sliderKey,
+        initialValues: const RangeValues(40, 80),
       );
       startFocusNodeOf(tester).requestFocus();
       await tester.pumpAndSettle();
@@ -2831,16 +2832,19 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pumpAndSettle();
       expect(
-        values(),
+        valuesOf(sliderKey),
         const RangeValues(40, 80),
         reason: 'arrow keys should not change the value after exiting editing mode',
       );
     });
 
     testWidgets('losing focus exits editing mode', (WidgetTester tester) async {
-      final ValueGetter<RangeValues> values = await buildFrame(
+      final GlobalKey sliderKey = GlobalKey();
+      await pumpRangeSlider(
         tester,
         navigationMode: NavigationMode.directional,
+        sliderKey: sliderKey,
+        initialValues: const RangeValues(40, 80),
       );
       final FocusNode startFocusNode = startFocusNodeOf(tester);
       startFocusNode.requestFocus();
@@ -2861,7 +2865,7 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pumpAndSettle();
       expect(
-        values(),
+        valuesOf(sliderKey),
         const RangeValues(40, 80),
         reason: 'editing mode should be reset after the slider lost focus',
       );
@@ -2870,9 +2874,12 @@ void main() {
     testWidgets('arrow keys change the value directly in traditional navigation mode', (
       WidgetTester tester,
     ) async {
-      final ValueGetter<RangeValues> values = await buildFrame(
+      final GlobalKey sliderKey = GlobalKey();
+      await pumpRangeSlider(
         tester,
         navigationMode: NavigationMode.traditional,
+        sliderKey: sliderKey,
+        initialValues: const RangeValues(40, 80),
       );
       startFocusNodeOf(tester).requestFocus();
       await tester.pumpAndSettle();
@@ -2880,8 +2887,8 @@ void main() {
       // No need to enter an editing mode in traditional navigation.
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pumpAndSettle();
-      expect(values().start, greaterThan(40));
-      expect(values().end, 80);
+      expect(valuesOf(sliderKey).start, greaterThan(40));
+      expect(valuesOf(sliderKey).end, 80);
     });
   });
 


### PR DESCRIPTION


This PR implements the alternative input method for `RangeSlider` in `NavigationMode.directional` that was discussed in #181968, following the UX pattern @chunhtai and the Material team suggested there: in directional mode the arrow keys only move focus, pressing **Enter** on a focused thumb enters a value-adjustment mode where Left/Right adjust the value, and pressing **Enter** again (or losing focus) exits it. Traditional navigation is unchanged. I've added a dedicated test group covering each of these cases.

**Dependency / sequencing note:** This builds directly on top of the keyboard support added in #181525, which is currently a draft held behind the Material/Cupertino code freeze (#184093). Because that work isn't in `master` yet, I'd appreciate guidance on how you'd like to sequence this — e.g. rebasing this onto #181525's branch as a stacked PR, or holding it until #181525 (or its post-decoupling port) lands. Happy to adjust the base or re-target to the new package once the decoupling path is settled.

Fixes #181968

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
