### PR TITLE
fix: resolve VM Service connection hang on Android startup crash

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -605,7 +605,7 @@ class AndroidDevice extends Device {
         // Avoid using getLogReader, which returns a singleton instance, because the
         // VM Service discovery will dispose at the end. creating a new logger here allows
         // logs to be surfaced normally during `flutter drive`.
-        await AdbLogReader.createLogReader(this, _processManager, _logger),
+        await AdbLogReader.createLogReader(this, _processManager, _logger, app: builtPackage),
         portForwarder: portForwarder,
         hostPort: debuggingOptions.hostVmServicePort,
         devicePort: debuggingOptions.deviceVmServicePort,
@@ -801,16 +801,21 @@ class AndroidDevice extends Device {
     ApplicationPackage? app,
     bool includePastLogs = false,
   }) async {
-    // The Android log reader isn't app-specific. The `app` parameter isn't used.
     if (includePastLogs) {
       return _pastLogReader ??= await AdbLogReader.createLogReader(
         this,
         _processManager,
         _logger,
         includePastLogs: true,
+        app: app,
       );
     } else {
-      return _logReader ??= await AdbLogReader.createLogReader(this, _processManager, _logger);
+      return _logReader ??= await AdbLogReader.createLogReader(
+        this,
+        _processManager,
+        _logger,
+        app: app,
+      );
     }
   }
 
