### PR TITLE
[flutter_tools] Fix flakiness in widget_preview_detection_test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/widget_preview_detection_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_detection_test.dart
@@ -77,13 +77,7 @@ Widget myNewPreview() => Container();
       );
       await reloadSub.cancel();
 
-      final DTDResponse result = await getPreviews(dtdConnection);
-      final FlutterWidgetPreviews previews = FlutterWidgetPreviews.fromJson(
-        result.result['result']! as Map<String, Object?>,
-      );
-      if (previews.previews.isEmpty) {
-        throw StateError('No previews detected in Add test!');
-      }
+      await waitForPreviews(dtdConnection, (FlutterWidgetPreviews p) => p.previews.isNotEmpty);
     });
 
     testUsingContext('Removed previews are detected (LSP)', () async {
@@ -125,13 +119,7 @@ Widget myRemovePreview() => Container();
       );
       await initReloadSub.cancel();
 
-      DTDResponse result = await getPreviews(dtdConnection);
-      FlutterWidgetPreviews previews = FlutterWidgetPreviews.fromJson(
-        result.result['result']! as Map<String, Object?>,
-      );
-      if (previews.previews.isEmpty) {
-        throw StateError('Preview was not detected initially in Remove test!');
-      }
+      await waitForPreviews(dtdConnection, (FlutterWidgetPreviews p) => p.previews.isNotEmpty);
 
       removeFile.deleteSync();
 
@@ -148,11 +136,7 @@ Widget myRemovePreview() => Container();
       );
       await deleteReloadSub.cancel();
 
-      result = await getPreviews(dtdConnection);
-      previews = FlutterWidgetPreviews.fromJson(result.result['result']! as Map<String, Object?>);
-      if (previews.previews.isNotEmpty) {
-        throw StateError('Preview was still detected after deletion!');
-      }
+      await waitForPreviews(dtdConnection, (FlutterWidgetPreviews p) => p.previews.isEmpty);
     });
 
     testUsingContext('Modified previews are detected (LSP)', () async {
@@ -194,13 +178,7 @@ Widget myModifyPreview() => Container();
       );
       await initReloadSub.cancel();
 
-      DTDResponse result = await getPreviews(dtdConnection);
-      FlutterWidgetPreviews previews = FlutterWidgetPreviews.fromJson(
-        result.result['result']! as Map<String, Object?>,
-      );
-      if (previews.previews.isEmpty) {
-        throw StateError('Preview was not detected initially in Modify test!');
-      }
+      await waitForPreviews(dtdConnection, (FlutterWidgetPreviews p) => p.previews.isNotEmpty);
 
       modifyFile.writeAsStringSync('''
 import 'package:flutter/material.dart';
@@ -223,17 +201,11 @@ Widget myModifyPreview() => Container();
       );
       await modifyReloadSub.cancel();
 
-      result = await getPreviews(dtdConnection);
-      previews = FlutterWidgetPreviews.fromJson(result.result['result']! as Map<String, Object?>);
-      if (previews.previews.isEmpty) {
-        throw StateError('Preview was lost after modification!');
-      }
-      final FlutterWidgetPreviewDetails preview = previews.previews.first;
-      if (!preview.previewAnnotation.contains("'Updated'")) {
-        throw StateError(
-          r'Preview annotation was not updated after modification! Found: ${preview.previewAnnotation}',
-        );
-      }
+      await waitForPreviews(
+        dtdConnection,
+        (FlutterWidgetPreviews p) =>
+            p.previews.isNotEmpty && p.previews.first.previewAnnotation.contains("'Updated'"),
+      );
     });
 
     testUsingContext('Previews within libraries with parts are detected (LSP)', () async {
@@ -286,13 +258,10 @@ Widget myPartPreview() => Container();
       );
       await reloadSub.cancel();
 
-      final DTDResponse result = await getPreviews(dtdConnection);
-      final FlutterWidgetPreviews previews = FlutterWidgetPreviews.fromJson(
-        result.result['result']! as Map<String, Object?>,
+      final FlutterWidgetPreviews previews = await waitForPreviews(
+        dtdConnection,
+        (FlutterWidgetPreviews p) => p.previews.isNotEmpty,
       );
-      if (previews.previews.isEmpty) {
-        throw StateError('No previews detected in Parts test!');
-      }
 
       final FlutterWidgetPreviewDetails preview = previews.previews.first;
       if (preview.functionName != 'myPartPreview') {

--- a/packages/flutter_tools/test/integration.shard/widget_preview_detection_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_detection_test.dart
@@ -77,7 +77,7 @@ Widget myNewPreview() => Container();
       );
       await reloadSub.cancel();
 
-      await waitForPreviews(dtdConnection, (FlutterWidgetPreviews p) => p.previews.isNotEmpty);
+      await waitForPreviews(dtdConnection);
     });
 
     testUsingContext('Removed previews are detected (LSP)', () async {
@@ -119,7 +119,7 @@ Widget myRemovePreview() => Container();
       );
       await initReloadSub.cancel();
 
-      await waitForPreviews(dtdConnection, (FlutterWidgetPreviews p) => p.previews.isNotEmpty);
+      await waitForPreviews(dtdConnection);
 
       removeFile.deleteSync();
 
@@ -136,7 +136,16 @@ Widget myRemovePreview() => Container();
       );
       await deleteReloadSub.cancel();
 
-      await waitForPreviews(dtdConnection, (FlutterWidgetPreviews p) => p.previews.isEmpty);
+      // We can safely check for the empty state immediately here because we
+      // already waited for the reload trigger above. The tool only triggers
+      // the reload after it has successfully processed the deletion, waited
+      // for the Analysis Server, and verified the empty state in DTD.
+      // This guarantees that DTD is in its final empty state and won't
+      // succeed prematurely.
+      await waitForPreviews(
+        dtdConnection,
+        predicate: (FlutterWidgetPreviews p) => p.previews.isEmpty,
+      );
     });
 
     testUsingContext('Modified previews are detected (LSP)', () async {
@@ -178,7 +187,7 @@ Widget myModifyPreview() => Container();
       );
       await initReloadSub.cancel();
 
-      await waitForPreviews(dtdConnection, (FlutterWidgetPreviews p) => p.previews.isNotEmpty);
+      await waitForPreviews(dtdConnection);
 
       modifyFile.writeAsStringSync('''
 import 'package:flutter/material.dart';
@@ -203,7 +212,7 @@ Widget myModifyPreview() => Container();
 
       await waitForPreviews(
         dtdConnection,
-        (FlutterWidgetPreviews p) =>
+        predicate: (FlutterWidgetPreviews p) =>
             p.previews.isNotEmpty && p.previews.first.previewAnnotation.contains("'Updated'"),
       );
     });
