### PR TITLE
Move strech fragment shader to widget layer

### DIFF
--- a/packages/flutter/lib/src/widgets/shaders/stretch_effect.frag
+++ b/packages/flutter/lib/src/widgets/shaders/stretch_effect.frag
@@ -1,0 +1,155 @@
+#version 320 es
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This shader was created based on or with reference to the implementation found at:
+// https://cs.android.com/android/platform/superproject/main/+/512046e84bcc51cc241bc6599f83ab345e93ab12:frameworks/base/libs/hwui/effects/StretchEffect.cpp
+
+#include <flutter/runtime_effect.glsl>
+
+uniform vec2 u_size;
+uniform sampler2D u_texture;
+
+// Multiplier to apply to scale effect.
+uniform float u_max_stretch_intensity;
+
+// Normalized overscroll amount in the horizontal direction.
+uniform float u_overscroll_x;
+
+// Normalized overscroll amount in the vertical direction.
+uniform float u_overscroll_y;
+
+// u_interpolation_strength is the intensity of the interpolation.
+uniform float u_interpolation_strength;
+
+float ease_in(float t, float d) {
+  return t * d;
+}
+
+float compute_overscroll_start(
+  float in_pos,
+  float overscroll,
+  float u_stretch_affected_dist,
+  float u_inverse_stretch_affected_dist,
+  float distance_stretched,
+  float interpolation_strength
+) {
+  float offset_pos = u_stretch_affected_dist - in_pos;
+  float pos_based_variation = mix(
+    1.0,
+    ease_in(offset_pos, u_inverse_stretch_affected_dist),
+    interpolation_strength
+  );
+  float stretch_intensity = overscroll * pos_based_variation;
+  return distance_stretched - (offset_pos / (1.0 + stretch_intensity));
+}
+
+float compute_overscroll_end(
+  float in_pos,
+  float overscroll,
+  float reverse_stretch_dist,
+  float u_stretch_affected_dist,
+  float u_inverse_stretch_affected_dist,
+  float distance_stretched,
+  float interpolation_strength,
+  float viewport_dimension
+) {
+  float offset_pos = in_pos - reverse_stretch_dist;
+  float pos_based_variation = mix(
+    1.0,
+    ease_in(offset_pos, u_inverse_stretch_affected_dist),
+    interpolation_strength
+  );
+  float stretch_intensity = (-overscroll) * pos_based_variation;
+  return viewport_dimension - (distance_stretched - (offset_pos / (1.0 + stretch_intensity)));
+}
+
+float compute_streched_effect(
+  float in_pos,
+  float overscroll,
+  float u_stretch_affected_dist,
+  float u_inverse_stretch_affected_dist,
+  float distance_stretched,
+  float distance_diff,
+  float interpolation_strength,
+  float viewport_dimension
+) {
+  if (overscroll > 0.0) {
+    if (in_pos <= u_stretch_affected_dist) {
+      return compute_overscroll_start(
+        in_pos, overscroll, u_stretch_affected_dist,
+        u_inverse_stretch_affected_dist, distance_stretched,
+        interpolation_strength
+      );
+    } else {
+      return distance_diff + in_pos;
+    }
+  } else if (overscroll < 0.0) {
+    float stretch_affected_dist_calc = viewport_dimension - u_stretch_affected_dist;
+    if (in_pos >= stretch_affected_dist_calc) {
+      return compute_overscroll_end(
+        in_pos,
+        overscroll,
+        stretch_affected_dist_calc,
+        u_stretch_affected_dist,
+        u_inverse_stretch_affected_dist,
+        distance_stretched,
+        interpolation_strength,
+        viewport_dimension
+      );
+    } else {
+      return -distance_diff + in_pos;
+    }
+  } else {
+    return in_pos;
+  }
+}
+
+out vec4 frag_color;
+
+void main() {
+  vec2 uv = FlutterFragCoord().xy / u_size;
+  float in_u_norm = uv.x;
+  float in_v_norm = uv.y;
+
+  float out_u_norm;
+  float out_v_norm;
+
+  bool isVertical = u_overscroll_y != 0;
+  float overscroll = isVertical ? u_overscroll_y : u_overscroll_x;
+
+  float norm_distance_stretched = 1.0 / (1.0 + abs(overscroll));
+  float norm_dist_diff = norm_distance_stretched - 1.0;
+
+  const float norm_viewport = 1.0;
+  const float norm_stretch_affected_dist = 1.0;
+  const float norm_inverse_stretch_affected_dist = 1.0;
+
+  out_u_norm = isVertical ? in_u_norm : compute_streched_effect(
+    in_u_norm,
+    overscroll,
+    norm_stretch_affected_dist,
+    norm_inverse_stretch_affected_dist,
+    norm_distance_stretched,
+    norm_dist_diff,
+    u_interpolation_strength,
+    norm_viewport
+  );
+
+  out_v_norm = isVertical ? compute_streched_effect(
+    in_v_norm,
+    overscroll,
+    norm_stretch_affected_dist,
+    norm_inverse_stretch_affected_dist,
+    norm_distance_stretched,
+    norm_dist_diff,
+    u_interpolation_strength,
+    norm_viewport
+  ) : in_v_norm;
+
+  uv.x = out_u_norm;
+  uv.y = out_v_norm;
+
+  frag_color = texture(u_texture, uv);
+}

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -128,8 +128,6 @@ const kMaterialFonts = <Map<String, Object>>[
   },
 ];
 
