### PR TITLE
[CP-beta] [Impeller] Wait for the Vulkan device to become idle before destroying Vulkan objects in the AHBSwapchainImplVK destructor (#187477)

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
@@ -10,6 +10,7 @@
 
 namespace impeller::android::testing {
 
+using impeller::testing::GetMockVulkanFunctions;
 using impeller::testing::MockVulkanContextBuilder;
 
 const std::vector<std::string> kAndroidDeviceExtensions = {
@@ -54,6 +55,22 @@ TEST(AndroidAHBSwapchainTest,
 
   ahb_swapchain->AcquireNextDrawable();
   EXPECT_FALSE(wait_for_fences_called);
+}
+
+TEST(AndroidAHBSwapchainTest, AHBSwapchainDtorCallsWaitIdle) {
+  const auto context = MockVulkanContextBuilder()
+                           .SetDeviceExtensions(kAndroidDeviceExtensions)
+                           .Build();
+
+  auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
+      context, std::make_shared<FakeSurfaceControl>(), {}, {100, 100}, false));
+
+  ahb_swapchain.reset();
+
+  auto called_functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_NE(std::find(called_functions->begin(), called_functions->end(),
+                      "vkDeviceWaitIdle"),
+            called_functions->end());
 }
 
 }  // namespace impeller::android::testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -105,7 +105,11 @@ AHBSwapchainImplVK::AHBSwapchainImplVK(
   is_valid_ = control && control->IsValid();
 }
 
-AHBSwapchainImplVK::~AHBSwapchainImplVK() = default;
+AHBSwapchainImplVK::~AHBSwapchainImplVK() {
+  // Ensure that the Vulkan device is idle before destroying objects that the
+  // device may have been using.
+  WaitIdle();
+}
 
 const ISize& AHBSwapchainImplVK::GetSize() const {
   return desc_.size;
@@ -118,6 +122,17 @@ bool AHBSwapchainImplVK::IsValid() const {
 const android::HardwareBufferDescriptor& AHBSwapchainImplVK::GetDescriptor()
     const {
   return desc_;
+}
+
+void AHBSwapchainImplVK::WaitIdle() const {
+  if (transients_) {
+    if (auto context = transients_->GetContext().lock()) {
+      auto result = ContextVK::Cast(*context).GetDevice().waitIdle();
+      if (result != vk::Result::eSuccess) {
+        FML_LOG(INFO) << "Device waitIdle failed: " << vk::to_string(result);
+      }
+    }
+  }
 }
 
 std::unique_ptr<Surface> AHBSwapchainImplVK::AcquireNextDrawable() {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.h
@@ -141,6 +141,8 @@ class AHBSwapchainImplVK final
 
   bool Present(const std::shared_ptr<AHBTextureSourceVK>& texture);
 
+  void WaitIdle() const;
+
   vk::UniqueSemaphore CreateRenderReadySemaphore(
       const std::shared_ptr<fml::UniqueFD>& fd) const;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.h
@@ -14,9 +14,10 @@
 namespace impeller {
 
 namespace android::testing {
+FML_TEST_CLASS(AndroidAHBSwapchainTest, AHBSwapchainDtorCallsWaitIdle);
 FML_TEST_CLASS(AndroidAHBSwapchainTest,
                AHBSwapchainNoFenceWaitAfterAcquireNextImageFailure);
-}
+}  // namespace android::testing
 
 using CreateTransactionCB = std::function<android::SurfaceTransaction()>;
 
@@ -60,6 +61,8 @@ class AHBSwapchainVK final : public SwapchainVK {
 
  private:
   friend class SwapchainVK;
+  FML_FRIEND_TEST(android::testing::AndroidAHBSwapchainTest,
+                  AHBSwapchainDtorCallsWaitIdle);
   FML_FRIEND_TEST(android::testing::AndroidAHBSwapchainTest,
                   AHBSwapchainNoFenceWaitAfterAcquireNextImageFailure);
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -467,6 +467,12 @@ VkResult vkCreateGraphicsPipelines(
   return VK_SUCCESS;
 }
 
+VkResult vkDeviceWaitIdle(VkDevice device) {
+  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  mock_device->AddCalledFunction("vkDeviceWaitIdle");
+  return VK_SUCCESS;
+}
+
 void vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
   MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
   mock_device->AddCalledFunction("vkDestroyDevice");
@@ -960,6 +966,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreatePipelineLayout);
   } else if (strcmp("vkCreateGraphicsPipelines", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateGraphicsPipelines);
+  } else if (strcmp("vkDeviceWaitIdle", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkDeviceWaitIdle);
   } else if (strcmp("vkDestroyDevice", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDevice);
   } else if (strcmp("vkDestroyInstance", pName) == 0) {


### PR DESCRIPTION
### Issue Link:

https://github.com/flutter/flutter/issues/187237

### Impact Description:

This can cause a crash on Impeller/Vulkan during app lifecycle events (shutdown/rotation/etc.) when using HCPP/AHBSwapchain.

### Changelog Description:

[flutter/187237] Fixes a crash that can happen during app shutdown or rotation on some Android devices using Impeller/Vulkan with HCPP.

### Workaround:

Disable Impeller or use the Impeller GLES back end

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:

Run the `AndroidAHBSwapchainTest.AHBSwapchainDtorCallsWaitIdle` unit test.  Or try reproducing the crash in the https://github.com/flutter/flutter/issues/187237 example app and verifying that it is fixed.