### PR TITLE
[flutter_tools] Fix native assets crash on Linux custom devices

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -101,6 +101,11 @@ Future<CCompilerConfig?> cCompilerConfigLinux({
       rethrow;
     }
     return null;
+  } on FileSystemException {
+    if (throwIfNotFound) {
+      rethrow;
+    }
+    return null;
   }
 }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -17,7 +17,10 @@ import '../../../globals.dart' as globals;
 ///
 /// Flutter also builds code assets for widget tests. Since there is no app build in that context,
 /// [cmakeDirectory] should be set to null for those builds.
-Future<CCompilerConfig?> cCompilerConfigLinux({Directory? cmakeDirectory}) async {
+Future<CCompilerConfig?> cCompilerConfigLinux({
+  Directory? cmakeDirectory,
+  bool throwIfNotFound = true,
+}) async {
   if (cmakeDirectory == null) {
     // No CMake reference (e.g. for a widget test). Hooks can resolve to any
     // compiler.
@@ -27,9 +30,12 @@ Future<CCompilerConfig?> cCompilerConfigLinux({Directory? cmakeDirectory}) async
   // For app builds, use the same compiler as the native/GTK parts of the app.
   final File cmakeCacheTxt = cmakeDirectory.childFile('CMakeCache.txt');
   if (!cmakeCacheTxt.existsSync()) {
-    throwToolExit(
-      'Could not read compiler configurations for build hooks, expected ${cmakeCacheTxt.path} to exist.',
-    );
+    if (throwIfNotFound) {
+      throwToolExit(
+        'Could not read compiler configurations for build hooks, expected ${cmakeCacheTxt.path} to exist.',
+      );
+    }
+    return null;
   }
 
   const archiverVariable = 'CMAKE_AR';
@@ -76,19 +82,26 @@ Future<CCompilerConfig?> cCompilerConfigLinux({Directory? cmakeDirectory}) async
     return file.uri;
   }
 
-  // Find clang next to the clang++ we use in CMake
-  File clangPpFile = globals.fs.file(requireTool(cxxCompiler, compilerVariable));
-  clangPpFile = globals.fs.file(await clangPpFile.resolveSymbolicLinks());
-  final File clangFile = clangPpFile.parent.childFile('clang');
-  if (!clangFile.existsSync()) {
-    throwToolExit('Expected to find clang next to ${clangPpFile.path}');
-  }
+  try {
+    // Find clang next to the clang++ we use in CMake
+    File clangPpFile = globals.fs.file(requireTool(cxxCompiler, compilerVariable));
+    clangPpFile = globals.fs.file(await clangPpFile.resolveSymbolicLinks());
+    final File clangFile = clangPpFile.parent.childFile('clang');
+    if (!clangFile.existsSync()) {
+      throwToolExit('Expected to find clang next to ${clangPpFile.path}');
+    }
 
-  return CCompilerConfig(
-    compiler: clangFile.uri,
-    linker: requireTool(linker, linkerVariable),
-    archiver: requireTool(archiver, archiverVariable),
-  );
+    return CCompilerConfig(
+      compiler: clangFile.uri,
+      linker: requireTool(linker, linkerVariable),
+      archiver: requireTool(archiver, archiverVariable),
+    );
+  } on ToolExit {
+    if (throwIfNotFound) {
+      rethrow;
+    }
+    return null;
+  }
 }
 
 // Format: `VARIABLE_NAME:TYPE=value`;

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -280,7 +280,7 @@ final class LinuxAssetTarget extends CodeAssetTarget {
 
     cCompilerConfigSync = await cCompilerConfigLinux(
       cmakeDirectory: isNativeAppBuild ? cmakeBuildDirectory : null,
-      throwIfNotFound: mustMatchAppBuild && isNativeAppBuild,
+      throwIfNotFound: mustMatchAppBuild,
     );
   }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -276,12 +276,11 @@ final class LinuxAssetTarget extends CodeAssetTarget {
 
   @override
   Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async {
-    if (cmakeBuildDirectory == null && mustMatchAppBuild) {
-      throw StateError('Missing CMake build directory on LinuxAssetTarget');
-    }
+    final bool isNativeAppBuild = cmakeBuildDirectory != null && cmakeBuildDirectory!.existsSync();
 
     cCompilerConfigSync = await cCompilerConfigLinux(
-      cmakeDirectory: mustMatchAppBuild ? cmakeBuildDirectory! : null,
+      cmakeDirectory: isNativeAppBuild ? cmakeBuildDirectory : null,
+      throwIfNotFound: mustMatchAppBuild && isNativeAppBuild,
     );
   }
 

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' as io;
+
 import 'package:code_assets/code_assets.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -289,6 +291,111 @@ CMAKE_LINKER:FILEPATH=/some/path/to/ld.lld
       expect(result, isNull);
     },
   );
