### PR TITLE
fix: resolve Android collapsed selection handle alignment issue (#45556)

### DIFF
--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -117,6 +117,19 @@ class MaterialTextSelectionControls extends TextSelectionControls {
     };
   }
 
+  @override
+  Offset calculateHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, [
+    double targetWidth = 0.0,
+  ]) {
+    final Offset anchor = getHandleAnchor(type, textLineHeight);
+    return switch (type) {
+      TextSelectionHandleType.collapsed => anchor - Offset(targetWidth / 2.0, 0.0),
+      TextSelectionHandleType.left || TextSelectionHandleType.right => anchor,
+    };
+  }
+
   @Deprecated(
     'Use `contextMenuBuilder` instead. '
     'This feature was deprecated after v3.3.0-0.5.pre.',

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -116,6 +116,18 @@ abstract class TextSelectionControls {
   /// often visually "points to" that location.
   Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight);
 
+  /// Returns the anchor point of the handle relative to itself, taking the target
+  /// width (e.g., the caret width) into account.
+  ///
+  /// By default, this returns `getHandleAnchor(type, textLineHeight)`.
+  Offset calculateHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, [
+    double targetWidth = 0.0,
+  ]) {
+    return getHandleAnchor(type, textLineHeight);
+  }
+
   /// Builds a toolbar near a text selection.
   ///
   /// Typically displays buttons for copying and pasting text.
@@ -361,12 +373,14 @@ class TextSelectionOverlay {
       startHandleType: TextSelectionHandleType.collapsed,
       startHandlesVisible: _effectiveStartHandleVisibility,
       lineHeightAtStart: 0.0,
+      startHandleTargetWidth: renderObject.cursorWidth,
       onStartHandleDragStart: _handleSelectionStartHandleDragStart,
       onStartHandleDragUpdate: _handleSelectionStartHandleDragUpdate,
       onEndHandleDragEnd: _handleAnyDragEnd,
       endHandleType: TextSelectionHandleType.collapsed,
       endHandlesVisible: _effectiveEndHandleVisibility,
       lineHeightAtEnd: 0.0,
+      endHandleTargetWidth: renderObject.cursorWidth,
       onEndHandleDragStart: _handleSelectionEndHandleDragStart,
       onEndHandleDragUpdate: _handleSelectionEndHandleDragUpdate,
       onStartHandleDragEnd: _handleAnyDragEnd,
@@ -556,12 +570,14 @@ class TextSelectionOverlay {
         TextSelectionHandleType.right,
       )
       ..lineHeightAtStart = _getStartGlyphHeight()
+      ..startHandleTargetWidth = renderObject.cursorWidth
       ..endHandleType = _chooseType(
         renderObject.textDirection,
         TextSelectionHandleType.right,
         TextSelectionHandleType.left,
       )
       ..lineHeightAtEnd = _getEndGlyphHeight()
+      ..endHandleTargetWidth = renderObject.cursorWidth
       // Update selection toolbar metrics.
       ..selectionEndpoints = renderObject.getEndpointsForSelection(_selection)
       ..toolbarLocation = renderObject.lastSecondaryTapDownPosition;
@@ -1061,12 +1077,14 @@ class SelectionOverlay {
     this.debugRequiredFor,
     required TextSelectionHandleType startHandleType,
     required double lineHeightAtStart,
+    double startHandleTargetWidth = 0.0,
     this.startHandlesVisible,
     this.onStartHandleDragStart,
     this.onStartHandleDragUpdate,
     this.onStartHandleDragEnd,
     required TextSelectionHandleType endHandleType,
     required double lineHeightAtEnd,
+    double endHandleTargetWidth = 0.0,
     this.endHandlesVisible,
     this.onEndHandleDragStart,
     this.onEndHandleDragUpdate,
@@ -1093,8 +1111,10 @@ class SelectionOverlay {
     this.magnifierConfiguration = TextMagnifierConfiguration.disabled,
   }) : _startHandleType = startHandleType,
        _lineHeightAtStart = lineHeightAtStart,
+       _startHandleTargetWidth = startHandleTargetWidth,
        _endHandleType = endHandleType,
        _lineHeightAtEnd = lineHeightAtEnd,
+       _endHandleTargetWidth = endHandleTargetWidth,
        _selectionEndpoints = selectionEndpoints,
        _toolbarLocation = toolbarLocation,
        assert(debugCheckHasOverlay(context)) {
@@ -1232,6 +1252,21 @@ class SelectionOverlay {
     markNeedsBuild();
   }
 
+  /// The target width (e.g. caret width) of the start handle.
+  ///
+  /// This value is used for calculating the offset of the start selection handle.
+  ///
+  /// Changing the value while the handles are visible causes them to rebuild.
+  double get startHandleTargetWidth => _startHandleTargetWidth;
+  double _startHandleTargetWidth;
+  set startHandleTargetWidth(double value) {
+    if (_startHandleTargetWidth == value) {
+      return;
+    }
+    _startHandleTargetWidth = value;
+    markNeedsBuild();
+  }
+
   // Whether a drag is in progress on the start handle. This differs from
   // `_isDraggingStartHandle` in that it is not blocked by `_canDragStartHandle`.
   bool _startHandleDragInProgress = false;
@@ -1350,6 +1385,21 @@ class SelectionOverlay {
       return;
     }
     _lineHeightAtEnd = value;
+    markNeedsBuild();
+  }
+
+  /// The target width (e.g. caret width) of the end handle.
+  ///
+  /// This value is used for calculating the offset of the end selection handle.
+  ///
+  /// Changing the value while the handles are visible causes them to rebuild.
+  double get endHandleTargetWidth => _endHandleTargetWidth;
+  double _endHandleTargetWidth;
+  set endHandleTargetWidth(double value) {
+    if (_endHandleTargetWidth == value) {
+      return;
+    }
+    _endHandleTargetWidth = value;
     markNeedsBuild();
   }
 
@@ -1783,6 +1833,7 @@ class SelectionOverlay {
         visibility: startHandlesVisible,
         preferredLineHeight: _lineHeightAtStart,
         dragStartBehavior: dragStartBehavior,
+        targetWidth: startHandleTargetWidth,
       );
     }
     return TapRegion(
@@ -1814,6 +1865,7 @@ class SelectionOverlay {
         visibility: endHandlesVisible,
         preferredLineHeight: _lineHeightAtEnd,
         dragStartBehavior: dragStartBehavior,
+        targetWidth: endHandleTargetWidth,
       );
     }
     return TapRegion(
@@ -1994,6 +2046,7 @@ class _SelectionHandleOverlay extends StatefulWidget {
     this.visibility,
     required this.preferredLineHeight,
     this.dragStartBehavior = DragStartBehavior.start,
+    this.targetWidth = 0.0,
   });
 
   final LayerLink handleLayerLink;
