### PR TITLE
Introduce `DefaultAnimationStyle` widget

### DIFF
--- a/packages/flutter/lib/src/widgets/default_animation_style.dart
+++ b/packages/flutter/lib/src/widgets/default_animation_style.dart
@@ -58,7 +58,7 @@ class DefaultAnimationStyle extends StatefulWidget {
   /// This can be useful for responding to animation style updates
   /// without notifying the respective [BuildContext] to rebuild.
   static ValueListenable<AnimationStyle> getNotifier(BuildContext context) {
-    const fallback = AlwaysStoppedAnimation<AnimationStyle>(.new());
+    const fallback = AlwaysStoppedAnimation<AnimationStyle>(AnimationStyle());
     if (!context.mounted) {
       return fallback;
     }
@@ -77,6 +77,13 @@ class DefaultAnimationStyle extends StatefulWidget {
 
   @override
   State<DefaultAnimationStyle> createState() => _DefaultAnimationStyleState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<AnimationStyle>('style', style));
+    properties.add(FlagProperty('inherit', value: inherit));
+  }
 }
 
 class _DefaultAnimationStyleState extends State<DefaultAnimationStyle> {

--- a/packages/flutter/lib/src/widgets/default_animation_style.dart
+++ b/packages/flutter/lib/src/widgets/default_animation_style.dart
@@ -1,0 +1,132 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport 'implicit_animations.dart';
+library;
+
+import 'package:flutter/animation.dart';
+import 'package:flutter/foundation.dart';
+
+import 'framework.dart';
+import 'inherited_notifier.dart';
+import 'inherited_theme.dart';
+
+/// Defines a default configuration for animation [Duration]s and [Curve]s.
+///
+/// If an [ImplicitlyAnimatedWidget]'s duration or curve is not defined,
+/// it will default to the values specified in the closest ancestor
+/// `DefaultAnimationStyle`, if one exists; otherwise it will use
+/// [fallbackDuration] and/or [fallbackCurve] respectively.
+class DefaultAnimationStyle extends StatefulWidget {
+  /// Creates a default configuration for animation [Duration]s and [Curve]s.
+  const DefaultAnimationStyle({
+    super.key,
+    required this.style,
+    this.inherit = true,
+    required this.child,
+  });
+
+  /// The animation style to be used by the widget's descendants.
+  final AnimationStyle style;
+
+  /// Determines whether null values from the provided `style` are filled in with
+  /// non-null properties from further up in the widget tree, if applicable.
+  ///
+  /// Defaults to `true`.
+  final bool inherit;
+
+  /// {@macro flutter.widgets.ProxyWidget.child}
+  final Widget child;
+
+  /// Returns the [AnimationStyle] corresponding to the nearest ancestor
+  /// [DefaultAnimationStyle] widget.
+  ///
+  /// If no such widget is found, returns an [AnimationStyle] object with
+  /// each property set to `null`.
+  static AnimationStyle of(BuildContext context, {bool createDependency = true}) {
+    final _InheritedAnimationStyle? inherited = createDependency
+        ? context.dependOnInheritedWidgetOfExactType()
+        : context.getInheritedWidgetOfExactType();
+
+    return inherited?.notifier?.value ?? const AnimationStyle();
+  }
+
+  /// Returns a [ValueListenable] object from the nearest ancestor
+  /// [DefaultAnimationStyle] widget.
+  ///
+  /// This can be useful for responding to animation style updates
+  /// without notifying the respective [BuildContext] to rebuild.
+  static ValueListenable<AnimationStyle> getNotifier(BuildContext context) {
+    const fallback = AlwaysStoppedAnimation<AnimationStyle>(.new());
+    if (!context.mounted) {
+      return fallback;
+    }
+
+    final _InheritedAnimationStyle? inheritedWidget = context.getInheritedWidgetOfExactType();
+    return inheritedWidget?.notifier ?? fallback;
+  }
+
+  /// A duration of 300 ms, used by widgets that depend on an ancestor [DefaultAnimationStyle]
+  /// when no such ancestor can be found.
+  static const Duration fallbackDuration = Duration(milliseconds: 300);
+
+  /// A linear curve, used by widgets that depend on an ancestor [DefaultAnimationStyle]
+  /// when no such ancestor can be found.
+  static const Curve fallbackCurve = Curves.linear;
+
+  @override
+  State<DefaultAnimationStyle> createState() => _DefaultAnimationStyleState();
+}
+
+class _DefaultAnimationStyleState extends State<DefaultAnimationStyle> {
+  late final ValueNotifier<AnimationStyle> notifier = ValueNotifier<AnimationStyle>(widget.style);
+  late ValueListenable<AnimationStyle> ancestor = DefaultAnimationStyle.getNotifier(context);
+
+  @override
+  void initState() {
+    super.initState();
+    ancestor.addListener(_updateStyle);
+  }
+
+  @override
+  void activate() {
+    super.activate();
+    final ValueListenable<AnimationStyle> newAncestorNotifier = DefaultAnimationStyle.getNotifier(
+      context,
+    );
+    if (newAncestorNotifier == ancestor) {
+      return;
+    }
+    ancestor.removeListener(_updateStyle);
+    ancestor = newAncestorNotifier..addListener(_updateStyle);
+  }
+
+  void _updateStyle() {
+    final AnimationStyle style = widget.style;
+    notifier.value = widget.inherit ? ancestor.value.merge(style) : style;
+  }
+
+  @override
+  void dispose() {
+    ancestor.removeListener(_updateStyle);
+    notifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _updateStyle();
+    return _InheritedAnimationStyle(notifier: notifier, child: widget.child);
+  }
+}
+
+class _InheritedAnimationStyle extends InheritedNotifier<ValueListenable<AnimationStyle>>
+    implements InheritedTheme {
+  const _InheritedAnimationStyle({required super.notifier, required super.child});
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return DefaultAnimationStyle(style: notifier!.value, child: child);
+  }
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -41,6 +41,7 @@ export 'src/widgets/context_menu_controller.dart';
 export 'src/widgets/date.dart';
 export 'src/widgets/debug.dart';
 export 'src/widgets/decorated_sliver.dart';
+export 'src/widgets/default_animation_style.dart';
 export 'src/widgets/default_selection_style.dart';
 export 'src/widgets/default_text_editing_shortcuts.dart';
 export 'src/widgets/desktop_text_selection_toolbar_layout_delegate.dart';

--- a/packages/flutter/test/widgets/default_animation_style_test.dart
+++ b/packages/flutter/test/widgets/default_animation_style_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('DefaultAnimationStyle notifier value matches widget', (WidgetTester tester) async {
+    late StateSetter setState;
+    var style = const AnimationStyle();
+    const Widget child = SizedBox.shrink(key: Key('key'));
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter stateSetter) {
+          setState = stateSetter;
+          return DefaultAnimationStyle(style: style, child: child);
+        },
+      ),
+    );
+
+    final ValueListenable<AnimationStyle> styleNotifier = DefaultAnimationStyle.getNotifier(
+      tester.element(find.byKey(const Key('key'))),
+    );
+    expect(styleNotifier.value, style);
+
+    setState(() {
+      style = const AnimationStyle(curve: Curves.ease);
+    });
+    await tester.pump();
+    expect(styleNotifier.value, style);
+
+    setState(() {
+      style = const AnimationStyle(
+        curve: Curves.bounceIn,
+        duration: Durations.extralong4,
+        reverseCurve: SawTooth(2),
+        reverseDuration: Duration(days: DateTime.thursday),
+      );
+    });
+    await tester.pump();
+    expect(styleNotifier.value, style);
+  });
+}

