### PR TITLE
Fix Windows flutter_tools stamp git revision lookup

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -72,7 +72,7 @@ GOTO :after_subroutine
     REM before getting the git revision.
     REM
     REM See https://github.com/flutter/flutter/issues/159018
-    FOR /f %%r IN ('PUSHD %FLUTTER_ROOT% ^& $git rev-parse HEAD') DO (
+    FOR /f %%r IN ('PUSHD %FLUTTER_ROOT% ^& git rev-parse HEAD') DO (
       SET revision=%%r
     )
   )

--- a/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
@@ -70,6 +70,19 @@ Future<void> main() async {
     result = await processManager.run(<String>[flutterBatch.path, '--version']);
     expect(result.stderr, isNot(contains('Building flutter tool...')));
   });
+
+  test('shared.bat writes a revision-bearing flutter tool stamp', () async {
+    final ProcessResult result = await processManager.run(<String>[flutterBatch.path, '--version']);
+    expect(
+      result,
+      const ProcessResultMatcher(stdoutPattern: 'Flutter'),
+    );
+
+    expect(flutterToolStamp.existsSync(), true);
+    final String stamp = flutterToolStamp.readAsStringSync().trim();
+    expect(stamp, isNot('":"'));
+    expect(stamp, matches(RegExp(r'^"[a-f0-9]{40}:.*"$')));
+  });
 }
 
 Future<String> runDartBatch() async {
@@ -120,5 +133,14 @@ File get dartSdkStamp {
       .childDirectory('bin')
       .childDirectory('cache')
       .childFile('engine-dart-sdk.stamp')
+      .absolute;
+}
+
+// The Flutter tool's stamp file.
+File get flutterToolStamp {
+  return flutterRoot
+      .childDirectory('bin')
+      .childDirectory('cache')
+      .childFile('flutter_tools.stamp')
       .absolute;
 }

--- a/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
@@ -72,6 +72,9 @@ Future<void> main() async {
   });
 
   test('shared.bat writes a revision-bearing flutter tool stamp', () async {
+    if (flutterToolStamp.existsSync()) {
+      flutterToolStamp.deleteSync();
+    }
     final ProcessResult result = await processManager.run(<String>[flutterBatch.path, '--version']);
     expect(
       result,


### PR DESCRIPTION
Fixes flutter/flutter#187907

This updates `bin/internal/shared.bat` to use `git rev-parse HEAD` instead of `$git rev-parse HEAD` when computing the flutter_tools stamp compile key on Windows.

That typo currently leaves the revision empty, causing `bin/cache/flutter_tools.stamp` to collapse to `":"` and preventing git-revision-based cache invalidation from working on Windows.

A Windows-only regression test was added to verify that `shared.bat` writes a revision-bearing `flutter_tools.stamp` after running `flutter --version`.

## Tests

- [x] `../../bin/flutter analyze test/integration.shard/batch_entrypoint_test.dart`
- [x] `../../bin/flutter test test/integration.shard/batch_entrypoint_test.dart` *(skips locally on macOS because the file is `@TestOn("windows")`)*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), or this change does not require documentation updates.
- [x] I added new tests to check the change I am making.
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported, or this change is not a breaking change.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
