### PR TITLE
Add tests for flutter_view and platform_view examples

### DIFF
--- a/examples/flutter_view/pubspec.yaml
+++ b/examples/flutter_view/pubspec.yaml
@@ -11,6 +11,10 @@ dependencies:
     sdk: flutter
 
 
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
 flutter:
   uses-material-design: true
   assets:

--- a/examples/flutter_view/test/flutter_view_test.dart
+++ b/examples/flutter_view/test/flutter_view_test.dart
@@ -46,16 +46,17 @@ void main() {
         return null;
       },
     );
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        'increment',
+        null,
+      );
+    });
 
     await tester.pumpWidget(const flutter_view.FlutterView());
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pump();
 
     expect(lastSentMessage, 'pong');
-
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
-      'increment',
-      null,
-    );
   });
 }

--- a/examples/flutter_view/test/flutter_view_test.dart
+++ b/examples/flutter_view/test/flutter_view_test.dart
@@ -1,0 +1,61 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_view/main.dart' as flutter_view;
+
+void main() {
+  testWidgets('FlutterView smoke test', (WidgetTester tester) async {
+    await tester.pumpWidget(const flutter_view.FlutterView());
+
+    // The counter starts at zero.
+    expect(find.text('Platform button tapped 0 times.'), findsOneWidget);
+
+    // The Flutter logo asset and label are rendered.
+    expect(find.text('Flutter'), findsOneWidget);
+    expect(find.byType(flutter_view.FlutterView), findsOneWidget);
+  });
+
+  testWidgets('incrementing via the platform channel updates the counter text', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const flutter_view.FlutterView());
+
+    expect(find.text('Platform button tapped 0 times.'), findsOneWidget);
+
+    // Simulate the host platform sending an increment message.
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+      'increment',
+      const StringCodec().encodeMessage('increment'),
+      (ByteData? data) {},
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Platform button tapped 1 time.'), findsOneWidget);
+  });
+
+  testWidgets('tapping the FAB sends a pong message to the platform', (WidgetTester tester) async {
+    String? lastSentMessage;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      'increment',
+      (ByteData? message) async {
+        lastSentMessage = const StringCodec().decodeMessage(message);
+        return null;
+      },
+    );
+
+    await tester.pumpWidget(const flutter_view.FlutterView());
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+
+    expect(lastSentMessage, 'pong');
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      'increment',
+      null,
+    );
+  });
+}

--- a/examples/platform_view/pubspec.yaml
+++ b/examples/platform_view/pubspec.yaml
@@ -10,6 +10,11 @@ dependencies:
     sdk: flutter
 
 
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+
 flutter:
 
   uses-material-design: true

--- a/examples/platform_view/pubspec.yaml
+++ b/examples/platform_view/pubspec.yaml
@@ -11,6 +11,11 @@ dependencies:
   material_ui: ^0.0.2
 
 
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+
 flutter:
 
   uses-material-design: true

--- a/examples/platform_view/test/platform_view_test.dart
+++ b/examples/platform_view/test/platform_view_test.dart
@@ -1,0 +1,72 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_view/main.dart' as platform_view;
+
+void main() {
+  const channel = MethodChannel('samples.flutter.io/platform_view');
+
+  setUp(() {
+    // The example invokes `switchView` on a method channel and expects an
+    // integer reply. Provide a mock handler so the widget test can exercise
+    // that path without a native counterpart.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (MethodCall call) async {
+        if (call.method == 'switchView') {
+          return call.arguments as int?;
+        }
+        return null;
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      null,
+    );
+  });
+
+  testWidgets('PlatformView smoke test', (WidgetTester tester) async {
+    await tester.pumpWidget(const platform_view.PlatformView());
+
+    // The counter starts at zero.
+    expect(find.text('Button tapped 0 times.'), findsOneWidget);
+    // The app bar title is rendered.
+    expect(find.text('Platform View'), findsOneWidget);
+    // The Flutter label is rendered.
+    expect(find.text('Flutter'), findsOneWidget);
+  });
+
+  testWidgets('tapping the FAB increments the counter', (WidgetTester tester) async {
+    await tester.pumpWidget(const platform_view.PlatformView());
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+
+    expect(find.text('Button tapped 1 time.'), findsOneWidget);
+  });
+
+  testWidgets('tapping the continue button updates the counter from the platform response', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const platform_view.PlatformView());
+
+    // Increment locally first so the value passed to the platform is non-zero.
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+
+    expect(find.text('Button tapped 1 time.'), findsOneWidget);
+
+    // The platform mock echoes back the received counter value.
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Button tapped 1 time.'), findsOneWidget);
+  });
+}

--- a/examples/platform_view/test/platform_view_test.dart
+++ b/examples/platform_view/test/platform_view_test.dart
@@ -55,18 +55,27 @@ void main() {
   testWidgets('tapping the continue button updates the counter from the platform response', (
     WidgetTester tester,
   ) async {
+    // Override the default mock to return a distinct value so we can verify
+    // the counter is actually updated from the platform response rather than
+    // just echoing back the value that was sent.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (MethodCall call) async {
+        if (call.method == 'switchView') {
+          return 42;
+        }
+        return null;
+      },
+    );
+
     await tester.pumpWidget(const platform_view.PlatformView());
 
-    // Increment locally first so the value passed to the platform is non-zero.
-    await tester.tap(find.byType(FloatingActionButton));
-    await tester.pump();
+    expect(find.text('Button tapped 0 times.'), findsOneWidget);
 
-    expect(find.text('Button tapped 1 time.'), findsOneWidget);
-
-    // The platform mock echoes back the received counter value.
+    // Tapping the continue button invokes switchView; the mock responds with 42.
     await tester.tap(find.byType(ElevatedButton));
     await tester.pumpAndSettle();
 
-    expect(find.text('Button tapped 1 time.'), findsOneWidget);
+    expect(find.text('Button tapped 42 times.'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Fixes #187972

The `flutter_view` and `platform_view` examples under `/examples` had no tests. This PR adds widget tests for both.

## flutter_view (3 tests)
- **Smoke test**: counter starts at 0 and the Flutter label renders
- **Platform channel increment**: simulating a platform increment message updates the counter text
- **FAB tap**: tapping the FAB sends a `pong` message to the platform via `BasicMessageChannel`

## platform_view (3 tests)
- **Smoke test**: counter starts at 0 and app bar title renders
- **FAB increment**: tapping the FAB increments the counter
- **Continue button**: tapping the continue button calls `switchView` via `MethodChannel` and updates the counter from the platform response

## Pre-launch checklist

- [x] Tests pass locally (`flutter test`)
- [x] `dart format` applied
- [x] `flutter analyze` passes with no issues
- [x] `pubspec.lock` not included (only mirror URL change, environment artifact)
