### PR TITLE
[Linux] Fix GLib-GIO-CRITICAL warnings in keyboard manager test

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -541,6 +541,19 @@ TEST_F(FlKeyboardManagerTest, CorrectLogicalKeyForLayouts) {
         return kSuccess;
       }));
 
+  // Respond to the key event channel so its async messages complete instead of
+  // leaking their GTasks.
+  fl_mock_binary_messenger_set_json_message_channel(
+      messenger, "flutter/keyevent",
+      [](FlMockBinaryMessenger* messenger, GTask* task, FlValue* message,
+         gpointer user_data) {
+        g_autoptr(FlValue) return_value = fl_value_new_map();
+        fl_value_set_string_take(return_value, "handled",
+                                 fl_value_new_bool(FALSE));
+        return fl_value_ref(return_value);
+      },
+      nullptr);
+
   auto sendTap = [&](guint8 keycode, guint keyval, guint8 group) {
     g_autoptr(FlKeyEvent) event1 = fl_key_event_new(
         0, TRUE, keycode, keyval, static_cast<GdkModifierType>(0), group);


### PR DESCRIPTION
FlKeyboardManagerTest.CorrectLogicalKeyForLayouts sent key events through the keyboard manager without registering a handler for the flutter/keyevent channel. The key channel responder's messages were therefore never answered, leaking their GTasks and producing "GTask finalized without ever returning" GLib-GIO-CRITICAL warnings (one per dispatched event).

Register a flutter/keyevent channel handler that responds, matching the other handle_event tests, so the channel messages complete.
