### PR TITLE
[VPAT] Update a11y assessment app FAB example to announce value change when it's updated.

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/floating_action_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/floating_action_button.dart
@@ -40,7 +40,11 @@ class MainWidgetState extends State<MainWidget> {
     return Scaffold(
       appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
-        child: Semantics(liveRegion: !supportsAnnounce, child: Text('Tap count: $_tapCount')),
+        child: Semantics(
+          container: !supportsAnnounce,
+          liveRegion: !supportsAnnounce,
+          child: Text('Tap count: $_tapCount'),
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {

--- a/dev/a11y_assessments/lib/use_cases/floating_action_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/floating_action_button.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import '../utils.dart';
 import 'use_cases.dart';
 
@@ -36,28 +35,16 @@ class MainWidgetState extends State<MainWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final bool supportsAnnounce = MediaQuery.maybeSupportsAnnounceOf(context) ?? false;
     return Scaffold(
       appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: Center(
-        child: Semantics(
-          container: !supportsAnnounce,
-          liveRegion: !supportsAnnounce,
-          child: Text('Tap count: $_tapCount'),
-        ),
+        child: Semantics(container: true, liveRegion: true, child: Text('Tap count: $_tapCount')),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
           setState(() {
             _tapCount++;
           });
-          if (supportsAnnounce) {
-            SemanticsService.sendAnnouncement(
-              View.of(context),
-              'Tap count: $_tapCount',
-              Directionality.of(context),
-            );
-          }
         },
         tooltip: 'Increment',
         child: const Icon(Icons.add),

--- a/dev/a11y_assessments/lib/use_cases/floating_action_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/floating_action_button.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import '../utils.dart';
 import 'use_cases.dart';
 
@@ -35,14 +36,24 @@ class MainWidgetState extends State<MainWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final bool supportsAnnounce = MediaQuery.maybeSupportsAnnounceOf(context) ?? false;
     return Scaffold(
       appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
-      body: Center(child: Text('Tap count: $_tapCount')),
+      body: Center(
+        child: Semantics(liveRegion: !supportsAnnounce, child: Text('Tap count: $_tapCount')),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
           setState(() {
             _tapCount++;
           });
+          if (supportsAnnounce) {
+            SemanticsService.sendAnnouncement(
+              View.of(context),
+              'Tap count: $_tapCount',
+              Directionality.of(context),
+            );
+          }
         },
         tooltip: 'Increment',
         child: const Icon(Icons.add),

--- a/dev/a11y_assessments/test/floating_action_button_test.dart
+++ b/dev/a11y_assessments/test/floating_action_button_test.dart
@@ -16,19 +16,75 @@ void main() {
     expect(findHeadingLevelOnes, findsOne);
   });
 
-  testWidgets('floating action button can increment tap count', (WidgetTester tester) async {
-    await pumpsUseCase(tester, FloatingActionButtonUseCase());
+  testWidgets('floating action button can increment tap count (with supportsAnnounce = true)', (
+    WidgetTester tester,
+  ) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(supportsAnnounce: true),
+          child: Builder(
+            builder: (BuildContext context) {
+              return FloatingActionButtonUseCase().buildWithTitle(context);
+            },
+          ),
+        ),
+      ),
+    );
 
     expect(find.text('Tap count: 0'), findsOneWidget);
+    expect(tester.getSemantics(find.text('Tap count: 0')), matchesSemantics(label: 'Tap count: 0'));
 
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pump();
 
     expect(find.text('Tap count: 1'), findsOneWidget);
+    expect(tester.takeAnnouncements(), <Matcher>[isAccessibilityAnnouncement('Tap count: 1')]);
 
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pump();
 
     expect(find.text('Tap count: 2'), findsOneWidget);
+    expect(tester.takeAnnouncements(), <Matcher>[isAccessibilityAnnouncement('Tap count: 2')]);
+
+    handle.dispose();
   });
+
+  testWidgets(
+    'floating action button can increment tap count (with supportsAnnounce = false, using liveRegion)',
+    (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(), // defaults to supportsAnnounce = false
+            child: Builder(
+              builder: (BuildContext context) {
+                return FloatingActionButtonUseCase().buildWithTitle(context);
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Tap count: 0'), findsOneWidget);
+      expect(
+        tester.getSemantics(find.text('Tap count: 0')),
+        matchesSemantics(label: 'Tap count: 0', isLiveRegion: true),
+      );
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pump();
+
+      expect(find.text('Tap count: 1'), findsOneWidget);
+      expect(
+        tester.getSemantics(find.text('Tap count: 1')),
+        matchesSemantics(label: 'Tap count: 1', isLiveRegion: true),
+      );
+      expect(tester.takeAnnouncements(), isEmpty);
+
+      handle.dispose();
+    },
+  );
 }

--- a/dev/a11y_assessments/test/floating_action_button_test.dart
+++ b/dev/a11y_assessments/test/floating_action_button_test.dart
@@ -16,75 +16,34 @@ void main() {
     expect(findHeadingLevelOnes, findsOne);
   });
 
-  testWidgets('floating action button can increment tap count (with supportsAnnounce = true)', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('floating action button can increment tap count', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
-    await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(supportsAnnounce: true),
-          child: Builder(
-            builder: (BuildContext context) {
-              return FloatingActionButtonUseCase().buildWithTitle(context);
-            },
-          ),
-        ),
-      ),
-    );
+    await pumpsUseCase(tester, FloatingActionButtonUseCase());
 
     expect(find.text('Tap count: 0'), findsOneWidget);
-    expect(tester.getSemantics(find.text('Tap count: 0')), matchesSemantics(label: 'Tap count: 0'));
+    expect(
+      tester.getSemantics(find.text('Tap count: 0')),
+      matchesSemantics(label: 'Tap count: 0', isLiveRegion: true),
+    );
 
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pump();
 
     expect(find.text('Tap count: 1'), findsOneWidget);
-    expect(tester.takeAnnouncements(), <Matcher>[isAccessibilityAnnouncement('Tap count: 1')]);
+    expect(
+      tester.getSemantics(find.text('Tap count: 1')),
+      matchesSemantics(label: 'Tap count: 1', isLiveRegion: true),
+    );
 
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pump();
 
     expect(find.text('Tap count: 2'), findsOneWidget);
-    expect(tester.takeAnnouncements(), <Matcher>[isAccessibilityAnnouncement('Tap count: 2')]);
+    expect(
+      tester.getSemantics(find.text('Tap count: 2')),
+      matchesSemantics(label: 'Tap count: 2', isLiveRegion: true),
+    );
 
     handle.dispose();
   });
