### PR TITLE
Add Impeller+OpenGLES startup benchmark for mokey

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2595,6 +2595,20 @@ targets:
           {"dependency": "open_jdk", "version": "version:21"}
         ]
 
+  # linux mokey benchmark - Impeller (OpenGLES) startup test
+  - name: Linux_mokey complex_layout_android__impeller_gles_start_up
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "android", "linux", "mokey"]
+      task_name: complex_layout_android__impeller_gles_start_up
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "version:21"}
+        ]
+
   # linux mokey benchmark
   - name: Linux_mokey cubic_bezier_perf__e2e_summary
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2600,6 +2600,7 @@ targets:
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
+    bringup: true
     properties:
       tags: >
         ["devicelab", "android", "linux", "mokey"]

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -41,6 +41,7 @@
 /dev/devicelab/bin/tasks/complex_layout_scroll_perf_impeller__timeline_summary.dart @jonahwilliams @flutter/engine
 /dev/devicelab/bin/tasks/complex_layout_scroll_perf_impeller_gles__timeline_summary.dart @jonahwilliams @flutter/engine
 /dev/devicelab/bin/tasks/complex_layout_semantics_perf.dart @jtmcdole @flutter/engine
+/dev/devicelab/bin/tasks/complex_layout_android__impeller_gles_start_up.dart @gaaclarke @flutter/engine
 /dev/devicelab/bin/tasks/cubic_bezier_perf__e2e_summary.dart @jtmcdole @flutter/engine
 /dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__e2e_summary.dart @jtmcdole @flutter/engine
 /dev/devicelab/bin/tasks/cull_opacity_perf__e2e_summary.dart @jtmcdole @flutter/engine

--- a/dev/devicelab/bin/tasks/complex_layout_android__impeller_gles_start_up.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_android__impeller_gles_start_up.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createComplexLayoutStartupTest(enableImpeller: true, forceOpenGLES: true));
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -932,7 +932,7 @@ class StartupTest {
       if (enableHcpp) {
         _addHcppSupportToManifest(testDirectory);
       }
-      if ((enableImpeller ?? false) && forceOpenGLES) {
+      if ((enableImpeller ?? true) && forceOpenGLES) {
         _addOpenGLESToManifest(testDirectory);
       }
 

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -284,10 +284,11 @@ TaskFunction createFlutterGalleryStartupTest({
   ).run;
 }
 
-TaskFunction createComplexLayoutStartupTest({bool? enableImpeller}) {
+TaskFunction createComplexLayoutStartupTest({bool? enableImpeller, bool forceOpenGLES = false}) {
   return StartupTest(
     '${flutterDirectory.path}/dev/benchmarks/complex_layout',
     enableImpeller: enableImpeller,
+    forceOpenGLES: forceOpenGLES,
   ).run;
 }
 
@@ -906,6 +907,7 @@ class StartupTest {
     this.enableLazyShaderMode = false,
     this.enableHcpp = false,
     this.enableImpeller,
+    this.forceOpenGLES = false,
   });
 
   final String testDirectory;
@@ -913,6 +915,7 @@ class StartupTest {
   final bool enableLazyShaderMode;
   final bool enableHcpp;
   final bool? enableImpeller;
+  final bool forceOpenGLES;
   final String target;
   final Map<String, String>? runEnvironment;
 
@@ -928,6 +931,9 @@ class StartupTest {
       }
       if (enableHcpp) {
         _addHcppSupportToManifest(testDirectory);
+      }
+      if ((enableImpeller ?? false) && forceOpenGLES) {
+        _addOpenGLESToManifest(testDirectory);
       }
 
       try {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->
This PR adds a new benchmark test (`complex_layout_android__impeller_gles_start_up`) that measures app startup performance with Impeller renderer forced to use OpenGLES backend on Android low-end devices (mokey).

### Purpose

This benchmark is designed to:

- Measure startup performance when Impeller uses OpenGLES backend on Android devices
- Provide baseline metrics for tracking startup time improvements on low-end Android devices
- Enable performance comparison for PRs that modify the IO context setup for OpenGLES

### Test Configuration

- __Device:__ mokey (Android low-end device)
- __Renderer:__ Impeller with OpenGLES backend (forced via `forceOpenGLES: true`)
- __Test App:__ complex_layout benchmark
- __Metric:__ App startup time
### Related Work

This benchmark supports the performance validation for [](https://github.com/flutter/flutter/pull/185723)<https://github.com/flutter/flutter/pull/185723>, which improves startup time on low-end devices by using IO context for OpenGLES setup.

### Expected Outcome

This benchmark will provide measurable data to demonstrate the performance improvements from PR #185723 by comparing:

1. Baseline measurements (before IO context changes)
2. Post-merge measurements (after IO context changes are applied)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
