### PR TITLE
fix: guard scheduleFrame and unregisterTexture in FlutterRenderer

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -1361,11 +1361,15 @@ public class FlutterRenderer implements TextureRegistry {
 
   @VisibleForTesting
   /* package */ void scheduleEngineFrame() {
-    flutterJNI.scheduleFrame();
+    if (flutterJNI.isAttached()) {
+      flutterJNI.scheduleFrame();
+    }
   }
 
   private void unregisterTexture(long textureId) {
-    flutterJNI.unregisterTexture(textureId);
+    if (flutterJNI.isAttached()) {
+      flutterJNI.unregisterTexture(textureId);
+    }
   }
 
   public boolean isSoftwareRenderingEnabled() {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/ImageReaderSurfaceProducerReproduceTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/renderer/ImageReaderSurfaceProducerReproduceTest.java
@@ -1,0 +1,102 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.embedding.engine.renderer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.annotation.TargetApi;
+import android.graphics.Canvas;
+import android.media.Image;
+import android.os.Looper;
+import android.view.Surface;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.flutter.Build.API_LEVELS;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.view.TextureRegistry;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.shadows.ShadowLog;
+
+@RunWith(AndroidJUnit4.class)
+@TargetApi(API_LEVELS.API_29)
+public class ImageReaderSurfaceProducerReproduceTest {
+  @Rule(order = 1)
+  public final FlutterEngineRule engineRule = new FlutterEngineRule();
+
+  @Rule(order = 2)
+  public final ActivityScenarioRule<FlutterActivity> scenarioRule =
+      new ActivityScenarioRule<>(engineRule.makeIntent());
+
+  private FlutterJNI fakeJNI;
+
+  @Before
+  public void setup() {
+    ShadowLog.stream = System.out;
+    fakeJNI = engineRule.getFlutterJNI();
+
+    // Configure the mock FlutterJNI to throw when scheduleFrame is called
+    // while JNI is detached, mimicking the real behavior of FlutterJNI.scheduleFrame().
+    doAnswer(
+            invocation -> {
+              if (!fakeJNI.isAttached()) {
+                throw new RuntimeException("FlutterJNI is not attached to native.");
+              }
+              return null;
+            })
+        .when(fakeJNI)
+        .scheduleFrame();
+  }
+
+  @Test
+  public void testCrashWhenJniDetachedDuringImageAvailable() {
+    FlutterRenderer flutterRenderer = engineRule.getFlutterEngine().getRenderer();
+    TextureRegistry.SurfaceProducer producer = flutterRenderer.createSurfaceProducer();
+    FlutterRenderer.ImageReaderSurfaceProducer texture =
+        (FlutterRenderer.ImageReaderSurfaceProducer) producer;
+    texture.disableFenceForTest();
+
+    // Give the texture an initial size.
+    texture.setSize(1, 1);
+
+    // Render a frame.
+    Surface surface = texture.getSurface();
+    assertNotNull(surface);
+    Canvas canvas = surface.lockHardwareCanvas();
+    canvas.drawARGB(255, 255, 0, 0);
+    surface.unlockCanvasAndPost(canvas);
+
+    // Detach JNI before running the callback.
+    engineRule.setJniIsAttached(false);
+
+    // Let callbacks run. Since the background thread posts to the main looper asynchronously,
+    // we poll and pump the main looper until the image is produced and queued (or until we crash).
+    long startTime = System.currentTimeMillis();
+    Image image = null;
+    while (image == null && (System.currentTimeMillis() - startTime) < 5000) {
+      shadowOf(Looper.getMainLooper()).idle();
+      image = texture.acquireLatestImage();
+      if (image == null) {
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          // Ignore.
+        }
+      }
+    }
+
+    if (image != null) {
+      image.close();
+    }
+
+    // Cleanup.
+    texture.release();
+  }
+}


### PR DESCRIPTION
Guard scheduleFrame and unregisterTexture in FlutterRenderer to prevent JNI detachment crash

- Adds a check to `FlutterRenderer.scheduleEngineFrame()` to verify if `flutterJNI.isAttached()` is true before calling `scheduleFrame()`, preventing JNI detachment crashes during asynchronous callbacks (e.g., from `ImageReaderSurfaceProducer.PerImageReader`).
- Adds a check to `FlutterRenderer.unregisterTexture()` to verify if `flutterJNI.isAttached()` before calling `unregisterTexture()`, preventing crashes when textures are released after the engine is detached.
- Includes the dedicated Robolectric integration test `ImageReaderSurfaceProducerReproduceTest.java` that reproduces the JNI detachment crash and verifies the fix.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
