### PR TITLE
[flutter_tools] Add TargetPlatform.linux_arm so native-assets manifests are keyed linux_arm, not android_arm

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -227,6 +227,7 @@ class AndroidDevice extends Device {
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.fuchsia_x64:
       case TargetPlatform.ios:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.linux_x64:
@@ -552,6 +553,7 @@ class AndroidDevice extends Device {
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.fuchsia_x64:
       case TargetPlatform.ios:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -237,6 +237,7 @@ class AndroidDevice extends Device {
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.fuchsia_x64:
       case TargetPlatform.ios:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -211,6 +211,7 @@ TargetPlatform? _mapTargetPlatform(TargetPlatform? targetPlatform) {
     case TargetPlatform.ios:
     case TargetPlatform.darwin:
     case TargetPlatform.linux_x64:
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.linux_riscv64:
     case TargetPlatform.windows_x64:
@@ -433,6 +434,7 @@ class CachedArtifacts implements Artifacts {
         return _getIosArtifactPath(artifact, platform!, mode, environmentType);
       case TargetPlatform.darwin:
       case TargetPlatform.linux_x64:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.windows_x64:
@@ -787,6 +789,7 @@ class CachedArtifacts implements Artifacts {
     final String platformName = _enginePlatformDirectoryName(platform);
     switch (platform) {
       case TargetPlatform.linux_x64:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.darwin:
@@ -1581,6 +1584,7 @@ String _getPrebuiltTarget(Platform platform, OperatingSystemUtils operatingSyste
       return 'macos-x64';
     case TargetPlatform.linux_riscv64:
       return 'linux-riscv64';
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
       return 'linux-arm64';
     case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -1585,6 +1585,7 @@ String _getPrebuiltTarget(Platform platform, OperatingSystemUtils operatingSyste
     case TargetPlatform.linux_riscv64:
       return 'linux-riscv64';
     case TargetPlatform.linux_arm:
+      return 'linux-arm';
     case TargetPlatform.linux_arm64:
       return 'linux-arm64';
     case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -211,6 +211,7 @@ TargetPlatform? _mapTargetPlatform(TargetPlatform? targetPlatform) {
     case TargetPlatform.ios:
     case TargetPlatform.darwin:
     case TargetPlatform.linux_x64:
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.linux_riscv64:
     case TargetPlatform.windows_x64:
@@ -433,6 +434,7 @@ class CachedArtifacts implements Artifacts {
         return _getIosArtifactPath(artifact, platform!, mode, environmentType);
       case TargetPlatform.darwin:
       case TargetPlatform.linux_x64:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.windows_x64:
@@ -782,6 +784,7 @@ class CachedArtifacts implements Artifacts {
     final String platformName = _enginePlatformDirectoryName(platform);
     switch (platform) {
       case TargetPlatform.linux_x64:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.darwin:
@@ -1509,6 +1512,7 @@ String _getPrebuiltTarget(Platform platform, OperatingSystemUtils operatingSyste
       return 'macos-x64';
     case TargetPlatform.linux_riscv64:
       return 'linux-riscv64';
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
       return 'linux-arm64';
     case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -1513,6 +1513,7 @@ String _getPrebuiltTarget(Platform platform, OperatingSystemUtils operatingSyste
     case TargetPlatform.linux_riscv64:
       return 'linux-riscv64';
     case TargetPlatform.linux_arm:
+      return 'linux-arm';
     case TargetPlatform.linux_arm64:
       return 'linux-arm64';
     case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -625,6 +625,7 @@ enum TargetPlatform {
   ios('ios'),
   darwin('darwin'),
   linux_x64('linux-x64'),
+  linux_arm('linux-arm'),
   linux_arm64('linux-arm64'),
   linux_riscv64('linux-riscv64'),
   windows_x64('windows-x64'),
@@ -657,6 +658,7 @@ enum TargetPlatform {
       // host platform name (HostPlatform.darwin_x64)
       'darwin' || 'darwin-x64' || 'darwin-arm64' => TargetPlatform.darwin,
       'linux-x64' => TargetPlatform.linux_x64,
+      'linux-arm' => TargetPlatform.linux_arm,
       'linux-arm64' => TargetPlatform.linux_arm64,
       'linux-riscv64' => TargetPlatform.linux_riscv64,
       'windows-x64' => TargetPlatform.windows_x64,
@@ -686,6 +688,7 @@ enum TargetPlatform {
     android_x64 ||
     darwin ||
     ios ||
+    linux_arm ||
     linux_arm64 ||
     linux_riscv64 ||
     linux_x64 ||
@@ -697,7 +700,7 @@ enum TargetPlatform {
   };
 
   String get osName => switch (this) {
-    linux_x64 || linux_arm64 || linux_riscv64 => 'linux',
+    linux_x64 || linux_arm || linux_arm64 || linux_riscv64 => 'linux',
     darwin => 'macos',
     windows_x64 || windows_arm64 => 'windows',
     android || android_arm || android_arm64 || android_x64 => 'android',
@@ -711,6 +714,7 @@ enum TargetPlatform {
   String get simpleName => switch (this) {
     linux_x64 || darwin || windows_x64 => 'x64',
     linux_arm64 || windows_arm64 => 'arm64',
+    linux_arm => 'arm',
     linux_riscv64 => 'riscv64',
     android ||
     android_arm ||

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -736,6 +736,7 @@ enum TargetPlatform {
   ios('ios'),
   darwin('darwin'),
   linux_x64('linux-x64'),
+  linux_arm('linux-arm'),
   linux_arm64('linux-arm64'),
   linux_riscv64('linux-riscv64'),
   windows_x64('windows-x64'),
@@ -767,6 +768,7 @@ enum TargetPlatform {
       // host platform name (HostPlatform.darwin_x64)
       'darwin' || 'darwin-x64' || 'darwin-arm64' => TargetPlatform.darwin,
       'linux-x64' => TargetPlatform.linux_x64,
+      'linux-arm' => TargetPlatform.linux_arm,
       'linux-arm64' => TargetPlatform.linux_arm64,
       'linux-riscv64' => TargetPlatform.linux_riscv64,
       'windows-x64' => TargetPlatform.windows_x64,
@@ -796,6 +798,7 @@ enum TargetPlatform {
     android_x64 ||
     darwin ||
     ios ||
+    linux_arm ||
     linux_arm64 ||
     linux_riscv64 ||
     linux_x64 ||
@@ -807,7 +810,7 @@ enum TargetPlatform {
   };
 
   String get osName => switch (this) {
-    linux_x64 || linux_arm64 || linux_riscv64 => 'linux',
+    linux_x64 || linux_arm || linux_arm64 || linux_riscv64 => 'linux',
     darwin => 'macos',
     windows_x64 || windows_arm64 => 'windows',
     android || android_arm || android_arm64 || android_x64 => 'android',
@@ -821,6 +824,7 @@ enum TargetPlatform {
   String get simpleName => switch (this) {
     linux_x64 || darwin || windows_x64 => 'x64',
     linux_arm64 || windows_arm64 => 'arm64',
+    linux_arm => 'arm',
     linux_riscv64 => 'riscv64',
     android ||
     android_arm ||

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -250,6 +250,7 @@ class KernelSnapshot extends Target {
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.fuchsia_x64:
       case TargetPlatform.ios:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.tester:
@@ -267,6 +268,7 @@ class KernelSnapshot extends Target {
       TargetPlatform.android_x64 => 'android',
       TargetPlatform.darwin => 'macos',
       TargetPlatform.ios => 'ios',
+      TargetPlatform.linux_arm ||
       TargetPlatform.linux_arm64 ||
       TargetPlatform.linux_riscv64 ||
       TargetPlatform.linux_x64 => 'linux',

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -248,6 +248,7 @@ class KernelSnapshot extends Target {
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.fuchsia_x64:
       case TargetPlatform.ios:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.tester:
@@ -265,6 +266,7 @@ class KernelSnapshot extends Target {
       TargetPlatform.android_x64 => 'android',
       TargetPlatform.darwin => 'macos',
       TargetPlatform.ios => 'ios',
+      TargetPlatform.linux_arm ||
       TargetPlatform.linux_arm64 ||
       TargetPlatform.linux_riscv64 ||
       TargetPlatform.linux_x64 => 'linux',

--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -111,6 +111,7 @@ class ShaderCompiler {
       case TargetPlatform.android_arm64:
       case TargetPlatform.android:
       case TargetPlatform.linux_x64:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.windows_x64:

--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -181,6 +181,7 @@ class ShaderCompiler {
       case TargetPlatform.android_arm64:
       case TargetPlatform.android:
       case TargetPlatform.linux_x64:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.windows_x64:

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -45,6 +45,7 @@ class BuildBundleCommand extends BuildSubCommand {
           'ios',
           'darwin',
           'linux-x64',
+          'linux-arm',
           'linux-arm64',
           'linux-riscv64',
           'windows-x64',

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -122,6 +122,7 @@ class BuildBundleCommand extends BuildSubCommand {
           throwToolExit('Windows is not a supported target platform.');
         }
       case TargetPlatform.linux_x64:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
         if (!featureFlags.isLinuxEnabled) {

--- a/packages/flutter_tools/lib/src/flutter_application_package.dart
+++ b/packages/flutter_tools/lib/src/flutter_application_package.dart
@@ -90,6 +90,7 @@ class FlutterApplicationPackageFactory extends ApplicationPackageFactory {
         }
         return WebApplicationPackage(FlutterProject.current());
       case TargetPlatform.linux_x64:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
         return applicationBinary == null

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -968,6 +968,7 @@ OS getNativeOSFromTargetPlatform(TargetPlatform platform) {
     case TargetPlatform.darwin:
       return OS.macOS;
     case TargetPlatform.linux_x64:
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.linux_riscv64:
       return OS.linux;

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -971,6 +971,7 @@ OS getNativeOSFromTargetPlatform(TargetPlatform platform) {
     case TargetPlatform.darwin:
       return OS.macOS;
     case TargetPlatform.linux_x64:
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.linux_riscv64:
       return OS.linux;

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -74,6 +74,8 @@ sealed class AssetBuildTarget {
         return _windowsTarget(supportedAssetTypes, Architecture.x64);
       case TargetPlatform.linux_x64:
         return _linuxTarget(supportedAssetTypes, Architecture.x64, buildMode, buildDirectory);
+      case TargetPlatform.linux_arm:
+        return _linuxTarget(supportedAssetTypes, Architecture.arm, buildMode, buildDirectory);
       case TargetPlatform.linux_arm64:
         return _linuxTarget(supportedAssetTypes, Architecture.arm64, buildMode, buildDirectory);
       case TargetPlatform.linux_riscv64:
@@ -439,6 +441,7 @@ List<AndroidArch> _androidArchs(TargetPlatform targetPlatform, String? androidAr
     case TargetPlatform.fuchsia_arm64:
     case TargetPlatform.fuchsia_x64:
     case TargetPlatform.ios:
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.linux_riscv64:
     case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -72,6 +72,8 @@ sealed class AssetBuildTarget {
         return _windowsTarget(supportedAssetTypes, Architecture.x64);
       case TargetPlatform.linux_x64:
         return _linuxTarget(supportedAssetTypes, Architecture.x64, buildMode, buildDirectory);
+      case TargetPlatform.linux_arm:
+        return _linuxTarget(supportedAssetTypes, Architecture.arm, buildMode, buildDirectory);
       case TargetPlatform.linux_arm64:
         return _linuxTarget(supportedAssetTypes, Architecture.arm64, buildMode, buildDirectory);
       case TargetPlatform.linux_riscv64:
@@ -435,6 +437,7 @@ List<CpuArch> _androidArchs(TargetPlatform targetPlatform, String? androidArchsE
     case TargetPlatform.fuchsia_arm64:
     case TargetPlatform.fuchsia_x64:
     case TargetPlatform.ios:
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.linux_riscv64:
     case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -598,6 +598,7 @@ class MDnsVmServiceDiscovery {
       case TargetPlatform.darwin:
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.fuchsia_x64:
+      case TargetPlatform.linux_arm:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.linux_riscv64:
       case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1599,6 +1599,7 @@ Future<String?> getMissingPackageHintForPlatform(TargetPlatform platform) async 
     case TargetPlatform.darwin:
     case TargetPlatform.fuchsia_arm64:
     case TargetPlatform.fuchsia_x64:
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.linux_riscv64:
     case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1610,6 +1610,7 @@ Future<String?> getMissingPackageHintForPlatform(TargetPlatform platform) async 
     case TargetPlatform.darwin:
     case TargetPlatform.fuchsia_arm64:
     case TargetPlatform.fuchsia_x64:
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.linux_riscv64:
     case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -2196,6 +2196,7 @@ DevelopmentArtifact? artifactFromTargetPlatform(TargetPlatform targetPlatform) {
       }
       return null;
     case TargetPlatform.linux_x64:
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.linux_riscv64:
       if (featureFlags.isLinuxEnabled) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -2126,6 +2126,7 @@ DevelopmentArtifact? artifactFromTargetPlatform(TargetPlatform targetPlatform) {
       }
       return null;
     case TargetPlatform.linux_x64:
+    case TargetPlatform.linux_arm:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.linux_riscv64:
       if (featureFlags.isLinuxEnabled) {

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -256,6 +256,54 @@ void main() {
   );
 
   testUsingContext(
+    'bundle accepts linux-arm as a target platform (embedded armv7)',
+    () async {
+      // Regression test for https://github.com/flutter/flutter/issues/187018:
+      // `--target-platform linux-arm` must be an accepted option value so that
+      // armv7 embedded (Yocto/meta-flutter) cross-builds get past argument
+      // parsing. Before linux-arm was added to the allowed list, this failed
+      // with "linux-arm" is not an allowed value for option "--target-platform".
+      // With the Linux feature disabled it now reaches the feature gate rather
+      // than being rejected at parse time.
+      globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+      globals.fs.file('pubspec.yaml').createSync();
+      final CommandRunner<void> runner = createTestCommandRunner(
+        BuildBundleCommand(logger: BufferLogger.test()),
+      );
+
+      expect(
+        () => runner.run(<String>['bundle', '--no-pub', '--target-platform=linux-arm']),
+        throwsToolExit(message: 'Linux is not a supported target platform.'),
+      );
+    },
+    overrides: <Type, Generator>{
+      BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
+      FileSystem: fsFactory,
+      ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: () => TestFeatureFlags(),
+    },
+  );
+
+  testUsingContext(
+    'bundle can build for linux-arm (embedded armv7) if feature is enabled',
+    () async {
+      globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+      globals.fs.file('pubspec.yaml').createSync();
+      final CommandRunner<void> runner = createTestCommandRunner(
+        BuildBundleCommand(logger: BufferLogger.test()),
+      );
+
+      await runner.run(<String>['bundle', '--no-pub', '--target-platform=linux-arm']);
+    },
+    overrides: <Type, Generator>{
+      BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
+      FileSystem: fsFactory,
+      ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
+    },
+  );
+
+  testUsingContext(
     'bundle can build for macOS if feature is enabled',
     () async {
       globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/linux/native_assets.dart';
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
+import 'package:hooks/hooks.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
@@ -69,6 +70,46 @@ void main() {
         (globals.logger as BufferLogger).traceText,
         isNot(contains('Running build hooks for ')),
       );
+    },
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/187018: a
+  // linux_arm build must hand the build runner a linux/arm target. Before
+  // linux_arm existed, armv7 Linux cross-builds emitted a NativeAssetsManifest
+  // keyed `android_arm`, so at load time the engine's `linux_arm` lookup missed
+  // and FFI/code-asset plugins were silently dropped. Mock the build runner and
+  // assert the OS and architecture carried on the BuildInput.
+  testUsingContext(
+    'linux_arm passes OS linux and architecture arm to the build runner',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.empty(),
+      FileSystem: () => fileSystem,
+    },
+    () async {
+      final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
+      await packageConfig.create(recursive: true);
+
+      BuildInput? capturedInput;
+      await runFlutterSpecificHooks(
+        environmentDefines: <String, String>{kBuildMode: BuildMode.debug.cliName},
+        targetPlatform: TargetPlatform.linux_arm,
+        projectUri: projectUri,
+        fileSystem: fileSystem,
+        buildRunner: FakeFlutterNativeAssetsBuildRunner(
+          packagesWithNativeAssetsResult: <String>['foo'],
+          onBuild: (BuildInput input) {
+            capturedInput = input;
+            return const FakeFlutterNativeAssetsBuilderResult();
+          },
+        ),
+        buildCodeAssets: BuildCodeAssetsOptions(appBuildDirectory: environment.outputDir),
+        buildDataAssets: true,
+        recordedUsesFile: null,
+      );
+
+      expect(capturedInput, isNotNull, reason: 'build runner should have been invoked');
+      expect(capturedInput!.config.code.targetOS, OS.linux);
+      expect(capturedInput!.config.code.targetArchitecture, Architecture.arm);
     },
   );
 

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/linux/native_assets.dart';
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
+import 'package:hooks/hooks.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
@@ -71,6 +72,46 @@ void main() {
         (globals.logger as BufferLogger).traceText,
         isNot(contains('Running build hooks for ')),
       );
+    },
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/187018: a
+  // linux_arm build must hand the build runner a linux/arm target. Before
+  // linux_arm existed, armv7 Linux cross-builds emitted a NativeAssetsManifest
+  // keyed `android_arm`, so at load time the engine's `linux_arm` lookup missed
+  // and FFI/code-asset plugins were silently dropped. Mock the build runner and
+  // assert the OS and architecture carried on the BuildInput.
+  testUsingContext(
+    'linux_arm passes OS linux and architecture arm to the build runner',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.empty(),
+      FileSystem: () => fileSystem,
+    },
+    () async {
+      final File packageConfig = environment.projectDir.childFile('.dart_tool/package_config.json');
+      await packageConfig.create(recursive: true);
+
+      BuildInput? capturedInput;
+      await runFlutterSpecificHooks(
+        environmentDefines: <String, String>{kBuildMode: BuildMode.debug.cliName},
+        targetPlatform: TargetPlatform.linux_arm,
+        projectUri: projectUri,
+        fileSystem: fileSystem,
+        buildRunner: FakeFlutterNativeAssetsBuildRunner(
+          packagesWithNativeAssetsResult: <String>['foo'],
+          onBuild: (BuildInput input) {
+            capturedInput = input;
+            return const FakeFlutterNativeAssetsBuilderResult();
+          },
+        ),
+        buildCodeAssets: BuildCodeAssetsOptions(appBuildDirectory: environment.outputDir),
+        buildDataAssets: true,
+        recordedUsesFile: null,
+      );
+
+      expect(capturedInput, isNotNull, reason: 'build runner should have been invoked');
+      expect(capturedInput!.config.code.targetOS, OS.linux);
+      expect(capturedInput!.config.code.targetArchitecture, Architecture.arm);
     },
   );
 

--- a/packages/flutter_tools/test/general.shard/isolated/native_assets_linux_arm_target_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/native_assets_linux_arm_target_test.dart
@@ -1,0 +1,71 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Regression test for https://github.com/flutter/flutter/issues/187018:
+// an armv7 Linux cross-build must resolve to a linux/arm native-assets target
+// so the emitted NativeAssetsManifest.json is keyed `linux_arm` — NOT the
+// `android_arm` key that previously leaked in and silently disabled FFI
+// plugins.
+//
+// This is a hermetic unit test: it exercises the TargetPlatform -> native
+// assets target translation directly, with no real build and no arm32 silicon
+// (per the maintainer's requested testing approach on the issue).
+
+import 'package:code_assets/code_assets.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
+import 'package:flutter_tools/src/isolated/native_assets/targets.dart';
+
+import '../../src/common.dart';
+
+List<AssetBuildTarget> _targetsFor(TargetPlatform targetPlatform) {
+  return AssetBuildTarget.targetsFor(
+    targetPlatform: targetPlatform,
+    buildMode: BuildMode.debug,
+    environmentDefines: <String, String>{},
+    fileSystem: MemoryFileSystem.test(),
+    supportedAssetTypes: <SupportedAssetTypes>[SupportedAssetTypes.codeAssets],
+    buildDirectory: null,
+  );
+}
+
+void main() {
+  testWithoutContext('linux_arm maps to the linux native OS (not android)', () {
+    expect(getNativeOSFromTargetPlatform(TargetPlatform.linux_arm), OS.linux);
+  });
+
+  testWithoutContext(
+    'linux_arm resolves to a single linux/arm code-asset target, not android_arm',
+    () {
+      final List<AssetBuildTarget> targets = _targetsFor(TargetPlatform.linux_arm);
+
+      expect(targets, hasLength(1));
+      final AssetBuildTarget target = targets.single;
+      expect(target, isA<LinuxAssetTarget>());
+
+      final codeTarget = target as CodeAssetTarget;
+      // The #187018 bug emitted an android_arm-keyed manifest; assert the
+      // resolved target is 32-bit arm AND linux (i.e. NOT android).
+      expect(codeTarget.architecture, Architecture.arm);
+      expect(codeTarget.os, OS.linux);
+      expect(codeTarget.os, isNot(OS.android));
+      // The native-assets manifest is keyed by `${os}_${arch}`; this is the
+      // key that must read `linux_arm` rather than `android_arm`.
+      expect(codeTarget.targetString, 'linux_arm');
+    },
+  );
+
+  testWithoutContext('linux_arm and linux_arm64 resolve to distinct linux targets', () {
+    final arm = _targetsFor(TargetPlatform.linux_arm).single as CodeAssetTarget;
+    final arm64 = _targetsFor(TargetPlatform.linux_arm64).single as CodeAssetTarget;
+
+    expect(arm.architecture, Architecture.arm);
+    expect(arm64.architecture, Architecture.arm64);
+    expect(arm.os, OS.linux);
+    expect(arm64.os, OS.linux);
+    expect(arm.targetString, 'linux_arm');
+    expect(arm64.targetString, 'linux_arm64');
+  });
+}

--- a/packages/flutter_tools/test/general.shard/isolated/native_assets_linux_arm_target_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/native_assets_linux_arm_target_test.dart
@@ -2,15 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Regression test for https://github.com/flutter/flutter/issues/187018:
-// an armv7 Linux cross-build must resolve to a linux/arm native-assets target
-// so the emitted NativeAssetsManifest.json is keyed `linux_arm` — NOT the
-// `android_arm` key that previously leaked in and silently disabled FFI
-// plugins.
+// Regression test for https://github.com/flutter/flutter/issues/187018.
 //
-// This is a hermetic unit test: it exercises the TargetPlatform -> native
-// assets target translation directly, with no real build and no arm32 silicon
-// (per the maintainer's requested testing approach on the issue).
+// Before linux_arm existed, armv7 Linux cross-builds emitted a
+// NativeAssetsManifest.json keyed `android_arm` instead of `linux_arm`. That
+// wrong key silently disabled FFI and code-asset plugins: at load time nothing
+// matched the linux/arm host, so the plugins were dropped without surfacing an
+// error.
+//
+// The TargetPlatform -> native-assets target translation is pure and
+// deterministic, so these are hermetic unit tests: they assert the resolved
+// target's OS, architecture, and manifest key directly. No arm32 silicon and
+// no engine artifacts are required to prove the manifest is keyed `linux_arm`.
 
 import 'package:code_assets/code_assets.dart';
 import 'package:file/memory.dart';

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
@@ -61,6 +61,11 @@ void main() {
       processManager: processManager,
       hooksVersionConstraint: constraint,
     );
+    _testBuildBundle(
+      targetPlatform: 'linux-arm',
+      processManager: processManager,
+      hooksVersionConstraint: constraint,
+    );
   }
 }
 


### PR DESCRIPTION
Fixes #187018.

armv7 Linux cross-builds had no dedicated `TargetPlatform`, so the native-assets build runner produced an `android_arm`-keyed `NativeAssetsManifest.json`, silently disabling FFI plugins. This adds `linux_arm` alongside the existing `linux_arm64` across flutter_tools — the enum value + name mappings, the native-assets OS/target translation, and the remaining exhaustive `TargetPlatform` switches — so a linux-arm build resolves to a `linux/arm` code-asset target whose manifest key is `linux_arm`.

Per the hermetic testing approach suggested on the issue (no arm32 silicon), this adds a unit test (`native_assets_linux_arm_target_test.dart`) that exercises the `TargetPlatform.linux_arm` → native-assets target translation directly and asserts the resolved target is `linux/arm` (not `android_arm`), mirroring the existing `linux_arm64` build-hook test.

**Scope:** flutter_tools only — no engine/artifact changes (engine artifact provisioning left to maintainers). The test is hermetic and runs on existing desktop CI; this change does **not** claim a validated armv7 end-to-end build — it ensures the manifest is keyed correctly when such a build is configured.

**Verification (BDE-verified, current master):** `dart analyze` of the changed files (`build_info.dart`, `native_assets.dart`, `targets.dart`, and the test) reports **No issues found**; the new hermetic unit test passes — **3/3 tests green** (`native_assets_linux_arm_target_test.dart`). Re-verified after rebase onto current `master`.
