### PR TITLE
[Linux] Move Flutter rendering into a new FlViewRenderer widget

### DIFF
--- a/engine/src/flutter/shell/platform/linux/BUILD.gn
+++ b/engine/src/flutter/shell/platform/linux/BUILD.gn
@@ -173,6 +173,7 @@ source_set("flutter_linux_sources") {
     "fl_view.cc",
     "fl_view_accessible.cc",
     "fl_view_monitor.cc",
+    "fl_view_renderer.cc",
     "fl_window_monitor.cc",
     "fl_window_state_monitor.cc",
   ]

--- a/engine/src/flutter/shell/platform/linux/fl_renderable.h
+++ b/engine/src/flutter/shell/platform/linux/fl_renderable.h
@@ -36,7 +36,7 @@ struct _FlRenderableInterface {
  * @layers: layers to draw.
  * @layers_count: number of layers.
  *
- * present_layers a frame. This method can be called from any thread.
+ * Present a frame. This method can be called from any thread.
  */
 void fl_renderable_present_layers(FlRenderable* renderable,
                                   const FlutterLayer** layers,

--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -12,8 +12,6 @@
 
 #include "flutter/common/constants.h"
 #include "flutter/shell/platform/linux/fl_accessible_node.h"
-#include "flutter/shell/platform/linux/fl_compositor_opengl.h"
-#include "flutter/shell/platform/linux/fl_compositor_software.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/fl_key_event.h"
 #include "flutter/shell/platform/linux/fl_opengl_manager.h"
@@ -24,6 +22,7 @@
 #include "flutter/shell/platform/linux/fl_touch_manager.h"
 #include "flutter/shell/platform/linux/fl_view_accessible.h"
 #include "flutter/shell/platform/linux/fl_view_private.h"
+#include "flutter/shell/platform/linux/fl_view_renderer.h"
 #include "flutter/shell/platform/linux/fl_window_state_monitor.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_plugin_registry.h"
@@ -41,25 +40,13 @@ struct _FlView {
   GtkGesture* rotate_gesture;
 
   // The widget rendering the Flutter view.
-  GtkDrawingArea* render_area;
-
-  // Rendering context when using OpenGL.
-  GdkGLContext* render_context;
+  FlViewRenderer* renderer;
 
   // Engine this view is showing.
   FlEngine* engine;
 
-  // Combines layers into frame.
-  FlCompositor* compositor;
-
   // ID for this view.
   FlutterViewId view_id;
-
-  // Background color.
-  GdkRGBA* background_color;
-
-  // TRUE if have got the first frame to render.
-  gboolean have_first_frame;
 
   // Monitor to track window state.
   FlWindowStateMonitor* window_state_monitor;
@@ -99,43 +86,9 @@ G_DEFINE_TYPE_WITH_CODE(
         G_IMPLEMENT_INTERFACE(fl_plugin_registry_get_type(),
                               fl_view_plugin_registry_iface_init))
 
-// Redraw the view from the GTK thread.
-static gboolean redraw_cb(gpointer user_data) {
-  g_autoptr(FlView) self = FL_VIEW(user_data);
-
-  if (!self->have_first_frame) {
-    self->have_first_frame = TRUE;
-    g_signal_emit(self, fl_view_signals[SIGNAL_FIRST_FRAME], 0);
-  }
-
-  // If Flutter is controlling the window size, then resize the view if
-  // necessary.
-  GtkAllocation allocation;
-  gtk_widget_get_allocation(GTK_WIDGET(self->render_area), &allocation);
-  gint scale_factor =
-      gtk_widget_get_scale_factor(GTK_WIDGET(self->render_area));
-  size_t width = allocation.width * scale_factor;
-  size_t height = allocation.height * scale_factor;
-  size_t frame_width, frame_height;
-  fl_compositor_get_frame_size(self->compositor, &frame_width, &frame_height);
-  gboolean frame_size_matches = width == frame_width && height == frame_height;
-  if (self->sized_to_content && !frame_size_matches) {
-    gtk_widget_set_size_request(GTK_WIDGET(self->render_area),
-                                frame_width / scale_factor,
-                                frame_height / scale_factor);
-    GtkWidget* toplevel =
-        gtk_widget_get_toplevel(GTK_WIDGET(self->render_area));
-    if (GTK_IS_WINDOW(toplevel)) {
-      // Resize to smallest size, so that the window will shrink to fit the new
-      // size of the render area.
-      gtk_window_resize(GTK_WINDOW(toplevel), 1, 1);
-    }
-    return G_SOURCE_REMOVE;
-  }
-
-  gtk_widget_queue_draw(GTK_WIDGET(self->render_area));
-
-  return G_SOURCE_REMOVE;
+// Called when the renderer has rendered its first frame.
+static void first_frame_cb(FlView* self) {
+  g_signal_emit(self, fl_view_signals[SIGNAL_FIRST_FRAME], 0);
 }
 
 // Signal handler for GtkWidget::delete-event
@@ -285,10 +238,7 @@ static void fl_view_present_layers(FlRenderable* renderable,
                                    size_t layers_count) {
   FlView* self = FL_VIEW(renderable);
 
-  fl_compositor_present_layers(self->compositor, layers, layers_count);
-
-  // Perform the redraw in the GTK thead.
-  g_idle_add(redraw_cb, g_object_ref(self));
+  fl_view_renderer_present_layers(self->renderer, layers, layers_count);
 }
 
 // Implements FlPluginRegistry::get_registrar_for_plugin.
@@ -468,48 +418,7 @@ static void gesture_zoom_end_cb(FlView* self) {
   fl_scrolling_manager_handle_zoom_end(self->scrolling_manager);
 }
 
-static void setup_opengl(FlView* self) {
-  g_autoptr(GError) error = nullptr;
-
-  self->render_context = gdk_window_create_gl_context(
-      gtk_widget_get_window(GTK_WIDGET(self->render_area)), &error);
-  if (self->render_context == nullptr) {
-    g_warning("Failed to create OpenGL context: %s", error->message);
-    return;
-  }
-
-  if (!gdk_gl_context_realize(self->render_context, &error)) {
-    g_warning("Failed to realize OpenGL context: %s", error->message);
-    return;
-  }
-
-  // If using Wayland, then EGL is in use and we can access the frame
-  // from the Flutter context using EGLImage. If not (i.e. X11 using GLX)
-  // then we have to copy the texture via the CPU.
-  gboolean shareable =
-      GDK_IS_WAYLAND_DISPLAY(gtk_widget_get_display(GTK_WIDGET(self)));
-  self->compositor = FL_COMPOSITOR(fl_compositor_opengl_new(
-      fl_engine_get_task_runner(self->engine),
-      fl_engine_get_opengl_manager(self->engine), shareable));
-}
-
-static void setup_software(FlView* self) {
-  self->compositor = FL_COMPOSITOR(
-      fl_compositor_software_new(fl_engine_get_task_runner(self->engine)));
-}
-
 static void realize_cb(FlView* self) {
-  switch (fl_engine_get_renderer_type(self->engine)) {
-    case kOpenGL:
-      setup_opengl(self);
-      break;
-    case kSoftware:
-      setup_software(self);
-      break;
-    default:
-      break;
-  }
-
   if (self->view_id != flutter::kFlutterImplicitViewId) {
     setup_cursor(self);
     return;
@@ -545,37 +454,6 @@ static void size_allocate_cb(FlView* self) {
   handle_geometry_changed(self);
 }
 
-static void paint_background(FlView* self, cairo_t* cr) {
-  // Don't bother drawing if fully transparent - the widget above this will
-  // already be drawn by GTK.
-  if (self->background_color->red == 0 && self->background_color->green == 0 &&
-      self->background_color->blue == 0 && self->background_color->alpha == 0) {
-    return;
-  }
-
-  gdk_cairo_set_source_rgba(cr, self->background_color);
-  cairo_paint(cr);
-}
-
-static gboolean draw_cb(FlView* self, cairo_t* cr) {
-  paint_background(self, cr);
-
-  if (self->render_context) {
-    gdk_gl_context_make_current(self->render_context);
-  }
-
-  gboolean wait_for_frame = !self->sized_to_content;
-  gboolean result = fl_compositor_render(
-      self->compositor, cr,
-      gtk_widget_get_window(GTK_WIDGET(self->render_area)), wait_for_frame);
-
-  if (self->render_context) {
-    gdk_gl_context_clear_current();
-  }
-
-  return result;
-}
-
 static void fl_view_notify(GObject* object, GParamSpec* pspec) {
   FlView* self = FL_VIEW(object);
 
@@ -601,10 +479,7 @@ static void fl_view_dispose(GObject* object) {
                           nullptr);
   }
 
-  g_clear_object(&self->render_context);
   g_clear_object(&self->engine);
-  g_clear_object(&self->compositor);
-  g_clear_pointer(&self->background_color, gdk_rgba_free);
   g_clear_object(&self->window_state_monitor);
   g_clear_object(&self->scrolling_manager);
   g_clear_object(&self->pointer_manager);
@@ -622,7 +497,7 @@ static void fl_view_realize(GtkWidget* widget) {
   GTK_WIDGET_CLASS(fl_view_parent_class)->realize(widget);
 
   // Realize the child widgets.
-  gtk_widget_realize(GTK_WIDGET(self->render_area));
+  gtk_widget_realize(GTK_WIDGET(self->renderer));
 }
 
 static gboolean handle_key_event(FlView* self, GdkEventKey* key_event) {
@@ -721,6 +596,16 @@ static void setup_engine(FlView* self) {
   g_signal_connect_object(self->engine, "update-semantics",
                           G_CALLBACK(update_semantics_cb), self,
                           G_CONNECT_SWAPPED);
+
+  self->renderer = fl_view_renderer_new(self->engine, self->sized_to_content);
+  gtk_widget_show(GTK_WIDGET(self->renderer));
+  gtk_container_add(GTK_CONTAINER(self->event_box), GTK_WIDGET(self->renderer));
+  g_signal_connect_swapped(self->renderer, "realize", G_CALLBACK(realize_cb),
+                           self);
+  g_signal_connect_swapped(self->renderer, "size-allocate",
+                           G_CALLBACK(size_allocate_cb), self);
+  g_signal_connect_swapped(self->renderer, "first-frame",
+                           G_CALLBACK(first_frame_cb), self);
 }
 
 static void fl_view_init(FlView* self) {
@@ -729,10 +614,6 @@ static void fl_view_init(FlView* self) {
   gtk_widget_set_can_focus(GTK_WIDGET(self), TRUE);
 
   self->view_id = -1;
-
-  GdkRGBA default_background = {
-      .red = 0.0, .green = 0.0, .blue = 0.0, .alpha = 1.0};
-  self->background_color = gdk_rgba_copy(&default_background);
 
   self->event_box = gtk_event_box_new();
   gtk_widget_set_hexpand(self->event_box, TRUE);
@@ -772,17 +653,6 @@ static void fl_view_init(FlView* self) {
                            G_CALLBACK(gesture_rotation_end_cb), self);
   g_signal_connect_swapped(self->event_box, "touch-event",
                            G_CALLBACK(touch_event_cb), self);
-
-  self->render_area = GTK_DRAWING_AREA(gtk_drawing_area_new());
-  gtk_widget_show(GTK_WIDGET(self->render_area));
-  gtk_container_add(GTK_CONTAINER(self->event_box),
-                    GTK_WIDGET(self->render_area));
-  g_signal_connect_swapped(self->render_area, "realize", G_CALLBACK(realize_cb),
-                           self);
-  g_signal_connect_swapped(self->render_area, "size-allocate",
-                           G_CALLBACK(size_allocate_cb), self);
-  g_signal_connect_swapped(self->render_area, "draw", G_CALLBACK(draw_cb),
-                           self);
 }
 
 G_MODULE_EXPORT FlView* fl_view_new(FlDartProject* project) {
@@ -847,8 +717,7 @@ int64_t fl_view_get_id(FlView* self) {
 G_MODULE_EXPORT void fl_view_set_background_color(FlView* self,
                                                   const GdkRGBA* color) {
   g_return_if_fail(FL_IS_VIEW(self));
-  gdk_rgba_free(self->background_color);
-  self->background_color = gdk_rgba_copy(color);
+  fl_view_renderer_set_background_color(self->renderer, color);
 }
 
 FlViewAccessible* fl_view_get_accessible(FlView* self) {

--- a/engine/src/flutter/shell/platform/linux/fl_view_renderer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view_renderer.cc
@@ -1,0 +1,235 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/linux/fl_view_renderer.h"
+
+#include <gdk/gdkwayland.h>
+
+#include "flutter/shell/platform/linux/fl_compositor.h"
+#include "flutter/shell/platform/linux/fl_compositor_opengl.h"
+#include "flutter/shell/platform/linux/fl_compositor_software.h"
+#include "flutter/shell/platform/linux/fl_engine_private.h"
+#include "flutter/shell/platform/linux/fl_opengl_manager.h"
+
+struct _FlViewRenderer {
+  GtkDrawingArea parent_instance;
+
+  // Engine this widget is rendering.
+  FlEngine* engine;
+
+  // Rendering context when using OpenGL.
+  GdkGLContext* render_context;
+
+  // Combines layers into frame.
+  FlCompositor* compositor;
+
+  // Background color.
+  GdkRGBA* background_color;
+
+  // TRUE if the view size should be controlled by Flutter.
+  gboolean sized_to_content;
+
+  // TRUE if have got the first frame to render.
+  gboolean have_first_frame;
+};
+
+enum { SIGNAL_FIRST_FRAME, LAST_SIGNAL };
+
+static guint fl_view_renderer_signals[LAST_SIGNAL];
+
+G_DEFINE_TYPE(FlViewRenderer, fl_view_renderer, GTK_TYPE_DRAWING_AREA)
+
+// Redraw the view from the GTK thread.
+static gboolean redraw_cb(gpointer user_data) {
+  g_autoptr(FlViewRenderer) self = FL_VIEW_RENDERER(user_data);
+
+  if (self->compositor == nullptr) {
+    return G_SOURCE_REMOVE;
+  }
+
+  if (!self->have_first_frame) {
+    self->have_first_frame = TRUE;
+    g_signal_emit(self, fl_view_renderer_signals[SIGNAL_FIRST_FRAME], 0);
+  }
+
+  // If Flutter is controlling the window size, then resize the view if
+  // necessary.
+  GtkWidget* render_widget = GTK_WIDGET(self);
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(render_widget, &allocation);
+  gint scale_factor = gtk_widget_get_scale_factor(render_widget);
+  size_t width = allocation.width * scale_factor;
+  size_t height = allocation.height * scale_factor;
+  size_t frame_width, frame_height;
+  fl_compositor_get_frame_size(self->compositor, &frame_width, &frame_height);
+  gboolean frame_size_matches = width == frame_width && height == frame_height;
+  if (self->sized_to_content && !frame_size_matches) {
+    gtk_widget_set_size_request(render_widget, frame_width / scale_factor,
+                                frame_height / scale_factor);
+    GtkWidget* toplevel = gtk_widget_get_toplevel(render_widget);
+    if (GTK_IS_WINDOW(toplevel)) {
+      // Resize to smallest size, so that the window will shrink to fit the new
+      // size of the render area.
+      gtk_window_resize(GTK_WINDOW(toplevel), 1, 1);
+    }
+    return G_SOURCE_REMOVE;
+  }
+
+  gtk_widget_queue_draw(render_widget);
+
+  return G_SOURCE_REMOVE;
+}
+
+static void setup_opengl(FlViewRenderer* self) {
+  g_autoptr(GError) error = nullptr;
+
+  self->render_context = gdk_window_create_gl_context(
+      gtk_widget_get_window(GTK_WIDGET(self)), &error);
+  if (self->render_context == nullptr) {
+    g_warning("Failed to create OpenGL context: %s", error->message);
+    return;
+  }
+
+  if (!gdk_gl_context_realize(self->render_context, &error)) {
+    g_warning("Failed to realize OpenGL context: %s", error->message);
+    return;
+  }
+
+  // If using Wayland, then EGL is in use and we can access the frame
+  // from the Flutter context using EGLImage. If not (i.e. X11 using GLX)
+  // then we have to copy the texture via the CPU.
+  gboolean shareable =
+      GDK_IS_WAYLAND_DISPLAY(gtk_widget_get_display(GTK_WIDGET(self)));
+  self->compositor = FL_COMPOSITOR(fl_compositor_opengl_new(
+      fl_engine_get_task_runner(self->engine),
+      fl_engine_get_opengl_manager(self->engine), shareable));
+}
+
+static void setup_software(FlViewRenderer* self) {
+  self->compositor = FL_COMPOSITOR(
+      fl_compositor_software_new(fl_engine_get_task_runner(self->engine)));
+}
+
+static void paint_background(FlViewRenderer* self, cairo_t* cr) {
+  // Don't bother drawing if fully transparent - the widget above this will
+  // already be drawn by GTK.
+  if (self->background_color->red == 0 && self->background_color->green == 0 &&
+      self->background_color->blue == 0 && self->background_color->alpha == 0) {
+    return;
+  }
+
+  gdk_cairo_set_source_rgba(cr, self->background_color);
+  cairo_paint(cr);
+}
+
+// Implements GtkWidget::realize.
+static void fl_view_renderer_realize(GtkWidget* widget) {
+  FlViewRenderer* self = FL_VIEW_RENDERER(widget);
+
+  GTK_WIDGET_CLASS(fl_view_renderer_parent_class)->realize(widget);
+
+  switch (fl_engine_get_renderer_type(self->engine)) {
+    case kOpenGL:
+      setup_opengl(self);
+      break;
+    case kSoftware:
+      setup_software(self);
+      break;
+    default:
+      break;
+  }
+}
+
+// Implements GtkWidget::draw.
+static gboolean fl_view_renderer_draw(GtkWidget* widget, cairo_t* cr) {
+  FlViewRenderer* self = FL_VIEW_RENDERER(widget);
+
+  paint_background(self, cr);
+
+  // The compositor is created when the widget is realized; if it is not yet
+  // available there is nothing to render beyond the background.
+  if (self->compositor == nullptr) {
+    return TRUE;
+  }
+
+  if (self->render_context) {
+    gdk_gl_context_make_current(self->render_context);
+  }
+
+  gboolean wait_for_frame = !self->sized_to_content;
+  gboolean result = fl_compositor_render(
+      self->compositor, cr, gtk_widget_get_window(widget), wait_for_frame);
+
+  if (self->render_context) {
+    gdk_gl_context_clear_current();
+  }
+
+  return result;
+}
+
+static void fl_view_renderer_dispose(GObject* object) {
+  FlViewRenderer* self = FL_VIEW_RENDERER(object);
+
+  g_clear_object(&self->render_context);
+  g_clear_object(&self->compositor);
+  g_clear_object(&self->engine);
+  g_clear_pointer(&self->background_color, gdk_rgba_free);
+
+  G_OBJECT_CLASS(fl_view_renderer_parent_class)->dispose(object);
+}
+
+static void fl_view_renderer_class_init(FlViewRendererClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = fl_view_renderer_dispose;
+
+  GtkWidgetClass* widget_class = GTK_WIDGET_CLASS(klass);
+  widget_class->realize = fl_view_renderer_realize;
+  widget_class->draw = fl_view_renderer_draw;
+
+  fl_view_renderer_signals[SIGNAL_FIRST_FRAME] =
+      g_signal_new("first-frame", fl_view_renderer_get_type(),
+                   G_SIGNAL_RUN_LAST, 0, NULL, NULL, NULL, G_TYPE_NONE, 0);
+}
+
+static void fl_view_renderer_init(FlViewRenderer* self) {
+  GdkRGBA default_background = {
+      .red = 0.0, .green = 0.0, .blue = 0.0, .alpha = 1.0};
+  self->background_color = gdk_rgba_copy(&default_background);
+}
+
+FlViewRenderer* fl_view_renderer_new(FlEngine* engine,
+                                     gboolean sized_to_content) {
+  g_return_val_if_fail(FL_IS_ENGINE(engine), nullptr);
+
+  FlViewRenderer* self =
+      FL_VIEW_RENDERER(g_object_new(fl_view_renderer_get_type(), nullptr));
+
+  self->engine = FL_ENGINE(g_object_ref(engine));
+  self->sized_to_content = sized_to_content;
+
+  return self;
+}
+
+void fl_view_renderer_set_background_color(FlViewRenderer* self,
+                                           const GdkRGBA* color) {
+  g_return_if_fail(FL_IS_VIEW_RENDERER(self));
+  gdk_rgba_free(self->background_color);
+  self->background_color = gdk_rgba_copy(color);
+}
+
+void fl_view_renderer_present_layers(FlViewRenderer* self,
+                                     const FlutterLayer** layers,
+                                     size_t layers_count) {
+  g_return_if_fail(FL_IS_VIEW_RENDERER(self));
+
+  // Frames may be presented before the widget is realized and the compositor
+  // is set up; ignore them.
+  if (self->compositor == nullptr) {
+    return;
+  }
+
+  fl_compositor_present_layers(self->compositor, layers, layers_count);
+
+  // Perform the redraw in the GTK thread.
+  g_idle_add(redraw_cb, g_object_ref(self));
+}

--- a/engine/src/flutter/shell/platform/linux/fl_view_renderer.h
+++ b/engine/src/flutter/shell/platform/linux/fl_view_renderer.h
@@ -1,0 +1,67 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_VIEW_RENDERER_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_FL_VIEW_RENDERER_H_
+
+#include <gtk/gtk.h>
+
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
+
+G_BEGIN_DECLS
+
+G_DECLARE_FINAL_TYPE(FlViewRenderer,
+                     fl_view_renderer,
+                     FL,
+                     VIEW_RENDERER,
+                     GtkDrawingArea)
+
+/**
+ * FlViewRenderer:
+ *
+ * #FlViewRenderer is a GTK widget that renders the contents of a Flutter view.
+ * It owns the compositor and OpenGL context used to draw frames produced by the
+ * Flutter engine. Input handling and other view responsibilities are handled by
+ * #FlView.
+ */
+
+/**
+ * fl_view_renderer_new:
+ * @engine: the #FlEngine to render.
+ * @sized_to_content: %TRUE if the view size is controlled by Flutter.
+ *
+ * Creates a new widget that renders Flutter frames.
+ *
+ * Returns: a new #FlViewRenderer.
+ */
+FlViewRenderer* fl_view_renderer_new(FlEngine* engine,
+                                     gboolean sized_to_content);
+
+/**
+ * fl_view_renderer_set_background_color:
+ * @renderer: an #FlViewRenderer.
+ * @color: the background color.
+ *
+ * Sets the background color drawn behind the Flutter frame.
+ */
+void fl_view_renderer_set_background_color(FlViewRenderer* renderer,
+                                           const GdkRGBA* color);
+
+/**
+ * fl_view_renderer_present_layers:
+ * @renderer: an #FlViewRenderer.
+ * @layers: layers to draw.
+ * @layers_count: number of layers.
+ *
+ * Composites a frame into the renderer. This method can be called from any
+ * thread.
+ */
+void fl_view_renderer_present_layers(FlViewRenderer* renderer,
+                                     const FlutterLayer** layers,
+                                     size_t layers_count);
+
+G_END_DECLS
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_VIEW_RENDERER_H_


### PR DESCRIPTION
Extracts the GtkDrawingArea and all Flutter rendering responsibilities out of FlView into a new FlViewRenderer widget. FlViewRenderer owns the compositor, OpenGL context and background color, and performs the frame drawing. FlView retains input handling, accessibility, geometry and engine lifecycle, delegating rendering to the new widget.

This reduces the complexity of FlView, but is mostly motivated by wanting to add a subsurface renderer, which will either add functionality to FlViewRenderer or we will have multiple renderer widgets.