-
-  testWidgets(
-    'floating action button can increment tap count (with supportsAnnounce = false, using liveRegion)',
-    (WidgetTester tester) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MediaQuery(
-            data: const MediaQueryData(), // defaults to supportsAnnounce = false
-            child: Builder(
-              builder: (BuildContext context) {
-                return FloatingActionButtonUseCase().buildWithTitle(context);
-              },
-            ),
-          ),
-        ),
-      );
-
-      expect(find.text('Tap count: 0'), findsOneWidget);
-      expect(
-        tester.getSemantics(find.text('Tap count: 0')),
-        matchesSemantics(label: 'Tap count: 0', isLiveRegion: true),
-      );
-
-      await tester.tap(find.byType(FloatingActionButton));
-      await tester.pump();
-
-      expect(find.text('Tap count: 1'), findsOneWidget);
-      expect(
-        tester.getSemantics(find.text('Tap count: 1')),
-        matchesSemantics(label: 'Tap count: 1', isLiveRegion: true),
-      );
-      expect(tester.takeAnnouncements(), isEmpty);
-
-      handle.dispose();
-    },
-  );
 }


### PR DESCRIPTION
context: this is to address a feedback from VPAT testing. 

also check supportsAnnounce because android 16 deprecated announcement we should use liveregion instead if the announcement is not supported.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
