### PR TITLE
Add macOS AppKitView gesture handling

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h
@@ -83,6 +83,12 @@ class PlatformViewLayer {
 /// (part of view obscured by Flutter contents).
 - (void)addHitTestIgnoreRegion:(CGRect)region;
 
+/// Releases the active mouse gesture to the embedded platform view.
+- (void)releaseGesture;
+
+/// Blocks the active mouse gesture from reaching the embedded platform view.
+- (void)blockGesture;
+
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERMUTATORVIEW_H_

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
@@ -148,13 +148,15 @@ PlatformViewLayer::PlatformViewLayer(FlutterPlatformViewIdentifier identifier,
 
 @implementation FlutterPlatformViewMouseInterceptor {
   __weak NSView* _platformView;
-  NSEvent* _pendingMouseDownEvent;
+  __weak NSView* _forwardingTargetView;
+  NSMutableArray<NSEvent*>* _pendingMouseEvents;
   BOOL _forwardingGesture;
 }
 
 - (instancetype)initWithPlatformView:(NSView*)platformView {
   if (self = [super initWithFrame:NSZeroRect]) {
     _platformView = platformView;
+    _pendingMouseEvents = [[NSMutableArray alloc] init];
   }
   return self;
 }
@@ -173,29 +175,67 @@ PlatformViewLayer::PlatformViewLayer(FlutterPlatformViewIdentifier identifier,
 
 - (void)releaseGesture {
   _forwardingGesture = YES;
-  if (_pendingMouseDownEvent != nil) {
-    NSEvent* pendingMouseDownEvent = _pendingMouseDownEvent;
-    _pendingMouseDownEvent = nil;
-    [self dispatchMouseDownEventToPlatformView:pendingMouseDownEvent];
+  if (_pendingMouseEvents.count != 0) {
+    NSArray<NSEvent*>* pendingMouseEvents = [_pendingMouseEvents copy];
+    [_pendingMouseEvents removeAllObjects];
+    _forwardingTargetView = [self targetViewForPlatformEvent:pendingMouseEvents.firstObject];
+    for (NSEvent* event in pendingMouseEvents) {
+      [self dispatchMouseEvent:event toPlatformTarget:_forwardingTargetView];
+    }
+    _forwardingGesture = ![self isMouseUpEvent:pendingMouseEvents.lastObject];
+    if (!_forwardingGesture) {
+      _forwardingTargetView = nil;
+    }
   }
 }
 
 - (void)blockGesture {
-  _pendingMouseDownEvent = nil;
+  [_pendingMouseEvents removeAllObjects];
+  _forwardingTargetView = nil;
   _forwardingGesture = NO;
 }
 
-- (void)dispatchMouseDownEventToPlatformView:(NSEvent*)event {
+- (BOOL)isMouseUpEvent:(NSEvent*)event {
+  switch (event.type) {
+    case NSEventTypeRightMouseUp:
+    case NSEventTypeOtherMouseUp:
+    case NSEventTypeLeftMouseUp:
+      return YES;
+    default:
+      return NO;
+  }
+}
+
+- (NSView*)targetViewForPlatformEvent:(NSEvent*)event {
+  NSPoint point = [_platformView convertPoint:event.locationInWindow fromView:nil];
+  return [_platformView hitTest:point] ?: _platformView;
+}
+
+- (NSView*)forwardingTargetForEvent:(NSEvent*)event {
+  if (_forwardingTargetView == nil) {
+    _forwardingTargetView = [self targetViewForPlatformEvent:event];
+  }
+  return _forwardingTargetView;
+}
+
+- (void)dispatchMouseEvent:(NSEvent*)event toPlatformTarget:(NSResponder*)target {
   switch (event.type) {
     case NSEventTypeRightMouseDown:
-      [_platformView rightMouseDown:event];
-      break;
     case NSEventTypeOtherMouseDown:
-      [_platformView otherMouseDown:event];
-      break;
     case NSEventTypeLeftMouseDown:
+      [self dispatchMouseDownEventToResponder:target event:event];
+      break;
+    case NSEventTypeRightMouseDragged:
+    case NSEventTypeOtherMouseDragged:
+    case NSEventTypeLeftMouseDragged:
+      [self dispatchMouseDraggedEventToResponder:target event:event];
+      break;
+    case NSEventTypeRightMouseUp:
+    case NSEventTypeOtherMouseUp:
+    case NSEventTypeLeftMouseUp:
+      [self dispatchMouseUpEventToResponder:target event:event];
+      break;
     default:
-      [_platformView mouseDown:event];
       break;
   }
 }
@@ -246,26 +286,30 @@ PlatformViewLayer::PlatformViewLayer(FlutterPlatformViewIdentifier identifier,
 }
 
 - (void)handleMouseDown:(NSEvent*)event {
-  _pendingMouseDownEvent = event;
+  [_pendingMouseEvents removeAllObjects];
+  [_pendingMouseEvents addObject:event];
+  _forwardingTargetView = nil;
   _forwardingGesture = NO;
   [self dispatchMouseDownEventToResponder:self.nextResponder event:event];
 }
 
 - (void)handleMouseDragged:(NSEvent*)event {
   if (_forwardingGesture) {
-    [self dispatchMouseDraggedEventToResponder:_platformView event:event];
+    [self dispatchMouseDraggedEventToResponder:[self forwardingTargetForEvent:event] event:event];
   } else {
+    [_pendingMouseEvents addObject:event];
     [self dispatchMouseDraggedEventToResponder:self.nextResponder event:event];
   }
 }
 
 - (void)handleMouseUp:(NSEvent*)event {
   if (_forwardingGesture) {
-    [self dispatchMouseUpEventToResponder:_platformView event:event];
+    [self dispatchMouseUpEventToResponder:[self forwardingTargetForEvent:event] event:event];
   } else {
+    [_pendingMouseEvents addObject:event];
     [self dispatchMouseUpEventToResponder:self.nextResponder event:event];
   }
-  _pendingMouseDownEvent = nil;
+  _forwardingTargetView = nil;
   _forwardingGesture = NO;
 }
 
@@ -306,7 +350,7 @@ PlatformViewLayer::PlatformViewLayer(FlutterPlatformViewIdentifier identifier,
 }
 
 - (void)scrollWheel:(NSEvent*)event {
-  [_platformView scrollWheel:event];
+  [[self targetViewForPlatformEvent:event] scrollWheel:event];
 }
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
@@ -852,9 +852,7 @@ NSMutableArray* ClipPathFromMutations(CGRect master_clip, const MutationVector& 
     }
   }
 
-  [_platformViewContainer addSubview:_mouseInterceptorView
-                          positioned:NSWindowAbove
-                          relativeTo:nil];
+  [_platformViewContainer addSubview:_mouseInterceptorView positioned:NSWindowAbove relativeTo:nil];
   _mouseInterceptorView.frame = untransformedBounds;
 
   // Transform for the platform view is finalTransform adjusted for bounding rect origin.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
@@ -89,6 +89,8 @@ PlatformViewLayer::PlatformViewLayer(FlutterPlatformViewIdentifier identifier,
 }
 @end
 
+@class FlutterPlatformViewMouseInterceptor;
+
 @interface FlutterMutatorView () {
   // Each of these views clips to a CGPathRef. These views, if present,
   // are nested (first is child of FlutterMutatorView and last is parent of
@@ -100,6 +102,8 @@ PlatformViewLayer::PlatformViewLayer(FlutterPlatformViewIdentifier identifier,
   NSView* _platformViewContainer;
 
   NSView* _platformView;
+
+  FlutterPlatformViewMouseInterceptor* _mouseInterceptorView;
 
   FlutterCursorCoordinator* _cursorCoordinator;
 
@@ -132,6 +136,177 @@ PlatformViewLayer::PlatformViewLayer(FlutterPlatformViewIdentifier identifier,
   // coordinate values increasing downwards. This affects the view, view transforms, and
   // sublayerTransforms.
   return YES;
+}
+
+@end
+
+@interface FlutterPlatformViewMouseInterceptor : NSView
+- (instancetype)initWithPlatformView:(NSView*)platformView;
+- (void)releaseGesture;
+- (void)blockGesture;
+@end
+
+@implementation FlutterPlatformViewMouseInterceptor {
+  __weak NSView* _platformView;
+  NSEvent* _pendingMouseDownEvent;
+  BOOL _forwardingGesture;
+}
+
+- (instancetype)initWithPlatformView:(NSView*)platformView {
+  if (self = [super initWithFrame:NSZeroRect]) {
+    _platformView = platformView;
+  }
+  return self;
+}
+
+- (BOOL)isFlipped {
+  return YES;
+}
+
+- (BOOL)acceptsFirstMouse:(NSEvent*)event {
+  return YES;
+}
+
+- (NSView*)hitTest:(NSPoint)point {
+  return NSPointInRect(point, self.bounds) ? self : nil;
+}
+
+- (void)releaseGesture {
+  _forwardingGesture = YES;
+  if (_pendingMouseDownEvent != nil) {
+    NSEvent* pendingMouseDownEvent = _pendingMouseDownEvent;
+    _pendingMouseDownEvent = nil;
+    [self dispatchMouseDownEventToPlatformView:pendingMouseDownEvent];
+  }
+}
+
+- (void)blockGesture {
+  _pendingMouseDownEvent = nil;
+  _forwardingGesture = NO;
+}
+
+- (void)dispatchMouseDownEventToPlatformView:(NSEvent*)event {
+  switch (event.type) {
+    case NSEventTypeRightMouseDown:
+      [_platformView rightMouseDown:event];
+      break;
+    case NSEventTypeOtherMouseDown:
+      [_platformView otherMouseDown:event];
+      break;
+    case NSEventTypeLeftMouseDown:
+    default:
+      [_platformView mouseDown:event];
+      break;
+  }
+}
+
+- (void)dispatchMouseDownEventToResponder:(NSResponder*)responder event:(NSEvent*)event {
+  switch (event.type) {
+    case NSEventTypeRightMouseDown:
+      [responder rightMouseDown:event];
+      break;
+    case NSEventTypeOtherMouseDown:
+      [responder otherMouseDown:event];
+      break;
+    case NSEventTypeLeftMouseDown:
+    default:
+      [responder mouseDown:event];
+      break;
+  }
+}
+
+- (void)dispatchMouseDraggedEventToResponder:(NSResponder*)responder event:(NSEvent*)event {
+  switch (event.type) {
+    case NSEventTypeRightMouseDragged:
+      [responder rightMouseDragged:event];
+      break;
+    case NSEventTypeOtherMouseDragged:
+      [responder otherMouseDragged:event];
+      break;
+    case NSEventTypeLeftMouseDragged:
+    default:
+      [responder mouseDragged:event];
+      break;
+  }
+}
+
+- (void)dispatchMouseUpEventToResponder:(NSResponder*)responder event:(NSEvent*)event {
+  switch (event.type) {
+    case NSEventTypeRightMouseUp:
+      [responder rightMouseUp:event];
+      break;
+    case NSEventTypeOtherMouseUp:
+      [responder otherMouseUp:event];
+      break;
+    case NSEventTypeLeftMouseUp:
+    default:
+      [responder mouseUp:event];
+      break;
+  }
+}
+
+- (void)handleMouseDown:(NSEvent*)event {
+  _pendingMouseDownEvent = event;
+  _forwardingGesture = NO;
+  [self dispatchMouseDownEventToResponder:self.nextResponder event:event];
+}
+
+- (void)handleMouseDragged:(NSEvent*)event {
+  if (_forwardingGesture) {
+    [self dispatchMouseDraggedEventToResponder:_platformView event:event];
+  } else {
+    [self dispatchMouseDraggedEventToResponder:self.nextResponder event:event];
+  }
+}
+
+- (void)handleMouseUp:(NSEvent*)event {
+  if (_forwardingGesture) {
+    [self dispatchMouseUpEventToResponder:_platformView event:event];
+  } else {
+    [self dispatchMouseUpEventToResponder:self.nextResponder event:event];
+  }
+  _pendingMouseDownEvent = nil;
+  _forwardingGesture = NO;
+}
+
+- (void)mouseDown:(NSEvent*)event {
+  [self handleMouseDown:event];
+}
+
+- (void)rightMouseDown:(NSEvent*)event {
+  [self handleMouseDown:event];
+}
+
+- (void)otherMouseDown:(NSEvent*)event {
+  [self handleMouseDown:event];
+}
+
+- (void)mouseDragged:(NSEvent*)event {
+  [self handleMouseDragged:event];
+}
+
+- (void)rightMouseDragged:(NSEvent*)event {
+  [self handleMouseDragged:event];
+}
+
+- (void)otherMouseDragged:(NSEvent*)event {
+  [self handleMouseDragged:event];
+}
+
+- (void)mouseUp:(NSEvent*)event {
+  [self handleMouseUp:event];
+}
+
+- (void)rightMouseUp:(NSEvent*)event {
+  [self handleMouseUp:event];
+}
+
+- (void)otherMouseUp:(NSEvent*)event {
+  [self handleMouseUp:event];
+}
+
+- (void)scrollWheel:(NSEvent*)event {
+  [_platformView scrollWheel:event];
 }
 
 @end
@@ -531,6 +706,14 @@ NSMutableArray* ClipPathFromMutations(CGRect master_clip, const MutationVector& 
   self->_hitTestIgnoreRegion.push_back(region);
 }
 
+- (void)releaseGesture {
+  [_mouseInterceptorView releaseGesture];
+}
+
+- (void)blockGesture {
+  [_mouseInterceptorView blockGesture];
+}
+
 - (void)mouseMoved:(NSEvent*)event {
   [_cursorCoordinator processMouseMoveEvent:event
                              forMutatorView:self
@@ -609,11 +792,26 @@ NSMutableArray* ClipPathFromMutations(CGRect master_clip, const MutationVector& 
     [_platformViewContainer addSubview:_platformView];
   }
 
+  if (_mouseInterceptorView == nil) {
+    _mouseInterceptorView =
+        [[FlutterPlatformViewMouseInterceptor alloc] initWithPlatformView:_platformView];
+  }
+
   // Originally first subview would be the _platformView. However during WKWebView full screen
   // the platform view gets replaced with a placeholder. Given that _platformViewContainer does
   // not contain any other views it is safe to assume that any subview found can be treated
   // as the platform view.
-  _platformViewContainer.subviews.firstObject.frame = untransformedBounds;
+  for (NSView* subview in _platformViewContainer.subviews) {
+    if (subview != _mouseInterceptorView) {
+      subview.frame = untransformedBounds;
+      break;
+    }
+  }
+
+  [_platformViewContainer addSubview:_mouseInterceptorView
+                          positioned:NSWindowAbove
+                          relativeTo:nil];
+  _mouseInterceptorView.frame = untransformedBounds;
 
   // Transform for the platform view is finalTransform adjusted for bounding rect origin.
   CATransform3D translation =

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
@@ -21,11 +21,19 @@
 
 @interface MouseTrackingPlatformView : NSView
 @property(nonatomic, assign) NSInteger mouseDownCount;
+@property(nonatomic, assign) NSInteger mouseUpCount;
+@property(nonatomic, assign) NSInteger scrollWheelCount;
 @end
 
 @implementation MouseTrackingPlatformView
 - (void)mouseDown:(NSEvent*)event {
   self.mouseDownCount += 1;
+}
+- (void)mouseUp:(NSEvent*)event {
+  self.mouseUpCount += 1;
+}
+- (void)scrollWheel:(NSEvent*)event {
+  self.scrollWheelCount += 1;
 }
 @end
 
@@ -81,6 +89,27 @@ NSEvent* MouseDownEvent() {
                          eventNumber:0
                           clickCount:1
                             pressure:1.0];
+}
+
+NSEvent* MouseUpEvent() {
+  return [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp
+                            location:NSMakePoint(10, 10)
+                       modifierFlags:0
+                           timestamp:0
+                        windowNumber:0
+                             context:nil
+                         eventNumber:0
+                          clickCount:1
+                            pressure:0.0];
+}
+
+NSEvent* ScrollWheelEvent() {
+  id event = [OCMockObject mockForClass:[NSEvent class]];
+  NSEventType eventType = NSEventTypeScrollWheel;
+  NSPoint locationInWindow = NSMakePoint(10, 10);
+  [(NSEvent*)[[event stub] andReturnValue:OCMOCK_VALUE(eventType)] type];
+  [(NSEvent*)[[event stub] andReturnValue:OCMOCK_VALUE(locationInWindow)] locationInWindow];
+  return event;
 }
 }  // namespace
 
@@ -607,6 +636,62 @@ TEST(FlutterMutatorViewTest, MouseInterceptorReleasesOrBlocksPlatformMouseDown) 
 
   [mutatorView blockGesture];
   EXPECT_EQ(platformView.mouseDownCount, 1);
+}
+
+TEST(FlutterMutatorViewTest, MouseInterceptorReleasesCompletedClickAcceptedAfterMouseUp) {
+  MouseTrackingPlatformView* platformView = [[MouseTrackingPlatformView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{100, 100}, {});
+
+  NSView* hitView = [mutatorView hitTest:NSMakePoint(10, 10)];
+  EXPECT_NE(hitView, platformView);
+
+  [hitView mouseDown:MouseDownEvent()];
+  [hitView mouseUp:MouseUpEvent()];
+  EXPECT_EQ(platformView.mouseDownCount, 0);
+  EXPECT_EQ(platformView.mouseUpCount, 0);
+
+  [mutatorView releaseGesture];
+  EXPECT_EQ(platformView.mouseDownCount, 1);
+  EXPECT_EQ(platformView.mouseUpCount, 1);
+}
+
+TEST(FlutterMutatorViewTest, MouseInterceptorDispatchesToPlatformHitTestTarget) {
+  NSView* platformView = [[NSView alloc] init];
+  MouseTrackingPlatformView* platformSubview = [[MouseTrackingPlatformView alloc] init];
+  platformSubview.frame = CGRectMake(0, 0, 100, 100);
+  [platformView addSubview:platformSubview];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{100, 100}, {});
+
+  NSView* hitView = [mutatorView hitTest:NSMakePoint(10, 10)];
+  EXPECT_NE(hitView, platformView);
+  EXPECT_NE(hitView, platformSubview);
+
+  [hitView mouseDown:MouseDownEvent()];
+  EXPECT_EQ(platformSubview.mouseDownCount, 0);
+
+  [mutatorView releaseGesture];
+  EXPECT_EQ(platformSubview.mouseDownCount, 1);
+}
+
+TEST(FlutterMutatorViewTest, MouseInterceptorDispatchesScrollWheelToPlatformHitTestTarget) {
+  NSView* platformView = [[NSView alloc] init];
+  MouseTrackingPlatformView* platformSubview = [[MouseTrackingPlatformView alloc] init];
+  platformSubview.frame = CGRectMake(0, 0, 100, 100);
+  [platformView addSubview:platformSubview];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{100, 100}, {});
+
+  NSView* hitView = [mutatorView hitTest:NSMakePoint(10, 10)];
+  EXPECT_NE(hitView, platformView);
+  EXPECT_NE(hitView, platformSubview);
+
+  [hitView scrollWheel:ScrollWheelEvent()];
+  EXPECT_EQ(platformSubview.scrollWheelCount, 1);
 }
 
 TEST(FlutterMutatorViewTest, ReparentingPlatformView) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
@@ -14,7 +14,19 @@
 
 @property(readonly, nonatomic, nonnull) NSMutableArray<NSView*>* pathClipViews;
 @property(readonly, nonatomic, nullable) NSView* platformViewContainer;
+- (void)releaseGesture;
+- (void)blockGesture;
 
+@end
+
+@interface MouseTrackingPlatformView : NSView
+@property(nonatomic, assign) NSInteger mouseDownCount;
+@end
+
+@implementation MouseTrackingPlatformView
+- (void)mouseDown:(NSEvent*)event {
+  self.mouseDownCount += 1;
+}
 @end
 
 static constexpr float kMaxErr = 1e-10;
@@ -57,6 +69,18 @@ void ExpectTransform3DEqual(const CATransform3D& t, const CATransform3D& u) {
   EXPECT_NEAR(t.m42, u.m42, kMaxErr);
   EXPECT_NEAR(t.m43, u.m43, kMaxErr);
   EXPECT_NEAR(t.m44, u.m44, kMaxErr);
+}
+
+NSEvent* MouseDownEvent() {
+  return [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                            location:NSMakePoint(10, 10)
+                       modifierFlags:0
+                           timestamp:0
+                        windowNumber:0
+                             context:nil
+                         eventNumber:0
+                          clickCount:1
+                            pressure:1.0];
 }
 }  // namespace
 
@@ -539,8 +563,8 @@ TEST(FlutterMutatorViewTest, HitTestIgnoreRegion) {
   NSView* platformView = [[NSView alloc] init];
   FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
   ApplyFlutterLayer(mutatorView, FlutterSize{100, 100}, {});
-  EXPECT_EQ([mutatorView hitTest:NSMakePoint(10, 10)], platformView);
-  EXPECT_EQ([mutatorView hitTest:NSMakePoint(50, 10)], platformView);
+  EXPECT_NE([mutatorView hitTest:NSMakePoint(10, 10)], nil);
+  EXPECT_NE([mutatorView hitTest:NSMakePoint(50, 10)], nil);
 
   [mutatorView resetHitTestRegion];
   [mutatorView addHitTestIgnoreRegion:CGRectMake(0, 0, 50, 50)];
@@ -550,16 +574,39 @@ TEST(FlutterMutatorViewTest, HitTestIgnoreRegion) {
   EXPECT_EQ([mutatorView hitTest:NSMakePoint(49, 10)], nil);
   EXPECT_EQ([mutatorView hitTest:NSMakePoint(10, 49)], nil);
   EXPECT_EQ([mutatorView hitTest:NSMakePoint(50, 50)], nil);
-  EXPECT_EQ([mutatorView hitTest:NSMakePoint(50, 10)], platformView);
-  EXPECT_EQ([mutatorView hitTest:NSMakePoint(10, 50)], platformView);
+  EXPECT_NE([mutatorView hitTest:NSMakePoint(50, 10)], nil);
+  EXPECT_NE([mutatorView hitTest:NSMakePoint(10, 50)], nil);
 
   [mutatorView resetHitTestRegion];
-  EXPECT_EQ([mutatorView hitTest:NSMakePoint(10, 10)], platformView);
-  EXPECT_EQ([mutatorView hitTest:NSMakePoint(49, 10)], platformView);
-  EXPECT_EQ([mutatorView hitTest:NSMakePoint(10, 49)], platformView);
-  EXPECT_EQ([mutatorView hitTest:NSMakePoint(50, 50)], platformView);
-  EXPECT_EQ([mutatorView hitTest:NSMakePoint(50, 10)], platformView);
-  EXPECT_EQ([mutatorView hitTest:NSMakePoint(10, 50)], platformView);
+  EXPECT_NE([mutatorView hitTest:NSMakePoint(10, 10)], nil);
+  EXPECT_NE([mutatorView hitTest:NSMakePoint(49, 10)], nil);
+  EXPECT_NE([mutatorView hitTest:NSMakePoint(10, 49)], nil);
+  EXPECT_NE([mutatorView hitTest:NSMakePoint(50, 50)], nil);
+  EXPECT_NE([mutatorView hitTest:NSMakePoint(50, 10)], nil);
+  EXPECT_NE([mutatorView hitTest:NSMakePoint(10, 50)], nil);
+}
+
+TEST(FlutterMutatorViewTest, MouseInterceptorReleasesOrBlocksPlatformMouseDown) {
+  MouseTrackingPlatformView* platformView = [[MouseTrackingPlatformView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{100, 100}, {});
+
+  NSView* hitView = [mutatorView hitTest:NSMakePoint(10, 10)];
+  EXPECT_NE(hitView, platformView);
+
+  [hitView mouseDown:MouseDownEvent()];
+  EXPECT_EQ(platformView.mouseDownCount, 0);
+
+  [mutatorView releaseGesture];
+  EXPECT_EQ(platformView.mouseDownCount, 1);
+
+  hitView = [mutatorView hitTest:NSMakePoint(10, 10)];
+  [hitView mouseDown:MouseDownEvent()];
+  EXPECT_EQ(platformView.mouseDownCount, 1);
+
+  [mutatorView blockGesture];
+  EXPECT_EQ(platformView.mouseDownCount, 1);
 }
 
 TEST(FlutterMutatorViewTest, ReparentingPlatformView) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
@@ -4,8 +4,8 @@
 
 #include "flutter/fml/logging.h"
 
-#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h"
 
 namespace {
 FlutterMutatorView* MutatorViewForPlatformView(NSView* platform_view) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
@@ -5,6 +5,18 @@
 #include "flutter/fml/logging.h"
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h"
+
+namespace {
+FlutterMutatorView* MutatorViewForPlatformView(NSView* platform_view) {
+  for (NSView* view = platform_view; view != nil; view = view.superview) {
+    if ([view isKindOfClass:[FlutterMutatorView class]]) {
+      return (FlutterMutatorView*)view;
+    }
+  }
+  return nil;
+}
+}  // namespace
 
 @implementation FlutterPlatformViewController {
   // NSDictionary maps platform view type identifiers to FlutterPlatformViewFactories.
@@ -136,7 +148,7 @@
     return;
   }
 
-  // TODO(cbracken): Implement. https://github.com/flutter/flutter/issues/124492
+  [MutatorViewForPlatformView(_platformViews[viewId]) releaseGesture];
   result(nil);
 }
 
@@ -151,7 +163,7 @@
     return;
   }
 
-  // TODO(cbracken): Implement. https://github.com/flutter/flutter/issues/124492
+  [MutatorViewForPlatformView(_platformViews[viewId]) blockGesture];
   result(nil);
 }
 

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -330,7 +330,7 @@ abstract class RenderDarwinPlatformView<T extends DarwinPlatformViewController> 
 
   PointerEvent? _lastPointerDownEvent;
 
-  _UiKitViewGestureRecognizer? _gestureRecognizer;
+  _DarwinViewGestureRecognizer<T>? _gestureRecognizer;
 
   @override
   @protected
@@ -448,7 +448,11 @@ class RenderUiKitView extends RenderDarwinPlatformView<UiKitViewController>
       return;
     }
     _gestureRecognizer?.dispose();
-    _gestureRecognizer = _UiKitViewGestureRecognizer(viewController, gestureRecognizers);
+    _gestureRecognizer = _DarwinViewGestureRecognizer(
+      viewController,
+      gestureRecognizers,
+      debugDescription: 'UIKit view',
+    );
   }
 
   @override
@@ -482,22 +486,61 @@ class RenderAppKitView extends RenderDarwinPlatformView<AppKitViewController> {
     required super.gestureRecognizers,
   });
 
