### PR TITLE
Detach LLDB and print stack trace on process stop

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -566,8 +566,9 @@ class IOSDevice extends Device {
         app: package,
         usingCISystem: debuggingOptions.usingCISystem,
       );
+      final appTerminatedCompleter = Completer<Uri?>();
       if (deviceLogReader is SharedIOSDeviceLogReader) {
-        await _addLogInterceptors(deviceLogReader);
+        await _addLogInterceptors(deviceLogReader, appTerminatedCompleter);
       }
 
       if (debuggingOptions.debuggingEnabled) {
@@ -677,6 +678,7 @@ class IOSDevice extends Device {
           vmServiceDiscovery: vmServiceDiscovery,
           package: package,
           deviceLogReader: deviceLogReader,
+          appTerminatedCompleter: appTerminatedCompleter,
         );
       } else if (isWirelesslyConnected) {
         // Wait for the Dart VM url to be discovered via logs (from `ios-deploy`)
@@ -836,7 +838,10 @@ class IOSDevice extends Device {
     _logger.printError('');
   }
 
-  Future<void> _addLogInterceptors(SharedIOSDeviceLogReader deviceLogReader) async {
+  Future<void> _addLogInterceptors(
+    SharedIOSDeviceLogReader deviceLogReader,
+    Completer<Uri?> appTerminatedCompleter,
+  ) async {
     final String? uisceneWarning = globals.userMessages.uiSceneMigrationWarning;
     if (uisceneWarning != null) {
       final uisceneWarningInterceptor = LogInterceptor(
@@ -856,6 +861,16 @@ class IOSDevice extends Device {
     if (jitCrashInterceptor != null) {
       deviceLogReader.addLogInterceptor(jitCrashInterceptor);
     }
+
+    final appTerminatedInterceptor = LogInterceptor(
+      identifier: 'app_terminated',
+      pattern: RegExp('App terminated'),
+      action: () {
+        appTerminatedCompleter.complete();
+      },
+      excludeFromStream: false,
+    );
+    deviceLogReader.addLogInterceptor(appTerminatedInterceptor);
   }
 
   /// Find the Dart VM url using ProtocolDiscovery (logs from `idevicesyslog`)
@@ -868,47 +883,8 @@ class IOSDevice extends Device {
     ProtocolDiscovery? vmServiceDiscovery,
     IOSApp? package,
     required DeviceLogReader deviceLogReader,
+    required Completer<Uri?> appTerminatedCompleter,
   }) async {
-    Timer? maxWaitForCI;
-    final cancelCompleter = Completer<Uri?>();
-
-    // When testing in CI, wait a max of 10 minutes for the Dart VM to be found.
-    // Afterwards, stop the app from running and upload DerivedData Logs to debug
-    // logs directory. CoreDevices are run through Xcode and launch logs are
-    // therefore found in DerivedData.
-    if (debuggingOptions.usingCISystem && debuggingOptions.debugLogsDirectoryPath != null) {
-      maxWaitForCI = Timer(const Duration(minutes: 10), () async {
-        _logger.printError('Failed to find Dart VM after 10 minutes.');
-        await _xcodeDebug.exit();
-        final String? homePath = _platform.environment['HOME'];
-        Directory? derivedData;
-        if (homePath != null) {
-          derivedData = _fileSystem.directory(
-            _fileSystem.path.join(homePath, 'Library', 'Developer', 'Xcode', 'DerivedData'),
-          );
-        }
-        if (derivedData != null && derivedData.existsSync()) {
-          final Directory debugLogsDirectory = _fileSystem.directory(
-            debuggingOptions.debugLogsDirectoryPath,
-          );
-          debugLogsDirectory.createSync(recursive: true);
-          for (final FileSystemEntity entity in derivedData.listSync()) {
-            if (entity is! Directory || !entity.childDirectory('Logs').existsSync()) {
-              continue;
-            }
-            final Directory logsToCopy = entity.childDirectory('Logs');
-            final Directory copyDestination = debugLogsDirectory
-                .childDirectory('DerivedDataLogs')
-                .childDirectory(entity.basename)
-                .childDirectory('Logs');
-            _logger.printTrace('Copying logs ${logsToCopy.path} to ${copyDestination.path}...');
-            copyDirectory(logsToCopy, copyDestination);
-          }
-        }
-        cancelCompleter.complete();
-      });
-    }
-
     final bool discoverVMUrlFromLogs = vmServiceDiscovery != null && !isWirelesslyConnected;
 
     // If mDNS fails, don't throw since url may still be findable through vmServiceDiscovery.
@@ -927,20 +903,26 @@ class IOSDevice extends Device {
       if (discoverVMUrlFromLogs) vmServiceDiscovery.uri,
     ];
 
-    Uri? localUri = await Future.any(<Future<Uri?>>[...discoveryOptions, cancelCompleter.future]);
+    Uri? localUri = await Future.any(<Future<Uri?>>[
+      ...discoveryOptions,
+      appTerminatedCompleter.future,
+    ]);
 
     // If the first future to return is null, wait for the other to complete
     // unless canceled.
-    if (localUri == null && !cancelCompleter.isCompleted) {
+    if (localUri == null && !appTerminatedCompleter.isCompleted) {
       final Future<List<Uri?>> allDiscoveryOptionsComplete = Future.wait(discoveryOptions);
-      await Future.any(<Future<Object?>>[allDiscoveryOptionsComplete, cancelCompleter.future]);
-      if (!cancelCompleter.isCompleted) {
+      await Future.any(<Future<Object?>>[
+        allDiscoveryOptionsComplete,
+        appTerminatedCompleter.future,
+      ]);
+      if (!appTerminatedCompleter.isCompleted) {
         // If it wasn't cancelled, that means one of the discovery options completed.
         final List<Uri?> vmUrls = await allDiscoveryOptionsComplete;
         localUri = vmUrls.where((Uri? vmUrl) => vmUrl != null).firstOrNull;
       }
     }
-    maxWaitForCI?.cancel();
+
     if (deviceLogReader is SharedIOSDeviceLogReader) {
       deviceLogReader.removeLogInterceptorByIdentifier(kJITCrashLogInterceptorIdentifier);
     }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -867,7 +867,7 @@ class IOSDevice extends Device {
 
     final appTerminatedInterceptor = LogInterceptor(
       identifier: 'app_terminated',
-      pattern: RegExp('App terminated'),
+      pattern: RegExp('^App terminated due to signal'),
       action: () {
         if (!appTerminatedCompleter.isCompleted) {
           appTerminatedCompleter.complete();

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -869,7 +869,9 @@ class IOSDevice extends Device {
       identifier: 'app_terminated',
       pattern: RegExp('App terminated'),
       action: () {
-        appTerminatedCompleter.complete();
+        if (!appTerminatedCompleter.isCompleted) {
+          appTerminatedCompleter.complete();
+        }
       },
       excludeFromStream: false,
     );

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -912,7 +912,7 @@ class IOSDevice extends Device {
     ]);
 
     // If the first future to return is null, wait for the other to complete
-    // unless canceled.
+    // unless the app was terminated.
     if (localUri == null && !appTerminatedCompleter.isCompleted) {
       final Future<List<Uri?>> allDiscoveryOptionsComplete = Future.wait(discoveryOptions);
       await Future.any(<Future<Object?>>[
@@ -920,7 +920,7 @@ class IOSDevice extends Device {
         appTerminatedCompleter.future,
       ]);
       if (!appTerminatedCompleter.isCompleted) {
-        // If it wasn't cancelled, that means one of the discovery options completed.
+        // If it wasn't terminated, that means one of the discovery options completed.
         final List<Uri?> vmUrls = await allDiscoveryOptionsComplete;
         localUri = vmUrls.where((Uri? vmUrl) => vmUrl != null).firstOrNull;
       }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -566,6 +566,9 @@ class IOSDevice extends Device {
         app: package,
         usingCISystem: debuggingOptions.usingCISystem,
       );
+
+      // This completer is used to intercept when the app crashes after the app launches but
+      // before the Dart VM service is found.
       final appTerminatedCompleter = Completer<Uri?>();
       if (deviceLogReader is SharedIOSDeviceLogReader) {
         await _addLogInterceptors(deviceLogReader, appTerminatedCompleter);

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -141,8 +141,7 @@ return False
         await _setBreakpoint();
       }
       await _attachToAppProcess(appProcessId);
-      await _setupBacktrace();
-      await _setupDetach();
+      await _setupStopHooks();
       await _resumeProcess(mode);
       _isAttached = true;
     } on _LLDBError catch (e) {
@@ -228,6 +227,9 @@ return False
   bool exit() {
     final bool success = (_lldbProcess == null) || _lldbProcess!.kill();
     _lldbProcess = null;
+    if (_logCompleter != null) {
+      _logCompleter!.completeError(_LLDBError('LLDB process exited'));
+    }
     _logCompleter = null;
     _isAttached = false;
     return success;
@@ -240,31 +242,24 @@ return False
 
   /// Attaches LLDB to the [appProcessId] running on the device.
   Future<void> _attachToAppProcess(int appProcessId) async {
-    if (_lldbProcess == null) {
-      throw _LLDBError('LLDB process is not running.');
-    }
-
     // Since the app starts stopped (--start-stopped), we expect a stopped state
     // after attaching.
     final Future<String> futureLog = _startWaitingForLog(
       _lldbProcessStopped,
     ).then((value) => value, onError: _handleAsyncError);
 
-    await _lldbProcess!.stdinWriteln('device process attach --pid $appProcessId');
+    await _lldbProcess?.stdinWriteln('device process attach --pid $appProcessId');
     await futureLog;
   }
 
   /// Sets a breakpoint, waits for it print the breakpoint id, and adds a python
   /// script command to be executed whenever the breakpoint is hit.
   Future<void> _setBreakpoint() async {
-    if (_lldbProcess == null) {
-      throw _LLDBError('LLDB process is not running.');
-    }
     final Future<String> futureLog = _startWaitingForLog(
       _breakpointPattern,
     ).then((value) => value, onError: _handleAsyncError);
 
-    await _lldbProcess!.stdinWriteln(
+    await _lldbProcess?.stdinWriteln(
       r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
     );
     final String log = await futureLog;
@@ -276,21 +271,18 @@ return False
 
     // Once it has the breakpoint id, set the python script.
     // For more information, see: lldb > help break command add
-    await _lldbProcess!.stdinWriteln('breakpoint command add --script-type python $breakpointId');
-    await _lldbProcess!.stdinWriteln(_pythonScript);
-    await _lldbProcess!.stdinWriteln('DONE');
+    await _lldbProcess?.stdinWriteln('breakpoint command add --script-type python $breakpointId');
+    await _lldbProcess?.stdinWriteln(_pythonScript);
+    await _lldbProcess?.stdinWriteln('DONE');
 
     // Disable asynchronous mode to workaround issues with rearming of breakpoints.
     // See https://github.com/flutter/flutter/issues/184254 and upstream issue
     // https://github.com/llvm/llvm-project/issues/190956.
-    await _lldbProcess!.stdinWriteln('script lldb.debugger.SetAsync(False)');
+    await _lldbProcess?.stdinWriteln('script lldb.debugger.SetAsync(False)');
   }
 
   /// Resume the stopped process.
   Future<void> _resumeProcess(BuildMode mode) async {
-    if (_lldbProcess == null) {
-      throw _LLDBError('LLDB process is not running.');
-    }
     final Future<String> futureLog = _startWaitingForLog(
       // When using debug mode, a breakpoint is added once the process resumes and no resume log
       // is shown. Instead we match on the breakpoint added log. In profile mode, a resume log is
@@ -298,33 +290,19 @@ return False
       mode == BuildMode.debug ? _lldbBreakpointAdded : _lldbProcessResuming,
     ).then((value) => value, onError: _handleAsyncError);
 
-    await _lldbProcess!.stdinWriteln('process continue');
+    await _lldbProcess?.stdinWriteln('process continue');
     await futureLog;
   }
 
-  /// Adds a stop hook to detach the debugger from the process once it stops, such as when it crashes.
+  /// Adds a stop hook to print the backtrace of all threads and then detach the debugger from the
+  /// process once it stops, such as when it crashes.
   ///
   /// Without this, the debugger would remain attached to the process and the app will hang on crash.
-  Future<void> _setupDetach() async {
-    if (_lldbProcess == null) {
-      throw _LLDBError('LLDB process is not running.');
-    }
+  Future<void> _setupStopHooks() async {
     final Future<String> futureLog = _startWaitingForLog(
       _stopHookAddedPattern,
     ).then((value) => value, onError: _handleAsyncError);
-    await _lldbProcess!.stdinWriteln('target stop-hook add -o "detach"');
-    await futureLog;
-  }
-
-  /// Setup a stop hook to print the backtrace of all threads when the app process stops.
-  Future<void> _setupBacktrace() async {
-    if (_lldbProcess == null) {
-      throw _LLDBError('LLDB process is not running.');
-    }
-    final Future<String> futureLog = _startWaitingForLog(
-      _stopHookAddedPattern,
-    ).then((value) => value, onError: _handleAsyncError);
-    await _lldbProcess!.stdinWriteln('target stop-hook add -o "thread backtrace all"');
+    await _lldbProcess?.stdinWriteln('target stop-hook add -o "thread backtrace all" -o "detach"');
     await futureLog;
   }
 

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -64,8 +64,21 @@ class LLDB {
   /// Example: Breakpoint 1: no locations (pending).
   static final _breakpointPattern = RegExp(r'Breakpoint (\d+)*:');
 
+  /// Pattern of lldb log when a stop hook is added.
+  ///
+  /// Example: Stop hook #1 added.
+  static final _stopHookAddedPattern = RegExp(r'Stop hook #[\d]+ added.');
+
+  /// Pattern of lldb log when a stop hook is processed.
+  ///
+  /// Example: "- Hook 1 (thread backtrace all)"
+  static final _stopHookProcessedPattern = RegExp(r'- Hook (\d+)*');
+
   /// A list of log patterns to ignore.
-  static final _ignorePatterns = <Pattern>[RegExp(r'\d+ location added to breakpoint \d+')];
+  static final _ignorePatterns = <Pattern>[
+    RegExp(r'\d+ location added to breakpoint \d+'),
+    _stopHookProcessedPattern,
+  ];
 
   /// Breakpoint script required for JIT on iOS.
   ///
@@ -128,6 +141,8 @@ return False
         await _setBreakpoint();
       }
       await _attachToAppProcess(appProcessId);
+      await _setupBacktrace();
+      await _setupDetach();
       await _resumeProcess(mode);
       _isAttached = true;
     } on _LLDBError catch (e) {
@@ -274,6 +289,26 @@ return False
     ).then((value) => value, onError: _handleAsyncError);
 
     await _lldbProcess?.stdinWriteln('process continue');
+    await futureLog;
+  }
+
+  /// Adds a stop hook to detach the debugger from the process once it stops, such as when it crashes.
+  ///
+  /// Without this, the debugger would remain attached to the process and the app will hang on crash.
+  Future<void> _setupDetach() async {
+    final Future<String> futureLog = _startWaitingForLog(
+      _stopHookAddedPattern,
+    ).then((value) => value, onError: _handleAsyncError);
+    await _lldbProcess?.stdinWriteln('target stop-hook add -o "detach"');
+    await futureLog;
+  }
+
+  /// Setup a stop hook to print the backtrace of all threads when the app process stops.
+  Future<void> _setupBacktrace() async {
+    final Future<String> futureLog = _startWaitingForLog(
+      _stopHookAddedPattern,
+    ).then((value) => value, onError: _handleAsyncError);
+    await _lldbProcess?.stdinWriteln('target stop-hook add -o "thread backtrace all"');
     await futureLog;
   }
 

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -67,12 +67,12 @@ class LLDB {
   /// Pattern of lldb log when a stop hook is added.
   ///
   /// Example: Stop hook #1 added.
-  static final _stopHookAddedPattern = RegExp(r'Stop hook #[\d]+ added.');
+  static final _stopHookAddedPattern = RegExp(r'Stop hook #\d+ added');
 
   /// Pattern of lldb log when a stop hook is processed.
   ///
   /// Example: "- Hook 1 (thread backtrace all)"
-  static final _stopHookProcessedPattern = RegExp(r'- Hook (\d+)*');
+  static final _stopHookProcessedPattern = RegExp(r'- Hook \d+');
 
   /// A list of log patterns to ignore.
   static final _ignorePatterns = <Pattern>[
@@ -240,24 +240,31 @@ return False
 
   /// Attaches LLDB to the [appProcessId] running on the device.
   Future<void> _attachToAppProcess(int appProcessId) async {
+    if (_lldbProcess == null) {
+      throw _LLDBError('LLDB process is not running.');
+    }
+
     // Since the app starts stopped (--start-stopped), we expect a stopped state
     // after attaching.
     final Future<String> futureLog = _startWaitingForLog(
       _lldbProcessStopped,
     ).then((value) => value, onError: _handleAsyncError);
 
-    await _lldbProcess?.stdinWriteln('device process attach --pid $appProcessId');
+    await _lldbProcess!.stdinWriteln('device process attach --pid $appProcessId');
     await futureLog;
   }
 
   /// Sets a breakpoint, waits for it print the breakpoint id, and adds a python
   /// script command to be executed whenever the breakpoint is hit.
   Future<void> _setBreakpoint() async {
+    if (_lldbProcess == null) {
+      throw _LLDBError('LLDB process is not running.');
+    }
     final Future<String> futureLog = _startWaitingForLog(
       _breakpointPattern,
     ).then((value) => value, onError: _handleAsyncError);
 
-    await _lldbProcess?.stdinWriteln(
+    await _lldbProcess!.stdinWriteln(
       r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
     );
     final String log = await futureLog;
@@ -269,18 +276,21 @@ return False
 
     // Once it has the breakpoint id, set the python script.
     // For more information, see: lldb > help break command add
-    await _lldbProcess?.stdinWriteln('breakpoint command add --script-type python $breakpointId');
-    await _lldbProcess?.stdinWriteln(_pythonScript);
-    await _lldbProcess?.stdinWriteln('DONE');
+    await _lldbProcess!.stdinWriteln('breakpoint command add --script-type python $breakpointId');
+    await _lldbProcess!.stdinWriteln(_pythonScript);
+    await _lldbProcess!.stdinWriteln('DONE');
 
     // Disable asynchronous mode to workaround issues with rearming of breakpoints.
     // See https://github.com/flutter/flutter/issues/184254 and upstream issue
     // https://github.com/llvm/llvm-project/issues/190956.
-    await _lldbProcess?.stdinWriteln('script lldb.debugger.SetAsync(False)');
+    await _lldbProcess!.stdinWriteln('script lldb.debugger.SetAsync(False)');
   }
 
   /// Resume the stopped process.
   Future<void> _resumeProcess(BuildMode mode) async {
+    if (_lldbProcess == null) {
+      throw _LLDBError('LLDB process is not running.');
+    }
     final Future<String> futureLog = _startWaitingForLog(
       // When using debug mode, a breakpoint is added once the process resumes and no resume log
       // is shown. Instead we match on the breakpoint added log. In profile mode, a resume log is
@@ -288,7 +298,7 @@ return False
       mode == BuildMode.debug ? _lldbBreakpointAdded : _lldbProcessResuming,
     ).then((value) => value, onError: _handleAsyncError);
 
-    await _lldbProcess?.stdinWriteln('process continue');
+    await _lldbProcess!.stdinWriteln('process continue');
     await futureLog;
   }
 
@@ -296,19 +306,25 @@ return False
   ///
   /// Without this, the debugger would remain attached to the process and the app will hang on crash.
   Future<void> _setupDetach() async {
+    if (_lldbProcess == null) {
+      throw _LLDBError('LLDB process is not running.');
+    }
     final Future<String> futureLog = _startWaitingForLog(
       _stopHookAddedPattern,
     ).then((value) => value, onError: _handleAsyncError);
-    await _lldbProcess?.stdinWriteln('target stop-hook add -o "detach"');
+    await _lldbProcess!.stdinWriteln('target stop-hook add -o "detach"');
     await futureLog;
   }
 
   /// Setup a stop hook to print the backtrace of all threads when the app process stops.
   Future<void> _setupBacktrace() async {
+    if (_lldbProcess == null) {
+      throw _LLDBError('LLDB process is not running.');
+    }
     final Future<String> futureLog = _startWaitingForLog(
       _stopHookAddedPattern,
     ).then((value) => value, onError: _handleAsyncError);
-    await _lldbProcess?.stdinWriteln('target stop-hook add -o "thread backtrace all"');
+    await _lldbProcess!.stdinWriteln('target stop-hook add -o "thread backtrace all"');
     await futureLog;
   }
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -1411,7 +1411,7 @@ void main() {
           device.setLogReader(iosApp, deviceLogReader);
 
           unawaited(
-            mdnsDiscovery.completer.future.whenComplete(() {
+            mdnsDiscovery.discoveryStarted.future.whenComplete(() {
               // Start writing messages to the log reader.
               Timer.run(() {
                 deviceLogReader.addLine('Foo');
@@ -1440,9 +1440,15 @@ void main() {
         }, overrides: <Type, Generator>{MDnsVmServiceDiscovery: () => mdnsDiscovery});
       });
 
-      testUsingContext(
-        'IOSDevice.startApp fails to find Dart VM when app terminates',
-        () async {
+      group('IOSDevice.startApp fails to find Dart VM', () {
+        late FakeMDnsVmServiceDiscovery mdnsDiscovery;
+        late Completer<void> mdnsDiscoveryWaitToComplete;
+        setUp(() {
+          mdnsDiscoveryWaitToComplete = Completer<void>();
+          mdnsDiscovery = FakeMDnsVmServiceDiscovery(waitToReturn: mdnsDiscoveryWaitToComplete);
+        });
+
+        testUsingContext('when app terminates', () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
           final processManager = FakeProcessManager.empty();
 
@@ -1494,6 +1500,12 @@ void main() {
             platformArgs: <String, dynamic>{},
           );
           unawaited(
+            mdnsDiscovery.discoveryStarted.future.whenComplete(() {
+              deviceLogReader.addLine('App terminated');
+            }),
+          );
+
+          unawaited(
             futureLaunchResult.then((LaunchResult launchResult) {
               expect(launchResult.started, false);
               expect(launchResult.hasVmService, false);
@@ -1505,18 +1517,13 @@ void main() {
                 ),
               ]);
               completer.complete();
+              mdnsDiscoveryWaitToComplete.complete();
             }),
           );
 
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-          deviceLogReader.addLine('App terminated');
-
           await completer.future;
-        },
-        overrides: <Type, Generator>{
-          MDnsVmServiceDiscovery: () => FakeMDnsVmServiceDiscovery(returnsNull: true),
-        },
-      );
+        }, overrides: <Type, Generator>{MDnsVmServiceDiscovery: () => mdnsDiscovery});
+      });
 
       testUsingContext(
         'IOSDevice.startApp prints guided message when iOS 18.4 crashes due to JIT',
@@ -1729,11 +1736,14 @@ class FakeMDnsVmServiceDiscovery extends Fake implements MDnsVmServiceDiscovery 
   FakeMDnsVmServiceDiscovery({
     this.returnsNull = false,
     this.allowthrowOnMissingLocalNetworkPermissionsError = true,
+    this.waitToReturn,
   });
   bool returnsNull;
   bool allowthrowOnMissingLocalNetworkPermissionsError;
 
-  Completer<void> completer = Completer<void>();
+  Completer<void> discoveryStarted = Completer<void>();
+
+  Completer<void>? waitToReturn;
   @override
   Future<Uri?> getVMServiceUriForLaunch(
     String applicationId,
@@ -1745,7 +1755,8 @@ class FakeMDnsVmServiceDiscovery extends Fake implements MDnsVmServiceDiscovery 
     Duration timeout = Duration.zero,
     bool throwOnMissingLocalNetworkPermissionsError = true,
   }) async {
-    completer.complete();
+    discoveryStarted.complete();
+    await waitToReturn?.future;
     if (returnsNull) {
       return null;
     }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -974,71 +974,67 @@ void main() {
         ]);
       }, overrides: {Xcode: () => FakeXcode(currentVersion: Version(26, 0, 0))});
 
-      testUsingContext(
-        'uses Xcode if less than Xcode 26',
-        () async {
-          final FileSystem fileSystem = MemoryFileSystem.test();
-          final processManager = FakeProcessManager.empty();
-          final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
-              .childDirectory('flutter_empty_xcode.rand0');
-          final Directory bundleLocation = fileSystem.currentDirectory;
-          final fakeAnalytics = FakeAnalytics();
-          final fakeLauncher = FakeIOSCoreDeviceLauncher();
-          final IOSDevice device = setUpIOSDevice(
-            processManager: processManager,
-            fileSystem: fileSystem,
-            isCoreDevice: true,
-            coreDeviceControl: FakeIOSCoreDeviceControl(),
-            xcodeDebug: FakeXcodeDebug(
-              expectedProject: XcodeDebugProject(
-                scheme: 'Runner',
-                xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
-                xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
-                hostAppProjectName: 'Runner',
-              ),
-              expectedDeviceId: '123',
-              expectedLaunchArguments: <String>['--enable-dart-profiling'],
-              expectedBundlePath: bundleLocation.path,
+      testUsingContext('uses Xcode if less than Xcode 26', () async {
+        final FileSystem fileSystem = MemoryFileSystem.test();
+        final processManager = FakeProcessManager.empty();
+        final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
+            .childDirectory('flutter_empty_xcode.rand0');
+        final Directory bundleLocation = fileSystem.currentDirectory;
+        final fakeAnalytics = FakeAnalytics();
+        final fakeLauncher = FakeIOSCoreDeviceLauncher();
+        final IOSDevice device = setUpIOSDevice(
+          processManager: processManager,
+          fileSystem: fileSystem,
+          isCoreDevice: true,
+          coreDeviceControl: FakeIOSCoreDeviceControl(),
+          xcodeDebug: FakeXcodeDebug(
+            expectedProject: XcodeDebugProject(
+              scheme: 'Runner',
+              xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
+              xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
+              hostAppProjectName: 'Runner',
             ),
-            coreDeviceLauncher: fakeLauncher,
-            analytics: fakeAnalytics,
-          );
-          final IOSApp iosApp = PrebuiltIOSApp(
-            projectBundleId: 'app',
-            bundleName: 'Runner',
-            uncompressedBundle: bundleLocation,
-            applicationPackage: bundleLocation,
-          );
-          final deviceLogReader = FakeDeviceLogReader();
+            expectedDeviceId: '123',
+            expectedLaunchArguments: <String>['--enable-dart-profiling'],
+            expectedBundlePath: bundleLocation.path,
+          ),
+          coreDeviceLauncher: fakeLauncher,
+          analytics: fakeAnalytics,
+        );
+        final IOSApp iosApp = PrebuiltIOSApp(
+          projectBundleId: 'app',
+          bundleName: 'Runner',
+          uncompressedBundle: bundleLocation,
+          applicationPackage: bundleLocation,
+        );
+        final deviceLogReader = FakeDeviceLogReader();
 
-          device.portForwarder = const NoOpDevicePortForwarder();
-          device.setLogReader(iosApp, deviceLogReader);
+        device.portForwarder = const NoOpDevicePortForwarder();
+        device.setLogReader(iosApp, deviceLogReader);
 
-          // Start writing messages to the log reader.
-          Timer.run(() {
-            deviceLogReader.addLine('Foo');
-            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
-          });
+        // Start writing messages to the log reader.
+        Timer.run(() {
+          deviceLogReader.addLine('Foo');
+          deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+        });
 
-          final LaunchResult launchResult = await device.startApp(
-            iosApp,
-            prebuiltApplication: true,
-            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-            platformArgs: <String, dynamic>{},
-          );
+        final LaunchResult launchResult = await device.startApp(
+          iosApp,
+          prebuiltApplication: true,
+          debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+          platformArgs: <String, dynamic>{},
+        );
 
-          expect(launchResult.started, true);
-          expect(fakeLauncher.launchedWithLLDB, false);
-          expect(fakeAnalytics.sentEvents, [
-            Event.appleUsageEvent(
-              workflow: 'ios-physical-deployment',
-              parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
-              result: 'debugging success',
-            ),
-          ]);
-        },
-        overrides: {Xcode: () => FakeXcode(currentVersion: Version(16, 0, 0))},
-      );
+        expect(launchResult.started, true);
+        expect(fakeLauncher.launchedWithLLDB, false);
+        expect(fakeAnalytics.sentEvents, [
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+            result: 'debugging success',
+          ),
+        ]);
+      }, overrides: {Xcode: () => FakeXcode(currentVersion: Version(16, 0, 0))});
 
       testUsingContext('succeeds', () async {
         final FileSystem fileSystem = MemoryFileSystem.test();
@@ -1445,12 +1441,11 @@ void main() {
       });
 
       testUsingContext(
-        'IOSDevice.startApp fails to find Dart VM in CI',
+        'IOSDevice.startApp fails to find Dart VM when app terminates',
         () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
           final processManager = FakeProcessManager.empty();
 
-          const pathToFlutterLogs = '/path/to/flutter/logs';
           const pathToHome = '/path/to/home';
 
           final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
@@ -1486,37 +1481,22 @@ void main() {
             uncompressedBundle: bundleLocation,
             applicationPackage: bundleLocation,
           );
-          final deviceLogReader = FakeDeviceLogReader();
+          final deviceLogReader = FakeSharedIOSDeviceLogReader();
 
           device.portForwarder = const NoOpDevicePortForwarder();
           device.setLogReader(iosApp, deviceLogReader);
 
-          const projectLogsPath = 'Runner-project1/Logs/Launch/Runner.xcresults';
-          fileSystem
-              .directory('$pathToHome/Library/Developer/Xcode/DerivedData/$projectLogsPath')
-              .createSync(recursive: true);
-
           final completer = Completer<void>();
-          await FakeAsync().run((FakeAsync time) {
-            final Future<LaunchResult> futureLaunchResult = device.startApp(
-              iosApp,
-              prebuiltApplication: true,
-              debuggingOptions: DebuggingOptions.enabled(
-                BuildInfo.debug,
-                usingCISystem: true,
-                debugLogsDirectoryPath: pathToFlutterLogs,
-              ),
-              platformArgs: <String, dynamic>{},
-            );
+          final Future<LaunchResult> futureLaunchResult = device.startApp(
+            iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            platformArgs: <String, dynamic>{},
+          );
+          unawaited(
             futureLaunchResult.then((LaunchResult launchResult) {
               expect(launchResult.started, false);
               expect(launchResult.hasVmService, false);
-              expect(
-                fileSystem
-                    .directory('$pathToFlutterLogs/DerivedDataLogs/$projectLogsPath')
-                    .existsSync(),
-                true,
-              );
               expect(fakeAnalytics.sentEvents, [
                 Event.appleUsageEvent(
                   workflow: 'ios-physical-deployment',
@@ -1525,11 +1505,13 @@ void main() {
                 ),
               ]);
               completer.complete();
-            });
-            time.elapse(const Duration(minutes: 15));
-            time.flushMicrotasks();
-            return completer.future;
-          });
+            }),
+          );
+
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          deviceLogReader.addLine('App terminated');
+
+          await completer.future;
         },
         overrides: <Type, Generator>{
           MDnsVmServiceDiscovery: () => FakeMDnsVmServiceDiscovery(returnsNull: true),

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -1501,7 +1501,7 @@ void main() {
           );
           unawaited(
             mdnsDiscovery.discoveryStarted.future.whenComplete(() {
-              deviceLogReader.addLine('App terminated');
+              deviceLogReader.addLine('App terminated due to signal 5');
             }),
           );
 

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -64,15 +64,13 @@ void main() {
 
     final breakPointCompleter = Completer<List<int>>();
     final processAttachCompleter = Completer<List<int>>();
-    final setupBacktraceCompleter = Completer<List<int>>();
-    final setupDetachCompleter = Completer<List<int>>();
+    final setupStopHooksCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       breakPointCompleter.future,
       processAttachCompleter.future,
-      setupBacktraceCompleter.future,
-      setupDetachCompleter.future,
+      setupStopHooksCompleter.future,
       processResumedCompleted.future,
     ]);
 
@@ -100,16 +98,14 @@ void main() {
     const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
-    const setupBacktraceMatcher = 'target stop-hook add -o "thread backtrace all"';
-    const setupDetachMatcher = 'target stop-hook add -o "detach"';
+    const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
     final expectedInputs = [
       'device select $deviceId',
       breakPointMatcher,
       'breakpoint command add --script-type python $breakpointId',
       'script lldb.debugger.SetAsync(False)',
       processAttachMatcher,
-      setupBacktraceMatcher,
-      setupDetachMatcher,
+      setupStopHooksMatcher,
       processResumedMatcher,
     ];
 
@@ -137,11 +133,8 @@ Target 0: (Runner) stopped.
 '''),
         );
       }
-      if (line == setupBacktraceMatcher) {
-        setupBacktraceCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
-      }
-      if (line == setupDetachMatcher) {
-        setupDetachCompleter.complete(utf8.encode('Stop hook #2 added.\n'));
+      if (line == setupStopHooksMatcher) {
+        setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
       }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));
@@ -167,14 +160,12 @@ Target 0: (Runner) stopped.
     const appProcessId = 5678;
 
     final processAttachCompleter = Completer<List<int>>();
-    final setupBacktraceCompleter = Completer<List<int>>();
-    final setupDetachCompleter = Completer<List<int>>();
+    final setupStopHooksCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       processAttachCompleter.future,
-      setupBacktraceCompleter.future,
-      setupDetachCompleter.future,
+      setupStopHooksCompleter.future,
       processResumedCompleted.future,
     ]);
 
@@ -201,13 +192,11 @@ Target 0: (Runner) stopped.
 
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
-    const setupBacktraceMatcher = 'target stop-hook add -o "thread backtrace all"';
-    const setupDetachMatcher = 'target stop-hook add -o "detach"';
+    const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
     final expectedInputs = [
       'device select $deviceId',
       processAttachMatcher,
-      setupBacktraceMatcher,
-      setupDetachMatcher,
+      setupStopHooksMatcher,
       processResumedMatcher,
     ];
 
@@ -230,11 +219,8 @@ Target 0: (Runner) stopped.
 '''),
         );
       }
-      if (line == setupBacktraceMatcher) {
-        setupBacktraceCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
-      }
-      if (line == setupDetachMatcher) {
-        setupDetachCompleter.complete(utf8.encode('Stop hook #2 added.\n'));
+      if (line == setupStopHooksMatcher) {
+        setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
       }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
@@ -345,14 +331,19 @@ Target 0: (Runner) stopped.
       processUtils: processUtils,
       xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
     );
-    final expectedInputs = ['device select $deviceId'];
+    final expectedInputs = [
+      'device select $deviceId',
+      r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
+    ];
     const errorText = "error: 'device' is not a valid command.\n";
 
     stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
       String line,
     ) {
       expectedInputs.remove(line);
-      errorCompleter.complete(utf8.encode(errorText));
+      if (expectedInputs.isEmpty) {
+        errorCompleter.complete(utf8.encode(errorText));
+      }
     });
 
     final bool success = await lldb.attachAndStart(
@@ -429,16 +420,14 @@ Target 0: (Runner) stopped.
 
     final breakPointCompleter = Completer<List<int>>();
     final processAttachCompleter = Completer<List<int>>();
-    final setupBacktraceCompleter = Completer<List<int>>();
-    final setupDetachCompleter = Completer<List<int>>();
+    final setupStopHooksCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
     final logAfterAttachCompleter = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       breakPointCompleter.future,
       processAttachCompleter.future,
-      setupBacktraceCompleter.future,
-      setupDetachCompleter.future,
+      setupStopHooksCompleter.future,
       processResumedCompleted.future,
       logAfterAttachCompleter.future,
     ]);
@@ -467,16 +456,14 @@ Target 0: (Runner) stopped.
     const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
-    const setupBacktraceMatcher = 'target stop-hook add -o "thread backtrace all"';
-    const setupDetachMatcher = 'target stop-hook add -o "detach"';
+    const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
     final expectedInputs = [
       'device select $deviceId',
       breakPointMatcher,
       'breakpoint command add --script-type python $breakpointId',
       'script lldb.debugger.SetAsync(False)',
       processAttachMatcher,
-      setupBacktraceMatcher,
-      setupDetachMatcher,
+      setupStopHooksMatcher,
       processResumedMatcher,
     ];
 
@@ -504,11 +491,8 @@ Target 0: (Runner) stopped.
 '''),
         );
       }
-      if (line == setupBacktraceMatcher) {
-        setupBacktraceCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
-      }
-      if (line == setupDetachMatcher) {
-        setupDetachCompleter.complete(utf8.encode('Stop hook #2 added.\n'));
+      if (line == setupStopHooksMatcher) {
+        setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
       }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -64,11 +64,15 @@ void main() {
 
     final breakPointCompleter = Completer<List<int>>();
     final processAttachCompleter = Completer<List<int>>();
+    final setupBacktraceCompleter = Completer<List<int>>();
+    final setupDetachCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       breakPointCompleter.future,
       processAttachCompleter.future,
+      setupBacktraceCompleter.future,
+      setupDetachCompleter.future,
       processResumedCompleted.future,
     ]);
 
@@ -96,12 +100,16 @@ void main() {
     const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
+    const setupBacktraceMatcher = 'target stop-hook add -o "thread backtrace all"';
+    const setupDetachMatcher = 'target stop-hook add -o "detach"';
     final expectedInputs = [
       'device select $deviceId',
       breakPointMatcher,
       'breakpoint command add --script-type python $breakpointId',
       'script lldb.debugger.SetAsync(False)',
       processAttachMatcher,
+      setupBacktraceMatcher,
+      setupDetachMatcher,
       processResumedMatcher,
     ];
 
@@ -129,6 +137,12 @@ Target 0: (Runner) stopped.
 '''),
         );
       }
+      if (line == setupBacktraceMatcher) {
+        setupBacktraceCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
+      }
+      if (line == setupDetachMatcher) {
+        setupDetachCompleter.complete(utf8.encode('Stop hook #2 added.\n'));
+      }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));
       }
@@ -153,10 +167,14 @@ Target 0: (Runner) stopped.
     const appProcessId = 5678;
 
     final processAttachCompleter = Completer<List<int>>();
+    final setupBacktraceCompleter = Completer<List<int>>();
+    final setupDetachCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       processAttachCompleter.future,
+      setupBacktraceCompleter.future,
+      setupDetachCompleter.future,
       processResumedCompleted.future,
     ]);
 
@@ -183,7 +201,15 @@ Target 0: (Runner) stopped.
 
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
-    final expectedInputs = ['device select $deviceId', processAttachMatcher, processResumedMatcher];
+    const setupBacktraceMatcher = 'target stop-hook add -o "thread backtrace all"';
+    const setupDetachMatcher = 'target stop-hook add -o "detach"';
+    final expectedInputs = [
+      'device select $deviceId',
+      processAttachMatcher,
+      setupBacktraceMatcher,
+      setupDetachMatcher,
+      processResumedMatcher,
+    ];
 
     stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
       String line,
@@ -203,6 +229,12 @@ dyld`_dyld_start:
 Target 0: (Runner) stopped.
 '''),
         );
+      }
+      if (line == setupBacktraceMatcher) {
+        setupBacktraceCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
+      }
+      if (line == setupDetachMatcher) {
+        setupDetachCompleter.complete(utf8.encode('Stop hook #2 added.\n'));
       }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
@@ -397,12 +429,16 @@ Target 0: (Runner) stopped.
 
     final breakPointCompleter = Completer<List<int>>();
     final processAttachCompleter = Completer<List<int>>();
+    final setupBacktraceCompleter = Completer<List<int>>();
+    final setupDetachCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
     final logAfterAttachCompleter = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       breakPointCompleter.future,
       processAttachCompleter.future,
+      setupBacktraceCompleter.future,
+      setupDetachCompleter.future,
       processResumedCompleted.future,
       logAfterAttachCompleter.future,
     ]);
@@ -431,12 +467,16 @@ Target 0: (Runner) stopped.
     const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
+    const setupBacktraceMatcher = 'target stop-hook add -o "thread backtrace all"';
+    const setupDetachMatcher = 'target stop-hook add -o "detach"';
     final expectedInputs = [
       'device select $deviceId',
       breakPointMatcher,
       'breakpoint command add --script-type python $breakpointId',
       'script lldb.debugger.SetAsync(False)',
       processAttachMatcher,
+      setupBacktraceMatcher,
+      setupDetachMatcher,
       processResumedMatcher,
     ];
 
@@ -463,6 +503,12 @@ dyld`_dyld_start:
 Target 0: (Runner) stopped.
 '''),
         );
+      }
+      if (line == setupBacktraceMatcher) {
+        setupBacktraceCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
+      }
+      if (line == setupDetachMatcher) {
+        setupDetachCompleter.complete(utf8.encode('Stop hook #2 added.\n'));
       }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));


### PR DESCRIPTION
This PR automatically detaches LLDB from the process and prints the stack trace if the app process stops.

This prevents the app from hanging on crash.

Fixes https://github.com/flutter/flutter/issues/186366.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
