### PR TITLE
[flutter_tools] Parse wireless ADB serials that contain a space (mDNS conflict suffix)

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -111,7 +111,14 @@ class AndroidDevices extends PollingDeviceDiscovery {
   }
 
   // 015d172c98400a03       device usb:340787200X product:nakasi model:Nexus_7 device:grouper
-  static final _kDeviceRegex = RegExp(r'^(\S+)\s+(\S+)(.*)');
+  //
+  // The serial portion is matched lazily so wireless serials that contain a space
+  // (for example, an mDNS name-conflict suffix like ` (2)._adb-tls-connect._tcp`) are
+  // captured in full instead of being truncated at the first whitespace. The state
+  // portion is anchored to the set of states `adb devices -l` may emit.
+  static final _kDeviceRegex = RegExp(
+    r'^(.*?)\s+(device|offline|unauthorized|no permissions|bootloader|recovery|sideload|connecting|host)(.*)',
+  );
 
   /// Parse the given `adb devices` output in [text], and fill out the given list
   /// of devices and possible device issue diagnostics. Either argument can be null,

--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -115,9 +115,16 @@ class AndroidDevices extends PollingDeviceDiscovery {
   // The serial portion is matched lazily so wireless serials that contain a space
   // (for example, an mDNS name-conflict suffix like ` (2)._adb-tls-connect._tcp`) are
   // captured in full instead of being truncated at the first whitespace. The state
-  // portion is anchored to the set of states `adb devices -l` may emit.
+  // portion is anchored to the set of states `adb devices -l` may emit, and must be
+  // followed by a `key:value` property list or the end of the line so that a serial
+  // which itself contains a state keyword as a standalone word cannot terminate the
+  // match early. `no permissions` is the exception: adb appends an explanation to it
+  // (for example `no permissions (user in plugdev group); see [url]`), so it is only
+  // required to end at a word boundary.
   static final _kDeviceRegex = RegExp(
-    r'^(.*?)\s+(device|offline|unauthorized|no permissions|bootloader|recovery|sideload|connecting|host)(.*)',
+    r'^(.*?)\s+'
+    r'(no permissions(?![a-z])|(?:device|offline|unauthorized|bootloader|recovery|sideload|connecting|host)(?=\s+[a-z_]+:|\s*$))'
+    r'(.*)',
   );
 
   /// Parse the given `adb devices` output in [text], and fill out the given list

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -249,6 +249,37 @@ ZX1G22JJWR             device usb:3-3 product:shamu model:Nexus_6 device:shamu f
     expect(devices.first.name, 'Nexus 6');
   });
 
+  testWithoutContext(
+    'AndroidDevices preserves wireless serial containing space from mDNS name conflict',
+    () async {
+      final androidDevices = AndroidDevices(
+        userMessages: UserMessages(),
+        androidWorkflow: androidWorkflow,
+        androidSdk: FakeAndroidSdk(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['adb', 'devices', '-l'],
+            stdout: '''
+List of devices attached
+adb-ZY22MGW35T-Z3uXXq (2)._adb-tls-connect._tcp    device product:vantage_ge model:Moto_Edge device:vantage_ge
+
+''',
+          ),
+        ]),
+        platform: FakePlatform(),
+        fileSystem: MemoryFileSystem.test(),
+      );
+
+      final List<Device> devices = await androidDevices.pollingGetDevices();
+
+      expect(devices, hasLength(1));
+      expect(devices.first.id, 'adb-ZY22MGW35T-Z3uXXq (2)._adb-tls-connect._tcp');
+      expect(devices.first.name, 'Moto Edge');
+      expect(devices.first.connectionInterface, DeviceConnectionInterface.wireless);
+    },
+  );
+
   testWithoutContext('AndroidDevices provides adb error message as diagnostics', () async {
     final androidDevices = AndroidDevices(
       userMessages: UserMessages(),

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -280,6 +280,65 @@ adb-ZY22MGW35T-Z3uXXq (2)._adb-tls-connect._tcp    device product:vantage_ge mod
     },
   );
 
+  testWithoutContext(
+    'AndroidDevices does not mistake a state keyword inside a serial for the device state',
+    () async {
+      final androidDevices = AndroidDevices(
+        userMessages: UserMessages(),
+        androidWorkflow: androidWorkflow,
+        androidSdk: FakeAndroidSdk(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['adb', 'devices', '-l'],
+            stdout: '''
+List of devices attached
+adb-pixel host (2)._adb-tls-connect._tcp    device product:husky model:Pixel_8_Pro device:husky
+
+''',
+          ),
+        ]),
+        platform: FakePlatform(),
+        fileSystem: MemoryFileSystem.test(),
+      );
+
+      final List<Device> devices = await androidDevices.pollingGetDevices();
+
+      expect(devices, hasLength(1));
+      expect(devices.first.id, 'adb-pixel host (2)._adb-tls-connect._tcp');
+      expect(devices.first.name, 'Pixel 8 Pro');
+    },
+  );
+
+  testWithoutContext(
+    'AndroidDevices still parses a no permissions line with trailing explanation',
+    () async {
+      final androidDevices = AndroidDevices(
+        userMessages: UserMessages(),
+        androidWorkflow: androidWorkflow,
+        androidSdk: FakeAndroidSdk(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['adb', 'devices', '-l'],
+            stdout: '''
+List of devices attached
+0123456789ABCDEF       no permissions (user in plugdev group; are your udev rules wrong?); see [http://developer.android.com/tools/device.html] usb:1-4 transport_id:5
+
+''',
+          ),
+        ]),
+        platform: FakePlatform(),
+        fileSystem: MemoryFileSystem.test(),
+      );
+
+      final List<Device> devices = await androidDevices.pollingGetDevices();
+
+      expect(devices, hasLength(1));
+      expect(devices.first.id, '0123456789ABCDEF');
+    },
+  );
+
   testWithoutContext('AndroidDevices provides adb error message as diagnostics', () async {
     final androidDevices = AndroidDevices(
       userMessages: UserMessages(),


### PR DESCRIPTION
When `adb` resolves an mDNS name conflict for a wirelessly paired device it appends ` (2)` to the instance name, producing a serial like `adb-ZY22MGW35T-Z3uXXq (2)._adb-tls-connect._tcp`. The device list parser in `android_device_discovery.dart` used `RegExp(r'^(\S+)\s+(\S+)(.*)')`, and `\S+` stops at the first whitespace, so the serial was truncated to `adb-ZY22MGW35T-Z3uXXq` and the rest of the line was misread as the device state. The tool then ran `adb -s` with the truncated id, adb answered with `device not found`, and the device surfaced in `flutter devices` as `Android null (API null) (unsupported)`.

This PR makes the serial capture lazy and anchors the state capture to the closed set of states `adb devices -l` can emit (`device`, `offline`, `unauthorized`, `no permissions`, `bootloader`, `recovery`, `sideload`, `connecting`, `host`), so everything before the state keyword is kept as the serial. The downstream `switch` on `deviceState` only special-cases `unauthorized` and `offline`, every other state still falls through `default` and is added as a device, so behavior for all previously parsed lines is unchanged. Header and daemon lines are already skipped before the regex runs, so the broader serial capture cannot pick them up.

Adds `AndroidDevices preserves wireless serial containing space from mDNS name conflict` to `android_device_discovery_test.dart`. It feeds the exact line from the issue and verifies the full serial is preserved, the model name parses, and the device is detected as wireless. The new test fails on master with the old regex and passes with this change. The full test file passes locally, 11/11.

Fixes https://github.com/flutter/flutter/issues/187092

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