-const kMaterialShaders = <String>['shaders/ink_sparkle.frag', 'shaders/stretch_effect.frag'];
-
 /// Injected factory class for spawning [AssetBundle] instances.
 abstract class AssetBundleFactory {
   /// The singleton instance, pulled from the [AppContext].
@@ -606,14 +604,14 @@ class ManifestAssetBundle implements AssetBundle {
         }
       }
     }
-    final materialAssets = <_Asset>[
+    final materialAndFrameworkAssets = <_Asset>[
       if (flutterManifest.usesMaterialDesign) ..._getMaterialFonts(),
       // For all platforms, include the shaders unconditionally. They are
       // small, and whether they're used is determined only by the app source
       // code and not by the Flutter manifest.
-      ..._getMaterialShaders(),
+      ..._getFrameworkShaders(),
     ];
-    for (final asset in materialAssets) {
+    for (final asset in materialAndFrameworkAssets) {
       final File assetFile = asset.lookupAssetFile(_fileSystem);
       assert(assetFile.existsSync(), 'Missing ${assetFile.path}');
       entries[asset.entryUri.path] ??= AssetBundleEntry(
@@ -783,8 +781,10 @@ class ManifestAssetBundle implements AssetBundle {
     return result;
   }
 
-  List<_Asset> _getMaterialShaders() {
-    final String shaderPath = _fileSystem.path.join(
+  List<_Asset> _getFrameworkShaders() {
+    final result = <_Asset>[];
+
+    final String materialShaderPath = _fileSystem.path.join(
       _flutterRoot,
       'packages',
       'flutter',
@@ -793,21 +793,33 @@ class ManifestAssetBundle implements AssetBundle {
       'material',
       'shaders',
     );
-    // This file will exist in a real invocation unless the git checkout is
-    // corrupted somehow, but unit tests generally don't create this file
-    // in their mock file systems. Leaving it out in those cases is harmless.
-    if (!_fileSystem.directory(shaderPath).existsSync()) {
-      return <_Asset>[];
-    }
-
-    final result = <_Asset>[];
-    for (final String shader in kMaterialShaders) {
-      final Uri entryUri = _fileSystem.path.toUri(shader);
+    if (_fileSystem.directory(materialShaderPath).existsSync()) {
       result.add(
         _Asset(
-          baseDir: shaderPath,
-          relativeUri: Uri(path: entryUri.pathSegments.last),
-          entryUri: entryUri,
+          baseDir: materialShaderPath,
+          relativeUri: Uri(path: 'ink_sparkle.frag'),
+          entryUri: _fileSystem.path.toUri('shaders/ink_sparkle.frag'),
+          package: null,
+          kind: AssetKind.shader,
+        ),
+      );
+    }
+
+    final String widgetsShaderPath = _fileSystem.path.join(
+      _flutterRoot,
+      'packages',
+      'flutter',
+      'lib',
+      'src',
+      'widgets',
+      'shaders',
+    );
+    if (_fileSystem.directory(widgetsShaderPath).existsSync()) {
+      result.add(
+        _Asset(
+          baseDir: widgetsShaderPath,
+          relativeUri: Uri(path: 'stretch_effect.frag'),
+          entryUri: _fileSystem.path.toUri('shaders/stretch_effect.frag'),
           package: null,
           kind: AssetKind.shader,
         ),

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -794,6 +794,8 @@ class ManifestAssetBundle implements AssetBundle {
       'shaders',
     );
     if (_fileSystem.directory(materialShaderPath).existsSync()) {
+      // TODO(chunhtai): remove ink_sparkle.frag sideloading.
+      // https://github.com/flutter/flutter/issues/188545.
       result.add(
         _Asset(
           baseDir: materialShaderPath,

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -1053,44 +1053,96 @@ flutter:
         );
         fileSystem.file(materialIconsPath).createSync(recursive: true);
 
-        final String materialPath = fileSystem.path.join(
-          getFlutterRoot(),
+        final String flutterRoot = getFlutterRoot();
+        fileSystem
+            .file(
+              fileSystem.path.join(
+                flutterRoot,
+                'packages',
+                'flutter',
+                'lib',
+                'src',
+                'material',
+                'shaders',
+                'ink_sparkle.frag',
+              ),
+            )
+            .createSync(recursive: true);
+        fileSystem
+            .file(
+              fileSystem.path.join(
+                flutterRoot,
+                'packages',
+                'flutter',
+                'lib',
+                'src',
+                'widgets',
+                'shaders',
+                'stretch_effect.frag',
+              ),
+            )
+            .createSync(recursive: true);
+
+        final String materialShaderDir = fileSystem.path.join(
+          flutterRoot,
           'packages',
           'flutter',
           'lib',
           'src',
           'material',
+          'shaders',
         );
-        final Directory materialDir = fileSystem.directory(materialPath)
-          ..createSync(recursive: true);
-        for (final String shader in kMaterialShaders) {
-          materialDir.childFile(shader).createSync(recursive: true);
-        }
+        final String widgetsShaderDir = fileSystem.path.join(
+          flutterRoot,
+          'packages',
+          'flutter',
+          'lib',
+          'src',
+          'widgets',
+          'shaders',
+        );
 
-        final testShaders = <String>['ink_sparkle.frag', 'stretch_effect.frag'];
+        (globals.processManager as FakeProcessManager).addCommand(
+          FakeCommand(
+            command: <String>[
+              impellerc,
+              '--sksl',
+              '--iplr',
+              '--json',
+              '--sl=${fileSystem.path.join(output.path, 'shaders', 'ink_sparkle.frag')}',
+              '--spirv=${fileSystem.path.join(output.path, 'shaders', 'ink_sparkle.frag.spirv')}',
+              '--input=${fileSystem.path.join(materialShaderDir, 'ink_sparkle.frag')}',
+              '--input-type=frag',
+              '--include=$materialShaderDir',
+              '--include=$shaderLibDir',
+            ],
+            onRun: (_) {
+              fileSystem.file(outputPath).createSync(recursive: true);
+              fileSystem.file('$outputPath.spirv').createSync(recursive: true);
+            },
+          ),
+        );
 
-        for (final shader in testShaders) {
-          (globals.processManager as FakeProcessManager).addCommand(
-            FakeCommand(
-              command: <String>[
-                impellerc,
-                '--sksl',
-                '--iplr',
-                '--json',
-                '--sl=${fileSystem.path.join(output.path, 'shaders', shader)}',
-                '--spirv=${fileSystem.path.join(output.path, 'shaders', '$shader.spirv')}',
-                '--input=${fileSystem.path.join(materialDir.path, 'shaders', shader)}',
-                '--input-type=frag',
-                '--include=${fileSystem.path.join(materialDir.path, 'shaders')}',
-                '--include=$shaderLibDir',
-              ],
-              onRun: (_) {
-                fileSystem.file(outputPath).createSync(recursive: true);
-                fileSystem.file('$outputPath.spirv').createSync(recursive: true);
-              },
-            ),
-          );
-        }
+        (globals.processManager as FakeProcessManager).addCommand(
+          FakeCommand(
+            command: <String>[
+              impellerc,
+              '--sksl',
+              '--iplr',
+              '--json',
+              '--sl=${fileSystem.path.join(output.path, 'shaders', 'stretch_effect.frag')}',
+              '--spirv=${fileSystem.path.join(output.path, 'shaders', 'stretch_effect.frag.spirv')}',
+              '--input=${fileSystem.path.join(widgetsShaderDir, 'stretch_effect.frag')}',
+              '--input-type=frag',
+              '--include=$widgetsShaderDir',
+              '--include=$shaderLibDir',
+            ],
+            onRun: (_) {
+              fileSystem.file(outputPath).createSync(recursive: true);
+              fileSystem.file('$outputPath.spirv').createSync(recursive: true);
+            },
+          ),
+        );
 
         fileSystem.file('pubspec.yaml')
           ..createSync()

--- a/packages/flutter_tools/test/general.shard/asset_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_test.dart
@@ -307,22 +307,30 @@ flutter:
         expect(assetBundle.inputFiles.map((File f) => f.path), <String>[]);
       });
 
-      final testShaders = <String>['ink_sparkle.frag', 'stretch_effect.frag'];
-
       testWithoutContext('bundles material shaders on non-web platforms', () async {
-        for (final shader in testShaders) {
-          final String shaderPath = fileSystem.path.join(
-            flutterRoot,
-            'packages',
-            'flutter',
-            'lib',
-            'src',
-            'material',
-            'shaders',
-            shader,
-          );
-          fileSystem.file(shaderPath).createSync(recursive: true);
-        }
+        final String inkSparklePath = fileSystem.path.join(
+          flutterRoot,
+          'packages',
+          'flutter',
+          'lib',
+          'src',
+          'material',
+          'shaders',
+          'ink_sparkle.frag',
+        );
+        fileSystem.file(inkSparklePath).createSync(recursive: true);
+
+        final String stretchEffectPath = fileSystem.path.join(
+          flutterRoot,
+          'packages',
+          'flutter',
+          'lib',
+          'src',
+          'widgets',
+          'shaders',
+          'stretch_effect.frag',
+        );
+        fileSystem.file(stretchEffectPath).createSync(recursive: true);
 
         writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'my_package');
         fileSystem.file('pubspec.yaml').writeAsStringSync('name: my_package');
@@ -339,25 +347,34 @@ flutter:
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         );
 
-        for (final shader in testShaders) {
-          expect(assetBundle.entries.keys, contains('shaders/$shader'));
-        }
+        expect(assetBundle.entries.keys, contains('shaders/ink_sparkle.frag'));
+        expect(assetBundle.entries.keys, contains('shaders/stretch_effect.frag'));
       });
 
       testWithoutContext('bundles material shaders on web platforms', () async {
-        for (final shader in testShaders) {
-          final String shaderPath = fileSystem.path.join(
-            flutterRoot,
-            'packages',
-            'flutter',
-            'lib',
-            'src',
-            'material',
-            'shaders',
-            shader,
-          );
-          fileSystem.file(shaderPath).createSync(recursive: true);
-        }
+        final String inkSparklePath = fileSystem.path.join(
+          flutterRoot,
+          'packages',
+          'flutter',
+          'lib',
+          'src',
+          'material',
+          'shaders',
+          'ink_sparkle.frag',
+        );
+        fileSystem.file(inkSparklePath).createSync(recursive: true);
+
+        final String stretchEffectPath = fileSystem.path.join(
+          flutterRoot,
+          'packages',
+          'flutter',
+          'lib',
+          'src',
+          'widgets',
+          'shaders',
+          'stretch_effect.frag',
+        );
+        fileSystem.file(stretchEffectPath).createSync(recursive: true);
 
         writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'my_package');
         fileSystem.file('pubspec.yaml').writeAsStringSync('name: my_package');
@@ -374,9 +391,8 @@ flutter:
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         );
 
-        for (final shader in testShaders) {
-          expect(assetBundle.entries.keys, contains('shaders/$shader'));
-        }
+        expect(assetBundle.entries.keys, contains('shaders/ink_sparkle.frag'));
+        expect(assetBundle.entries.keys, contains('shaders/stretch_effect.frag'));
       });
 
       testWithoutContext('fails if shader is also in assets', () async {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This fragment is used in widget layer. With the decoupling, this fragment should stay in flutter/flutter

In this pr, I moved the shader from material/shaders to widgets/shaders, also adjust the flutter tooling to use the updated file path

fixes https://github.com/flutter/flutter/issues/187807

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
