### PR TITLE
[Linux] Fix incorrect GL datatypes for uniform locations

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -67,10 +67,10 @@ struct _FlCompositorOpenGL {
   GLuint program;
 
   // Location of layer offset in [program].
-  GLuint offset_location;
+  GLint offset_location;
 
   // Location of layer scale in [program].
-  GLuint scale_location;
+  GLint scale_location;
 
   // Verticies for the uniform square.
   GLuint vertex_buffer;


### PR DESCRIPTION
glGetUniformLocation() returns a GLint (and -1 when the uniform is not found), but offset_location and scale_location were declared as GLuint. Storing the result in a GLuint would turn -1 into a large positive value, defeating the safe no-op behavior of glUniform2f for invalid locations.
