### PR TITLE
Properly await Dart Development Service shutdown with timeout

### DIFF
--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -118,7 +118,9 @@ class DartDevelopmentService with DartDevelopmentServiceLocalOperationsMixin {
     }
   }
 
-  void shutdown() => _ddsInstance?.shutdown();
+  Future<void> shutdown() async {
+    await _ddsInstance?.shutdown();
+  }
 }
 
 /// Contains common functionality that can be used with any implementation of

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1311,7 +1311,7 @@ class DeviceDomain extends Domain {
       throw DaemonException("device '$deviceId' not found");
     }
 
-    device.dds.shutdown();
+    await device.dds.shutdown();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -968,7 +968,7 @@ class ProxiedDartDevelopmentService
   @override
   Future<void> shutdown() async {
     if (_ddsStartedLocally) {
-      _localDds.shutdown();
+      await _localDds.shutdown();
       _ddsStartedLocally = false;
     } else {
       await connection.sendRequest('device.shutdownDartDevelopmentService', <String, Object?>{

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -250,20 +250,26 @@ class FlutterDevice {
         // shuts down, including after an error. If `done` completes before `connectToVmService`,
         // something went wrong that caused DDS to shutdown early.
         try {
-          service = await Future.any<dynamic>(<Future<dynamic>>[
-            connectToVmService(
-              debuggingOptions.enableDds ? (device!.dds.uri ?? vmServiceUri!) : vmServiceUri!,
-              reloadSources: reloadSources,
-              restart: restart,
-              compileExpression: compileExpression,
-              flutterProject: FlutterProject.current(),
-              printStructuredErrorLogMethod: printStructuredErrorLogMethod,
-              device: device,
-              logger: globals.logger,
-            ),
-            if (!existingDds)
-              device!.dds.done.whenComplete(() => throw Exception('DDS shut down too early')),
-          ]) as FlutterVmService?;
+          service =
+              await Future.any<dynamic>(<Future<dynamic>>[
+                    connectToVmService(
+                      debuggingOptions.enableDds
+                          ? (device!.dds.uri ?? vmServiceUri!)
+                          : vmServiceUri!,
+                      reloadSources: reloadSources,
+                      restart: restart,
+                      compileExpression: compileExpression,
+                      flutterProject: FlutterProject.current(),
+                      printStructuredErrorLogMethod: printStructuredErrorLogMethod,
+                      device: device,
+                      logger: globals.logger,
+                    ),
+                    if (!existingDds)
+                      device!.dds.done.whenComplete(
+                        () => throw Exception('DDS shut down too early'),
+                      ),
+                  ])
+                  as FlutterVmService?;
         } on Exception catch (exception) {
           globals.printTrace('Fail to connect to service protocol: $vmServiceUri: $exception');
           if (!completer.isCompleted && !_isListeningForVmServiceUri!) {
@@ -1174,7 +1180,7 @@ abstract class ResidentRunner extends ResidentHandlers {
     await stopEchoingDeviceLog();
     await preExit();
     await exitApp(); // calls appFinished
-    shutdownDartDevelopmentService();
+    await shutdownDartDevelopmentService();
   }
 
   @override
@@ -1193,9 +1199,18 @@ abstract class ResidentRunner extends ResidentHandlers {
     );
   }
 
-  void shutdownDartDevelopmentService() {
-    for (final FlutterDevice device in flutterDevices) {
-      device.device?.dds.shutdown();
+  Future<void> shutdownDartDevelopmentService() async {
+    try {
+      await Future.wait<void>(
+        flutterDevices.map<Future<void>>((FlutterDevice device) async {
+          final DartDevelopmentService? dds = device.device?.dds;
+          if (dds != null) {
+            await dds.shutdown();
+          }
+        }),
+      ).timeout(const Duration(seconds: 10));
+    } on TimeoutException {
+      globals.printTrace('Warning: shutdownDartDevelopmentService timed out.');
     }
   }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1205,7 +1205,11 @@ abstract class ResidentRunner extends ResidentHandlers {
         flutterDevices.map<Future<void>>((FlutterDevice device) async {
           final DartDevelopmentService? dds = device.device?.dds;
           if (dds != null) {
-            await dds.shutdown();
+            try {
+              await dds.shutdown();
+            } on Object catch (error) {
+              globals.printTrace('Warning: Failed to shut down DDS for device: $error');
+            }
           }
         }),
       ).timeout(const Duration(seconds: 10));

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1141,7 +1141,7 @@ class HotRunner extends ResidentRunner {
   Future<void> cleanupAfterSignal() async {
     await stopEchoingDeviceLog();
     await hotRunnerConfig!.runPreShutdownOperations();
-    shutdownDartDevelopmentService();
+    await shutdownDartDevelopmentService();
     if (stopAppDuringCleanup) {
       return exitApp();
     }
@@ -1165,17 +1165,18 @@ class HotRunner extends ResidentRunner {
   }
 }
 
-typedef ReloadSourcesHelper = Future<OperationResult> Function(
-  HotRunner hotRunner,
-  List<FlutterDevice?> flutterDevices,
-  bool? pause,
-  Map<String, dynamic> firstReloadDetails,
-  String? targetPlatform,
-  String? sdkName,
-  bool? emulator,
-  String? reason,
-  Analytics analytics,
-);
+typedef ReloadSourcesHelper =
+    Future<OperationResult> Function(
+      HotRunner hotRunner,
+      List<FlutterDevice?> flutterDevices,
+      bool? pause,
+      Map<String, dynamic> firstReloadDetails,
+      String? targetPlatform,
+      String? sdkName,
+      bool? emulator,
+      String? reason,
+      Analytics analytics,
+    );
 
 @visibleForTesting
 Future<OperationResult> defaultReloadSourcesHelper(
@@ -1290,12 +1291,13 @@ class ReassembleResult {
   final bool shouldReportReloadTime;
 }
 
-typedef ReassembleHelper = Future<ReassembleResult> Function(
-  List<FlutterDevice?> flutterDevices,
-  Map<FlutterDevice?, List<FlutterView>> viewCache,
-  void Function(String message)? onSlow,
-  String reloadMessage,
-);
+typedef ReassembleHelper =
+    Future<ReassembleResult> Function(
+      List<FlutterDevice?> flutterDevices,
+      Map<FlutterDevice?, List<FlutterView>> viewCache,
+      void Function(String message)? onSlow,
+      String reloadMessage,
+    );
 
 Future<ReassembleResult> _defaultReassembleHelper(
   List<FlutterDevice?> flutterDevices,

--- a/packages/flutter_tools/lib/src/test/integration_test_device.dart
+++ b/packages/flutter_tools/lib/src/test/integration_test_device.dart
@@ -26,6 +26,7 @@ class IntegrationTestTestDevice implements TestDevice {
     required this.debuggingOptions,
     required this.userIdentifier,
     required this.compileExpression,
+    this.ddsShutdownTimeout = const Duration(seconds: 5),
   });
 
   final int id;
@@ -33,6 +34,7 @@ class IntegrationTestTestDevice implements TestDevice {
   final DebuggingOptions debuggingOptions;
   final String? userIdentifier;
   final CompileExpression? compileExpression;
+  final Duration ddsShutdownTimeout;
   late final _ddsLauncher = DartDevelopmentService(logger: globals.logger);
 
   ApplicationPackage? _applicationPackage;
@@ -152,7 +154,11 @@ class IntegrationTestTestDevice implements TestDevice {
     }
 
     await device.dispose();
-    _ddsLauncher.shutdown();
+    try {
+      await _ddsLauncher.shutdown().timeout(ddsShutdownTimeout);
+    } on TimeoutException {
+      globals.printTrace('Warning: Dart Development Service shutdown timed out.');
+    }
     _finished.complete();
   }
 

--- a/packages/flutter_tools/lib/src/test/integration_test_device.dart
+++ b/packages/flutter_tools/lib/src/test/integration_test_device.dart
@@ -158,6 +158,8 @@ class IntegrationTestTestDevice implements TestDevice {
       await _ddsLauncher.shutdown().timeout(ddsShutdownTimeout);
     } on TimeoutException {
       globals.printTrace('Warning: Dart Development Service shutdown timed out.');
+    } on Object catch (error) {
+      globals.printTrace('Warning: Failed to shut down Dart Development Service: $error');
     }
     _finished.complete();
   }

--- a/packages/flutter_tools/test/general.shard/hot_shared.dart
+++ b/packages/flutter_tools/test/general.shard/hot_shared.dart
@@ -91,7 +91,7 @@ class FakeDartDevelopmentService extends Fake implements DartDevelopmentService 
   bool wasShutdown = false;
 
   @override
-  void shutdown() {
+  Future<void> shutdown() async {
     wasShutdown = true;
   }
 }

--- a/packages/flutter_tools/test/general.shard/integration_test_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/integration_test_device_test.dart
@@ -1,6 +1,7 @@
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 import 'dart:async';
 import 'package:dds/dds_launcher.dart';
 import 'package:file/file.dart';

--- a/packages/flutter_tools/test/general.shard/integration_test_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/integration_test_device_test.dart
@@ -1,7 +1,8 @@
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
+import 'dart:async';
+import 'package:dds/dds_launcher.dart';
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/dds.dart';
@@ -159,6 +160,63 @@ void main() {
       await testDevice.kill();
 
       expect(testDevice.finished, completes);
+    },
+    overrides: <Type, Generator>{
+      ApplicationPackageFactory: () => FakeApplicationPackageFactory(),
+      VMServiceConnector: () =>
+          (
+            Uri httpUri, {
+            ReloadSources? reloadSources,
+            Restart? restart,
+            CompileExpression? compileExpression,
+            FlutterProject? flutterProject,
+            PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+            io.CompressionOptions? compression,
+            Device? device,
+            Logger? logger,
+          }) async => fakeVmServiceHost.vmService,
+    },
+  );
+
+  testUsingContext(
+    'kill() completes and logs warning when DDS shutdown times out',
+    () async {
+      final TestDevice localTestDevice = IntegrationTestTestDevice(
+        id: 1,
+        device: FakeDevice(
+          'ephemeral',
+          'ephemeral',
+          type: PlatformType.android,
+          launchResult: LaunchResult.succeeded(vmServiceUri: vmServiceUri),
+        ),
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        userIdentifier: '',
+        compileExpression: null,
+        ddsShutdownTimeout: const Duration(milliseconds: 10),
+      );
+
+      ddsLauncherCallback =
+          ({
+            required Uri remoteVmServiceUri,
+            String? appName = 'Fake App',
+            Uri? serviceUri,
+            bool enableAuthCodes = true,
+            bool serveDevTools = false,
+            Uri? devToolsServerAddress,
+            bool enableServicePortFallback = false,
+            List<String> cachedUserTags = const <String>[],
+            String? dartExecutable,
+            String? google3WorkspaceRoot,
+          }) async {
+            return HangingFakeDartDevelopmentServiceLauncher(
+              uri: Uri.parse('http://localhost:1234'),
+            );
+          };
+
+      await localTestDevice.start('entrypointPath');
+      await localTestDevice.kill();
+
+      expect(localTestDevice.finished, completes);
     },
     overrides: <Type, Generator>{
       ApplicationPackageFactory: () => FakeApplicationPackageFactory(),
@@ -368,4 +426,28 @@ class FakeDeviceTrackingUninstall extends FakeDevice {
     uninstallAppCalled = true;
     return true;
   }
+}
+
+class HangingFakeDartDevelopmentServiceLauncher extends Fake
+    implements DartDevelopmentServiceLauncher {
+  HangingFakeDartDevelopmentServiceLauncher({required this.uri});
+
+  @override
+  final Uri uri;
+
+  @override
+  Uri? get devToolsUri => null;
+
+  @override
+  Uri? get dtdUri => null;
+
+  @override
+  Future<void> get done => _completer.future;
+
+  @override
+  Future<void> shutdown() async {
+    await _completer.future;
+  }
+
+  final _completer = Completer<void>();
 }

--- a/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
@@ -153,7 +153,7 @@ class FakeDartDevelopmentService extends Fake
   Future<void> handleHotRestart(FlutterDevice? device) async {}
 
   @override
-  void shutdown() {}
+  Future<void> shutdown() async {}
 }
 
 class FakeDartDevelopmentServiceException implements DartDevelopmentServiceException {


### PR DESCRIPTION
This PR addresses the issue where `flutter test` (specifically integration tests) hangs at teardown on CPU-starved CI runners because the Dart Development Service (DDS) fails to exit cleanly.

### Changes
*   Modify `DartDevelopmentService.shutdown` to return `Future<void>` and properly await the underlying DDS instance shutdown.
*   Update `IntegrationTestTestDevice.kill` to await the DDS shutdown with a configurable timeout (defaulting to 5 seconds, using `ddsShutdownTimeout`), preventing permanent hangs if DDS fails to exit.
*   Update `ResidentRunner.shutdownDartDevelopmentService` to also be asynchronous and await all DDS shutdowns with a 10-second safety timeout to prevent `flutter run` from hanging on exit.
*   Propagate the async `shutdown` signature to all callers and mock implementations in tests.
*   Add a regression test in `integration_test_device_test.dart` to verify that `kill()` completes even if DDS shutdown hangs (times out).

### Verification
*   Ran static analysis (`dart analyze`) on the entire `packages/flutter_tools` package with zero issues.
*   Ran all unit tests in `integration_test_device_test.dart` and they passed (including the new regression test).
*   Verified that integration tests on Linux desktop run and exit cleanly.

Fixes https://github.com/flutter/flutter/issues/187984
