### PR TITLE
[CP-stable][Impeller] Wait for the Vulkan device to become idle before destroying Vulkan objects in the AHBSwapchainImplVK destructor

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -6,6 +6,20 @@ import("//flutter/testing/android/native_activity/native_activity.gni")
 import("//flutter/vulkan/config.gni")
 import("../../../tools/impeller.gni")
 
+source_set("mock_vulkan") {
+  testonly = true
+
+  sources = [
+    "test/mock_vulkan.cc",
+    "test/mock_vulkan.h",
+  ]
+
+  deps = [
+    ":vulkan",
+    "//flutter/fml",
+  ]
+}
+
 impeller_component("vulkan_unittests") {
   testonly = true
   sources = [
@@ -25,13 +39,12 @@ impeller_component("vulkan_unittests") {
     "resource_manager_vk_unittests.cc",
     "surface_context_vk_unittests.cc",
     "test/gpu_tracer_unittests.cc",
-    "test/mock_vulkan.cc",
-    "test/mock_vulkan.h",
     "test/mock_vulkan_unittests.cc",
     "test/sampler_library_vk_unittests.cc",
     "test/swapchain_unittests.cc",
   ]
   deps = [
+    ":mock_vulkan",
     ":vulkan",
     "../../../playground:playground_test",
     "//flutter/testing:testing_lib",
@@ -179,9 +192,13 @@ if (is_android) {
 
     testonly = true
 
-    sources = [ "android/ahb_texture_source_vk_unittests.cc" ]
+    sources = [
+      "android/ahb_swapchain_vk_unittests.cc",
+      "android/ahb_texture_source_vk_unittests.cc",
+    ]
 
     deps = [
+      ":mock_vulkan",
       ":unittests_fixtures",
       ":vulkan",
       "//flutter/testing",

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include "impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.h"
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
+#include "impeller/toolkit/android/surface_control.h"
+
+namespace impeller::android::testing {
+
+using impeller::testing::GetMockVulkanFunctions;
+using impeller::testing::MockVulkanContextBuilder;
+
+const std::vector<std::string> kAndroidDeviceExtensions = {
+    "VK_KHR_swapchain",
+    "VK_ANDROID_external_memory_android_hardware_buffer",
+    "VK_KHR_sampler_ycbcr_conversion",
+    "VK_KHR_external_memory",
+    "VK_EXT_queue_family_foreign",
+    "VK_KHR_dedicated_allocation",
+};
+
+class FakeSurfaceControl : public SurfaceControl {
+ public:
+  bool IsValid() const override { return true; }
+
+  ASurfaceControl* GetHandle() const override { return nullptr; }
+
+  bool RemoveFromParent() const override { return true; }
+};
+
+TEST(AndroidAHBSwapchainTest, AHBSwapchainDtorCallsWaitIdle) {
+  const auto context = MockVulkanContextBuilder()
+                           .SetDeviceExtensions(kAndroidDeviceExtensions)
+                           .Build();
+
+  auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
+      context, std::make_shared<FakeSurfaceControl>(), {}, {100, 100}, false));
+
+  ahb_swapchain.reset();
+
+  auto called_functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_NE(std::find(called_functions->begin(), called_functions->end(),
+                      "vkDeviceWaitIdle"),
+            called_functions->end());
+}
+
+}  // namespace impeller::android::testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -102,7 +102,11 @@ AHBSwapchainImplVK::AHBSwapchainImplVK(
   is_valid_ = control && control->IsValid();
 }
 
-AHBSwapchainImplVK::~AHBSwapchainImplVK() = default;
+AHBSwapchainImplVK::~AHBSwapchainImplVK() {
+  // Ensure that the Vulkan device is idle before destroying objects that the
+  // device may have been using.
+  WaitIdle();
+}
 
 const ISize& AHBSwapchainImplVK::GetSize() const {
   return desc_.size;
@@ -115,6 +119,17 @@ bool AHBSwapchainImplVK::IsValid() const {
 const android::HardwareBufferDescriptor& AHBSwapchainImplVK::GetDescriptor()
     const {
   return desc_;
+}
+
+void AHBSwapchainImplVK::WaitIdle() const {
+  if (transients_) {
+    if (auto context = transients_->GetContext().lock()) {
+      auto result = ContextVK::Cast(*context).GetDevice().waitIdle();
+      if (result != vk::Result::eSuccess) {
+        FML_LOG(INFO) << "Device waitIdle failed: " << vk::to_string(result);
+      }
+    }
+  }
 }
 
 std::unique_ptr<Surface> AHBSwapchainImplVK::AcquireNextDrawable() {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.h
@@ -140,6 +140,8 @@ class AHBSwapchainImplVK final
 
   bool Present(const std::shared_ptr<AHBTextureSourceVK>& texture);
 
+  void WaitIdle() const;
+
   vk::UniqueSemaphore CreateRenderReadySemaphore(
       const std::shared_ptr<fml::UniqueFD>& fd) const;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.cc
@@ -17,14 +17,14 @@ bool AHBSwapchainVK::IsAvailableOnPlatform() {
          android::HardwareBuffer::IsAvailableOnPlatform();
 }
 
-AHBSwapchainVK::AHBSwapchainVK(const std::shared_ptr<Context>& context,
-                               ANativeWindow* window,
-                               const CreateTransactionCB& cb,
-                               const ISize& size,
-                               bool enable_msaa)
+AHBSwapchainVK::AHBSwapchainVK(
+    const std::shared_ptr<Context>& context,
+    const std::shared_ptr<android::SurfaceControl>& surface_control,
+    const CreateTransactionCB& cb,
+    const ISize& size,
+    bool enable_msaa)
     : context_(context),
-      surface_control_(
-          std::make_shared<android::SurfaceControl>(window, "ImpellerSurface")),
+      surface_control_(surface_control),
       enable_msaa_(enable_msaa),
       cb_(cb) {
   UpdateSurfaceSize(size);

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.h
@@ -13,6 +13,10 @@
 
 namespace impeller {
 
+namespace android::testing {
+FML_TEST_CLASS(AndroidAHBSwapchainTest, AHBSwapchainDtorCallsWaitIdle);
+}  // namespace android::testing
+
 using CreateTransactionCB = std::function<android::SurfaceTransaction()>;
 
 //------------------------------------------------------------------------------
@@ -55,6 +59,8 @@ class AHBSwapchainVK final : public SwapchainVK {
 
  private:
   friend class SwapchainVK;
+  FML_FRIEND_TEST(android::testing::AndroidAHBSwapchainTest,
+                  AHBSwapchainDtorCallsWaitIdle);
 
   std::weak_ptr<Context> context_;
   std::shared_ptr<android::SurfaceControl> surface_control_;
@@ -62,11 +68,12 @@ class AHBSwapchainVK final : public SwapchainVK {
   CreateTransactionCB cb_;
   std::shared_ptr<AHBSwapchainImplVK> impl_;
 
-  explicit AHBSwapchainVK(const std::shared_ptr<Context>& context,
-                          ANativeWindow* window,
-                          const CreateTransactionCB& cb,
-                          const ISize& size,
-                          bool enable_msaa);
+  explicit AHBSwapchainVK(
+      const std::shared_ptr<Context>& context,
+      const std::shared_ptr<android::SurfaceControl>& surface_control,
+      const CreateTransactionCB& cb,
+      const ISize& size,
+      bool enable_msaa);
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
@@ -50,13 +50,15 @@ std::shared_ptr<SwapchainVK> SwapchainVK::Create(
       AHBSwapchainVK::IsAvailableOnPlatform()) {
     CreateTransactionCB callback =
         android_get_device_api_level() >= 34 ? cb : CreateTransactionCB({});
-    auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
-        context,             //
-        window.GetHandle(),  //
-        callback,            //
-        window.GetSize(),    //
-        enable_msaa          //
-        ));
+    auto surface_control = std::shared_ptr(
+        android::SurfaceControl::Create(window.GetHandle(), "ImpellerSurface"));
+    auto ahb_swapchain =
+        std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(context,           //
+                                                           surface_control,   //
+                                                           callback,          //
+                                                           window.GetSize(),  //
+                                                           enable_msaa        //
+                                                           ));
 
     if (ahb_swapchain->IsValid()) {
       return ahb_swapchain;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -110,6 +110,7 @@ class MockDevice final {
 struct MockVulkanState {
   std::vector<std::string> instance_extensions;
   std::vector<std::string> instance_layers;
+  std::vector<std::string> device_extensions;
   std::function<void(VkPhysicalDevice physicalDevice,
                      VkFormat format,
                      VkFormatProperties* pFormatProperties)>
@@ -165,32 +166,46 @@ VkResult vkEnumerateInstanceExtensionProperties(
     VkExtensionProperties* pProperties) {
   if (!pProperties) {
     *pPropertyCount = GetMockVulkanState().instance_extensions.size();
+    return VK_SUCCESS;
   } else {
     uint32_t count = 0;
+    VkResult result = VK_SUCCESS;
     for (const std::string& ext : GetMockVulkanState().instance_extensions) {
-      strncpy(pProperties[count].extensionName, ext.c_str(),
-              sizeof(VkExtensionProperties::extensionName));
+      if (count >= *pPropertyCount) {
+        result = VK_INCOMPLETE;
+        break;
+      }
+      snprintf(pProperties[count].extensionName,
+               sizeof(pProperties[count].extensionName), "%s", ext.c_str());
       pProperties[count].specVersion = 0;
       count++;
     }
+    *pPropertyCount = count;
+    return result;
   }
-  return VK_SUCCESS;
 }
 
 VkResult vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                             VkLayerProperties* pProperties) {
   if (!pProperties) {
     *pPropertyCount = GetMockVulkanState().instance_layers.size();
+    return VK_SUCCESS;
   } else {
     uint32_t count = 0;
-    for (const std::string& layer : GetMockVulkanState().instance_layers) {
-      strncpy(pProperties[count].layerName, layer.c_str(),
-              sizeof(VkLayerProperties::layerName));
+    VkResult result = VK_SUCCESS;
+    for (const std::string& ext : GetMockVulkanState().instance_layers) {
+      if (count >= *pPropertyCount) {
+        result = VK_INCOMPLETE;
+        break;
+      }
+      snprintf(pProperties[count].layerName,
+               sizeof(pProperties[count].layerName), "%s", ext.c_str());
       pProperties[count].specVersion = 0;
       count++;
     }
+    *pPropertyCount = count;
+    return result;
   }
-  return VK_SUCCESS;
 }
 
 VkResult vkEnumeratePhysicalDevices(VkInstance instance,
@@ -246,12 +261,24 @@ VkResult vkEnumerateDeviceExtensionProperties(
     uint32_t* pPropertyCount,
     VkExtensionProperties* pProperties) {
   if (!pProperties) {
-    *pPropertyCount = 1;
+    *pPropertyCount = GetMockVulkanState().device_extensions.size();
+    return VK_SUCCESS;
   } else {
-    strcpy(pProperties[0].extensionName, "VK_KHR_swapchain");
-    pProperties[0].specVersion = 0;
+    uint32_t count = 0;
+    VkResult result = VK_SUCCESS;
+    for (const std::string& ext : GetMockVulkanState().device_extensions) {
+      if (count >= *pPropertyCount) {
+        result = VK_INCOMPLETE;
+        break;
+      }
+      snprintf(pProperties[count].extensionName,
+               sizeof(pProperties[count].extensionName), "%s", ext.c_str());
+      pProperties[count].specVersion = 0;
+      count++;
+    }
+    *pPropertyCount = count;
+    return result;
   }
-  return VK_SUCCESS;
 }
 
 VkResult vkCreateDevice(VkPhysicalDevice physicalDevice,
@@ -436,6 +463,12 @@ VkResult vkCreateGraphicsPipelines(
   MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
   mock_device->AddCalledFunction("vkCreateGraphicsPipelines");
   *pPipelines = reinterpret_cast<VkPipeline>(0x99999999);
+  return VK_SUCCESS;
+}
+
+VkResult vkDeviceWaitIdle(VkDevice device) {
+  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  mock_device->AddCalledFunction("vkDeviceWaitIdle");
   return VK_SUCCESS;
 }
 
@@ -929,6 +962,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreatePipelineLayout);
   } else if (strcmp("vkCreateGraphicsPipelines", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateGraphicsPipelines);
+  } else if (strcmp("vkDeviceWaitIdle", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkDeviceWaitIdle);
   } else if (strcmp("vkDestroyDevice", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDevice);
   } else if (strcmp("vkDestroyInstance", pName) == 0) {
@@ -1026,6 +1061,7 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
 
 MockVulkanContextBuilder::MockVulkanContextBuilder()
     : instance_extensions_({"VK_KHR_surface", "VK_MVK_macos_surface"}),
+      device_extensions_({"VK_KHR_swapchain"}),
       format_properties_callback_([](VkPhysicalDevice physicalDevice,
                                      VkFormat format,
                                      VkFormatProperties* pFormatProperties) {
@@ -1054,6 +1090,7 @@ std::shared_ptr<ContextVK> MockVulkanContextBuilder::Build() {
   g_mock_vulkan_state.reset(new MockVulkanState());
   g_mock_vulkan_state->instance_extensions = instance_extensions_;
   g_mock_vulkan_state->instance_layers = instance_layers_;
+  g_mock_vulkan_state->device_extensions = device_extensions_;
   g_mock_vulkan_state->format_properties_callback = format_properties_callback_;
   g_mock_vulkan_state->physical_device_properties_callback =
       physical_properties_callback_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -89,6 +89,12 @@ class MockVulkanContextBuilder {
     return *this;
   }
 
+  MockVulkanContextBuilder& SetDeviceExtensions(
+      const std::vector<std::string>& device_extensions) {
+    device_extensions_ = device_extensions;
+    return *this;
+  }
+
   /// Set the behavior of vkGetPhysicalDeviceFormatProperties, which needs to
   /// respond differently for different formats.
   MockVulkanContextBuilder& SetPhysicalDeviceFormatPropertiesCallback(
@@ -132,6 +138,7 @@ class MockVulkanContextBuilder {
   std::function<void(ContextVK::Settings&)> settings_callback_;
   std::vector<std::string> instance_extensions_;
   std::vector<std::string> instance_layers_;
+  std::vector<std::string> device_extensions_;
   std::optional<ContextVK::EmbedderData> embedder_data_;
   std::function<void(VkPhysicalDevice physicalDevice,
                      VkFormat format,

--- a/engine/src/flutter/impeller/toolkit/android/BUILD.gn
+++ b/engine/src/flutter/impeller/toolkit/android/BUILD.gn
@@ -21,6 +21,8 @@ impeller_component("android") {
     "proc_table.h",
     "surface_control.cc",
     "surface_control.h",
+    "surface_control_impl.cc",
+    "surface_control_impl.h",
     "surface_transaction.cc",
     "surface_transaction.h",
     "surface_transaction_stats.cc",

--- a/engine/src/flutter/impeller/toolkit/android/surface_control.cc
+++ b/engine/src/flutter/impeller/toolkit/android/surface_control.cc
@@ -5,46 +5,15 @@
 #include "impeller/toolkit/android/surface_control.h"
 
 #include "impeller/base/validation.h"
+#include "impeller/toolkit/android/surface_control_impl.h"
 #include "impeller/toolkit/android/surface_transaction.h"
 
 namespace impeller::android {
 
-SurfaceControl::SurfaceControl(ANativeWindow* window, const char* debug_name) {
-  if (window == nullptr) {
-    VALIDATION_LOG << "Parent window of surface was null.";
-    return;
-  }
-  if (debug_name == nullptr) {
-    debug_name = "Impeller Layer";
-  }
-  control_.reset(
-      GetProcTable().ASurfaceControl_createFromWindow(window, debug_name));
-}
-
-SurfaceControl::~SurfaceControl() {
-  if (IsValid() && !RemoveFromParent()) {
-    VALIDATION_LOG << "Surface control could not be removed from its parent. "
-                      "Expect a leak.";
-  }
-}
-
-bool SurfaceControl::IsValid() const {
-  return control_.is_valid();
-}
-
-ASurfaceControl* SurfaceControl::GetHandle() const {
-  return control_.get();
-}
-
-bool SurfaceControl::RemoveFromParent() const {
-  if (!IsValid()) {
-    return false;
-  }
-  SurfaceTransaction transaction;
-  if (!transaction.SetParent(*this, nullptr)) {
-    return false;
-  }
-  return transaction.Apply();
+std::unique_ptr<SurfaceControl> SurfaceControl::Create(ANativeWindow* window,
+                                                       const char* debug_name) {
+  return std::unique_ptr<SurfaceControl>(
+      new SurfaceControlImpl(window, debug_name));
 }
 
 bool SurfaceControl::IsAvailableOnPlatform() {

--- a/engine/src/flutter/impeller/toolkit/android/surface_control.h
+++ b/engine/src/flutter/impeller/toolkit/android/surface_control.h
@@ -5,7 +5,8 @@
 #ifndef FLUTTER_IMPELLER_TOOLKIT_ANDROID_SURFACE_CONTROL_H_
 #define FLUTTER_IMPELLER_TOOLKIT_ANDROID_SURFACE_CONTROL_H_
 
-#include "flutter/fml/unique_object.h"
+#include <memory>
+
 #include "impeller/toolkit/android/proc_table.h"
 
 namespace impeller::android {
@@ -37,8 +38,9 @@ class SurfaceControl {
   ///                         other control properties. If no debug name is
   ///                         specified, the value "Impeller Layer" is used.
   ///
-  explicit SurfaceControl(ANativeWindow* window,
-                          const char* debug_name = nullptr);
+  static std::unique_ptr<SurfaceControl> Create(
+      ANativeWindow* window,
+      const char* debug_name = nullptr);
 
   //----------------------------------------------------------------------------
   /// @brief      Removes the surface control from the presentation hierarchy
@@ -46,15 +48,11 @@ class SurfaceControl {
   ///             reference to the control. At this point, it may be collected
   ///             when the compositor is also done using it.
   ///
-  ~SurfaceControl();
+  virtual ~SurfaceControl() = default;
 
-  SurfaceControl(const SurfaceControl&) = delete;
+  virtual bool IsValid() const = 0;
 
-  SurfaceControl& operator=(const SurfaceControl&) = delete;
-
-  bool IsValid() const;
-
-  ASurfaceControl* GetHandle() const;
+  virtual ASurfaceControl* GetHandle() const = 0;
 
   //----------------------------------------------------------------------------
   /// @brief      Remove the surface control from the hierarchy of nodes
@@ -66,22 +64,7 @@ class SurfaceControl {
   /// @return     `true` If the control will be removed from the hierarchy of
   ///             nodes presented by the system compositor.
   ///
-  bool RemoveFromParent() const;
-
- private:
-  struct UniqueASurfaceControlTraits {
-    static ASurfaceControl* InvalidValue() { return nullptr; }
-
-    static bool IsValid(ASurfaceControl* value) {
-      return value != InvalidValue();
-    }
-
-    static void Free(ASurfaceControl* value) {
-      GetProcTable().ASurfaceControl_release(value);
-    }
-  };
-
-  fml::UniqueObject<ASurfaceControl*, UniqueASurfaceControlTraits> control_;
+  virtual bool RemoveFromParent() const = 0;
 };
 
 }  // namespace impeller::android

--- a/engine/src/flutter/impeller/toolkit/android/surface_control_impl.cc
+++ b/engine/src/flutter/impeller/toolkit/android/surface_control_impl.cc
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/toolkit/android/surface_control_impl.h"
+
+#include "impeller/base/validation.h"
+#include "impeller/toolkit/android/surface_transaction.h"
+
+namespace impeller::android {
+
+SurfaceControlImpl::SurfaceControlImpl(ANativeWindow* window,
+                                       const char* debug_name) {
+  if (window == nullptr) {
+    VALIDATION_LOG << "Parent window of surface was null.";
+    return;
+  }
+  if (debug_name == nullptr) {
+    debug_name = "Impeller Layer";
+  }
+  control_.reset(
+      GetProcTable().ASurfaceControl_createFromWindow(window, debug_name));
+}
+
+SurfaceControlImpl::~SurfaceControlImpl() {
+  if (IsValid() && !RemoveFromParent()) {
+    VALIDATION_LOG << "Surface control could not be removed from its parent. "
+                      "Expect a leak.";
+  }
+}
+
+bool SurfaceControlImpl::IsValid() const {
+  return control_.is_valid();
+}
+
+ASurfaceControl* SurfaceControlImpl::GetHandle() const {
+  return control_.get();
+}
+
+bool SurfaceControlImpl::RemoveFromParent() const {
+  if (!IsValid()) {
+    return false;
+  }
+  SurfaceTransaction transaction;
+  if (!transaction.SetParent(*this, nullptr)) {
+    return false;
+  }
+  return transaction.Apply();
+}
+
+}  // namespace impeller::android

--- a/engine/src/flutter/impeller/toolkit/android/surface_control_impl.h
+++ b/engine/src/flutter/impeller/toolkit/android/surface_control_impl.h
@@ -1,0 +1,49 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_TOOLKIT_ANDROID_SURFACE_CONTROL_IMPL_H_
+#define FLUTTER_IMPELLER_TOOLKIT_ANDROID_SURFACE_CONTROL_IMPL_H_
+
+#include "flutter/fml/unique_object.h"
+#include "impeller/toolkit/android/surface_control.h"
+
+namespace impeller::android {
+
+class SurfaceControlImpl final : public SurfaceControl {
+ public:
+  virtual ~SurfaceControlImpl();
+
+  SurfaceControlImpl(const SurfaceControlImpl&) = delete;
+
+  SurfaceControlImpl& operator=(const SurfaceControlImpl&) = delete;
+
+  SurfaceControlImpl(ANativeWindow* window, const char* debug_name);
+
+  bool IsValid() const override;
+
+  ASurfaceControl* GetHandle() const override;
+
+  bool RemoveFromParent() const override;
+
+ private:
+  friend class SurfaceControl;
+
+  struct UniqueASurfaceControlTraits {
+    static ASurfaceControl* InvalidValue() { return nullptr; }
+
+    static bool IsValid(ASurfaceControl* value) {
+      return value != InvalidValue();
+    }
+
+    static void Free(ASurfaceControl* value) {
+      GetProcTable().ASurfaceControl_release(value);
+    }
+  };
+
+  fml::UniqueObject<ASurfaceControl*, UniqueASurfaceControlTraits> control_;
+};
+
+}  // namespace impeller::android
+
+#endif  // FLUTTER_IMPELLER_TOOLKIT_ANDROID_SURFACE_CONTROL_IMPL_H_


### PR DESCRIPTION
### Issue Link:

https://github.com/flutter/flutter/issues/187237

### Impact Description:

This can cause a crash on Impeller/Vulkan during app lifecycle events (shutdown/rotation/etc.) when using HCPP/AHBSwapchain.

### Changelog Description:

[flutter/187237] Fixes a crash that can happen during app shutdown or rotation on some Android devices using Impeller/Vulkan with HCPP.

### Workaround:

Disable Impeller or use the Impeller GLES back end

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:

Run the `AndroidAHBSwapchainTest.AHBSwapchainDtorCallsWaitIdle` unit test.  Or try reproducing the crash in the https://github.com/flutter/flutter/issues/187237 example app and verifying that it is fixed.