### PR TITLE
docs: document SliverAppBar stretch scroll physics requirements on Android

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1973,6 +1973,17 @@ class SliverAppBar extends StatefulWidget {
   ///
   /// The app bar can still expand and contract as the user scrolls, but it will
   /// also stretch when the user over-scrolls.
+  ///
+  /// Note that stretch behavior requires the scroll view to use a scroll physics
+  /// that supports overscroll (like [BouncingScrollPhysics]). On platforms
+  /// using clamping physics (like Android by default), stretching will not
+  /// occur unless [BouncingScrollPhysics] is explicitly set, even if
+  /// [AlwaysScrollableScrollPhysics] is used.
+  ///
+  /// See also:
+  ///
+  ///  * [FlexibleSpaceBar], which implements the stretch animations (like zoom,
+  ///    blur, or fading the title) using [FlexibleSpaceBar.stretchModes].
   final bool stretch;
 
   /// The offset of overscroll required to activate [onStretchTrigger].
@@ -1982,6 +1993,28 @@ class SliverAppBar extends StatefulWidget {
 
   /// The callback function to be executed when a user over-scrolls to the
   /// offset specified by [stretchTriggerOffset].
+  ///
+  /// This callback will only be triggered if [stretch] is true and the scroll
+  /// view's physics supports overscroll (like [BouncingScrollPhysics]).
+  ///
+  /// For example, on Android where [ClampingScrollPhysics] is the default,
+  /// [onStretchTrigger] will not be called unless the scroll view is explicitly
+  /// configured with [BouncingScrollPhysics]:
+  ///
+  /// ```dart
+  /// CustomScrollView(
+  ///   physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+  ///   slivers: <Widget>[
+  ///     SliverAppBar(
+  ///       stretch: true,
+  ///       onStretchTrigger: () async {
+  ///         // Perform async refresh work here...
+  ///       },
+  ///     ),
+  ///     // ...
+  ///   ],
+  /// )
+  /// ```
   final AsyncCallback? onStretchTrigger;
 
   /// {@macro flutter.material.appbar.toolbarHeight}

--- a/packages/flutter/test/material/sliver_app_bar_stretch_reproduce_test.dart
+++ b/packages/flutter/test/material/sliver_app_bar_stretch_reproduce_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'SliverAppBar stretch functions in CustomScrollView with AlwaysScrollableScrollPhysics on Android',
+    (WidgetTester tester) async {
+      var stretchTriggerCount = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.android),
+          home: Scaffold(
+            body: CustomScrollView(
+              physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+              slivers: <Widget>[
+                SliverAppBar(
+                  pinned: true,
+                  stretch: true,
+                  flexibleSpace: const FlexibleSpaceBar(title: Text('title')),
+                  expandedHeight: 160.0,
+                  onStretchTrigger: () async {
+                    stretchTriggerCount++;
+                  },
+                ),
+                SliverToBoxAdapter(child: Container(key: const Key('drag'), height: 10.0)),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final RenderSliverPinnedPersistentHeader header = tester.renderObject(
+        find.byType(SliverAppBar),
+      );
+      expect(header.child!.size.height, equals(160.0));
+
+      // Drag down to stretch the app bar
+      final Offset target = tester.getCenter(find.byKey(const Key('drag')));
+      final TestGesture gesture = await tester.startGesture(target);
+      await gesture.moveBy(const Offset(0.0, 150.0));
+      await tester.pump();
+
+      // Verify that the app bar stretched and triggered the callback.
+      expect(header.child!.size.height, greaterThan(160.0));
+      expect(stretchTriggerCount, equals(1));
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    },
+  );
+}


### PR DESCRIPTION
Document that SliverAppBar.stretch requires a scroll physics that supports overscroll (like BouncingScrollPhysics), and thus will not occur under Android's default ClampingScrollPhysics even if AlwaysScrollableScrollPhysics is used. Provide a code example of how to enable it on Android by explicitly configuring BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()).

Also add a regression test confirming that stretch works on Android when configured with the correct physics.

Fixes https://github.com/flutter/flutter/issues/90339
