### PR TITLE
fix: map Android IR Remote select button correctly

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
@@ -73,6 +73,13 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
   // The returned value is never null.
   private Long getPhysicalKey(@NonNull KeyEvent event) {
     final long scancode = event.getScanCode();
+    // Android IR Remotes send scanCode 97 (0x61) and keyCode 23 (KEYCODE_DPAD_CENTER).
+    // Scan code 97 is otherwise mapped to PhysicalKeyboardKey.controlRight.
+    // Since DPAD_CENTER is not a modifier key, override the mapping to return
+    // PhysicalKeyboardKey.select to prevent key synchronization issues.
+    if (scancode == 0x61 && event.getKeyCode() == KeyEvent.KEYCODE_DPAD_CENTER) {
+      return 0x0000070077L; // PhysicalKeyboardKey.select
+    }
     // Scancode 0 can occur during emulation using `adb shell input keyevent`. Synthesize a physical
     // key from the key code so that keys can be told apart.
     if (scancode == 0) {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
@@ -2122,4 +2122,36 @@ public class KeyboardManagerTest {
         });
     calls.clear();
   }
+
+  @Test
+  public void androidIrRemoteDpadCenterMapsToPhysicalSelect() {
+    final KeyboardTester tester = new KeyboardTester();
+    final ArrayList<CallRecord> calls = new ArrayList<>();
+    tester.recordEmbedderCallsTo(calls);
+    tester.respondToTextInputWith(true); // Suppress redispatching
+
+    // Scan code 97 with KEYCODE_DPAD_CENTER (23) on Android IR Remotes.
+    final KeyEvent irRemoteDownEvent =
+        new FakeKeyEvent(
+            ACTION_DOWN, 97, KEYCODE_DPAD_CENTER, 0, '\0', 0, InputDevice.SOURCE_KEYBOARD);
+    assertTrue(tester.keyboardManager.handleEvent(irRemoteDownEvent));
+    verifyEmbedderEvents(
+        calls,
+        new KeyData[] {
+          buildKeyData(
+              Type.kDown, PHYSICAL_SELECT, LOGICAL_SELECT, null, false, DeviceType.kKeyboard),
+        });
+    calls.clear();
+
+    final KeyEvent irRemoteUpEvent =
+        new FakeKeyEvent(
+            ACTION_UP, 97, KEYCODE_DPAD_CENTER, 0, '\0', 0, InputDevice.SOURCE_KEYBOARD);
+    assertTrue(tester.keyboardManager.handleEvent(irRemoteUpEvent));
+    verifyEmbedderEvents(
+        calls,
+        new KeyData[] {
+          buildKeyData(
+              Type.kUp, PHYSICAL_SELECT, LOGICAL_SELECT, null, false, DeviceType.kKeyboard),
+        });
+  }
 }

--- a/packages/flutter/lib/src/services/raw_keyboard_android.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_android.dart
@@ -161,6 +161,13 @@ class RawKeyEventDataAndroid extends RawKeyEventData {
 
   @override
   PhysicalKeyboardKey get physicalKey {
+    // Android IR Remotes send scanCode 97 and keyCode 23 for DPAD_CENTER/Select.
+    // Scan code 97 is otherwise mapped to PhysicalKeyboardKey.controlRight.
+    // Since DPAD_CENTER is not a modifier key, override the mapping to return
+    // PhysicalKeyboardKey.select to prevent key synchronization issues.
+    if (scanCode == 97 && keyCode == 23) {
+      return PhysicalKeyboardKey.select;
+    }
     if (kAndroidToPhysicalKey.containsKey(scanCode)) {
       return kAndroidToPhysicalKey[scanCode]!;
     }

--- a/packages/flutter/test/services/raw_keyboard_reproduce_65233_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_reproduce_65233_test.dart
@@ -1,0 +1,71 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('OK/Select on IR Remotes (scan code 97, key code 23) does not cause Exception', (
+    WidgetTester _,
+  ) async {
+    final keyEventMessage = <String, Object?>{
+      'type': 'keydown',
+      'keymap': 'android',
+      'productId': 1,
+      'flags': 8,
+      'vendorId': 1,
+      'source': 769,
+      'deviceId': 3,
+      'scanCode': 97,
+      'keyCode': 23,
+      'plainCodePoint': 0,
+      'metaState': 0,
+      'codePoint': 0,
+      'repeatCount': 0,
+    };
+
+    // We expect this to run without throwing an AssertionError.
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+      SystemChannels.keyEvent.name,
+      SystemChannels.keyEvent.codec.encodeMessage(keyEventMessage),
+      (ByteData? data) {},
+    );
+
+    expect(RawKeyboard.instance.keysPressed, contains(LogicalKeyboardKey.select));
+    expect(HardwareKeyboard.instance.physicalKeysPressed, contains(PhysicalKeyboardKey.select));
+    expect(HardwareKeyboard.instance.logicalKeysPressed, contains(LogicalKeyboardKey.select));
+
+    final keyUpEventMessage = <String, Object?>{
+      'type': 'keyup',
+      'keymap': 'android',
+      'productId': 1,
+      'flags': 8,
+      'vendorId': 1,
+      'source': 769,
+      'deviceId': 3,
+      'scanCode': 97,
+      'keyCode': 23,
+      'plainCodePoint': 0,
+      'metaState': 0,
+      'codePoint': 0,
+      'repeatCount': 0,
+    };
+
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+      SystemChannels.keyEvent.name,
+      SystemChannels.keyEvent.codec.encodeMessage(keyUpEventMessage),
+      (ByteData? data) {},
+    );
+
+    expect(RawKeyboard.instance.keysPressed, isNot(contains(LogicalKeyboardKey.select)));
+    expect(
+      HardwareKeyboard.instance.physicalKeysPressed,
+      isNot(contains(PhysicalKeyboardKey.select)),
+    );
+    expect(
+      HardwareKeyboard.instance.logicalKeysPressed,
+      isNot(contains(LogicalKeyboardKey.select)),
+    );
+  });
+}


### PR DESCRIPTION
Overrides Android key mapping for scanCode 97 and keyCode 23 (DPAD_CENTER/Select)
to prevent it from being incorrectly treated as PhysicalKeyboardKey.controlRight.
This resolves the assertion error 'Attempted to send a key down event when no keys are in keysPressed'
because DPAD_CENTER is not a modifier key.

Addresses: flutter/flutter#65233