+
+  testUsingContext(
+    'cCompilerConfigLinux FileSystemException on resolveSymbolicLinks and throwIfNotFound: false',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.empty(),
+      FileSystem: () => _ThrowingResolveFileSystem(
+            fileSystem,
+            '${environment.outputDir.path}/mock_clang++',
+          ),
+    },
+    () async {
+      if (!const LocalPlatform().isLinux) {
+        return;
+      }
+
+      await environment.outputDir.childFile('CMakeCache.txt').writeAsString('''
+CMAKE_CXX_COMPILER:FILEPATH=${environment.outputDir.path}/mock_clang++
+CMAKE_AR:FILEPATH=/some/path/to/llvm-ar
+CMAKE_LINKER:FILEPATH=/some/path/to/ld.lld
+''');
+
+      // Create the file so requireTool passes existsSync()
+      await environment.outputDir.childFile('mock_clang++').create();
+
+      final CCompilerConfig? result = await cCompilerConfigLinux(
+        cmakeDirectory: environment.outputDir,
+        throwIfNotFound: false,
+      );
+      expect(result, isNull);
+    },
+  );
+
+  testUsingContext(
+    'cCompilerConfigLinux FileSystemException on resolveSymbolicLinks and throwIfNotFound: true',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.empty(),
+      FileSystem: () => _ThrowingResolveFileSystem(
+            fileSystem,
+            '${environment.outputDir.path}/mock_clang++',
+          ),
+    },
+    () async {
+      if (!const LocalPlatform().isLinux) {
+        return;
+      }
+
+      await environment.outputDir.childFile('CMakeCache.txt').writeAsString('''
+CMAKE_CXX_COMPILER:FILEPATH=${environment.outputDir.path}/mock_clang++
+CMAKE_AR:FILEPATH=/some/path/to/llvm-ar
+CMAKE_LINKER:FILEPATH=/some/path/to/ld.lld
+''');
+
+      // Create the file so requireTool passes existsSync()
+      await environment.outputDir.childFile('mock_clang++').create();
+
+      expect(
+        cCompilerConfigLinux(cmakeDirectory: environment.outputDir),
+        throwsA(isA<FileSystemException>()),
+      );
+    },
+  );
 }
 
 class _BuildRunnerWithoutClang extends FakeFlutterNativeAssetsBuildRunner {}
+
+class _ThrowingResolveFileSystem extends ForwardingFileSystem {
+  _ThrowingResolveFileSystem(super.delegate, this.throwingPath);
+
+  final String throwingPath;
+
+  @override
+  File file(dynamic path) {
+    final File delegateFile = super.file(path);
+    if (delegateFile.path == throwingPath) {
+      return _ThrowingResolveFile(this, delegateFile);
+    }
+    return delegateFile;
+  }
+}
+
+class _ThrowingResolveFile extends ForwardingFileSystemEntity<File, io.File> with ForwardingFile {
+  _ThrowingResolveFile(this.fileSystem, this.delegate);
+
+  @override
+  final io.File delegate;
+
+  @override
+  final FileSystem fileSystem;
+
+  @override
+  File wrapFile(io.File delegate) => _ThrowingResolveFile(fileSystem, delegate);
+
+  @override
+  Directory wrapDirectory(io.Directory delegate) => throw UnimplementedError();
+
+  @override
+  Link wrapLink(io.Link delegate) => throw UnimplementedError();
+
+  @override
+  Future<String> resolveSymbolicLinks() async {
+    throw const FileSystemException('Mock FileSystemException during resolveSymbolicLinks');
+  }
+
+  @override
+  String resolveSymbolicLinksSync() {
+    throw const FileSystemException('Mock FileSystemException during resolveSymbolicLinksSync');
+  }
+}

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -180,7 +180,7 @@ CMAKE_LINKER:FILEPATH=/usr/bin/ld
 # CMAKE_LINKER:FILEPATH=/some/path/to/ld.lld
 ''');
 
-      expect(cCompilerConfigLinux(cmakeDirectory: environment.buildDir), throwsA(isA<ToolExit>()));
+      expect(cCompilerConfigLinux(cmakeDirectory: environment.outputDir), throwsA(isA<ToolExit>()));
     },
   );
 
@@ -201,7 +201,7 @@ CMAKE_AR:FILEPATH=/some/path/to/llvm-ar
 CMAKE_LINKER:FILEPATH=/some/path/to/ld.lld
 ''');
 
-      expect(cCompilerConfigLinux(cmakeDirectory: environment.buildDir), throwsA(isA<ToolExit>()));
+      expect(cCompilerConfigLinux(cmakeDirectory: environment.outputDir), throwsA(isA<ToolExit>()));
     },
   );
 
@@ -218,6 +218,75 @@ CMAKE_LINKER:FILEPATH=/some/path/to/ld.lld
 
       await fileSystem.file('/a/path/to/clang++').create(recursive: true);
       expect(cCompilerConfigLinux(), completes);
