### PR TITLE
[gen_l10n] Exclude inherited keys from untranslated-messages-file

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1058,11 +1058,18 @@ class LocalizationsGenerator {
     final LocaleInfo locale = bundle.locale;
     final baseClassName = '$className${LocaleInfo.fromString(locale.languageCode).camelCase()}';
 
-    _allMessages.where((Message message) => message.messages[locale] == null).forEach((
-      Message message,
-    ) {
-      _addUnimplementedMessage(locale, message.resourceId);
-    });
+    // Only mark a message as unimplemented/untranslated for a regional subclass
+    // (e.g. en_US) if it is also missing in the parent base locale (e.g. en).
+    // If it is present in the parent locale, it will be correctly inherited
+    // at runtime via Dart class inheritance, so it shouldn't be reported as missing.
+    final parentLocale = LocaleInfo.fromString(locale.languageCode);
+    _allMessages
+        .where((Message message) {
+          return message.messages[locale] == null && message.messages[parentLocale] == null;
+        })
+        .forEach((Message message) {
+          _addUnimplementedMessage(locale, message.resourceId);
+        });
 
     final Iterable<String> methods = _allMessages
         .where((Message message) => message.parsedMessages[locale] != null)

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -406,6 +406,30 @@ void main() {
     expect(unimplementedOutputString, contains('subtitle'));
   });
 
+  testWithoutContext('does not include inherited keys in untranslated messages file', () {
+    final String untranslatedMessagesFilePath = fs.path.join(
+      'lib',
+      'l10n',
+      'unimplemented_message_translations.json',
+    );
+    setupLocalizations(<String, String>{
+      'en': twoMessageArbFileString,
+      'en_US': singleMessageArbFileString,
+    }, untranslatedMessagesFile: untranslatedMessagesFilePath);
+    final String unimplementedOutputString = fs
+        .file(untranslatedMessagesFilePath)
+        .readAsStringSync();
+    try {
+      json.decode(unimplementedOutputString);
+    } on Exception {
+      fail('Parsing arb file should not fail');
+    }
+    // en_US misses 'subtitle', but it is present in 'en' (base/template).
+    // So it should NOT be in the untranslated messages file.
+    expect(unimplementedOutputString, isNot(contains('en_US')));
+    expect(unimplementedOutputString, isNot(contains('subtitle')));
+  });
+
   testWithoutContext('correctly creates an untranslated messages file when project directory is '
       'not the current directory', () {
     // Regression test for https://github.com/flutter/flutter/issues/174205


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/176020