### PR TITLE
Add `StreamBuilder` sample for changing streams

### DIFF
--- a/examples/api/lib/widgets/async/stream_builder.1.dart
+++ b/examples/api/lib/widgets/async/stream_builder.1.dart
@@ -1,0 +1,115 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [StreamBuilder] that switches between two streams.
+///
+/// Uses an [ObjectKey] keyed on the current stream so that the [StreamBuilder]'s
+/// state is recreated when the stream changes, resetting its data immediately
+/// rather than retaining the previous stream's snapshot.
+
+void main() => runApp(StreamBuilderExampleApp());
+
+class StreamBuilderExampleApp extends StatelessWidget {
+  const StreamBuilderExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        appBar: AppBar(title: const Text('StreamBuilder Switch Sample')),
+        body: const Center(child: StreamBuilderExample()),
+      ),
+    );
+  }
+}
+
+class StreamBuilderExample extends StatefulWidget {
+  const StreamBuilderExample({super.key});
+
+  @override
+  State<StreamBuilderExample> createState() => _StreamBuilderExampleState();
+}
+
+class _StreamBuilderExampleState extends State<StreamBuilderExample> {
+  late final _fastController = StreamController<String>.broadcast();
+  late final _slowController = StreamController<String>.broadcast();
+
+  late final Stream<String> _fastStream = _fastController.stream;
+  late final Stream<String> _slowStream = _slowController.stream;
+
+  late Stream<String> _currentStream = _fastStream;
+
+  late final Timer _fastTimer;
+  late final Timer _slowTimer;
+  int _fastCount = 0;
+  int _slowCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _fastTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      _fastController.add('${_fastCount++}');
+    });
+    _slowTimer = Timer.periodic(const Duration(milliseconds: 1500), (_) {
+      _slowController.add('${_slowCount++}');
+    });
+  }
+
+  @override
+  void dispose() {
+    _fastTimer.cancel();
+    _slowTimer.cancel();
+    _fastController.close();
+    _slowController.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = TextTheme.of(context);
+
+    final streamBuilder = StreamBuilder<String>(
+      // This key makes it so the StreamBuilder's state restarts
+      // each time the stream switches, so that 'waiting...' is displayed
+      // instead of the old stream's value.
+      key: ObjectKey(_currentStream),
+      stream: _currentStream,
+      builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
+        return Text(
+          snapshot.data ?? 'waiting...',
+          style: textTheme.displayMedium,
+        );
+      },
+    );
+
+    return Column(
+      mainAxisAlignment: .center,
+      spacing: 24,
+      children: <Widget>[
+        Text(
+          _currentStream == _fastStream ? 'Fast stream' : 'Slow stream',
+          style: textTheme.titleLarge,
+        ),
+        streamBuilder,
+        ElevatedButton(
+          onPressed: () {
+            setState(() {
+              if (_currentStream == _fastStream) {
+                _currentStream = _slowStream;
+              } else {
+                _currentStream = _fastStream;
+              }
+            });
+          },
+          child: const Text('Switch stream'),
+        ),
+      ],
+    );
+  }
+}

--- a/examples/api/lib/widgets/async/stream_builder.1.dart
+++ b/examples/api/lib/widgets/async/stream_builder.1.dart
@@ -12,7 +12,7 @@ import 'package:flutter/material.dart';
 /// state is recreated when the stream changes, resetting its data immediately
 /// rather than retaining the previous stream's snapshot.
 
-void main() => runApp(StreamBuilderExampleApp());
+void main() => runApp(const StreamBuilderExampleApp());
 
 class StreamBuilderExampleApp extends StatelessWidget {
   const StreamBuilderExampleApp({super.key});

--- a/examples/api/test/widgets/async/stream_builder.1_test.dart
+++ b/examples/api/test/widgets/async/stream_builder.1_test.dart
@@ -1,0 +1,74 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/async/stream_builder.1.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('StreamBuilder starts on the fast stream in a waiting state', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.StreamBuilderExampleApp());
+
+    expect(find.text('Fast stream'), findsOneWidget);
+    expect(find.text('waiting...'), findsOneWidget);
+    expect(find.text('Switch stream'), findsOneWidget);
+  });
+
+  testWidgets(
+    'Switching streams resets to waiting via ObjectKey on the stream',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.StreamBuilderExampleApp());
+
+      // Advance the fast stream so a value is displayed.
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+      expect(find.text('0'), findsOneWidget);
+
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+      expect(find.text('1'), findsOneWidget);
+
+      // Switch to the slow stream; ObjectKey forces a new StreamBuilder that
+      // starts with no data, showing 'waiting...' instead of the fast stream's
+      // last value (1).
+      await tester.tap(find.text('Switch stream'));
+      await tester.pump();
+
+      expect(find.text('Slow stream'), findsOneWidget);
+      expect(find.text('waiting...'), findsOneWidget);
+
+      // Switch back without waiting for a slow-stream event; should still
+      // reset to waiting, not retain the fast stream's last value either.
+      await tester.tap(find.text('Switch stream'));
+      await tester.pump();
+
+      expect(find.text('Fast stream'), findsOneWidget);
+      expect(find.text('waiting...'), findsOneWidget);
+    },
+  );
+
+  testWidgets('StreamBuilder is keyed on the active stream', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.StreamBuilderExampleApp());
+
+    final StreamBuilder<String> firstBuilder = tester.widget(
+      find.byType(StreamBuilder<String>),
+    );
+    expect(firstBuilder.key, isA<ObjectKey>());
+    final Object? firstKey = firstBuilder.key;
+
+    await tester.tap(find.text('Switch stream'));
+    await tester.pump();
+
+    final StreamBuilder<String> secondBuilder = tester.widget(
+      find.byType(StreamBuilder<String>),
+    );
+    expect(secondBuilder.key, isA<ObjectKey>());
+    expect(secondBuilder.key, isNot(equals(firstKey)));
+  });
+}

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -397,6 +397,16 @@ typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, AsyncSnaps
 /// ** See code in examples/api/lib/widgets/async/stream_builder.0.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// This sample shows how to switch between two streams with a [StreamBuilder].
+/// Without a [Key], changing the [stream] keeps the previous stream's snapshot
+/// until the new stream emits. Keying the builder on the current stream (here
+/// with an [ObjectKey]) recreates its state so the UI resets to a waiting
+/// state immediately when switching.
+///
+/// ** See code in examples/api/lib/widgets/async/stream_builder.1.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [ValueListenableBuilder], which wraps a [ValueListenable] instead of a


### PR DESCRIPTION
This PR adds an example to the [StreamBuilder docs](https://main-api.flutter.dev/flutter/widgets/StreamBuilder-class.html) that shows how to switch back and forth between multiple streams, resetting the StreamBuilder's state each time.

Closes #64916