### PR TITLE
[stable] Allow selecting multi-digit device options

### DIFF
--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -8,6 +8,7 @@ import 'io.dart' as io;
 import 'logger.dart';
 import 'platform.dart';
 import 'process.dart';
+import 'utils.dart';
 
 enum TerminalColor { red, green, blue, cyan, yellow, magenta, grey }
 
@@ -128,6 +129,11 @@ abstract class Terminal {
   ///
   /// Useful when the console is in [singleCharMode].
   Stream<String> get keystrokes;
+
+  /// Reads a full line from the console.
+  ///
+  /// Useful when the console is not in [singleCharMode].
+  Future<String> readLine();
 
   /// Prompts the user to input a character within a given list. Re-prompts if
   /// entered character is not in the list.
@@ -360,6 +366,16 @@ class AnsiTerminal implements Terminal {
         .asBroadcastStream();
   }
 
+  Stream<String>? _broadcastStdInLines;
+
+  @override
+  Future<String> readLine() {
+    return (_broadcastStdInLines ??= _stdio.stdin
+            .transform<String>(utf8AllowMalformedLineDecoder)
+            .asBroadcastStream())
+        .first;
+  }
+
   @override
   Future<String> promptForCharInput(
     List<String> acceptedCharacters, {
@@ -419,6 +435,11 @@ class _TestTerminal implements Terminal {
 
   @override
   Stream<String> get keystrokes => const Stream<String>.empty();
+
+  @override
+  Future<String> readLine() {
+    throw UnsupportedError('readLine not supported in the test terminal.');
+  }
 
   @override
   Future<String> promptForCharInput(

--- a/packages/flutter_tools/lib/src/runner/target_devices.dart
+++ b/packages/flutter_tools/lib/src/runner/target_devices.dart
@@ -359,6 +359,13 @@ class TargetDevices {
   }
 
   Future<String> _readUserInput(int deviceCount) async {
+    if (deviceCount >= 10) {
+      return _readDeviceChoiceLine(
+        terminal: globals.terminal,
+        logger: _logger,
+        deviceCount: deviceCount,
+      );
+    }
     globals.terminal.usesTerminalUi = true;
     final String result = await globals.terminal.promptForCharInput(
       <String>[for (int i = 0; i < deviceCount; i++) '${i + 1}', 'q', 'Q'],
@@ -787,6 +794,16 @@ class TargetDeviceSelection {
   /// Only allow input of a number or `q`.
   @visibleForTesting
   Future<String> readUserInput() async {
+    if (devices.length >= 10) {
+      return _readDeviceChoiceLine(
+        terminal: globals.terminal,
+        logger: _logger,
+        deviceCount: devices.length,
+        onInvalidInput: () {
+          invalidAttempts++;
+        },
+      );
+    }
     final pattern = RegExp(r'\d+$|q', caseSensitive: false);
     String? choice;
     globals.terminal.singleCharMode = true;
@@ -801,4 +818,32 @@ class TargetDeviceSelection {
     globals.terminal.singleCharMode = false;
     return choice;
   }
+}
+
+Future<String> _readDeviceChoiceLine({
+  required Terminal terminal,
+  required Logger logger,
+  required int deviceCount,
+  void Function()? onInvalidInput,
+}) async {
+  while (true) {
+    logger.printStatus(_chooseOneMessage, emphasis: true, newline: false);
+    logger.printStatus(': ', emphasis: true, newline: false);
+    final String choice = (await terminal.readLine()).trim();
+    if (_isValidDeviceChoice(choice, deviceCount)) {
+      return choice;
+    }
+    onInvalidInput?.call();
+  }
+}
+
+bool _isValidDeviceChoice(String? choice, int deviceCount) {
+  if (choice == null) {
+    return false;
+  }
+  if (choice.toLowerCase() == 'q') {
+    return true;
+  }
+  final int? deviceNumber = int.tryParse(choice);
+  return deviceNumber != null && deviceNumber >= 1 && deviceNumber <= deviceCount;
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
@@ -204,6 +204,9 @@ class FakeTerminal implements Terminal {
   Stream<String> get keystrokes => terminal.keystrokes;
 
   @override
+  Future<String> readLine() => terminal.readLine();
+
+  @override
   Future<String> promptForCharInput(
     List<String> acceptedCharacters, {
     required Logger logger,

--- a/packages/flutter_tools/test/general.shard/base/terminal_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/terminal_test.dart
@@ -231,6 +231,16 @@ void main() {
       expect(bufferLogger.statusText, 'Please choose something: \n');
     });
 
+    testWithoutContext('line input prompt', () async {
+      final stdio = FakeStdio()
+        .._stdin = Stream<List<int>>.fromIterable(<List<int>>[
+          <int>[49, 49, 10], // 11\n
+        ]);
+      terminalUnderTest = AnsiTerminal(stdio: stdio, platform: const LocalPlatform());
+
+      expect(await terminalUnderTest.readLine(), '11');
+    });
+
     testWithoutContext('Does not set single char mode when a terminal is not attached', () {
       final Stdio stdio = FakeStdio()..stdinHasTerminal = false;
       final ansiTerminal = AnsiTerminal(stdio: stdio, platform: const LocalPlatform());

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -706,6 +706,27 @@ target-device-2 (mobile) • xxx • android • Android 10
             expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
           }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
+          testUsingContext('can select the eleventh attached device', () async {
+            final attachedDevices = List<Device>.generate(
+              11,
+              (int index) =>
+                  FakeDevice(deviceId: 'id-${index + 1}', deviceName: 'target-device-${index + 1}'),
+            );
+            deviceManager.androidDiscoverer.deviceList = attachedDevices;
+            terminal.addInputLine('11');
+
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(devices, <Device>[attachedDevices[10]]);
+            expect(logger.statusText, contains('[11]: target-device-11 (id-11)'));
+            expect(logger.statusText, contains('Please choose one (or "q" to quit): '));
+            expect(logger.statusText, isNot(contains('Please choose one (or "q" to quit): 11')));
+            expect(terminal.singleCharMode, isFalse);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
+
           testUsingContext('including only wireless devices', () async {
             deviceManager.androidDiscoverer.deviceList = <Device>[
               wirelessAndroidDevice1,
@@ -3354,6 +3375,19 @@ class FakeTerminal extends Fake implements AnsiTerminal {
 
   List<String>? _nextPrompt;
   late String _nextResult;
+  final List<String> _inputLines = <String>[];
+
+  void addInputLine(String line) {
+    _inputLines.add(line);
+  }
+
+  @override
+  Stream<String> get keystrokes => const Stream<String>.empty();
+
+  @override
+  Future<String> readLine() async {
+    return _inputLines.removeAt(0);
+  }
 
   @override
   Future<String> promptForCharInput(


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
https://github.com/flutter/flutter/issues/186182

### Impact Description:
When 10 or more target devices are available, the interactive `flutter run` prompt only accepted a single character. This made it impossible to select devices `[10]`, `[11]`, etc., because pressing `1` immediately selected device `[1]`. This fix allows selecting multi-digit device options by switching to line input when 10 or more devices are available.

### Changelog Description:
[flutter/186182] When 10 or more devices are available, allow selecting multi-digit device options in the interactive prompt.

### Workaround:
Disconnect devices until there are fewer than 10, or use the `-d` flag to specify the device ID directly.

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
1. Connect 10 or more devices (or mock them).
2. Run `flutter run` without specifying a device.
3. Verify that you can type a multi-digit number (e.g., `10`) and press Enter to select it.
