### PR TITLE
fix: support --trace-systrace in release mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -318,6 +318,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webCrossOriginIsolation: webCrossOriginIsolation,
         webRenderer: webRenderer,
         webUseWasm: useWasm,
+        traceSystrace: boolArg('trace-systrace'),
         enableImpeller: enableImpeller,
         enableFlutterGpu: enableFlutterGpu,
         enableVulkanValidation: enableVulkanValidation,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -1013,6 +1013,7 @@ class DebuggingOptions {
     WebRendererMode? webRenderer,
     this.webUseWasm = false,
     this.traceAllowlist,
+    this.traceSystrace = false,
     this.enableImpeller = ImpellerStatus.platformDefault,
     this.enableFlutterGpu = false,
     this.enableVulkanValidation = false,

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_reproduce_91279_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_reproduce_91279_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/run.dart';
+import 'package:flutter_tools/src/device.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/test_flutter_command_runner.dart';
+
+void main() {
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  testUsingContext(
+    'run --release --trace-systrace propagates traceSystrace to DebuggingOptions',
+    () async {
+      final command = RunCommand();
+      await expectLater(
+        () =>
+            createTestCommandRunner(command).run(<String>['run', '--release', '--trace-systrace']),
+        throwsToolExit(),
+      );
+
+      final DebuggingOptions options = await command.createDebuggingOptions();
+
+      // In release mode, traceSystrace should be enabled if requested.
+      expect(options.traceSystrace, true);
+    },
+    overrides: <Type, Generator>{
+      Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+    },
+  );
+}


### PR DESCRIPTION
Fixes flutter/flutter#91279 by accepting and propagating the traceSystrace parameter in DebuggingOptions.disabled constructor when running the tool in release mode.
