### PR TITLE
fix: redirect gradle and device status logs to stderr in machine-readable test format

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -2,12 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+import 'dart:io' as io;
+
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config_types.dart';
 
 import '../asset.dart';
 import '../base/common.dart';
+import '../base/context.dart';
 import '../base/file_system.dart';
+import '../base/io.dart' as tools_io;
+import '../base/logger.dart';
+import '../base/terminal.dart';
 import '../build_info.dart';
 import '../bundle_builder.dart';
 import '../devfs.dart';
@@ -408,6 +415,61 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    final bool machine = outputMachineFormat || stringArg('reporter') == 'json';
+    final io.Stdout originalStdout = globals.stdio.stdout;
+    if (machine) {
+      final tools_io.Stdio redirectStdio = StderrRedirectingStdio(globals.stdio);
+      Logger redirectLogger;
+      final Logger currentLogger = globals.logger;
+      StdoutLogger? stdoutLogger;
+      try {
+        stdoutLogger = asLogger<StdoutLogger>(currentLogger);
+      } on StateError {
+        // No StdoutLogger in the delegate chain.
+      }
+
+      if (stdoutLogger != null) {
+        final StdoutLogger newStdoutLogger = globals.platform.isWindows
+            ? WindowsStdoutLogger(
+                terminal: globals.terminal,
+                stdio: redirectStdio,
+                outputPreferences: globals.outputPreferences,
+              )
+            : StdoutLogger(
+                terminal: globals.terminal,
+                stdio: redirectStdio,
+                outputPreferences: globals.outputPreferences,
+              );
+        if (currentLogger.isVerbose) {
+          redirectLogger = VerboseLogger(newStdoutLogger);
+        } else {
+          redirectLogger = newStdoutLogger;
+        }
+      } else {
+        redirectLogger = _RedirectingLogger(currentLogger);
+      }
+
+      try {
+        return await context.run<FlutterCommandResult>(
+          overrides: <Type, Generator>{
+            tools_io.Stdio: () => redirectStdio,
+            Logger: () => redirectLogger,
+          },
+          body: () => _runCommand(originalStdout),
+        );
+      } finally {
+        if (redirectLogger.hadErrorOutput) {
+          currentLogger.hadErrorOutput = true;
+        }
+        if (redirectLogger.hadWarningOutput) {
+          currentLogger.hadWarningOutput = true;
+        }
+      }
+    }
+    return _runCommand(originalStdout);
+  }
+
+  Future<FlutterCommandResult> _runCommand(io.Stdout originalStdout) async {
     if (!globals.fs.isFileSync('pubspec.yaml')) {
       throwToolExit(
         'Error: No pubspec.yaml file found in the current working directory.\n'
@@ -603,7 +665,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
 
     TestWatcher? watcher;
     if (outputMachineFormat) {
-      watcher = EventPrinter(parent: collector, out: globals.stdio.stdout);
+      watcher = EventPrinter(parent: collector, out: originalStdout);
     } else if (collector != null) {
       watcher = collector;
     }
@@ -904,4 +966,182 @@ bool _shouldRunAsIntegrationTests(String currentDirectory, List<String> testFile
     ' Use separate invocations of `flutter test` to run integration tests'
     ' and unit tests.',
   );
+}
+
+class _RedirectingStdout implements io.Stdout {
+  _RedirectingStdout(this._stdio);
+
+  final tools_io.Stdio _stdio;
+  io.IOSink get _sink => _stdio.stderr;
+
+  @override
+  Encoding get encoding => _sink.encoding;
+  @override
+  set encoding(Encoding value) => _sink.encoding = value;
+
+  @override
+  void add(List<int> data) => _sink.add(data);
+  @override
+  void write(Object? object) => _sink.write(object);
+  @override
+  void writeAll(Iterable<dynamic> objects, [String sep = '']) => _sink.writeAll(objects, sep);
+  @override
+  void writeCharCode(int charCode) => _sink.writeCharCode(charCode);
+  @override
+  void writeln([Object? object = '']) => _sink.writeln(object);
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) => _sink.addError(error, stackTrace);
+  @override
+  Future<void> addStream(Stream<List<int>> stream) => _sink.addStream(stream);
+  @override
+  Future<void> close() => _sink.close();
+  @override
+  Future<void> get done => _sink.done;
+  @override
+  Future<void> flush() => _sink.flush();
+
+  @override
+  bool get hasTerminal => _stdio.hasTerminal;
+  @override
+  int get terminalColumns => _stdio.terminalColumns ?? 80;
+  @override
+  int get terminalLines => _stdio.terminalLines ?? 24;
+  @override
+  bool get supportsAnsiEscapes => _stdio.supportsAnsiEscapes;
+  @override
+  io.IOSink get nonBlocking => _sink;
+  @override
+  String get lineTerminator => _stdio.stdout.lineTerminator;
+  @override
+  set lineTerminator(String value) => _stdio.stdout.lineTerminator = value;
+}
+
+class StderrRedirectingStdio extends tools_io.Stdio {
+  StderrRedirectingStdio(this._stdio);
+
+  final tools_io.Stdio _stdio;
+
+  late final io.Stdout _stdout = _RedirectingStdout(_stdio);
+
+  @override
+  Stream<List<int>> get stdin => _stdio.stdin;
+
+  @override
+  io.Stdout get stdout => _stdout;
+
+  @override
+  io.IOSink get stderr => _stdio.stderr;
+
+  @override
+  bool get hasTerminal => _stdio.hasTerminal;
+
+  @override
+  bool get stdinHasTerminal => _stdio.stdinHasTerminal;
+
+  @override
+  int? get terminalColumns => _stdio.terminalColumns;
+
+  @override
+  int? get terminalLines => _stdio.terminalLines;
+
+  @override
+  bool get supportsAnsiEscapes => _stdio.supportsAnsiEscapes;
+
+  @override
+  void stdoutWrite(String message, {void Function(String, dynamic, StackTrace)? fallback}) {
+    _stdio.stderrWrite(message, fallback: fallback);
+  }
+
+  @override
+  void stderrWrite(String message, {void Function(String, dynamic, StackTrace)? fallback}) {
+    _stdio.stderrWrite(message, fallback: fallback);
+  }
+
+  @override
+  Future<void> addStdoutStream(Stream<List<int>> stream) => _stdio.addStderrStream(stream);
+
+  @override
+  Future<void> addStderrStream(Stream<List<int>> stream) => _stdio.addStderrStream(stream);
+}
+
+class _RedirectingLogger extends DelegatingLogger {
+  _RedirectingLogger(super.delegate);
+
+  bool _hadErrorOutput = false;
+
+  @override
+  bool get hadErrorOutput => _hadErrorOutput;
+
+  @override
+  set hadErrorOutput(bool value) {
+    _hadErrorOutput = value;
+    super.hadErrorOutput = value;
+  }
+
+  @override
+  void printStatus(
+    String message, {
+    bool? emphasis,
+    TerminalColor? color,
+    bool? newline,
+    int? indent,
+    int? hangingIndent,
+    bool? wrap,
+  }) {
+    final bool parentHadError = super.hadErrorOutput;
+    super.printError(
+      message,
+      emphasis: emphasis,
+      color: color,
+      indent: indent,
+      hangingIndent: hangingIndent,
+      wrap: wrap,
+    );
+    super.hadErrorOutput = parentHadError;
+  }
+
+  @override
+  void printBox(String message, {String? title}) {
+    final bool parentHadError = super.hadErrorOutput;
+    if (title != null) {
+      super.printError('┌─ $title ─┐');
+    } else {
+      super.printError('┌──────────┐');
+    }
+    super.printError('│ $message │');
+    super.printError('└──────────┘');
+    super.hadErrorOutput = parentHadError;
+  }
+
+  @override
+  void printError(
+    String message, {
+    StackTrace? stackTrace,
+    bool? emphasis,
+    TerminalColor? color,
+    int? indent,
+    int? hangingIndent,
+    bool? wrap,
+  }) {
+    _hadErrorOutput = true;
+    super.printError(
+      message,
+      stackTrace: stackTrace,
+      emphasis: emphasis,
+      color: color,
+      indent: indent,
+      hangingIndent: hangingIndent,
+      wrap: wrap,
+    );
+  }
+
+  @override
+  Status startProgress(
+    String message, {
+    String? progressId,
+    int progressIndicatorPadding = kDefaultStatusPadding,
+  }) {
+    printStatus(message);
+    return SilentStatus(stopwatch: const StopwatchFactory().createStopwatch())..start();
+  }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/integration_test_json_reporter_reproduce_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/integration_test_json_reporter_reproduce_test.dart
@@ -1,0 +1,298 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:args/command_runner.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/application_package.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart' as io;
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/test.dart';
+import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/test/flutter_platform.dart';
+import 'package:flutter_tools/src/test/test_wrapper.dart';
+import 'package:flutter_tools/src/vmservice.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/fake.dart';
+import 'package:test_core/src/platform.dart'; // ignore: implementation_imports
+import 'package:vm_service/vm_service.dart' as vm_service;
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/fake_devices.dart';
+import '../../src/package_config.dart';
+import '../../src/test_flutter_command_runner.dart';
+
+const _pubspecContents = '''
+name: my_app
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter''';
+
+void main() {
+  Cache.disableLocking();
+  late MemoryFileSystem fs;
+  late BufferLogger logger;
+  late BuildSpammyDevice spammyDevice;
+  FakeFlutterVmService? fakeVmService;
+
+  setUp(() {
+    fs = MemoryFileSystem.test(
+      style: globals.platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
+    );
+
+    final Directory package = fs.directory('package');
+
+    package.childFile('pubspec.yaml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(_pubspecContents);
+
+    writePackageConfigFiles(
+      directory: package,
+      packages: <String, String>{
+        'test_api': 'file:///path/to/pubcache/.pub-cache/hosted/pub.dartlang.org/test_api-0.2.19',
+        'integration_test': 'file:///path/to/flutter/packages/integration_test',
+      },
+      mainLibName: 'my_app',
+      devDependencies: <String>['test_api', 'integration_test'],
+    );
+
+    package
+        .childDirectory('integration_test')
+        .childFile('some_integration_test.dart')
+        .createSync(recursive: true);
+
+    writePackageConfigFiles(
+      directory: fs.directory(fs.path.join(getFlutterRoot(), 'packages', 'flutter_tools')),
+      packages: <String, String>{
+        'ffi': 'file:///path/to/pubcache/.pub-cache/hosted/pub.dev/ffi-2.1.2',
+        'test': 'file:///path/to/pubcache/.pub-cache/hosted/pub.dev/test-1.24.9',
+        'test_api': 'file:///path/to/pubcache/.pub-cache/hosted/pub.dev/test_api-0.6.1',
+        'test_core': 'file:///path/to/pubcache/.pub-cache/hosted/pub.dev/test_core-0.5.9',
+      },
+      mainLibName: 'my_app',
+    );
+
+    fs.currentDirectory = package.path;
+
+    logger = BufferLogger.test();
+    spammyDevice = BuildSpammyDevice();
+    fakeVmService = null;
+  });
+
+  testUsingContext(
+    'integration test with json reporter does not include Gradle output or status messages in stdout (statusText)',
+    () async {
+      final fakeTestWrapper = FakeTestWrapper();
+      StreamChannel<Object?>? channel;
+
+      fakeTestWrapper.runInsideMain = (FlutterPlatform platformPlugin) async {
+        // Trigger the platform plugin to load the test, which will launch the spammy device.
+        final suitePlatform = SuitePlatform(Runtime.vm);
+
+        // Just start a dummy listener channel.
+        channel = platformPlugin.loadChannel(
+          'integration_test/some_integration_test.dart',
+          suitePlatform,
+        );
+
+        // We expect the device to be started and print status logs.
+        Future<void> expectEventually(bool Function() condition) async {
+          final sw = Stopwatch()..start();
+          while (!condition()) {
+            if (sw.elapsed > const Duration(seconds: 5)) {
+              throw StateError('Timed out waiting for condition');
+            }
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+          }
+        }
+
+        await expectEventually(() => logger.errorText.contains('Running Gradle task'));
+
+        expect(logger.statusText, isNot(contains('Running Gradle task')));
+        expect(logger.statusText, isNot(contains('Installing app')));
+        expect(logger.statusText, isNot(contains('Built some_app.apk')));
+
+        // Instead, it should be redirected to errorText!
+        expect(logger.errorText, contains('Running Gradle task'));
+        expect(logger.errorText, contains('Installing app'));
+        expect(logger.errorText, contains('Built some_app.apk'));
+      };
+
+      final testCommand = TestCommand(testWrapper: fakeTestWrapper);
+      final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+      await commandRunner.run(const <String>[
+        'test',
+        '--no-pub',
+        '--no-dds',
+        '-r',
+        'json',
+        'integration_test/some_integration_test.dart',
+      ]);
+      fakeVmService?.service.done();
+      await channel!.sink.close();
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+      Logger: () => logger,
+      DeviceManager: () => _FakeDeviceManager(<Device>[spammyDevice]),
+      ApplicationPackageFactory: () => FakeApplicationPackageFactory(),
+      VMServiceConnector: () =>
+          (
+            Uri httpUri, {
+            ReloadSources? reloadSources,
+            Restart? restart,
+            CompileExpression? compileExpression,
+            FlutterProject? flutterProject,
+            PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+            io.CompressionOptions? compression,
+            Device? device,
+            Logger? logger,
+          }) async {
+            fakeVmService = FakeFlutterVmService();
+            return fakeVmService!;
+          },
+    },
+  );
+}
+
+class FakeTestWrapper implements TestWrapper {
+  PlatformPlugin? platformPlugin;
+  List<String>? lastArgs;
+  Future<void> Function(FlutterPlatform platformPlugin)? runInsideMain;
+
+  @override
+  void registerPlatformPlugin(
+    Iterable<Runtime> runtimes,
+    FutureOr<PlatformPlugin> Function() platforms,
+  ) {
+    final FutureOr<PlatformPlugin> platform = platforms();
+    if (platform is PlatformPlugin) {
+      platformPlugin = platform;
+    } else {
+      platform.then((PlatformPlugin value) {
+        platformPlugin = value;
+      });
+    }
+  }
+
+  @override
+  Future<void> main(List<String> args) async {
+    lastArgs = args;
+    if (runInsideMain != null) {
+      while (platformPlugin == null) {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+      }
+      await runInsideMain!(platformPlugin! as FlutterPlatform);
+    }
+  }
+}
+
+class BuildSpammyDevice extends FakeDevice {
+  BuildSpammyDevice() : super('spammy', 'spammy', type: PlatformType.android);
+
+  @override
+  Future<LaunchResult> startApp(
+    ApplicationPackage? package, {
+    String? mainPath,
+    String? route,
+    DebuggingOptions? debuggingOptions,
+    Map<String, dynamic>? platformArgs,
+    bool prebuiltApplication = false,
+    bool ipv6 = false,
+    String? userIdentifier,
+  }) async {
+    // Print Gradle build output and installation progress.
+    globals.logger.printStatus("Running Gradle task 'assembleDebug'...");
+    globals.logger.printStatus('Built some_app.apk.');
+    final Status progress = globals.logger.startProgress('Installing app...');
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    progress.stop();
+    return LaunchResult.succeeded(vmServiceUri: Uri.parse('http://127.0.0.1:12345/'));
+  }
+}
+
+class _FakeDeviceManager extends DeviceManager {
+  _FakeDeviceManager(this._devices) : super(logger: BufferLogger.test());
+
+  final List<Device> _devices;
+
+  @override
+  Future<List<Device>> getAllDevices({DeviceDiscoveryFilter? filter}) async {
+    if (filter?.deviceConnectionInterface == DeviceConnectionInterface.wireless) {
+      return <Device>[];
+    }
+    return _devices;
+  }
+
+  @override
+  List<DeviceDiscovery> get deviceDiscoverers => <DeviceDiscovery>[];
+}
+
+class FakeApplicationPackageFactory extends Fake implements ApplicationPackageFactory {
+  @override
+  Future<ApplicationPackage> getPackageForPlatform(
+    TargetPlatform platform, {
+    BuildInfo? buildInfo,
+    File? applicationBinary,
+  }) async {
+    return FakeApplicationPackage();
+  }
+}
+
+class FakeApplicationPackage extends Fake implements ApplicationPackage {
+  @override
+  String get name => 'Fake Integration Test Package';
+}
+
+class FakeFlutterVmService extends Fake implements FlutterVmService {
+  @override
+  Future<vm_service.IsolateRef> findExtensionIsolate(String extensionName) async {
+    return vm_service.IsolateRef(id: '1', number: '1', name: 'main');
+  }
+
+  @override
+  final FakeVmService service = FakeVmService();
+}
+
+class FakeVmService extends Fake implements vm_service.VmService {
+  final Completer<void> _onDoneCompleter = Completer<void>();
+
+  @override
+  Future<void> get onDone => _onDoneCompleter.future;
+
+  void done() {
+    if (!_onDoneCompleter.isCompleted) {
+      _onDoneCompleter.complete();
+    }
+  }
+
+  @override
+  Future<vm_service.Success> streamListen(String streamId) async {
+    return vm_service.Success();
+  }
+
+  @override
+  Stream<vm_service.Event> get onExtensionEvent => const Stream<vm_service.Event>.empty();
+
+  @override
+  Stream<vm_service.Event> get onIsolateEvent => const Stream<vm_service.Event>.empty();
+
+  @override
+  Future<vm_service.Success> streamCancel(String streamId) async {
+    return vm_service.Success();
+  }
+
+  @override
+  Stream<vm_service.Event> onEvent(String streamId) => const Stream<vm_service.Event>.empty();
+}


### PR DESCRIPTION
When running flutter tests in machine-readable JSON format (-r json or --machine), Gradle build progress messages and device installation output are printed directly to stdout, corrupting the JSON output stream.

Wrap machine-readable test executions inside a zone overriding Stdio and Logger providers to redirect status output and stdout writes to stderr, while explicitly passing the original stdout to EventPrinter to preserve JSON test events.