+    },
+  );
+
+  testUsingContext(
+    'cCompilerConfigLinux missing CMakeCache and throwIfNotFound: false',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.empty(),
+      FileSystem: () => fileSystem,
+    },
+    () async {
+      if (!const LocalPlatform().isLinux) {
+        return;
+      }
+
+      final CCompilerConfig? result = await cCompilerConfigLinux(
+        cmakeDirectory: environment.buildDir,
+        throwIfNotFound: false,
+      );
+      expect(result, isNull);
+    },
+  );
+
+  testUsingContext(
+    'cCompilerConfigLinux missing entry and throwIfNotFound: false',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.empty(),
+      FileSystem: () => fileSystem,
+    },
+    () async {
+      if (!const LocalPlatform().isLinux) {
+        return;
+      }
+
+      await environment.outputDir.childFile('CMakeCache.txt').writeAsString('''
+//CMAKE_CXX_COMPILER:FILEPATH=/some/path/to/clang++
+//CMAKE_AR:FILEPATH=/some/path/to/llvm-ar
+# CMAKE_LINKER:FILEPATH=/some/path/to/ld.lld
+''');
+
+      final CCompilerConfig? result = await cCompilerConfigLinux(
+        cmakeDirectory: environment.outputDir,
+        throwIfNotFound: false,
+      );
+      expect(result, isNull);
+    },
+  );
+
+  testUsingContext(
+    'cCompilerConfigLinux invalid paths and throwIfNotFound: false',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.empty(),
+      FileSystem: () => fileSystem,
+    },
+    () async {
+      if (!const LocalPlatform().isLinux) {
+        return;
+      }
+
+      await environment.outputDir.childFile('CMakeCache.txt').writeAsString('''
+CMAKE_CXX_COMPILER:FILEPATH=/some/path/to/clang++
+CMAKE_AR:FILEPATH=/some/path/to/llvm-ar
+CMAKE_LINKER:FILEPATH=/some/path/to/ld.lld
+''');
+
+      final CCompilerConfig? result = await cCompilerConfigLinux(
+        cmakeDirectory: environment.outputDir,
+        throwIfNotFound: false,
+      );
+      expect(result, isNull);
     },
   );
 }

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_without_cbuild_assemble_test.dart
@@ -54,6 +54,14 @@ void main() {
       codeSign: buildCommand != 'ios',
     );
   }
+
+  if (platform.isLinux) {
+    _testBuildBundle(
+      targetPlatform: 'linux-x64',
+      processManager: processManager,
+      hooksVersionConstraint: constraint,
+    );
+  }
 }
 
 void _testBuildCommand({
@@ -149,4 +157,70 @@ String _getPackageFfiTemplatePubspecVersion() {
   final dependencies = rootNode.nodes['dependencies']! as YamlMap;
   final version = dependencies['hooks']! as String;
   return version;
+}
+
+void _testBuildBundle({
+  required String targetPlatform,
+  required String hooksVersionConstraint,
+  required ProcessManager processManager,
+}) {
+  testWithoutContext(
+    'flutter build bundle --target-platform=$targetPlatform succeeds without libraries',
+    () async {
+      await inTempDir((Directory tempDirectory) async {
+        const packageName = 'uses_package_hooks';
+
+        // Create a new (plain Dart SDK) project.
+        await expectLater(
+          processManager.run(<String>[
+            flutterBin,
+            'create',
+            '--no-pub',
+            packageName,
+          ], workingDirectory: tempDirectory.path),
+          completion(const ProcessResultMatcher()),
+        );
+
+        final Directory packageDirectory = tempDirectory.childDirectory(packageName);
+
+        // Add hooks and resolve implicitly (pub add does pub get).
+        await expectLater(
+          processManager.run(<String>[
+            flutterBin,
+            'packages',
+            'add',
+            'hooks:$hooksVersionConstraint',
+          ], workingDirectory: packageDirectory.path),
+          completion(const ProcessResultMatcher()),
+        );
+
+        // Add a build hook that does nothing to the package.
+        packageDirectory.childDirectory('hook').childFile('build.dart')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+import 'package:hooks/hooks.dart';
+
+void main(List<String> args) async {
+  await build(args, (config, output) async {});
+}
+''');
+
+        // Try building bundle.
+        final args = <String>[
+          flutterBin,
+          'build',
+          'bundle',
+          '--target-platform=$targetPlatform',
+          '--debug',
+        ];
+        io.stderr.writeln('Running $args...');
+        final io.Process process = await processManager.start(
+          args,
+          workingDirectory: packageDirectory.path,
+          mode: ProcessStartMode.inheritStdio,
+        );
+        expect(await process.exitCode, 0);
+      });
+    },
+  );
 }


### PR DESCRIPTION
When native assets are enabled, the Flutter tool attempts to resolve the C compiler configuration. On Linux, this is done by reading `CMakeCache.txt` from the native build directory to align toolchains.

However, for custom devices or `flutter build bundle` commands, no native app build is performed, meaning `CMakeCache.txt` does not exist. This previously caused the tool to crash unconditionally.

This PR:
1. Adds a `throwIfNotFound` parameter to `cCompilerConfigLinux` (defaulting to `true`) to allow graceful failures (returning `null`) when the CMake cache or toolchain is missing.
2. Updates `LinuxAssetTarget.setCCompilerConfig` to only require the compiler configuration (passing `throwIfNotFound: true`) if a native app build directory actually exists. Otherwise, it allows it to be optional and return `null`.
3. Fixes and adds unit tests, and introduces a new integration test verifying that `flutter build bundle` succeeds on Linux with native assets.

Fixes https://github.com/flutter/flutter/issues/187980
