### PR TITLE
Avoid unnecessary work in `BoxDecoration` and `RenderPhysicalModel`

### DIFF
--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -384,8 +384,9 @@ class BoxDecoration extends Decoration {
       case BoxShape.circle:
         // Circles are inscribed into our smallest dimension.
         final Offset center = size.center(Offset.zero);
-        final double distance = (position - center).distance;
-        return distance <= math.min(size.width, size.height) / 2.0;
+        final double radius = math.min(size.width, size.height) / 2.0;
+        // Comparing squared distances avoids computing sqrt(dx * dx + dy * dy).
+        return (position - center).distanceSquared <= radius * radius;
     }
   }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2210,7 +2210,6 @@ class RenderPhysicalModel extends _RenderPhysicalModelBase<RRect> {
 
     _updateClip();
     final RRect offsetRRect = _clip!.shift(offset);
-    final offsetRRectAsPath = Path()..addRRect(offsetRRect);
     var paintShadows = true;
     assert(() {
       if (debugDisableShadows) {
@@ -2230,6 +2229,7 @@ class RenderPhysicalModel extends _RenderPhysicalModelBase<RRect> {
 
     final Canvas canvas = context.canvas;
     if (elevation != 0.0 && paintShadows) {
+      final offsetRRectAsPath = Path()..addRRect(offsetRRect);
       canvas.drawShadow(offsetRRectAsPath, shadowColor, elevation, color.alpha != 0xFF);
     }
     final usesSaveLayer = clipBehavior == Clip.antiAliasWithSaveLayer;

--- a/packages/flutter/test/painting/box_decoration_test.dart
+++ b/packages/flutter/test/painting/box_decoration_test.dart
@@ -174,6 +174,16 @@ void main() {
     expect(clipPath, isLookLikeExpectedPath);
   });
 
+  test('BoxDecoration.hitTest with shape BoxShape.circle', () {
+    const decoration = BoxDecoration(shape: BoxShape.circle);
+    const size = Size(100.0, 20.0);
+
+    expect(decoration.hitTest(size, const Offset(50.0, 0.0)), isTrue);
+    expect(decoration.hitTest(size, const Offset(40.0, 10.0)), isTrue);
+    expect(decoration.hitTest(size, const Offset(40.0, 0.0)), isFalse);
+    expect(decoration.hitTest(size, const Offset(10.0, 10.0)), isFalse);
+  });
+
   test('BoxDecorations with different blendModes are not equal', () {
     // Regression test for https://github.com/flutter/flutter/issues/100754.
     const one = BoxDecoration(color: Color(0x00000000), backgroundBlendMode: BlendMode.color);

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -78,6 +78,25 @@ void main() {
     expect(root.needsCompositing, isFalse);
   });
 
+  test('RenderPhysicalModel paints shadow only for non-zero elevation', () {
+    final root = RenderPhysicalModel(
+      color: const Color(0xffff00ff),
+      child: RenderSizedBox(const Size(10.0, 10.0)),
+    );
+    layout(root, phase: EnginePhase.paint);
+    expect(
+      (PaintingContext context, Offset offset) => root.paint(context, offset),
+      paintsExactlyCountTimes(#drawShadow, 0),
+    );
+
+    root.elevation = 1.0;
+    pumpFrame(phase: EnginePhase.paint);
+    expect(
+      (PaintingContext context, Offset offset) => root.paint(context, offset),
+      paintsExactlyCountTimes(#drawShadow, 1),
+    );
+  });
+
   test('RenderSemanticsGestureHandler adds/removes correct semantic actions', () {
     final renderObj = RenderSemanticsGestureHandler(
       onTap: () {},


### PR DESCRIPTION

<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/81610206-2f7f-441b-8d31-c242ea797898" />
Part of https://github.com/flutter/flutter/issues/187894

Improve `box_decoration.dart` 


In Flutter’s codebase that pattern already exists in similar hit-test code (RenderClipOval.hitTest https://github.com/flutter/flutter/blob/8c17c5e0677a5c923a9f606d8963e2e0350e6ec2/packages/flutter/lib/src/rendering/proxy_box.dart#L1932).

Old code:
```dart
final double distance = (position - center).distance;
return distance <= math.min(size.width, size.height) / 2.0;
```
Offset.distance computes: `sqrt(dx * dx + dy * dy)`

---

New code:
```dart
final double radius = math.min(size.width, size.height) / 2.0;
return (position - center).distanceSquared <= radius * radius;
```
Offset.distanceSquared computes only: `dx * dx + dy * dy`
Then it compares that to radius * radius.
Mathematically: `sqrt(dx² + dy²) <= r` is equivalent to: `dx² + dy² <= r²`


Then, I also found an issue: `elevated` shadow path doesn't need to be initialized when there is no elevation to use it for.