### PR TITLE
Use g_signal_connect_object in the Linux embedder

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_keyboard_manager.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_keyboard_manager.cc
@@ -112,8 +112,6 @@ struct _FlKeyboardManager {
       logical_to_mandatory_goals;
 
   GdkKeymap* keymap;
-  gulong keymap_keys_changed_cb_id;  // Signal connection ID for
-                                     // keymap-keys-changed
 
   GCancellable* cancellable;
 };
@@ -318,10 +316,6 @@ static void fl_keyboard_manager_dispose(GObject* object) {
   g_clear_object(&self->key_embedder_responder);
   g_clear_object(&self->key_channel_responder);
   g_clear_object(&self->derived_layout);
-  if (self->keymap_keys_changed_cb_id != 0) {
-    g_signal_handler_disconnect(self->keymap, self->keymap_keys_changed_cb_id);
-    self->keymap_keys_changed_cb_id = 0;
-  }
   g_clear_object(&self->cancellable);
 
   G_OBJECT_CLASS(fl_keyboard_manager_parent_class)->dispose(object);
@@ -348,8 +342,9 @@ static void fl_keyboard_manager_init(FlKeyboardManager* self) {
   }
 
   self->keymap = gdk_keymap_get_for_display(gdk_display_get_default());
-  self->keymap_keys_changed_cb_id = g_signal_connect_swapped(
-      self->keymap, "keys-changed", G_CALLBACK(keymap_keys_changed_cb), self);
+  g_signal_connect_object(self->keymap, "keys-changed",
+                          G_CALLBACK(keymap_keys_changed_cb), self,
+                          G_CONNECT_SWAPPED);
   self->cancellable = g_cancellable_new();
 }
 