@@ -1059,10 +1064,15 @@ class AndroidMemoryInfo extends MemoryInfo {
 
 /// A log reader that logs from `adb logcat`.
 class AdbLogReader extends DeviceLogReader {
-  AdbLogReader._(this._adbProcess, this.name, this._logger);
+  AdbLogReader._(this._adbProcess, this.name, this._logger, {this.app});
 
   @visibleForTesting
-  factory AdbLogReader.test(Process adbProcess, String name, Logger logger) = AdbLogReader._;
+  factory AdbLogReader.test(
+    Process adbProcess,
+    String name,
+    Logger logger, {
+    ApplicationPackage? app,
+  }) = AdbLogReader._;
 
   /// Create a new [AdbLogReader] from an [AndroidDevice] instance.
   static Future<AdbLogReader> createLogReader(
@@ -1070,6 +1080,7 @@ class AdbLogReader extends DeviceLogReader {
     ProcessManager processManager,
     Logger logger, {
     bool includePastLogs = false,
+    ApplicationPackage? app,
   }) async {
     // logcat -T is not supported on Android releases before Lollipop.
     const kLollipopVersionCode = 21;
@@ -1097,8 +1108,16 @@ class AdbLogReader extends DeviceLogReader {
       ]);
     }
     final Process process = await processManager.start(device.adbCommandForDevice(args));
-    return AdbLogReader._(process, device.displayName, logger);
+    return AdbLogReader._(process, device.displayName, logger, app: app);
   }
+
+  final ApplicationPackage? app;
+
+  Timer? _crashTimer;
+
+  late final RegExp? _crashRegExp = app == null
+      ? null
+      : RegExp('Process: ${RegExp.escape(app!.id)}\\b');
 
   int? _appPid;
 
@@ -1219,7 +1238,20 @@ class AdbLogReader extends DeviceLogReader {
     if (logMatch != null) {
       var acceptLine = false;
 
-      if (_fatalCrash) {
+      if (app != null &&
+          logMatch.group(0)!.contains('/AndroidRuntime') &&
+          _crashRegExp!.hasMatch(line)) {
+        _appPid = int.tryParse(logMatch.group(1)!);
+        acceptLine = true;
+        // If the application crashed on startup, close the log reader stream after
+        // a short delay to allow the crash log/stacktrace to be flushed and printed,
+        // while preventing the runner from waiting indefinitely for a VM Service port.
+        _crashTimer ??= Timer(const Duration(milliseconds: 100), () {
+          if (!_linesController.isClosed) {
+            _linesController.close();
+          }
+        });
+      } else if (_fatalCrash) {
         // While a fatal crash is going on, only accept lines from the crash
         // Otherwise the crash log in the console may get interrupted
 
@@ -1267,6 +1299,7 @@ class AdbLogReader extends DeviceLogReader {
   }
 
   void _stop() {
+    _crashTimer?.cancel();
     _linesController.close();
     _adbProcess.kill();
   }

--- a/packages/flutter_tools/test/general.shard/android/adb_log_reader_reproduce_58299_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/adb_log_reader_reproduce_58299_test.dart
@@ -1,0 +1,113 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_tools/src/android/android_device.dart';
+import 'package:flutter_tools/src/application_package.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:test/fake.dart';
+
+import '../../src/common.dart';
+import '../../src/fake_process_manager.dart';
+
+const kLastLogcatTimestamp = '11-27 15:39:04.506';
+const kDummyLine = 'Contents are not important\n';
+
+void main() {
+  testWithoutContext('AdbLogReader completes stream on AndroidRuntime crash of the app', () async {
+    final FakeApplicationPackage app = FakeApplicationPackage('com.example.foobar');
+    final processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(
+        command: const <String>['adb', '-s', '1234', 'shell', '-x', 'logcat', '-v', 'time'],
+        completer: Completer<void>.sync(),
+        stdout:
+            '$kDummyLine'
+            // 1. Crash of a different application package (should not close the stream)
+            '05-11 12:54:46.665 E/AndroidRuntime(11787): FATAL EXCEPTION: main\n'
+            '05-11 12:54:46.665 E/AndroidRuntime(11787): Process: com.example.other, PID: 11787\n'
+            '05-11 12:54:46.665 java.lang.RuntimeException: Unable to instantiate application '
+            'io.flutter.app.FlutterApplicationOther: java.lang.ClassNotFoundException:\n'
+            // 2. Crash of our application package (should trigger the stream to close)
+            '05-11 12:54:47.665 E/AndroidRuntime(11788): FATAL EXCEPTION: main\n'
+            '05-11 12:54:47.665 E/AndroidRuntime(11788): Process: com.example.foobar, PID: 11788\n'
+            '05-11 12:54:47.665 java.lang.RuntimeException: Unable to instantiate application '
+            'io.flutter.app.FlutterApplication2: java.lang.ClassNotFoundException:\n',
+      ),
+    ]);
+
+    final AdbLogReader logReader = await AdbLogReader.createLogReader(
+      createFakeDevice(null),
+      processManager,
+      BufferLogger.test(),
+      app: app,
+    );
+    addTearDown(logReader.dispose);
+
+    final List<String> lines = <String>[];
+    final Completer<void> streamCompleted = Completer<void>();
+    
+    logReader.logLines.listen(
+      lines.add,
+      onDone: streamCompleted.complete,
+    );
+
+    // Wait for the stream to complete with a short timeout.
+    // If it does not complete (the bug), it will throw a StateError, which makes the test fail.
+    await streamCompleted.future.timeout(
+      const Duration(seconds: 3),
+      onTimeout: () {
+        throw StateError('Stream did not complete (hung waiting for VM Service/log Lines).');
+      },
+    );
+
+    // Assert that we did not filter out logs from the other app crash.
+    expect(lines, contains('E/AndroidRuntime(11787): Process: com.example.other, PID: 11787'));
+    expect(lines, contains('java.lang.RuntimeException: Unable to instantiate application io.flutter.app.FlutterApplicationOther: java.lang.ClassNotFoundException:'));
+
+    // Assert that we did not filter out our app crash logs.
+    expect(lines, contains('E/AndroidRuntime(11788): Process: com.example.foobar, PID: 11788'));
+    expect(lines, contains('java.lang.RuntimeException: Unable to instantiate application io.flutter.app.FlutterApplication2: java.lang.ClassNotFoundException:'));
+
+    expect(processManager, hasNoRemainingExpectations);
+  });
+}
+
+class FakeApplicationPackage extends Fake implements ApplicationPackage {
+  FakeApplicationPackage(this.id);
+
+  @override
+  final String id;
+
+  @override
+  String get name => 'FakeApp';
+}
+
+AndroidDevice createFakeDevice(int? sdkLevel) {
+  return FakeAndroidDevice(sdkLevel.toString(), kLastLogcatTimestamp);
+}
+
+class FakeAndroidDevice extends Fake implements AndroidDevice {
+  FakeAndroidDevice(this._apiVersion, this._lastLogcatTimestamp);
+
+  final String _lastLogcatTimestamp;
+  final String _apiVersion;
+
+  @override
+  String get name => 'test-device';
+
+  @override
+  String get displayName => name;
+
+  @override
+  Future<String> get apiVersion => Future<String>.value(_apiVersion);
+
+  @override
+  Future<String> lastLogcatTimestamp() async => _lastLogcatTimestamp;
+
+  @override
+  List<String> adbCommandForDevice(List<String> command) {
+    return <String>['adb', '-s', '1234', ...command];
+  }
+}


### PR DESCRIPTION
Closes flutter/flutter#58299.

Updates AdbLogReader to detect when an AndroidRuntime crash occurs for the target package during startup. If detected, it starts a 100ms timer to close the log reader stream, giving adb logcat enough time to dump the crash log/stack trace, while preventing the runner from hanging indefinitely waiting for a VM Service port to become available.
