### PR TITLE
fix: throw IllegalStateException when FlutterLoader methods are called before initialization

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -701,6 +701,9 @@ public class FlutterLoader {
 
   @NonNull
   public String findAppBundlePath() {
+    if (flutterApplicationInfo == null) {
+      throw new IllegalStateException("findAppBundlePath must be called after startInitialization");
+    }
     return flutterApplicationInfo.flutterAssetsDir;
   }
 
@@ -713,6 +716,10 @@ public class FlutterLoader {
    */
   @NonNull
   public String getLookupKeyForAsset(@NonNull String asset) {
+    if (flutterApplicationInfo == null) {
+      throw new IllegalStateException(
+          "getLookupKeyForAsset must be called after startInitialization");
+    }
     return fullAssetPathFrom(asset);
   }
 
@@ -733,6 +740,10 @@ public class FlutterLoader {
   /** Returns the configuration on whether flutter engine should automatically register plugins. */
   @NonNull
   public boolean automaticallyRegisterPlugins() {
+    if (flutterApplicationInfo == null) {
+      throw new IllegalStateException(
+          "automaticallyRegisterPlugins must be called after startInitialization");
+    }
     return flutterApplicationInfo.automaticallyRegisterPlugins;
   }
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderReproduce180047Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderReproduce180047Test.java
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.embedding.engine.loader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class FlutterLoaderReproduce180047Test {
+
+  @Test
+  public void testFindAppBundlePathThrowsIllegalStateExceptionWhenUninitialized() {
+    FlutterLoader flutterLoader = new FlutterLoader();
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              flutterLoader.findAppBundlePath();
+            });
+    assertEquals(
+        "findAppBundlePath must be called after startInitialization", exception.getMessage());
+  }
+
+  @Test
+  public void testGetLookupKeyForAssetThrowsIllegalStateExceptionWhenUninitialized() {
+    FlutterLoader flutterLoader = new FlutterLoader();
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              flutterLoader.getLookupKeyForAsset("some_asset");
+            });
+    assertEquals(
+        "getLookupKeyForAsset must be called after startInitialization", exception.getMessage());
+  }
+
+  @Test
+  public void testAutomaticallyRegisterPluginsThrowsIllegalStateExceptionWhenUninitialized() {
+    FlutterLoader flutterLoader = new FlutterLoader();
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              flutterLoader.automaticallyRegisterPlugins();
+            });
+    assertEquals(
+        "automaticallyRegisterPlugins must be called after startInitialization",
+        exception.getMessage());
+  }
+}


### PR DESCRIPTION
Check that flutterApplicationInfo is non-null in findAppBundlePath,
getLookupKeyForAsset, and automaticallyRegisterPlugins, throwing a
clear IllegalStateException instead of a NullPointerException if
FlutterLoader is called before startInitialization.

Resolves flutter/flutter#180047
