### PR TITLE
[Impeller] Share a pipeline library among GLES contexts

### DIFF
--- a/engine/src/flutter/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/engine/src/flutter/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -70,7 +70,9 @@ void PlaygroundImplGLES::DestroyWindowHandle(WindowHandle handle) {
 static std::vector<std::shared_ptr<fml::Mapping>>
 ShaderLibraryMappingsForPlayground(bool is_gles3);
 
-PlaygroundImplGLES::PlaygroundImplGLES(PlaygroundSwitches switches)
+PlaygroundImplGLES::PlaygroundImplGLES(
+    PlaygroundSwitches switches,
+    std::shared_ptr<PipelineLibraryGLES>* shared_pipeline)
     : PlaygroundImpl(switches),
       handle_(nullptr, &DestroyWindowHandle),
       worker_(std::shared_ptr<ReactorWorker>(new ReactorWorker())),
@@ -142,9 +144,9 @@ PlaygroundImplGLES::PlaygroundImplGLES(PlaygroundSwitches switches)
 #endif
   }
   bool is_gles3 = gl->GetDescription()->GetGlVersion().IsAtLeast(Version(3));
-  auto context_gles =
-      ContextGLES::Create(switches_.flags, std::move(gl),
-                          ShaderLibraryMappingsForPlayground(is_gles3), true);
+  auto context_gles = ContextGLES::Create(
+      switches_.flags, std::move(gl),
+      ShaderLibraryMappingsForPlayground(is_gles3), true, shared_pipeline);
   if (!context_gles) {
     FML_LOG(ERROR) << "Could not create context.";
     return;

--- a/engine/src/flutter/impeller/playground/backend/gles/playground_impl_gles.h
+++ b/engine/src/flutter/impeller/playground/backend/gles/playground_impl_gles.h
@@ -7,11 +7,15 @@
 
 #include "impeller/playground/playground_impl.h"
 
+#include "impeller/renderer/backend/gles/pipeline_library_gles.h"
+
 namespace impeller {
 
 class PlaygroundImplGLES final : public PlaygroundImpl {
  public:
-  explicit PlaygroundImplGLES(PlaygroundSwitches switches);
+  explicit PlaygroundImplGLES(
+      PlaygroundSwitches switches,
+      std::shared_ptr<PipelineLibraryGLES>* shared_pipeline = nullptr);
 
   ~PlaygroundImplGLES();
 

--- a/engine/src/flutter/impeller/playground/playground_impl.cc
+++ b/engine/src/flutter/impeller/playground/playground_impl.cc
@@ -34,11 +34,15 @@ std::unique_ptr<PlaygroundImpl> PlaygroundImpl::Create(
       return std::make_unique<PlaygroundImplMTL>(switches);
 #endif  // IMPELLER_ENABLE_METAL
 #if IMPELLER_ENABLE_OPENGLES
-    case PlaygroundBackend::kOpenGLES:
-      return std::make_unique<PlaygroundImplGLES>(switches);
-    case PlaygroundBackend::kOpenGLESSDF:
+    case PlaygroundBackend::kOpenGLES: {
+      static std::shared_ptr<PipelineLibraryGLES> shared_pipeline;
+      return std::make_unique<PlaygroundImplGLES>(switches, &shared_pipeline);
+    }
+    case PlaygroundBackend::kOpenGLESSDF: {
+      static std::shared_ptr<PipelineLibraryGLES> shared_pipeline;
       switches.flags.use_sdfs = true;
-      return std::make_unique<PlaygroundImplGLES>(switches);
+      return std::make_unique<PlaygroundImplGLES>(switches, &shared_pipeline);
+    }
 #endif  // IMPELLER_ENABLE_OPENGLES
 #if IMPELLER_ENABLE_VULKAN
     case PlaygroundBackend::kVulkan:

--- a/engine/src/flutter/impeller/renderer/backend/gles/context_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/context_gles.cc
@@ -22,16 +22,19 @@ std::shared_ptr<ContextGLES> ContextGLES::Create(
     const Flags& flags,
     std::unique_ptr<ProcTableGLES> gl,
     const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries,
-    bool enable_gpu_tracing) {
-  return std::shared_ptr<ContextGLES>(new ContextGLES(
-      flags, std::move(gl), shader_libraries, enable_gpu_tracing));
+    bool enable_gpu_tracing,
+    std::shared_ptr<PipelineLibraryGLES>* shared_pipelines) {
+  return std::shared_ptr<ContextGLES>(
+      new ContextGLES(flags, std::move(gl), shader_libraries,
+                      enable_gpu_tracing, shared_pipelines));
 }
 
 ContextGLES::ContextGLES(
     const Flags& flags,
     std::unique_ptr<ProcTableGLES> gl,
     const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries_mappings,
-    bool enable_gpu_tracing)
+    bool enable_gpu_tracing,
+    std::shared_ptr<PipelineLibraryGLES>* shared_pipelines)
     : Context(flags) {
   reactor_ = std::make_shared<ReactorGLES>(std::move(gl));
   if (!reactor_->IsValid()) {
@@ -52,8 +55,15 @@ ContextGLES::ContextGLES(
 
   // Create the pipeline library.
   {
-    pipeline_library_ =
-        std::shared_ptr<PipelineLibraryGLES>(new PipelineLibraryGLES(reactor_));
+    if (shared_pipelines != nullptr) {
+      if (!shared_pipelines->get()) {
+        shared_pipelines->reset(new PipelineLibraryGLES(reactor_));
+      }
+      pipeline_library_ = *shared_pipelines;
+    } else {
+      pipeline_library_.reset(new PipelineLibraryGLES(reactor_));
+    }
+    FML_CHECK(pipeline_library_);
   }
 
   // Create allocators.

--- a/engine/src/flutter/impeller/renderer/backend/gles/context_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/context_gles.h
@@ -28,7 +28,8 @@ class ContextGLES final : public Context,
       const Flags& flags,
       std::unique_ptr<ProcTableGLES> gl,
       const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries,
-      bool enable_gpu_tracing);
+      bool enable_gpu_tracing,
+      std::shared_ptr<PipelineLibraryGLES>* shared_pipelines = nullptr);
 
   // |Context|
   ~ContextGLES() override;
@@ -64,7 +65,8 @@ class ContextGLES final : public Context,
       const Flags& flags,
       std::unique_ptr<ProcTableGLES> gl,
       const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries,
-      bool enable_gpu_tracing);
+      bool enable_gpu_tracing,
+      std::shared_ptr<PipelineLibraryGLES>* shared_pipelines = nullptr);
 
   // |Context|
   std::string DescribeGpuModel() const override;


### PR DESCRIPTION
Currently running all of the impeller unit tests can take 25 minutes most all of which is caused by recreating an OpenGL context. While https://github.com/flutter/flutter/pull/187690 attempts to share that context among all playground implementations to amortize that cost, it is running into issues with interactions between the reused context and the ImGui code. Investigating more deeply we find that the creation of all of the pipeline objects costs nearly all of the time when creating a new GL context. This PR attempts to eliminate that cost by sharing the PipelineLibrary object among all of the created GL contexts.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.