### PR TITLE
Add markInsets property to Checkbox

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -415,7 +415,7 @@ class Checkbox extends StatefulWidget {
   /// effect, because the checkbox delegates to [CupertinoCheckbox], which does
   /// not support insets.
   ///
-  /// Must be non-negative. If the resolved horizontal or vertical insets are
+  /// Must be non-negative. If the horizontal or vertical insets are
   /// greater than or equal to the checkbox size, the check mark or indeterminate
   /// dash is not painted.
   ///
@@ -666,7 +666,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
           ..previousValue = _previousValue
           ..shape = widget.shape ?? checkboxTheme.shape ?? defaults.shape!
           ..activeSide = activeSide
-          ..padding = markInsets
+          ..markInsets = markInsets
           ..inactiveSide = inactiveSide,
       ),
     );
@@ -717,13 +717,13 @@ class _CheckboxPainter extends ToggleablePainter {
     notifyListeners();
   }
 
-  EdgeInsets get padding => _padding;
-  EdgeInsets _padding = EdgeInsets.zero;
-  set padding(EdgeInsets value) {
-    if (_padding == value) {
+  EdgeInsets get markInsets => _markInsets;
+  EdgeInsets _markInsets = EdgeInsets.zero;
+  set markInsets(EdgeInsets value) {
+    if (_markInsets == value) {
       return;
     }
-    _padding = value;
+    _markInsets = value;
     notifyListeners(); // triggers repaint when it changes
   }
 
@@ -788,8 +788,8 @@ class _CheckboxPainter extends ToggleablePainter {
     // As t goes from 0.0 to 1.0, animate the two check mark strokes from the
     // short side to the long side.
     final path = Path();
-    final double innerW = (_kEdgeSize - _padding.horizontal).clamp(0.0, _kEdgeSize);
-    final double innerH = (_kEdgeSize - _padding.vertical).clamp(0.0, _kEdgeSize);
+    final double innerW = (_kEdgeSize - _markInsets.horizontal).clamp(0.0, _kEdgeSize);
+    final double innerH = (_kEdgeSize - _markInsets.vertical).clamp(0.0, _kEdgeSize);
     if (innerW <= 0 || innerH <= 0) {
       return;
     } // no room — paint nothing
@@ -798,9 +798,9 @@ class _CheckboxPainter extends ToggleablePainter {
     final double scale = (innerW < innerH ? innerW : innerH) / _kEdgeSize;
     paint.strokeWidth = _kStrokeWidth * scale;
 
-    final start = Offset(_padding.left + innerW * 0.15, _padding.top + innerH * 0.45);
-    final mid = Offset(_padding.left + innerW * 0.40, _padding.top + innerH * 0.70);
-    final end = Offset(_padding.left + innerW * 0.85, _padding.top + innerH * 0.25);
+    final start = Offset(_markInsets.left + innerW * 0.15, _markInsets.top + innerH * 0.45);
+    final mid = Offset(_markInsets.left + innerW * 0.40, _markInsets.top + innerH * 0.70);
+    final end = Offset(_markInsets.left + innerW * 0.85, _markInsets.top + innerH * 0.25);
 
     if (t < 0.5) {
       final double strokeT = t * 2.0;
@@ -821,8 +821,8 @@ class _CheckboxPainter extends ToggleablePainter {
     assert(t >= 0.0 && t <= 1.0);
     // As t goes from 0.0 to 1.0, animate the horizontal line from the
     // mid point outwards.
-    final double innerW = (_kEdgeSize - _padding.horizontal).clamp(0.0, _kEdgeSize);
-    final double innerH = (_kEdgeSize - _padding.vertical).clamp(0.0, _kEdgeSize);
+    final double innerW = (_kEdgeSize - _markInsets.horizontal).clamp(0.0, _kEdgeSize);
+    final double innerH = (_kEdgeSize - _markInsets.vertical).clamp(0.0, _kEdgeSize);
     if (innerW <= 0 || innerH <= 0) {
       return;
     } // nothing to draw
@@ -830,9 +830,9 @@ class _CheckboxPainter extends ToggleablePainter {
     final double scale = (innerW < innerH ? innerW : innerH) / _kEdgeSize;
     paint.strokeWidth = _kStrokeWidth * scale; // shrink stroke too
 
-    final start = Offset(_padding.left + innerW * 0.2, _padding.top + innerH * 0.5);
-    final mid = Offset(_padding.left + innerW * 0.5, _padding.top + innerH * 0.5);
-    final end = Offset(_padding.left + innerW * 0.8, _padding.top + innerH * 0.5);
+    final start = Offset(_markInsets.left + innerW * 0.2, _markInsets.top + innerH * 0.5);
+    final mid = Offset(_markInsets.left + innerW * 0.5, _markInsets.top + innerH * 0.5);
+    final end = Offset(_markInsets.left + innerW * 0.8, _markInsets.top + innerH * 0.5);
 
     final Offset drawStart = Offset.lerp(start, mid, 1.0 - t)!;
     final Offset drawEnd = Offset.lerp(mid, end, t)!;

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -116,9 +116,9 @@ class Checkbox extends StatefulWidget {
   ///
   /// If a [CupertinoCheckbox] is created, the following parameters are ignored:
   /// [fillColor], [hoverColor], [overlayColor], [splashRadius],
-  /// [materialTapTargetSize], [visualDensity], [isError]. However, [shape] and
-  /// [side] will still affect the [CupertinoCheckbox] and should be handled if
-  /// native fidelity is important.
+  /// [materialTapTargetSize], [visualDensity], [isError], [markInsets]. However,
+  /// [shape] and [side] will still affect the [CupertinoCheckbox] and should be
+  /// handled if native fidelity is important.
   ///
   /// The target platform is based on the current [Theme]: [ThemeData.platform].
   const Checkbox.adaptive({

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -11,7 +11,6 @@
 library;
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 
 import 'checkbox_theme.dart';
 import 'color_scheme.dart';
@@ -102,7 +101,7 @@ class Checkbox extends StatefulWidget {
     this.side,
     this.isError = false,
     this.semanticLabel,
-    this.padding,
+    this.markInsets,
   }) : _checkboxType = _CheckboxType.material,
        assert(tristate || value != null);
 
@@ -143,7 +142,7 @@ class Checkbox extends StatefulWidget {
     this.side,
     this.isError = false,
     this.semanticLabel,
-    this.padding,
+    this.markInsets,
   }) : _checkboxType = _CheckboxType.adaptive,
        assert(tristate || value != null);
 
@@ -404,28 +403,26 @@ class Checkbox extends StatefulWidget {
   /// {@endtemplate}
   final String? semanticLabel;
 
-  /// {@template flutter.material.checkbox.padding}
-  /// The padding around the check mark when the checkbox is checked or
+  /// {@template flutter.material.checkbox.markInsets}
+  /// The insets applied around the check mark when the checkbox is checked or
   /// in its indeterminate (tristate) state.
   ///
   /// This insets the check mark inward; the size of the checkbox box itself
   /// is not affected. The check mark and its stroke shrink to fit the
   /// remaining space, so the mark stays proportional.
   ///
-  /// Resolved against the ambient [Directionality], so [EdgeInsetsDirectional]
-  /// values are supported.
-  ///
   /// On iOS and macOS, when using [Checkbox.adaptive], this property has no
   /// effect, because the checkbox delegates to [CupertinoCheckbox], which does
-  /// not support padding.
+  /// not support insets.
   ///
-  /// Must be non-negative. Padding larger than the box collapses the check
-  /// mark to nothing.
+  /// Must be non-negative. If the resolved horizontal or vertical insets are
+  /// greater than or equal to the checkbox size, the check mark or indeterminate
+  /// dash is not painted.
   ///
-  /// If null, [CheckboxThemeData.padding] is used. If that is also null,
+  /// If null, [CheckboxThemeData.markInsets] is used. If that is also null,
   /// it defaults to [EdgeInsets.zero] and the check mark renders at full size.
   /// {@endtemplate}
-  final EdgeInsetsGeometry? padding;
+  final EdgeInsets? markInsets;
 
   /// The width of a checkbox widget.
   static const double width = 18.0;
@@ -434,12 +431,6 @@ class Checkbox extends StatefulWidget {
 
   @override
   State<Checkbox> createState() => _CheckboxState();
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
-  }
 }
 
 class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, ToggleableStateMixin {
@@ -644,10 +635,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
     final double effectiveSplashRadius =
         widget.splashRadius ?? checkboxTheme.splashRadius ?? defaults.splashRadius!;
 
-    final EdgeInsets resolvedPadding = (widget.padding ?? checkboxTheme.padding ?? EdgeInsets.zero)
-        .resolve(Directionality.maybeOf(context));
-
-    assert(resolvedPadding.isNonNegative, 'Checkbox.padding cannot be negative.');
+    final EdgeInsets markInsets = widget.markInsets ?? checkboxTheme.markInsets ?? EdgeInsets.zero;
 
     return Semantics(
       label: widget.semanticLabel,
@@ -678,7 +666,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
           ..previousValue = _previousValue
           ..shape = widget.shape ?? checkboxTheme.shape ?? defaults.shape!
           ..activeSide = activeSide
-          ..padding = resolvedPadding
+          ..padding = markInsets
           ..inactiveSide = inactiveSide,
       ),
     );

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -11,6 +11,7 @@
 library;
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 
 import 'checkbox_theme.dart';
 import 'color_scheme.dart';
@@ -403,6 +404,7 @@ class Checkbox extends StatefulWidget {
   /// {@endtemplate}
   final String? semanticLabel;
 
+  /// {@template flutter.material.checkbox.padding}
   /// The padding around the check mark when the checkbox is checked or
   /// in its indeterminate (tristate) state.
   ///
@@ -413,11 +415,16 @@ class Checkbox extends StatefulWidget {
   /// Resolved against the ambient [Directionality], so [EdgeInsetsDirectional]
   /// values are supported.
   ///
+  /// On iOS and macOS, when using [Checkbox.adaptive], this property has no
+  /// effect, because the checkbox delegates to [CupertinoCheckbox], which does
+  /// not support padding.
+  ///
   /// Must be non-negative. Padding larger than the box collapses the check
   /// mark to nothing.
   ///
-  /// Defaults to [EdgeInsets.zero], which renders the check mark at its full
-  /// size (the same as before this property existed).
+  /// If null, [CheckboxThemeData.padding] is used. If that is also null,
+  /// it defaults to [EdgeInsets.zero] and the check mark renders at full size.
+  /// {@endtemplate}
   final EdgeInsetsGeometry? padding;
 
   /// The width of a checkbox widget.
@@ -427,6 +434,12 @@ class Checkbox extends StatefulWidget {
 
   @override
   State<Checkbox> createState() => _CheckboxState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
+  }
 }
 
 class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, ToggleableStateMixin {
@@ -631,9 +644,9 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
     final double effectiveSplashRadius =
         widget.splashRadius ?? checkboxTheme.splashRadius ?? defaults.splashRadius!;
 
-    final EdgeInsets resolvedPadding = (widget.padding ?? EdgeInsets.zero).resolve(
-      Directionality.maybeOf(context),
-    );
+    final EdgeInsets resolvedPadding = (widget.padding ?? checkboxTheme.padding ?? EdgeInsets.zero)
+        .resolve(Directionality.maybeOf(context));
+
     assert(resolvedPadding.isNonNegative, 'Checkbox.padding cannot be negative.');
 
     return Semantics(

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -101,6 +101,7 @@ class Checkbox extends StatefulWidget {
     this.side,
     this.isError = false,
     this.semanticLabel,
+    this.padding,
   }) : _checkboxType = _CheckboxType.material,
        assert(tristate || value != null);
 
@@ -141,6 +142,7 @@ class Checkbox extends StatefulWidget {
     this.side,
     this.isError = false,
     this.semanticLabel,
+    this.padding,
   }) : _checkboxType = _CheckboxType.adaptive,
        assert(tristate || value != null);
 
@@ -401,6 +403,23 @@ class Checkbox extends StatefulWidget {
   /// {@endtemplate}
   final String? semanticLabel;
 
+  /// The padding around the check mark when the checkbox is checked or
+  /// in its indeterminate (tristate) state.
+  ///
+  /// This insets the check mark inward; the size of the checkbox box itself
+  /// is not affected. The check mark and its stroke shrink to fit the
+  /// remaining space, so the mark stays proportional.
+  ///
+  /// Resolved against the ambient [Directionality], so [EdgeInsetsDirectional]
+  /// values are supported.
+  ///
+  /// Must be non-negative. Padding larger than the box collapses the check
+  /// mark to nothing.
+  ///
+  /// Defaults to [EdgeInsets.zero], which renders the check mark at its full
+  /// size (the same as before this property existed).
+  final EdgeInsetsGeometry? padding;
+
   /// The width of a checkbox widget.
   static const double width = 18.0;
 
@@ -612,6 +631,11 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
     final double effectiveSplashRadius =
         widget.splashRadius ?? checkboxTheme.splashRadius ?? defaults.splashRadius!;
 
+    final EdgeInsets resolvedPadding = (widget.padding ?? EdgeInsets.zero).resolve(
+      Directionality.maybeOf(context),
+    );
+    assert(resolvedPadding.isNonNegative, 'Checkbox.padding cannot be negative.');
+
     return Semantics(
       label: widget.semanticLabel,
       checked: widget.value ?? false,
@@ -641,6 +665,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
           ..previousValue = _previousValue
           ..shape = widget.shape ?? checkboxTheme.shape ?? defaults.shape!
           ..activeSide = activeSide
+          ..padding = resolvedPadding
           ..inactiveSide = inactiveSide,
       ),
     );
@@ -689,6 +714,16 @@ class _CheckboxPainter extends ToggleablePainter {
     }
     _shape = value;
     notifyListeners();
+  }
+
+  EdgeInsets get padding => _padding;
+  EdgeInsets _padding = EdgeInsets.zero;
+  set padding(EdgeInsets value) {
+    if (_padding == value) {
+      return;
+    }
+    _padding = value;
+    notifyListeners(); // triggers repaint when it changes
   }
 
   BorderSide get activeSide => _activeSide!;
@@ -752,9 +787,20 @@ class _CheckboxPainter extends ToggleablePainter {
     // As t goes from 0.0 to 1.0, animate the two check mark strokes from the
     // short side to the long side.
     final path = Path();
-    const start = Offset(_kEdgeSize * 0.15, _kEdgeSize * 0.45);
-    const mid = Offset(_kEdgeSize * 0.4, _kEdgeSize * 0.7);
-    const end = Offset(_kEdgeSize * 0.85, _kEdgeSize * 0.25);
+    final double innerW = (_kEdgeSize - _padding.horizontal).clamp(0.0, _kEdgeSize);
+    final double innerH = (_kEdgeSize - _padding.vertical).clamp(0.0, _kEdgeSize);
+    if (innerW <= 0 || innerH <= 0) {
+      return;
+    } // no room — paint nothing
+
+    // Shrink the stroke proportionally so a smaller mark doesn't look chunky.
+    final double scale = (innerW < innerH ? innerW : innerH) / _kEdgeSize;
+    paint.strokeWidth = _kStrokeWidth * scale;
+
+    final start = Offset(_padding.left + innerW * 0.15, _padding.top + innerH * 0.45);
+    final mid = Offset(_padding.left + innerW * 0.40, _padding.top + innerH * 0.70);
+    final end = Offset(_padding.left + innerW * 0.85, _padding.top + innerH * 0.25);
+
     if (t < 0.5) {
       final double strokeT = t * 2.0;
       final Offset drawMid = Offset.lerp(start, mid, strokeT)!;
@@ -774,9 +820,19 @@ class _CheckboxPainter extends ToggleablePainter {
     assert(t >= 0.0 && t <= 1.0);
     // As t goes from 0.0 to 1.0, animate the horizontal line from the
     // mid point outwards.
-    const start = Offset(_kEdgeSize * 0.2, _kEdgeSize * 0.5);
-    const mid = Offset(_kEdgeSize * 0.5, _kEdgeSize * 0.5);
-    const end = Offset(_kEdgeSize * 0.8, _kEdgeSize * 0.5);
+    final double innerW = (_kEdgeSize - _padding.horizontal).clamp(0.0, _kEdgeSize);
+    final double innerH = (_kEdgeSize - _padding.vertical).clamp(0.0, _kEdgeSize);
+    if (innerW <= 0 || innerH <= 0) {
+      return;
+    } // nothing to draw
+
+    final double scale = (innerW < innerH ? innerW : innerH) / _kEdgeSize;
+    paint.strokeWidth = _kStrokeWidth * scale; // shrink stroke too
+
+    final start = Offset(_padding.left + innerW * 0.2, _padding.top + innerH * 0.5);
+    final mid = Offset(_padding.left + innerW * 0.5, _padding.top + innerH * 0.5);
+    final end = Offset(_padding.left + innerW * 0.8, _padding.top + innerH * 0.5);
+
     final Offset drawStart = Offset.lerp(start, mid, 1.0 - t)!;
     final Offset drawEnd = Offset.lerp(mid, end, t)!;
     canvas.drawLine(origin + drawStart, origin + drawEnd, paint);

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -11,6 +11,7 @@
 library;
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show clampDouble;
 
 import 'checkbox_theme.dart';
 import 'color_scheme.dart';
@@ -788,8 +789,8 @@ class _CheckboxPainter extends ToggleablePainter {
     // As t goes from 0.0 to 1.0, animate the two check mark strokes from the
     // short side to the long side.
     final path = Path();
-    final double innerW = (_kEdgeSize - _markInsets.horizontal).clamp(0.0, _kEdgeSize);
-    final double innerH = (_kEdgeSize - _markInsets.vertical).clamp(0.0, _kEdgeSize);
+    final double innerW = clampDouble(_kEdgeSize - _markInsets.horizontal, 0.0, _kEdgeSize);
+    final double innerH = clampDouble(_kEdgeSize - _markInsets.vertical, 0.0, _kEdgeSize);
     if (innerW <= 0 || innerH <= 0) {
       return;
     } // no room — paint nothing
@@ -821,8 +822,8 @@ class _CheckboxPainter extends ToggleablePainter {
     assert(t >= 0.0 && t <= 1.0);
     // As t goes from 0.0 to 1.0, animate the horizontal line from the
     // mid point outwards.
-    final double innerW = (_kEdgeSize - _markInsets.horizontal).clamp(0.0, _kEdgeSize);
-    final double innerH = (_kEdgeSize - _markInsets.vertical).clamp(0.0, _kEdgeSize);
+    final double innerW = clampDouble(_kEdgeSize - _markInsets.horizontal, 0.0, _kEdgeSize);
+    final double innerH = clampDouble(_kEdgeSize - _markInsets.vertical, 0.0, _kEdgeSize);
     if (innerW <= 0 || innerH <= 0) {
       return;
     } // nothing to draw

--- a/packages/flutter/lib/src/material/checkbox_theme.dart
+++ b/packages/flutter/lib/src/material/checkbox_theme.dart
@@ -235,7 +235,6 @@ class CheckboxThemeData with Diagnosticable {
     );
     properties.add(DiagnosticsProperty<OutlinedBorder>('shape', shape, defaultValue: null));
     properties.add(DiagnosticsProperty<BorderSide>('side', side, defaultValue: null));
-    properties.add(DiagnosticsProperty<BorderSide>('side', side, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
   }
 

--- a/packages/flutter/lib/src/material/checkbox_theme.dart
+++ b/packages/flutter/lib/src/material/checkbox_theme.dart
@@ -48,7 +48,7 @@ class CheckboxThemeData with Diagnosticable {
     this.visualDensity,
     this.shape,
     this.side,
-    this.padding,
+    this.markInsets,
   });
 
   /// {@macro flutter.material.checkbox.mouseCursor}
@@ -103,8 +103,8 @@ class CheckboxThemeData with Diagnosticable {
   /// If specified, overrides the default value of [Checkbox.side].
   final BorderSide? side;
 
-  /// {@macro flutter.material.checkbox.padding}
-  final EdgeInsetsGeometry? padding;
+  /// {@macro flutter.material.checkbox.markInsets}
+  final EdgeInsets? markInsets;
 
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
@@ -118,7 +118,7 @@ class CheckboxThemeData with Diagnosticable {
     VisualDensity? visualDensity,
     OutlinedBorder? shape,
     BorderSide? side,
-    EdgeInsetsGeometry? padding,
+    EdgeInsets? markInsets,
   }) {
     return CheckboxThemeData(
       mouseCursor: mouseCursor ?? this.mouseCursor,
@@ -130,7 +130,7 @@ class CheckboxThemeData with Diagnosticable {
       visualDensity: visualDensity ?? this.visualDensity,
       shape: shape ?? this.shape,
       side: side ?? this.side,
-      padding: padding ?? this.padding,
+      markInsets: markInsets ?? this.markInsets,
     );
   }
 
@@ -156,7 +156,7 @@ class CheckboxThemeData with Diagnosticable {
       visualDensity: t < 0.5 ? a?.visualDensity : b?.visualDensity,
       shape: ShapeBorder.lerp(a?.shape, b?.shape, t) as OutlinedBorder?,
       side: _lerpSides(a?.side, b?.side, t),
-      padding: EdgeInsetsGeometry.lerp(a?.padding, b?.padding, t),
+      markInsets: EdgeInsets.lerp(a?.markInsets, b?.markInsets, t),
     );
   }
 
@@ -171,7 +171,7 @@ class CheckboxThemeData with Diagnosticable {
     visualDensity,
     shape,
     side,
-    padding,
+    markInsets,
   );
 
   @override
@@ -192,7 +192,7 @@ class CheckboxThemeData with Diagnosticable {
         other.visualDensity == visualDensity &&
         other.shape == shape &&
         other.side == side &&
-        other.padding == padding;
+        other.markInsets == markInsets;
   }
 
   @override
@@ -235,7 +235,7 @@ class CheckboxThemeData with Diagnosticable {
     );
     properties.add(DiagnosticsProperty<OutlinedBorder>('shape', shape, defaultValue: null));
     properties.add(DiagnosticsProperty<BorderSide>('side', side, defaultValue: null));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('markInsets', markInsets, defaultValue: null));
   }
 
   // Special case because BorderSide.lerp() doesn't support null arguments

--- a/packages/flutter/lib/src/material/checkbox_theme.dart
+++ b/packages/flutter/lib/src/material/checkbox_theme.dart
@@ -48,6 +48,7 @@ class CheckboxThemeData with Diagnosticable {
     this.visualDensity,
     this.shape,
     this.side,
+    this.padding,
   });
 
   /// {@macro flutter.material.checkbox.mouseCursor}
@@ -102,6 +103,9 @@ class CheckboxThemeData with Diagnosticable {
   /// If specified, overrides the default value of [Checkbox.side].
   final BorderSide? side;
 
+  /// {@macro flutter.material.checkbox.padding}
+  final EdgeInsetsGeometry? padding;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   CheckboxThemeData copyWith({
@@ -114,6 +118,7 @@ class CheckboxThemeData with Diagnosticable {
     VisualDensity? visualDensity,
     OutlinedBorder? shape,
     BorderSide? side,
+    EdgeInsetsGeometry? padding,
   }) {
     return CheckboxThemeData(
       mouseCursor: mouseCursor ?? this.mouseCursor,
@@ -125,6 +130,7 @@ class CheckboxThemeData with Diagnosticable {
       visualDensity: visualDensity ?? this.visualDensity,
       shape: shape ?? this.shape,
       side: side ?? this.side,
+      padding: padding ?? this.padding,
     );
   }
 
@@ -150,6 +156,7 @@ class CheckboxThemeData with Diagnosticable {
       visualDensity: t < 0.5 ? a?.visualDensity : b?.visualDensity,
       shape: ShapeBorder.lerp(a?.shape, b?.shape, t) as OutlinedBorder?,
       side: _lerpSides(a?.side, b?.side, t),
+      padding: EdgeInsetsGeometry.lerp(a?.padding, b?.padding, t),
     );
   }
 
@@ -164,6 +171,7 @@ class CheckboxThemeData with Diagnosticable {
     visualDensity,
     shape,
     side,
+    padding,
   );
 
   @override
@@ -183,7 +191,8 @@ class CheckboxThemeData with Diagnosticable {
         other.materialTapTargetSize == materialTapTargetSize &&
         other.visualDensity == visualDensity &&
         other.shape == shape &&
-        other.side == side;
+        other.side == side &&
+        other.padding == padding;
   }
 
   @override
@@ -226,6 +235,8 @@ class CheckboxThemeData with Diagnosticable {
     );
     properties.add(DiagnosticsProperty<OutlinedBorder>('shape', shape, defaultValue: null));
     properties.add(DiagnosticsProperty<BorderSide>('side', side, defaultValue: null));
+    properties.add(DiagnosticsProperty<BorderSide>('side', side, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
   }
 
   // Special case because BorderSide.lerp() doesn't support null arguments

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -2485,12 +2485,12 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Checkbox.padding defaults to null', (WidgetTester tester) async {
+  testWidgets('Checkbox.markInsets defaults to null', (WidgetTester tester) async {
     await tester.pumpWidget(_padFrame(true));
-    expect(tester.widget<Checkbox>(find.byType(Checkbox)).padding, isNull);
+    expect(tester.widget<Checkbox>(find.byType(Checkbox)).markInsets, isNull);
   });
 
-  testWidgets('Checkbox with no padding paints the check at full stroke width', (
+  testWidgets('Checkbox with no markInsets paints the check at full stroke width', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(_padFrame(true));
@@ -2499,60 +2499,57 @@ void main() {
     expect(_checkboxRenderer(tester), paints..path(strokeWidth: 2.0));
   });
 
-  testWidgets('Checkbox.padding shrinks the check mark and its stroke', (
+  testWidgets('Checkbox.markInsets shrinks the check mark and its stroke', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(_padFrame(true, padding: const EdgeInsets.all(4.5)));
+    await tester.pumpWidget(_padFrame(true, markInsets: const EdgeInsets.all(4.5)));
     await tester.pumpAndSettle();
     // inner = 18 - 9 = 9, scale = 9/18 = 0.5, strokeWidth = 2.0 * 0.5 = 1.0
     expect(_checkboxRenderer(tester), paints..path(strokeWidth: 1.0));
   });
 
-  testWidgets('Checkbox.padding shrinks the indeterminate dash too', (WidgetTester tester) async {
-    await tester.pumpWidget(_padFrame(null, tristate: true, padding: const EdgeInsets.all(4.5)));
+  testWidgets('Checkbox.markInsets shrinks the indeterminate dash', (WidgetTester tester) async {
+    await tester.pumpWidget(_padFrame(null, tristate: true, markInsets: const EdgeInsets.all(4.5)));
     await tester.pumpAndSettle();
     expect(_checkboxRenderer(tester), paints..line(strokeWidth: 1.0));
   });
 
-  testWidgets('Checkbox.padding larger than the box collapses the mark without crashing', (
+  testWidgets('Checkbox.markInsets larger than the box collapses the mark without crashing', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(_padFrame(true, padding: const EdgeInsets.all(9.0)));
+    await tester.pumpWidget(_padFrame(true, markInsets: const EdgeInsets.all(9.0)));
     await tester.pumpAndSettle();
     expect(tester.takeException(), isNull); // no exception thrown
     expect(_checkboxRenderer(tester), isNot(paints..path())); // mark collapsed away
   });
 
-  testWidgets('Checkbox asserts when padding is negative', (WidgetTester tester) async {
-    await tester.pumpWidget(_padFrame(true, padding: const EdgeInsets.all(-1.0)));
-    expect(tester.takeException(), isAssertionError);
-  });
-
-  testWidgets('Checkbox.padding falls back to CheckboxThemeData.padding', (
+  testWidgets('Checkbox.markInsets falls back to CheckboxThemeData.markInsets', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(checkboxTheme: const CheckboxThemeData(padding: EdgeInsets.all(4.5))),
+        theme: ThemeData(checkboxTheme: const CheckboxThemeData(markInsets: EdgeInsets.all(4.5))),
         home: Material(
           child: Center(child: Checkbox(value: true, onChanged: (bool? v) {})),
         ),
       ),
     );
     await tester.pumpAndSettle();
-    expect(_checkboxRenderer(tester), paints..path(strokeWidth: 1.0)); // theme padding applied
+    expect(_checkboxRenderer(tester), paints..path(strokeWidth: 1.0)); // theme markInsets applied
   });
 
-  testWidgets('Checkbox.padding overrides CheckboxThemeData.padding', (WidgetTester tester) async {
+  testWidgets('Checkbox.markInsets overrides CheckboxThemeData.markInsets', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(checkboxTheme: const CheckboxThemeData(padding: EdgeInsets.zero)),
+        theme: ThemeData(checkboxTheme: const CheckboxThemeData(markInsets: EdgeInsets.zero)),
         home: Material(
           child: Center(
             child: Checkbox(
               value: true,
               onChanged: (bool? v) {},
-              padding: const EdgeInsets.all(4.5),
+              markInsets: const EdgeInsets.all(4.5),
             ),
           ),
         ),
@@ -2566,14 +2563,14 @@ void main() {
 RenderBox _checkboxRenderer(WidgetTester tester) =>
     tester.renderObject<RenderBox>(find.byType(Checkbox));
 
-Widget _padFrame(bool? value, {EdgeInsetsGeometry? padding, bool tristate = false}) {
+Widget _padFrame(bool? value, {EdgeInsets? markInsets, bool tristate = false}) {
   return MaterialApp(
     home: Material(
       child: Center(
         child: Checkbox(
           value: value,
           tristate: tristate,
-          padding: padding,
+          markInsets: markInsets,
           onChanged: (bool? v) {},
         ),
       ),

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -2484,6 +2484,67 @@ void main() {
     );
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('Checkbox.padding defaults to null', (WidgetTester tester) async {
+    await tester.pumpWidget(_padFrame(true));
+    expect(tester.widget<Checkbox>(find.byType(Checkbox)).padding, isNull);
+  });
+
+  testWidgets('Checkbox with no padding paints the check at full stroke width', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_padFrame(true));
+    await tester.pumpAndSettle();
+    // default: scale == 1.0, so strokeWidth stays at _kStrokeWidth (2.0)
+    expect(_checkboxRenderer(tester), paints..path(strokeWidth: 2.0));
+  });
+
+  testWidgets('Checkbox.padding shrinks the check mark and its stroke', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_padFrame(true, padding: const EdgeInsets.all(4.5)));
+    await tester.pumpAndSettle();
+    // inner = 18 - 9 = 9, scale = 9/18 = 0.5, strokeWidth = 2.0 * 0.5 = 1.0
+    expect(_checkboxRenderer(tester), paints..path(strokeWidth: 1.0));
+  });
+
+  testWidgets('Checkbox.padding shrinks the indeterminate dash too', (WidgetTester tester) async {
+    await tester.pumpWidget(_padFrame(null, tristate: true, padding: const EdgeInsets.all(4.5)));
+    await tester.pumpAndSettle();
+    expect(_checkboxRenderer(tester), paints..line(strokeWidth: 1.0));
+  });
+
+  testWidgets('Checkbox.padding larger than the box collapses the mark without crashing', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_padFrame(true, padding: const EdgeInsets.all(9.0)));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull); // no exception thrown
+    expect(_checkboxRenderer(tester), isNot(paints..path())); // mark collapsed away
+  });
+
+  testWidgets('Checkbox asserts when padding is negative', (WidgetTester tester) async {
+    await tester.pumpWidget(_padFrame(true, padding: const EdgeInsets.all(-1.0)));
+    expect(tester.takeException(), isAssertionError);
+  });
+}
+
+RenderBox _checkboxRenderer(WidgetTester tester) =>
+    tester.renderObject<RenderBox>(find.byType(Checkbox));
+
+Widget _padFrame(bool? value, {EdgeInsetsGeometry? padding, bool tristate = false}) {
+  return MaterialApp(
+    home: Material(
+      child: Center(
+        child: Checkbox(
+          value: value,
+          tristate: tristate,
+          padding: padding,
+          onChanged: (bool? v) {},
+        ),
+      ),
+    ),
+  );
 }
 
 class _SelectedGrabMouseCursor extends WidgetStateMouseCursor {

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -2527,6 +2527,40 @@ void main() {
     await tester.pumpWidget(_padFrame(true, padding: const EdgeInsets.all(-1.0)));
     expect(tester.takeException(), isAssertionError);
   });
+
+  testWidgets('Checkbox.padding falls back to CheckboxThemeData.padding', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(checkboxTheme: const CheckboxThemeData(padding: EdgeInsets.all(4.5))),
+        home: Material(
+          child: Center(child: Checkbox(value: true, onChanged: (bool? v) {})),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(_checkboxRenderer(tester), paints..path(strokeWidth: 1.0)); // theme padding applied
+  });
+
+  testWidgets('Checkbox.padding overrides CheckboxThemeData.padding', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(checkboxTheme: const CheckboxThemeData(padding: EdgeInsets.zero)),
+        home: Material(
+          child: Center(
+            child: Checkbox(
+              value: true,
+              onChanged: (bool? v) {},
+              padding: const EdgeInsets.all(4.5),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(_checkboxRenderer(tester), paints..path(strokeWidth: 1.0)); // widget value wins
+  });
 }
 
 RenderBox _checkboxRenderer(WidgetTester tester) =>


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR adds an optional padding property to the Checkbox widget.
Currently the check mark always fills the entire checkbox box, with no way to add space between the mark and the box edges (see flutter/flutter#188031). This adds a padding field (EdgeInsetsGeometry?) that insets the check mark — and the indeterminate dash — inside the box.

Fixes [flutter/flutter#188031](https://github.com/flutter/flutter/issues/188031)

## Tests
Added to test/material/checkbox_test.dart:
- Checkbox.padding defaults to null
- Checkbox with no padding paints at full stroke width (backward-compat)
- Checkbox.padding shrinks the check mark and its stroke
- Checkbox.padding shrinks the indeterminate dash
- Checkbox.padding larger than the box collapses the mark without crashing
- Checkbox asserts when padding is negative

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
