### PR TITLE
Clear cached directional focus history on a non-directional focus request 

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1189,7 +1189,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       return;
     }
     _setAsFocusedChildForScope();
-    propogateFocusRequest(this);
+    propagateFocusRequest(this);
     if (hasPrimaryFocus &&
         (_manager!._markedForFocus == null || _manager!._markedForFocus == this)) {
       return;
@@ -1250,8 +1250,8 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// their subtree.
   @protected
   @mustCallSuper
-  void propogateFocusRequest(FocusNode descendant) {
-    _parent?.propogateFocusRequest(descendant);
+  void propagateFocusRequest(FocusNode descendant) {
+    _parent?.propagateFocusRequest(descendant);
   }
 
   /// Request to move the focus to the next focus node, by calling the

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1241,6 +1241,11 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     }
   }
 
+  /// Invalidates cached traversal policy data across all enclosing scopes if
+  /// focus shifted outside of an active traversal action.
+  ///
+  /// For instance, if focus moves via a direct tap, then stale traversal
+  /// history is cleared.
   void _maybeInvalidatePolicyData() {
     FocusNode? current = this;
     while (current != null) {

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1189,6 +1189,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       return;
     }
     _setAsFocusedChildForScope();
+    _maybeInvalidatePolicyData();
     if (hasPrimaryFocus &&
         (_manager!._markedForFocus == null || _manager!._markedForFocus == this)) {
       return;
@@ -1237,6 +1238,21 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       // end of the list represents the currently focused child.
       ancestor._focusedChildren.add(scopeFocus);
       scopeFocus = ancestor;
+    }
+  }
+
+  void _maybeInvalidatePolicyData() {
+    FocusNode? current = this;
+    while (current != null) {
+      final FocusTraversalPolicy? policy = FocusTraversalGroup.maybeOfNode(current);
+      if (policy != null && !FocusTraversalGroup.underTraversal(current)) {
+        FocusScopeNode? scope = current.nearestScope;
+        while (scope != null) {
+          policy.invalidateScopeData(scope);
+          scope = scope.enclosingScope;
+        }
+      }
+      current = current.parent;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1189,7 +1189,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       return;
     }
     _setAsFocusedChildForScope();
-    _maybeInvalidatePolicyData();
+    propogateFocusRequest(this);
     if (hasPrimaryFocus &&
         (_manager!._markedForFocus == null || _manager!._markedForFocus == this)) {
       return;
@@ -1241,24 +1241,17 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     }
   }
 
-  /// Invalidates cached traversal policy data across all enclosing scopes if
-  /// focus shifted outside of an active traversal action.
+  /// Notifies the node and its ancestors that a focus request has occurred
+  /// within its subtree.
   ///
-  /// For instance, if focus moves via a direct tap, then stale traversal
-  /// history is cleared.
-  void _maybeInvalidatePolicyData() {
-    FocusNode? current = this;
-    while (current != null) {
-      final FocusTraversalPolicy? policy = FocusTraversalGroup.maybeOfNode(current);
-      if (policy != null && !FocusTraversalGroup.underTraversal(current)) {
-        FocusScopeNode? scope = current.nearestScope;
-        while (scope != null) {
-          policy.invalidateScopeData(scope);
-          scope = scope.enclosingScope;
-        }
-      }
-      current = current.parent;
-    }
+  /// This is called on the newly focused node and all of its ancestors.
+  ///
+  /// Subclasses can override this to respond to focus change requests within
+  /// their subtree.
+  @protected
+  @mustCallSuper
+  void propogateFocusRequest(FocusNode descendant) {
+    _parent?.propogateFocusRequest(descendant);
   }
 
   /// Request to move the focus to the next focus node, by calling the

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1189,7 +1189,6 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       return;
     }
     _setAsFocusedChildForScope();
-    propagateFocusRequest(this);
     if (hasPrimaryFocus &&
         (_manager!._markedForFocus == null || _manager!._markedForFocus == this)) {
       return;
@@ -1239,19 +1238,6 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       ancestor._focusedChildren.add(scopeFocus);
       scopeFocus = ancestor;
     }
