### PR TITLE
Expose the app's build name and number as compile-time constants

### DIFF
--- a/packages/flutter/lib/services.dart
+++ b/packages/flutter/lib/services.dart
@@ -10,6 +10,7 @@
 /// library.
 library services;
 
+export 'src/services/app_version.dart';
 export 'src/services/asset_bundle.dart';
 export 'src/services/asset_manifest.dart';
 export 'src/services/autofill.dart';

--- a/packages/flutter/lib/src/services/app_version.dart
+++ b/packages/flutter/lib/src/services/app_version.dart
@@ -1,0 +1,31 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// The build name this application was built with.
+///
+/// This is the part of the `version` field in the app's `pubspec.yaml` before
+/// the `+` separator (for example `1.2.3` for `version: 1.2.3+45`), or the
+/// value of the `--build-name` option if it was provided at build time.
+///
+/// Unlike runtime lookups (such as reading `version.json` over the network on
+/// the web), this constant is embedded in the compiled application itself, so
+/// it always describes the code that is actually running.
+///
+/// This will be `null` if the pubspec has no `version` field and no
+/// `--build-name` option was provided.
+const String? appBuildName = bool.hasEnvironment('FLUTTER_BUILD_NAME')
+    ? String.fromEnvironment('FLUTTER_BUILD_NAME')
+    : null;
+
+/// The build number this application was built with.
+///
+/// This is the part of the `version` field in the app's `pubspec.yaml` after
+/// the `+` separator (for example `45` for `version: 1.2.3+45`), or the value
+/// of the `--build-number` option if it was provided at build time.
+///
+/// This will be `null` if the version has no build number and no
+/// `--build-number` option was provided.
+const String? appBuildNumber = bool.hasEnvironment('FLUTTER_BUILD_NUMBER')
+    ? String.fromEnvironment('FLUTTER_BUILD_NUMBER')
+    : null;

--- a/packages/flutter/test/services/app_version_test.dart
+++ b/packages/flutter/test/services/app_version_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('appBuildName matches the FLUTTER_BUILD_NAME environment declaration', () {
+    expect(
+      appBuildName,
+      const bool.hasEnvironment('FLUTTER_BUILD_NAME')
+          ? const String.fromEnvironment('FLUTTER_BUILD_NAME')
+          : null,
+    );
+  });
+
+  test('appBuildNumber matches the FLUTTER_BUILD_NUMBER environment declaration', () {
+    expect(
+      appBuildNumber,
+      const bool.hasEnvironment('FLUTTER_BUILD_NUMBER')
+          ? const String.fromEnvironment('FLUTTER_BUILD_NUMBER')
+          : null,
+    );
+  });
+}

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -1070,6 +1070,14 @@ const kFlavor = 'Flavor';
 /// by the `appFlavor` service.
 const kAppFlavor = 'FLUTTER_APP_FLAVOR';
 
