### PR TITLE
[Impeller] Fix dirty-range race in DeviceBufferGLES uploads

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.cc
@@ -63,6 +63,7 @@ std::optional<GLuint> DeviceBufferGLES::GetHandle() const {
 }
 
 void DeviceBufferGLES::Flush(std::optional<Range> range) const {
+  Lock lock(dirty_range_mutex_);
   if (!range.has_value()) {
     dirty_range_ = Range{
         0, static_cast<size_t>(backing_store_->GetLength().GetByteSize())};
@@ -116,11 +117,19 @@ bool DeviceBufferGLES::BindAndUploadDataIfNecessary(BindingType type) const {
     initialized_ = true;
   }
 
-  if (dirty_range_.has_value()) {
-    auto range = dirty_range_.value();
-    gl.BufferSubData(target_type, range.offset, range.length,
-                     backing_store_->GetBuffer() + range.offset);
+  // Take and clear the dirty range BEFORE uploading. A Flush() from another
+  // thread during the upload then merges into a fresh dirty range that the
+  // next bind uploads, instead of being silently discarded by a clear that
+  // runs after the upload.
+  std::optional<Range> dirty;
+  {
+    Lock lock(dirty_range_mutex_);
+    dirty = dirty_range_;
     dirty_range_ = std::nullopt;
+  }
+  if (dirty.has_value()) {
+    gl.BufferSubData(target_type, dirty->offset, dirty->length,
+                     backing_store_->GetBuffer() + dirty->offset);
   }
 
   return true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.cc
@@ -124,8 +124,7 @@ bool DeviceBufferGLES::BindAndUploadDataIfNecessary(BindingType type) const {
   std::optional<Range> dirty;
   {
     Lock lock(dirty_range_mutex_);
-    dirty = dirty_range_;
-    dirty_range_ = std::nullopt;
+    std::swap(dirty_range_, dirty);
   }
   if (dirty.has_value()) {
     gl.BufferSubData(target_type, dirty->offset, dirty->length,

--- a/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.h
@@ -10,6 +10,7 @@
 
 #include "impeller/base/allocation.h"
 #include "impeller/base/backend_cast.h"
+#include "impeller/base/thread.h"
 #include "impeller/core/device_buffer.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 
@@ -49,7 +50,12 @@ class DeviceBufferGLES final
   // Mutable for lazy evaluation.
   mutable std::optional<HandleGLES> handle_;
   mutable std::unique_ptr<Allocation> backing_store_;
-  mutable std::optional<Range> dirty_range_ = std::nullopt;
+  // Guards dirty_range_. Flush() merges ranges from writer threads (e.g. the
+  // UI thread for flutter_gpu host-visible buffers) while
+  // BindAndUploadDataIfNecessary() consumes the range on a reactor thread.
+  mutable Mutex dirty_range_mutex_;
+  mutable std::optional<Range> dirty_range_
+      IPLR_GUARDED_BY(dirty_range_mutex_) = std::nullopt;
   mutable bool initialized_ = false;
 
   // |DeviceBuffer|

--- a/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles_unittests.cc
@@ -22,6 +22,49 @@ class TestWorker : public ReactorGLES::Worker {
 };
 }  // namespace
 
+// A Flush() that lands while BindAndUploadDataIfNecessary is mid-upload (as
+// happens when another thread writes to a host-visible buffer during the GL
+// upload) must not be discarded; the next bind must upload the new range.
+TEST(DeviceBufferGLESTest, FlushDuringUploadIsNotDiscarded) {
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+
+  DeviceBufferGLES* device_buffer_ptr = nullptr;
+  int upload_count = 0;
+  EXPECT_CALL(*mock_gles_impl, BufferSubData(_, _, _, _))
+      .Times(2)
+      .WillRepeatedly([&](GLenum target, GLintptr offset, GLsizeiptr size,
+                          const void* data) {
+        ++upload_count;
+        if (upload_count == 1) {
+          // Simulates a writer thread flushing new data during the upload.
+          device_buffer_ptr->Flush(Range{0, 4});
+        }
+      });
+
+  std::shared_ptr<MockGLES> mock_gles =
+      MockGLES::Init(std::move(mock_gles_impl));
+  ProcTableGLES::Resolver resolver = kMockResolverGLES;
+  auto proc_table = std::make_unique<ProcTableGLES>(resolver);
+  auto worker = std::make_shared<TestWorker>();
+  auto reactor = std::make_shared<ReactorGLES>(std::move(proc_table));
+  reactor->AddWorker(worker);
+
+  auto backing_store = std::make_unique<Allocation>();
+  ASSERT_TRUE(backing_store->Truncate(Bytes{16}));
+  DeviceBufferGLES device_buffer(DeviceBufferDescriptor{.size = 16}, reactor,
+                                 std::move(backing_store));
+  device_buffer_ptr = &device_buffer;
+
+  device_buffer.Flush(Range{0, 4});
+  // First bind uploads the flushed range; the mock flushes again mid-upload.
+  EXPECT_TRUE(device_buffer.BindAndUploadDataIfNecessary(
+      DeviceBufferGLES::BindingType::kArrayBuffer));
+  // Second bind must see the mid-upload flush and upload again.
+  EXPECT_TRUE(device_buffer.BindAndUploadDataIfNecessary(
+      DeviceBufferGLES::BindingType::kArrayBuffer));
+  EXPECT_EQ(upload_count, 2);
+}
+
 TEST(DeviceBufferGLESTest, BindUniformData) {
   auto mock_gles_impl = std::make_unique<MockGLESImpl>();
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -244,6 +244,16 @@ void mockGenBuffers(GLsizei n, GLuint* buffers) {
   CallMockMethod(&IMockGLESImpl::GenBuffers, n, buffers);
 }
 
+void mockBufferSubData(GLenum target,
+                       GLintptr offset,
+                       GLsizeiptr size,
+                       const void* data) {
+  CallMockMethod(&IMockGLESImpl::BufferSubData, target, offset, size, data);
+}
+
+static_assert(CheckSameSignature<decltype(mockBufferSubData),  //
+                                 decltype(glBufferSubData)>::value);
+
 static_assert(CheckSameSignature<decltype(mockGenTextures),  //
                                  decltype(glGenTextures)>::value);
 
@@ -499,6 +509,8 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockObjectLabelKHR);
   } else if (strcmp(name, "glGenBuffers") == 0) {
     return reinterpret_cast<void*>(mockGenBuffers);
+  } else if (strcmp(name, "glBufferSubData") == 0) {
+    return reinterpret_cast<void*>(mockBufferSubData);
   } else if (strcmp(name, "glIsTexture") == 0) {
     return reinterpret_cast<void*>(mockIsTexture);
   } else if (strcmp(name, "glCheckFramebufferStatus") == 0) {

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -97,6 +97,10 @@ class IMockGLESImpl {
   virtual void DeleteQueriesEXT(GLsizei size, const GLuint* queries) {}
   virtual void GenBuffers(GLsizei n, GLuint* buffers) {}
   virtual void DeleteBuffers(GLsizei n, const GLuint* buffers) {}
+  virtual void BufferSubData(GLenum target,
+                             GLintptr offset,
+                             GLsizeiptr size,
+                             const void* data) {}
   virtual GLboolean IsTexture(GLuint texture) { return true; }
   virtual void DiscardFramebufferEXT(GLenum target,
                                      GLsizei numAttachments,
@@ -248,6 +252,11 @@ class MockGLESImpl : public IMockGLESImpl {
               DeleteBuffers,
               (GLsizei n, const GLuint* buffers),
               (override));
+  MOCK_METHOD(
+      void,
+      BufferSubData,
+      (GLenum target, GLintptr offset, GLsizeiptr size, const void* data),
+      (override));
   MOCK_METHOD(GLboolean, IsTexture, (GLuint texture), (override));
   MOCK_METHOD(void,
               DiscardFramebufferEXT,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/187931.

`DeviceBufferGLES::Flush()` merges dirty ranges from writer threads (for example the UI thread writing to a flutter_gpu host-visible buffer) while `BindAndUploadDataIfNecessary()` consumes the range on a reactor thread. The upload read the dirty range, called `glBufferSubData`, and cleared `dirty_range_` afterwards, so any flush landing during the upload was silently discarded and its data never reached the GPU. Draws could then read stale vertex/instance/uniform data, and when a buffer's only flush was lost, uninitialized buffer contents.

This change guards `dirty_range_` with a mutex and takes and clears it before uploading, so a concurrent flush merges into a fresh range that the next bind uploads.

Also adds `BufferSubData` to the GLES test mocks and a regression test that flushes from inside the mocked upload, which fails with the previous ordering.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
