### PR TITLE
feat: add --log-filter option to flutter run and logs commands

### DIFF
--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -19,6 +19,10 @@ class LogsCommand extends FlutterCommand {
       abbr: 'c',
       help: 'Clear log history before reading from logs.',
     );
+    argParser.addOption(
+      'log-filter',
+      help: 'Only show log lines matching this string or regular expression.',
+    );
     usesDeviceTimeoutOption();
     usesDeviceConnectionOption();
   }
@@ -44,6 +48,14 @@ class LogsCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> verifyThenRunCommand(String? commandPath) async {
+    final String? filter = stringArg('log-filter');
+    if (filter != null && filter.isNotEmpty) {
+      try {
+        RegExp(filter);
+      } on FormatException catch (e) {
+        throwToolExit('Invalid RegExp pattern for --log-filter: ${e.message}');
+      }
+    }
     device = await findTargetDevice(includeDevicesUnsupportedByProject: true);
     if (device == null) {
       throwToolExit(null);
@@ -77,9 +89,16 @@ class LogsCommand extends FlutterCommand {
       exitCompleter.complete(exitCode);
     }
 
+    final String? filter = stringArg('log-filter');
+    final RegExp? regExp = filter != null && filter.isNotEmpty ? RegExp(filter) : null;
+
     // Start reading.
     final StreamSubscription<String> subscription = logReader.logLines.listen(
-      (String message) => globals.printStatus(message, wrap: false),
+      (String message) {
+        if (regExp == null || regExp.hasMatch(message)) {
+          globals.printStatus(message, wrap: false);
+        }
+      },
       onDone: () => maybeComplete(),
       onError: (dynamic error) => maybeComplete(error is int ? error : 1),
     );

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -224,6 +224,10 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         FlutterOptions.kWebWasmFlag,
         help: 'Compile to WebAssembly rather than JavaScript.\n$kWasmMoreInfo',
         negatable: false,
+      )
+      ..addOption(
+        'log-filter',
+        help: 'Only show log lines matching this string or regular expression.',
       );
     usesWebOptions(verboseHelp: verboseHelp);
     usesTargetOption();
@@ -288,6 +292,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   @visibleForTesting
   @protected
   Future<DebuggingOptions> createDebuggingOptions({WebDevServerConfig? webDevServerConfig}) async {
+    final String? logFilter = stringArg('log-filter');
     final BuildInfo buildInfo = await getBuildInfo();
     final int? webBrowserDebugPort =
         featureFlags.isWebEnabled && argResults!.wasParsed('web-browser-debug-port')
@@ -330,6 +335,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         enableHcpp: enableHcpp,
         testFlag: testFlag,
         traceSystrace: traceSystrace,
+        logFilter: logFilter,
       );
     } else {
       return DebuggingOptions.enabled(
@@ -395,6 +401,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         enableHcpp: enableHcpp,
         webDevServerConfig: webDevServerConfig,
         testFlag: testFlag,
+        logFilter: logFilter,
       );
     }
   }
@@ -683,6 +690,14 @@ class RunCommand extends RunCommandBase {
 
   @override
   Future<void> validateCommand() async {
+    final String? logFilter = stringArg('log-filter');
+    if (logFilter != null && logFilter.isNotEmpty) {
+      try {
+        RegExp(logFilter);
+      } on FormatException catch (e) {
+        throwToolExit('Invalid RegExp pattern for --log-filter: ${e.message}');
+      }
+    }
     // When running with a prebuilt application, no command validation is
     // necessary.
     if (!runningWithPrebuiltApplication) {

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -994,6 +994,7 @@ class DebuggingOptions {
     this.printDtd = false,
     this.webDevServerConfig,
     this.testFlag = false,
+    this.logFilter,
   }) : debuggingEnabled = true,
        webCrossOriginIsolation = webCrossOriginIsolation ?? webUseWasm,
        webRenderer = webRenderer ?? WebRendererMode.getDefault(useWasm: webUseWasm);
@@ -1027,6 +1028,7 @@ class DebuggingOptions {
     this.webDevServerConfig,
     this.testFlag = false,
     this.traceSystrace = false,
+    this.logFilter,
   }) : debuggingEnabled = false,
        useTestFonts = false,
        startPaused = false,
@@ -1114,6 +1116,7 @@ class DebuggingOptions {
     required this.google3WorkspaceRoot,
     required this.printDtd,
     this.webDevServerConfig,
+    required this.logFilter,
   }) : testFlag = false;
 
   final bool debuggingEnabled;
