### PR TITLE
Add debug check for platform view filter layer conflict

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1023,6 +1023,51 @@ class PlatformViewLayer extends Layer {
   void addToScene(ui.SceneBuilder builder) {
     builder.addPlatformView(viewId, offset: rect.topLeft, width: rect.width, height: rect.height);
   }
+
+  @override
+  void redepthChildren() {
+    assert(() {
+      _debugCheckForRasterizationConflict();
+      return true;
+    }());
+  }
+
+  void _debugCheckForRasterizationConflict() {
+    Layer? ancestor = parent;
+    final path = <Layer>[this];
+    while (ancestor != null) {
+      path.add(ancestor);
+      if (ancestor is ImageFilterLayer ||
+          ancestor is ColorFilterLayer ||
+          ancestor is ShaderMaskLayer) {
+        final propertiesBuilder = DiagnosticPropertiesBuilder();
+        ancestor.debugFillProperties(propertiesBuilder);
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('PlatformViewLayer cannot be a descendant of ${ancestor.runtimeType}'),
+          ErrorDescription(
+            'You might be wrapping a PlatformView (viewID: $viewId) inside a filter-based widget, '
+            'or using an implicit filter layer created by setting "filterQuality" on a Transform.',
+          ),
+          ErrorHint(
+            'Filters generally cannot sample pixels from platform views. '
+            'Try moving the PlatformView outside of any ImageFiltered, ColorFiltered, or ShaderMask widgets. '
+            'Also, ensure ancestor Transform or transform-related widgets '
+            '(e.g. ScaleTransition, MatrixTransition) do not have a non-null "filterQuality".',
+          ),
+          DiagnosticsBlock(
+            name: 'Conflicting ancestor details',
+            properties: propertiesBuilder.properties,
+          ),
+          DiagnosticsProperty<String>(
+            'Layer path',
+            path.reversed.map((Layer l) => l.toStringShort()).join(' ➔ '),
+            style: DiagnosticsTreeStyle.whitespace,
+          ),
+        ]);
+      }
+      ancestor = ancestor.parent;
+    }
+  }
 }
 
 /// A layer that indicates to the compositor that it should display

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1034,12 +1034,19 @@ class PlatformViewLayer extends Layer {
 
   void _debugCheckForRasterizationConflict() {
     Layer? ancestor = parent;
-    final path = <Layer>[this];
     while (ancestor != null) {
-      path.add(ancestor);
       if (ancestor is ImageFilterLayer ||
           ancestor is ColorFilterLayer ||
           ancestor is ShaderMaskLayer) {
+        final path = <Layer>[this];
+        Layer? current = parent;
+        while (current != null) {
+          path.add(current);
+          if (current == ancestor) {
+            break;
+          }
+          current = current.parent;
+        }
         final propertiesBuilder = DiagnosticPropertiesBuilder();
         ancestor.debugFillProperties(propertiesBuilder);
         throw FlutterError.fromParts(<DiagnosticsNode>[

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2769,11 +2769,11 @@ class RenderTransform extends RenderProxyBox {
         } else {
           layer = ImageFilterLayer(imageFilter: filter);
         }
-        context.pushLayer(layer!, super.paint, offset);
         assert(() {
           layer!.debugCreator = debugCreator;
           return true;
         }());
+        context.pushLayer(layer!, super.paint, offset);
       }
     }
   }

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -1018,6 +1018,30 @@ void main() {
 
     expect(platformViewLayer.supportsRasterization(), false);
   });
+
+  test('PlatformViewLayer cannot be a descendant of a filter-based layer', () {
+    final List<ContainerLayer> conflictingLayers = [
+      ImageFilterLayer(),
+      ColorFilterLayer(),
+      ShaderMaskLayer(),
+    ];
+    for (final conflictingLayer in conflictingLayers) {
+      final middleLayer = ContainerLayer();
+      middleLayer.append(PlatformViewLayer(rect: Rect.zero, viewId: 1));
+      expect(
+        () => conflictingLayer.append(middleLayer),
+        throwsA(
+          isA<FlutterError>().having(
+            (error) => error.message,
+            'message',
+            startsWith(
+              'PlatformViewLayer cannot be a descendant of ${conflictingLayer.runtimeType}',
+            ),
+          ),
+        ),
+      );
+    }
+  });
 }
 
 class FakeEngineLayer extends Fake implements EngineLayer {


### PR DESCRIPTION
PR split from #182935

Adds a debug check to detect PlatformViewLayers embedded within filter-based layers. This issue was discovered while investigating the cupertino sheet scaling bug and the check helps surface similar issues earlier during development.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.