### PR TITLE
[Android] Close FlutterRenderer texture image SyncFence objects immediately after waiting on them

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -785,9 +785,9 @@ public class FlutterRenderer implements TextureRegistry {
     }
 
     @RequiresApi(API_LEVELS.API_33)
-    private void waitOnFence(Image image) {
-      try {
-        SyncFence fence = image.getFence();
+    @VisibleForTesting
+    void waitOnFence(Image image) {
+      try (SyncFence fence = image.getFence()) {
         fence.awaitForever();
       } catch (IOException e) {
         // Drop.
@@ -1066,8 +1066,7 @@ public class FlutterRenderer implements TextureRegistry {
 
     @RequiresApi(API_LEVELS.API_33)
     private void waitOnFence(Image image) {
-      try {
-        SyncFence fence = image.getFence();
+      try (SyncFence fence = image.getFence()) {
         fence.awaitForever();
       } catch (IOException e) {
         // Drop.

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -28,6 +28,7 @@ import static org.robolectric.Shadows.shadowOf;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.SurfaceTexture;
+import android.hardware.SyncFence;
 import android.media.Image;
 import android.media.ImageReader;
 import android.os.Looper;
@@ -1073,5 +1074,17 @@ public class FlutterRendererTest {
     verify(imageReaderProducer2.callback).onSurfaceAvailable();
     assertFalse(imageReaderProducer1.notifiedDestroy);
     assertFalse(imageReaderProducer2.notifiedDestroy);
+  }
+
+  @Test
+  public void waitOnFence_closesFence() throws Exception {
+    FlutterRenderer.ImageReaderSurfaceProducer producer =
+        (FlutterRenderer.ImageReaderSurfaceProducer)
+            engineRule.getFlutterEngine().getRenderer().createSurfaceProducer();
+    Image image = mock(Image.class);
+    SyncFence fence = mock(SyncFence.class);
+    when(image.getFence()).thenReturn(fence);
+    producer.waitOnFence(image);
+    verify(fence, times(1)).close();
   }
 }


### PR DESCRIPTION
Each SyncFence may use a file descriptor.  But the SyncFences were not being closed promptly and their file descriptors were not being deleted until the SyncFences were garbage collected.

If the process is rendering video and creating a SyncFence for each frame, then it may run out of file descriptor capacity before Java GC happens.

Fixes https://github.com/flutter/flutter/issues/188161