### PR TITLE
Add recursion depth limit to StandardCodecSerializer::ReadValue

### DIFF
--- a/engine/src/flutter/shell/platform/common/client_wrapper/standard_codec.cc
+++ b/engine/src/flutter/shell/platform/common/client_wrapper/standard_codec.cc
@@ -25,6 +25,22 @@ namespace flutter {
 
 namespace {
 
+// Maximum nesting depth for ReadValue deserialization. Prevents stack
+// overflow from deeply nested or crafted messages received over platform
+// channels. 128 levels is far beyond any legitimate message depth while
+// staying well within typical stack limits.
+constexpr int kMaxReadDepth = 128;
+
+thread_local int g_read_depth = 0;
+
+// RAII guard that increments g_read_depth on construction and decrements
+// on destruction, ensuring correct bookkeeping even if an exception or
+// early return interrupts deserialization.
+struct ReadDepthGuard {
+  ReadDepthGuard() { ++g_read_depth; }
+  ~ReadDepthGuard() { --g_read_depth; }
+};
+
 // The order/values here must match the constants in message_codecs.dart.
 enum class EncodedType {
   kNull = 0,
@@ -91,6 +107,11 @@ const StandardCodecSerializer& StandardCodecSerializer::GetInstance() {
 
 EncodableValue StandardCodecSerializer::ReadValue(
     ByteStreamReader* stream) const {
+  ReadDepthGuard depth_guard;
+  if (g_read_depth > kMaxReadDepth) {
+    std::cerr << "StandardCodecSerializer: maximum nesting depth exceeded\n";
+    return EncodableValue();
+  }
   uint8_t type = stream->ReadByte();
   return ReadValueOfType(type, stream);
 }

--- a/engine/src/flutter/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
@@ -262,4 +262,22 @@ TEST(StandardMessageCodec, CanEncodeAndDecodeVariableLengthCustomType) {
                     some_data_comparator);
 }
 
+TEST(StandardMessageCodec, DepthLimitPreventsStackOverflow) {
+  // Construct a message with 200 nested lists, exceeding the depth limit.
+  // Each nesting level is encoded as: 0x0c (kList) + 0x01 (length = 1).
+  const int kNestingDepth = 200;
+  std::vector<uint8_t> bytes;
+  for (int i = 0; i < kNestingDepth; ++i) {
+    bytes.push_back(0x0c);  // kList
+    bytes.push_back(0x01);  // length = 1
+  }
+  bytes.push_back(0x00);  // kNull at the innermost level
+
+  const StandardMessageCodec& codec = StandardMessageCodec::GetInstance();
+  // Must not crash. The depth limit truncates deserialization instead of
+  // overflowing the call stack.
+  auto decoded = codec.DecodeMessage(bytes);
+  ASSERT_NE(decoded, nullptr);
+}
+
 }  // namespace flutter


### PR DESCRIPTION
## Summary
- Add a thread-local recursion depth limit (128) to `StandardCodecSerializer::ReadValue()` to prevent stack overflow from deeply nested platform channel messages
- `ReadValue` and `ReadValueOfType` form a mutually recursive loop when deserializing nested lists (`kList`) and maps (`kMap`); a crafted message with sufficient nesting depth exhausts the call stack and crashes the engine
- No header or ABI changes: `ReadValue` is non-virtual so only the `.cc` implementation is modified; the virtual `ReadValueOfType` signature is unchanged

## Context

The standard message codec is used for all platform channel communication in Flutter. Messages are deserialized without any depth bound on nested containers. A message containing ~10K nested lists (each encoded as a single byte type tag + single byte length) is only ~20KB but causes a stack overflow crash.

The fix uses a thread-local counter with an RAII guard. When depth exceeds 128, `ReadValue` returns a null `EncodableValue` instead of recursing further. 128 levels is far beyond any legitimate message depth.

## Test plan
- [ ] Existing `StandardMessageCodec` and `StandardMethodCodec` unit tests pass (normal messages are well under 128 depth)
- [ ] Manually verified that a message with 200 nested lists returns null at depth 128 instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)