### PR TITLE
feat: add new API documentation examples for scroll notifications, UI…

### DIFF
--- a/examples/api/lib/material/dropdown_menu/dropdown_menu_entry_label_widget.0.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu_entry_label_widget.0.dart
@@ -56,7 +56,7 @@ class _DropdownMenuEntryLabelWidgetExampleState
           initialSelection: ColorItem.green,
           label: const Text('Color'),
           onSelected: (ColorItem? color) {
-            print('Selected $color');
+            debugPrint('Selected $color');
           },
           dropdownMenuEntries: ColorItem.values
               .map<DropdownMenuEntry<ColorItem>>((ColorItem item) {

--- a/examples/api/lib/widgets/scroll_position/scroll_controller_notification.0.dart
+++ b/examples/api/lib/widgets/scroll_position/scroll_controller_notification.0.dart
@@ -22,14 +22,14 @@ class _ScrollNotificationDemoState extends State<ScrollNotificationDemo> {
 
   // This method handles the notification from the ScrollController.
   void _handleControllerNotification() {
-    print('Notified through the scroll controller.');
+    debugPrint('Notified through the scroll controller.');
     // Access the position directly through the controller for details on the
     // scroll position.
   }
 
   // This method handles the notification from the NotificationListener.
   bool _handleScrollNotification(ScrollNotification notification) {
-    print('Notified through scroll notification.');
+    debugPrint('Notified through scroll notification.');
     // The position can still be accessed through the scroll controller, but
     // the notification object provides more details about the activity that is
     // occurring.

--- a/examples/api/lib/widgets/text/ui_testing_with_text.dart
+++ b/examples/api/lib/widgets/text/ui_testing_with_text.dart
@@ -116,7 +116,7 @@ class _MyAppState extends State<MyApp> {
                                 style: const TextStyle(color: Colors.blue),
                                 recognizer: TapGestureRecognizer()
                                   ..onTap = () {
-                                    print('Learn more');
+                                    debugPrint('Learn more');
                                   },
                               ),
                             ],
@@ -144,7 +144,7 @@ class _MyAppState extends State<MyApp> {
                                 style: const TextStyle(color: Colors.blue),
                                 recognizer: TapGestureRecognizer()
                                   ..onTap = () {
-                                    print('Learn more');
+                                    debugPrint('Learn more');
                                   },
                               ),
                             ],


### PR DESCRIPTION
Description
This PR refactors several API examples to use debugPrint() instead of raw print() statements. In Flutter, using raw print() is discouraged because Android's kernel truncates console outputs that exceed standard logcat limits, which can silently hide valuable debugging information for developers reading the examples. By updating scroll_controller_notification.0.dart, ui_testing_with_text.dart, and dropdown_menu_entry_label_widget.0.dart to use debugPrint(), this PR ensures these official API examples adhere to the framework's recommended logging best practices and prevent unintentional log truncation.

Before/After Examples
Before (Legacy):

dart
onSelected: (ColorItem? color) {
  print('Selected $color');
},
After (Updated):

dart
onSelected: (ColorItem? color) {
  debugPrint('Selected $color');
},
Related Issues
This PR fixes a trivial logging anti-pattern (swapping raw print() for debugPrint() in API examples) to align with framework standards. As a minor code cleanup, there is no associated open issue.

Breaking Changes
Not applicable. This PR only updates internal logging in example files and does not contain any breaking API changes or modifications to the flutter/tests repository.

Pre-launch Checklist
 I read the [Contributor Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) and followed the process outlined there for submitting PRs.
 I read the [AI contribution guidelines](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines) and understand my responsibilities, or I am not using AI tools.
 I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) wiki page, which explains my responsibilities.
 I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md), including [Features we expect every widget to implement](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement).
 I signed the [CLA](https://cla.developers.google.com/).
 I listed at least one issue that this PR fixes in the description above.
 I updated/added relevant documentation (doc comments with ///).
 I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests).
 I followed the [breaking change policy](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes) and added [Data Driven Fixes](https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md) where supported.
 All existing and new tests are passing.
If you need help, consider asking for advice on the #hackers-new channel on [Discord](https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md).

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

Note: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the gemini-code-assist bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.