@@ -1161,6 +1164,7 @@ class DebuggingOptions {
   final bool printDtd;
   final WebDevServerConfig? webDevServerConfig;
   final bool testFlag;
+  final String? logFilter;
 
   /// Whether the tool should try to uninstall a previously installed version of the app.
   ///
@@ -1319,6 +1323,7 @@ class DebuggingOptions {
     'ipv6': ipv6,
     'google3WorkspaceRoot': google3WorkspaceRoot,
     'printDtd': printDtd,
+    'logFilter': logFilter,
     // TODO(jsimmons): This field is required for backward compatibility with
     // the flutter_tools binary that is currently checked into Google3.
     // Remove this when that binary has been updated.
@@ -1393,6 +1398,7 @@ class DebuggingOptions {
           https: HttpsConfig.parse(json['tlsCertPath'], json['tlsCertKeyPath']),
           headers: (json['webHeaders']! as Map<dynamic, dynamic>).cast<String, String>(),
         ),
+        logFilter: json['logFilter'] as String?,
       );
 }
 

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -88,6 +88,7 @@ class WebDriverService extends DriverService {
               webDevServerConfig: debuggingOptions.webDevServerConfig,
               webRenderer: debuggingOptions.webRenderer,
               webUseWasm: debuggingOptions.webUseWasm,
+              logFilter: debuggingOptions.logFilter,
             )
           : DebuggingOptions.enabled(
               buildInfo,
@@ -95,6 +96,7 @@ class WebDriverService extends DriverService {
               disablePortPublication: debuggingOptions.disablePortPublication,
               webRenderer: debuggingOptions.webRenderer,
               webUseWasm: debuggingOptions.webUseWasm,
+              logFilter: debuggingOptions.logFilter,
             ),
       platformArgs: platformArgs,
       stayResident: true,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -250,20 +250,26 @@ class FlutterDevice {
         // shuts down, including after an error. If `done` completes before `connectToVmService`,
         // something went wrong that caused DDS to shutdown early.
         try {
-          service = await Future.any<dynamic>(<Future<dynamic>>[
-            connectToVmService(
-              debuggingOptions.enableDds ? (device!.dds.uri ?? vmServiceUri!) : vmServiceUri!,
-              reloadSources: reloadSources,
-              restart: restart,
-              compileExpression: compileExpression,
-              flutterProject: FlutterProject.current(),
-              printStructuredErrorLogMethod: printStructuredErrorLogMethod,
-              device: device,
-              logger: globals.logger,
-            ),
-            if (!existingDds)
-              device!.dds.done.whenComplete(() => throw Exception('DDS shut down too early')),
-          ]) as FlutterVmService?;
+          service =
+              await Future.any<dynamic>(<Future<dynamic>>[
+                    connectToVmService(
+                      debuggingOptions.enableDds
+                          ? (device!.dds.uri ?? vmServiceUri!)
+                          : vmServiceUri!,
+                      reloadSources: reloadSources,
+                      restart: restart,
+                      compileExpression: compileExpression,
+                      flutterProject: FlutterProject.current(),
+                      printStructuredErrorLogMethod: printStructuredErrorLogMethod,
+                      device: device,
+                      logger: globals.logger,
+                    ),
+                    if (!existingDds)
+                      device!.dds.done.whenComplete(
+                        () => throw Exception('DDS shut down too early'),
+                      ),
+                  ])
+                  as FlutterVmService?;
         } on Exception catch (exception) {
           globals.printTrace('Fail to connect to service protocol: $vmServiceUri: $exception');
           if (!completer.isCompleted && !_isListeningForVmServiceUri!) {
@@ -349,9 +355,20 @@ class FlutterDevice {
     } else {
       logStream = (await device!.getLogReader(app: package)).logLines;
     }
+    final String? filterString = debuggingOptions.logFilter;
+    RegExp? filter;
+    if (filterString != null && filterString.isNotEmpty) {
+      try {
+        filter = RegExp(filterString);
+      } on FormatException catch (e) {
+        globals.printError('Invalid log filter pattern "$filterString": $e');
+      }
+    }
     _loggingSubscription = logStream.listen((String line) {
       if (!line.contains(globals.kVMServiceMessageRegExp)) {
-        globals.printStatus(line, wrap: false);
+        if (filter == null || filter.hasMatch(line)) {
+          globals.printStatus(line, wrap: false);
+        }
       }
     });
   }

--- a/packages/flutter_tools/test/general.shard/log_filter_reproduce_test.dart
+++ b/packages/flutter_tools/test/general.shard/log_filter_reproduce_test.dart
@@ -1,0 +1,233 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/logs.dart';
+import 'package:flutter_tools/src/commands/run.dart';
+import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/resident_runner.dart';
+import 'package:flutter_tools/src/vmservice.dart';
+import 'package:test/fake.dart';
+
+import '../src/context.dart';
+import '../src/fake_devices.dart';
+import '../src/test_flutter_command_runner.dart';
+import 'resident_runner_helpers.dart' hide FakeDevice;
+
+void main() {
+  Cache.disableLocking();
+
+  group('logs --log-filter option', () {
+    late Platform platform;
+    late FakeDeviceManager deviceManager;
+    const deviceId = 'abc123';
+
+    setUp(() {
+      deviceManager = FakeDeviceManager();
+      platform = FakePlatform();
+    });
+
+    testUsingContext(
+      'logs command filters output based on --log-filter option',
+      () async {
+        final logReader = FakeDeviceLogReader();
+        final fakeDevice = FakeDevice('phone', deviceId, deviceLogReader: logReader);
+        deviceManager.attachedDevices.add(fakeDevice);
+        final termSignal = FakeProcessSignal();
+        final intSignal = FakeProcessSignal();
+        final command = LogsCommand(sigterm: termSignal, sigint: intSignal);
+
+        // Verify that command runner parses the options.
+        final Future<void> commandFuture = createTestCommandRunner(
+          command,
+        ).run(<String>['-d', deviceId, 'logs', '--log-filter', 'hello']);
+
+        var commandFinished = false;
+        unawaited(commandFuture.whenComplete(() => commandFinished = true));
+
+        final bufferLogger = globals.logger as BufferLogger;
+        while (!commandFinished && !bufferLogger.statusText.contains('Showing')) {
+          await pumpEventQueue();
+        }
+
+        logReader.addLine('hello world');
+        logReader.addLine('foo bar');
+        logReader.addLine('say hello again');
+
+        await pumpEventQueue(times: 5);
+
+        // Terminate the command
+        intSignal.send(1);
+        await commandFuture;
+
+        // Verify status output only contains lines matching filter
+        expect(bufferLogger.statusText, contains('hello world'));
+        expect(bufferLogger.statusText, contains('say hello again'));
+        expect(bufferLogger.statusText, isNot(contains('foo bar')));
+      },
+      overrides: <Type, Generator>{
+        Platform: () => platform,
+        DeviceManager: () => deviceManager,
+        Logger: () => BufferLogger.test(),
+      },
+    );
+
+    testUsingContext('logs command throws ToolExit on invalid RegExp pattern', () async {
+      final command = LogsCommand(sigterm: FakeProcessSignal(), sigint: FakeProcessSignal());
+      expect(
+        () => createTestCommandRunner(
+          command,
+        ).run(<String>['-d', deviceId, 'logs', '--log-filter', '[invalid']),
+        throwsA(
+          isA<ToolExit>().having(
+            (ToolExit e) => e.message,
+            'message',
+            contains('Invalid RegExp pattern'),
+          ),
+        ),
+      );
+    }, overrides: <Type, Generator>{Platform: () => platform, DeviceManager: () => deviceManager});
+  });
+
+  group('run --log-filter option', () {
+    late FakeDeviceManager testDeviceManager;
+    late MemoryFileSystem fileSystem;
+
+    setUp(() {
+      testDeviceManager = FakeDeviceManager();
+      fileSystem = MemoryFileSystem.test();
+      fileSystem.file('pubspec.yaml').createSync();
+      fileSystem.file('.dart_tool/package_config.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{"configVersion": 2, "packages": []}');
+      fileSystem.file('lib/main.dart').createSync(recursive: true);
+    });
+
+    testUsingContext(
+      'logFilter is populated in DebuggingOptions when --log-filter is provided',
+      () async {
+        final command = RunCommand();
+        final CommandRunner<void> runner = createTestCommandRunner(command);
+        try {
+          await runner.run(<String>['run', '--no-pub', '--log-filter=my-filter']);
+        } on ToolExit {
+          // Expected to fail because we don't have a device or real project.
+        }
+
+        final DebuggingOptions options = await command.createDebuggingOptions();
+        expect(options.logFilter, 'my-filter');
+      },
+      overrides: <Type, Generator>{
+        DeviceManager: () => testDeviceManager,
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+      },
+    );
+
+    testUsingContext(
+      'run command throws ToolExit on invalid RegExp pattern',
+      () async {
+        final command = RunCommand();
+        final CommandRunner<void> runner = createTestCommandRunner(command);
+        expect(
+          () => runner.run(<String>['run', '--no-pub', '--log-filter=[invalid']),
+          throwsA(
+            isA<ToolExit>().having(
+              (ToolExit e) => e.message,
+              'message',
+              contains('Invalid RegExp pattern'),
+            ),
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        DeviceManager: () => testDeviceManager,
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+      },
+    );
+  });
+
+  group('ResidentRunner log filtering', () {
+    testUsingContext(
+      'startEchoingDeviceLog filters logs based on logFilter in DebuggingOptions',
+      () async {
+        final logReader = FakeDeviceLogReader();
+        final fakeDevice = FakeDevice('phone', 'abc123', deviceLogReader: logReader);
+
+        final flutterDevice = FlutterDevice(
+          fakeDevice,
+          buildInfo: BuildInfo.debug,
+          targetPlatform: TargetPlatform.android,
+          generator: FakeResidentCompiler(),
+          developmentShaderCompiler: const FakeShaderCompiler(),
+        );
+
+        await flutterDevice.startEchoingDeviceLog(
+          DebuggingOptions.enabled(BuildInfo.debug, logFilter: 'match-me'),
+        );
+
+        logReader.addLine('match-me: yes');
+        logReader.addLine('no match');
+        logReader.addLine('match-me: also yes');
+
+        await pumpEventQueue(times: 5);
+
+        final bufferLogger = globals.logger as BufferLogger;
+        expect(bufferLogger.statusText, contains('match-me: yes'));
+        expect(bufferLogger.statusText, contains('match-me: also yes'));
+        expect(bufferLogger.statusText, isNot(contains('no match')));
+
+        await flutterDevice.stopEchoingDeviceLog();
+      },
+      overrides: <Type, Generator>{Logger: () => BufferLogger.test()},
+    );
+  });
+}
+
+class FakeProcessSignal extends Fake implements ProcessSignal {
+  late final _controller = StreamController<ProcessSignal>();
+
+  @override
+  Stream<ProcessSignal> watch() => _controller.stream;
+
+  @override
+  bool send(int pid) {
+    _controller.add(this);
+    return true;
+  }
+}
+
+class FakeDeviceLogReader extends DeviceLogReader {
+  final _controller = StreamController<String>.broadcast();
+
+  @override
+  Stream<String> get logLines => _controller.stream;
+
+  @override
+  String get name => 'FakeDeviceLogReader';
+
+  void addLine(String line) {
+    _controller.add(line);
+  }
+
+  @override
+  void dispose() {}
+
+  @override
+  Future<void> provideVmService(FlutterVmService connectedVmService) async {}
+}


### PR DESCRIPTION
Add a `--log-filter` option to `flutter run` and `flutter logs` to allow developers to filter the output stream by a string or regular expression pattern. This provides a configurable way to manage noisy output while preserving benchmark and crash logs.

Fixes #50808
