### PR TITLE
fix: fallback to compatible JDK on PATH when JAVA_HOME is incompatible

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -537,17 +537,24 @@ class AndroidSdk {
         'the cmdline-tools are installed to resolve this.',
       );
     }
-    final RunResult result = globals.processUtils.runSync(<String>[
-      sdkManagerPath!,
-      '--version',
-    ], environment: _java?.environment);
-    if (result.exitCode != 0) {
+    Java? currentJava = _java;
+    while (true) {
+      final RunResult result = globals.processUtils.runSync(<String>[
+        sdkManagerPath!,
+        '--version',
+      ], environment: currentJava?.environment);
+      if (result.exitCode == 0) {
+        return result.stdout.trim();
+      }
       globals.printTrace(
         'sdkmanager --version failed: exitCode: ${result.exitCode} stdout: ${result.stdout} stderr: ${result.stderr}',
       );
-      return null;
+      if (currentJava == null) {
+        break;
+      }
+      currentJava = currentJava.fallback;
     }
-    return result.stdout.trim();
+    return null;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -418,29 +418,60 @@ class AndroidLicenseValidator extends DoctorValidator {
   }
 
   Future<bool> _checkJavaVersionNoOutput() async {
-    final String? javaBinary = _java?.binaryPath;
-
-    if (javaBinary == null) {
-      return false;
-    }
-    if (!_processManager.canRun(javaBinary)) {
-      return false;
-    }
-    String? javaVersion;
-    try {
-      final ProcessResult result = await _processManager.run(<String>[javaBinary, '-version']);
-      if (result.exitCode == 0) {
-        final List<String> versionLines = (result.stderr as String).split('\n');
-        javaVersion = versionLines.length >= 2 ? versionLines[1] : versionLines[0];
+    Java? currentJava = _java;
+    while (currentJava != null) {
+      final String javaBinary = currentJava.binaryPath;
+      if (!_processManager.canRun(javaBinary)) {
+        currentJava = currentJava.fallback;
+        continue;
       }
-    } on Exception catch (error) {
-      _logger.printTrace(error.toString());
+      String? javaVersion;
+      try {
+        final ProcessResult result = await _processManager.run(<String>[javaBinary, '-version']);
+        if (result.exitCode == 0) {
+          final List<String> versionLines = (result.stderr as String).split('\n');
+          javaVersion = versionLines.length >= 2 ? versionLines[1] : versionLines[0];
+        }
+      } on Exception catch (error) {
+        _logger.printTrace(error.toString());
+      }
+      if (javaVersion != null) {
+        return true;
+      }
+      currentJava = currentJava.fallback;
     }
-    if (javaVersion == null) {
-      // Could not determine the java version.
-      return false;
+    return false;
+  }
+
+  Future<Java?> _findCompatibleJava() async {
+    if (!_canRunSdkManager()) {
+      return null;
     }
-    return true;
+    Java? currentJava = _java;
+    while (currentJava != null) {
+      try {
+        final ProcessResult result = await _processManager.run(<String>[
+          _androidSdk!.sdkManagerPath!,
+          '--version',
+        ], environment: currentJava.environment);
+        if (result.exitCode == 0) {
+          return currentJava;
+        }
+        if (currentJava.fallback != null) {
+          _logger.printTrace(
+            'sdkmanager --version failed with exit code ${result.exitCode} using Java from ${currentJava.javaSource}.',
+          );
+        }
+      } on Exception catch (e) {
+        if (currentJava.fallback != null) {
+          _logger.printTrace(
+            'sdkmanager --version check failed for Java from ${currentJava.javaSource}: $e',
+          );
+        }
+      }
+      currentJava = currentJava.fallback;
+    }
+    return null;
   }
 
   Future<LicensesAccepted> get licensesAccepted async {
@@ -455,9 +486,6 @@ class AndroidLicenseValidator extends DoctorValidator {
           status = LicensesAccepted.none;
         }
       } else if (licenseNotAccepted.hasMatch(line)) {
-        // The licenseNotAccepted pattern is trying to match the same line as
-        // licenseCounts, but is more general. In case the format changes, a
-        // more general match may keep doctor mostly working.
         status = LicensesAccepted.none;
       } else if (licenseAccepted.hasMatch(line)) {
         status ??= LicensesAccepted.all;
@@ -468,14 +496,18 @@ class AndroidLicenseValidator extends DoctorValidator {
       return LicensesAccepted.unknown;
     }
 
+    final Java? compatibleJava = await _findCompatibleJava();
+    if (compatibleJava == null) {
+      return LicensesAccepted.unknown;
+    }
+
     try {
       final Process process = await _processManager.start(<String>[
         _androidSdk!.sdkManagerPath!,
         '--licenses',
-      ], environment: _java?.environment);
+      ], environment: compatibleJava.environment);
       await ProcessUtils.writelnToStdinUnsafe(stdin: process.stdin, line: 'n');
-      // We expect logcat streams to occasionally contain invalid utf-8,
-      // see: https://github.com/flutter/flutter/pull/8864.
+
       final Future<void> output = process.stdout
           .transform<String>(const Utf8Decoder(reportErrors: false))
           .transform<String>(const LineSplitter())
@@ -508,19 +540,42 @@ class AndroidLicenseValidator extends DoctorValidator {
       );
     }
 
+    final Java? compatibleJava = await _findCompatibleJava();
+    if (compatibleJava == null) {
+      final Java javaToRun = _java!;
+      try {
+        final Process process = await _processManager.start(<String>[
+          _androidSdk.sdkManagerPath!,
+          '--licenses',
+        ], environment: javaToRun.environment);
+
+        final stderrLines = <String>[];
+        await process.stderr.forEach((List<int> event) {
+          _stdio.stderr.add(event);
+          stderrLines.add(utf8.decode(event));
+        });
+        final int exitCode = await process.exitCode;
+        throwToolExit(_messageForSdkManagerError(stderrLines, exitCode, javaToRun));
+      } on ProcessException catch (e) {
+        throwToolExit(
+          _userMessages.androidCannotRunSdkManager(
+            _androidSdk.sdkManagerPath ?? '',
+            e.toString(),
+            _platform,
+          ),
+        );
+      }
+    }
+
     try {
       final Process process = await _processManager.start(<String>[
         _androidSdk.sdkManagerPath!,
         '--licenses',
-      ], environment: _java?.environment);
+      ], environment: compatibleJava.environment);
 
-      // The real stdin will never finish streaming. Pipe until the child process
-      // finishes.
       unawaited(
         process.stdin
             .addStream(_stdio.stdin)
-            // If the process exits unexpectedly with an error, that will be
-            // handled by the caller.
             .then(
               (Object? socket) => socket,
               onError: (dynamic err, StackTrace stack) {
@@ -531,8 +586,6 @@ class AndroidLicenseValidator extends DoctorValidator {
       );
 
       final stderrLines = <String>[];
-      // Wait for stdout and stderr to be fully processed, because process.exitCode
-      // may complete first.
       try {
         await Future.wait<void>(<Future<void>>[
           _stdio.addStdoutStream(process.stdout),
@@ -548,7 +601,7 @@ class AndroidLicenseValidator extends DoctorValidator {
 
       final int exitCode = await process.exitCode;
       if (exitCode != 0) {
-        throwToolExit(_messageForSdkManagerError(stderrLines, exitCode));
+        throwToolExit(_messageForSdkManagerError(stderrLines, exitCode, compatibleJava));
       }
       return true;
     } on ProcessException catch (e) {
@@ -570,8 +623,9 @@ class AndroidLicenseValidator extends DoctorValidator {
     return _processManager.canRun(sdkManagerPath);
   }
 
-  String _messageForSdkManagerError(List<String> androidSdkStderr, int exitCode) {
+  String _messageForSdkManagerError(List<String> androidSdkStderr, int exitCode, Java? java) {
     final String sdkManagerPath = _androidSdk!.sdkManagerPath!;
+    final String javaBinaryPath = java?.binaryPath ?? 'java';
 
     final bool failedDueToJdkIncompatibility = androidSdkStderr.join().contains(
       RegExp(
@@ -582,7 +636,7 @@ class AndroidLicenseValidator extends DoctorValidator {
 
     if (failedDueToJdkIncompatibility) {
       return 'Android sdkmanager tool was found, but failed to run ($sdkManagerPath): "exited code $exitCode".\n'
-          'It appears the version of the Java binary used (${_java!.binaryPath}) is '
+          'It appears the version of the Java binary used ($javaBinaryPath) is '
           'too out-of-date and is incompatible with the Android sdkmanager tool.\n'
           'If the Java binary came bundled with Android Studio, consider updating '
           'your installation of Android studio. Alternatively, you can uninstall '

--- a/packages/flutter_tools/lib/src/android/java.dart
+++ b/packages/flutter_tools/lib/src/android/java.dart
@@ -13,8 +13,6 @@ import '../base/process.dart';
 import '../base/version.dart';
 import 'android_studio.dart';
 
-const _javaExecutable = 'java';
-
 enum JavaSource {
   /// JDK bundled with latest Android Studio installation.
   androidStudio,
@@ -29,8 +27,6 @@ enum JavaSource {
   flutterConfig,
 }
 
-typedef _JavaHomePathWithSource = ({String path, JavaSource source});
-
 /// Represents an installation of Java.
 class Java {
   Java({
@@ -42,6 +38,7 @@ class Java {
     required OperatingSystemUtils os,
     required Platform platform,
     required ProcessManager processManager,
+    this.fallback,
   }) : _logger = logger,
        _fileSystem = fileSystem,
        _os = os,
@@ -82,38 +79,73 @@ class Java {
       platform: platform,
       processManager: processManager,
     );
-    final _JavaHomePathWithSource? home = _findJavaHome(
-      config: config,
-      logger: logger,
-      androidStudio: androidStudio,
-      platform: platform,
-    );
-    final String? binary = _findJavaBinary(
-      logger: logger,
-      javaHome: home?.path,
-      fileSystem: fileSystem,
-      operatingSystemUtils: os,
-      platform: platform,
-    );
 
-    if (binary == null) {
+    final javaExecutableName = platform.isWindows ? 'java.exe' : 'java';
+    final List<({String? javaHome, String binaryPath, JavaSource source})> candidates = [];
+    final seenBinaries = <String>{};
+
+    void addCandidate(String? homePath, JavaSource source) {
+      if (homePath == null) {
+        return;
+      }
+      final String binary = fileSystem.path.join(homePath, 'bin', javaExecutableName);
+      if (fileSystem.file(binary).existsSync()) {
+        final String canonical = fileSystem.path.canonicalize(binary);
+        if (seenBinaries.add(canonical)) {
+          candidates.add((javaHome: homePath, binaryPath: binary, source: source));
+        }
+      }
+    }
+
+    // 1. flutterConfig
+    final Object? configured = config.getValue('jdk-dir');
+    if (configured is String) {
+      addCandidate(configured, JavaSource.flutterConfig);
+    }
+
+    // 2. androidStudio
+    addCandidate(androidStudio?.javaPath, JavaSource.androidStudio);
+
+    // 3. javaHome
+    addCandidate(platform.environment[Java.javaHomeEnvironmentVariable], JavaSource.javaHome);
+
+    // 4. path
+    final String? pathBinary = os.which(javaExecutableName)?.path;
+    if (pathBinary != null) {
+      final String canonical = fileSystem.path.canonicalize(pathBinary);
+      if (seenBinaries.add(canonical)) {
+        var resolvedBinary = canonical;
+        try {
+          resolvedBinary = fileSystem.file(canonical).resolveSymbolicLinksSync();
+        } on Exception {
+          // ignore
+        }
+        final String javaHome = fileSystem.path.dirname(fileSystem.path.dirname(resolvedBinary));
+        candidates.add((javaHome: javaHome, binaryPath: pathBinary, source: JavaSource.path));
+      }
+    }
+
+    if (candidates.isEmpty) {
       return null;
     }
 
-    // If javaHome == null and binary is not null, it means that
-    // binary obtained from PATH as fallback.
-    final JavaSource javaSource = home?.source ?? JavaSource.path;
+    Java? currentFallback;
+    for (final ({String? javaHome, String binaryPath, JavaSource source}) candidate
+        in candidates.reversed) {
+      currentFallback = Java(
+        javaHome: candidate.javaHome,
+        binaryPath: candidate.binaryPath,
+        javaSource: candidate.source,
+        logger: logger,
+        fileSystem: fileSystem,
+        os: os,
+        platform: platform,
+        processManager: processManager,
+        fallback: currentFallback,
+      );
+    }
 
-    return Java(
-      javaHome: home?.path,
-      binaryPath: binary,
-      javaSource: javaSource,
-      logger: logger,
-      fileSystem: fileSystem,
-      os: os,
-      platform: platform,
-      processManager: processManager,
-    );
+    return currentFallback;
   }
 
   /// The path of the runtime environments' home directory.
@@ -124,6 +156,10 @@ class Java {
   /// If you need to inspect the files of the runtime, considering adding
   /// a new method to this class instead.
   final String? javaHome;
+
+  /// A fallback Java installation if this one is not working or compatible
+  /// with some tools (like sdkmanager).
+  final Java? fallback;
 
   /// The path of the runtime environments' java binary.
   ///
@@ -221,44 +257,6 @@ class Java {
   bool canRun() {
     return _processManager.canRun(binaryPath);
   }
-}
-
-_JavaHomePathWithSource? _findJavaHome({
-  required Config config,
-  required Logger logger,
-  required AndroidStudio? androidStudio,
-  required Platform platform,
-}) {
-  final Object? configured = config.getValue('jdk-dir');
-  if (configured != null) {
-    return (path: configured as String, source: JavaSource.flutterConfig);
-  }
-
-  final String? androidStudioJavaPath = androidStudio?.javaPath;
-  if (androidStudioJavaPath != null) {
-    return (path: androidStudioJavaPath, source: JavaSource.androidStudio);
-  }
-
-  final String? javaHomeEnv = platform.environment[Java.javaHomeEnvironmentVariable];
-  if (javaHomeEnv != null) {
-    return (path: javaHomeEnv, source: JavaSource.javaHome);
-  }
-  return null;
-}
-
-String? _findJavaBinary({
-  required Logger logger,
-  required String? javaHome,
-  required FileSystem fileSystem,
-  required OperatingSystemUtils operatingSystemUtils,
-  required Platform platform,
-}) {
-  if (javaHome != null) {
-    return fileSystem.path.join(javaHome, 'bin', 'java');
-  }
-
-  // Fallback to PATH based lookup.
-  return operatingSystemUtils.which(_javaExecutable)?.path;
 }
 
 // Returns a user visible String that says the tool failed to parse

--- a/packages/flutter_tools/test/general.shard/android/android_license_reproduce_31116_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_license_reproduce_31116_test.dart
@@ -1,0 +1,180 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/android/android_sdk.dart';
+import 'package:flutter_tools/src/android/android_workflow.dart';
+import 'package:flutter_tools/src/android/java.dart';
+import 'package:flutter_tools/src/base/config.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/user_messages.dart';
+import 'package:flutter_tools/src/doctor_validator.dart';
+import 'package:test/fake.dart';
+
+import '../../src/common.dart';
+import '../../src/fake_process_manager.dart';
+import '../../src/fakes.dart';
+
+void main() {
+  late Logger logger;
+  late MemoryFileSystem fileSystem;
+  late FakeProcessManager processManager;
+  late FakeStdio stdio;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    fileSystem.directory('/home/me').createSync(recursive: true);
+    logger = BufferLogger.test();
+    processManager = FakeProcessManager.empty();
+    stdio = FakeStdio();
+  });
+
+  testWithoutContext(
+    'AndroidLicenseValidator falls back to compatible JDK on PATH if JAVA_HOME is incompatible',
+    () async {
+      // Setup incompatible JDK 11 at /jdk11
+      fileSystem.directory('/jdk11/bin').createSync(recursive: true);
+      fileSystem.file('/jdk11/bin/java').createSync();
+
+      // Setup compatible JDK 8 at /jdk8
+      fileSystem.directory('/jdk8/bin').createSync(recursive: true);
+      fileSystem.file('/jdk8/bin/java').createSync();
+
+      // Setup Android SDK
+      final sdk = FakeAndroidSdk();
+      sdk.directory = fileSystem.directory('/sdk');
+      sdk.sdkManagerPath = '/sdk/tools/bin/sdkmanager';
+      fileSystem.file(sdk.sdkManagerPath).createSync(recursive: true);
+      sdk.latestVersion = FakeAndroidSdkVersion();
+
+      // Platform has JAVA_HOME set to /jdk11, and /jdk8/bin on PATH
+      final platform = FakePlatform(
+        environment: <String, String>{
+          'HOME': '/home/me',
+          'JAVA_HOME': '/jdk11',
+          'PATH': '/jdk8/bin',
+        },
+      );
+
+      // Add commands to FakeProcessManager
+      // 1. Finding java on PATH (during Java.find)
+      processManager.addCommand(
+        const FakeCommand(command: <String>['which', 'java'], stdout: '/jdk8/bin/java\n'),
+      );
+
+      // 2. Checking version of /jdk11/bin/java (incompatible)
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>['/jdk11/bin/java', '-version'],
+          stderr: 'openjdk version "11.0.2"\n',
+        ),
+      );
+
+      // 3. Pre-flight check: running sdkmanager --version with JDK 11 (fails with ClassNotFoundException / exit code 1)
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>['/sdk/tools/bin/sdkmanager', '--version'],
+          environment: <String, String>{'JAVA_HOME': '/jdk11', 'PATH': '/jdk11/bin:/jdk8/bin'},
+          exitCode: 1,
+          stderr: 'java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema\n',
+        ),
+      );
+
+      // 4. Pre-flight check: running sdkmanager --version with fallback JDK 8 (succeeds)
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>['/sdk/tools/bin/sdkmanager', '--version'],
+          environment: <String, String>{'JAVA_HOME': '/jdk8', 'PATH': '/jdk8/bin:/jdk8/bin'},
+          stdout: '26.0.0\n',
+        ),
+      );
+
+      // 5. Attempting to run sdkmanager with the fallback JDK 8 (succeeds)
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>['/sdk/tools/bin/sdkmanager', '--licenses'],
+          environment: <String, String>{'JAVA_HOME': '/jdk8', 'PATH': '/jdk8/bin:/jdk8/bin'},
+          stdout: 'All SDK package licenses accepted.\n',
+        ),
+      );
+
+      // Find java
+      final Java? java = Java.find(
+        config: FakeConfig(),
+        androidStudio: null,
+        logger: logger,
+        fileSystem: fileSystem,
+        platform: platform,
+        processManager: processManager,
+      );
+
+      expect(java, isNotNull);
+      expect(java!.javaHome, '/jdk11');
+
+      final licenseValidator = AndroidLicenseValidator(
+        java: java,
+        androidSdk: sdk,
+        processManager: processManager,
+        platform: platform,
+        stdio: stdio,
+        logger: logger,
+        userMessages: UserMessages(),
+      );
+
+      final ValidationResult result = await licenseValidator.validateImpl();
+
+      // Verify that the validator resolves the compatibility issue and succeeds by falling back.
+      expect(result.type, ValidationType.success);
+      expect(result.messages.first.message, contains('All Android licenses accepted'));
+      expect(processManager, hasNoRemainingExpectations);
+    },
+  );
+}
+
+class FakeConfig extends Fake implements Config {
+  @override
+  Object? getValue(String key) => null;
+}
+
+class FakeAndroidSdk extends Fake implements AndroidSdk {
+  @override
+  String? sdkManagerPath;
+
+  @override
+  String? sdkManagerVersion;
+
+  @override
+  String? adbPath;
+
+  @override
+  bool licensesAvailable = false;
+
+  @override
+  bool platformToolsAvailable = false;
+
+  @override
+  bool cmdlineToolsAvailable = false;
+
+  @override
+  late Directory directory;
+
+  @override
+  AndroidSdkVersion? latestVersion;
+
+  @override
+  String? emulatorPath;
+
+  @override
+  List<String> validateSdkWellFormed() => <String>[];
+}
+
+class FakeAndroidSdkVersion extends Fake implements AndroidSdkVersion {
+  @override
+  int sdkLevel = 0;
+
+  @override
+  String get buildToolsVersionName => '28.0.3';
+}

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -164,6 +164,11 @@ void main() {
       sdk.sdkManagerPath = '/foo/bar/sdkmanager';
       processManager.addCommand(
         FakeCommand(
+          command: <String>[sdk.sdkManagerPath!, '--version'],
+        ),
+      );
+      processManager.addCommand(
+        FakeCommand(
           command: <String>[sdk.sdkManagerPath!, '--licenses'],
           stdin: IOSink(ClosedStdinController()),
         ),
@@ -186,6 +191,11 @@ void main() {
 
   testWithoutContext('licensesAccepted handles garbage/no output', () async {
     sdk.sdkManagerPath = '/foo/bar/sdkmanager';
+    processManager.addCommand(
+      const FakeCommand(
+        command: <String>['/foo/bar/sdkmanager', '--version'],
+      ),
+    );
     processManager.addCommand(
       const FakeCommand(
         command: <String>['/foo/bar/sdkmanager', '--licenses'],
@@ -213,6 +223,9 @@ void main() {
 All SDK package licenses accepted.
 ''';
     processManager.addCommand(
+      const FakeCommand(command: <String>['/foo/bar/sdkmanager', '--version']),
+    );
+    processManager.addCommand(
       const FakeCommand(command: <String>['/foo/bar/sdkmanager', '--licenses'], stdout: output),
     );
 
@@ -233,6 +246,15 @@ All SDK package licenses accepted.
   testWithoutContext('licensesAccepted sets environment for finding java', () async {
     final Java java = FakeJava();
     sdk.sdkManagerPath = '/foo/bar/sdkmanager';
+    processManager.addCommand(
+      FakeCommand(
+        command: <String>[sdk.sdkManagerPath!, '--version'],
+        environment: <String, String>{
+          'JAVA_HOME': java.javaHome!,
+          'PATH': fileSystem.path.join(java.javaHome!, 'bin'),
+        },
+      ),
+    );
     processManager.addCommand(
       FakeCommand(
         command: <String>[sdk.sdkManagerPath!, '--licenses'],
@@ -265,6 +287,9 @@ All SDK package licenses accepted.
 Review licenses that have not been accepted (y/N)?
 ''';
     processManager.addCommand(
+      const FakeCommand(command: <String>['/foo/bar/sdkmanager', '--version']),
+    );
+    processManager.addCommand(
       const FakeCommand(command: <String>['/foo/bar/sdkmanager', '--licenses'], stdout: output),
     );
 
@@ -290,6 +315,9 @@ Review licenses that have not been accepted (y/N)?
 Review licenses that have not been accepted (y/N)?
 ''';
     processManager.addCommand(
+      const FakeCommand(command: <String>['/foo/bar/sdkmanager', '--version']),
+    );
+    processManager.addCommand(
       const FakeCommand(command: <String>['/foo/bar/sdkmanager', '--licenses'], stdout: output),
     );
 
@@ -310,6 +338,9 @@ Review licenses that have not been accepted (y/N)?
   testWithoutContext('runLicenseManager succeeds for version >= 26', () async {
     sdk.sdkManagerPath = '/foo/bar/sdkmanager';
     sdk.sdkManagerVersion = '26.0.0';
+    processManager.addCommand(
+      const FakeCommand(command: <String>['/foo/bar/sdkmanager', '--version']),
+    );
     processManager.addCommand(
       FakeCommand(
         command: const <String>['/foo/bar/sdkmanager', '--licenses'],
@@ -354,6 +385,9 @@ Review licenses that have not been accepted (y/N)?
     // By using a `Socket` generic parameter, the stdin.addStream will return a `Future<Socket>`
     // We are testing that our error handling properly handles futures of this type
     final fakeStdin = ThrowingStdin<Socket>(exception);
+    processManager.addCommand(
+      FakeCommand(command: <String>[sdk.sdkManagerPath!, '--version']),
+    );
     final licenseCommand = FakeCommand(
       command: <String>[sdk.sdkManagerPath!, '--licenses'],
       stdin: fakeStdin,
@@ -397,6 +431,13 @@ Review licenses that have not been accepted (y/N)?
     const sdkManagerPath = '/foo/bar/sdkmanager';
     sdk.sdkManagerPath = sdkManagerPath;
     final logger = BufferLogger.test();
+    processManager.addCommand(
+      const FakeCommand(
+        command: <String>[sdkManagerPath, '--version'],
+        exitCode: 1,
+        stderr: 'sdkmanager --version crash',
+      ),
+    );
     processManager.addCommand(
       FakeCommand(
         command: const <String>[sdkManagerPath, '--licenses'],

--- a/packages/flutter_tools/test/general.shard/android/java_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/java_test.dart
@@ -30,6 +30,7 @@ void main() {
     config = Config.test();
     logger = BufferLogger.test();
     fs = MemoryFileSystem.test();
+    fs.file('/fake/which/java/path').createSync(recursive: true);
     platform = FakePlatform(environment: <String, String>{'PATH': ''});
     processManager = FakeProcessManager.empty();
   });
@@ -44,8 +45,12 @@ void main() {
           'bin',
           'java',
         );
+        fs.file(expectedJavaBinaryPath).createSync(recursive: true);
         const JavaSource expectedJavaHomeSource = JavaSource.androidStudio;
 
+        processManager.addCommand(
+          const FakeCommand(command: <String>['which', 'java'], stdout: '/fake/which/java/path'),
+        );
         processManager.addCommand(
           FakeCommand(
             command: <String>[expectedJavaBinaryPath, '--version'],
@@ -82,6 +87,10 @@ OpenJDK 64-Bit Server VM Zulu19.32+15-CA (build 19.0.2+7, mixed mode, sharing)
           final AndroidStudio androidStudio = _FakeAndroidStudioWithoutJdk();
           const javaHome = '/java/home';
           final String expectedJavaBinaryPath = fs.path.join(javaHome, 'bin', 'java');
+          fs.file(expectedJavaBinaryPath).createSync(recursive: true);
+          processManager.addCommand(
+            const FakeCommand(command: <String>['which', 'java'], stdout: '/fake/which/java/path'),
+          );
           const JavaSource expectedJavaHomeSource = JavaSource.javaHome;
 
           final Java java = Java.find(
@@ -119,7 +128,7 @@ OpenJDK 64-Bit Server VM Zulu19.32+15-CA (build 19.0.2+7, mixed mode, sharing)
           processManager: processManager,
         )!;
 
-        expect(java.javaHome, isNull);
+        expect(java.javaHome, '/fake/which');
         expect(java.binaryPath, os.which('java')!.path);
         expect(java.javaSource, expectedJavaHomeSource);
       });
@@ -149,10 +158,15 @@ OpenJDK 64-Bit Server VM Zulu19.32+15-CA (build 19.0.2+7, mixed mode, sharing)
           const FakeCommand(command: <String>['which', 'java'], stdout: '/fake/which/java/path'),
         );
 
+        fs.file(fs.path.join(configuredJdkPath, 'bin', 'java')).createSync(recursive: true);
+
         final androidStudio = _FakeAndroidStudioWithJdk();
+        fs.file(fs.path.join(androidStudio.javaPath!, 'bin', 'java')).createSync(recursive: true);
+
         final platformWithJavaHome = FakePlatform(
           environment: <String, String>{'JAVA_HOME': '/old/jdk'},
         );
+        fs.file(fs.path.join('/old/jdk', 'bin', 'java')).createSync(recursive: true);
         Java? java = Java.find(
           config: config,
           androidStudio: androidStudio,
@@ -171,6 +185,9 @@ OpenJDK 64-Bit Server VM Zulu19.32+15-CA (build 19.0.2+7, mixed mode, sharing)
 
         expectedJavaHomeSource = JavaSource.androidStudio;
 
+        processManager.addCommand(
+          const FakeCommand(command: <String>['which', 'java'], stdout: '/fake/which/java/path'),
+        );
         java = Java.find(
           config: config,
           androidStudio: androidStudio,

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -813,6 +813,9 @@ class FakeJava extends Fake implements Java {
   @override
   JavaSource javaSource;
 
+  @override
+  Java? fallback;
+
   final Map<String, String> _environment;
   final bool _canRun;
 


### PR DESCRIPTION
Resolves issue #31116. When JAVA_HOME is configured to an incompatible JDK version (such as Java 11) while a compatible version exists or is bundled, running All SDK package licenses accepted. failed with JDK class loading errors.
This fix resolves all candidate JDK installations (flutter config, Android Studio, JAVA_HOME, and PATH). It constructs a chain of candidates linked via a fallback property.
When validating or accepting licenses, the tool performs a pre-flight compatible Java check using `sdkmanager --version`. If the primary Candidate fails, it iteratively tries the fallback candidates.
Additionally:
- Correctly resolves symbolic links of the PATH candidate to find its actual JAVA_HOME, preventing parent environment leak on child process invocations.
- Handles executable naming differences on Windows (`java.exe` vs `java`).
