### PR TITLE
fix: support predictive back in 3-button navigation mode

### DIFF
--- a/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
+++ b/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
@@ -459,6 +459,7 @@ class _PredictiveBackSharedElementPageTransitionState
         begin: switch (widget.currentBackEvent?.swipeEdge) {
           SwipeEdge.left => Offset(xShift, _getYShiftPosition(screenSize.height)),
           SwipeEdge.right => Offset(-xShift, _getYShiftPosition(screenSize.height)),
+          SwipeEdge.none => Offset(xShift, _getYShiftPosition(screenSize.height)),
           null => Offset(xShift, _getYShiftPosition(screenSize.height)),
         },
         end: Offset.zero,

--- a/packages/flutter/lib/src/services/predictive_back_event.dart
+++ b/packages/flutter/lib/src/services/predictive_back_event.dart
@@ -16,6 +16,10 @@ enum SwipeEdge {
 
   /// Indicates that the swipe gesture starts from the right edge of the screen.
   right,
+
+  /// Indicates that the back gesture was triggered without a swipe direction,
+  /// such as in 3-button navigation mode.
+  none,
 }
 
 /// Object used to report back gesture progress in Android.
@@ -80,13 +84,17 @@ final class PredictiveBackEvent {
   ///
   /// Returns false for a predictive back gesture.
   bool get isButtonEvent =>
+      // SwipeEdge.none is used for 3-button navigation in Android 16+, which
+      // should be treated as an animating predictive back gesture (and therefore
+      // is not a button event).
+      swipeEdge != SwipeEdge.none &&
       // The Android documentation for BackEvent
       // (https://developer.android.com/reference/android/window/BackEvent#getTouchX())
       // says that getTouchX and getTouchY should return NaN when the system
       // back button is pressed, but in practice it seems to return 0.0, hence
       // the check for Offset.zero here. This was tested directly in the engine
       // on Android emulator running API 34.
-      touchOffset == null || (progress == 0.0 && touchOffset == Offset.zero);
+      (touchOffset == null || (progress == 0.0 && touchOffset == Offset.zero));
 
   @override
   bool operator ==(Object other) {

--- a/packages/flutter/test/material/predictive_back_none_transition_reproduce_test.dart
+++ b/packages/flutter/test/material/predictive_back_none_transition_reproduce_test.dart
@@ -1,0 +1,112 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'PredictiveBackPageTransitionsBuilder supports SwipeEdge.none (3-button navigation mode)',
+    (WidgetTester tester) async {
+      // Only Android supports backGesture channel methods. Other platforms will
+      // do nothing.
+      if (defaultTargetPlatform != TargetPlatform.android) {
+        return;
+      }
+
+      final routes = <String, WidgetBuilder>{
+        '/': (BuildContext context) => Material(
+          child: TextButton(
+            child: const Text('push'),
+            onPressed: () {
+              Navigator.of(context).pushNamed('/b');
+            },
+          ),
+        ),
+        '/b': (BuildContext context) => const Text('page b'),
+      };
+
+      const pageTransitionsBuilder = PredictiveBackPageTransitionsBuilder();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            pageTransitionsTheme: const PageTransitionsTheme(
+              builders: <TargetPlatform, PageTransitionsBuilder>{
+                TargetPlatform.android: pageTransitionsBuilder,
+              },
+            ),
+          ),
+          routes: routes,
+        ),
+      );
+
+      expect(find.text('push'), findsOneWidget);
+      expect(find.text('page b'), findsNothing);
+      expect(_findPredictiveBackPageTransition(pageTransitionsBuilder), findsNothing);
+      expect(_findFallbackPageTransition(pageTransitionsBuilder), findsOneWidget);
+
+      await tester.tap(find.text('push'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('push'), findsNothing);
+      expect(find.text('page b'), findsOneWidget);
+      expect(_findPredictiveBackPageTransition(pageTransitionsBuilder), findsNothing);
+      expect(_findFallbackPageTransition(pageTransitionsBuilder), findsOneWidget);
+
+      // Start a system pop gesture with swipeEdge 2 (none).
+      // This will fail with RangeError before SwipeEdge.none is added.
+      final ByteData startMessage = const StandardMethodCodec().encodeMethodCall(
+        const MethodCall('startBackGesture', <String, dynamic>{
+          'touchOffset': null,
+          'progress': 0.0,
+          'swipeEdge': 2,
+        }),
+      );
+      await binding.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/backgesture',
+        startMessage,
+        (ByteData? _) {},
+      );
+      await tester.pump();
+
+      // Verify that the predictive back page transition is active.
+      expect(_findPredictiveBackPageTransition(pageTransitionsBuilder), findsOneWidget);
+      expect(_findFallbackPageTransition(pageTransitionsBuilder), findsNothing);
+    },
+  );
+}
+
+String _getTransitionsString(PageTransitionsBuilder pageTransitionsBuilder) {
+  return switch (pageTransitionsBuilder) {
+    PredictiveBackPageTransitionsBuilder() => '_PredictiveBackSharedElementPageTransition',
+    PredictiveBackFullscreenPageTransitionsBuilder() => '_PredictiveBackFullscreenPageTransition',
+    _ => throw UnsupportedError('Unsupported subclass of PageTransitionsBuilder'),
+  };
+}
+
+Finder _findPredictiveBackPageTransition(PageTransitionsBuilder pageTransitionsBuilder) {
+  return find.descendant(
+    of: find.byType(MaterialApp),
+    matching: find.byWidgetPredicate(
+      (Widget w) => '${w.runtimeType}' == _getTransitionsString(pageTransitionsBuilder),
+    ),
+  );
+}
+
+Finder _findFallbackPageTransition(PageTransitionsBuilder pageTransitionsBuilder) {
+  final String fallback = switch (pageTransitionsBuilder) {
+    final PredictiveBackPageTransitionsBuilder _ => '_FadeForwardsPageTransition',
+    final PredictiveBackFullscreenPageTransitionsBuilder _ => '_ZoomPageTransition',
+    _ => throw TypeError(),
+  };
+  return find.descendant(
+    of: find.byType(MaterialApp),
+    matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == fallback),
+  );
+}

