### PR TITLE
fix: resolve issue #186098 by correcting kMigrateToBuiltInKotlinDocsUrl

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -663,7 +663,7 @@ final missingNdkSourcePropertiesFile = GradleHandledError(
 
 /// The URL for documentation on migrating to built-in Kotlin.
 const String kMigrateToBuiltInKotlinDocsUrl =
-    'https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin';
+    'https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers#report-incompatible-kotlin-gradle-plugin-usage-to-plugin-authors';
 
 /// The URL for documentation on opting out of the new AGP DSL.
 const String kOptOutOfNewDslDocsUrl =

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1660,7 +1660,10 @@ An exception occurred applying plugin request [id: 'kotlin-android']
       );
       expect(testLogger.statusText, contains('applying the kotlin-android plugin'));
       expect(testLogger.statusText, contains('For instructions on how to migrate, see:'));
-      expect(testLogger.statusText, contains(kMigrateToBuiltInKotlinDocsUrl));
+      expect(
+        testLogger.statusText.replaceAll('│', '').replaceAll(RegExp(r'\s+'), ''),
+        contains(kMigrateToBuiltInKotlinDocsUrl),
+      );
     },
     overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),

--- a/packages/flutter_tools/test/general.shard/android/reproduce_186098_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/reproduce_186098_test.dart
@@ -1,0 +1,15 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/android/gradle_errors.dart';
+import '../../src/common.dart';
+
+void main() {
+  test('kMigrateToBuiltInKotlinDocsUrl points to the correct anchor for reporting unmigrated plugins', () {
+    expect(
+      kMigrateToBuiltInKotlinDocsUrl,
+      'https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers#report-incompatible-kotlin-gradle-plugin-usage-to-plugin-authors',
+    );
+  });
+}


### PR DESCRIPTION
Updates the built-in Kotlin docs link constant to point to the correct sub-section for reporting unmigrated Kotlin plugins.

Also updates the existing Gradle error test assertion to ignore terminal wrapping formatting and whitespace so that the longer URL does not break testing.