-  }
-
-  /// Notifies the node and its ancestors that a focus request has occurred
-  /// within its subtree.
-  ///
-  /// This is called on the newly focused node and all of its ancestors.
-  ///
-  /// Subclasses can override this to respond to focus change requests within
-  /// their subtree.
-  @protected
-  @mustCallSuper
-  void propagateFocusRequest(FocusNode descendant) {
-    _parent?.propagateFocusRequest(descendant);
   }
 
   /// Request to move the focus to the next focus node, by calling the

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -2230,7 +2230,7 @@ class _FocusTraversalGroupNode extends FocusNode {
   bool isTraversing = false;
 
   @override
-  void propogateFocusRequest(FocusNode descendant) {
+  void propagateFocusRequest(FocusNode descendant) {
     if (!isTraversing) {
       FocusScopeNode? scope = descendant.nearestScope;
       while (scope != null) {
@@ -2238,7 +2238,7 @@ class _FocusTraversalGroupNode extends FocusNode {
         scope = scope.enclosingScope;
       }
     }
-    super.propogateFocusRequest(descendant);
+    super.propagateFocusRequest(descendant);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -2119,16 +2119,6 @@ class FocusTraversalGroup extends StatefulWidget {
     return _getGroupNode(node)?.policy;
   }
 
-  /// Returns whether the nearest enclosing [FocusTraversalGroup] ancestor of
-  /// the given [FocusNode] is currently executing a directional focus
-  /// traversal.
-  ///
-  /// This is used to determine if focus shifts occurred as a result of active
-  /// traversal or external events (such as direct taps).
-  static bool underTraversal(FocusNode node) {
-    return _getGroupNode(node)?.isTraversing ?? false;
-  }
-
   static _FocusTraversalGroupNode? _getGroupNode(FocusNode node) {
     while (node.parent != null) {
       if (node.context == null) {
@@ -2238,6 +2228,18 @@ class _FocusTraversalGroupNode extends FocusNode {
   ///
   /// It is set to true during [FocusTraversalPolicy.inDirection].
   bool isTraversing = false;
+
+  @override
+  void propogateFocusRequest(FocusNode descendant) {
+    if (!isTraversing) {
+      FocusScopeNode? scope = descendant.nearestScope;
+      while (scope != null) {
+        policy.invalidateScopeData(scope);
+        scope = scope.enclosingScope;
+      }
+    }
+    super.propogateFocusRequest(descendant);
+  }
 }
 
 class _FocusTraversalGroupState extends State<FocusTraversalGroup> {

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1123,6 +1123,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     TraversalDirection direction,
     FocusScopeNode nearestScope,
     FocusNode focusedChild,
+    _FocusTraversalGroupNode? groupNode,
   ) {
     final _DirectionalPolicyData? policyData = _policyData[nearestScope];
     if (policyData != null &&
@@ -1154,7 +1155,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
           case TraversalDirection.down:
             alignmentPolicy = ScrollPositionAlignmentPolicy.keepVisibleAtEnd;
         }
-        requestFocusCallback(lastNode, alignmentPolicy: alignmentPolicy);
+        _requestFocus(lastNode, alignmentPolicy: alignmentPolicy, groupNode);
         return true;
       }
 
@@ -1213,24 +1214,34 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     FocusNode currentNode,
     FocusNode node,
     FocusScopeNode nearestScope,
-    TraversalDirection direction,
+    TraversalDirection direction, 
+    _FocusTraversalGroupNode? groupNode,
+    
   ) {
     if (node is FocusScopeNode) {
       if (node.focusedChild != null) {
-        return _requestTraversalFocusInDirection(currentNode, node.focusedChild!, node, direction);
+        return _requestTraversalFocusInDirection(
+          currentNode,
+          node.focusedChild!,
+          node,
+          direction,
+          groupNode,
+        );
       }
       final FocusNode firstNode = findFirstFocusInDirection(node, direction) ?? currentNode;
       switch (direction) {
         case TraversalDirection.up:
         case TraversalDirection.left:
-          requestFocusCallback(
+          _requestFocus(
             firstNode,
+            groupNode,
             alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
           );
         case TraversalDirection.right:
         case TraversalDirection.down:
-          requestFocusCallback(
+          _requestFocus(
             firstNode,
+            groupNode,
             alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
           );
       }
@@ -1240,20 +1251,44 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     switch (direction) {
       case TraversalDirection.up:
       case TraversalDirection.left:
-        requestFocusCallback(
+        _requestFocus(
           node,
+          groupNode,
           alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
         );
       case TraversalDirection.right:
       case TraversalDirection.down:
-        requestFocusCallback(node, alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd);
+        _requestFocus(
+          node,
+          groupNode,
+          alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+        );
     }
     return !nodeHadPrimaryFocus;
+  }
+
+  void _requestFocus(
+    FocusNode node,
+    _FocusTraversalGroupNode? groupNode, {
+    ScrollPositionAlignmentPolicy? alignmentPolicy,
+    double? alignment,
+    Duration? duration,
+    Curve? curve,
+  }) {
+    groupNode?.lastRequestedFocus = node;
+    requestFocusCallback(
+      node,
+      alignmentPolicy: alignmentPolicy,
+      alignment: alignment,
+      duration: duration,
+      curve: curve,
+    );
   }
 
   bool _onEdgeForDirection(
     FocusNode currentNode,
     FocusNode focusedChild,
+    _FocusTraversalGroupNode? groupNode,
     TraversalDirection direction, {
     FocusScopeNode? scope,
   }) {
@@ -1275,7 +1310,13 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
             direction,
           );
           if (found == null) {
-            return _onEdgeForDirection(currentNode, focusedChild, direction, scope: nearestScope);
+            return _onEdgeForDirection(
+              currentNode,
+              focusedChild,
+              groupNode,
+              direction,
+              scope: nearestScope,
+            );
           }
         } else {
           found = _findNextFocusInDirection(
@@ -1296,7 +1337,13 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         return false;
     }
     if (found != null) {
-      return _requestTraversalFocusInDirection(currentNode, found, nearestScope, direction);
+      return _requestTraversalFocusInDirection(
+        currentNode,
+        found,
+        nearestScope,
+        direction,
+        groupNode,
+      );
     }
     return false;
   }
@@ -1332,20 +1379,22 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         switch (direction) {
           case TraversalDirection.up:
           case TraversalDirection.left:
-            requestFocusCallback(
+            _requestFocus(
               firstFocus,
               alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
+              groupNode,
             );
           case TraversalDirection.right:
           case TraversalDirection.down:
-            requestFocusCallback(
+            _requestFocus(
               firstFocus,
               alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+              groupNode,
             );
         }
         return true;
       }
-      if (_popPolicyDataIfNeeded(direction, nearestScope, focusedChild)) {
+      if (_popPolicyDataIfNeeded(direction, nearestScope, focusedChild, groupNode)) {
         return true;
       }
       final FocusNode? found = _findNextFocusInDirection(
@@ -1355,9 +1404,15 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
       );
       if (found != null) {
         _pushPolicyData(direction, nearestScope, focusedChild);
-        return _requestTraversalFocusInDirection(currentNode, found, nearestScope, direction);
+        return _requestTraversalFocusInDirection(
+          currentNode,
+          found,
+          nearestScope,
+          direction,
+          groupNode,
+        );
       }
-      return _onEdgeForDirection(currentNode, focusedChild, direction);
+      return _onEdgeForDirection(currentNode, focusedChild, groupNode, direction);
     } finally {
       groupNode?.isTraversing = false;
     }
@@ -2213,8 +2268,11 @@ class FocusTraversalGroup extends StatefulWidget {
 }
 
 // A special focus node subclass that only FocusTraversalGroup uses so that it
-// can be used to cache the policy in the focus tree, and so that the traversal
-// code can find groups in the focus tree.
+// can be used to cache the following in the focus tree:
+//  - the focus traversal policy - this allows traversal code to find groups in
+//    the focus tree.
+//  - the last focused node - this allows the policy to be invalidated when a
+//    focus change was not triggered via a traversal request.
 class _FocusTraversalGroupNode extends FocusNode {
   _FocusTraversalGroupNode({super.debugLabel, required this.policy}) {
     if (kFlutterMemoryAllocationsEnabled) {
@@ -2224,22 +2282,12 @@ class _FocusTraversalGroupNode extends FocusNode {
 
   FocusTraversalPolicy policy;
 
+  FocusNode? lastRequestedFocus;
+
   /// Whether the group is actively evaluating a focus traversal decision.
   ///
   /// It is set to true during [FocusTraversalPolicy.inDirection].
   bool isTraversing = false;
-
-  @override
-  void propagateFocusRequest(FocusNode descendant) {
-    if (!isTraversing) {
-      FocusScopeNode? scope = descendant.nearestScope;
-      while (scope != null) {
-        policy.invalidateScopeData(scope);
-        scope = scope.enclosingScope;
-      }
-    }
-    super.propagateFocusRequest(descendant);
-  }
 }
 
 class _FocusTraversalGroupState extends State<FocusTraversalGroup> {
@@ -2256,11 +2304,13 @@ class _FocusTraversalGroupState extends State<FocusTraversalGroup> {
   @override
   void initState() {
     super.initState();
+    FocusManager.instance.addListener(_handleFocusChanged);
     widget.onFocusNodeCreated?.call(focusNode);
   }
 
   @override
   void dispose() {
+    FocusManager.instance.removeListener(_handleFocusChanged);
     focusNode.dispose();
     super.dispose();
   }
@@ -2285,6 +2335,24 @@ class _FocusTraversalGroupState extends State<FocusTraversalGroup> {
       descendantsAreTraversable: widget.descendantsAreTraversable,
       child: widget.child,
     );
+  }
+
+  void _handleFocusChanged() {
+    final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
+    final FocusNode? lastRequestedFocus = focusNode.lastRequestedFocus;
+
+    if (primaryFocus == null || lastRequestedFocus == null) {
+      return;
+    }
+
+    if (primaryFocus != lastRequestedFocus) {
+      FocusScopeNode? scope = primaryFocus.nearestScope;
+      while (scope != null) {
+        widget.policy.invalidateScopeData(scope);
+        scope = scope.enclosingScope;
+      }
+      focusNode.lastRequestedFocus = null;
+    }
   }
 }
 

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1368,53 +1368,48 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
   @override
   bool inDirection(FocusNode currentNode, TraversalDirection direction) {
     final _FocusTraversalGroupNode? groupNode = FocusTraversalGroup._getGroupNode(currentNode);
-    groupNode?.isTraversing = true;
-    try {
-      final FocusScopeNode nearestScope = currentNode.nearestScope!;
-      final FocusNode? focusedChild = nearestScope.focusedChild;
-      if (focusedChild == null) {
-        final FocusNode firstFocus =
-            findFirstFocusInDirection(currentNode, direction) ?? currentNode;
-        switch (direction) {
-          case TraversalDirection.up:
-          case TraversalDirection.left:
-            _requestFocus(
-              firstFocus,
-              alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
-              groupNode,
-            );
-          case TraversalDirection.right:
-          case TraversalDirection.down:
-            _requestFocus(
-              firstFocus,
-              alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
-              groupNode,
-            );
-        }
-        return true;
+    final FocusScopeNode nearestScope = currentNode.nearestScope!;
+    final FocusNode? focusedChild = nearestScope.focusedChild;
+    if (focusedChild == null) {
+      final FocusNode firstFocus =
+          findFirstFocusInDirection(currentNode, direction) ?? currentNode;
+      switch (direction) {
+        case TraversalDirection.up:
+        case TraversalDirection.left:
+          _requestFocus(
+            firstFocus,
+            alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
+            groupNode,
+          );
+        case TraversalDirection.right:
+        case TraversalDirection.down:
+          _requestFocus(
+            firstFocus,
+            alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+            groupNode,
+          );
       }
-      if (_popPolicyDataIfNeeded(direction, nearestScope, focusedChild, groupNode)) {
-        return true;
-      }
-      final FocusNode? found = _findNextFocusInDirection(
-        focusedChild,
-        nearestScope.traversalDescendants,
-        direction,
-      );
-      if (found != null) {
-        _pushPolicyData(direction, nearestScope, focusedChild);
-        return _requestTraversalFocusInDirection(
-          currentNode,
-          found,
-          nearestScope,
-          direction,
-          groupNode,
-        );
-      }
-      return _onEdgeForDirection(currentNode, focusedChild, groupNode, direction);
-    } finally {
-      groupNode?.isTraversing = false;
+      return true;
     }
+    if (_popPolicyDataIfNeeded(direction, nearestScope, focusedChild, groupNode)) {
+      return true;
+    }
+    final FocusNode? found = _findNextFocusInDirection(
+      focusedChild,
+      nearestScope.traversalDescendants,
+      direction,
+    );
+    if (found != null) {
+      _pushPolicyData(direction, nearestScope, focusedChild);
+      return _requestTraversalFocusInDirection(
+        currentNode,
+        found,
+        nearestScope,
+        direction,
+        groupNode,
+      );
+    }
+  return _onEdgeForDirection(currentNode, focusedChild, groupNode, direction);
   }
 }
 
@@ -2282,11 +2277,6 @@ class _FocusTraversalGroupNode extends FocusNode {
   FocusTraversalPolicy policy;
 
   FocusNode? lastRequestedFocus;
-
-  /// Whether the group is actively evaluating a focus traversal decision.
-  ///
-  /// It is set to true during [FocusTraversalPolicy.inDirection].
-  bool isTraversing = false;
 }
 
 class _FocusTraversalGroupState extends State<FocusTraversalGroup> {

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -2330,12 +2330,12 @@ class _FocusTraversalGroupState extends State<FocusTraversalGroup> {
     final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
     final FocusNode? lastRequestedFocus = focusNode.lastRequestedFocus;
 
-    if (primaryFocus == null || lastRequestedFocus == null) {
+    if (lastRequestedFocus == null) {
       return;
     }
 
     if (primaryFocus != lastRequestedFocus) {
-      FocusScopeNode? scope = primaryFocus.nearestScope;
+      FocusScopeNode? scope = primaryFocus?.nearestScope;
       while (scope != null) {
         widget.policy.invalidateScopeData(scope);
         scope = scope.enclosingScope;

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1321,39 +1321,46 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
   @mustCallSuper
   @override
   bool inDirection(FocusNode currentNode, TraversalDirection direction) {
-    final FocusScopeNode nearestScope = currentNode.nearestScope!;
-    final FocusNode? focusedChild = nearestScope.focusedChild;
-    if (focusedChild == null) {
-      final FocusNode firstFocus = findFirstFocusInDirection(currentNode, direction) ?? currentNode;
-      switch (direction) {
-        case TraversalDirection.up:
-        case TraversalDirection.left:
-          requestFocusCallback(
-            firstFocus,
-            alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
-          );
-        case TraversalDirection.right:
-        case TraversalDirection.down:
-          requestFocusCallback(
-            firstFocus,
-            alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
-          );
+    final _FocusTraversalGroupNode? groupNode = FocusTraversalGroup._getGroupNode(currentNode);
+    groupNode?.isTraversing = true;
+    try {
+      final FocusScopeNode nearestScope = currentNode.nearestScope!;
+      final FocusNode? focusedChild = nearestScope.focusedChild;
+      if (focusedChild == null) {
+        final FocusNode firstFocus =
+            findFirstFocusInDirection(currentNode, direction) ?? currentNode;
+        switch (direction) {
+          case TraversalDirection.up:
+          case TraversalDirection.left:
+            requestFocusCallback(
+              firstFocus,
+              alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
+            );
+          case TraversalDirection.right:
+          case TraversalDirection.down:
+            requestFocusCallback(
+              firstFocus,
+              alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+            );
+        }
+        return true;
       }
-      return true;
+      if (_popPolicyDataIfNeeded(direction, nearestScope, focusedChild)) {
+        return true;
+      }
+      final FocusNode? found = _findNextFocusInDirection(
+        focusedChild,
+        nearestScope.traversalDescendants,
+        direction,
+      );
+      if (found != null) {
+        _pushPolicyData(direction, nearestScope, focusedChild);
+        return _requestTraversalFocusInDirection(currentNode, found, nearestScope, direction);
+      }
+      return _onEdgeForDirection(currentNode, focusedChild, direction);
+    } finally {
+      groupNode?.isTraversing = false;
     }
-    if (_popPolicyDataIfNeeded(direction, nearestScope, focusedChild)) {
-      return true;
-    }
-    final FocusNode? found = _findNextFocusInDirection(
-      focusedChild,
-      nearestScope.traversalDescendants,
-      direction,
-    );
-    if (found != null) {
-      _pushPolicyData(direction, nearestScope, focusedChild);
-      return _requestTraversalFocusInDirection(currentNode, found, nearestScope, direction);
-    }
-    return _onEdgeForDirection(currentNode, focusedChild, direction);
   }
 }
 
@@ -2112,6 +2119,10 @@ class FocusTraversalGroup extends StatefulWidget {
     return _getGroupNode(node)?.policy;
   }
 
+  static bool underTraversal(FocusNode node) {
+    return _getGroupNode(node)?.isTraversing ?? false;
+  }
+
   static _FocusTraversalGroupNode? _getGroupNode(FocusNode node) {
     while (node.parent != null) {
       if (node.context == null) {
@@ -2216,6 +2227,7 @@ class _FocusTraversalGroupNode extends FocusNode {
   }
 
   FocusTraversalPolicy policy;
+  bool isTraversing = false;
 }
 
 class _FocusTraversalGroupState extends State<FocusTraversalGroup> {

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1409,7 +1409,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         groupNode,
       );
     }
-  return _onEdgeForDirection(currentNode, focusedChild, groupNode, direction);
+    return _onEdgeForDirection(currentNode, focusedChild, groupNode, direction);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -2119,6 +2119,12 @@ class FocusTraversalGroup extends StatefulWidget {
     return _getGroupNode(node)?.policy;
   }
 
+  /// Returns whether the nearest enclosing [FocusTraversalGroup] ancestor of
+  /// the given [FocusNode] is currently executing a directional focus
+  /// traversal.
+  ///
+  /// This is used to determine if focus shifts occurred as a result of active
+  /// traversal or external events (such as direct taps).
   static bool underTraversal(FocusNode node) {
     return _getGroupNode(node)?.isTraversing ?? false;
   }
@@ -2227,6 +2233,10 @@ class _FocusTraversalGroupNode extends FocusNode {
   }
 
   FocusTraversalPolicy policy;
+
+  /// Whether the group is actively evaluating a focus traversal decision.
+  ///
+  /// It is set to true during [FocusTraversalPolicy.inDirection].
   bool isTraversing = false;
 }
 

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1214,9 +1214,8 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     FocusNode currentNode,
     FocusNode node,
     FocusScopeNode nearestScope,
-    TraversalDirection direction, 
+    TraversalDirection direction,
     _FocusTraversalGroupNode? groupNode,
-    
   ) {
     if (node is FocusScopeNode) {
       if (node.focusedChild != null) {

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -1922,7 +1922,10 @@ void main() {
       clear();
     });
 
-    testWidgets('Directional focus history is cleared on tap', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/186154.
+    testWidgets('Directional focus history is cleared on explicit focus request', (
+      WidgetTester tester,
+    ) async {
       var focus = List<bool?>.generate(5, (int _) => null);
       final nodes = List<FocusNode>.generate(
         5,
@@ -1973,7 +1976,7 @@ void main() {
       await tester.pump();
       clear();
 
-      // Move down twice.
+      // Move down three times.
       expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
       expect(focus, orderedEquals(<bool?>[false, true, null, null, null]));
@@ -1995,11 +1998,13 @@ void main() {
       expect(focus, orderedEquals(<bool?>[null, true, null, false, null]));
       clear();
 
+      // Move down once.
       expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
       expect(focus, orderedEquals(<bool?>[null, false, true, null, null]));
       clear();
 
+      // Move up twice.
       expect(scope.focusInDirection(TraversalDirection.up), isTrue);
       await tester.pump();
       expect(focus, orderedEquals(<bool?>[null, true, false, null, null]));

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -1923,9 +1923,9 @@ void main() {
     });
 
     testWidgets('Directional focus history is cleared on tap', (WidgetTester tester) async {
-      var focus = List<bool?>.generate(3, (int _) => null);
+      var focus = List<bool?>.generate(5, (int _) => null);
       final nodes = List<FocusNode>.generate(
-        3,
+        5,
         (int index) => FocusNode(debugLabel: 'Node $index'),
       );
       addTearDown(() {
@@ -1950,7 +1950,15 @@ void main() {
             policy: WidgetOrderTraversalPolicy(),
             child: FocusScope(
               debugLabel: 'Scope',
-              child: Column(children: <Widget>[makeFocus(0), makeFocus(1), makeFocus(2)]),
+              child: Column(
+                children: <Widget>[
+                  makeFocus(0),
+                  makeFocus(1),
+                  makeFocus(2),
+                  makeFocus(3),
+                  makeFocus(4),
+                ],
+              ),
             ),
           ),
         ),
@@ -1968,22 +1976,39 @@ void main() {
       // Move down twice.
       expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
-      expect(focus, orderedEquals(<bool?>[false, true, null]));
+      expect(focus, orderedEquals(<bool?>[false, true, null, null, null]));
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
-      expect(focus, orderedEquals(<bool?>[null, false, true]));
+      expect(focus, orderedEquals(<bool?>[null, false, true, null, null]));
       clear();
 
-      // Shift focus externally back to [0].
-      nodes[0].requestFocus();
+      expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
-      expect(focus, orderedEquals(<bool?>[true, null, false]));
+      expect(focus, orderedEquals(<bool?>[null, null, false, true, null]));
       clear();
 
-      // Pressing UP from [0] should return false (at top edge), NOT pop history to [1].
-      expect(scope.focusInDirection(TraversalDirection.up), isFalse);
+      // Shift focus externally back to [1].
+      nodes[1].requestFocus();
+      await tester.pump();
+      expect(focus, orderedEquals(<bool?>[null, true, null, false, null]));
+      clear();
+
+      expect(scope.focusInDirection(TraversalDirection.down), isTrue);
+      await tester.pump();
+      expect(focus, orderedEquals(<bool?>[null, false, true, null, null]));
+      clear();
+
+      expect(scope.focusInDirection(TraversalDirection.up), isTrue);
+      await tester.pump();
+      expect(focus, orderedEquals(<bool?>[null, true, false, null, null]));
+      clear();
+
+      expect(scope.focusInDirection(TraversalDirection.up), isTrue);
+      await tester.pump();
+      expect(focus, orderedEquals(<bool?>[true, false, null, null, null]));
+      clear();
     });
 
     testWidgets('Directional prefers the closest node even on irregular grids', (

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -1805,7 +1805,7 @@ void main() {
     });
 
     testWidgets('Directional focus avoids hysteresis.', (WidgetTester tester) async {
-      var focus = List<bool?>.generate(6, (int _) => null);
+      List<bool?> focus = _createFocusTracker(6);
       final nodes = List<FocusNode>.generate(
         6,
         (int index) => FocusNode(debugLabel: 'Node $index'),
@@ -1858,7 +1858,7 @@ void main() {
       );
 
       void clear() {
-        focus = List<bool?>.generate(focus.length, (int _) => null);
+        focus = _createFocusTracker(focus.length);
       }
 
       final FocusNode scope = nodes[0].enclosingScope!;
@@ -1922,11 +1922,11 @@ void main() {
       clear();
     });
 
-    // Regression test for https://github.com/flutter/flutter/issues/186154.
+    // Regression test for https://github.com/flutter/flutter/issues/85941.
     testWidgets('Directional focus history is cleared on explicit focus request', (
       WidgetTester tester,
     ) async {
-      var focus = List<bool?>.generate(5, (int _) => null);
+      List<bool?> focus = _createFocusTracker(5);
       final nodes = List<FocusNode>.generate(
         5,
         (int index) => FocusNode(debugLabel: 'Node $index'),
@@ -1968,7 +1968,7 @@ void main() {
       );
 
       void clear() {
-        focus = List<bool?>.generate(focus.length, (int _) => null);
+        focus = _createFocusTracker(focus.length);
       }
 
       final FocusNode scope = nodes[0].enclosingScope!;
@@ -2021,7 +2021,7 @@ void main() {
     ) async {
       const cols = 3;
       const rows = 3;
-      var focus = List<bool?>.generate(rows * cols, (int _) => null);
+      List<bool?> focus = _createFocusTracker(rows * cols);
       final nodes = List<FocusNode>.generate(
         rows * cols,
         (int index) => FocusNode(debugLabel: 'Node $index'),
@@ -2083,7 +2083,7 @@ void main() {
       );
 
       void clear() {
-        focus = List<bool?>.generate(focus.length, (int _) => null);
+        focus = _createFocusTracker(focus.length);
       }
 
       final FocusNode scope = nodes[0].enclosingScope!;
@@ -2154,7 +2154,7 @@ void main() {
       WidgetTester tester,
     ) async {
       const rows = 4;
-      var focus = List<bool?>.generate(rows, (int _) => null);
+      List<bool?> focus = _createFocusTracker(rows);
       final nodes = List<FocusNode>.generate(
         rows,
         (int index) => FocusNode(debugLabel: 'Node $index'),
@@ -2208,7 +2208,7 @@ void main() {
       );
 
       void clear() {
-        focus = List<bool?>.generate(focus.length, (int _) => null);
+        focus = _createFocusTracker(focus.length);
       }
 
       final FocusNode scope = nodes[0].enclosingScope!;
@@ -2245,7 +2245,7 @@ void main() {
       WidgetTester tester,
     ) async {
       const cols = 4;
-      var focus = List<bool?>.generate(cols, (int _) => null);
+      List<bool?> focus = _createFocusTracker(cols);
       final nodes = List<FocusNode>.generate(
         cols,
         (int index) => FocusNode(debugLabel: 'Node $index'),
@@ -2299,7 +2299,7 @@ void main() {
       );
 
       void clear() {
-        focus = List<bool?>.generate(focus.length, (int _) => null);
+        focus = _createFocusTracker(focus.length);
       }
 
       final FocusNode scope = nodes[0].enclosingScope!;
@@ -3969,7 +3969,7 @@ void main() {
   });
 
   testWidgets('Edge cases for inDirection', (WidgetTester tester) async {
-    var focus = List<bool?>.generate(6, (int _) => null);
+    List<bool?> focus = _createFocusTracker(6);
     final nodes = List<FocusNode>.generate(6, (int index) => FocusNode(debugLabel: 'Node $index'));
     final childScope = FocusScopeNode(debugLabel: 'Child Scope');
     addTearDown(() {
@@ -4040,7 +4040,7 @@ void main() {
     await pumpApp();
 
     void clear() {
-      focus = List<bool?>.generate(focus.length, (int _) => null);
+      focus = _createFocusTracker(focus.length);
     }
 
     Future<void> resetTo(int index) async {
@@ -4236,3 +4236,6 @@ class SkipAllButFirstAndLastPolicy extends FocusTraversalPolicy
     ];
   }
 }
+
+/// Creates a list of [length] to track focus changes during the test suite.
+List<bool?> _createFocusTracker(int length) => List<bool?>.generate(length, (int index) => null);

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -1922,6 +1922,70 @@ void main() {
       clear();
     });
 
+    testWidgets('Directional focus history is cleared on tap', (WidgetTester tester) async {
+      var focus = List<bool?>.generate(3, (int _) => null);
+      final nodes = List<FocusNode>.generate(
+        3,
+        (int index) => FocusNode(debugLabel: 'Node $index'),
+      );
+      addTearDown(() {
+        for (final node in nodes) {
+          node.dispose();
+        }
+      });
+
+      Widget makeFocus(int index) {
+        return Focus(
+          debugLabel: '[$index]',
+          focusNode: nodes[index],
+          onFocusChange: (bool isFocused) => focus[index] = isFocused,
+          child: const SizedBox(width: 100, height: 100),
+        );
+      }
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: FocusTraversalGroup(
+            policy: WidgetOrderTraversalPolicy(),
+            child: FocusScope(
+              debugLabel: 'Scope',
+              child: Column(children: <Widget>[makeFocus(0), makeFocus(1), makeFocus(2)]),
+            ),
+          ),
+        ),
+      );
+
+      void clear() {
+        focus = List<bool?>.generate(focus.length, (int _) => null);
+      }
+
+      final FocusNode scope = nodes[0].enclosingScope!;
+      nodes[0].requestFocus();
+      await tester.pump();
+      clear();
+
+      // Move down twice.
+      expect(scope.focusInDirection(TraversalDirection.down), isTrue);
+      await tester.pump();
+      expect(focus, orderedEquals(<bool?>[false, true, null]));
+      clear();
+
+      expect(scope.focusInDirection(TraversalDirection.down), isTrue);
+      await tester.pump();
+      expect(focus, orderedEquals(<bool?>[null, false, true]));
+      clear();
+
+      // Shift focus externally back to [0].
+      nodes[0].requestFocus();
+      await tester.pump();
+      expect(focus, orderedEquals(<bool?>[true, null, false]));
+      clear();
+
+      // Pressing UP from [0] should return false (at top edge), NOT pop history to [1].
+      expect(scope.focusInDirection(TraversalDirection.up), isFalse);
+    });
+
     testWidgets('Directional prefers the closest node even on irregular grids', (
       WidgetTester tester,
     ) async {
@@ -3014,169 +3078,165 @@ void main() {
       variant: KeySimulatorTransitModeVariant.all(),
     );
 
-    testWidgets(
-      'Arrow focus traversal actions can be re-enabled for text fields.',
-      (WidgetTester tester) async {
-        final GlobalKey upperLeftKey = GlobalKey(debugLabel: 'upperLeftKey');
-        final GlobalKey upperRightKey = GlobalKey(debugLabel: 'upperRightKey');
-        final GlobalKey lowerLeftKey = GlobalKey(debugLabel: 'lowerLeftKey');
-        final GlobalKey lowerRightKey = GlobalKey(debugLabel: 'lowerRightKey');
+    testWidgets('Arrow focus traversal actions can be re-enabled for text fields.', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey upperLeftKey = GlobalKey(debugLabel: 'upperLeftKey');
+      final GlobalKey upperRightKey = GlobalKey(debugLabel: 'upperRightKey');
+      final GlobalKey lowerLeftKey = GlobalKey(debugLabel: 'lowerLeftKey');
+      final GlobalKey lowerRightKey = GlobalKey(debugLabel: 'lowerRightKey');
 
-        final controller1 = TextEditingController();
-        addTearDown(controller1.dispose);
-        final controller2 = TextEditingController();
-        addTearDown(controller2.dispose);
-        final controller3 = TextEditingController();
-        addTearDown(controller3.dispose);
-        final controller4 = TextEditingController();
-        addTearDown(controller4.dispose);
+      final controller1 = TextEditingController();
+      addTearDown(controller1.dispose);
+      final controller2 = TextEditingController();
+      addTearDown(controller2.dispose);
+      final controller3 = TextEditingController();
+      addTearDown(controller3.dispose);
+      final controller4 = TextEditingController();
+      addTearDown(controller4.dispose);
 
-        final focusNodeUpperLeft = FocusNode(debugLabel: 'upperLeft');
-        addTearDown(focusNodeUpperLeft.dispose);
-        final focusNodeUpperRight = FocusNode(debugLabel: 'upperRight');
-        addTearDown(focusNodeUpperRight.dispose);
-        final focusNodeLowerLeft = FocusNode(debugLabel: 'lowerLeft');
-        addTearDown(focusNodeLowerLeft.dispose);
-        final focusNodeLowerRight = FocusNode(debugLabel: 'lowerRight');
-        addTearDown(focusNodeLowerRight.dispose);
+      final focusNodeUpperLeft = FocusNode(debugLabel: 'upperLeft');
+      addTearDown(focusNodeUpperLeft.dispose);
+      final focusNodeUpperRight = FocusNode(debugLabel: 'upperRight');
+      addTearDown(focusNodeUpperRight.dispose);
+      final focusNodeLowerLeft = FocusNode(debugLabel: 'lowerLeft');
+      addTearDown(focusNodeLowerLeft.dispose);
+      final focusNodeLowerRight = FocusNode(debugLabel: 'lowerRight');
+      addTearDown(focusNodeLowerRight.dispose);
 
-        Widget generateTestWidgets(bool ignoreTextFields) {
-          final shortcuts = <ShortcutActivator, Intent>{
-            const SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(
-              TraversalDirection.left,
-              ignoreTextFields: ignoreTextFields,
-            ),
-            const SingleActivator(LogicalKeyboardKey.arrowRight): DirectionalFocusIntent(
-              TraversalDirection.right,
-              ignoreTextFields: ignoreTextFields,
-            ),
-            const SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(
-              TraversalDirection.down,
-              ignoreTextFields: ignoreTextFields,
-            ),
-            const SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(
-              TraversalDirection.up,
-              ignoreTextFields: ignoreTextFields,
-            ),
-          };
+      Widget generateTestWidgets(bool ignoreTextFields) {
+        final shortcuts = <ShortcutActivator, Intent>{
+          const SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(
+            TraversalDirection.left,
+            ignoreTextFields: ignoreTextFields,
+          ),
+          const SingleActivator(LogicalKeyboardKey.arrowRight): DirectionalFocusIntent(
+            TraversalDirection.right,
+            ignoreTextFields: ignoreTextFields,
+          ),
+          const SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(
+            TraversalDirection.down,
+            ignoreTextFields: ignoreTextFields,
+          ),
+          const SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(
+            TraversalDirection.up,
+            ignoreTextFields: ignoreTextFields,
+          ),
+        };
 
-          return TestWidgetsApp(
-            home: Shortcuts(
-              shortcuts: shortcuts,
-              child: FocusScope(
-                debugLabel: 'scope',
-                child: Column(
-                  children: <Widget>[
-                    Row(
-                      children: <Widget>[
-                        SizedBox.square(
-                          dimension: 100.0,
-                          child: EditableText(
-                            autofocus: true,
-                            key: upperLeftKey,
-                            controller: controller1,
-                            focusNode: focusNodeUpperLeft,
-                            cursorColor: const Color(0xffffffff),
-                            backgroundCursorColor: const Color(0xff808080),
-                            style: const TextStyle(),
-                          ),
+        return TestWidgetsApp(
+          home: Shortcuts(
+            shortcuts: shortcuts,
+            child: FocusScope(
+              debugLabel: 'scope',
+              child: Column(
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      SizedBox.square(
+                        dimension: 100.0,
+                        child: EditableText(
+                          autofocus: true,
+                          key: upperLeftKey,
+                          controller: controller1,
+                          focusNode: focusNodeUpperLeft,
+                          cursorColor: const Color(0xffffffff),
+                          backgroundCursorColor: const Color(0xff808080),
+                          style: const TextStyle(),
                         ),
-                        SizedBox.square(
-                          dimension: 100.0,
-                          child: EditableText(
-                            key: upperRightKey,
-                            controller: controller2,
-                            focusNode: focusNodeUpperRight,
-                            cursorColor: const Color(0xffffffff),
-                            backgroundCursorColor: const Color(0xff808080),
-                            style: const TextStyle(),
-                          ),
+                      ),
+                      SizedBox.square(
+                        dimension: 100.0,
+                        child: EditableText(
+                          key: upperRightKey,
+                          controller: controller2,
+                          focusNode: focusNodeUpperRight,
+                          cursorColor: const Color(0xffffffff),
+                          backgroundCursorColor: const Color(0xff808080),
+                          style: const TextStyle(),
                         ),
-                      ],
-                    ),
-                    Row(
-                      children: <Widget>[
-                        SizedBox.square(
-                          dimension: 100.0,
-                          child: EditableText(
-                            key: lowerLeftKey,
-                            controller: controller3,
-                            focusNode: focusNodeLowerLeft,
-                            cursorColor: const Color(0xffffffff),
-                            backgroundCursorColor: const Color(0xff808080),
-                            style: const TextStyle(),
-                          ),
+                      ),
+                    ],
+                  ),
+                  Row(
+                    children: <Widget>[
+                      SizedBox.square(
+                        dimension: 100.0,
+                        child: EditableText(
+                          key: lowerLeftKey,
+                          controller: controller3,
+                          focusNode: focusNodeLowerLeft,
+                          cursorColor: const Color(0xffffffff),
+                          backgroundCursorColor: const Color(0xff808080),
+                          style: const TextStyle(),
                         ),
-                        SizedBox.square(
-                          dimension: 100.0,
-                          child: EditableText(
-                            key: lowerRightKey,
-                            controller: controller4,
-                            focusNode: focusNodeLowerRight,
-                            cursorColor: const Color(0xffffffff),
-                            backgroundCursorColor: const Color(0xff808080),
-                            style: const TextStyle(),
-                          ),
+                      ),
+                      SizedBox.square(
+                        dimension: 100.0,
+                        child: EditableText(
+                          key: lowerRightKey,
+                          controller: controller4,
+                          focusNode: focusNodeLowerRight,
+                          cursorColor: const Color(0xffffffff),
+                          backgroundCursorColor: const Color(0xff808080),
+                          style: const TextStyle(),
                         ),
-                      ],
-                    ),
-                  ],
-                ),
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ),
-          );
-        }
+          ),
+        );
+      }
 
-        await tester.pumpWidget(generateTestWidgets(false));
+      await tester.pumpWidget(generateTestWidgets(false));
 
-        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-        expect(focusNodeUpperRight.hasPrimaryFocus, isTrue);
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-        expect(focusNodeLowerRight.hasPrimaryFocus, isTrue);
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-        expect(focusNodeLowerLeft.hasPrimaryFocus, isTrue);
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      expect(focusNodeUpperRight.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusNodeLowerRight.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      expect(focusNodeLowerLeft.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
 
-        await tester.pumpWidget(generateTestWidgets(true));
+      await tester.pumpWidget(generateTestWidgets(true));
 
-        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-        expect(focusNodeUpperRight.hasPrimaryFocus, isFalse);
-        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-        expect(focusNodeLowerRight.hasPrimaryFocus, isFalse);
-        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-        expect(focusNodeLowerLeft.hasPrimaryFocus, isFalse);
-        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-      },
-      variant: KeySimulatorTransitModeVariant.all(),
-    );
+      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      expect(focusNodeUpperRight.hasPrimaryFocus, isFalse);
+      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusNodeLowerRight.hasPrimaryFocus, isFalse);
+      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      expect(focusNodeLowerLeft.hasPrimaryFocus, isFalse);
+      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+    }, variant: KeySimulatorTransitModeVariant.all());
 
-    testWidgets(
-      'Focus traversal does not break when no focusable is available on a WidgetsApp',
-      (WidgetTester tester) async {
-        final events = <Object>[];
+    testWidgets('Focus traversal does not break when no focusable is available on a WidgetsApp', (
+      WidgetTester tester,
+    ) async {
+      final events = <Object>[];
 
-        await tester.pumpWidget(TestWidgetsApp(home: Container()));
+      await tester.pumpWidget(TestWidgetsApp(home: Container()));
 
-        HardwareKeyboard.instance.addHandler((KeyEvent event) {
-          events.add(event);
-          return true;
-        });
+      HardwareKeyboard.instance.addHandler((KeyEvent event) {
+        events.add(event);
+        return true;
+      });
 
-        await tester.idle();
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-        await tester.idle();
+      await tester.idle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.idle();
 
-        expect(events.length, 2);
-      },
-      variant: KeySimulatorTransitModeVariant.all(),
-    );
+      expect(events.length, 2);
+    }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Focus traversal does not throw when no focusable is available in a group', (
       WidgetTester tester,
@@ -3192,26 +3252,24 @@ void main() {
       expect(primaryFocus, equals(initialFocus));
     });
 
-    testWidgets(
-      'Focus traversal does not break when no focusable is available on a WidgetsApp',
-      (WidgetTester tester) async {
-        final events = <KeyEvent>[];
+    testWidgets('Focus traversal does not break when no focusable is available on a WidgetsApp', (
+      WidgetTester tester,
+    ) async {
+      final events = <KeyEvent>[];
 
-        await tester.pumpWidget(const TestWidgetsApp(home: Placeholder()));
+      await tester.pumpWidget(const TestWidgetsApp(home: Placeholder()));
 
-        HardwareKeyboard.instance.addHandler((KeyEvent event) {
-          events.add(event);
-          return true;
-        });
+      HardwareKeyboard.instance.addHandler((KeyEvent event) {
+        events.add(event);
+        return true;
+      });
 
-        await tester.idle();
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-        await tester.idle();
+      await tester.idle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.idle();
 
-        expect(events.length, 2);
-      },
-      variant: KeySimulatorTransitModeVariant.all(),
-    );
+      expect(events.length, 2);
+    }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Custom requestFocusCallback gets called on focusInDirection up/down/left/right.', (
       WidgetTester tester,

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -3108,165 +3108,169 @@ void main() {
       variant: KeySimulatorTransitModeVariant.all(),
     );
 
-    testWidgets('Arrow focus traversal actions can be re-enabled for text fields.', (
-      WidgetTester tester,
-    ) async {
-      final GlobalKey upperLeftKey = GlobalKey(debugLabel: 'upperLeftKey');
-      final GlobalKey upperRightKey = GlobalKey(debugLabel: 'upperRightKey');
-      final GlobalKey lowerLeftKey = GlobalKey(debugLabel: 'lowerLeftKey');
-      final GlobalKey lowerRightKey = GlobalKey(debugLabel: 'lowerRightKey');
+    testWidgets(
+      'Arrow focus traversal actions can be re-enabled for text fields.',
+      (WidgetTester tester) async {
+        final GlobalKey upperLeftKey = GlobalKey(debugLabel: 'upperLeftKey');
+        final GlobalKey upperRightKey = GlobalKey(debugLabel: 'upperRightKey');
+        final GlobalKey lowerLeftKey = GlobalKey(debugLabel: 'lowerLeftKey');
+        final GlobalKey lowerRightKey = GlobalKey(debugLabel: 'lowerRightKey');
 
-      final controller1 = TextEditingController();
-      addTearDown(controller1.dispose);
-      final controller2 = TextEditingController();
-      addTearDown(controller2.dispose);
-      final controller3 = TextEditingController();
-      addTearDown(controller3.dispose);
-      final controller4 = TextEditingController();
-      addTearDown(controller4.dispose);
+        final controller1 = TextEditingController();
+        addTearDown(controller1.dispose);
+        final controller2 = TextEditingController();
+        addTearDown(controller2.dispose);
+        final controller3 = TextEditingController();
+        addTearDown(controller3.dispose);
+        final controller4 = TextEditingController();
+        addTearDown(controller4.dispose);
 
-      final focusNodeUpperLeft = FocusNode(debugLabel: 'upperLeft');
-      addTearDown(focusNodeUpperLeft.dispose);
-      final focusNodeUpperRight = FocusNode(debugLabel: 'upperRight');
-      addTearDown(focusNodeUpperRight.dispose);
-      final focusNodeLowerLeft = FocusNode(debugLabel: 'lowerLeft');
-      addTearDown(focusNodeLowerLeft.dispose);
-      final focusNodeLowerRight = FocusNode(debugLabel: 'lowerRight');
-      addTearDown(focusNodeLowerRight.dispose);
+        final focusNodeUpperLeft = FocusNode(debugLabel: 'upperLeft');
+        addTearDown(focusNodeUpperLeft.dispose);
+        final focusNodeUpperRight = FocusNode(debugLabel: 'upperRight');
+        addTearDown(focusNodeUpperRight.dispose);
+        final focusNodeLowerLeft = FocusNode(debugLabel: 'lowerLeft');
+        addTearDown(focusNodeLowerLeft.dispose);
+        final focusNodeLowerRight = FocusNode(debugLabel: 'lowerRight');
+        addTearDown(focusNodeLowerRight.dispose);
 
-      Widget generateTestWidgets(bool ignoreTextFields) {
-        final shortcuts = <ShortcutActivator, Intent>{
-          const SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(
-            TraversalDirection.left,
-            ignoreTextFields: ignoreTextFields,
-          ),
-          const SingleActivator(LogicalKeyboardKey.arrowRight): DirectionalFocusIntent(
-            TraversalDirection.right,
-            ignoreTextFields: ignoreTextFields,
-          ),
-          const SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(
-            TraversalDirection.down,
-            ignoreTextFields: ignoreTextFields,
-          ),
-          const SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(
-            TraversalDirection.up,
-            ignoreTextFields: ignoreTextFields,
-          ),
-        };
+        Widget generateTestWidgets(bool ignoreTextFields) {
+          final shortcuts = <ShortcutActivator, Intent>{
+            const SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(
+              TraversalDirection.left,
+              ignoreTextFields: ignoreTextFields,
+            ),
+            const SingleActivator(LogicalKeyboardKey.arrowRight): DirectionalFocusIntent(
+              TraversalDirection.right,
+              ignoreTextFields: ignoreTextFields,
+            ),
+            const SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(
+              TraversalDirection.down,
+              ignoreTextFields: ignoreTextFields,
+            ),
+            const SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(
+              TraversalDirection.up,
+              ignoreTextFields: ignoreTextFields,
+            ),
+          };
 
-        return TestWidgetsApp(
-          home: Shortcuts(
-            shortcuts: shortcuts,
-            child: FocusScope(
-              debugLabel: 'scope',
-              child: Column(
-                children: <Widget>[
-                  Row(
-                    children: <Widget>[
-                      SizedBox.square(
-                        dimension: 100.0,
-                        child: EditableText(
-                          autofocus: true,
-                          key: upperLeftKey,
-                          controller: controller1,
-                          focusNode: focusNodeUpperLeft,
-                          cursorColor: const Color(0xffffffff),
-                          backgroundCursorColor: const Color(0xff808080),
-                          style: const TextStyle(),
+          return TestWidgetsApp(
+            home: Shortcuts(
+              shortcuts: shortcuts,
+              child: FocusScope(
+                debugLabel: 'scope',
+                child: Column(
+                  children: <Widget>[
+                    Row(
+                      children: <Widget>[
+                        SizedBox.square(
+                          dimension: 100.0,
+                          child: EditableText(
+                            autofocus: true,
+                            key: upperLeftKey,
+                            controller: controller1,
+                            focusNode: focusNodeUpperLeft,
+                            cursorColor: const Color(0xffffffff),
+                            backgroundCursorColor: const Color(0xff808080),
+                            style: const TextStyle(),
+                          ),
                         ),
-                      ),
-                      SizedBox.square(
-                        dimension: 100.0,
-                        child: EditableText(
-                          key: upperRightKey,
-                          controller: controller2,
-                          focusNode: focusNodeUpperRight,
-                          cursorColor: const Color(0xffffffff),
-                          backgroundCursorColor: const Color(0xff808080),
-                          style: const TextStyle(),
+                        SizedBox.square(
+                          dimension: 100.0,
+                          child: EditableText(
+                            key: upperRightKey,
+                            controller: controller2,
+                            focusNode: focusNodeUpperRight,
+                            cursorColor: const Color(0xffffffff),
+                            backgroundCursorColor: const Color(0xff808080),
+                            style: const TextStyle(),
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                  Row(
-                    children: <Widget>[
-                      SizedBox.square(
-                        dimension: 100.0,
-                        child: EditableText(
-                          key: lowerLeftKey,
-                          controller: controller3,
-                          focusNode: focusNodeLowerLeft,
-                          cursorColor: const Color(0xffffffff),
-                          backgroundCursorColor: const Color(0xff808080),
-                          style: const TextStyle(),
+                      ],
+                    ),
+                    Row(
+                      children: <Widget>[
+                        SizedBox.square(
+                          dimension: 100.0,
+                          child: EditableText(
+                            key: lowerLeftKey,
+                            controller: controller3,
+                            focusNode: focusNodeLowerLeft,
+                            cursorColor: const Color(0xffffffff),
+                            backgroundCursorColor: const Color(0xff808080),
+                            style: const TextStyle(),
+                          ),
                         ),
-                      ),
-                      SizedBox.square(
-                        dimension: 100.0,
-                        child: EditableText(
-                          key: lowerRightKey,
-                          controller: controller4,
-                          focusNode: focusNodeLowerRight,
-                          cursorColor: const Color(0xffffffff),
-                          backgroundCursorColor: const Color(0xff808080),
-                          style: const TextStyle(),
+                        SizedBox.square(
+                          dimension: 100.0,
+                          child: EditableText(
+                            key: lowerRightKey,
+                            controller: controller4,
+                            focusNode: focusNodeLowerRight,
+                            cursorColor: const Color(0xffffffff),
+                            backgroundCursorColor: const Color(0xff808080),
+                            style: const TextStyle(),
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                ],
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-        );
-      }
+          );
+        }
 
-      await tester.pumpWidget(generateTestWidgets(false));
+        await tester.pumpWidget(generateTestWidgets(false));
 
-      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-      expect(focusNodeUpperRight.hasPrimaryFocus, isTrue);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-      expect(focusNodeLowerRight.hasPrimaryFocus, isTrue);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-      expect(focusNodeLowerLeft.hasPrimaryFocus, isTrue);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        expect(focusNodeUpperRight.hasPrimaryFocus, isTrue);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        expect(focusNodeLowerRight.hasPrimaryFocus, isTrue);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        expect(focusNodeLowerLeft.hasPrimaryFocus, isTrue);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
 
-      await tester.pumpWidget(generateTestWidgets(true));
+        await tester.pumpWidget(generateTestWidgets(true));
 
-      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-      expect(focusNodeUpperRight.hasPrimaryFocus, isFalse);
-      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-      expect(focusNodeLowerRight.hasPrimaryFocus, isFalse);
-      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-      expect(focusNodeLowerLeft.hasPrimaryFocus, isFalse);
-      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-      expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-    }, variant: KeySimulatorTransitModeVariant.all());
+        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        expect(focusNodeUpperRight.hasPrimaryFocus, isFalse);
+        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        expect(focusNodeLowerRight.hasPrimaryFocus, isFalse);
+        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        expect(focusNodeLowerLeft.hasPrimaryFocus, isFalse);
+        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
+      },
+      variant: KeySimulatorTransitModeVariant.all(),
+    );
 
-    testWidgets('Focus traversal does not break when no focusable is available on a WidgetsApp', (
-      WidgetTester tester,
-    ) async {
-      final events = <Object>[];
+    testWidgets(
+      'Focus traversal does not break when no focusable is available on a WidgetsApp',
+      (WidgetTester tester) async {
+        final events = <Object>[];
 
-      await tester.pumpWidget(TestWidgetsApp(home: Container()));
+        await tester.pumpWidget(TestWidgetsApp(home: Container()));
 
-      HardwareKeyboard.instance.addHandler((KeyEvent event) {
-        events.add(event);
-        return true;
-      });
+        HardwareKeyboard.instance.addHandler((KeyEvent event) {
+          events.add(event);
+          return true;
+        });
 
-      await tester.idle();
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-      await tester.idle();
+        await tester.idle();
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.idle();
 
-      expect(events.length, 2);
-    }, variant: KeySimulatorTransitModeVariant.all());
+        expect(events.length, 2);
+      },
+      variant: KeySimulatorTransitModeVariant.all(),
+    );
 
     testWidgets('Focus traversal does not throw when no focusable is available in a group', (
       WidgetTester tester,
@@ -3282,24 +3286,26 @@ void main() {
       expect(primaryFocus, equals(initialFocus));
     });
 
-    testWidgets('Focus traversal does not break when no focusable is available on a WidgetsApp', (
-      WidgetTester tester,
-    ) async {
-      final events = <KeyEvent>[];
+    testWidgets(
+      'Focus traversal does not break when no focusable is available on a WidgetsApp',
+      (WidgetTester tester) async {
+        final events = <KeyEvent>[];
 
-      await tester.pumpWidget(const TestWidgetsApp(home: Placeholder()));
+        await tester.pumpWidget(const TestWidgetsApp(home: Placeholder()));
 
-      HardwareKeyboard.instance.addHandler((KeyEvent event) {
-        events.add(event);
-        return true;
-      });
+        HardwareKeyboard.instance.addHandler((KeyEvent event) {
+          events.add(event);
+          return true;
+        });
 
-      await tester.idle();
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-      await tester.idle();
+        await tester.idle();
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.idle();
 
-      expect(events.length, 2);
-    }, variant: KeySimulatorTransitModeVariant.all());
+        expect(events.length, 2);
+      },
+      variant: KeySimulatorTransitModeVariant.all(),
+    );
 
     testWidgets('Custom requestFocusCallback gets called on focusInDirection up/down/left/right.', (
       WidgetTester tester,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/85941

When a user traverses focus nodes directionally (e.g. using `up`, `down` arrow keys), we maintain a history stack of visited nodes (called `policyData`). This allows us to avoid [hysteresis](https://en.wikipedia.org/wiki/Hysteresis) when a user switches direction (i.e. switching from `down` to `up`) - meaning, the forward traversal path and the reversed traversal path should match.

However, before this change, we were not detecting when a focus request occurred due to some outside event (e.g. a direct focus request from a tap on the screen). That means when a user switched direction, we would include the node they had tapped on in the history stack, and unexpectedly visit it. 

We now clear the stack (see method `propagateFocusRequest`) if a node is focused on outside of a directional navigation event.

**Before:**

<img width="454" height="656" alt="before" src="https://github.com/user-attachments/assets/26e3cdd2-2f39-4dc8-9616-4f21d4afcc52" />

**With fix:**

<img width="454" height="656" alt="fixed" src="https://github.com/user-attachments/assets/0e795e0c-8e07-4422-beed-f371407b4ae6" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
