### PR TITLE
build(deps): remove discontinued pedantic and device_info packages

### DIFF
--- a/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
+++ b/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   # This integration test includes a watchOS pod. Add a Flutter plugin
   # to prompt the tool to run pod install.
-  url_launcher: any
+  url_launcher: ^6.0.0
 
 
 dev_dependencies:
@@ -73,4 +73,4 @@ flutter:
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
 
-# PUBSPEC CHECKSUM: rh5vvs
+# PUBSPEC CHECKSUM: dqkobt

--- a/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
+++ b/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   # This integration test includes a watchOS pod. Add a Flutter plugin
   # to prompt the tool to run pod install.
-  device_info: 2.0.3
+  url_launcher: any
 
 
 dev_dependencies:

--- a/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
+++ b/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
@@ -73,4 +73,4 @@ flutter:
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
 
-# PUBSPEC CHECKSUM: 60tnc
+# PUBSPEC CHECKSUM: rh5vvs

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -275,22 +275,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
-  device_info:
-    dependency: "direct main"
-    description:
-      name: device_info
-      sha256: f4a8156cb7b7480d969cb734907d18b333c8f0bc0b1ad0b342cdcecf30d62c48
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.3"
-  device_info_platform_interface:
-    dependency: "direct main"
-    description:
-      name: device_info_platform_interface
-      sha256: b148e0bf9640145d09a4f8dea96614076f889e7f7f8b5ecab1c7e5c2dbc73c1b
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   devtools_shared:
     dependency: transitive
     description:
@@ -818,14 +802,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  pedantic:
-    dependency: "direct main"
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   petitparser:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -222,4 +222,4 @@ dependencies:
 dev_dependencies:
   ffigen: 20.1.1
 
-# PUBSPEC CHECKSUM: krp65v
+# PUBSPEC CHECKSUM: in3p1o

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -105,8 +105,6 @@ dependencies:
   crypto: 3.0.7
   csslib: 1.0.2
   cupertino_icons: 1.0.9
-  device_info: 2.0.3
-  device_info_platform_interface: 2.0.1
   fake_async: ^1.3.3
   ffi: 2.2.0
   file: 7.0.1
@@ -218,7 +216,6 @@ dependencies:
   file_testing: 3.0.2
   flutter_lints: 6.0.0
   lints: 6.1.0
-  pedantic: 1.11.1
   quiver: 3.2.2
   yaml_edit: 2.2.4
 


### PR DESCRIPTION
- Remove orphaned `pedantic: 1.11.1` from root `pubspec.yaml`.
- Replace dummy dependency `device_info: 2.0.3` with `url_launcher: any` in `dev/integration_tests/ios_app_with_extensions/pubspec.yaml` to preserve the CocoaPods pod install trigger.
- Remove orphaned `device_info: 2.0.3` and `device_info_platform_interface: 2.0.1` from root `pubspec.yaml`.
- Update `pubspec.lock`.

Towards https://github.com/flutter/flutter/issues/187982
