### PR TITLE
fix: identity mismatch for path dependency plugins

### DIFF
--- a/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
@@ -150,10 +150,23 @@ class SwiftPackageManager {
         continue;
       }
 
-      // Use the plugin basename as the symlink plugin directory name since the basename has the
-      // version number in it. This will make the symlink name change when the plugin version
-      // changes, which forces Xcode to re-process the package manifest.
-      final String basename = _fileSystem.directory(plugin.path).basename;
+      // Build the symlink name using the plugin's Dart package name as the
+      // base. This is critical because Swift Package Manager derives a
+      // package's identity from its directory name (lowercased), and it must
+      // match the `name:` field in the plugin's Package.swift.
+      //
+      // When the plugin's root directory name differs from its Dart package
+      // name (e.g. a path dependency whose repo folder is
+      // "MyOrg_MyPlugin_Repo" but whose package name is
+      // "my_plugin"), using the directory basename would cause an
+      // identity mismatch error from SPM.
+      //
+      // A version suffix from the directory basename (e.g. "-1.0.0" from
+      // "my_plugin-1.0.0") is preserved so that the symlink name changes
+      // when the plugin version changes, forcing Xcode to re-process the
+      // package manifest.
+      final String dirBasename = _fileSystem.directory(plugin.path).basename;
+      final String basename = _symlinkNameForPlugin(plugin.name, dirBasename);
 
       // Check if the plugin has a dependency on another Flutter plugin.
       // If the plugin has a dependency on another plugin, copy the plugin to the SourcePackages
@@ -289,7 +302,9 @@ class SwiftPackageManager {
         if (pluginDependency == null) {
           continue;
         }
-        final newPath = '"../${_fileSystem.directory(pluginDependency.path).basename}"';
+        final String depDirBasename = _fileSystem.directory(pluginDependency.path).basename;
+        final String depSymlinkName = _symlinkNameForPlugin(pluginDependency.name, depDirBasename);
+        final newPath = '"../$depSymlinkName"';
         if (path == newPath) {
           continue;
         }
@@ -297,6 +312,32 @@ class SwiftPackageManager {
       }
     }
     return pluginDependencies;
+  }
+
+  /// Computes the symlink directory name for a plugin.
+  ///
+  /// Uses the plugin's [name] (Dart package name) as the base to ensure the
+  /// directory name matches the `name:` field in Package.swift, which is how
+  /// SPM derives the package identity.
+  ///
+  /// If the [dirBasename] contains a version suffix (e.g.
+  /// "my_plugin-1.0.0"), that suffix is appended to the name so that
+  /// symlinks change on version upgrades, forcing Xcode to re-process the
+  /// package manifest.
+  static String _symlinkNameForPlugin(String name, String dirBasename) {
+    // Try to extract a version suffix from the directory basename.
+    // Pub cache directories follow the pattern "package_name-version".
+    final int dashIndex = dirBasename.lastIndexOf('-');
+    if (dashIndex != -1) {
+      final String possibleVersion = dirBasename.substring(dashIndex + 1);
+      // Validate it looks like a version (starts with a digit).
+      if (possibleVersion.isNotEmpty &&
+          possibleVersion.codeUnitAt(0) >= 0x30 &&
+          possibleVersion.codeUnitAt(0) <= 0x39) {
+        return '$name-$possibleVersion';
+      }
+    }
+    return name;
   }
 
   /// Copy the [plugin] to the build directory and update the manifest to use the versioned path.

