### PR TITLE
Exclude fuchsia-sdk/sdk/.build-id from the builder cache archive

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -81,6 +81,10 @@ targets:
           "builder",
           "git"
         ]
+      ignore_cache_paths: >-
+        [
+          "builder/engine/src/third_party/fuchsia-sdk/sdk/.build-id"
+        ]
       gclient_variables: >-
         {
           "download_emsdk": "true",
@@ -100,6 +104,10 @@ targets:
         [
           "builder",
           "git"
+        ]
+      ignore_cache_paths: >-
+        [
+          "builder/engine/src/third_party/fuchsia-sdk/sdk/.build-id"
         ]
       gclient_variables: >-
         {
@@ -122,6 +130,7 @@ targets:
         ]
       ignore_cache_paths: >-
         [
+          "builder/engine/src/third_party/fuchsia-sdk/sdk/.build-id",
           "builder/src/flutter/prebuilts/SDKs",
           "builder/src/flutter/prebuilts/Library"
         ]


### PR DESCRIPTION
The .build-id directory is created by the Fuchsia gen_build_defs.py script which is run during gclient sync.  It contains links to Fuchsia SDK binaries in a directory structure that indexes the binaries by their hashes.

The builder cache updater creates an archive of the source tree and its dependencies.  This archive does not need to include the .build-id tree.  Any necessary parts of .build-id will be written when each CI builder does its own local run of gclient sync.

Currently the gen_build_defs.py script does not delete any of the contents of .build-id when it updates .build-id for the current Fuchsia SDK.  That means that .build-id will continue to grow each time the tree syncs to a new Fuchsia SDK, and all of these files were being added to the builder cache archive.  In a recent sample of the builder cache, .build-id files were nearly 80% of the archive's contents.