--- a/packages/flutter/test/widgets/default_animation_style_test.dart
+++ b/packages/flutter/test/widgets/default_animation_style_test.dart
@@ -37,7 +37,7 @@ void main() {
         curve: Curves.bounceIn,
         duration: Durations.extralong4,
         reverseCurve: SawTooth(2),
-        reverseDuration: Duration(days: DateTime.thursday),
+        reverseDuration: Duration(days: 4),
       );
     });
     await tester.pump();

--- a/packages/flutter/test/widgets/default_animation_style_test.dart
+++ b/packages/flutter/test/widgets/default_animation_style_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -35,7 +35,7 @@ void main() {
     setState(() {
       style = const AnimationStyle(
         curve: Curves.bounceIn,
-        duration: Durations.extralong4,
+        duration: Duration(minutes: 2),
         reverseCurve: SawTooth(2),
         reverseDuration: Duration(days: 4),
       );


### PR DESCRIPTION
The aim of this new widget is to remove the need for a developer to explicitly set the duration/curve for every [AnimationController](https://main-api.flutter.dev/flutter/animation/AnimationController-class.html) and [ImplicitlyAnimatedWidget](https://main-api.flutter.dev/flutter/widgets/ImplicitlyAnimatedWidget-class.html) by setting a single [AnimationStyle](https://main-api.flutter.dev/flutter/animation/AnimationStyle-class.html) at the root of the widget tree.

Currently, this PR introduces `DefaultAnimationStyle` without applying it to animation controllers or implicitly animated widgets. I'd be happy to expand this PR to include those, or I could make another pull request after this one lands.

<br>

related:
- #155573
- #156248
- 📜 [direct link to Design Doc](https://flutter.dev/go/default-animation-style)