### PR TITLE
fix: update multi-pointer release behavior on Android for tap and long-press gestures

### DIFF
--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -720,12 +720,36 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
   @override
   void handleEvent(PointerEvent event) {
     assert(state != GestureRecognizerState.ready);
-    if (state == GestureRecognizerState.possible && event.pointer == primaryPointer) {
+
+    final isAndroid = defaultTargetPlatform == TargetPlatform.android;
+    var shouldProcess = false;
+
+    if (state == GestureRecognizerState.possible) {
+      if (isAndroid) {
+        // On Android, multi-touch tap and long-press gestures are only completed
+        // when the last tracked pointer is released. If the primary pointer is
+        // released but other pointers are still down, we delay processing the
+        // up event until the last pointer is released.
+        if (event.pointer == primaryPointer) {
+          shouldProcess = !(event is PointerUpEvent && _trackedPointers.length > 1);
+        } else if ((event is PointerUpEvent || event is PointerCancelEvent) &&
+            _trackedPointers.length == 1 &&
+            _trackedPointers.contains(event.pointer)) {
+          shouldProcess = true;
+        }
+      } else {
+        shouldProcess = event.pointer == primaryPointer;
+      }
+    }
+
+    if (shouldProcess) {
       final bool isPreAcceptSlopPastTolerance =
+          event.pointer == primaryPointer &&
           !_gestureAccepted &&
           preAcceptSlopTolerance != null &&
           _getGlobalDistance(event) > preAcceptSlopTolerance!;
       final bool isPostAcceptSlopPastTolerance =
+          event.pointer == primaryPointer &&
           _gestureAccepted &&
           postAcceptSlopTolerance != null &&
           _getGlobalDistance(event) > postAcceptSlopTolerance!;

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -278,7 +278,7 @@ abstract class BaseTapGestureRecognizer extends PrimaryPointerGestureRecognizer 
       // If there is no result in the previous gesture arena,
       // we ignore them and prepare to accept a new pointer.
       if (_down != null && _up != null) {
-        assert(_down!.pointer == _up!.pointer);
+        assert(defaultTargetPlatform == TargetPlatform.android || _down!.pointer == _up!.pointer);
         _reset();
       }
 
@@ -379,7 +379,7 @@ abstract class BaseTapGestureRecognizer extends PrimaryPointerGestureRecognizer 
     if (!_wonArenaForPrimaryPointer || _up == null) {
       return;
     }
-    assert(_up!.pointer == _down!.pointer);
+    assert(defaultTargetPlatform == TargetPlatform.android || _up!.pointer == _down!.pointer);
     handleTapUp(down: _down!, up: _up!);
     _reset();
   }

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -2055,66 +2056,71 @@ void main() {
 
   testGesture('On multiple pointers, DragGestureRecognizer is canceled '
       'when all pointers are canceled (FIFO)', (GestureTester tester) {
-    // This test simulates the following scenario:
-    // P1 down, P2 down, P1 up, P2 up
-    final logs = <String>[];
-    final hori = HorizontalDragGestureRecognizer()
-      ..onDown = (DragDownDetails details) {
-        logs.add('downH');
-      }
-      ..onStart = (DragStartDetails details) {
-        logs.add('startH');
-      }
-      ..onUpdate = (DragUpdateDetails details) {
-        logs.add('updateH');
-      }
-      ..onEnd = (DragEndDetails details) {
-        logs.add('endH');
-      }
-      ..onCancel = () {
-        logs.add('cancelH');
-      };
-    // Competitor
-    final vert = TapGestureRecognizer()
-      ..onTapDown = (TapDownDetails details) {
-        logs.add('downT');
-      }
-      ..onTapUp = (TapUpDetails details) {
-        logs.add('upT');
-      }
-      ..onTapCancel = () {};
-    addTearDown(hori.dispose);
-    addTearDown(vert.dispose);
+    try {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      // This test simulates the following scenario:
+      // P1 down, P2 down, P1 up, P2 up
+      final logs = <String>[];
+      final hori = HorizontalDragGestureRecognizer()
+        ..onDown = (DragDownDetails details) {
+          logs.add('downH');
+        }
+        ..onStart = (DragStartDetails details) {
+          logs.add('startH');
+        }
+        ..onUpdate = (DragUpdateDetails details) {
+          logs.add('updateH');
+        }
+        ..onEnd = (DragEndDetails details) {
+          logs.add('endH');
+        }
+        ..onCancel = () {
+          logs.add('cancelH');
+        };
+      // Competitor
+      final vert = TapGestureRecognizer()
+        ..onTapDown = (TapDownDetails details) {
+          logs.add('downT');
+        }
+        ..onTapUp = (TapUpDetails details) {
+          logs.add('upT');
+        }
+        ..onTapCancel = () {};
+      addTearDown(hori.dispose);
+      addTearDown(vert.dispose);
 
-    final pointer1 = TestPointer(4);
-    final pointer2 = TestPointer(5);
+      final pointer1 = TestPointer(4);
+      final pointer2 = TestPointer(5);
 
-    final PointerDownEvent down1 = pointer1.down(const Offset(10.0, 10.0));
-    final PointerDownEvent down2 = pointer2.down(const Offset(11.0, 10.0));
+      final PointerDownEvent down1 = pointer1.down(const Offset(10.0, 10.0));
+      final PointerDownEvent down2 = pointer2.down(const Offset(11.0, 10.0));
 
-    hori.addPointer(down1);
-    vert.addPointer(down1);
-    tester.route(down1);
-    tester.closeArena(pointer1.pointer);
-    expect(logs, <String>['downH']);
-    logs.clear();
+      hori.addPointer(down1);
+      vert.addPointer(down1);
+      tester.route(down1);
+      tester.closeArena(pointer1.pointer);
+      expect(logs, <String>['downH']);
+      logs.clear();
 
-    hori.addPointer(down2);
-    vert.addPointer(down2);
-    tester.route(down2);
-    tester.closeArena(pointer2.pointer);
-    expect(logs, <String>[]);
-    logs.clear();
+      hori.addPointer(down2);
+      vert.addPointer(down2);
+      tester.route(down2);
+      tester.closeArena(pointer2.pointer);
+      expect(logs, <String>[]);
+      logs.clear();
 
-    tester.route(pointer1.up());
-    GestureBinding.instance.gestureArena.sweep(pointer1.pointer);
-    expect(logs, <String>['downT', 'upT']);
-    logs.clear();
+      tester.route(pointer1.up());
+      GestureBinding.instance.gestureArena.sweep(pointer1.pointer);
+      expect(logs, <String>['downT', 'upT']);
+      logs.clear();
 
-    tester.route(pointer2.up());
-    GestureBinding.instance.gestureArena.sweep(pointer2.pointer);
-    expect(logs, <String>['cancelH']);
-    logs.clear();
+      tester.route(pointer2.up());
+      GestureBinding.instance.gestureArena.sweep(pointer2.pointer);
+      expect(logs, <String>['cancelH']);
+      logs.clear();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 
   testGesture('On multiple pointers, DragGestureRecognizer is canceled '
@@ -2252,70 +2258,75 @@ void main() {
 
   testGesture('On multiple pointers, canceled pointers (due to up) do not '
       'prevent later pointers getting accepted', (GestureTester tester) {
-    // This test simulates the following scenario:
-    // P1 down, P2 down, P1 Up, P2 moves away
-    final logs = <String>[];
-    final hori = HorizontalDragGestureRecognizer()
-      ..onDown = (DragDownDetails details) {
-        logs.add('downH');
-      }
-      ..onStart = (DragStartDetails details) {
-        logs.add('startH');
-      }
-      ..onUpdate = (DragUpdateDetails details) {
-        logs.add('updateH');
-      }
-      ..onEnd = (DragEndDetails details) {
-        logs.add('endH');
-      }
-      ..onCancel = () {
-        logs.add('cancelH');
-      };
-    // Competitor
-    final vert = TapGestureRecognizer()
-      ..onTapDown = (TapDownDetails details) {
-        logs.add('downT');
-      }
-      ..onTapUp = (TapUpDetails details) {
-        logs.add('upT');
-      }
-      ..onTapCancel = () {};
-    addTearDown(hori.dispose);
-    addTearDown(vert.dispose);
+    try {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      // This test simulates the following scenario:
+      // P1 down, P2 down, P1 Up, P2 moves away
+      final logs = <String>[];
+      final hori = HorizontalDragGestureRecognizer()
+        ..onDown = (DragDownDetails details) {
+          logs.add('downH');
+        }
+        ..onStart = (DragStartDetails details) {
+          logs.add('startH');
+        }
+        ..onUpdate = (DragUpdateDetails details) {
+          logs.add('updateH');
+        }
+        ..onEnd = (DragEndDetails details) {
+          logs.add('endH');
+        }
+        ..onCancel = () {
+          logs.add('cancelH');
+        };
+      // Competitor
+      final vert = TapGestureRecognizer()
+        ..onTapDown = (TapDownDetails details) {
+          logs.add('downT');
+        }
+        ..onTapUp = (TapUpDetails details) {
+          logs.add('upT');
+        }
+        ..onTapCancel = () {};
+      addTearDown(hori.dispose);
+      addTearDown(vert.dispose);
 
-    final pointer1 = TestPointer(4);
-    final pointer2 = TestPointer(5);
+      final pointer1 = TestPointer(4);
+      final pointer2 = TestPointer(5);
 
-    final PointerDownEvent down1 = pointer1.down(const Offset(10.0, 10.0));
-    final PointerDownEvent down2 = pointer2.down(const Offset(11.0, 10.0));
+      final PointerDownEvent down1 = pointer1.down(const Offset(10.0, 10.0));
+      final PointerDownEvent down2 = pointer2.down(const Offset(11.0, 10.0));
 
-    hori.addPointer(down1);
-    vert.addPointer(down1);
-    tester.route(down1);
-    tester.closeArena(pointer1.pointer);
-    expect(logs, <String>['downH']);
-    logs.clear();
+      hori.addPointer(down1);
+      vert.addPointer(down1);
+      tester.route(down1);
+      tester.closeArena(pointer1.pointer);
+      expect(logs, <String>['downH']);
+      logs.clear();
 
-    hori.addPointer(down2);
-    vert.addPointer(down2);
-    tester.route(down2);
-    tester.closeArena(pointer2.pointer);
-    expect(logs, <String>[]);
-    logs.clear();
+      hori.addPointer(down2);
+      vert.addPointer(down2);
+      tester.route(down2);
+      tester.closeArena(pointer2.pointer);
+      expect(logs, <String>[]);
+      logs.clear();
 
-    tester.route(pointer1.up());
-    GestureBinding.instance.gestureArena.sweep(pointer1.pointer);
-    expect(logs, <String>['downT', 'upT']);
-    logs.clear();
+      tester.route(pointer1.up());
+      GestureBinding.instance.gestureArena.sweep(pointer1.pointer);
+      expect(logs, <String>['downT', 'upT']);
+      logs.clear();
 
-    tester.route(pointer2.move(const Offset(100, 100)));
-    expect(logs, <String>['startH']);
-    logs.clear();
+      tester.route(pointer2.move(const Offset(100, 100)));
+      expect(logs, <String>['startH']);
+      logs.clear();
 
-    tester.route(pointer2.up());
-    GestureBinding.instance.gestureArena.sweep(pointer2.pointer);
-    expect(logs, <String>['endH']);
-    logs.clear();
+      tester.route(pointer2.up());
+      GestureBinding.instance.gestureArena.sweep(pointer2.pointer);
+      expect(logs, <String>['endH']);
+      logs.clear();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 
   testGesture('On multiple pointers, canceled pointers (due to buttons) do not '

--- a/packages/flutter/test/gestures/multi_pointer_fidelity_reproduce_test.dart
+++ b/packages/flutter/test/gestures/multi_pointer_fidelity_reproduce_test.dart
@@ -1,0 +1,511 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'gesture_tester.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const down1 = PointerDownEvent(pointer: 1, position: Offset(10.0, 10.0));
+  const up1 = PointerUpEvent(pointer: 1, position: Offset(11.0, 9.0));
+
+  const down2 = PointerDownEvent(pointer: 2, position: Offset(12.0, 12.0));
+  const up2 = PointerUpEvent(pointer: 2, position: Offset(13.0, 11.0));
+
+  group('TapGestureRecognizer', () {
+    testGesture(
+      'On Android, tap triggers on the release of the last pointer (down1, down2, up1, up2)',
+      (tester) {
+        final tap = TapGestureRecognizer();
+        addTearDown(tap.dispose);
+
+        try {
+          debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+          var tapRecognizedCount = 0;
+          tap.onTap = () {
+            tapRecognizedCount++;
+          };
+
+          var tapUpRecognizedCount = 0;
+          tap.onTapUp = (details) {
+            tapUpRecognizedCount++;
+          };
+
+          // First pointer down
+          tap.addPointer(down1);
+          tester.closeArena(1);
+          tester.route(down1);
+
+          // Second pointer down
+          tap.addPointer(down2);
+          tester.closeArena(2);
+          tester.route(down2);
+
+          final tapCountBeforeUp = tapRecognizedCount;
+          final tapUpCountBeforeUp = tapUpRecognizedCount;
+
+          // First pointer up
+          tester.route(up1);
+          GestureBinding.instance.gestureArena.sweep(1);
+
+          final tapCountOnUp1 = tapRecognizedCount;
+          final tapUpCountOnUp1 = tapUpRecognizedCount;
+
+          // Second pointer up
+          tester.route(up2);
+          GestureBinding.instance.gestureArena.sweep(2);
+
+          final tapCountOnUp2 = tapRecognizedCount;
+          final tapUpCountOnUp2 = tapUpRecognizedCount;
+
+          // Run assertions
+          expect(tapCountBeforeUp, 0);
+          expect(tapUpCountBeforeUp, 0);
+          expect(tapCountOnUp1, 0);
+          expect(tapUpCountOnUp1, 0);
+          expect(tapCountOnUp2, 1);
+          expect(tapUpCountOnUp2, 1);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testGesture(
+      'On Android, tap triggers on the release of the last pointer (down1, down2, up2, up1)',
+      (tester) {
+        final tap = TapGestureRecognizer();
+        addTearDown(tap.dispose);
+
+        try {
+          debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+          var tapRecognizedCount = 0;
+          tap.onTap = () {
+            tapRecognizedCount++;
+          };
+
+          var tapUpRecognizedCount = 0;
+          tap.onTapUp = (details) {
+            tapUpRecognizedCount++;
+          };
+
+          // First pointer down
+          tap.addPointer(down1);
+          tester.closeArena(1);
+          tester.route(down1);
+
+          // Second pointer down
+          tap.addPointer(down2);
+          tester.closeArena(2);
+          tester.route(down2);
+
+          final tapCountBeforeUp = tapRecognizedCount;
+          final tapUpCountBeforeUp = tapUpRecognizedCount;
+
+          // Second pointer up
+          tester.route(up2);
+          GestureBinding.instance.gestureArena.sweep(2);
+
+          final tapCountOnUp2 = tapRecognizedCount;
+          final tapUpCountOnUp2 = tapUpRecognizedCount;
+
+          // First pointer up
+          tester.route(up1);
+          GestureBinding.instance.gestureArena.sweep(1);
+
+          final tapCountOnUp1 = tapRecognizedCount;
+          final tapUpCountOnUp1 = tapUpRecognizedCount;
+
+          // Run assertions
+          expect(tapCountBeforeUp, 0);
+          expect(tapUpCountBeforeUp, 0);
+          expect(tapCountOnUp2, 0);
+          expect(tapUpCountOnUp2, 0);
+          expect(tapCountOnUp1, 1);
+          expect(tapUpCountOnUp1, 1);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testGesture(
+      'On iOS, tap triggers on the release of the first pointer (down1, down2, up1, up2)',
+      (tester) {
+        final tap = TapGestureRecognizer();
+        addTearDown(tap.dispose);
+
+        try {
+          debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+          var tapRecognizedCount = 0;
+          tap.onTap = () {
+            tapRecognizedCount++;
+          };
+
+          var tapUpRecognizedCount = 0;
+          tap.onTapUp = (details) {
+            tapUpRecognizedCount++;
+          };
+
+          // First pointer down
+          tap.addPointer(down1);
+          tester.closeArena(1);
+          tester.route(down1);
+
+          // Second pointer down
+          tap.addPointer(down2);
+          tester.closeArena(2);
+          tester.route(down2);
+
+          final tapCountBeforeUp = tapRecognizedCount;
+          final tapUpCountBeforeUp = tapUpRecognizedCount;
+
+          // First pointer up
+          tester.route(up1);
+          GestureBinding.instance.gestureArena.sweep(1);
+
+          final tapCountOnUp1 = tapRecognizedCount;
+          final tapUpCountOnUp1 = tapUpRecognizedCount;
+
+          // Second pointer up
+          tester.route(up2);
+          GestureBinding.instance.gestureArena.sweep(2);
+
+          final tapCountOnUp2 = tapRecognizedCount;
+          final tapUpCountOnUp2 = tapUpRecognizedCount;
+
+          // Run assertions
+          expect(tapCountBeforeUp, 0);
+          expect(tapUpCountBeforeUp, 0);
+          expect(tapCountOnUp1, 1);
+          expect(tapUpCountOnUp1, 1);
+          expect(tapCountOnUp2, 1);
+          expect(tapUpCountOnUp2, 1);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testGesture(
+      'On iOS, tap triggers on the release of the first pointer (down1, down2, up2, up1)',
+      (tester) {
+        final tap = TapGestureRecognizer();
+        addTearDown(tap.dispose);
+
+        try {
+          debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+          var tapRecognizedCount = 0;
+          tap.onTap = () {
+            tapRecognizedCount++;
+          };
+
+          var tapUpRecognizedCount = 0;
+          tap.onTapUp = (details) {
+            tapUpRecognizedCount++;
+          };
+
+          // First pointer down
+          tap.addPointer(down1);
+          tester.closeArena(1);
+          tester.route(down1);
+
+          // Second pointer down
+          tap.addPointer(down2);
+          tester.closeArena(2);
+          tester.route(down2);
+
+          final tapCountBeforeUp = tapRecognizedCount;
+          final tapUpCountBeforeUp = tapUpRecognizedCount;
+
+          // Second pointer up (non-primary pointer)
+          tester.route(up2);
+          GestureBinding.instance.gestureArena.sweep(2);
+
+          final tapCountOnUp2 = tapRecognizedCount;
+          final tapUpCountOnUp2 = tapUpRecognizedCount;
+
+          // First pointer up (primary pointer)
+          tester.route(up1);
+          GestureBinding.instance.gestureArena.sweep(1);
+
+          final tapCountOnUp1 = tapRecognizedCount;
+          final tapUpCountOnUp1 = tapUpRecognizedCount;
+
+          // Run assertions
+          expect(tapCountBeforeUp, 0);
+          expect(tapUpCountBeforeUp, 0);
+          expect(tapCountOnUp2, 0);
+          expect(tapUpCountOnUp2, 0);
+          expect(tapCountOnUp1, 1);
+          expect(tapUpCountOnUp1, 1);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+  });
+
+  group('LongPressGestureRecognizer', () {
+    testGesture(
+      'On Android, long press triggers on the release of the last pointer (down1, down2, up1, up2)',
+      (tester) {
+        final longPress = LongPressGestureRecognizer();
+        addTearDown(longPress.dispose);
+
+        try {
+          debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+          var longPressRecognizedCount = 0;
+          longPress.onLongPress = () {
+            longPressRecognizedCount++;
+          };
+
+          var longPressUpRecognizedCount = 0;
+          longPress.onLongPressUp = () {
+            longPressUpRecognizedCount++;
+          };
+
+          // First pointer down
+          longPress.addPointer(down1);
+          tester.closeArena(1);
+          tester.route(down1);
+
+          // Second pointer down
+          longPress.addPointer(down2);
+          tester.closeArena(2);
+          tester.route(down2);
+
+          final countBeforeTimeout = longPressRecognizedCount;
+          final upCountBeforeTimeout = longPressUpRecognizedCount;
+
+          // Wait for the long press deadline to trigger the long press gesture.
+          tester.async.elapse(kLongPressTimeout);
+
+          final countAfterTimeout = longPressRecognizedCount;
+          final upCountAfterTimeout = longPressUpRecognizedCount;
+
+          // First pointer up
+          tester.route(up1);
+          GestureBinding.instance.gestureArena.sweep(1);
+
+          final upCountOnUp1 = longPressUpRecognizedCount;
+
+          // Second pointer up
+          tester.route(up2);
+          GestureBinding.instance.gestureArena.sweep(2);
+
+          final upCountOnUp2 = longPressUpRecognizedCount;
+
+          // Run assertions
+          expect(countBeforeTimeout, 0);
+          expect(upCountBeforeTimeout, 0);
+          expect(countAfterTimeout, 1);
+          expect(upCountAfterTimeout, 0);
+          expect(upCountOnUp1, 0);
+          expect(upCountOnUp2, 1);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testGesture(
+      'On Android, long press triggers on the release of the last pointer (down1, down2, up2, up1)',
+      (tester) {
+        final longPress = LongPressGestureRecognizer();
+        addTearDown(longPress.dispose);
+
+        try {
+          debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+          var longPressRecognizedCount = 0;
+          longPress.onLongPress = () {
+            longPressRecognizedCount++;
+          };
+
+          var longPressUpRecognizedCount = 0;
+          longPress.onLongPressUp = () {
+            longPressUpRecognizedCount++;
+          };
+
+          // First pointer down
+          longPress.addPointer(down1);
+          tester.closeArena(1);
+          tester.route(down1);
+
+          // Second pointer down
+          longPress.addPointer(down2);
+          tester.closeArena(2);
+          tester.route(down2);
+
+          final countBeforeTimeout = longPressRecognizedCount;
+          final upCountBeforeTimeout = longPressUpRecognizedCount;
+
+          // Wait for the long press deadline.
+          tester.async.elapse(kLongPressTimeout);
+
+          final countAfterTimeout = longPressRecognizedCount;
+          final upCountAfterTimeout = longPressUpRecognizedCount;
+
+          // Second pointer up
+          tester.route(up2);
+          GestureBinding.instance.gestureArena.sweep(2);
+
+          final upCountOnUp2 = longPressUpRecognizedCount;
+
+          // First pointer up
+          tester.route(up1);
+          GestureBinding.instance.gestureArena.sweep(1);
+
+          final upCountOnUp1 = longPressUpRecognizedCount;
+
+          // Run assertions
+          expect(countBeforeTimeout, 0);
+          expect(upCountBeforeTimeout, 0);
+          expect(countAfterTimeout, 1);
+          expect(upCountAfterTimeout, 0);
+          expect(upCountOnUp2, 0);
+          expect(upCountOnUp1, 1);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testGesture(
+      'On iOS, long press triggers on the release of the first pointer (down1, down2, up1, up2)',
+      (tester) {
+        final longPress = LongPressGestureRecognizer();
+        addTearDown(longPress.dispose);
+
+        try {
+          debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+          var longPressRecognizedCount = 0;
+          longPress.onLongPress = () {
+            longPressRecognizedCount++;
+          };
+
+          var longPressUpRecognizedCount = 0;
+          longPress.onLongPressUp = () {
+            longPressUpRecognizedCount++;
+          };
+
+          // First pointer down
+          longPress.addPointer(down1);
+          tester.closeArena(1);
+          tester.route(down1);
+
+          // Second pointer down
+          longPress.addPointer(down2);
+          tester.closeArena(2);
+          tester.route(down2);
+
+          final countBeforeTimeout = longPressRecognizedCount;
+          final upCountBeforeTimeout = longPressUpRecognizedCount;
+
+          // Wait for the long press deadline.
+          tester.async.elapse(kLongPressTimeout);
+
+          final countAfterTimeout = longPressRecognizedCount;
+          final upCountAfterTimeout = longPressUpRecognizedCount;
+
+          // First pointer up (primary pointer)
+          tester.route(up1);
+          GestureBinding.instance.gestureArena.sweep(1);
+
+          final upCountOnUp1 = longPressUpRecognizedCount;
+
+          // Second pointer up
+          tester.route(up2);
+          GestureBinding.instance.gestureArena.sweep(2);
+
+          final upCountOnUp2 = longPressUpRecognizedCount;
+
+          // Run assertions
+          expect(countBeforeTimeout, 0);
+          expect(upCountBeforeTimeout, 0);
+          expect(countAfterTimeout, 1);
+          expect(upCountAfterTimeout, 0);
+          expect(upCountOnUp1, 1);
+          expect(upCountOnUp2, 1);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testGesture(
+      'On iOS, long press triggers on the release of the first pointer (down1, down2, up2, up1)',
+      (tester) {
+        final longPress = LongPressGestureRecognizer();
+        addTearDown(longPress.dispose);
+
+        try {
+          debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+          var longPressRecognizedCount = 0;
+          longPress.onLongPress = () {
+            longPressRecognizedCount++;
+          };
+
+          var longPressUpRecognizedCount = 0;
+          longPress.onLongPressUp = () {
+            longPressUpRecognizedCount++;
+          };
+
+          // First pointer down
+          longPress.addPointer(down1);
+          tester.closeArena(1);
+          tester.route(down1);
+
+          // Second pointer down
+          longPress.addPointer(down2);
+          tester.closeArena(2);
+          tester.route(down2);
+
+          final countBeforeTimeout = longPressRecognizedCount;
+          final upCountBeforeTimeout = longPressUpRecognizedCount;
+
+          // Wait for the long press deadline.
+          tester.async.elapse(kLongPressTimeout);
+
+          final countAfterTimeout = longPressRecognizedCount;
+          final upCountAfterTimeout = longPressUpRecognizedCount;
+
+          // Second pointer up (non-primary pointer)
+          tester.route(up2);
+          GestureBinding.instance.gestureArena.sweep(2);
+
+          final upCountOnUp2 = longPressUpRecognizedCount;
+
+          // First pointer up (primary pointer)
+          tester.route(up1);
+          GestureBinding.instance.gestureArena.sweep(1);
+
+          final upCountOnUp1 = longPressUpRecognizedCount;
+
+          // Run assertions
+          expect(countBeforeTimeout, 0);
+          expect(upCountBeforeTimeout, 0);
+          expect(countAfterTimeout, 1);
+          expect(upCountAfterTimeout, 0);
+          expect(upCountOnUp2, 0);
+          expect(upCountOnUp1, 1);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+  });
+}

--- a/packages/flutter/test/gestures/tap_test.dart
+++ b/packages/flutter/test/gestures/tap_test.dart
@@ -217,36 +217,41 @@ void main() {
   });
 
   testGesture('Should not recognize two overlapping taps (FIFO)', (GestureTester tester) {
-    final tap = TapGestureRecognizer();
+    try {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final tap = TapGestureRecognizer();
 
-    var tapsRecognized = 0;
-    tap.onTap = () {
-      tapsRecognized++;
-    };
+      var tapsRecognized = 0;
+      tap.onTap = () {
+        tapsRecognized++;
+      };
 
-    tap.addPointer(down1);
-    tester.closeArena(1);
-    expect(tapsRecognized, 0);
-    tester.route(down1);
-    expect(tapsRecognized, 0);
+      tap.addPointer(down1);
+      tester.closeArena(1);
+      expect(tapsRecognized, 0);
+      tester.route(down1);
+      expect(tapsRecognized, 0);
 
-    tap.addPointer(down2);
-    tester.closeArena(2);
-    expect(tapsRecognized, 0);
-    tester.route(down1);
-    expect(tapsRecognized, 0);
+      tap.addPointer(down2);
+      tester.closeArena(2);
+      expect(tapsRecognized, 0);
+      tester.route(down1);
+      expect(tapsRecognized, 0);
 
-    tester.route(up1);
-    expect(tapsRecognized, 1);
-    GestureBinding.instance.gestureArena.sweep(1);
-    expect(tapsRecognized, 1);
+      tester.route(up1);
+      expect(tapsRecognized, 1);
+      GestureBinding.instance.gestureArena.sweep(1);
+      expect(tapsRecognized, 1);
 
-    tester.route(up2);
-    expect(tapsRecognized, 1);
-    GestureBinding.instance.gestureArena.sweep(2);
-    expect(tapsRecognized, 1);
+      tester.route(up2);
+      expect(tapsRecognized, 1);
+      GestureBinding.instance.gestureArena.sweep(2);
+      expect(tapsRecognized, 1);
 
-    tap.dispose();
+      tap.dispose();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 
   testGesture('Should not recognize two overlapping taps (FILO)', (GestureTester tester) {
@@ -663,49 +668,54 @@ void main() {
   });
 
   testGesture('non-primary pointers does not trigger timeout', (GestureTester tester) {
-    // Regression test for https://github.com/flutter/flutter/issues/43310
-    // Pointer1 down, pointer2 down, then pointer 1 up, all within the timeout.
-    // In this way, `BaseTapGestureRecognizer.didExceedDeadline` can be triggered
-    // after its `_reset`.
-    final tap = TapGestureRecognizer();
-    addTearDown(tap.dispose);
+    try {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      // Regression test for https://github.com/flutter/flutter/issues/43310
+      // Pointer1 down, pointer2 down, then pointer 1 up, all within the timeout.
+      // In this way, `BaseTapGestureRecognizer.didExceedDeadline` can be triggered
+      // after its `_reset`.
+      final tap = TapGestureRecognizer();
+      addTearDown(tap.dispose);
 
-    final recognized = <String>[];
-    tap.onTapDown = (_) {
-      recognized.add('down');
-    };
-    tap.onTapUp = (_) {
-      recognized.add('up');
-    };
-    tap.onTap = () {
-      recognized.add('tap');
-    };
-    tap.onTapCancel = () {
-      recognized.add('cancel');
-    };
+      final recognized = <String>[];
+      tap.onTapDown = (_) {
+        recognized.add('down');
+      };
+      tap.onTapUp = (_) {
+        recognized.add('up');
+      };
+      tap.onTap = () {
+        recognized.add('tap');
+      };
+      tap.onTapCancel = () {
+        recognized.add('cancel');
+      };
 
-    tap.addPointer(down1);
-    tester.closeArena(down1.pointer);
+      tap.addPointer(down1);
+      tester.closeArena(down1.pointer);
 
-    tap.addPointer(down2);
-    tester.closeArena(down2.pointer);
+      tap.addPointer(down2);
+      tester.closeArena(down2.pointer);
 
-    expect(recognized, isEmpty);
+      expect(recognized, isEmpty);
 
-    tester.route(up1);
-    GestureBinding.instance.gestureArena.sweep(down1.pointer);
-    expect(recognized, <String>['down', 'up', 'tap']);
-    recognized.clear();
+      tester.route(up1);
+      GestureBinding.instance.gestureArena.sweep(down1.pointer);
+      expect(recognized, <String>['down', 'up', 'tap']);
+      recognized.clear();
 
-    // If regression happens, the following step will throw error
-    tester.async.elapse(const Duration(milliseconds: 200));
-    expect(recognized, isEmpty);
+      // If regression happens, the following step will throw error
+      tester.async.elapse(const Duration(milliseconds: 200));
+      expect(recognized, isEmpty);
 
-    tester.route(up2);
-    GestureBinding.instance.gestureArena.sweep(down2.pointer);
-    expect(recognized, isEmpty);
+      tester.route(up2);
+      GestureBinding.instance.gestureArena.sweep(down2.pointer);
+      expect(recognized, isEmpty);
 
-    tap.dispose();
+      tap.dispose();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 
   group('Enforce consistent-button restriction:', () {


### PR DESCRIPTION
Updates PrimaryPointerGestureRecognizer to delay pointer up events on Android if other pointers are currently tracked, completing the gesture only when the last pointer is released. Also updates BaseTapGestureRecognizer assertions to allow down/up events to have different pointer IDs on Android.
