### PR TITLE
Use Xcode's project minimum deployment target for SwiftPM generated package

### DIFF
--- a/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
@@ -115,13 +115,67 @@ class SwiftPackageManager {
     final pluginsPackage = SwiftPackage(
       manifest: project.flutterPluginSwiftPackageManifest,
       name: kFlutterGeneratedPluginSwiftPackageName,
-      platforms: <SwiftPackageSupportedPlatform>[platform.supportedPackagePlatform],
+      platforms: <SwiftPackageSupportedPlatform>[
+        _getSupportedPlatform(platform: platform, project: project),
+      ],
       products: <SwiftPackageProduct>[generatedProduct],
       dependencies: packageDependencies,
       targets: <SwiftPackageTarget>[generatedTarget],
       templateRenderer: _templateRenderer,
     );
     pluginsPackage.createSwiftPackage();
+  }
+
+  /// Returns the [SwiftPackageSupportedPlatform] for the given [platform] and [project].
+  ///
+  /// The FlutterGeneratedPluginSwiftPackage minimum deployment target should match the app's
+  /// minimum deployment target. However, the app's build settings are not available during
+  /// non-build Flutter commands (e.g. "flutter pub get"). This makes a best effort attempt to
+  /// determine the app's minimum deployment target by inspecting the Xcode pbxproj file. If the
+  /// app's minimum deployment target can't be determined, it falls back to the default supported
+  /// platform version. The version will be updated to the correct version during
+  /// [updateMinimumDeployment].
+  SwiftPackageSupportedPlatform _getSupportedPlatform({
+    required FlutterDarwinPlatform platform,
+    required XcodeBasedProject project,
+  }) {
+    if (!project.xcodeProjectInfoFile.existsSync()) {
+      return platform.supportedPackagePlatform;
+    }
+    final String contents = project.xcodeProjectInfoFile.readAsStringSync();
+    final String targetName = switch (platform) {
+      FlutterDarwinPlatform.ios => 'IPHONEOS_DEPLOYMENT_TARGET',
+      FlutterDarwinPlatform.macos => 'MACOSX_DEPLOYMENT_TARGET',
+    };
+
+    final int targetNameCount = targetName.allMatches(contents).length;
+    if (targetNameCount == 0) {
+      return platform.supportedPackagePlatform;
+    }
+
+    final regExp = RegExp('$targetName = ([\\d.]+);');
+    final Iterable<RegExpMatch> matches = regExp.allMatches(contents);
+    if (matches.length != targetNameCount) {
+      return platform.supportedPackagePlatform;
+    }
+
+    final String? firstVersionString = matches.first.group(1);
+    final Version? firstVersion = Version.parse(firstVersionString);
+    if (firstVersion == null || firstVersion < platform.supportedPackagePlatform.version) {
+      return platform.supportedPackagePlatform;
+    }
+
+    for (final match in matches) {
+      final Version? matchVersion = Version.parse(match.group(1));
+      if (matchVersion != firstVersion) {
+        return platform.supportedPackagePlatform;
+      }
+    }
+
+    return SwiftPackageSupportedPlatform(
+      platform: platform.swiftPackagePlatform,
+      version: firstVersion,
+    );
   }
 
   (List<SwiftPackagePackageDependency>, List<SwiftPackageTargetDependency>)

