### PR TITLE
Add FlatBuffers Verifier checks to Impeller asset loading

### DIFF
--- a/engine/src/flutter/impeller/runtime_stage/runtime_stage.cc
+++ b/engine/src/flutter/impeller/runtime_stage/runtime_stage.cc
@@ -183,6 +183,12 @@ absl::StatusOr<RuntimeStage::Map> RuntimeStage::DecodeRuntimeStages(
         "Payload does not have valid identifier.");
   }
 
+  flatbuffers::Verifier verifier(payload->GetMapping(), payload->GetSize());
+  if (!fb::VerifyRuntimeStagesBuffer(verifier)) {
+    return absl::InvalidArgumentError(
+        "Runtime stages buffer failed verification.");
+  }
+
   auto raw_stages = fb::GetRuntimeStages(payload->GetMapping());
   if (!raw_stages) {
     return absl::InvalidArgumentError("Failed to get runtime stages.");

--- a/engine/src/flutter/impeller/runtime_stage/runtime_stage_unittests.cc
+++ b/engine/src/flutter/impeller/runtime_stage/runtime_stage_unittests.cc
@@ -72,6 +72,27 @@ TEST_P(RuntimeStageTest, CanRejectInvalidBlob) {
   ASSERT_FALSE(stages.ok());
 }
 
+TEST_P(RuntimeStageTest, RejectsCorruptBufferWithValidIdentifier) {
+  ScopedValidationDisable disable_validation;
+  // Construct a buffer with a valid "IPLR" file identifier at bytes 4-7
+  // but a root table offset that points beyond the buffer. This passes
+  // the identifier check but fails FlatBuffer structural verification.
+  auto data = std::make_shared<std::vector<uint8_t>>(32, 0);
+  (*data)[4] = 'I';
+  (*data)[5] = 'P';
+  (*data)[6] = 'L';
+  (*data)[7] = 'R';
+  // Root offset (little-endian uint32 at offset 0) pointing out of bounds.
+  (*data)[0] = 0xFF;
+  (*data)[1] = 0xFF;
+
+  auto mapping = std::make_shared<fml::NonOwnedMapping>(
+      data->data(), data->size(), [data](auto, auto) {});
+  auto stages = RuntimeStage::DecodeRuntimeStages(mapping);
+  ASSERT_FALSE(stages.ok());
+  EXPECT_EQ(stages.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
 TEST_P(RuntimeStageTest, CanReadUniforms) {
   const std::shared_ptr<fml::Mapping> fixture =
       flutter::testing::OpenFixtureAsMapping(

--- a/engine/src/flutter/impeller/shader_archive/shader_archive.cc
+++ b/engine/src/flutter/impeller/shader_archive/shader_archive.cc
@@ -36,6 +36,12 @@ absl::StatusOr<ShaderArchive> ShaderArchive::Create(
     return absl::InvalidArgumentError("Invalid shader magic.");
   }
 
+  flatbuffers::Verifier verifier(payload->GetMapping(), payload->GetSize());
+  if (!fb::VerifyShaderArchiveBuffer(verifier)) {
+    return absl::InvalidArgumentError(
+        "Shader archive buffer failed verification.");
+  }
+
   auto shader_archive = fb::GetShaderArchive(payload->GetMapping());
   if (!shader_archive) {
     return absl::InvalidArgumentError("Could not read shader archive.");

--- a/engine/src/flutter/impeller/shader_archive/shader_archive_unittests.cc
+++ b/engine/src/flutter/impeller/shader_archive/shader_archive_unittests.cc
@@ -4,6 +4,7 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "flutter/fml/mapping.h"
 #include "flutter/testing/testing.h"
@@ -75,6 +76,26 @@ TEST(ShaderArchiveTest, ReturnsErrorOnInvalidVersion) {
          << static_cast<uint32_t>(fb::ShaderArchiveFormatVersion::kVersion)
          << ", Got: 4294967295";
   ASSERT_EQ(library.status().message(), stream.str());
+}
+
+TEST(ShaderArchiveTest, RejectsCorruptBufferWithValidIdentifier) {
+  // Construct a buffer with a valid "SHAR" file identifier at bytes 4-7
+  // but a root table offset that points beyond the buffer. This passes
+  // the identifier check but fails FlatBuffer structural verification.
+  auto data = std::make_shared<std::vector<uint8_t>>(32, 0);
+  (*data)[4] = 'S';
+  (*data)[5] = 'H';
+  (*data)[6] = 'A';
+  (*data)[7] = 'R';
+  // Root offset (little-endian uint32 at offset 0) pointing out of bounds.
+  (*data)[0] = 0xFF;
+  (*data)[1] = 0xFF;
+
+  auto mapping = std::make_shared<fml::NonOwnedMapping>(
+      data->data(), data->size(), [data](auto, auto) {});
+  auto archive = ShaderArchive::Create(mapping);
+  ASSERT_FALSE(archive.ok());
+  EXPECT_EQ(archive.status().code(), absl::StatusCode::kInvalidArgument);
 }
 
 }  // namespace testing


### PR DESCRIPTION
## Summary
- Add `flatbuffers::Verifier` validation to `RuntimeStage::DecodeRuntimeStages()` and `ShaderArchive::Create()` before accessing FlatBuffer contents
- Both functions already check the file identifier (`RuntimeStagesBufferHasIdentifier` / `ShaderArchiveBufferHasIdentifier`) but skip the structural verification step, meaning malformed `.iplr` or `.shar` payloads can cause out-of-bounds reads when FlatBuffer accessors follow corrupted offsets

## Context

The FlatBuffers library provides a `Verifier` class specifically for validating buffer integrity before access. The Impeller runtime stage and shader archive loaders currently skip this step. Adding it ensures that structurally invalid buffers are rejected with a clear error before any field is dereferenced.

## Test plan
- [ ] Existing `RuntimeStageTest::CanRejectInvalidBlob` continues to pass (already fills buffer with junk bytes — now rejected at the Verifier step rather than at later field access)
- [ ] Existing `RuntimeStageTest::CanReadValidBlob` and shader archive tests remain green (valid buffers pass verification)
- [ ] Manually verified that a truncated `.iplr` file is rejected with "buffer failed verification" rather than crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)