--- a/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
@@ -327,9 +327,8 @@ class SwiftPackageManager {
   static String _symlinkNameForPlugin(String name, String dirBasename) {
     // Try to extract a version suffix from the directory basename.
     // Pub cache directories follow the pattern "package_name-version".
-    final int dashIndex = dirBasename.lastIndexOf('-');
-    if (dashIndex != -1) {
-      final String possibleVersion = dirBasename.substring(dashIndex + 1);
+    if (dirBasename.startsWith('$name-')) {
+      final String possibleVersion = dirBasename.substring(name.length + 1);
       // Validate it looks like a version (starts with a digit).
       if (possibleVersion.isNotEmpty &&
           possibleVersion.codeUnitAt(0) >= 0x30 &&

--- a/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
@@ -373,6 +373,85 @@ let package = Package(
 ''');
           });
 
+          testWithoutContext(
+            'generate with plugin whose directory name differs from package name',
+            () async {
+              final fs = MemoryFileSystem();
+              final processManager = FakeProcessManager.any();
+              final logger = BufferLogger.test();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+
+              // Create a plugin whose directory name does not match its Dart
+              // package name. This simulates a path dependency whose repo
+              // folder has a different name than the Dart package name
+              // declared in pubspec.yaml and Package.swift.
+              final mismatchedPlugin = FakePlugin(
+                name: 'my_plugin',
+                platforms: <String, PluginPlatform>{platform.name: FakePluginPlatform()},
+                overridePath: '/local/path/to/plugins/MyOrg_MyPlugin_Repo',
+              );
+              fs
+                  .file(
+                    '${mismatchedPlugin.path}/${platform.name}/${mismatchedPlugin.name}/Package.swift',
+                  )
+                  .createSync(recursive: true);
+
+              final spm = SwiftPackageManager(
+                fileSystem: fs,
+                templateRenderer: const MustacheTemplateRenderer(),
+                processUtils: ProcessUtils(processManager: processManager, logger: logger),
+                config: FakeConfig(),
+              );
+              await spm.generatePluginsSwiftPackage(<Plugin>[mismatchedPlugin], platform, project);
+
+              final supportedPlatform = platform == FlutterDarwinPlatform.ios
+                  ? '.iOS("13.0")'
+                  : '.macOS("10.15")';
+              expect(project.flutterPluginSwiftPackageManifest.existsSync(), isTrue);
+              // The symlink name must be based on the plugin's Dart package
+              // name ("my_plugin"), NOT the directory basename
+              // ("MyOrg_MyPlugin_Repo"). This ensures SPM derives the correct
+              // identity that matches the Package.swift name field.
+              expect(project.relativeSwiftPackagesDirectory.childLink('my_plugin'), exists);
+              expect(
+                project.relativeSwiftPackagesDirectory.childLink('my_plugin').targetSync(),
+                '${mismatchedPlugin.path}/${platform.name}/my_plugin',
+              );
+              expect(project.flutterPluginSwiftPackageManifest.readAsStringSync(), '''
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+//
+// Generated file. Do not edit.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "FlutterGeneratedPluginSwiftPackage",
+    platforms: [
+        $supportedPlatform
+    ],
+    products: [
+        .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
+    ],
+    dependencies: [
+        .package(name: "my_plugin", path: "../.packages/my_plugin"),
+        .package(name: "FlutterFramework", path: "../.packages/FlutterFramework")
+    ],
+    targets: [
+        .target(
+            name: "FlutterGeneratedPluginSwiftPackage",
+            dependencies: [
+                .product(name: "my-plugin", package: "my_plugin"),
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ]
+        )
+    ]
+)
+''');
+            },
+          );
+
           testWithoutContext('generate with plugin with dependency on plugin', () async {
             final fs = MemoryFileSystem();
             final logger = BufferLogger.test();
@@ -787,8 +866,12 @@ class FakeXcodeProject extends Fake implements IosProject {
 }
 
 class FakePlugin extends Fake implements Plugin {
-  FakePlugin({required this.name, required this.platforms, this.hasSwiftPackage = true})
-    : path = '/local/path/to/plugins/$name-1.0.0';
+  FakePlugin({
+    required this.name,
+    required this.platforms,
+    this.hasSwiftPackage = true,
+    String? overridePath,
+  }) : path = overridePath ?? '/local/path/to/plugins/$name-1.0.0';
 
   @override
   final String name;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This pull request improves how symlink directory names are generated for Swift Package Manager (SPM) plugins in Flutter's macOS tooling. The main goal is to ensure that the symlink name matches the plugin's Dart package name (not just the directory name), which is critical for SPM to correctly identify packages—especially when the plugin's directory name differs from its package name (as with some path dependencies). The changes also preserve version suffixes to force Xcode to re-process package manifests on version upgrades. Additionally, new tests are added to verify this behavior.

Fixes #186881 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
