### PR TITLE
Fix TabBarView ignoring explicit duration passed to animateTo

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -117,6 +117,7 @@ class TabController extends ChangeNotifier {
        _index = initialIndex,
        _previousIndex = initialIndex,
        _animationDuration = animationDuration ?? kTabScrollDuration,
+       _currentAnimationDuration = animationDuration ?? kTabScrollDuration,
        _animationController = AnimationController.unbounded(
          value: initialIndex.toDouble(),
          vsync: vsync,
@@ -137,7 +138,8 @@ class TabController extends ChangeNotifier {
   }) : _index = index,
        _previousIndex = previousIndex,
        _animationController = animationController,
-       _animationDuration = animationDuration {
+       _animationDuration = animationDuration,
+       _currentAnimationDuration = animationDuration {
     if (kFlutterMemoryAllocationsEnabled) {
       ChangeNotifier.maybeDispatchObjectCreation(this);
     }
@@ -191,6 +193,13 @@ class TabController extends ChangeNotifier {
   /// Defaults to kTabScrollDuration.
   Duration get animationDuration => _animationDuration;
   final Duration _animationDuration;
+
+  /// The effective animation duration of the most recently initiated animation.
+  ///
+  /// Reflects the [duration] argument passed to [animateTo], if provided.
+  /// Falls back to [animationDuration] when no explicit duration was given.
+  Duration get currentAnimationDuration => _currentAnimationDuration;
+  Duration _currentAnimationDuration;
 
   /// The total number of tabs.
   ///
@@ -263,7 +272,8 @@ class TabController extends ChangeNotifier {
   /// While the animation is running [indexIsChanging] is true. When the
   /// animation completes [offset] will be 0.0.
   void animateTo(int value, {Duration? duration, Curve curve = Curves.ease}) {
-    _changeIndex(value, duration: duration ?? _animationDuration, curve: curve);
+    _currentAnimationDuration = duration ?? _animationDuration;
+    _changeIndex(value, duration: _currentAnimationDuration, curve: curve);
   }
 
   /// The difference between the [animation]'s value and [index].

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -2396,9 +2396,9 @@ class _TabBarViewState extends State<TabBarView> {
 
     final adjacentDestination = (_currentIndex! - _controller!.previousIndex).abs() == 1;
     if (adjacentDestination) {
-      _warpToAdjacentTab(_controller!.animationDuration);
+      _warpToAdjacentTab(_controller!.currentAnimationDuration);
     } else {
-      _warpToNonAdjacentTab(_controller!.animationDuration);
+      _warpToNonAdjacentTab(_controller!.currentAnimationDuration);
     }
   }
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1827,7 +1827,11 @@ class _TabBarState extends State<TabBar> {
   void _scrollToCurrentIndex() {
     final double offset = _tabCenteredScrollOffset(_currentIndex!);
 
-    _effectiveScrollController.animateTo(offset, duration: kTabScrollDuration, curve: Curves.ease);
+    _effectiveScrollController.animateTo(
+      offset,
+      duration: _controller!.currentAnimationDuration,
+      curve: Curves.ease,
+    );
   }
 
   void _scrollToControllerValue() {

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1733,6 +1733,65 @@ void main() {
     expect(position.pixels, 800);
   });
 
+  testWidgets('TabBarView uses explicit duration passed to animateTo', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/187373.
+    // TabBarView must use the duration from animateTo(), not the controller's
+    // default animationDuration, when the two differ.
+    const Duration defaultDuration = Duration(milliseconds: 100);
+    const Duration customDuration = Duration(milliseconds: 500);
+    final List<String> tabs = <String>['A', 'B', 'C'];
+
+    final TabController tabController = createTabController(
+      vsync: const TestVSync(),
+      initialIndex: 0,
+      length: tabs.length,
+      animationDuration: defaultDuration,
+    );
+    await tester.pumpWidget(
+      boilerplate(
+        child: Column(
+          children: <Widget>[
+            TabBar(
+              tabs: tabs.map<Widget>((String tab) => Tab(text: tab)).toList(),
+              controller: tabController,
+            ),
+            SizedBox.square(
+              dimension: 400.0,
+              child: TabBarView(
+                controller: tabController,
+                children: const <Widget>[
+                  Center(child: Text('0')),
+                  Center(child: Text('1')),
+                  Center(child: Text('2')),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final PageView pageView = tester.widget(find.byType(PageView));
+    final PageController pageController = pageView.controller!;
+    final ScrollPosition position = pageController.position;
+
+    // Page 0 is at offset 0.0, page 1 at 400.0, page 2 at 800.0.
+    expect(position.pixels, 0.0);
+
+    tabController.animateTo(1, duration: customDuration);
+    await tester.pump();
+
+    // After the default duration the scroll must NOT be complete — it should
+    // still be mid-animation because the custom duration is 5× longer.
+    await tester.pump(defaultDuration);
+    expect(position.pixels, greaterThan(0.0));
+    expect(position.pixels, lessThan(400.0));
+
+    // After the full custom duration the animation is complete.
+    await tester.pump(customDuration);
+    expect(position.pixels, 400.0);
+  });
+
   testWidgets('TabBarView animation can be interrupted', (WidgetTester tester) async {
     const animationDuration = Duration(seconds: 2);
     final tabs = <String>['A', 'B', 'C'];


### PR DESCRIPTION
## Description

\`TabController.animateTo()\` accepts an optional \`duration\` argument for a custom animation speed, but \`TabBarView\` was silently ignoring it — always using the controller's constructor-set \`animationDuration\` default. Only the TabBar indicator respected the custom duration; the page scroll did not.

Fixes #187373.

### Root cause

\`_TabBarViewState._warpToCurrentIndex()\` read \`_controller!.animationDuration\`, which is a \`final\` field set at construction time. The \`duration\` argument passed to \`animateTo()\` was never stored anywhere that \`_TabBarViewState\` could read.

### Fix

- Add a mutable \`_currentAnimationDuration\` field to \`TabController\`, initialised to \`animationDuration\`.
- Update \`animateTo()\` to set \`_currentAnimationDuration = duration ?? _animationDuration\` before delegating to \`_changeIndex\`.
- Expose it via a new public getter \`currentAnimationDuration\`.
- Change \`_warpToCurrentIndex()\` to read \`currentAnimationDuration\` instead of \`animationDuration\`.

This keeps \`animationDuration\` semantically unchanged (the configured default), while \`currentAnimationDuration\` always reflects the effective duration of the most recently initiated animation.

## Tests

Added \`'TabBarView uses explicit duration passed to animateTo'\` in \`tabs_test.dart\`. The test creates a controller with a 100 ms default, calls \`animateTo(duration: 500ms)\`, and asserts that the scroll is still incomplete after 100 ms but finishes exactly at 500 ms.

All 201 tests in \`tabs_test.dart\` and all tests in \`tab_controller_test.dart\` pass.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with \`///\`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md