### PR TITLE
Fix bounds checking in FlAccessibleTextField

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_accessible_text_field.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_accessible_text_field.cc
@@ -39,10 +39,13 @@ static gchar* get_substring(FlAccessibleTextField* self,
                             glong start,
                             glong end) {
   const gchar* value = gtk_entry_buffer_get_text(self->buffer);
+  glong length = g_utf8_strlen(value, -1);
   if (end == -1) {
     // g_utf8_substring() accepts -1 since 2.72
-    end = g_utf8_strlen(value, -1);
+    end = length;
   }
+  start = CLAMP(start, 0, length);
+  end = CLAMP(end, start, length);
   return g_utf8_substring(value, start, end);
 }
 
@@ -76,15 +79,19 @@ static gchar* get_string_at_offset(FlAccessibleTextField* self,
   const PangoLogAttr* attrs =
       pango_layout_get_log_attrs_readonly(layout, &n_attrs);
 
+  start = CLAMP(start, 0, MAX(n_attrs - 1, 0));
+  end = CLAMP(end, 0, MAX(n_attrs - 1, 0));
+
   while (start > 0 && !is_start(&attrs[start])) {
     --start;
-  }
-  if (start_offset != nullptr) {
-    *start_offset = start;
   }
 
   while (end < n_attrs && !is_end(&attrs[end])) {
     ++end;
+  }
+
+  if (start_offset != nullptr) {
+    *start_offset = start;
   }
   if (end_offset != nullptr) {
     *end_offset = end;

--- a/engine/src/flutter/shell/platform/linux/fl_accessible_text_field_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_accessible_text_field_test.cc
@@ -218,6 +218,33 @@ TEST(FlAccessibleTextFieldTest, GetText) {
   EXPECT_STREQ(tt, "tt");
 }
 
+// Tests AtkText::get_text with out-of-bounds offsets.
+TEST(FlAccessibleTextFieldTest, GetTextBoundsChecking) {
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  g_autoptr(FlEngine) engine = fl_engine_new(project);
+  g_autoptr(FlAccessibleNode) node =
+      fl_accessible_text_field_new(engine, 123, 1);
+
+  fl_accessible_node_set_value(node, "Hello");
+
+  // start beyond end of text
+  g_autofree gchar* beyond = atk_text_get_text(ATK_TEXT(node), 100, -1);
+  EXPECT_STREQ(beyond, "");
+
+  // end beyond text length
+  g_autofree gchar* end_beyond = atk_text_get_text(ATK_TEXT(node), 2, 100);
+  EXPECT_STREQ(end_beyond, "llo");
+
+  // both beyond text length
+  g_autofree gchar* both_beyond = atk_text_get_text(ATK_TEXT(node), 50, 100);
+  EXPECT_STREQ(both_beyond, "");
+
+  // empty buffer
+  fl_accessible_node_set_value(node, "");
+  g_autofree gchar* empty_beyond = atk_text_get_text(ATK_TEXT(node), 5, 10);
+  EXPECT_STREQ(empty_beyond, "");
+}
+
 // Tests AtkText::get_caret_offset.
 TEST(FlAccessibleTextFieldTest, GetCaretOffset) {
   g_autoptr(FlDartProject) project = fl_dart_project_new();
@@ -694,6 +721,117 @@ TEST(FlAccessibleTextFieldTest, TextBoundary) {
   EXPECT_STREQ(felis_paragraph, "\nPraesent et felis dui.");
   EXPECT_EQ(start_offset, 47);
   EXPECT_EQ(end_offset, 70);
+}
+
+// Tests that get_string_at_offset handles offset beyond text length.
+TEST(FlAccessibleTextFieldTest, TextBoundaryOffsetBeyondEnd) {
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  g_autoptr(FlEngine) engine = fl_engine_new(project);
+  g_autoptr(FlAccessibleNode) node =
+      fl_accessible_text_field_new(engine, 123, 1);
+
+  fl_accessible_node_set_value(node, "Hello");
+
+  // Offset well beyond the text length should not crash and should return
+  // a valid result clamped to the text boundaries.
+  gint start_offset = -1, end_offset = -1;
+  g_autofree gchar* char_result = atk_text_get_string_at_offset(
+      ATK_TEXT(node), 100, ATK_TEXT_GRANULARITY_CHAR, &start_offset,
+      &end_offset);
+  EXPECT_NE(char_result, nullptr);
+  EXPECT_GE(start_offset, 0);
+  EXPECT_LE(end_offset, 5);
+
+  g_autofree gchar* word_result = atk_text_get_string_at_offset(
+      ATK_TEXT(node), 100, ATK_TEXT_GRANULARITY_WORD, &start_offset,
+      &end_offset);
+  EXPECT_NE(word_result, nullptr);
+  EXPECT_GE(start_offset, 0);
+  EXPECT_LE(end_offset, 5);
+
+  g_autofree gchar* sentence_result = atk_text_get_string_at_offset(
+      ATK_TEXT(node), 100, ATK_TEXT_GRANULARITY_SENTENCE, &start_offset,
+      &end_offset);
+  EXPECT_NE(sentence_result, nullptr);
+  EXPECT_GE(start_offset, 0);
+  EXPECT_LE(end_offset, 5);
+}
+
+// Tests that get_string_at_offset handles offset at position zero.
+TEST(FlAccessibleTextFieldTest, TextBoundaryOffsetAtStart) {
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  g_autoptr(FlEngine) engine = fl_engine_new(project);
+  g_autoptr(FlAccessibleNode) node =
+      fl_accessible_text_field_new(engine, 123, 1);
+
+  fl_accessible_node_set_value(node, "Hello");
+
+  // Offset at zero should return the first character/word.
+  gint start_offset = -1, end_offset = -1;
+  g_autofree gchar* char_result = atk_text_get_string_at_offset(
+      ATK_TEXT(node), 0, ATK_TEXT_GRANULARITY_CHAR, &start_offset, &end_offset);
+  EXPECT_NE(char_result, nullptr);
+  EXPECT_EQ(start_offset, 0);
+  EXPECT_EQ(end_offset, 1);
+  EXPECT_STREQ(char_result, "H");
+
+  g_autofree gchar* word_result = atk_text_get_string_at_offset(
+      ATK_TEXT(node), 0, ATK_TEXT_GRANULARITY_WORD, &start_offset, &end_offset);
+  EXPECT_NE(word_result, nullptr);
+  EXPECT_EQ(start_offset, 0);
+  EXPECT_EQ(end_offset, 5);
+  EXPECT_STREQ(word_result, "Hello");
+}
+
+// Tests that get_string_at_offset handles empty text.
+TEST(FlAccessibleTextFieldTest, TextBoundaryEmptyText) {
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  g_autoptr(FlEngine) engine = fl_engine_new(project);
+  g_autoptr(FlAccessibleNode) node =
+      fl_accessible_text_field_new(engine, 123, 1);
+
+  // Empty text - should not crash.
+  gint start_offset = -1, end_offset = -1;
+  g_autofree gchar* char_result = atk_text_get_string_at_offset(
+      ATK_TEXT(node), 0, ATK_TEXT_GRANULARITY_CHAR, &start_offset, &end_offset);
+  EXPECT_NE(char_result, nullptr);
+  EXPECT_EQ(start_offset, 0);
+  EXPECT_STREQ(char_result, "");
+
+  g_autofree gchar* word_result = atk_text_get_string_at_offset(
+      ATK_TEXT(node), 0, ATK_TEXT_GRANULARITY_WORD, &start_offset, &end_offset);
+  EXPECT_NE(word_result, nullptr);
+  EXPECT_EQ(start_offset, 0);
+  EXPECT_STREQ(word_result, "");
+}
+
+// Tests that get_string_at_offset handles offset at exact text length.
+TEST(FlAccessibleTextFieldTest, TextBoundaryOffsetAtEnd) {
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  g_autoptr(FlEngine) engine = fl_engine_new(project);
+  g_autoptr(FlAccessibleNode) node =
+      fl_accessible_text_field_new(engine, 123, 1);
+
+  fl_accessible_node_set_value(node, "Hello world");
+
+  // Offset at exactly the character count (one past last char).
+  gint char_count = atk_text_get_character_count(ATK_TEXT(node));
+  EXPECT_EQ(char_count, 11);
+
+  gint start_offset = -1, end_offset = -1;
+  g_autofree gchar* char_result = atk_text_get_string_at_offset(
+      ATK_TEXT(node), char_count, ATK_TEXT_GRANULARITY_CHAR, &start_offset,
+      &end_offset);
+  EXPECT_NE(char_result, nullptr);
+  EXPECT_GE(start_offset, 0);
+  EXPECT_LE(end_offset, char_count);
+
+  g_autofree gchar* word_result = atk_text_get_string_at_offset(
+      ATK_TEXT(node), char_count, ATK_TEXT_GRANULARITY_WORD, &start_offset,
+      &end_offset);
+  EXPECT_NE(word_result, nullptr);
+  EXPECT_GE(start_offset, 0);
+  EXPECT_LE(end_offset, char_count);
 }
 
 // NOLINTEND(clang-analyzer-core.StackAddressEscape)


### PR DESCRIPTION
Add bounds validation to get_substring and get_string_at_offset to prevent out-of-bounds memory access when ATK clients pass offsets beyond the text length.

- get_substring: clamp start and end to [0, length] and ensure start <= end before calling g_utf8_substring.
- get_string_at_offset: clamp start and end to [0, n_attrs-1] before accessing the PangoLogAttr array.

Add tests for offset-beyond-end, empty text, and offset-at-end boundary conditions.
