### PR TITLE
Fixing corrupted window size OnEmptyFrameGenerated due to transpsed width/height

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
@@ -152,7 +152,7 @@ bool FlutterWindowsView::OnEmptyFrameGenerated() {
     return true;
   }
 
-  if (!ResizeRenderSurface(resize_target_height_, resize_target_width_)) {
+  if (!ResizeRenderSurface(resize_target_width_, resize_target_height_)) {
     return false;
   }
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -992,7 +992,7 @@ TEST(FlutterWindowsViewTest, TestEmptyFrameResizes) {
   EXPECT_CALL(*surface.get(), Destroy).WillOnce(Return(true));
 
   EXPECT_CALL(*egl_manager.get(),
-              CreateWindowSurface(_, /*width=*/500, /*height=*/500))
+              CreateWindowSurface(_, /*width=*/500, /*height=*/300))
       .WillOnce(Return(std::move((resized_surface))));
   EXPECT_CALL(*resized_surface_ptr, MakeCurrent).WillOnce(Return(true));
   EXPECT_CALL(*resized_surface_ptr, SetVSyncEnabled).WillOnce(Return(true));
@@ -1028,7 +1028,7 @@ TEST(FlutterWindowsViewTest, TestEmptyFrameResizes) {
 
   // Start the window resize. This sends the new window metrics
   // and then blocks until another thread completes the window resize.
-  EXPECT_TRUE(view->OnWindowSizeChanged(500, 500));
+  EXPECT_TRUE(view->OnWindowSizeChanged(500, 300));
   frame_thread.join();
 }
 


### PR DESCRIPTION
## What's new?
- Fixed bug where the width and height were swapped in `FlutterWindowsView::OnFrameGenerated`
- Update the test to NOT use square dimensions so that the error would be obvious going forward

fixes https://github.com/flutter/flutter/issues/187922

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.