### PR TITLE
[beta] Print trace when skipping flavor-specific and platform-specific assets

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1104,7 +1104,7 @@ class ManifestAssetBundle implements AssetBundle {
 
     result.removeWhere((_Asset asset, List<_Asset> variants) {
       if (!asset.matchesFlavor(flavor)) {
-        _logger.printWarning(
+        _logger.printTrace(
           'Skipping assets entry "${asset.entryUri.path}" since '
           'its configured flavor(s) did not match the provided flavor (if any).\n'
           'Configured flavors: ${asset.flavors.join(', ')}\n',
@@ -1112,7 +1112,7 @@ class ManifestAssetBundle implements AssetBundle {
         return true;
       }
       if (!asset.matchesPlatform(targetPlatform)) {
-        _logger.printWarning(
+        _logger.printTrace(
           'Skipping assets entry "${asset.entryUri.path}" since '
           'its configured platform(s) did not match the target platform.\n'
           'Configured platforms: ${asset.platforms.join(', ')}\n'

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -32,12 +32,13 @@ void main() {
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
+    logger = BufferLogger.test();
     environment = Environment.test(
       fileSystem.currentDirectory,
       processManager: FakeProcessManager.any(),
       artifacts: Artifacts.test(),
       fileSystem: fileSystem,
-      logger: BufferLogger.test(),
+      logger: logger,
       platform: FakePlatform(),
       defines: <String, String>{kBuildMode: BuildMode.debug.cliName},
     );
@@ -60,7 +61,6 @@ flutter:
     - assets/foo/bar.png
     - assets/wildcard/
 ''');
-    logger = BufferLogger.test();
   });
 
   testUsingContext(
@@ -166,6 +166,18 @@ flutter:
             ),
             isNot(exists),
           );
+          expect(
+            logger.traceText,
+            contains('Skipping assets entry "assets/vanilla/ice-cream.png"'),
+          );
+          expect(
+            logger.traceText,
+            contains('Skipping assets entry "assets/strawberry/ice-cream.png"'),
+          );
+          expect(
+            logger.traceText,
+            isNot(contains('Skipping assets entry "assets/common/image.png"')),
+          );
         },
         overrides: <Type, Generator>{
           FileSystem: () => fileSystem,
@@ -214,6 +226,14 @@ flutter:
               '${environment.buildDir.path}/flutter_assets/assets/strawberry/ice-cream.png',
             ),
             exists,
+          );
+          expect(
+            logger.traceText,
+            contains('Skipping assets entry "assets/vanilla/ice-cream.png"'),
+          );
+          expect(
+            logger.traceText,
+            isNot(contains('Skipping assets entry "assets/strawberry/ice-cream.png"')),
           );
         },
         overrides: <Type, Generator>{
@@ -834,6 +854,7 @@ flutter:
               isFalse,
               reason: 'Expected asset for $platform to be skipped when target is $targetPlatform',
             );
+            expect(logger.traceText, contains('Skipping assets entry "assets/test-$platform.txt"'));
           },
           overrides: <Type, Generator>{
             FileSystem: () => fileSystem,


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
https://github.com/flutter/flutter/issues/186738

### Impact Description:
Starting in Flutter 3.44, building a flavored app (Android/iOS) emits a noisy warning for every single asset file that is skipped because it belongs to a different flavor. For projects with many flavor-specific assets, this floods the build console with hundreds of non-actionable warnings, cluttering the build output and making it harder to see real warnings or errors.

### Changelog Description:
[flutter/186738] Demote flavor/platform asset skipping messages from warning to trace level to reduce build log noise.

### Workaround:
None, other than ignoring the warnings in the build output.

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
1. Declare multi-flavor asset directories in `pubspec.yaml`.
2. Place files inside these directories.
3. Build a single flavor (e.g., `flutter build apk --flavor <flavor>`).
4. Verify that the console does not output "Skipping assets entry..." warnings for non-active flavors at default verbosity.
5. Verify that these messages still appear when running with verbose logging (`-v`).