--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -52,12 +52,6 @@ struct _FlView {
   // Combines layers into frame.
   FlCompositor* compositor;
 
-  // Signal subscription for engine restart signal.
-  guint on_pre_engine_restart_cb_id;
-
-  // Signal subscription for updating semantics signal.
-  guint update_semantics_cb_id;
-
   // ID for this view.
   FlutterViewId view_id;
 
@@ -81,9 +75,6 @@ struct _FlView {
 
   // Accessible tree from Flutter, exposed as an AtkPlug.
   FlViewAccessible* view_accessible;
-
-  // Signal subscripton for cursor changes.
-  guint cursor_changed_cb_id;
 
   // TRUE if the view size should be controlled by Flutter.
   gboolean sized_to_content;
@@ -205,8 +196,9 @@ static void setup_cursor(FlView* self) {
   FlMouseCursorHandler* handler =
       fl_engine_get_mouse_cursor_handler(self->engine);
 
-  self->cursor_changed_cb_id = g_signal_connect_swapped(
-      handler, "cursor-changed", G_CALLBACK(cursor_changed_cb), self);
+  g_signal_connect_object(handler, "cursor-changed",
+                          G_CALLBACK(cursor_changed_cb), self,
+                          G_CONNECT_SWAPPED);
   cursor_changed_cb(self);
 }
 
@@ -603,27 +595,9 @@ static void fl_view_dispose(GObject* object) {
   g_clear_object(&self->zoom_gesture);
   g_clear_object(&self->rotate_gesture);
   if (self->engine != nullptr) {
-    FlMouseCursorHandler* handler =
-        fl_engine_get_mouse_cursor_handler(self->engine);
-    if (self->cursor_changed_cb_id != 0) {
-      g_signal_handler_disconnect(handler, self->cursor_changed_cb_id);
-      self->cursor_changed_cb_id = 0;
-    }
-
     // Release the view ID from the engine.
     fl_engine_remove_view(self->engine, self->view_id, nullptr, nullptr,
                           nullptr);
-  }
-
-  if (self->on_pre_engine_restart_cb_id != 0) {
-    g_signal_handler_disconnect(self->engine,
-                                self->on_pre_engine_restart_cb_id);
-    self->on_pre_engine_restart_cb_id = 0;
-  }
-
-  if (self->update_semantics_cb_id != 0) {
-    g_signal_handler_disconnect(self->engine, self->update_semantics_cb_id);
-    self->update_semantics_cb_id = 0;
   }
 
   g_clear_object(&self->render_context);
@@ -740,11 +714,12 @@ static void setup_engine(FlView* self) {
   init_scrolling(self);
   init_touch(self);
 
-  self->on_pre_engine_restart_cb_id =
-      g_signal_connect_swapped(self->engine, "on-pre-engine-restart",
-                               G_CALLBACK(on_pre_engine_restart_cb), self);
-  self->update_semantics_cb_id = g_signal_connect_swapped(
-      self->engine, "update-semantics", G_CALLBACK(update_semantics_cb), self);
+  g_signal_connect_object(self->engine, "on-pre-engine-restart",
+                          G_CALLBACK(on_pre_engine_restart_cb), self,
+                          G_CONNECT_SWAPPED);
+  g_signal_connect_object(self->engine, "update-semantics",
+                          G_CALLBACK(update_semantics_cb), self,
+                          G_CONNECT_SWAPPED);
 }
 
 static void fl_view_init(FlView* self) {

--- a/engine/src/flutter/shell/platform/linux/fl_view_monitor.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view_monitor.cc
@@ -32,9 +32,6 @@ static void first_frame_cb(FlViewMonitor* self) {
 static void fl_view_monitor_dispose(GObject* object) {
   FlViewMonitor* self = FL_VIEW_MONITOR(object);
 
-  // Disconnect all handlers using data. If we try and disconnect them
-  // individually they generate warnings after the widget has been destroyed.
-  g_signal_handlers_disconnect_by_data(self->view, self);
   g_clear_object(&self->view);
 
   G_OBJECT_CLASS(fl_view_monitor_parent_class)->dispose(object);
@@ -55,8 +52,8 @@ G_MODULE_EXPORT FlViewMonitor* fl_view_monitor_new(
   self->view = FL_VIEW(g_object_ref(view));
   self->isolate = flutter::Isolate::Current();
   self->on_first_frame = on_first_frame;
-  g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb),
-                           self);
+  g_signal_connect_object(view, "first-frame", G_CALLBACK(first_frame_cb), self,
+                          G_CONNECT_SWAPPED);
 
   return self;
 }

--- a/engine/src/flutter/shell/platform/linux/fl_window_monitor.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_window_monitor.cc
@@ -80,9 +80,6 @@ static void destroy_cb(FlWindowMonitor* self) {
 static void fl_window_monitor_dispose(GObject* object) {
   FlWindowMonitor* self = FL_WINDOW_MONITOR(object);
 
-  // Disconnect all handlers using data. If we try and disconnect them
-  // individually they generated warnings after the widget has been destroyed.
-  g_signal_handlers_disconnect_by_data(self->window, self);
   g_clear_object(&self->window);
 
   G_OBJECT_CLASS(fl_window_monitor_parent_class)->dispose(object);
@@ -115,19 +112,24 @@ G_MODULE_EXPORT FlWindowMonitor* fl_window_monitor_new(
   self->on_moved_to_rect = on_moved_to_rect;
   self->on_close = on_close;
   self->on_destroy = on_destroy;
-  g_signal_connect_swapped(window, "configure-event",
-                           G_CALLBACK(configure_event_cb), self);
-  g_signal_connect_swapped(window, "window-state-event",
-                           G_CALLBACK(window_state_event_cb), self);
-  g_signal_connect_swapped(window, "notify::is-active",
-                           G_CALLBACK(is_active_notify_cb), self);
-  g_signal_connect_swapped(window, "notify::title", G_CALLBACK(title_notify_cb),
-                           self);
-  g_signal_connect_swapped(gtk_widget_get_window(GTK_WIDGET(window)),
-                           "moved-to-rect", G_CALLBACK(moved_to_rect_cb), self);
-  g_signal_connect_swapped(window, "delete-event", G_CALLBACK(delete_event_cb),
-                           self);
-  g_signal_connect_swapped(window, "destroy", G_CALLBACK(destroy_cb), self);
+  g_signal_connect_object(window, "configure-event",
+                          G_CALLBACK(configure_event_cb), self,
+                          G_CONNECT_SWAPPED);
+  g_signal_connect_object(window, "window-state-event",
+                          G_CALLBACK(window_state_event_cb), self,
+                          G_CONNECT_SWAPPED);
+  g_signal_connect_object(window, "notify::is-active",
+                          G_CALLBACK(is_active_notify_cb), self,
+                          G_CONNECT_SWAPPED);
+  g_signal_connect_object(window, "notify::title", G_CALLBACK(title_notify_cb),
+                          self, G_CONNECT_SWAPPED);
+  g_signal_connect_object(gtk_widget_get_window(GTK_WIDGET(window)),
+                          "moved-to-rect", G_CALLBACK(moved_to_rect_cb), self,
+                          G_CONNECT_SWAPPED);
+  g_signal_connect_object(window, "delete-event", G_CALLBACK(delete_event_cb),
+                          self, G_CONNECT_SWAPPED);
+  g_signal_connect_object(window, "destroy", G_CALLBACK(destroy_cb), self,
+                          G_CONNECT_SWAPPED);
 
   return self;
 }

--- a/engine/src/flutter/shell/platform/linux/fl_window_state_monitor.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_window_state_monitor.cc
@@ -28,9 +28,6 @@ struct _FlWindowStateMonitor {
 
   // Current state information.
   GdkWindowState window_state;
-
-  // Signal connection ID for window-state-changed
-  gulong window_state_event_cb_id;
 };
 
 G_DEFINE_TYPE(FlWindowStateMonitor, fl_window_state_monitor, G_TYPE_OBJECT);
@@ -86,10 +83,6 @@ static void fl_window_state_monitor_dispose(GObject* object) {
   FlWindowStateMonitor* self = FL_WINDOW_STATE_MONITOR(object);
 
   g_clear_object(&self->messenger);
-  if (self->window_state_event_cb_id != 0) {
-    g_signal_handler_disconnect(self->window, self->window_state_event_cb_id);
-    self->window_state_event_cb_id = 0;
-  }
 
   G_OBJECT_CLASS(fl_window_state_monitor_parent_class)->dispose(object);
 }
@@ -109,9 +102,9 @@ FlWindowStateMonitor* fl_window_state_monitor_new(FlBinaryMessenger* messenger,
   self->window = window;
 
   // Listen to window state changes.
-  self->window_state_event_cb_id =
-      g_signal_connect_swapped(self->window, "window-state-event",
-                               G_CALLBACK(window_state_event_cb), self);
+  g_signal_connect_object(self->window, "window-state-event",
+                          G_CALLBACK(window_state_event_cb), self,
+                          G_CONNECT_SWAPPED);
   self->window_state =
       gdk_window_get_state(gtk_widget_get_window(GTK_WIDGET(self->window)));
 


### PR DESCRIPTION
Replace g_signal_connect_swapped with g_signal_connect_object (with G_CONNECT_SWAPPED) in cases where the signal emitter can outlive the user-data object. g_signal_connect_object automatically disconnects the handler when the user-data object is finalized, which lets us drop the manually tracked signal-connection IDs and the manual disconnect code in the dispose functions.
