### PR TITLE
[ios]add swift-style-guide skill

### DIFF
--- a/.agents/skills/swift-style-guide/SKILL.md
+++ b/.agents/skills/swift-style-guide/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: swift-style-guide
+description: Guidelines for enforcing and adhering to Google's Swift Style Guide when writing or reviewing Swift code.
+---
+
+# Google Swift Style Guide Rules & Enforcement
+
+This document outlines the strict guidelines and best practices for writing, reviewing, and formatting Swift code in this repository. All Swift code must strictly adhere to the [Google Swift Style Guide](https://google.github.io/swift/).
+
+---
+
+## 🛡️ Core Directives & Verification
+
+To ensure style consistency and prevent personal preferences or external conventions from leaking into the codebase, you must follow these rules:
+
+1. **Mandatory Quote Verification**: Never flag a style violation or suggest a style change unless you can point to the exact section and provide a verbatim quote from the [Google Swift Style Guide](https://google.github.io/swift/).
+2. **No External Style Contamination**: Do not carry over conventions from other popular style guides (e.g., Apple's API Design Guidelines or the Ray Wenderlich/Kodeco Swift Style Guide). If a rule is not explicitly documented in the Google Swift Style Guide, it is **not** a violation.
+   * *Example*: The Google Swift Style Guide is silent on the use of the `self.` prefix outside of initializers (where it is required to disambiguate properties from parameter names). Therefore, using an explicit `self.` (e.g., `self.myMethod()`) is **not** a violation.
+
+---
+
+## 🏷️ Non-Formatting Issues
+
+Pay extra attention to non-formatting issues, such as variable or file naming conventions, which are not detectable by the `swift-format` tool. For example, extension files should be named `<TypeName>+<ExtensionName>.swift` instead of `<TypeName>Extension.swift`.
+
+---
+
+## 🛠️ Known Issues in `swift-format`
+
+Even if a developer runs `swift-format` on the code, there can still be formatting issues that violate Google's Swift Style Guide. You need to manually check and fix these issues.
+
+### Line Wrapping
+Google's style guide requires that comma-separated items be laid out in **only one direction**: entirely horizontally (on a single line) or entirely vertically (one element per line). **Mixed layouts are strictly forbidden.**
+
+#### Good Example 1: Horizontal Layout
+```swift
+// 👍 Good: Horizontally laid out on one line
+func myMethod(param1: Int, param2: Int)
+```
+
+#### Good Example 2: Vertical Layout
+```swift
+// 👍 Good: Vertically laid out, one per line
+func myMethod(
+  param1: Int,
+  param2: Int,
+  param3: Int,
+  param4: Int,
+  param5: Int,
+  param6: Int
+)
+```
+
+#### Bad Example: Mixed Layout (Style Violation)
+```swift
+// 👎 Bad: Mixed layout (violates the Line-Wrapping rule)
+func myMethod(
+  param1: Int, param2: Int, param3: Int,
+  param4: Int, param5: Int, param6: Int
+)
+```
+
+The last example violates the Google Swift Style Guide under the **Line-Wrapping** section:
+* **Scenario #4**: *"The breakable comma-delimited list of formal arguments."*
+* **Rule #2**: *"Comma-delimited lists are only laid out in one direction: horizontally or vertically. In other words, all elements must fit on the same line, or each element must be on its own line."*

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -50,7 +50,7 @@ flutter/flutter repository. It is based on the more comprehensive official
 - Kotlin code is formatted using `ktformat`, linted with `ktlint`, and should follow the [Android Kotlin Style Guide](https://developer.android.com/kotlin/style-guide).
 - Java code is formatted using `google-java-format` and should follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
 - Objective-C is formatted using `clang-format`, linted with `clang-tidy`, and should follow the [Google Objective-C Style Guide](https://google.github.io/styleguide/objcguide.html).
-- Swift is formatted and linted using `swift-format` and should follow the [Google Swift Style Guide](https://google.github.io/swift).
+- Swift is formatted and linted using `swift-format` and should follow the [Google Swift Style Guide](https://google.github.io/swift). Refer to the [swift-style-guide](.agents/skills/swift-style-guide) skill for more details.
 - GN code is formatted using `gn format` and should follow the [GN Style Guide](https://gn.googlesource.com/gn/+/main/docs/style_guide.md).
 
 ## Documentation


### PR DESCRIPTION
## Why add this skill? 

See https://github.com/flutter/flutter/issues/188282

## Example prompt: 

> Analyze existing swift code and find me any violations

## Example output: 

Interestingly, instead of relying the result to me, Gemini created an MD file, which is pretty good: [swift_violations_report.md](https://github.com/user-attachments/files/29182267/swift_violations_report.md)

## Key observation

-  I instructed the AI to always quote the exact violation in the style guide. This way it doesn't hallucinate a non-existing guide for explicit `self` anymore (discussed in the issue)
- I added additional info such as `swift-format` tool doesn't catch line wrapping violations for parameter lists, which gives me good result below: (also discussed in the issue)

#### Violation 3.2: Mixed List-Layout (Line-Wrapping)
* **Line Numbers**: [L21-22](file:///Users/huanlin/Desktop/flutter/flutter/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngineTest.swift#L21-L22)
* **Exact Code**:
  ```swift
  #expect(
    launchEngine.acquireEngine() === firstAccessEngine, "Should return the cached engine instance.")
  ```
* **Style Guide Section**: *Section 4.5: Line-wrapping*
* **Verbatim Quote**:
  > "When line-wrapping a comma-delimited list (such as function parameters, argument lists, array/dictionary literals, etc.), the elements must be laid out in only one direction: entirely horizontally, or entirely vertically. If laid out vertically, each element must be on its own line, and the closing delimiter must be on its own line, aligned with the start of the statement."
* **Proposed Correction**:
  ```diff
  -    #expect(
  -      launchEngine.acquireEngine() === firstAccessEngine, "Should return the cached engine instance.")
  +    #expect(
  +      launchEngine.acquireEngine() === firstAccessEngine,
  +      "Should return the cached engine instance."
  +    )
  ```


*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