--- a/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
@@ -139,6 +139,159 @@ $_doubleIndent
           });
 
           testWithoutContext(
+            'generate and use project deployment target when all match and are valid',
+            () async {
+              final fs = MemoryFileSystem();
+              final processManager = FakeProcessManager.any();
+              final logger = BufferLogger.test();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+              project.xcodeProjectInfoFile.createSync(recursive: true);
+
+              final targetName = platform == FlutterDarwinPlatform.ios
+                  ? 'IPHONEOS_DEPLOYMENT_TARGET'
+                  : 'MACOSX_DEPLOYMENT_TARGET';
+              final version = platform == FlutterDarwinPlatform.ios ? '14.0' : '11.0';
+
+              project.xcodeProjectInfoFile.writeAsStringSync('''
+'		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };';
+        $targetName = $version;
+        $targetName = $version;
+''');
+
+              final spm = SwiftPackageManager(
+                fileSystem: fs,
+                templateRenderer: const MustacheTemplateRenderer(),
+                processUtils: ProcessUtils(processManager: processManager, logger: logger),
+                config: FakeConfig(),
+              );
+              await spm.generatePluginsSwiftPackage(<Plugin>[], platform, project);
+
+              final expectedPlatform = platform == FlutterDarwinPlatform.ios
+                  ? '.iOS("$version")'
+                  : '.macOS("$version")';
+              expect(project.flutterPluginSwiftPackageManifest.existsSync(), isTrue);
+              expect(
+                project.flutterPluginSwiftPackageManifest.readAsStringSync(),
+                contains(expectedPlatform),
+              );
+            },
+          );
+
+          testWithoutContext(
+            'fall back to default deployment target when versions do not all match',
+            () async {
+              final fs = MemoryFileSystem();
+              final processManager = FakeProcessManager.any();
+              final logger = BufferLogger.test();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+              project.xcodeProjectInfoFile.createSync(recursive: true);
+
+              final targetName = platform == FlutterDarwinPlatform.ios
+                  ? 'IPHONEOS_DEPLOYMENT_TARGET'
+                  : 'MACOSX_DEPLOYMENT_TARGET';
+
+              project.xcodeProjectInfoFile.writeAsStringSync('''
+'		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };';
+        $targetName = 14.0;
+        $targetName = 15.0;
+''');
+
+              final spm = SwiftPackageManager(
+                fileSystem: fs,
+                templateRenderer: const MustacheTemplateRenderer(),
+                processUtils: ProcessUtils(processManager: processManager, logger: logger),
+                config: FakeConfig(),
+              );
+              await spm.generatePluginsSwiftPackage(<Plugin>[], platform, project);
+
+              final defaultPlatform = platform == FlutterDarwinPlatform.ios
+                  ? '.iOS("13.0")'
+                  : '.macOS("10.15")';
+              expect(project.flutterPluginSwiftPackageManifest.existsSync(), isTrue);
+              expect(
+                project.flutterPluginSwiftPackageManifest.readAsStringSync(),
+                contains(defaultPlatform),
+              );
+            },
+          );
+
+          testWithoutContext(
+            'fall back to default deployment target when a usage is invalid or missing version',
+            () async {
+              final fs = MemoryFileSystem();
+              final processManager = FakeProcessManager.any();
+              final logger = BufferLogger.test();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+              project.xcodeProjectInfoFile.createSync(recursive: true);
+
+              final targetName = platform == FlutterDarwinPlatform.ios
+                  ? 'IPHONEOS_DEPLOYMENT_TARGET'
+                  : 'MACOSX_DEPLOYMENT_TARGET';
+
+              project.xcodeProjectInfoFile.writeAsStringSync('''
+'		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };';
+        $targetName = 14.0;
+        $targetName = \$(ANOTHER_VARIABLE);
+''');
+
+              final spm = SwiftPackageManager(
+                fileSystem: fs,
+                templateRenderer: const MustacheTemplateRenderer(),
+                processUtils: ProcessUtils(processManager: processManager, logger: logger),
+                config: FakeConfig(),
+              );
+              await spm.generatePluginsSwiftPackage(<Plugin>[], platform, project);
+
+              final defaultPlatform = platform == FlutterDarwinPlatform.ios
+                  ? '.iOS("13.0")'
+                  : '.macOS("10.15")';
+              expect(project.flutterPluginSwiftPackageManifest.existsSync(), isTrue);
+              expect(
+                project.flutterPluginSwiftPackageManifest.readAsStringSync(),
+                contains(defaultPlatform),
+              );
+            },
+          );
+
+          testWithoutContext(
+            'fall back to default deployment target when version is less than minimum supported',
+            () async {
+              final fs = MemoryFileSystem();
+              final processManager = FakeProcessManager.any();
+              final logger = BufferLogger.test();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+              project.xcodeProjectInfoFile.createSync(recursive: true);
+
+              final targetName = platform == FlutterDarwinPlatform.ios
+                  ? 'IPHONEOS_DEPLOYMENT_TARGET'
+                  : 'MACOSX_DEPLOYMENT_TARGET';
+              final version = platform == FlutterDarwinPlatform.ios ? '12.0' : '10.14';
+
+              project.xcodeProjectInfoFile.writeAsStringSync('''
+'		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };';
+        $targetName = $version;
+''');
+
+              final spm = SwiftPackageManager(
+                fileSystem: fs,
+                templateRenderer: const MustacheTemplateRenderer(),
+                processUtils: ProcessUtils(processManager: processManager, logger: logger),
+                config: FakeConfig(),
+              );
+              await spm.generatePluginsSwiftPackage(<Plugin>[], platform, project);
+
+              final defaultPlatform = platform == FlutterDarwinPlatform.ios
+                  ? '.iOS("13.0")'
+                  : '.macOS("10.15")';
+              expect(project.flutterPluginSwiftPackageManifest.existsSync(), isTrue);
+              expect(
+                project.flutterPluginSwiftPackageManifest.readAsStringSync(),
+                contains(defaultPlatform),
+              );
+            },
+          );
+
+          testWithoutContext(
             'generate if no dependencies, no Flutter dependency, and already migrated',
             () async {
               final fs = MemoryFileSystem();


### PR DESCRIPTION
During `flutter pub get`, you can't get the Xcode project's build settings because you're not doing a build. For example, you don't have flavor information. However, people have come to expect that `flutter pub get` generates all files needed to do a Flutter / xcodebuild. 

The `FlutterGeneratedPluginSwiftPackage` uses the app's minimum deployment version as its minimum deployment version. This value is set during [`buildXcodeProject`](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/ios/mac.dart#L377-L386), therefore not during `flutter pub get`.

This PR makes a best attempt of parsing the `IPHONEOS_DEPLOYMENT_TARGET`/`MACOSX_DEPLOYMENT_TARGET` from the pbxproj file and if it's the same for all targets, then it uses that as FlutterGeneratedPluginSwiftPackage's minimum version. This happens within `generatePluginsSwiftPackage` (therefore also `flutter pub get`)

Toward https://github.com/flutter/flutter/issues/186804.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
