### PR TITLE
fix: support flavor-specific targets in the Flutter Gradle plugin (#55366)

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -16,8 +16,10 @@ import com.flutter.gradle.FlutterPluginConstants.PLATFORM_ABI_LIST
 import com.flutter.gradle.FlutterPluginUtils.readPropertiesIfExist
 import com.flutter.gradle.plugins.PluginHandler
 import com.flutter.gradle.tasks.FlutterTask
+import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
@@ -244,9 +246,15 @@ class FlutterPlugin : Plugin<Project> {
             }
             localEngineHost = engineHostOut.name
         }
-        FlutterPluginUtils.getLegacyAndroidExtension(project).buildTypes.all {
+        val androidExtension = FlutterPluginUtils.getLegacyAndroidExtension(project)
+        androidExtension.buildTypes.all {
             addFlutterDependencies(this)
         }
+        androidExtension.productFlavors.all(object : Action<com.android.builder.model.ProductFlavor> {
+            override fun execute(flavor: com.android.builder.model.ProductFlavor) {
+                (flavor as ExtensionAware).extensions.create("flutter", FlutterExtension::class.java)
+            }
+        })
     }
 
     private fun addFlutterDependencies(buildType: com.android.builder.model.BuildType) {
@@ -686,7 +694,7 @@ class FlutterPlugin : Plugin<Project> {
                     localEngine = flutterPlugin.localEngine
                     localEngineHost = flutterPlugin.localEngineHost
                     localEngineSrcPath = flutterPlugin.localEngineSrcPath
-                    targetPath = FlutterPluginUtils.getFlutterTarget(project)
+                    targetPath = FlutterPluginUtils.getFlutterTarget(project, variant)
                     verbose = FlutterPluginUtils.isProjectVerbose(project)
                     fileSystemRoots = fileSystemRootsValue
                     fileSystemScheme = fileSystemSchemeValue

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -9,6 +9,7 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.BaseExtension
+import org.gradle.api.plugins.ExtensionAware
 import com.android.builder.model.BuildType
 import com.flutter.gradle.plugins.PluginHandler
 import com.flutter.gradle.tasks.DeepLinkJsonFromManifestTask
@@ -387,6 +388,35 @@ object FlutterPluginUtils {
         val target: String = getFlutterExtensionOrNull(project)!!.target ?: "lib/main.dart"
         return target
     }
+
+    /**
+     * Gets the target file for a specific variant.
+     *
+     * Precedence:
+     *  1. the target path defined as a project property (PROP_TARGET)
+     *  2. the target path defined in one of the variant's product flavors (the first non-null target found)
+     *  3. the project-level target fallback
+     *  4. `lib/main.dart` otherwise
+     */
+    @JvmStatic
+    @JvmName("getFlutterTarget")
+    internal fun getFlutterTarget(
+        project: Project,
+        @Suppress("DEPRECATION") variant: com.android.build.gradle.api.BaseVariant
+    ): String {
+        if (project.hasProperty(PROP_TARGET)) {
+            return project.property(PROP_TARGET).toString()
+        }
+        for (flavor in variant.productFlavors) {
+            val extensionAware = flavor as? ExtensionAware
+            val flavorExtension = extensionAware?.extensions?.findByType(FlutterExtension::class.java)
+            if (flavorExtension?.target != null) {
+                return flavorExtension.target!!
+            }
+        }
+        return getFlutterTarget(project)
+    }
+
 
     @JvmStatic
     @JvmName("isBuiltAsApp")

--- a/packages/flutter_tools/gradle/src/test/kotlin/DeeplinkTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/DeeplinkTest.kt
@@ -4,7 +4,7 @@
 
 package com.flutter.gradle
 
-import org.gradle.internal.impldep.org.junit.Assert.assertThrows
+import kotlin.test.assertFailsWith
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertFalse
@@ -41,7 +41,7 @@ class DeeplinkTest {
         val deeplink1 = Deeplink("scheme1", "host1", "path1", IntentFilterCheck())
         val deeplink2 = null
 
-        assertThrows(NullPointerException::class.java) { deeplink1.equals(deeplink2) }
+        assertFailsWith<NullPointerException> { deeplink1.equals(deeplink2) }
     }
 
     @Test

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterFlavorTargetReproductionTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterFlavorTargetReproductionTest.kt
@@ -1,0 +1,284 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import com.android.build.api.dsl.ApplicationBuildType
+import com.android.build.api.dsl.ApplicationDefaultConfig
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.gradle.AbstractAppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.api.AndroidSourceDirectorySet
+import com.android.builder.model.ProductFlavor
+import com.android.build.gradle.internal.core.InternalBaseVariant
+import com.android.build.gradle.tasks.MergeSourceSetFolders
+import com.android.build.gradle.tasks.ProcessAndroidResources
+import com.flutter.gradle.tasks.FlutterTask
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.slot
+import io.mockk.verify
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.io.File
+import kotlin.io.path.writeText
+import kotlin.test.Test
+
+class FlutterFlavorTargetReproductionTest {
+    private val FAKE_ENGINE_STAMP = "901b0f1afe77c3555abee7b86a26aaa37f131379"
+    private val FAKE_ENGINE_REALM = "made_up_realm"
+
+    @Test
+    fun `reproduce flavor target overriding bug`(@TempDir tempDir: Path) {
+        val projectDir = tempDir.resolve("project-dir").resolve("android").resolve("app")
+        projectDir.toFile().mkdirs()
+        val settingsFile = projectDir.parent.resolve("settings.gradle")
+        settingsFile.writeText("empty for now")
+        val fakeFlutterSdkDir = tempDir.resolve("fake-flutter-sdk")
+        fakeFlutterSdkDir.toFile().mkdirs()
+        val fakeCacheDir = fakeFlutterSdkDir.resolve("bin").resolve("cache")
+        fakeCacheDir.toFile().mkdirs()
+        val fakeEngineStampFile = fakeCacheDir.resolve("engine.stamp")
+        fakeEngineStampFile.writeText(FAKE_ENGINE_STAMP)
+        val fakeEngineRealmFile = fakeCacheDir.resolve("engine.realm")
+        fakeEngineRealmFile.writeText(FAKE_ENGINE_REALM)
+
+        val project = mockk<Project>(relaxed = true)
+        val mockAbstractAppExtension = mockk<AbstractAppExtension>(
+            moreInterfaces = arrayOf(ApplicationExtension::class),
+            relaxed = true
+        )
+        every { project.extensions.findByType(AbstractAppExtension::class.java) } returns mockAbstractAppExtension
+        every { project.extensions.getByType(AbstractAppExtension::class.java) } returns mockAbstractAppExtension
+        every { project.extensions.findByName("android") } returns mockAbstractAppExtension
+        val mockAndroidComponentsExtension = mockk<AndroidComponentsExtension<*, *, *>>(relaxed = true)
+        every { project.extensions.getByType(AndroidComponentsExtension::class.java) } returns mockAndroidComponentsExtension
+        every { mockAndroidComponentsExtension.selector() } returns mockk {
+            every { all() } returns mockk()
+        }
+        every { project.projectDir } returns projectDir.toFile()
+        every { project.findProperty("flutter.sdk") } returns fakeFlutterSdkDir.toString()
+        every { project.file(fakeFlutterSdkDir.toString()) } returns fakeFlutterSdkDir.toFile()
+
+        val projectFlutterExtension = FlutterExtension().apply { target = "lib/main_prod.dart" } // project-level fallback
+        every { project.extensions.create("flutter", any<Class<*>>()) } returns projectFlutterExtension
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns projectFlutterExtension
+        every { project.extensions.getByType(FlutterExtension::class.java) } returns projectFlutterExtension
+
+        val mockBaseExtension = mockk<BaseExtension>(relaxed = true)
+        val mockCommonExtension = mockk<CommonExtension<*, *, *, *, *, *>>(relaxed = true)
+        val mockDebugBuildType = mockk<ApplicationBuildType>(relaxed = true)
+        val mockReleaseBuildType = mockk<ApplicationBuildType>(relaxed = true)
+
+        val mockApplicationExtension = mockAbstractAppExtension as ApplicationExtension
+        every { mockApplicationExtension.buildTypes.getByName("debug") } returns mockDebugBuildType
+        every { mockApplicationExtension.buildTypes.getByName("release") } returns mockReleaseBuildType
+        every { mockCommonExtension.buildTypes.getByName("debug") } returns mockDebugBuildType
+        every { mockCommonExtension.buildTypes.getByName("release") } returns mockReleaseBuildType
+
+        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
+        every { project.extensions.findByType(CommonExtension::class.java) } returns mockCommonExtension
+        every { project.extensions.findByType(ApplicationExtension::class.java) } returns mockApplicationExtension
+        every { project.extensions.getByType(ApplicationExtension::class.java) } returns mockApplicationExtension
+
+        val mockApplicationDefaultConfig = mockk<com.android.build.gradle.internal.dsl.DefaultConfig>(
+            moreInterfaces = arrayOf(ApplicationDefaultConfig::class),
+            relaxed = true
+        )
+        every { mockApplicationExtension.defaultConfig } returns mockApplicationDefaultConfig
+        every { project.rootProject } returns project
+        every { project.state.failure as Throwable? } returns null
+        val mockDirectory = mockk<Directory>(relaxed = true)
+        every { project.layout.buildDirectory.get() } returns mockDirectory
+
+        val mockAndroidSourceSet = mockk<com.android.build.gradle.api.AndroidSourceSet>(relaxed = true)
+        val mockAndroidSourceDirectorySet = mockk<AndroidSourceDirectorySet>(relaxed = true)
+        every { mockAndroidSourceSet.jniLibs.srcDir(any()) } returns mockAndroidSourceDirectorySet
+        every { mockAbstractAppExtension.sourceSets.getByName("main") } returns mockAndroidSourceSet
+
+        mockkObject(NativePluginLoaderReflectionBridge)
+        try {
+            every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns listOf()
+            every { project.extraProperties } returns mockk<ExtraPropertiesExtension>(relaxed = true)
+            
+            // Return concrete files
+            val localPropertiesFile = projectDir.parent.resolve("local.properties").toFile()
+            localPropertiesFile.writeText("flutter.sdk=${fakeFlutterSdkDir.toString()}")
+            every { project.file("local.properties") } returns localPropertiesFile
+            every { project.file(projectFlutterExtension.source!!) } returns projectDir.parent.toFile()
+
+            val taskContainer = mockk<TaskContainer>(relaxed = true)
+            every { project.tasks } returns taskContainer
+
+            // Mock named tasks mapping
+            val mockTaskProvider = mockk<TaskProvider<Task>>(relaxed = true)
+            every { mockTaskProvider.hint(Task::class).get() } returns mockk<Task>(relaxed = true)
+            every { taskContainer.named(any<String>()) } returns mockTaskProvider
+
+            // Setup two variants: devDebug and prodDebug
+            val devVariant = mockk<com.android.build.gradle.api.ApplicationVariant>(relaxed = true)
+            every { devVariant.name } returns "devDebug"
+            every { devVariant.buildType.name } returns "debug"
+            every { devVariant.flavorName } returns "dev"
+
+            val prodVariant = mockk<com.android.build.gradle.api.ApplicationVariant>(relaxed = true)
+            every { prodVariant.name } returns "prodDebug"
+            every { prodVariant.buildType.name } returns "debug"
+            every { prodVariant.flavorName } returns "prod"
+
+            // Mock product flavors for the variants
+            val devFlavor = mockk<ProductFlavor>(
+                moreInterfaces = arrayOf(ExtensionAware::class),
+                relaxed = true
+            )
+            every { devVariant.productFlavors } returns listOf(devFlavor)
+
+            val prodFlavor = mockk<ProductFlavor>(
+                moreInterfaces = arrayOf(ExtensionAware::class),
+                relaxed = true
+            )
+            every { prodVariant.productFlavors } returns listOf(prodFlavor)
+
+            // Mock flavor-specific extensions
+            val devFlutterExtension = FlutterExtension().apply { target = "lib/main_dev.dart" }
+            every { (devFlavor as ExtensionAware).extensions.findByType(FlutterExtension::class.java) } returns devFlutterExtension
+
+            // prodFlavor does NOT define flavor-specific flutter extension target; it should fall back to project-level fallback
+            every { (prodFlavor as ExtensionAware).extensions.findByType(FlutterExtension::class.java) } returns null
+
+            val mergedFlavor = mockk<InternalBaseVariant.MergedFlavor>(relaxed = true)
+            every { devVariant.mergedFlavor } returns mergedFlavor
+            every { prodVariant.mergedFlavor } returns mergedFlavor
+            val apiLevel = mockk<com.android.builder.model.ApiVersion>(relaxed = true)
+            every { apiLevel.apiLevel } returns 21
+            every { mergedFlavor.minSdkVersion } returns apiLevel
+
+            val variantOutput = mockk<com.android.build.gradle.api.BaseVariantOutput>(relaxed = true)
+            val variantOutputCollection = mockk<org.gradle.api.DomainObjectCollection<com.android.build.gradle.api.BaseVariantOutput>>()
+            every { variantOutputCollection.iterator() } answers {
+                val outputsIterator = mockk<MutableIterator<com.android.build.gradle.api.BaseVariantOutput>>()
+                every { outputsIterator.hasNext() } returns true andThen false
+                every { outputsIterator.next() } returns variantOutput
+                outputsIterator
+            }
+            every { devVariant.outputs } returns variantOutputCollection
+            every { prodVariant.outputs } returns variantOutputCollection
+
+            val processResourcesProvider = mockk<TaskProvider<ProcessAndroidResources>>(relaxed = true)
+            every { processResourcesProvider.hint(ProcessAndroidResources::class).get() } returns mockk<ProcessAndroidResources>(relaxed = true)
+            every { variantOutput.processResourcesProvider } returns processResourcesProvider
+
+            val assembleTask = mockk<Task>(relaxed = true)
+            val assembleTaskProvider = mockk<TaskProvider<Task>>(relaxed = true)
+            every { assembleTaskProvider.get() } returns assembleTask
+            every { devVariant.assembleProvider } returns assembleTaskProvider
+            every { prodVariant.assembleProvider } returns assembleTaskProvider
+
+            val variants = listOf(devVariant, prodVariant)
+            val variantsIterator = mockk<MutableIterator<com.android.build.gradle.api.ApplicationVariant>>()
+            every { variantsIterator.hasNext() } returns true andThen true andThen false
+            every { variantsIterator.next() } returns devVariant andThen prodVariant
+            val variantCollection = mockk<org.gradle.api.DomainObjectSet<com.android.build.gradle.api.ApplicationVariant>>()
+            every { mockAbstractAppExtension.applicationVariants } returns variantCollection
+            every { variantCollection.iterator() } returns variantsIterator
+            every {
+                variantCollection.configureEach(any<Action<com.android.build.gradle.api.ApplicationVariant>>())
+            } answers {
+                variants.forEach { firstArg<Action<com.android.build.gradle.api.ApplicationVariant>>().execute(it) }
+            }
+
+            every { devVariant.mergeAssetsProvider.hint(MergeSourceSetFolders::class).get() } returns mockk<MergeSourceSetFolders>(relaxed = true)
+            every { prodVariant.mergeAssetsProvider.hint(MergeSourceSetFolders::class).get() } returns mockk<MergeSourceSetFolders>(relaxed = true)
+
+            val devFlutterTask = mockk<FlutterTask>(relaxed = true)
+            val prodFlutterTask = mockk<FlutterTask>(relaxed = true)
+
+            val devFlutterTaskProvider = mockk<TaskProvider<FlutterTask>>(relaxed = true)
+            every { devFlutterTaskProvider.hint(FlutterTask::class).get() } returns devFlutterTask
+
+            val prodFlutterTaskProvider = mockk<TaskProvider<FlutterTask>>(relaxed = true)
+            every { prodFlutterTaskProvider.hint(FlutterTask::class).get() } returns prodFlutterTask
+
+            every {
+                taskContainer.register(
+                    eq("compileFlutterBuildDevDebug"),
+                    eq(FlutterTask::class.java),
+                    any()
+                )
+            } answers {
+                devFlutterTaskProvider
+            }
+
+            every {
+                taskContainer.register(
+                    eq("compileFlutterBuildProdDebug"),
+                    eq(FlutterTask::class.java),
+                    any()
+                )
+            } answers {
+                prodFlutterTaskProvider
+            }
+
+            // Mock copyFlutterAssets task registration to avoid ClassCastException
+            val mockCopyTask = mockk<Copy>(relaxed = true)
+            val mockCopyTaskProvider = mockk<TaskProvider<Copy>>(relaxed = true)
+            every { mockCopyTaskProvider.hint(Copy::class).get() } returns mockCopyTask
+            every {
+                taskContainer.register(
+                    match { it.startsWith("copyFlutterAssets") },
+                    eq(Copy::class.java),
+                    any()
+                )
+            } answers {
+                mockCopyTaskProvider
+            }
+
+            val flutterPlugin = FlutterPlugin()
+            flutterPlugin.apply(project)
+
+            // Capture and execute the configuration block passed to register("compileFlutterBuildDevDebug")
+            // and register("compileFlutterBuildProdDebug").
+            val devConfigActionSlot = slot<Action<FlutterTask>>()
+            verify {
+                taskContainer.register(
+                    eq("compileFlutterBuildDevDebug"),
+                    eq(FlutterTask::class.java),
+                    capture(devConfigActionSlot)
+                )
+            }
+            devConfigActionSlot.captured.execute(devFlutterTask)
+
+            val prodConfigActionSlot = slot<Action<FlutterTask>>()
+            verify {
+                taskContainer.register(
+                    eq("compileFlutterBuildProdDebug"),
+                    eq(FlutterTask::class.java),
+                    capture(prodConfigActionSlot)
+                )
+            }
+            prodConfigActionSlot.captured.execute(prodFlutterTask)
+
+            // Verify that compileFlutterBuildDevDebug got lib/main_dev.dart (specifically configured on devFlavor)
+            verify { devFlutterTask.targetPath = "lib/main_dev.dart" }
+            // Verify that compileFlutterBuildProdDebug got lib/main_prod.dart (project fallback, since prodFlavor has no specific target)
+            verify { prodFlutterTask.targetPath = "lib/main_prod.dart" }
+        } finally {
+            unmockkObject(NativePluginLoaderReflectionBridge)
+        }
+    }
+}

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
@@ -425,6 +425,97 @@ class FlutterPluginUtilsTest {
         assertEquals("lib/main.dart", result)
     }
 
+    @Test
+    fun `getFlutterTarget returns target from flavor when it exists`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_TARGET) } returns false
+
+        val flavor = mockk<com.android.builder.model.ProductFlavor>(
+            moreInterfaces = arrayOf(org.gradle.api.plugins.ExtensionAware::class),
+            relaxed = true
+        )
+        val flavorExtension = FlutterExtension().apply { target = "lib/flavor.dart" }
+        every { (flavor as org.gradle.api.plugins.ExtensionAware).extensions.findByType(FlutterExtension::class.java) } returns flavorExtension
+
+        val variant = mockk<com.android.build.gradle.api.ApplicationVariant>(relaxed = true)
+        every { variant.productFlavors } returns listOf(flavor)
+
+        val result = FlutterPluginUtils.getFlutterTarget(project, variant)
+        assertEquals("lib/flavor.dart", result)
+    }
+
+    @Test
+    fun `getFlutterTarget falls back to project-level target when flavor does not specify one`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_TARGET) } returns false
+
+        val projectExtension = FlutterExtension().apply { target = "lib/project_fallback.dart" }
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns projectExtension
+
+        val flavor = mockk<com.android.builder.model.ProductFlavor>(
+            moreInterfaces = arrayOf(org.gradle.api.plugins.ExtensionAware::class),
+            relaxed = true
+        )
+        every { (flavor as org.gradle.api.plugins.ExtensionAware).extensions.findByType(FlutterExtension::class.java) } returns null
+
+        val variant = mockk<com.android.build.gradle.api.ApplicationVariant>(relaxed = true)
+        every { variant.productFlavors } returns listOf(flavor)
+
+        val result = FlutterPluginUtils.getFlutterTarget(project, variant)
+        assertEquals("lib/project_fallback.dart", result)
+    }
+
+    @Test
+    fun `getFlutterTarget resolves to second flavor target when first flavor has no target`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_TARGET) } returns false
+
+        val flavor1 = mockk<com.android.builder.model.ProductFlavor>(
+            moreInterfaces = arrayOf(org.gradle.api.plugins.ExtensionAware::class),
+            relaxed = true
+        )
+        every { (flavor1 as org.gradle.api.plugins.ExtensionAware).extensions.findByType(FlutterExtension::class.java) } returns null
+
+        val flavor2 = mockk<com.android.builder.model.ProductFlavor>(
+            moreInterfaces = arrayOf(org.gradle.api.plugins.ExtensionAware::class),
+            relaxed = true
+        )
+        val flavorExtension2 = FlutterExtension().apply { target = "lib/flavor2.dart" }
+        every { (flavor2 as org.gradle.api.plugins.ExtensionAware).extensions.findByType(FlutterExtension::class.java) } returns flavorExtension2
+
+        val variant = mockk<com.android.build.gradle.api.ApplicationVariant>(relaxed = true)
+        every { variant.productFlavors } returns listOf(flavor1, flavor2)
+
+        val result = FlutterPluginUtils.getFlutterTarget(project, variant)
+        assertEquals("lib/flavor2.dart", result)
+    }
+
+    @Test
+    fun `getFlutterTarget resolves to first flavor target when both flavors define targets`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_TARGET) } returns false
+
+        val flavor1 = mockk<com.android.builder.model.ProductFlavor>(
+            moreInterfaces = arrayOf(org.gradle.api.plugins.ExtensionAware::class),
+            relaxed = true
+        )
+        val flavorExtension1 = FlutterExtension().apply { target = "lib/flavor1.dart" }
+        every { (flavor1 as org.gradle.api.plugins.ExtensionAware).extensions.findByType(FlutterExtension::class.java) } returns flavorExtension1
+
+        val flavor2 = mockk<com.android.builder.model.ProductFlavor>(
+            moreInterfaces = arrayOf(org.gradle.api.plugins.ExtensionAware::class),
+            relaxed = true
+        )
+        val flavorExtension2 = FlutterExtension().apply { target = "lib/flavor2.dart" }
+        every { (flavor2 as org.gradle.api.plugins.ExtensionAware).extensions.findByType(FlutterExtension::class.java) } returns flavorExtension2
+
+        val variant = mockk<com.android.build.gradle.api.ApplicationVariant>(relaxed = true)
+        every { variant.productFlavors } returns listOf(flavor1, flavor2)
+
+        val result = FlutterPluginUtils.getFlutterTarget(project, variant)
+        assertEquals("lib/flavor1.dart", result)
+    }
+
     // isBuiltAsApp skipped as it is a wrapper for a single getter
 
     // addApiDependencies
