### PR TITLE
fix: [android] Fall back to new engine when cached engine is missing

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -1081,10 +1081,16 @@ public class FlutterActivity extends Activity
   public boolean shouldDestroyEngineWithHost() {
     boolean explicitDestructionRequested =
         getIntent().getBooleanExtra(EXTRA_DESTROY_ENGINE_WITH_ACTIVITY, false);
-    if (getCachedEngineId() != null || delegate.isFlutterEngineFromHost()) {
+    boolean isEngineFromHost =
+        delegate != null ? delegate.isFlutterEngineFromHost() : getCachedEngineId() != null;
+    if (isEngineFromHost) {
       // Only destroy a cached engine if explicitly requested by app developer.
       return explicitDestructionRequested;
     } else {
+      if (getCachedEngineId() != null) {
+        // Fallback engine. Always destroy it because it's not cached and would otherwise leak.
+        return true;
+      }
       // If this Activity created the FlutterEngine, destroy it by default unless
       // explicitly requested not to.
       return getIntent().getBooleanExtra(EXTRA_DESTROY_ENGINE_WITH_ACTIVITY, true);

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -290,13 +290,15 @@ import java.util.Set;
     if (cachedEngineId != null) {
       flutterEngine = FlutterEngineCache.getInstance().get(cachedEngineId);
       isFlutterEngineFromHost = true;
-      if (flutterEngine == null) {
-        throw new IllegalStateException(
-            "The requested cached FlutterEngine did not exist in the FlutterEngineCache: '"
-                + cachedEngineId
-                + "'");
+      if (flutterEngine != null) {
+        return;
       }
-      return;
+      Log.w(
+          TAG,
+          "The requested cached FlutterEngine did not exist in the FlutterEngineCache: '"
+              + cachedEngineId
+              + "'. Falling back to a newly created engine.");
+      isFlutterEngineFromHost = false;
     }
 
     // Second, defer to subclasses for a custom FlutterEngine.
@@ -501,7 +503,7 @@ import java.util.Set;
    */
   private void doInitialFlutterViewRun() {
     // Don't attempt to start a FlutterEngine if we're using a cached FlutterEngine.
-    if (host.getCachedEngineId() != null) {
+    if (host.getCachedEngineId() != null && isFlutterEngineFromHost) {
       return;
     }
 
@@ -810,7 +812,7 @@ import java.util.Set;
     if (host.shouldDestroyEngineWithHost()) {
       flutterEngine.destroy();
 
-      if (host.getCachedEngineId() != null) {
+      if (host.getCachedEngineId() != null && isFlutterEngineFromHost) {
         FlutterEngineCache.getInstance().remove(host.getCachedEngineId());
       }
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -1400,10 +1400,16 @@ public class FlutterFragment extends Fragment
   public boolean shouldDestroyEngineWithHost() {
     boolean explicitDestructionRequested =
         getArguments().getBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, false);
-    if (getCachedEngineId() != null || delegate.isFlutterEngineFromHost()) {
+    boolean isEngineFromHost =
+        delegate != null ? delegate.isFlutterEngineFromHost() : getCachedEngineId() != null;
+    if (isEngineFromHost) {
       // Only destroy a cached engine if explicitly requested by app developer.
       return explicitDestructionRequested;
     } else {
+      if (getCachedEngineId() != null) {
+        // Fallback engine. Always destroy it because it's not cached and would otherwise leak.
+        return true;
+      }
       // If this Fragment created the FlutterEngine, destroy it by default unless
       // explicitly requested not to.
       return getArguments().getBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, true);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -303,14 +303,21 @@ public class FlutterActivityAndFragmentDelegateTest {
     verify(cachedEngine.getLifecycleChannel(), times(1)).appIsResumed();
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void itThrowsExceptionIfCachedEngineDoesNotExist() {
+  @Test
+  public void itFallsBackToNewEngineIfCachedEngineDoesNotExist() {
     // ---- Test setup ----
     // Adjust fake host to request cached engine that does not exist.
-    when(mockHost.getCachedEngineId()).thenReturn("my_flutter_engine");
+    when(mockHost.getCachedEngineId()).thenReturn("non_existent_engine_id");
+    when(mockHost.provideFlutterEngine(any(Context.class))).thenReturn(null);
+
+    FlutterEngineGroup mockEngineGroup = mock(FlutterEngineGroup.class);
+    when(mockEngineGroup.createAndRunEngine(any(FlutterEngineGroup.Options.class)))
+        .thenReturn(mockFlutterEngine);
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+    FlutterActivityAndFragmentDelegate delegate =
+        new FlutterActivityAndFragmentDelegate(mockHost, mockEngineGroup);
+
     try (ActivityScenario<Activity> scenario = ActivityScenario.launch(Activity.class)) {
       scenario.onActivity(
           activity -> {
@@ -319,10 +326,10 @@ public class FlutterActivityAndFragmentDelegateTest {
             // --- Execute the behavior under test ---
             // The FlutterEngine existence is verified in onAttach()
             delegate.onAttach(ctx);
+
+            assertEquals(mockFlutterEngine, delegate.getFlutterEngine());
+            assertFalse(delegate.isFlutterEngineFromHost());
           });
-    } catch (IllegalStateException e) {
-      // Expect IllegalStateException.
-      throw e;
     }
   }
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -4,7 +4,6 @@
 
 package io.flutter.embedding.android;
 
-import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_CACHED_ENGINE_ID;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.HANDLE_DEEPLINKING_META_DATA_KEY;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -105,19 +104,23 @@ public class FlutterActivityTest {
     FlutterEngine cachedEngine = new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni);
     FlutterEngineCache.getInstance().put("my_cached_engine", cachedEngine);
 
-    ActivityScenario<FlutterActivity> flutterActivityScenario =
-        ActivityScenario.launch(FlutterActivity.class);
+    Intent intent =
+        FlutterActivity.withCachedEngine("my_cached_engine")
+            .destroyEngineWithActivity(false)
+            .build(ctx);
+
+    ActivityScenario<FlutterActivity> flutterActivityScenario = ActivityScenario.launch(intent);
 
     // Set to framework handling and then recreate the activity and check the state is preserved.
     flutterActivityScenario.onActivity(activity -> activity.setFrameworkHandlesBack(true));
-    flutterActivityScenario.onActivity(
-        activity -> activity.getIntent().putExtra(EXTRA_CACHED_ENGINE_ID, "my_cached_engine"));
 
     flutterActivityScenario.recreate();
     flutterActivityScenario.onActivity(activity -> assertTrue(activity.hasRegisteredBackCallback));
 
     // Clean up.
     flutterActivityScenario.close();
+    FlutterEngineCache.getInstance().remove("my_cached_engine");
+    cachedEngine.destroy();
   }
 
   @Test
@@ -412,6 +415,24 @@ public class FlutterActivityTest {
     assertArrayEquals(new String[] {}, flutterActivity.getFlutterShellArgs().toArray());
     assertTrue(flutterActivity.shouldAttachEngineToActivity());
     assertEquals("my_cached_engine", flutterActivity.getCachedEngineId());
+    assertTrue(flutterActivity.shouldDestroyEngineWithHost());
+  }
+
+  @Test
+  public void itDestroysFallbackEngine() {
+    Intent intent =
+        FlutterActivity.withCachedEngine("my_cached_engine")
+            .destroyEngineWithActivity(false)
+            .build(ctx);
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    FlutterActivityAndFragmentDelegate mockDelegate =
+        mock(FlutterActivityAndFragmentDelegate.class);
+    when(mockDelegate.isFlutterEngineFromHost()).thenReturn(false);
+    flutterActivity.setDelegate(mockDelegate);
+
     assertTrue(flutterActivity.shouldDestroyEngineWithHost());
   }
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityReproductionTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityReproductionTest.java
@@ -1,0 +1,78 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.embedding.android;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.Intent;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.flutter.FlutterInjector;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.FlutterEngineCache;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.loader.FlutterLoader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class FlutterFragmentActivityReproductionTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
+
+  @Before
+  public void setUp() {
+    FlutterInjector.reset();
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    when(mockFlutterJNI.isAttached()).thenReturn(true);
+    FlutterJNI.Factory mockFlutterJNIFactory = mock(FlutterJNI.Factory.class);
+    when(mockFlutterJNIFactory.provideFlutterJNI()).thenReturn(mockFlutterJNI);
+    FlutterInjector.setInstance(
+        new FlutterInjector.Builder().setFlutterJNIFactory(mockFlutterJNIFactory).build());
+  }
+
+  @After
+  public void tearDown() {
+    FlutterInjector.reset();
+  }
+
+  @Test
+  public void testCachedEngineFallbackOnRecreation() {
+    FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
+    FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
+    when(mockFlutterJni.isAttached()).thenReturn(true);
+    when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(false);
+
+    FlutterEngine cachedEngine =
+        new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni, new String[] {}, false);
+    final String cachedEngineId = "reproduction_cached_engine";
+    FlutterEngineCache.getInstance().put(cachedEngineId, cachedEngine);
+
+    Intent intent = FlutterFragmentActivity.withCachedEngine(cachedEngineId).build(ctx);
+
+    try (ActivityScenario<FlutterFragmentActivity> scenario = ActivityScenario.launch(intent)) {
+      // Remove it from cache to simulate engine being destroyed/removed.
+      FlutterEngineCache.getInstance().remove(cachedEngineId);
+
+      // Recreate the activity.
+      // With the bug, this will fail with IllegalStateException (wrapped).
+      // With the fix, this should succeed.
+      scenario.recreate();
+
+      scenario.onActivity(
+          activity -> {
+            assertNotNull(activity.getFlutterEngine());
+          });
+    } finally {
+      FlutterEngineCache.getInstance().remove(cachedEngineId);
+      cachedEngine.destroy();
+    }
+  }
+}

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -169,6 +169,21 @@ public class FlutterFragmentTest {
   }
 
   @Test
+  public void itDestroysFallbackEngine() {
+    FlutterFragment fragment =
+        FlutterFragment.withCachedEngine("my_cached_engine")
+            .destroyEngineWithFragment(false)
+            .build();
+
+    FlutterActivityAndFragmentDelegate mockDelegate =
+        mock(FlutterActivityAndFragmentDelegate.class);
+    when(mockDelegate.isFlutterEngineFromHost()).thenReturn(false);
+    fragment.delegate = mockDelegate;
+
+    assertTrue(fragment.shouldDestroyEngineWithHost());
+  }
+
+  @Test
   public void itCreatesCachedEngineFragmentThatDelaysFirstDrawWhenRequested() {
     FlutterFragment fragment =
         FlutterFragment.withCachedEngine("my_cached_engine")


### PR DESCRIPTION
Falls back to creating a new FlutterEngine when a cached engine is specified (e.g. during activity recreation) but does not exist in the FlutterEngineCache, rather than throwing an IllegalStateException. Also ensures the fallback engine is correctly destroyed on activity/fragment destruction to avoid memory leaks.

Fixes: flutter/flutter#116947