@@ -258,10 +267,7 @@ Widget myPartPreview() => Container();
       );
       await reloadSub.cancel();
 
-      final FlutterWidgetPreviews previews = await waitForPreviews(
-        dtdConnection,
-        (FlutterWidgetPreviews p) => p.previews.isNotEmpty,
-      );
+      final FlutterWidgetPreviews previews = await waitForPreviews(dtdConnection);
 
       final FlutterWidgetPreviewDetails preview = previews.previews.first;
       if (preview.functionName != 'myPartPreview') {

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test_helpers.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test_helpers.dart
@@ -162,6 +162,14 @@ Future<DTDResponse> getPreviews(DartToolingDaemon dtdConnection) async {
   return dtdConnection.call('Lsp', 'dart/workspace/getFlutterWidgetPreviews');
 }
 
+/// Polls DTD for widget previews until the [predicate] is met, or [timeout] is reached.
+///
+/// This is useful in integration tests to wait for the background analysis server
+/// to finish analyzing changes and updating the semantic model.
+///
+/// Gracefully ignores [Exception]s (such as DTD connection issues or RPC errors)
+/// during polling, as these are often temporary while the server is re-analyzing.
+/// Programming [Error]s will still propagate and fail the test immediately.
 Future<FlutterWidgetPreviews> waitForPreviews(
   DartToolingDaemon dtdConnection,
   bool Function(FlutterWidgetPreviews) predicate, {
@@ -180,7 +188,7 @@ Future<FlutterWidgetPreviews> waitForPreviews(
       if (predicate(previews)) {
         return previews;
       }
-    } on Object {
+    } on Exception {
       // Ignore DTD errors or JSON parsing errors during polling, as they might be temporary
       // while the analysis server is restarting or re-analyzing.
     }

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test_helpers.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test_helpers.dart
@@ -167,17 +167,27 @@ Future<DTDResponse> getPreviews(DartToolingDaemon dtdConnection) async {
 /// This is useful in integration tests to wait for the background analysis server
 /// to finish analyzing changes and updating the semantic model.
 ///
+/// Polls DTD for widget previews until the [predicate] is met, or [timeout] is reached.
+///
+/// If [predicate] is null, it defaults to waiting until the previews list is not empty.
+///
+/// This is useful in integration tests to wait for the background analysis server
+/// to finish analyzing changes and updating the semantic model.
+///
 /// Gracefully ignores all [Object]s (such as DTD connection issues, RPC errors, or
 /// temporary parsing errors) during polling, as these are often temporary while
-/// the server is re-analyzing.
+/// the server is re-analyzing. Swallowed errors are logged to stdout for diagnostics
+/// in case of timeouts.
 Future<FlutterWidgetPreviews> waitForPreviews(
-  DartToolingDaemon dtdConnection,
-  bool Function(FlutterWidgetPreviews) predicate, {
+  DartToolingDaemon dtdConnection, {
+  bool Function(FlutterWidgetPreviews)? predicate,
   Duration timeout = const Duration(seconds: 10),
   Duration pollInterval = const Duration(milliseconds: 200),
 }) async {
   final stopwatch = Stopwatch()..start();
   late FlutterWidgetPreviews previews;
+  final bool Function(FlutterWidgetPreviews) actualPredicate =
+      predicate ?? (FlutterWidgetPreviews p) => p.previews.isNotEmpty;
   while (stopwatch.elapsed < timeout) {
     try {
       final DTDResponse result = await dtdConnection.call(
@@ -185,22 +195,37 @@ Future<FlutterWidgetPreviews> waitForPreviews(
         'dart/workspace/getFlutterWidgetPreviews',
       );
       previews = FlutterWidgetPreviews.fromJson(result.result['result']! as Map<String, Object?>);
-      if (predicate(previews)) {
+      if (actualPredicate(previews)) {
         return previews;
       }
-    } on Object {
-      // Ignore DTD errors or JSON parsing errors during polling, as they might be temporary
-      // while the analysis server is restarting or re-analyzing.
+    } on Object catch (e) {
+      // During file modification, the background Analysis Server re-analyzes the project.
+      // This transition state can cause DTD to temporarily return RPC errors (e.g., if the
+      // LSP service is temporarily re-registering or busy), socket/connection issues, or
+      // transient JSON parsing errors if we query in the middle of an update.
+      //
+      // We catch and ignore all errors here to allow the polling loop to continue and tolerate
+      // these transient hiccups. Any genuine, non-transient errors will eventually cause a
+      // timeout, at which point we will perform a final query without a try-catch to propagate
+      // the real failure.
+      //
+      // We print the swallowed error so that if the test does time out, the developer can
+      // see the history of transient errors in the test output for diagnostics.
+      // ignore: avoid_print
+      print('waitForPreviews: swallowed transient error during polling: $e');
     }
     await Future<void>.delayed(pollInterval);
   }
-  // Try one last time without catching errors to propagate them if it still fails
+
+  // If we timed out, we perform one last query *without* a try-catch. If the failure is
+  // permanent (e.g., the Analysis Server crashed or the method is genuinely unimplemented),
+  // this call will throw and propagate the real exception/stack trace to fail the test clearly.
   final DTDResponse result = await dtdConnection.call(
     'Lsp',
     'dart/workspace/getFlutterWidgetPreviews',
   );
   previews = FlutterWidgetPreviews.fromJson(result.result['result']! as Map<String, Object?>);
-  if (predicate(previews)) {
+  if (actualPredicate(previews)) {
     return previews;
   }
   throw StateError(

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test_helpers.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test_helpers.dart
@@ -164,11 +164,6 @@ Future<DTDResponse> getPreviews(DartToolingDaemon dtdConnection) async {
 
 /// Polls DTD for widget previews until the [predicate] is met, or [timeout] is reached.
 ///
-/// This is useful in integration tests to wait for the background analysis server
-/// to finish analyzing changes and updating the semantic model.
-///
-/// Polls DTD for widget previews until the [predicate] is met, or [timeout] is reached.
-///
 /// If [predicate] is null, it defaults to waiting until the previews list is not empty.
 ///
 /// This is useful in integration tests to wait for the background analysis server

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test_helpers.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test_helpers.dart
@@ -10,6 +10,7 @@ import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/commands/widget_preview.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
+import 'package:flutter_tools/src/widget_preview/dtd_types.dart';
 import 'package:process/process.dart';
 
 import '../src/common.dart';
@@ -159,4 +160,42 @@ Future<DTDResponse> getPreviews(DartToolingDaemon dtdConnection) async {
     await Future<void>.delayed(const Duration(seconds: 2));
   }
   return dtdConnection.call('Lsp', 'dart/workspace/getFlutterWidgetPreviews');
+}
+
+Future<FlutterWidgetPreviews> waitForPreviews(
+  DartToolingDaemon dtdConnection,
+  bool Function(FlutterWidgetPreviews) predicate, {
+  Duration timeout = const Duration(seconds: 10),
+  Duration pollInterval = const Duration(milliseconds: 200),
+}) async {
+  final stopwatch = Stopwatch()..start();
+  late FlutterWidgetPreviews previews;
+  while (stopwatch.elapsed < timeout) {
+    try {
+      final DTDResponse result = await dtdConnection.call(
+        'Lsp',
+        'dart/workspace/getFlutterWidgetPreviews',
+      );
+      previews = FlutterWidgetPreviews.fromJson(result.result['result']! as Map<String, Object?>);
+      if (predicate(previews)) {
+        return previews;
+      }
+    } on Object {
+      // Ignore DTD errors or JSON parsing errors during polling, as they might be temporary
+      // while the analysis server is restarting or re-analyzing.
+    }
+    await Future<void>.delayed(pollInterval);
+  }
+  // Try one last time without catching errors to propagate them if it still fails
+  final DTDResponse result = await dtdConnection.call(
+    'Lsp',
+    'dart/workspace/getFlutterWidgetPreviews',
+  );
+  previews = FlutterWidgetPreviews.fromJson(result.result['result']! as Map<String, Object?>);
+  if (predicate(previews)) {
+    return previews;
+  }
+  throw StateError(
+    'Timed out waiting for previews condition. Last value had ${previews.previews.length} previews.',
+  );
 }

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test_helpers.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test_helpers.dart
@@ -167,9 +167,9 @@ Future<DTDResponse> getPreviews(DartToolingDaemon dtdConnection) async {
 /// This is useful in integration tests to wait for the background analysis server
 /// to finish analyzing changes and updating the semantic model.
 ///
-/// Gracefully ignores [Exception]s (such as DTD connection issues or RPC errors)
-/// during polling, as these are often temporary while the server is re-analyzing.
-/// Programming [Error]s will still propagate and fail the test immediately.
+/// Gracefully ignores all [Object]s (such as DTD connection issues, RPC errors, or
+/// temporary parsing errors) during polling, as these are often temporary while
+/// the server is re-analyzing.
 Future<FlutterWidgetPreviews> waitForPreviews(
   DartToolingDaemon dtdConnection,
   bool Function(FlutterWidgetPreviews) predicate, {
@@ -188,7 +188,7 @@ Future<FlutterWidgetPreviews> waitForPreviews(
       if (predicate(previews)) {
         return previews;
       }
-    } on Exception {
+    } on Object {
       // Ignore DTD errors or JSON parsing errors during polling, as they might be temporary
       // while the analysis server is restarting or re-analyzing.
     }


### PR DESCRIPTION
### Description
Fixes flakiness in `widget_preview_detection_test.dart` by introducing a robust polling mechanism when querying DTD for previews.

Previously, the integration tests were flaking on slow CI environments because they queried DTD immediately after a file modification, without waiting for the background Dart Analysis Server to finish re-analyzing the changes. This led to stale (empty) preview results and assertion failures like `Bad state: Preview was lost after modification!`.

### Changes
*   **Introduced `waitForPreviews` Helper**: Added a robust polling helper in `widget_preview_test_helpers.dart` that repeatedly queries DTD for previews until a user-specified predicate is met (or a 10-second timeout occurs).
*   **Error Resilience**: The helper gracefully ignores all `Object`s (including DTD connection issues, RPC errors, or temporary parsing errors) during the polling loop, as these are common transient states while the Analysis Server is re-analyzing.
*   **Test Refactoring**: Updated all four integration tests in `widget_preview_detection_test.dart` to use `waitForPreviews` with appropriate predicates (waiting for previews to be non-empty, empty, or containing specific updated content).
*   **Documentation**: Added comprehensive Dartdoc comments to the new public helper.

### Related Issues
*   Fixes https://github.com/flutter/flutter/issues/187514