@@ -2006,6 +2059,7 @@ class _SelectionHandleOverlay extends StatefulWidget {
   final double preferredLineHeight;
   final TextSelectionHandleType type;
   final DragStartBehavior dragStartBehavior;
+  final double targetWidth;
 
   @override
   State<_SelectionHandleOverlay> createState() => _SelectionHandleOverlayState();
@@ -2080,9 +2134,10 @@ class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay>
             math.max((interactiveRect.height - handleRect.height) / 2, 0),
           );
 
-    final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
+    final Offset handleAnchor = widget.selectionControls.calculateHandleAnchor(
       widget.type,
       widget.preferredLineHeight,
+      widget.targetWidth,
     );
 
     // Make sure a drag is eagerly accepted. This is used on iOS to match the

--- a/packages/flutter/test/material/cursor_pointer_reproduce_test.dart
+++ b/packages/flutter/test/material/cursor_pointer_reproduce_test.dart
@@ -1,0 +1,64 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../widgets/editable_text_utils.dart' show findRenderEditable;
+
+void main() {
+  testWidgets('Android collapsed selection handle is centered relative to the caret', (WidgetTester tester) async {
+    const double cursorWidth = 20.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.android),
+        home: const Scaffold(
+          body: Center(
+            child: TextField(
+              showCursor: true,
+              autofocus: true,
+              cursorWidth: cursorWidth,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Focus the TextField and show the selection handles.
+    await tester.pumpAndSettle();
+
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = renderEditable.getEndpointsForSelection(
+      const TextSelection.collapsed(offset: 0),
+    );
+    expect(endpoints.length, 1);
+
+    // Tap the caret to show the handle (cursor pointer).
+    final Offset caretOffset = renderEditable.localToGlobal(
+      renderEditable.getLocalRectForCaret(const TextPosition(offset: 0)).center,
+    );
+    await tester.tapAt(caretOffset);
+    await tester.pumpAndSettle();
+
+    // Find the collapsed selection handle CustomPaint.
+    final Finder handleFinder = find.descendant(
+      of: find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_SelectionHandleOverlay'),
+      matching: find.byType(CustomPaint),
+    );
+    expect(handleFinder, findsOneWidget);
+
+    final RenderBox handleBox = tester.renderObject(handleFinder);
+    final Offset handleGlobalCenter = handleBox.localToGlobal(
+      Offset(handleBox.size.width / 2, handleBox.size.height / 2),
+    );
+
+    final Rect caretRect = renderEditable.getLocalRectForCaret(const TextPosition(offset: 0));
+    final Offset caretGlobalCenter = renderEditable.localToGlobal(caretRect.center);
+
+    // Verify that the horizontal center of the handle is aligned with the center of the caret.
+    expect(handleGlobalCenter.dx, closeTo(caretGlobalCenter.dx, 0.001));
+  });
+}


### PR DESCRIPTION
Shifts the Material collapsed selection handle (cursor pointer) horizontally by half of the targetWidth so that the handle's horizontal center is aligned with the center of the caret.

Introduces TextSelectionControls.calculateHandleAnchor to support passing targetWidth, maintaining backward compatibility for existing custom controls by defaulting to getHandleAnchor.
