### PR TITLE
Fix date localization missing ZERODIGIT in Arabic(ar)

### DIFF
--- a/dev/tools/localization/bin/gen_date_localizations.dart
+++ b/dev/tools/localization/bin/gen_date_localizations.dart
@@ -12,6 +12,14 @@ import '../localizations_utils.dart';
 
 const String _kCommandName = 'gen_date_localizations.dart';
 
+const Map<String, Map<String, Object>> _dateSymbolOverrides = <String, Map<String, Object>>{
+  // Preserve Flutter's historical generic Arabic DateFormat behavior until
+  // package:intl restores ZERODIGIT for ar.
+  // TODO(QuncCccccc): Remove this override once the upstream intl data is fixed.
+  // See https://github.com/flutter/flutter/issues/187767.
+  'ar': <String, Object>{'ZERODIGIT': '\u0660'},
+};
+
 // Used to let _jsonToMap know what locale it's date symbols converting for.
 // Date symbols for the Kannada locale ('kn') are handled specially because
 // some of the strings contain characters that can crash Emacs on Linux.
@@ -107,6 +115,9 @@ import 'package:intl/date_symbols.dart' as intl;
     currentLocale = locale;
     if (supportedLocales.contains(locale)) {
       final objData = json.decode(data.readAsStringSync()) as Map<String, Object?>;
+      _dateSymbolOverrides[locale]?.forEach((String key, Object value) {
+        objData.putIfAbsent(key, () => value);
+      });
       buffer.writeln("'$locale': intl.DateSymbols(");
       objData.forEach((String key, Object? value) {
         if (value == null) {

--- a/packages/flutter_localizations/lib/src/l10n/generated_date_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_date_localizations.dart
@@ -331,6 +331,7 @@ final Map<String, intl.DateSymbols> dateSymbols = <String, intl.DateSymbols>{
     WEEKENDRANGE: const <int>[4, 5],
     FIRSTWEEKCUTOFFDAY: 4,
     DATETIMEFORMATS: const <String>['{1}، {0}', '{1}، {0}', '{1}، {0}', '{1}، {0}'],
+    ZERODIGIT: '٠',
   ),
   'as': intl.DateSymbols(
     NAME: 'as',

--- a/packages/flutter_localizations/test/material/date_picker_test.dart
+++ b/packages/flutter_localizations/test/material/date_picker_test.dart
@@ -46,7 +46,7 @@ void main() {
         'textDirection': TextDirection.rtl,
         'expectedDaysOfWeek': <String>['ح', 'ن', 'ث', 'ر', 'خ', 'ج', 'س'],
         'expectedDaysOfMonth': List<String>.generate(30, (int i) => arabicNumbers.format(i + 1)),
-        'expectedMonthYearHeader': 'سبتمبر 2017',
+        'expectedMonthYearHeader': 'سبتمبر ٢٠١٧',
       },
     };
 

--- a/packages/flutter_localizations/test/material/date_time_test.dart
+++ b/packages/flutter_localizations/test/material/date_time_test.dart
@@ -362,6 +362,27 @@ void main() {
     expect(dateFormat.locale, 'ga');
     expect(dateFormat.format(DateTime(2023, 4, 10, 2, 32)), equals('10 Aib 2023'));
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/187767.
+  testWidgets('ar is initialized correctly when DateFormat is used', (WidgetTester tester) async {
+    late DateFormat dateFormat;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('ar'),
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        home: Builder(
+          builder: (BuildContext context) {
+            dateFormat = DateFormat.jm('ar');
+            return Container();
+          },
+        ),
+      ),
+    );
+
+    expect(dateFormat.locale, 'ar');
+    expect(dateFormat.format(DateTime(2026, 1, 1, 20, 30)), equals('٨:٣٠ م'));
+  });
 }
 
 enum DateType { year, medium, full, monthYear }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/187767

The date localization data update removed `ZERODIGIT` from Flutter's generated generic Arabic (`ar`) `DateSymbols`, which caused `DateFormat` to fall back to ASCII digits for Arabic date formatting.

The upstream `package:intl` data change came from dart-lang/i18n commit https://github.com/dart-lang/i18n/commit/4d96553d475806731e83008215faf8f1d39e5f83, which removed `"ZERODIGIT":"٠"` from `pkgs/intl/lib/src/data/dates/symbols/ar.json`.

This PR is to add narrow Flutter-side compatibility override in `gen_date_localizations.dart` to preserve Flutter's historical generic Arabic `DateFormat` behavior until the upstream `intl` data is fixed. The override uses `putIfAbsent`, so an upstream fix will take precedence once available.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
