### PR TITLE
Fix $git typo in shared.bat (Windows cache invalidation broken since 3.29)

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -72,7 +72,7 @@ GOTO :after_subroutine
     REM before getting the git revision.
     REM
     REM See https://github.com/flutter/flutter/issues/159018
-    FOR /f %%r IN ('PUSHD %FLUTTER_ROOT% ^& $git rev-parse HEAD') DO (
+    FOR /f %%r IN ('PUSHD "%FLUTTER_ROOT%" ^& git rev-parse HEAD') DO (
       SET revision=%%r
     )
   )


### PR DESCRIPTION
## Description

The git revision lookup in `bin/internal/shared.bat` used `$git` instead of `git`, which is invalid cmd.exe syntax. This caused the revision variable to always be empty, making the compile key degenerate to the constant `":"` on Windows. As a result, git-revision-based invalidation of the flutter_tools snapshot has never worked on Windows since version 3.29.0 (introduced by #159424).

Also quotes `%FLUTTER_ROOT%` to handle paths with spaces, consistent with the pre-#159424 code.

## Related Issues

Fixes #187907

## Tests

This is a one-character fix in a `.bat` launcher script. The fix was verified by inspecting the diff:

- Before: `FOR /f %%r IN ('PUSHD %FLUTTER_ROOT% ^& $git rev-parse HEAD')` — `$git` is not valid cmd.exe syntax, silently fails
- After: `FOR /f %%r IN ('PUSHD "%FLUTTER_ROOT%" ^& git rev-parse HEAD')` — correct `git` command

The bash counterpart `shared.sh` already computes the revision correctly using plain `git rev-parse HEAD`. This fix brings the `.bat` in line with the `.sh` contract stated in both file headers.

No Dart code changes, no test changes needed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and updated the relevant `analysis_options.yaml` if necessary.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I listed why this is not needed (launcher script fix, no Dart code).
- [x] I followed the [breaking change policy] and updated the guide if necessary.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/wiki/Contributing-to-Flutter