-  // TODO(schectman): Add gesture functionality to macOS platform view when implemented.
-  // https://github.com/flutter/flutter/issues/128519
-  // This method will need to behave the same as the same-named method for RenderUiKitView,
-  // but use a _AppKitViewGestureRecognizer or equivalent, whose constructor shall accept an
-  // AppKitViewController.
   @override
-  void updateGestureRecognizers(Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers) {}
+  void updateGestureRecognizers(Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers) {
+    assert(
+      _factoriesTypeSet(gestureRecognizers).length == gestureRecognizers.length,
+      'There were multiple gesture recognizer factories for the same type, there must only be a single '
+      'gesture recognizer factory for each gesture recognizer type.',
+    );
+    if (_factoryTypesSetEquals(
+      gestureRecognizers,
+      _gestureRecognizer?.gestureRecognizerFactories,
+    )) {
+      return;
+    }
+    _gestureRecognizer?.dispose();
+    _gestureRecognizer = _DarwinViewGestureRecognizer(
+      viewController,
+      gestureRecognizers,
+      debugDescription: 'AppKit view',
+    );
+  }
+
+  @override
+  void handleEvent(PointerEvent event, HitTestEntry entry) {
+    if (event is! PointerDownEvent) {
+      return;
+    }
+    _gestureRecognizer!.addPointer(event);
+    _lastPointerDownEvent = event.original ?? event;
+  }
+
+  @override
+  void detach() {
+    _gestureRecognizer!.reset();
+    super.detach();
+  }
+
+  @override
+  void dispose() {
+    _gestureRecognizer?.dispose();
+    super.dispose();
+  }
 }
 
 // This recognizer constructs gesture recognizers from a set of gesture recognizer factories