+/// Environment variable of the build name to be set in dartDefines to be
+/// accessed by the `appBuildName` service.
+const kAppBuildName = 'FLUTTER_BUILD_NAME';
+
+/// Environment variable of the build number to be set in dartDefines to be
+/// accessed by the `appBuildNumber` service.
+const kAppBuildNumber = 'FLUTTER_BUILD_NUMBER';
+
 /// Environment variable of the enabled feature flags to be set in the
 /// dartDefines.
 ///

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1500,7 +1500,9 @@ abstract class FlutterCommand extends Command<void> {
     if (globals.platform.environment[kAppFlavor] != null) {
       throwToolExit('$kAppFlavor is used by the framework and cannot be set in the environment.');
     }
-    if (dartDefines.any((String define) => define.startsWith(kAppFlavor))) {
+    if (dartDefines.any(
+      (String define) => define == kAppFlavor || define.startsWith('$kAppFlavor='),
+    )) {
       throwToolExit(
         '$kAppFlavor is used by the framework and cannot be '
         'set using --${FlutterOptions.kDartDefinesOption} or --${FlutterOptions.kDartDefineFromFileOption}',
@@ -1516,7 +1518,7 @@ abstract class FlutterCommand extends Command<void> {
       if (globals.platform.environment[define] != null) {
         throwToolExit('$define is used by the framework and cannot be set in the environment.');
       }
-      if (dartDefines.any((String d) => d.startsWith(define))) {
+      if (dartDefines.any((String d) => d == define || d.startsWith('$define='))) {
         throwToolExit(
           '$define is used by the framework and cannot be '
           'set using --${FlutterOptions.kDartDefinesOption} or --${FlutterOptions.kDartDefineFromFileOption}',

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1375,6 +1375,10 @@ abstract class FlutterCommand extends Command<void> {
         ? stringArg('build-number')
         : null;
 
+    final String? buildName = argParser.options.containsKey('build-name')
+        ? stringArg('build-name')
+        : null;
+
     final File packageConfigFile = globals.fs.file(packageConfigPath());
 
     final PackageConfig packageConfig = await loadPackageConfigWithLogging(
@@ -1505,6 +1509,23 @@ abstract class FlutterCommand extends Command<void> {
     if (flavor != null) {
       dartDefines.add('$kAppFlavor=$flavor');
     }
+    for (final (String define, String? value) in <(String, String?)>[
+      (kAppBuildName, buildName ?? project.manifest.buildName),
+      (kAppBuildNumber, buildNumber ?? project.manifest.buildNumber),
+    ]) {
+      if (globals.platform.environment[define] != null) {
+        throwToolExit('$define is used by the framework and cannot be set in the environment.');
+      }
+      if (dartDefines.any((String d) => d.startsWith(define))) {
+        throwToolExit(
+          '$define is used by the framework and cannot be '
+          'set using --${FlutterOptions.kDartDefinesOption} or --${FlutterOptions.kDartDefineFromFileOption}',
+        );
+      }
+      if (value != null) {
+        dartDefines.add('$define=$value');
+      }
+    }
     _addFlutterVersionToDartDefines(globals.flutterVersion, dartDefines);
     _addFeatureFlagsToDartDefines(dartDefines);
 
@@ -1521,7 +1542,7 @@ abstract class FlutterCommand extends Command<void> {
       fileSystemRoots: fileSystemRoots,
       fileSystemScheme: fileSystemScheme,
       buildNumber: buildNumber,
-      buildName: argParser.options.containsKey('build-name') ? stringArg('build-name') : null,
+      buildName: buildName,
       treeShakeIcons: treeShakeIcons,
       splitDebugInfoPath: splitDebugInfoPath,
       dartObfuscation: dartObfuscation,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1497,17 +1497,7 @@ abstract class FlutterCommand extends Command<void> {
     final String? cliFlavor = argParser.options.containsKey('flavor') ? stringArg('flavor') : null;
     final String? flavor = cliFlavor ?? defaultFlavor;
 
-    if (globals.platform.environment[kAppFlavor] != null) {
-      throwToolExit('$kAppFlavor is used by the framework and cannot be set in the environment.');
-    }
-    if (dartDefines.any(
-      (String define) => define == kAppFlavor || define.startsWith('$kAppFlavor='),
-    )) {
-      throwToolExit(
-        '$kAppFlavor is used by the framework and cannot be '
-        'set using --${FlutterOptions.kDartDefinesOption} or --${FlutterOptions.kDartDefineFromFileOption}',
-      );
-    }
+    _ensureReservedDartDefineIsUnset(kAppFlavor, dartDefines);
     if (flavor != null) {
       dartDefines.add('$kAppFlavor=$flavor');
     }
@@ -1515,15 +1505,7 @@ abstract class FlutterCommand extends Command<void> {
       (kAppBuildName, buildName ?? project.manifest.buildName),
       (kAppBuildNumber, buildNumber ?? project.manifest.buildNumber),
     ]) {
-      if (globals.platform.environment[define] != null) {
-        throwToolExit('$define is used by the framework and cannot be set in the environment.');
-      }
-      if (dartDefines.any((String d) => d == define || d.startsWith('$define='))) {
-        throwToolExit(
-          '$define is used by the framework and cannot be '
-          'set using --${FlutterOptions.kDartDefinesOption} or --${FlutterOptions.kDartDefineFromFileOption}',
-        );
-      }
+      _ensureReservedDartDefineIsUnset(define, dartDefines);
       if (value != null) {
         dartDefines.add('$define=$value');
       }
@@ -1567,6 +1549,21 @@ abstract class FlutterCommand extends Command<void> {
       useLocalCanvasKit: useLocalCanvasKit,
       webEnableHotReload: webEnableHotReload,
     );
+  }
+
+  /// Throws a [ToolExit] if [define], a dart-define key reserved by the
+  /// framework, has been set either in the environment or through
+  /// `--${FlutterOptions.kDartDefinesOption}` / `--${FlutterOptions.kDartDefineFromFileOption}`.
+  void _ensureReservedDartDefineIsUnset(String define, List<String> dartDefines) {
+    if (globals.platform.environment[define] != null) {
+      throwToolExit('$define is used by the framework and cannot be set in the environment.');
+    }
+    if (dartDefines.any((String d) => d == define || d.startsWith('$define='))) {
+      throwToolExit(
+        '$define is used by the framework and cannot be '
+        'set using --${FlutterOptions.kDartDefinesOption} or --${FlutterOptions.kDartDefineFromFileOption}',
+      );
+    }
   }
 
   // This adds the Dart defines used to access various Flutter version information at runtime.

--- a/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
@@ -376,6 +376,8 @@ void main() {
               '-q',
               '-Ptarget=${globals.fs.path.join('lib', 'main.dart')}',
               '-Pdart-defines=${encodeDartDefinesMap(<String, String>{
+                'FLUTTER_BUILD_NAME': '1.0.0',
+                'FLUTTER_BUILD_NUMBER': '1',
                 'FLUTTER_VERSION': '0.0.0', //
                 'FLUTTER_CHANNEL': 'master',
                 'FLUTTER_GIT_URL': 'https://github.com/flutter/flutter.git',

--- a/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
@@ -522,6 +522,8 @@ void main() {
               '-Ptarget=${globals.fs.path.join(tempDir.path, 'flutter_project', 'lib', 'main.dart')}',
               '-Pbase-application-name=android.app.Application',
               '-Pdart-defines=${encodeDartDefinesMap(<String, String>{
+                'FLUTTER_BUILD_NAME': '1.0.0',
+                'FLUTTER_BUILD_NUMBER': '1',
                 'FLUTTER_VERSION': '0.0.0', //
                 'FLUTTER_CHANNEL': 'master',
                 'FLUTTER_GIT_URL': 'https://github.com/flutter/flutter.git',
@@ -569,6 +571,8 @@ void main() {
               '-Ptarget=${globals.fs.path.join(tempDir.path, 'flutter_project', 'lib', 'main.dart')}',
               '-Pbase-application-name=android.app.Application',
               '-Pdart-defines=${encodeDartDefinesMap(<String, String>{
+                'FLUTTER_BUILD_NAME': '1.0.0',
+                'FLUTTER_BUILD_NUMBER': '1',
                 'FLUTTER_VERSION': '0.0.0', //
                 'FLUTTER_CHANNEL': 'master',
                 'FLUTTER_GIT_URL': 'https://github.com/flutter/flutter.git',
@@ -620,6 +624,8 @@ void main() {
               '-Ptarget=${globals.fs.path.join(tempDir.path, 'flutter_project', 'lib', 'main.dart')}',
               '-Pbase-application-name=android.app.Application',
               '-Pdart-defines=${encodeDartDefinesMap(<String, String>{
+                'FLUTTER_BUILD_NAME': '1.0.0',
+                'FLUTTER_BUILD_NUMBER': '1',
                 'FLUTTER_VERSION': '0.0.0', //
                 'FLUTTER_CHANNEL': 'master',
                 'FLUTTER_GIT_URL': 'https://github.com/flutter/flutter.git',
@@ -671,6 +677,8 @@ void main() {
               '-Ptarget=${globals.fs.path.join(tempDir.path, 'flutter_project', 'lib', 'main.dart')}',
               '-Pbase-application-name=android.app.Application',
               '-Pdart-defines=${encodeDartDefinesMap(<String, String>{
+                'FLUTTER_BUILD_NAME': '1.0.0',
+                'FLUTTER_BUILD_NUMBER': '1',
                 'FLUTTER_VERSION': '0.0.0', //
                 'FLUTTER_CHANNEL': 'master',
                 'FLUTTER_GIT_URL': 'https://github.com/flutter/flutter.git',
@@ -724,6 +732,8 @@ void main() {
               '-Ptarget=${globals.fs.path.join(tempDir.path, 'flutter_project', 'lib', 'main.dart')}',
               '-Pbase-application-name=android.app.Application',
               '-Pdart-defines=${encodeDartDefinesMap(<String, String>{
+                'FLUTTER_BUILD_NAME': '1.0.0',
+                'FLUTTER_BUILD_NUMBER': '1',
                 'FLUTTER_VERSION': '0.0.0', //
                 'FLUTTER_CHANNEL': 'master',
                 'FLUTTER_GIT_URL': 'https://github.com/flutter/flutter.git',
@@ -782,6 +792,8 @@ void main() {
               '-Ptarget=${globals.fs.path.join(tempDir.path, 'flutter_project', 'lib', 'main.dart')}',
               '-Pbase-application-name=android.app.Application',
               '-Pdart-defines=${encodeDartDefinesMap(<String, String>{
+                'FLUTTER_BUILD_NAME': '1.0.0',
+                'FLUTTER_BUILD_NUMBER': '1',
                 'FLUTTER_VERSION': '0.0.0', //
                 'FLUTTER_CHANNEL': 'master',
                 'FLUTTER_GIT_URL': 'https://github.com/flutter/flutter.git',

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -1458,6 +1458,34 @@ name: test
           ProcessManager: FakeProcessManager.empty,
         },
       );
+
+      testUsingContext(
+        'user defines sharing a prefix with a reserved key are allowed',
+        () async {
+          final CommandRunner<void> runner = createTestCommandRunner(
+            _TestRunCommandThatOnlyValidates(),
+          );
+          await runner.run(<String>[
+            'run',
+            '--dart-define=${kAppFlavor}_CUSTOM=foo',
+            '--dart-define=${kAppBuildName}SPACE=bar',
+            '--dart-define=${kAppBuildNumber}_OFFSET=7',
+            '--no-pub',
+            '--no-hot',
+          ]);
+        },
+        overrides: <Type, Generator>{
+          DeviceManager: () =>
+              FakeDeviceManager()..attachedDevices = <Device>[FakeDevice('name', 'id')],
+          FileSystem: () {
+            final fileSystem = MemoryFileSystem.test();
+            fileSystem.file('lib/main.dart').createSync(recursive: true);
+            fileSystem.file('pubspec.yaml').createSync();
+            return fileSystem;
+          },
+          ProcessManager: FakeProcessManager.empty,
+        },
+      );
     });
 
     group('Flutter version', () {

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -1342,6 +1342,124 @@ flutter:
       },
     );
 
+    group('build name and number', () {
+      late FileSystem fileSystem;
+
+      setUp(() {
+        fileSystem = MemoryFileSystem.test();
+      });
+
+      testUsingContext(
+        'are injected as dart defines from the pubspec version',
+        () async {
+          final File pubspec = fileSystem.file('pubspec.yaml');
+          await pubspec.create();
+          await pubspec.writeAsString('''
+name: test
+version: 1.2.3+45
+        ''');
+
+          final flutterCommand = DummyFlutterCommand();
+          final BuildInfo buildInfo = await flutterCommand.getBuildInfo(
+            forcedBuildMode: BuildMode.debug,
+          );
+          expect(buildInfo.dartDefines, contains('$kAppBuildName=1.2.3'));
+          expect(buildInfo.dartDefines, contains('$kAppBuildNumber=45'));
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fileSystem,
+          ProcessManager: () => FakeProcessManager.empty(),
+        },
+      );
+
+      testUsingContext(
+        'are not injected when the pubspec has no version',
+        () async {
+          final File pubspec = fileSystem.file('pubspec.yaml');
+          await pubspec.create();
+          await pubspec.writeAsString('''
+name: test
+        ''');
+
+          final flutterCommand = DummyFlutterCommand();
+          final BuildInfo buildInfo = await flutterCommand.getBuildInfo(
+            forcedBuildMode: BuildMode.debug,
+          );
+          expect(
+            buildInfo.dartDefines.where(
+              (String define) =>
+                  define.startsWith(kAppBuildName) || define.startsWith(kAppBuildNumber),
+            ),
+            isEmpty,
+          );
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fileSystem,
+          ProcessManager: () => FakeProcessManager.empty(),
+        },
+      );
+
+      testUsingContext(
+        "tool exits when $kAppBuildName is already set in user's environment",
+        () async {
+          final CommandRunner<void> runner = createTestCommandRunner(
+            _TestRunCommandThatOnlyValidates(),
+          );
+          expect(
+            runner.run(<String>['run', '--no-pub', '--no-hot']),
+            throwsToolExit(
+              message:
+                  '$kAppBuildName is used by the framework and cannot be set in the environment.',
+            ),
+          );
+        },
+        overrides: <Type, Generator>{
+          DeviceManager: () =>
+              FakeDeviceManager()..attachedDevices = <Device>[FakeDevice('name', 'id')],
+          FileSystem: () {
+            final fileSystem = MemoryFileSystem.test();
+            fileSystem.file('lib/main.dart').createSync(recursive: true);
+            fileSystem.file('pubspec.yaml').createSync();
+            return fileSystem;
+          },
+          ProcessManager: FakeProcessManager.empty,
+          Platform: () => FakePlatform()..environment = <String, String>{kAppBuildName: '1.0.0'},
+        },
+      );
+
+      testUsingContext(
+        'tool exits when $kAppBuildNumber is set in --dart-define',
+        () async {
+          final CommandRunner<void> runner = createTestCommandRunner(
+            _TestRunCommandThatOnlyValidates(),
+          );
+          expect(
+            runner.run(<String>[
+              'run',
+              '--dart-define=$kAppBuildNumber=42',
+              '--no-pub',
+              '--no-hot',
+            ]),
+            throwsToolExit(
+              message:
+                  '$kAppBuildNumber is used by the framework and cannot be set using --dart-define',
+            ),
+          );
+        },
+        overrides: <Type, Generator>{
+          DeviceManager: () =>
+              FakeDeviceManager()..attachedDevices = <Device>[FakeDevice('name', 'id')],
+          FileSystem: () {
+            final fileSystem = MemoryFileSystem.test();
+            fileSystem.file('lib/main.dart').createSync(recursive: true);
+            fileSystem.file('pubspec.yaml').createSync();
+            return fileSystem;
+          },
+          ProcessManager: FakeProcessManager.empty,
+        },
+      );
+    });
+
     group('Flutter version', () {
       for (final String dartDefine in FlutterCommand.flutterVersionDartDefines) {
         testUsingContext(

--- a/packages/flutter_tools/test/integration.shard/build_name_and_number_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_name_and_number_test.dart
@@ -1,0 +1,74 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@Tags(<String>['flutter-test-driver'])
+library;
+
+import 'package:flutter_tools/src/base/file_system.dart';
+
+import '../src/common.dart';
+import 'test_data/project.dart';
+import 'test_driver.dart';
+import 'test_utils.dart';
+
+void main() {
+  final Project project = _BuildNameAndNumberProject();
+  late Directory tempDir;
+  late FlutterTestTestDriver flutter;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('build_name_and_number_test.');
+    await project.setUpIn(tempDir);
+    flutter = FlutterTestTestDriver(tempDir);
+  });
+
+  tearDown(() async {
+    tryToDelete(tempDir);
+  });
+
+  testWithoutContext('Reads "version" build name and number in "flutter test"', () async {
+    await flutter.test();
+
+    // Without an assertion, this test always passes.
+    final int? exitCode = await flutter.done;
+    expect(exitCode, 0, reason: 'flutter test failed with exit code $exitCode');
+  });
+}
+
+final class _BuildNameAndNumberProject extends Project {
+  @override
+  final main = r'''
+    // Irrelevant to this test.
+    void main() {}
+  ''';
+
+  @override
+  final pubspec = r'''
+  name: test
+  environment:
+    sdk: ^3.7.0-0
+
+  version: 1.2.3+4
+
+  dependencies:
+    flutter:
+      sdk: flutter
+  dev_dependencies:
+    flutter_test:
+      sdk: flutter
+  ''';
+
+  @override
+  final test = r'''
+    import 'package:flutter/services.dart';
+    import 'package:flutter_test/flutter_test.dart';
+
+    void main() {
+      test('receives build name and number with flutter test', () async {
+        expect(appBuildName, '1.2.3');
+        expect(appBuildNumber, '4');
+      });
+    }
+  ''';
+}


### PR DESCRIPTION
The tool already injects `FLUTTER_VERSION`, `FLUTTER_CHANNEL`, framework/engine revisions (exposed as `FlutterVersion`) and `FLUTTER_APP_FLAVOR` (exposed as `appFlavor`) as dart-defines. The application's own `version:` from `pubspec.yaml` is the one missing field, even though the tool already parses it (`FlutterManifest.buildName`/`buildNumber`) and embeds it into `version.json`, `Info.plist` and `build.gradle` on every build.

Without it, the *running* version is unknowable on the web: `version.json` is fetched from the server at runtime, so a stale cached client reports the freshly deployed version instead of its own, and version gates / update prompts built on `package_info_plus` silently fail for exactly the users they exist for (fluttercommunity/plus_plugins#2675).

This PR:

- injects `FLUTTER_BUILD_NAME` and `FLUTTER_BUILD_NUMBER` (the app's pubspec `version`, overridable via `--build-name`/`--build-number`) in `FlutterCommand.getBuildInfo`, following the `FLUTTER_APP_FLAVOR` pattern including its reserved-name guards;
- exposes them as `appBuildName` / `appBuildNumber` constants in `package:flutter/services.dart` (new `src/services/app_version.dart`, same style as `flavor.dart` / `flutter_version.dart`);
- adds tool tests (injection from pubspec, no injection without a version, environment/dart-define collision guards) and framework tests.

Like all `String.fromEnvironment` constants, these are tree-shaken when unreferenced, so nothing ships in the binary unless the app reads them.

`package_info_plus` is ready to consume these defines (fluttercommunity/plus_plugins#3874), which would make the fix transparent for the ecosystem. A companion proposal for the pure-Dart side (`dart compile`, servers/CLIs) is dart-lang/sdk#38855 — neither subsumes the other, since Flutter does not build through `dartdev`.

Fixes https://github.com/flutter/flutter/issues/187934

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