@@ -578,7 +669,9 @@ class FlutterPluginUtilsTest {
     @Test
     fun `getCompileSdkFromProject returns the compileSdk from the project`() {
         val project = mockk<Project>()
-        every { project.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+        val mockExtension = mockk<BaseExtension>()
+        every { project.extensions.findByType(BaseExtension::class.java) } returns mockExtension
+        every { mockExtension.compileSdkVersion } returns "android-35"
         val result = FlutterPluginUtils.getCompileSdkFromProject(project)
         assertEquals("35", result)
     }
@@ -1544,12 +1637,10 @@ class FlutterPluginUtilsTest {
         val project = mockk<Project>()
         val mockCmakeOptions = mockk<CmakeOptions>()
         val mockDefaultConfig = mockk<DefaultConfig>()
-        every {
-            project.extensions
-                .findByType(BaseExtension::class.java)!!
-                .externalNativeBuild.cmake
-        } returns mockCmakeOptions
-        every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
+        val mockExtension = mockk<BaseExtension>()
+        every { project.extensions.findByType(BaseExtension::class.java) } returns mockExtension
+        every { mockExtension.externalNativeBuild.cmake } returns mockCmakeOptions
+        every { mockExtension.defaultConfig } returns mockDefaultConfig
 
         every { mockCmakeOptions.path } returns fakeCmakeFile
 
@@ -1569,12 +1660,10 @@ class FlutterPluginUtilsTest {
         val mockDefaultConfig = mockk<DefaultConfig>()
         val mockDirectoryProperty = mockk<DirectoryProperty>()
         val mockDirectory = mockk<Directory>()
-        every {
-            project.extensions
-                .findByType(BaseExtension::class.java)!!
-                .externalNativeBuild.cmake
-        } returns mockCmakeOptions
-        every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
+        val mockExtension = mockk<BaseExtension>()
+        every { project.extensions.findByType(BaseExtension::class.java) } returns mockExtension
+        every { mockExtension.externalNativeBuild.cmake } returns mockCmakeOptions
+        every { mockExtension.defaultConfig } returns mockDefaultConfig
 
         val basePath = "/base/path"
         val fakeBuildPath = "/randomapp/build/app/"
@@ -1584,15 +1673,13 @@ class FlutterPluginUtilsTest {
         every { project.layout.buildDirectory } returns mockDirectoryProperty
         every { mockDirectoryProperty.dir(any<String>()) } returns mockDirectoryProperty
         every { mockDirectoryProperty.get() } returns mockDirectory
-        every { mockDirectory.asFile.path } returns fakeBuildPath
+        val mockFile = File(fakeBuildPath)
+        every { mockDirectory.getAsFile() } returns mockFile
 
         val mockBuildType = mockk<com.android.build.gradle.internal.dsl.BuildType>()
-        every {
-            project.extensions
-                .findByType(BaseExtension::class.java)!!
-                .buildTypes
-                .iterator()
-        } returns mutableListOf(mockBuildType).iterator()
+        val mockBuildTypesContainer = mockk<org.gradle.api.NamedDomainObjectContainer<com.android.build.gradle.internal.dsl.BuildType>>()
+        every { mockExtension.buildTypes } returns mockBuildTypesContainer
+        every { mockBuildTypesContainer.iterator() } returns mutableListOf(mockBuildType).iterator()
         every { mockBuildType.name } returns "Debug"
         every { mockBuildType.externalNativeBuild.cmake.arguments(any(), any(), any()) } returns Unit
 


### PR DESCRIPTION
- Registers a 'flutter' extension dynamically on each ProductFlavor.
- Resolves target paths by checking the variant's product flavors for a flavor-specific extension, falling back to the project-level extension or default target file path.
- Resolves intermediate chained mock bugs and adds multi-flavor precedence unit tests.