-// it was give, adds all of them to a gesture arena team with the _UiKitViewGestureRecognizer
+// it was give, adds all of them to a gesture arena team with the _DarwinViewGestureRecognizer
 // as the team captain.
 // When the team wins a gesture the recognizer notifies the engine that it should release
-// the touch sequence to the embedded UIView.
-class _UiKitViewGestureRecognizer extends OneSequenceGestureRecognizer {
-  _UiKitViewGestureRecognizer(this.controller, this.gestureRecognizerFactories) {
+// the touch sequence to the embedded UIView or NSView.
+class _DarwinViewGestureRecognizer<T extends DarwinPlatformViewController>
+    extends OneSequenceGestureRecognizer {
+  _DarwinViewGestureRecognizer(
+    this.controller,
+    this.gestureRecognizerFactories, {
+    required String debugDescription,
+  }) : _debugDescription = debugDescription {
     team = GestureArenaTeam()..captain = this;
     _gestureRecognizers = gestureRecognizerFactories.map((
       Factory<OneSequenceGestureRecognizer> recognizerFactory,
@@ -524,7 +567,8 @@ class _UiKitViewGestureRecognizer extends OneSequenceGestureRecognizer {
   final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizerFactories;
   late Set<OneSequenceGestureRecognizer> _gestureRecognizers;
 
-  final UiKitViewController controller;
+  final T controller;
+  final String _debugDescription;
 
   @override
   void addAllowedPointer(PointerDownEvent event) {
@@ -535,7 +579,7 @@ class _UiKitViewGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   @override
-  String get debugDescription => 'UIKit view';
+  String get debugDescription => _debugDescription;
 
   @override
   void didStopTrackingLastPointer(int pointer) {}

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -315,9 +315,11 @@ class PlatformViewsService {
   }) async {
     assert(creationParams == null || creationParamsCodec != null);
 
-    // TODO(amirh): pass layoutDirection once the system channel supports it.
-    // https://github.com/flutter/flutter/issues/133682
-    final args = <String, dynamic>{'id': id, 'viewType': viewType};
+    final args = <String, dynamic>{
+      'id': id,
+      'viewType': viewType,
+      'direction': AndroidViewController._getAndroidDirection(layoutDirection),
+    };
     if (creationParams != null) {
       final ByteData paramsByteData = creationParamsCodec!.encodeMessage(creationParams)!;
       args['params'] = Uint8List.view(paramsByteData.buffer, 0, paramsByteData.lengthInBytes);

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -490,6 +490,7 @@ class FakeMacosPlatformViewsController {
 
   Iterable<FakeAppKitView> get views => _views.values;
   final Map<int, FakeAppKitView> _views = <int, FakeAppKitView>{};
+  final Map<int, int?> layoutDirections = <int, int?>{};
 
   final Set<String> _registeredViewTypes = <String>{};
 
@@ -534,6 +535,7 @@ class FakeMacosPlatformViewsController {
     final args = call.arguments as Map<dynamic, dynamic>;
     final id = args['id'] as int;
     final viewType = args['viewType'] as String;
+    final layoutDirection = args['direction'] as int?;
     final creationParams = args['params'] as Uint8List?;
 
     if (_views.containsKey(id)) {
@@ -551,6 +553,7 @@ class FakeMacosPlatformViewsController {
     }
 
     _views[id] = FakeAppKitView(id, viewType, creationParams);
+    layoutDirections[id] = layoutDirection;
     gesturesAccepted[id] = 0;
     gesturesRejected[id] = 0;
     return Future<int?>.sync(() => null);
@@ -581,6 +584,7 @@ class FakeMacosPlatformViewsController {
     }
 
     _views.remove(id);
+    layoutDirections.remove(id);
     return Future<dynamic>.sync(() => null);
   }
 }

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -2482,6 +2482,27 @@ void main() {
       );
     });
 
+    testWidgets('Create AppKitView passes layout direction', (WidgetTester tester) async {
+      final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+      final viewsController = FakeMacosPlatformViewsController();
+      viewsController.registerViewType('webview');
+
+      await tester.pumpWidget(
+        const Center(
+          child: SizedBox(
+            width: 200.0,
+            height: 100.0,
+            child: AppKitView(viewType: 'webview', layoutDirection: TextDirection.rtl),
+          ),
+        ),
+      );
+
+      expect(
+        viewsController.layoutDirections[currentViewId + 1],
+        AndroidViewController.kAndroidLayoutDirectionRtl,
+      );
+    });
+
     testWidgets('Change AppKitView view type', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final viewsController = FakeMacosPlatformViewsController();
@@ -2621,8 +2642,6 @@ void main() {
       );
     });
 
-    // TODO(schectman): De-skip the following tests once macOS gesture recognizers are present.
-    // https://github.com/flutter/flutter/issues/128519
     testWidgets('AppKitView accepts gestures', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final viewsController = FakeMacosPlatformViewsController();
@@ -2649,7 +2668,7 @@ void main() {
       await gesture.up();
 
       expect(viewsController.gesturesAccepted[currentViewId + 1], 1);
-    }, skip: true); // https://github.com/flutter/flutter/issues/128519
+    });
 
     testWidgets('AppKitView transparent hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
@@ -2694,7 +2713,7 @@ void main() {
       expect(viewsController.gesturesAccepted[currentViewId + 1], 0);
 
       expect(numPointerDownsOnParent, 1);
-    }, skip: true); // https://github.com/flutter/flutter/issues/128519
+    });
 
     testWidgets('AppKitView translucent hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
@@ -2739,7 +2758,7 @@ void main() {
       expect(viewsController.gesturesAccepted[currentViewId + 1], 1);
 
       expect(numPointerDownsOnParent, 1);
-    }, skip: true); // https://github.com/flutter/flutter/issues/128519
+    });
 
     testWidgets('AppKitView opaque hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
@@ -2779,7 +2798,7 @@ void main() {
 
       expect(viewsController.gesturesAccepted[currentViewId + 1], 1);
       expect(numPointerDownsOnParent, 0);
-    }, skip: true); // https://github.com/flutter/flutter/issues/128519
+    });
 
     testWidgets('UiKitView can lose gesture arenas', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();


### PR DESCRIPTION
## Summary

This updates macOS `AppKitView` so it participates in the Darwin platform-view gesture contract instead of leaving accepted/rejected gestures as framework-only decisions.

The main behavior change is that macOS now routes `acceptGesture` / `rejectGesture` to the platform-view mutator, and accepted mouse and wheel events are delivered to the AppKit hit-test target inside the hosted view. This matters for embedded controls such as `WKWebView`, where the interactive target is often an internal AppKit subview rather than only the root platform `NSView`.

Related: #41722.

## Changes

- Wire `RenderAppKitView` into the shared Darwin platform-view gesture recognizer path.
- Include initial `layoutDirection` in AppKitView creation arguments.
- Enable AppKitView gesture and transparent/translucent/opaque hit-test widget coverage.
- Route macOS `acceptGesture` / `rejectGesture` to the active `FlutterMutatorView`.
- Add AppKit mouse interception that can release, block, or replay a completed mouse sequence.
- Dispatch accepted mouse and wheel events to the native AppKit hit-test target inside the platform view.

## Validation

- AppKitView framework gesture, hit-test, and `layoutDirection` tests pass locally.
- `FlutterMutatorViewTest.*` passes locally in the rebuilt macOS engine test binary.
- A local `WKWebView` AppKitView harness verifies fixed-target native click delivery and fixed-target wheel routing, including CGEvent wheel automation and physical trackpad input.

## Scope

This does not claim complete macOS desktop platform-view maturity. Broader focus traversal, accessibility merging, trackpad momentum/nested-scroll behavior, external issuer/PSP pages, and Windows/Linux platform views remain separate follow-up work.

The latest broad local OS-pointer harness run is also not a clean full-matrix pass, so the runtime evidence should stay scoped to the targeted tests and fixture lanes above.
