### PR TITLE
Fix onPointerDown parameters and fix tests to reflect rotation pressu…

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window.cc
@@ -257,8 +257,8 @@ void FlutterWindow::OnPointerDown(double x,
                                   FlutterPointerDeviceKind device_kind,
                                   int32_t device_id,
                                   uint64_t buttons,
-                                  uint32_t pressure,
-                                  uint32_t rotation) {
+                                  uint32_t rotation,
+                                  uint32_t pressure) {
   if (buttons != 0) {
     binding_handler_delegate_->OnPointerDown(x, y, device_kind, device_id,
                                              buttons, rotation, pressure);

--- a/engine/src/flutter/shell/platform/windows/flutter_window_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window_unittests.cc
@@ -306,7 +306,7 @@ TEST_F(FlutterWindowTest, OnStylusPointerDown) {
       .WillRepeatedly([](UINT32 pointer_id, POINTER_PEN_INFO* pen_info) {
         if (pen_info != nullptr) {
           pen_info->pressure = 720;  // Non-zero pressure for contact events
-          pen_info->rotation = 0;
+          pen_info->rotation = 10;
           pen_info->penFlags = 0;
         }
         return TRUE;
@@ -323,7 +323,7 @@ TEST_F(FlutterWindowTest, OnStylusPointerDown) {
   EXPECT_CALL(delegate,
               OnPointerDown(10.0, 10.0, kFlutterPointerDeviceKindStylus,
                             kDefaultPointerDeviceId,
-                            kFlutterPointerButtonStylusContact, 720, 0))
+                            kFlutterPointerButtonStylusContact, 10, 720))
       .Times(1);
 
   UINT32 pointerId = 1;
@@ -410,7 +410,7 @@ TEST_F(FlutterWindowTest, OnStylusPointerUp) {
   EXPECT_CALL(delegate,
               OnPointerDown(25, 30, kFlutterPointerDeviceKindStylus,
                             kDefaultPointerDeviceId,
-                            kFlutterPointerButtonStylusContact, 720, 0))
+                            kFlutterPointerButtonStylusContact, 0, 720))
       .Times(1);
   EXPECT_CALL(delegate, OnPointerUp(25, 30, kFlutterPointerDeviceKindStylus,
                                     kDefaultPointerDeviceId, 0))
@@ -570,7 +570,7 @@ TEST_F(FlutterWindowTest, OnStylusHoverAfterPointerUp) {
   EXPECT_CALL(delegate,
               OnPointerDown(10.0, 10.0, kFlutterPointerDeviceKindStylus,
                             kDefaultPointerDeviceId,
-                            kFlutterPointerButtonStylusContact, 720, 0))
+                            kFlutterPointerButtonStylusContact, 0, 720))
       .Times(1);
   EXPECT_CALL(delegate, OnPointerUp(10.0, 10.0, kFlutterPointerDeviceKindStylus,
                                     kDefaultPointerDeviceId, 0))
@@ -622,7 +622,7 @@ TEST_F(FlutterWindowTest, OnStylusBarrelButtonUsesPenFlags) {
                             kDefaultPointerDeviceId,
                             kFlutterPointerButtonStylusContact |
                                 kFlutterPointerButtonStylusPrimary,
-                            720, 0))
+                            0, 720))
       .Times(1);
 
   UINT32 pointerId = 1;
@@ -663,7 +663,7 @@ TEST_F(FlutterWindowTest, OnStylusEraserButtonUsesPenFlags) {
                             kDefaultPointerDeviceId,
                             kFlutterPointerButtonStylusContact |
                                 kFlutterPointerButtonStylusSecondary,
-                            720, 0))
+                            0, 720))
       .Times(1);
 
   UINT32 pointerId = 1;
@@ -702,7 +702,7 @@ TEST_F(FlutterWindowTest, OnInvertedStylusPointerDownUsesDeviceKind) {
   EXPECT_CALL(delegate,
               OnPointerDown(10.0, 10.0, kFlutterPointerDeviceKindInvertedStylus,
                             kDefaultPointerDeviceId,
-                            kFlutterPointerButtonStylusContact, 720, 0))
+                            kFlutterPointerButtonStylusContact, 0, 720))
       .Times(1);
 
   UINT32 pointerId = 1;
@@ -749,7 +749,7 @@ TEST_F(FlutterWindowTest, OnStylusBarrelButtonUpdateMovesWithUpdatedButtons) {
   EXPECT_CALL(delegate,
               OnPointerDown(10.0, 10.0, kFlutterPointerDeviceKindStylus,
                             kDefaultPointerDeviceId,
-                            kFlutterPointerButtonStylusContact, 720, 0))
+                            kFlutterPointerButtonStylusContact, 0, 720))
       .Times(1);
   EXPECT_CALL(delegate,
               OnPointerMove(10.0, 10.0, kFlutterPointerDeviceKindStylus,
@@ -807,7 +807,7 @@ TEST_F(FlutterWindowTest, OnStylusBarrelButtonUpdateMovesWithReleasedButton) {
                             kDefaultPointerDeviceId,
                             kFlutterPointerButtonStylusContact |
                                 kFlutterPointerButtonStylusPrimary,
-                            720, 0))
+                            0, 720))
       .Times(1);
   EXPECT_CALL(delegate,
               OnPointerMove(10.0, 10.0, kFlutterPointerDeviceKindStylus,


### PR DESCRIPTION
Fixed an argument ordering problem on onPointerDown on windows.
This bug was introduced in #187629 and found by gemini in https://github.com/flutter/flutter/pull/188341#discussion_r3454667237.

Additionally I changed the tests to have different values for rotation and pressure to also test for this bug.

PS: I can't change this pull request to be active since i can only have one pr open (this is currently open: #186831)
<img width="1855" height="289" alt="grafik" src="https://github.com/user-attachments/assets/8a5b5b11-99f2-41be-b320-e18ef2fb6974" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
