### PR TITLE
[CP-stable] Upgrade iOS version

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -283,7 +283,7 @@ platform_properties:
           {"dependency": "apple_signing", "version": "version:to_2027"}
         ]
       os: Mac-15.7
-      device_os: iOS-18
+      device_os: iOS-18|iOS-26
       $flutter/osx_sdk : >-
         {
           "sdk_version": "17c52"
@@ -302,7 +302,7 @@ platform_properties:
         ]
       os: Mac-15.7
       cpu: x86
-      device_os: iOS-18
+      device_os: iOS-18|iOS-26
       $flutter/osx_sdk : >-
         {
           "sdk_version": "17c52"
@@ -321,7 +321,7 @@ platform_properties:
         ]
       os: Mac-15.7
       cpu: arm64
-      device_os: iOS-18
+      device_os: iOS-18|iOS-26
       $flutter/osx_sdk : >-
         {
           "sdk_version": "17c52"
@@ -5525,7 +5525,7 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery__transition_perf_e2e_ios
       drone_dimensions: >
-        ["device_os=iOS-18","os=Mac-15.7", "cpu=x86"]
+        ["device_os=iOS-18|iOS-26","os=Mac-15.7", "cpu=x86"]
 
   - name: Mac_ios animated_blur_backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/186090

### Impact Description:
Updating CI to use either iOS 18 or 26 for easy transition when we update our devicelab bots

< Replace with impact description here >

### Changelog Description:
Explain this cherry pick:
* In one line that is accessible to most Flutter developers.
* That describes the state prior to the fix.
* That includes which platforms are impacted.
See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples.

< Replace with changelog description here >
[flutter/<ISSUE_NUMBER>] When <SCENARIO> [on <PLAFORMS(S)>], <DESCRIPTION>

### Workaround:
Is there a workaround for this issue?

n/a

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

< Replace with validation steps here >
