### PR TITLE
[web/skwasm] Remove name-based export of function

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
@@ -21,7 +21,6 @@ extension type RasterResult._(JSObject _) implements JSObject {
   external JSArray<JSAny> get imageBitmaps;
 }
 
-@pragma('wasm:export')
 WasmVoid callbackHandler(WasmI32 callbackId, WasmI32 context, WasmExternRef? jsContext) {
   // Actually hide this call behind whether skwasm is enabled. Otherwise, the SkwasmCallbackHandler
   // won't actually be tree-shaken, and we end up with skwasm imports in non-skwasm builds.


### PR DESCRIPTION
The `@pragma('wasm:export')` is intended to be used on functions that are called by-name
from JS or imported by-name by other wasm modules.

Though the `callbackHandler` seems to be not called by name, instead a wasm funcref
is taken from the function and passed to an imported `skwasmWrapper.addFunction` function.

Removing the annotation can improve scenarios where flutter is loaded via deferred loading.
It allows deferring this function and anything it depends on (including ffi things).