### PR TITLE
Format Flutter templates to match latest dart format style

### DIFF
--- a/packages/flutter_tools/templates/app_integration_test/integration_test/plugin_integration_test.dart.tmpl
+++ b/packages/flutter_tools/templates/app_integration_test/integration_test/plugin_integration_test.dart.tmpl
@@ -7,7 +7,6 @@
 //
 // For more information about Flutter integration tests, please see
 // https://flutter.dev/to/integration-testing
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 

--- a/packages/flutter_tools/templates/plugin/lib/projectName.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/lib/projectName.dart.tmpl
@@ -6,7 +6,6 @@
 // platforms in the `pubspec.yaml` at
 // https://flutter.dev/to/pubspec-plugin-platforms.
 {{/no_platforms}}
-
 import '{{projectName}}_platform_interface.dart';
 
 class {{pluginDartClass}} {


### PR DESCRIPTION
## Description

Update templates used by `flutter create` to be consistent with the latest `dart format` output.

## Changes

- Remove extra blank line before imports in integration test template
- Remove extra blank line before imports in plugin template

## Related Issue

Fixes #175960

## Test Plan

Verified by following the repro steps from the issue:
1. Create projects using `flutter create` with relevant templates
2. Run `dart format .`
3. Verify no unexpected formatting changes are produced