### PR TITLE
[Android] Migrate ABI splits config off legacy AGP DSL

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/AgpCommonExtensionWrapper.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/AgpCommonExtensionWrapper.kt
@@ -8,6 +8,7 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.BuildType
 import com.android.build.api.dsl.DynamicFeatureExtension
 import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.dsl.Splits
 import com.android.build.api.dsl.TestExtension
 import org.gradle.api.NamedDomainObjectContainer
 import java.io.File
@@ -84,6 +85,16 @@ class AgpCommonExtensionWrapper(
                 is LibraryExtension -> backingExtension.buildTypes
                 is DynamicFeatureExtension -> backingExtension.buildTypes
                 is TestExtension -> backingExtension.buildTypes
+                else -> throw IllegalArgumentException(unsupportedMessage())
+            }
+
+    val splits: Splits
+        get() =
+            when (backingExtension) {
+                is ApplicationExtension -> backingExtension.splits
+                is LibraryExtension -> backingExtension.splits
+                is DynamicFeatureExtension -> backingExtension.splits
+                is TestExtension -> backingExtension.splits
                 else -> throw IllegalArgumentException(unsupportedMessage())
             }
 

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -7,7 +7,6 @@ package com.flutter.gradle
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.BuildType
 import com.android.build.gradle.AbstractAppExtension
-import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.tasks.PackageAndroidArtifact
@@ -154,8 +153,7 @@ class FlutterPlugin : Plugin<Project> {
 
         FlutterPluginUtils.getTargetPlatforms(project).forEach { targetArch ->
             val abiValue: String? = FlutterPluginConstants.PLATFORM_ARCH_MAP[targetArch]
-            val androidExtension: BaseExtension = FlutterPluginUtils.getLegacyAndroidExtension(project)
-            androidExtension.splits.abi.include(abiValue!!)
+            FlutterPluginUtils.getAndroidExtension(project).splits.abi.include(abiValue!!)
         }
 
         val flutterExecutableName = getExecutableNameForPlatform("flutter")

--- a/packages/flutter_tools/gradle/src/test/kotlin/AgpCommonExtensionWrapperTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/AgpCommonExtensionWrapperTest.kt
@@ -1,0 +1,71 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.DynamicFeatureExtension
+import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.dsl.Splits
+import com.android.build.api.dsl.TestExtension
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+
+class AgpCommonExtensionWrapperTest {
+    @Test
+    fun `splits delegates to the backing ApplicationExtension`() {
+        val mockSplits = mockk<Splits>()
+        val backingExtension = mockk<ApplicationExtension>()
+        every { backingExtension.splits } returns mockSplits
+
+        val wrapper = AgpCommonExtensionWrapper(backingExtension)
+
+        assertEquals(mockSplits, wrapper.splits)
+    }
+
+    @Test
+    fun `splits delegates to the backing LibraryExtension`() {
+        val mockSplits = mockk<Splits>()
+        val backingExtension = mockk<LibraryExtension>()
+        every { backingExtension.splits } returns mockSplits
+
+        val wrapper = AgpCommonExtensionWrapper(backingExtension)
+
+        assertEquals(mockSplits, wrapper.splits)
+    }
+
+    @Test
+    fun `splits delegates to the backing DynamicFeatureExtension`() {
+        val mockSplits = mockk<Splits>()
+        val backingExtension = mockk<DynamicFeatureExtension>()
+        every { backingExtension.splits } returns mockSplits
+
+        val wrapper = AgpCommonExtensionWrapper(backingExtension)
+
+        assertEquals(mockSplits, wrapper.splits)
+    }
+
+    @Test
+    fun `splits delegates to the backing TestExtension`() {
+        val mockSplits = mockk<Splits>()
+        val backingExtension = mockk<TestExtension>()
+        every { backingExtension.splits } returns mockSplits
+
+        val wrapper = AgpCommonExtensionWrapper(backingExtension)
+
+        assertEquals(mockSplits, wrapper.splits)
+    }
+
+    @Test
+    fun `splits throws for an unsupported backing extension type`() {
+        val wrapper = AgpCommonExtensionWrapper(backingExtension = "not an android extension")
+
+        assertThrows<IllegalArgumentException> {
+            wrapper.splits
+        }
+    }
+}


### PR DESCRIPTION
## Description

Incremental step in the [AGP "newDsl" migration](https://github.com/flutter/flutter/issues/180137).

`FlutterPlugin.apply()` configured the per-ABI `splits.abi.include(...)` call through `getLegacyAndroidExtension(project)`, which returns the deprecated old-DSL `com.android.build.gradle.BaseExtension`. This PR routes that call through `getAndroidExtension(project)` / `AgpCommonExtensionWrapper` instead, which is backed by the AGP "newDsl" extension types (`ApplicationExtension`, `LibraryExtension`, `DynamicFeatureExtension`, `TestExtension`).

To support this, a `splits` accessor was added to `AgpCommonExtensionWrapper`, mirroring the existing members (`compileSdk`, `namespace`, `ndkVersion`, `buildTypes`, ...). The now-unused `BaseExtension` import was removed from `FlutterPlugin.kt`.

This removes one more usage of the old DSL, support for which is dropped in AGP 10.

## Tests

- Adds `AgpCommonExtensionWrapperTest`, covering the new `splits` accessor for each supported backing extension type plus the unsupported-type error path. (This is the first dedicated unit test for the wrapper.)
- The existing `FlutterPluginTest.apply()` test already exercises this code path and continues to do so through the wrapper.

> Note: I was unable to run the `flutter_tools/gradle` Gradle test suite in my local environment (no JDK/Gradle available); relying on CI (`android_run_flutter_gradle_plugin_tests_test.dart`) to validate.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests