### PR TITLE
Fix segfault on Win32 cause by the sized-to-content delegate being invalid

### DIFF
--- a/engine/src/flutter/shell/platform/windows/host_window_dialog.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_dialog.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/windows/host_window_dialog.h"
 
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
+#include "flutter/shell/platform/windows/flutter_windows_view_controller.h"
 #include "flutter/shell/platform/windows/window_proc_delegate_manager.h"
 
 namespace flutter {
@@ -70,6 +71,13 @@ HostWindowDialog::HostWindowDialog(WindowManager* window_manager,
   if (owner_window) {
     UpdateModalState();
   }
+}
+
+HostWindowDialog::~HostWindowDialog() {
+  // Reset the view while this most-derived object is still fully alive, to stop
+  // the raster thread from sizing it before any subobject is torn down. See the
+  // destructor comment in host_window_sized.h for the rationale.
+  view_controller_.reset();
 }
 
 Rect HostWindowDialog::GetInitialRect(FlutterWindowsEngine* engine,

--- a/engine/src/flutter/shell/platform/windows/host_window_dialog.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_dialog.h
@@ -35,6 +35,8 @@ class HostWindowDialog : public HostWindowSized {
                    bool sized_to_content,
                    bool resizable);
 
+  ~HostWindowDialog() override;
+
   void SetFullscreen(bool fullscreen,
                      std::optional<FlutterEngineDisplayId> display_id) override;
   bool GetFullscreen() const override;

--- a/engine/src/flutter/shell/platform/windows/host_window_popup.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_popup.cc
@@ -15,11 +15,10 @@ HostWindowPopup::HostWindowPopup(
     const BoxConstraints& constraints,
     GetWindowPositionCallback get_position_callback,
     HWND parent)
-    : HostWindow(window_manager, engine),
+    : HostWindowSized(window_manager, engine, /*resizable=*/false),
       get_position_callback_(get_position_callback),
       parent_(parent),
-      isolate_(Isolate::Current()),
-      view_alive_(std::make_shared<int>(0)) {
+      isolate_(Isolate::Current()) {
   // Use minimum constraints as initial size to ensure the view can be created
   // with valid metrics. The size will be updated when content is rendered.
   auto const initial_width =
@@ -36,45 +35,13 @@ HostWindowPopup::HostWindowPopup(
       .title = L"",
       .owner_window = parent,
       .nCmdShow = SW_SHOWNOACTIVATE,
-      .sizing_delegate = this,
+      .sizing_delegate = AsSizingDelegate(),
       .is_sized_to_content = true});
 }
 
-HostWindowPopup::~HostWindowPopup() {
-  // Destroy the view (and therefore the raster thread's access to this object
-  // as a sizing delegate) while this HostWindowPopup is still fully alive.
-  //
-  // This popup is itself the view's FlutterWindowsViewSizingDelegate. The view
-  // is owned by |view_controller_|, a member of the HostWindow base class,
-  // which would otherwise be destroyed *after* this derived object's
-  // FlutterWindowsViewSizingDelegate subobject. Resetting it here triggers
-  // FlutterWindowsEngine::RemoveView, which guarantees the raster thread no
-  // longer presents to (or sizes) this view, before the sizing delegate is
-  // torn down. Without this, the raster thread's sized-to-content path can
-  // call into a destroyed sizing delegate and crash.
-  view_controller_.reset();
-}
-
-void HostWindowPopup::DidUpdateViewSize(int32_t width, int32_t height) {
-  // This is called from the raster thread.
-  std::weak_ptr<int> weak_view_alive = view_alive_;
-  engine_->task_runner()->PostTask([this, width, height, weak_view_alive]() {
-    auto const view_alive = weak_view_alive.lock();
-    if (!view_alive) {
-      return;
-    }
-    if (width_ == width && height_ == height) {
-      return;
-    }
-
-    if (is_being_destroyed_) {
-      return;
-    }
-
-    width_ = width;
-    height_ = height;
-    UpdatePosition();
-  });
+void HostWindowPopup::ApplyContentSize(int32_t physical_width,
+                                       int32_t physical_height) {
+  UpdatePosition();
 }
 
 WindowRect HostWindowPopup::GetWorkArea() const {
@@ -117,7 +84,7 @@ void HostWindowPopup::UpdatePosition() {
   // rect goes out of scope.
   std::unique_ptr<WindowRect, decltype(&free)> rect(
       get_position_callback_(
-          WindowSize{width_, height_},
+          WindowSize{physical_width_, physical_height_},
           WindowRect{parent_top_left.x, parent_top_left.y,
                      parent_bottom_right.x - parent_top_left.x,
                      parent_bottom_right.y - parent_top_left.y},
@@ -128,7 +95,7 @@ void HostWindowPopup::UpdatePosition() {
 
   // The positioner constrained the dimensions more than current size, apply
   // positioner constraints.
-  if (rect->width < width_ || rect->height < height_) {
+  if (rect->width < physical_width_ || rect->height < physical_height_) {
     auto metrics_event = view_controller_->view()->CreateWindowMetricsEvent();
     view_controller_->engine()->SendWindowMetricsEvent(metrics_event);
   }

--- a/engine/src/flutter/shell/platform/windows/host_window_popup.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_popup.cc
@@ -39,6 +39,14 @@ HostWindowPopup::HostWindowPopup(
       .is_sized_to_content = true});
 }
 
+HostWindowPopup::~HostWindowPopup() {
+  // Reset the view while this most-derived object is still fully alive, to stop
+  // the raster thread from sizing it (via the overridden ApplyContentSize /
+  // GetWorkArea) before any subobject is torn down. See the destructor comment
+  // in host_window_sized.h for the rationale.
+  view_controller_.reset();
+}
+
 void HostWindowPopup::ApplyContentSize(int32_t physical_width,
                                        int32_t physical_height) {
   UpdatePosition();

--- a/engine/src/flutter/shell/platform/windows/host_window_popup.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_popup.cc
@@ -40,6 +40,21 @@ HostWindowPopup::HostWindowPopup(
       .is_sized_to_content = true});
 }
 
+HostWindowPopup::~HostWindowPopup() {
+  // Destroy the view (and therefore the raster thread's access to this object
+  // as a sizing delegate) while this HostWindowPopup is still fully alive.
+  //
+  // This popup is itself the view's FlutterWindowsViewSizingDelegate. The view
+  // is owned by |view_controller_|, a member of the HostWindow base class,
+  // which would otherwise be destroyed *after* this derived object's
+  // FlutterWindowsViewSizingDelegate subobject. Resetting it here triggers
+  // FlutterWindowsEngine::RemoveView, which guarantees the raster thread no
+  // longer presents to (or sizes) this view, before the sizing delegate is
+  // torn down. Without this, the raster thread's sized-to-content path can
+  // call into a destroyed sizing delegate and crash.
+  view_controller_.reset();
+}
+
 void HostWindowPopup::DidUpdateViewSize(int32_t width, int32_t height) {
   // This is called from the raster thread.
   std::weak_ptr<int> weak_view_alive = view_alive_;

--- a/engine/src/flutter/shell/platform/windows/host_window_popup.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_popup.h
@@ -21,6 +21,8 @@ class HostWindowPopup : public HostWindow,
                   GetWindowPositionCallback get_position_callback,
                   HWND parent);
 
+  ~HostWindowPopup() override;
+
   // Update the position of the popup window based off the current size
   // of the popup.
   void UpdatePosition();

--- a/engine/src/flutter/shell/platform/windows/host_window_popup.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_popup.h
@@ -24,6 +24,8 @@ class HostWindowPopup : public HostWindowSized {
   // of the popup.
   void UpdatePosition();
 
+  ~HostWindowPopup() override;
+
  protected:
   void ApplyContentSize(int32_t physical_width,
                         int32_t physical_height) override;

--- a/engine/src/flutter/shell/platform/windows/host_window_popup.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_popup.h
@@ -6,13 +6,12 @@
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_HOST_WINDOW_POPUP_H_
 
 #include <cstdint>
-#include "host_window.h"
+#include "host_window_sized.h"
 #include "shell/platform/windows/flutter_windows_view.h"
 #include "shell/platform/windows/window_manager.h"
 
 namespace flutter {
-class HostWindowPopup : public HostWindow,
-                        private FlutterWindowsViewSizingDelegate {
+class HostWindowPopup : public HostWindowSized {
  public:
   // Creates a popup window.
   HostWindowPopup(WindowManager* window_manager,
@@ -21,29 +20,20 @@ class HostWindowPopup : public HostWindow,
                   GetWindowPositionCallback get_position_callback,
                   HWND parent);
 
-  ~HostWindowPopup() override;
-
   // Update the position of the popup window based off the current size
   // of the popup.
   void UpdatePosition();
 
+ protected:
+  void ApplyContentSize(int32_t physical_width,
+                        int32_t physical_height) override;
+
  private:
-  void DidUpdateViewSize(int32_t width, int32_t height) override;
   WindowRect GetWorkArea() const override;
 
   GetWindowPositionCallback get_position_callback_;
   HWND parent_;
   Isolate isolate_;
-
-  // Used to track whether the view is still in tasks scheduled from raster
-  // thread.
-  std::shared_ptr<int> view_alive_;
-
-  // The current width of the popup.
-  int width_ = 0;
-
-  // The current height of the popup.
-  int height_ = 0;
 };
 }  // namespace flutter
 

--- a/engine/src/flutter/shell/platform/windows/host_window_regular.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_regular.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/windows/host_window_regular.h"
 
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
+#include "flutter/shell/platform/windows/flutter_windows_view_controller.h"
 
 namespace flutter {
 
@@ -46,6 +47,13 @@ HostWindowRegular::HostWindowRegular(WindowManager* window_manager,
       .sizing_delegate = sized_to_content ? AsSizingDelegate() : nullptr,
       .is_sized_to_content = sized_to_content,
   });
+}
+
+HostWindowRegular::~HostWindowRegular() {
+  // Reset the view while this most-derived object is still fully alive, to stop
+  // the raster thread from sizing it before any subobject is torn down. See the
+  // destructor comment in host_window_sized.h for the rationale.
+  view_controller_.reset();
 }
 
 Rect HostWindowRegular::GetInitialRect(FlutterWindowsEngine* engine,

--- a/engine/src/flutter/shell/platform/windows/host_window_regular.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_regular.h
@@ -29,6 +29,8 @@ class HostWindowRegular : public HostWindowSized {
                     bool sized_to_content,
                     bool resizable);
 
+  ~HostWindowRegular() override;
+
  private:
   static Rect GetInitialRect(FlutterWindowsEngine* engine,
                              const WindowSizeRequest& preferred_size,

--- a/engine/src/flutter/shell/platform/windows/host_window_sized.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_sized.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/windows/host_window_sized.h"
+#include "flutter/fml/logging.h"
 #include "flutter/shell/platform/windows/dpi_utils.h"
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 #include "flutter/shell/platform/windows/flutter_windows_view_controller.h"
@@ -17,24 +18,14 @@ HostWindowSized::HostWindowSized(WindowManager* window_manager,
       view_alive_(std::make_shared<int>(0)) {}
 
 HostWindowSized::~HostWindowSized() {
-  // Destroy the view (and therefore the raster thread's access to this object
-  // as a sizing delegate) while this object is still fully alive.
-  //
-  // When sized to content, this object is the view's
-  // FlutterWindowsViewSizingDelegate. The view is owned by |view_controller_|,
-  // a member of the HostWindow base class, which would otherwise be destroyed
-  // *after* this object's FlutterWindowsViewSizingDelegate subobject. Resetting
-  // it here triggers FlutterWindowsEngine::RemoveView, which guarantees the
-  // raster thread no longer presents to (or sizes) this view, before the
-  // sizing delegate is torn down. Without this, the raster thread's
-  // sized-to-content path can call into a destroyed sizing delegate and crash.
-  //
-  // Subclasses (e.g. HostWindowPopup, HostWindowTooltip) must not define their
-  // own destructor for this purpose: the sizing-delegate entry point
-  // (DidUpdateViewSize) lives in this class, so resetting the view here, in the
-  // most-derived sizing-delegate owner's destructor, is sufficient to stop the
-  // raster thread before any subobject is destroyed.
-  view_controller_.reset();
+  // By the time the base destructor runs, the most-derived class must have
+  // already reset |view_controller_| (and therefore stopped the raster thread
+  // from sizing this object). See the destructor comment in host_window_sized.h
+  // for the rationale. If this fires, a HostWindowSized subclass is missing the
+  // required |view_controller_.reset()| at the start of its destructor.
+  FML_DCHECK(!view_controller_)
+      << "HostWindowSized subclass must reset view_controller_ in its "
+         "destructor.";
 }
 
 void HostWindowSized::DidUpdateViewSize(int32_t width, int32_t height) {

--- a/engine/src/flutter/shell/platform/windows/host_window_sized.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_sized.cc
@@ -16,6 +16,21 @@ HostWindowSized::HostWindowSized(WindowManager* window_manager,
       resizable_(resizable),
       view_alive_(std::make_shared<int>(0)) {}
 
+HostWindowSized::~HostWindowSized() {
+  // Destroy the view (and therefore the raster thread's access to this object
+  // as a sizing delegate) while this HostWindowSized is still fully alive.
+  //
+  // When sized to content, this object is the view's
+  // FlutterWindowsViewSizingDelegate. The view is owned by |view_controller_|,
+  // a member of the HostWindow base class, which would otherwise be destroyed
+  // *after* this object's FlutterWindowsViewSizingDelegate subobject. Resetting
+  // it here triggers FlutterWindowsEngine::RemoveView, which guarantees the
+  // raster thread no longer presents to (or sizes) this view, before the
+  // sizing delegate is torn down. Without this, the raster thread's
+  // sized-to-content path can call into a destroyed sizing delegate and crash.
+  view_controller_.reset();
+}
+
 void HostWindowSized::DidUpdateViewSize(int32_t width, int32_t height) {
   // This is called from the raster thread.
   std::weak_ptr<int> weak_view_alive = view_alive_;

--- a/engine/src/flutter/shell/platform/windows/host_window_sized.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_sized.cc
@@ -18,7 +18,7 @@ HostWindowSized::HostWindowSized(WindowManager* window_manager,
 
 HostWindowSized::~HostWindowSized() {
   // Destroy the view (and therefore the raster thread's access to this object
-  // as a sizing delegate) while this HostWindowSized is still fully alive.
+  // as a sizing delegate) while this object is still fully alive.
   //
   // When sized to content, this object is the view's
   // FlutterWindowsViewSizingDelegate. The view is owned by |view_controller_|,
@@ -28,6 +28,12 @@ HostWindowSized::~HostWindowSized() {
   // raster thread no longer presents to (or sizes) this view, before the
   // sizing delegate is torn down. Without this, the raster thread's
   // sized-to-content path can call into a destroyed sizing delegate and crash.
+  //
+  // Subclasses (e.g. HostWindowPopup, HostWindowTooltip) must not define their
+  // own destructor for this purpose: the sizing-delegate entry point
+  // (DidUpdateViewSize) lives in this class, so resetting the view here, in the
+  // most-derived sizing-delegate owner's destructor, is sufficient to stop the
+  // raster thread before any subobject is destroyed.
   view_controller_.reset();
 }
 
@@ -39,40 +45,46 @@ void HostWindowSized::DidUpdateViewSize(int32_t width, int32_t height) {
     if (!view_alive) {
       return;
     }
-    if (physical_width_ == width && physical_width_ == height) {
+    if (physical_width_ == width && physical_height_ == height) {
       return;
     }
     if (is_being_destroyed_) {
       return;
     }
     physical_width_ = width;
-    physical_width_ = height;
+    physical_height_ = height;
 
-    WINDOWINFO window_info = {.cbSize = sizeof(WINDOWINFO)};
-    GetWindowInfo(window_handle_, &window_info);
-
-    // Convert physical pixels to logical pixels.
-    UINT const dpi = GetDpiForHWND(window_handle_);
-    double const scale = static_cast<double>(dpi > 0 ? dpi : 96) / 96.0;
-    std::optional<Size> const window_size = GetWindowSizeForClientSize(
-        *engine_->windows_proc_table(), Size(width / scale, height / scale),
-        box_constraints_.smallest(), box_constraints_.biggest(),
-        window_info.dwStyle, window_info.dwExStyle, nullptr);
-
-    if (!window_size) {
-      return;
-    }
-
-    SetWindowPos(window_handle_, NULL, 0, 0, window_size->width(),
-                 window_size->height(),
-                 SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-
-    if (resizable_) {
-      // For resizable windows, stop tracking content size after the initial
-      // frame so subsequent user-initiated resizes are forwarded to Flutter.
-      view_controller_->view()->SetSizedToContent(false);
-    }
+    ApplyContentSize(width, height);
   });
+}
+
+void HostWindowSized::ApplyContentSize(int32_t physical_width,
+                                       int32_t physical_height) {
+  WINDOWINFO window_info = {.cbSize = sizeof(WINDOWINFO)};
+  GetWindowInfo(window_handle_, &window_info);
+
+  // Convert physical pixels to logical pixels.
+  UINT const dpi = GetDpiForHWND(window_handle_);
+  double const scale = static_cast<double>(dpi > 0 ? dpi : 96) / 96.0;
+  std::optional<Size> const window_size = GetWindowSizeForClientSize(
+      *engine_->windows_proc_table(),
+      Size(physical_width / scale, physical_height / scale),
+      box_constraints_.smallest(), box_constraints_.biggest(),
+      window_info.dwStyle, window_info.dwExStyle, nullptr);
+
+  if (!window_size) {
+    return;
+  }
+
+  SetWindowPos(window_handle_, NULL, 0, 0, window_size->width(),
+               window_size->height(),
+               SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+
+  if (resizable_) {
+    // For resizable windows, stop tracking content size after the initial
+    // frame so subsequent user-initiated resizes are forwarded to Flutter.
+    view_controller_->view()->SetSizedToContent(false);
+  }
 }
 
 WindowRect HostWindowSized::GetWorkArea() const {

--- a/engine/src/flutter/shell/platform/windows/host_window_sized.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_sized.h
@@ -27,6 +27,8 @@ class HostWindowSized : public HostWindow,
                   FlutterWindowsEngine* engine,
                   bool resizable);
 
+  ~HostWindowSized() override;
+
   // Returns a pointer to this as a FlutterWindowsViewSizingDelegate, for use
   // as HostWindowInitializationParams::sizing_delegate. This is necessary
   // because FlutterWindowsViewSizingDelegate is a private base of this class

--- a/engine/src/flutter/shell/platform/windows/host_window_sized.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_sized.h
@@ -29,7 +29,28 @@ class HostWindowSized : public HostWindow,
                   FlutterWindowsEngine* engine,
                   bool resizable);
 
-  ~HostWindowSized() override;
+  // Pure virtual to make HostWindowSized abstract: only the concrete
+  // archetypes (HostWindowRegular, HostWindowDialog, HostWindowPopup,
+  // HostWindowTooltip) may be instantiated.
+  //
+  // Each derived class must reset |view_controller_| at the very start of its
+  // own destructor, while the most-derived object is still fully alive.
+  //
+  // When sized to content, this object is the view's
+  // FlutterWindowsViewSizingDelegate, and the view (owned by
+  // |view_controller_|, a member of the HostWindow base class) drives sizing
+  // from the raster thread via DidUpdateViewSize -> ApplyContentSize /
+  // GetWorkArea. Several of these entry points are overridden by derived
+  // classes. If the view were destroyed by the HostWindow base destructor
+  // instead, it would run *after* the derived destructor: by then the derived
+  // subobject (and its vtable overrides) is gone, so an in-flight raster-thread
+  // sizing call could land in a destroyed object and crash. Resetting
+  // |view_controller_| in the derived destructor triggers
+  // FlutterWindowsEngine::RemoveView, which guarantees the raster thread no
+  // longer presents to (or sizes) this view before any subobject is torn down.
+  //
+  // The base destructor asserts that |view_controller_| has already been reset.
+  ~HostWindowSized() override = 0;
 
   // Returns a pointer to this as a FlutterWindowsViewSizingDelegate, for use
   // as HostWindowInitializationParams::sizing_delegate. This is necessary

--- a/engine/src/flutter/shell/platform/windows/host_window_sized.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_sized.h
@@ -12,14 +12,16 @@
 
 namespace flutter {
 
-// Base class for HostWindowRegular and HostWindowDialog.
+// Base class for the sized-to-content archetypes: HostWindowRegular,
+// HostWindowDialog, HostWindowPopup, and HostWindowTooltip.
 //
-// Provides the shared sized-to-content implementation used by both archetypes:
-// tracking the last rendered content size, calling SetContentSize() after each
-// frame, and optionally disabling content-size tracking once the user resizes
-// the window. HostWindowPopup and HostWindowTooltip are not derived from this
-// class because they position themselves relative to a parent window rather
-// than sizing to their own content.
+// Provides the shared sized-to-content implementation used by these
+// archetypes: tracking the last rendered content size and reacting to it after
+// each frame. The default reaction resizes the window in place and optionally
+// disables content-size tracking once the user resizes the window.
+// HostWindowPopup and HostWindowTooltip override ApplyContentSize() to instead
+// reposition themselves relative to a parent window whenever their content
+// size changes.
 class HostWindowSized : public HostWindow,
                         private FlutterWindowsViewSizingDelegate {
  protected:
@@ -34,6 +36,14 @@ class HostWindowSized : public HostWindow,
   // because FlutterWindowsViewSizingDelegate is a private base of this class
   // and the conversion is therefore inaccessible to derived classes.
   FlutterWindowsViewSizingDelegate* AsSizingDelegate() { return this; }
+
+  // Called on the platform thread after the rendered content size has changed
+  // to |physical_width| x |physical_height| (in physical pixels). The base
+  // implementation resizes the window in place to fit the content and, for
+  // resizable windows, stops tracking content size after the initial frame.
+  // Subclasses that position themselves relative to a parent override this.
+  virtual void ApplyContentSize(int32_t physical_width,
+                                int32_t physical_height);
 
   // Whether the user can manually resize this window.
   const bool resizable_;

--- a/engine/src/flutter/shell/platform/windows/host_window_tooltip.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_tooltip.cc
@@ -14,11 +14,10 @@ HostWindowTooltip::HostWindowTooltip(
     const BoxConstraints& constraints,
     GetWindowPositionCallback get_position_callback,
     HWND parent)
-    : HostWindow(window_manager, engine),
+    : HostWindowSized(window_manager, engine, /*resizable=*/false),
       get_position_callback_(get_position_callback),
       parent_(parent),
-      isolate_(Isolate::Current()),
-      view_alive_(std::make_shared<int>(0)) {
+      isolate_(Isolate::Current()) {
   // Use minimum constraints as initial size to ensure the view can be created
   // with valid metrics.
   auto const initial_width =
@@ -35,47 +34,15 @@ HostWindowTooltip::HostWindowTooltip(
       .title = L"",
       .owner_window = parent,
       .nCmdShow = SW_SHOWNOACTIVATE,
-      .sizing_delegate = this,
+      .sizing_delegate = AsSizingDelegate(),
       .is_sized_to_content = true});
   SetWindowLongPtr(window_handle_, GWLP_HWNDPARENT,
                    reinterpret_cast<LONG_PTR>(parent_));
 }
 
-HostWindowTooltip::~HostWindowTooltip() {
-  // Destroy the view (and therefore the raster thread's access to this object
-  // as a sizing delegate) while this HostWindowTooltip is still fully alive.
-  //
-  // This tooltip is itself the view's FlutterWindowsViewSizingDelegate. The
-  // view is owned by |view_controller_|, a member of the HostWindow base class,
-  // which would otherwise be destroyed *after* this derived object's
-  // FlutterWindowsViewSizingDelegate subobject. Resetting it here triggers
-  // FlutterWindowsEngine::RemoveView, which guarantees the raster thread no
-  // longer presents to (or sizes) this view, before the sizing delegate is
-  // torn down. Without this, the raster thread's sized-to-content path can
-  // call into a destroyed sizing delegate and crash.
-  view_controller_.reset();
-}
-
-void HostWindowTooltip::DidUpdateViewSize(int32_t width, int32_t height) {
-  // This is called from the raster thread.
-  std::weak_ptr<int> weak_view_alive = view_alive_;
-  engine_->task_runner()->PostTask([this, width, height, weak_view_alive]() {
-    auto const view_alive = weak_view_alive.lock();
-    if (!view_alive) {
-      return;
-    }
-    if (width_ == width && height_ == height) {
-      return;
-    }
-
-    if (is_being_destroyed_) {
-      return;
-    }
-
-    width_ = width;
-    height_ = height;
-    UpdatePosition();
-  });
+void HostWindowTooltip::ApplyContentSize(int32_t physical_width,
+                                         int32_t physical_height) {
+  UpdatePosition();
 }
 
 WindowRect HostWindowTooltip::GetWorkArea() const {
@@ -113,7 +80,7 @@ void HostWindowTooltip::UpdatePosition() {
 
   IsolateScope scope(isolate_);
   auto rect = get_position_callback_(
-      WindowSize{width_, height_},
+      WindowSize{physical_width_, physical_height_},
       WindowRect{parent_top_left.x, parent_top_left.y,
                  parent_bottom_right.x - parent_top_left.x,
                  parent_bottom_right.y - parent_top_left.y},
@@ -124,7 +91,7 @@ void HostWindowTooltip::UpdatePosition() {
 
   // The positioner constrained the dimensions more than current size, apply
   // positioner constraints.
-  if (rect->width < width_ || rect->height < height_) {
+  if (rect->width < physical_width_ || rect->height < physical_height_) {
     auto metrics_event = view_controller_->view()->CreateWindowMetricsEvent();
     view_controller_->engine()->SendWindowMetricsEvent(metrics_event);
   }

--- a/engine/src/flutter/shell/platform/windows/host_window_tooltip.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_tooltip.cc
@@ -40,6 +40,14 @@ HostWindowTooltip::HostWindowTooltip(
                    reinterpret_cast<LONG_PTR>(parent_));
 }
 
+HostWindowTooltip::~HostWindowTooltip() {
+  // Reset the view while this most-derived object is still fully alive, to stop
+  // the raster thread from sizing it (via the overridden ApplyContentSize /
+  // GetWorkArea) before any subobject is torn down. See the destructor comment
+  // in host_window_sized.h for the rationale.
+  view_controller_.reset();
+}
+
 void HostWindowTooltip::ApplyContentSize(int32_t physical_width,
                                          int32_t physical_height) {
   UpdatePosition();

--- a/engine/src/flutter/shell/platform/windows/host_window_tooltip.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_tooltip.cc
@@ -41,6 +41,21 @@ HostWindowTooltip::HostWindowTooltip(
                    reinterpret_cast<LONG_PTR>(parent_));
 }
 
+HostWindowTooltip::~HostWindowTooltip() {
+  // Destroy the view (and therefore the raster thread's access to this object
+  // as a sizing delegate) while this HostWindowTooltip is still fully alive.
+  //
+  // This tooltip is itself the view's FlutterWindowsViewSizingDelegate. The
+  // view is owned by |view_controller_|, a member of the HostWindow base class,
+  // which would otherwise be destroyed *after* this derived object's
+  // FlutterWindowsViewSizingDelegate subobject. Resetting it here triggers
+  // FlutterWindowsEngine::RemoveView, which guarantees the raster thread no
+  // longer presents to (or sizes) this view, before the sizing delegate is
+  // torn down. Without this, the raster thread's sized-to-content path can
+  // call into a destroyed sizing delegate and crash.
+  view_controller_.reset();
+}
+
 void HostWindowTooltip::DidUpdateViewSize(int32_t width, int32_t height) {
   // This is called from the raster thread.
   std::weak_ptr<int> weak_view_alive = view_alive_;

--- a/engine/src/flutter/shell/platform/windows/host_window_tooltip.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_tooltip.h
@@ -6,13 +6,12 @@
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_HOST_WINDOW_TOOLTIP_H_
 
 #include <cstdint>
-#include "host_window.h"
+#include "host_window_sized.h"
 #include "shell/platform/windows/flutter_windows_view.h"
 #include "shell/platform/windows/window_manager.h"
 
 namespace flutter {
-class HostWindowTooltip : public HostWindow,
-                          private FlutterWindowsViewSizingDelegate {
+class HostWindowTooltip : public HostWindowSized {
  public:
   // Creates a tooltip window.
   HostWindowTooltip(WindowManager* window_manager,
@@ -21,35 +20,25 @@ class HostWindowTooltip : public HostWindow,
                     GetWindowPositionCallback get_position_callback,
                     HWND parent);
 
-  ~HostWindowTooltip() override;
-
   // Update the position of the tooltip window based off the current size
   // of the tooltip.
   void UpdatePosition();
 
  protected:
+  void ApplyContentSize(int32_t physical_width,
+                        int32_t physical_height) override;
+
   LRESULT HandleMessage(HWND hwnd,
                         UINT message,
                         WPARAM wparam,
                         LPARAM lparam) override;
 
  private:
-  void DidUpdateViewSize(int32_t width, int32_t height) override;
   WindowRect GetWorkArea() const override;
 
   GetWindowPositionCallback get_position_callback_;
   HWND parent_;
   Isolate isolate_;
-
-  // Used to track whether the view is still in tasks scheduled from raster
-  // thread.
-  std::shared_ptr<int> view_alive_;
-
-  // The current width of the tooltip.
-  int width_ = 0;
-
-  // The current height of the tooltip.
-  int height_ = 0;
 };
 }  // namespace flutter
 

--- a/engine/src/flutter/shell/platform/windows/host_window_tooltip.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_tooltip.h
@@ -24,6 +24,8 @@ class HostWindowTooltip : public HostWindowSized {
   // of the tooltip.
   void UpdatePosition();
 
+  ~HostWindowTooltip() override;
+
  protected:
   void ApplyContentSize(int32_t physical_width,
                         int32_t physical_height) override;

--- a/engine/src/flutter/shell/platform/windows/host_window_tooltip.h
+++ b/engine/src/flutter/shell/platform/windows/host_window_tooltip.h
@@ -21,6 +21,8 @@ class HostWindowTooltip : public HostWindow,
                     GetWindowPositionCallback get_position_callback,
                     HWND parent);
 
+  ~HostWindowTooltip() override;
+
   // Update the position of the tooltip window based off the current size
   // of the tooltip.
   void UpdatePosition();


### PR DESCRIPTION
## What's new?
This PR fixes a teardown bug with popups, tooltips, and sized-to-content windows in general. It also updates tooltips and popups to use the same path as other sized-to-content windows.

## Problem

- `HostWindowSized` is the `FlutterWindowsViewSizingDelegate`
- The view uses this delegate to size to content
- The view is rendering on the raster thread (in the sized to content path), which assumes that this delegate is alive

So what happens? The window is being torn down (the delegate is in a deconstructed state). Meanwhile, we get a new frame and try to size ourselves to the content of that frame, but the delegate is currently being destructed.

## Solution
We teardown the view immediately in the subclass so it never has a chance to reference its deconstructing owner from another thread.

I admit that this isn't great, but the sizing delegate solution clearly has some issues to begin with. We should reconsider it later.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