--- a/packages/flutter/test/services/predictive_back_event_test.dart
+++ b/packages/flutter/test/services/predictive_back_event_test.dart
@@ -26,6 +26,16 @@ void main() {
     expect(event.isButtonEvent, isFalse);
   });
 
+  test('fromMap can be created with valid Map - SwipeEdge.none', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.0,
+      'swipeEdge': 2,
+    });
+    expect(event.swipeEdge, SwipeEdge.none);
+    expect(event.isButtonEvent, isFalse);
+  });
+
   test('fromMap can be created with valid Map - isButtonEvent zero position', () async {
     final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
       'touchOffset': <double>[0.0, 0.0],
@@ -60,7 +70,7 @@ void main() {
       () => PredictiveBackEvent.fromMap(const <String?, Object?>{
         'touchOffset': <double>[0.0, 100.0],
         'progress': 0.0,
-        'swipeEdge': 2,
+        'swipeEdge': 3,
       }),
       throwsRangeError,
     );

--- a/packages/flutter/test/services/predictive_back_none_reproduce_test.dart
+++ b/packages/flutter/test/services/predictive_back_none_reproduce_test.dart
@@ -1,0 +1,32 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('fromMap can be created with SwipeEdge.none (2) at progress 0.5', () async {
+    // Index 2 maps to SwipeEdge.none.
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': null,
+      'progress': 0.5,
+      'swipeEdge': 2,
+    });
+
+    expect(event.swipeEdge.toString(), 'SwipeEdge.none');
+    expect(event.isButtonEvent, isFalse);
+  });
+
+  test('fromMap can be created with SwipeEdge.none (2) at progress 0.0', () async {
+    // Index 2 maps to SwipeEdge.none.
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': null,
+      'progress': 0.0,
+      'swipeEdge': 2,
+    });
+
+    expect(event.swipeEdge.toString(), 'SwipeEdge.none');
+    expect(event.isButtonEvent, isFalse);
+  });
+}


### PR DESCRIPTION
Add SwipeEdge.none to SwipeEdge enum to represent Android 16's BackEvent.EDGE_NONE. Update PredictiveBackEvent.isButtonEvent to not treat SwipeEdge.none as a button event, allowing it to start a predictive back gesture. Handle SwipeEdge.none in PredictiveBackPageTransitionsBuilder. Fixes #183635
