### PR TITLE
[Flutter GPU] Add Texture.fromImage to wrap a ui.Image texture

### DIFF
--- a/engine/src/flutter/lib/gpu/formats.h
+++ b/engine/src/flutter/lib/gpu/formats.h
@@ -38,6 +38,18 @@ constexpr impeller::StorageMode ToImpellerStorageMode(int value) {
   return ToImpellerStorageMode(static_cast<FlutterGPUStorageMode>(value));
 }
 
+constexpr FlutterGPUStorageMode FromImpellerStorageMode(
+    impeller::StorageMode value) {
+  switch (value) {
+    case impeller::StorageMode::kHostVisible:
+      return FlutterGPUStorageMode::kHostVisible;
+    case impeller::StorageMode::kDevicePrivate:
+      return FlutterGPUStorageMode::kDevicePrivate;
+    case impeller::StorageMode::kDeviceTransient:
+      return FlutterGPUStorageMode::kDeviceTransient;
+  }
+}
+
 enum class FlutterGPUPixelFormat {
   kUnknown,
   kA8UNormInt,

--- a/engine/src/flutter/lib/gpu/lib/src/texture.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/texture.dart
@@ -86,6 +86,52 @@ base class Texture extends NativeFieldWrapperClass1 {
       enableShaderWriteUsage = false,
       mipLevelCount = 1;
 
+  /// Wraps the GPU texture that backs [image] as a Flutter GPU [Texture],
+  /// without copying any pixel data.
+  ///
+  /// The returned texture shares its storage with [image], so it stays valid
+  /// for as long as either the returned texture or [image] is alive. It is
+  /// intended for sampling (for example as a material texture) and reflects
+  /// the usage of the underlying texture, so it is not guaranteed to be usable
+  /// as a render pass attachment.
+  ///
+  /// [image] must be backed by a GPU texture. Use an image produced by the
+  /// asynchronous `RepaintBoundary.toImage` (or `Picture.toImage`). An image
+  /// from `toImageSync` rasterizes asynchronously and may not have a texture
+  /// yet when this is called. Throws if [image] has no compatible texture.
+  factory Texture.fromImage(GpuContext gpuContext, ui.Image image) {
+    final Int32List info = _imageTextureInfo(gpuContext, image);
+    if (info.length != 10) {
+      throw Exception(
+        'Texture.fromImage could not wrap the image because it is not backed '
+        'by a compatible GPU texture. Use an image from the asynchronous '
+        'RepaintBoundary.toImage rather than toImageSync.',
+      );
+    }
+    return Texture._fromImage(gpuContext, image, info);
+  }
+
+  /// Builds the wrapper from the metadata returned by [_imageTextureInfo] and
+  /// associates it with the image's backing texture. The field layout must
+  /// match `InternalFlutterGpu_Texture_ImageTextureInfo` on the native side.
+  Texture._fromImage(GpuContext gpuContext, ui.Image image, Int32List info)
+    : _gpuContext = gpuContext,
+      storageMode = StorageMode.values[info[0]],
+      format = PixelFormat.values[info[1]],
+      width = info[2],
+      height = info[3],
+      sampleCount = info[4],
+      textureType = TextureType.values[info[5]],
+      enableRenderTargetUsage = info[6] != 0,
+      enableShaderReadUsage = info[7] != 0,
+      enableShaderWriteUsage = info[8] != 0,
+      mipLevelCount = info[9] {
+    _valid = _initializeFromImage(gpuContext, image);
+    if (!_valid) {
+      throw Exception("Texture.fromImage failed to wrap the image texture");
+    }
+  }
+
   GpuContext _gpuContext;
 
   final StorageMode storageMode;
@@ -253,4 +299,17 @@ base class Texture extends NativeFieldWrapperClass1 {
     symbol: 'InternalFlutterGpu_Texture_AsImage',
   )
   external ui.Image _asImage();
+
+  @Native<Handle Function(Pointer<Void>, Handle)>(
+    symbol: 'InternalFlutterGpu_Texture_ImageTextureInfo',
+  )
+  external static Int32List _imageTextureInfo(
+    GpuContext gpuContext,
+    ui.Image image,
+  );
+
+  @Native<Bool Function(Handle, Pointer<Void>, Handle)>(
+    symbol: 'InternalFlutterGpu_Texture_InitializeFromImage',
+  )
+  external bool _initializeFromImage(GpuContext gpuContext, ui.Image image);
 }

--- a/engine/src/flutter/lib/gpu/texture.cc
+++ b/engine/src/flutter/lib/gpu/texture.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/lib/gpu/texture.h"
 
+#include <cstring>
+
 #include "flutter/lib/gpu/formats.h"
 #include "flutter/lib/ui/painting/image.h"
 #include "flutter/lib/ui/ui_dart_state.h"
@@ -21,8 +23,11 @@
 #include "impeller/renderer/context.h"
 
 #if IMPELLER_SUPPORTS_RENDERING
+#include "flutter/display_list/image/dl_image.h"      // nogncheck
 #include "impeller/display_list/dl_image_impeller.h"  // nogncheck
 #endif
+#include "third_party/tonic/converter/dart_converter.h"
+#include "third_party/tonic/dart_wrappable.h"
 #include "third_party/tonic/typed_data/dart_byte_data.h"
 
 namespace flutter {
@@ -140,6 +145,41 @@ bool Texture::Overwrite(Context& gpu_context,
   return true;
 }
 
+#if IMPELLER_SUPPORTS_RENDERING
+// Extracts the impeller::Texture that backs the ui.Image `image_wrapper`.
+// Returns nullptr if the image is not backed by a Flutter GPU compatible
+// texture, for example a non-Impeller image or a deferred image (from
+// Picture.toImageSync) that has not finished rasterizing yet.
+static std::shared_ptr<impeller::Texture> GetTextureFromImage(
+    Context* gpu_context,
+    Dart_Handle image_wrapper) {
+  if (gpu_context == nullptr || Dart_IsNull(image_wrapper)) {
+    return nullptr;
+  }
+  // A `ui.Image` wraps the private `_Image` native field holder.
+  Dart_Handle inner = Dart_GetField(image_wrapper, tonic::ToDart("_image"));
+  if (Dart_IsError(inner) || Dart_IsNull(inner)) {
+    return nullptr;
+  }
+  intptr_t peer = 0;
+  Dart_Handle result = Dart_GetNativeInstanceField(
+      inner, tonic::DartWrappable::kPeerIndex, &peer);
+  if (Dart_IsError(result) || peer == 0) {
+    return nullptr;
+  }
+  auto* canvas_image = reinterpret_cast<flutter::CanvasImage*>(peer);
+  sk_sp<flutter::DlImage> dl_image = canvas_image->image();
+  if (!dl_image) {
+    return nullptr;
+  }
+  const impeller::DlImageImpeller* impeller_image = dl_image->asImpellerImage();
+  if (!impeller_image) {
+    return nullptr;
+  }
+  return impeller_image->GetImpellerTexture(gpu_context->GetContextShared());
+}
+#endif
+
 Dart_Handle Texture::AsImage() const {
   // DlImageImpeller isn't compiled in builds with Impeller disabled. If
   // Impeller is disabled, it's impossible to get here anyhow, so just ifdef it
@@ -237,4 +277,68 @@ bool InternalFlutterGpu_Texture_Overwrite(flutter::gpu::Texture* texture,
 
 Dart_Handle InternalFlutterGpu_Texture_AsImage(flutter::gpu::Texture* wrapper) {
   return wrapper->AsImage();
+}
+
+Dart_Handle InternalFlutterGpu_Texture_ImageTextureInfo(
+    flutter::gpu::Context* gpu_context,
+    Dart_Handle image_wrapper) {
+#if IMPELLER_SUPPORTS_RENDERING
+  auto texture = flutter::gpu::GetTextureFromImage(gpu_context, image_wrapper);
+  if (!texture) {
+    return Dart_NewTypedData(Dart_TypedData_kInt32, 0);
+  }
+  const impeller::TextureDescriptor& desc = texture->GetTextureDescriptor();
+  const impeller::TextureUsageMask usage = desc.usage;
+
+  // Layout must match the parsing in the Dart `Texture._fromImage`.
+  int32_t values[10];
+  values[0] = static_cast<int32_t>(
+      flutter::gpu::FromImpellerStorageMode(desc.storage_mode));
+  values[1] =
+      static_cast<int32_t>(flutter::gpu::FromImpellerPixelFormat(desc.format));
+  values[2] = static_cast<int32_t>(desc.size.width);
+  values[3] = static_cast<int32_t>(desc.size.height);
+  values[4] = static_cast<int32_t>(desc.sample_count);
+  // The Flutter GPU `TextureType` enum mirrors `impeller::TextureType`.
+  values[5] = static_cast<int32_t>(desc.type);
+  values[6] = (usage & impeller::TextureUsage::kRenderTarget) ? 1 : 0;
+  values[7] = (usage & impeller::TextureUsage::kShaderRead) ? 1 : 0;
+  values[8] = (usage & impeller::TextureUsage::kShaderWrite) ? 1 : 0;
+  values[9] = static_cast<int32_t>(desc.mip_count);
+
+  const intptr_t length = sizeof(values) / sizeof(values[0]);
+  Dart_Handle list = Dart_NewTypedData(Dart_TypedData_kInt32, length);
+  if (Dart_IsError(list)) {
+    return Dart_NewTypedData(Dart_TypedData_kInt32, 0);
+  }
+  Dart_TypedData_Type type;
+  void* data = nullptr;
+  intptr_t data_length = 0;
+  if (Dart_IsError(
+          Dart_TypedDataAcquireData(list, &type, &data, &data_length))) {
+    return Dart_NewTypedData(Dart_TypedData_kInt32, 0);
+  }
+  std::memcpy(data, values, sizeof(values));
+  Dart_TypedDataReleaseData(list);
+  return list;
+#else
+  return Dart_NewTypedData(Dart_TypedData_kInt32, 0);
+#endif
+}
+
+bool InternalFlutterGpu_Texture_InitializeFromImage(
+    Dart_Handle wrapper,
+    flutter::gpu::Context* gpu_context,
+    Dart_Handle image_wrapper) {
+#if IMPELLER_SUPPORTS_RENDERING
+  auto texture = flutter::gpu::GetTextureFromImage(gpu_context, image_wrapper);
+  if (!texture) {
+    return false;
+  }
+  auto res = fml::MakeRefCounted<flutter::gpu::Texture>(std::move(texture));
+  res->AssociateWithDartWrapper(wrapper);
+  return true;
+#else
+  return false;
+#endif
 }

--- a/engine/src/flutter/lib/gpu/texture.cc
+++ b/engine/src/flutter/lib/gpu/texture.cc
@@ -161,13 +161,11 @@ static std::shared_ptr<impeller::Texture> GetTextureFromImage(
   if (Dart_IsError(inner) || Dart_IsNull(inner)) {
     return nullptr;
   }
-  intptr_t peer = 0;
-  Dart_Handle result = Dart_GetNativeInstanceField(
-      inner, tonic::DartWrappable::kPeerIndex, &peer);
-  if (Dart_IsError(result) || peer == 0) {
+  auto* canvas_image =
+      tonic::DartConverter<flutter::CanvasImage*>::FromDart(inner);
+  if (!canvas_image) {
     return nullptr;
   }
-  auto* canvas_image = reinterpret_cast<flutter::CanvasImage*>(peer);
   sk_sp<flutter::DlImage> dl_image = canvas_image->image();
   if (!dl_image) {
     return nullptr;
@@ -309,14 +307,15 @@ Dart_Handle InternalFlutterGpu_Texture_ImageTextureInfo(
   const intptr_t length = sizeof(values) / sizeof(values[0]);
   Dart_Handle list = Dart_NewTypedData(Dart_TypedData_kInt32, length);
   if (Dart_IsError(list)) {
-    return Dart_NewTypedData(Dart_TypedData_kInt32, 0);
+    return list;
   }
   Dart_TypedData_Type type;
   void* data = nullptr;
   intptr_t data_length = 0;
-  if (Dart_IsError(
-          Dart_TypedDataAcquireData(list, &type, &data, &data_length))) {
-    return Dart_NewTypedData(Dart_TypedData_kInt32, 0);
+  Dart_Handle acquire_result =
+      Dart_TypedDataAcquireData(list, &type, &data, &data_length);
+  if (Dart_IsError(acquire_result)) {
+    return acquire_result;
   }
   std::memcpy(data, values, sizeof(values));
   Dart_TypedDataReleaseData(list);

--- a/engine/src/flutter/lib/gpu/texture.h
+++ b/engine/src/flutter/lib/gpu/texture.h
@@ -74,6 +74,23 @@ FLUTTER_GPU_EXPORT
 extern Dart_Handle InternalFlutterGpu_Texture_AsImage(
     flutter::gpu::Texture* wrapper);
 
+// Returns an Int32List describing the texture that backs the given ui.Image,
+// or an empty list if the image is not backed by a Flutter GPU compatible
+// texture. See the Dart `Texture.fromImage` for the field layout.
+FLUTTER_GPU_EXPORT
+extern Dart_Handle InternalFlutterGpu_Texture_ImageTextureInfo(
+    flutter::gpu::Context* gpu_context,
+    Dart_Handle image_wrapper);
+
+// Associates `wrapper` with the impeller texture that backs the given
+// ui.Image, without copying. Returns false if the image is not backed by a
+// Flutter GPU compatible texture.
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_Texture_InitializeFromImage(
+    Dart_Handle wrapper,
+    flutter::gpu::Context* gpu_context,
+    Dart_Handle image_wrapper);
+
 }  // extern "C"
 
 #endif  // FLUTTER_LIB_GPU_TEXTURE_H_

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -897,6 +897,53 @@ void main() async {
     expect(image.height, 100);
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
+  test('Texture.fromImage wraps a ui.Image without a copy', () async {
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    final ui.Canvas canvas = ui.Canvas(recorder);
+    canvas.drawPaint(ui.Paint()..color = const ui.Color(0xFF00FF00));
+    final ui.Picture picture = recorder.endRecording();
+    final ui.Image image = await picture.toImage(16, 24);
+    picture.dispose();
+
+    final gpu.Texture texture = gpu.Texture.fromImage(gpu.gpuContext, image);
+    expect(texture.width, 16);
+    expect(texture.height, 24);
+    expect(texture.sampleCount, 1);
+    expect(texture.textureType, gpu.TextureType.texture2D);
+    expect(texture.enableShaderReadUsage, true);
+    expect(texture.mipLevelCount, greaterThanOrEqualTo(1));
+    expect(
+      texture.format,
+      anyOf(gpu.PixelFormat.r8g8b8a8UNormInt, gpu.PixelFormat.b8g8r8a8UNormInt),
+    );
+
+    // The wrapped texture is GPU resident and can be handed back to the UI.
+    final ui.Image roundTrip = texture.asImage();
+    expect(roundTrip.width, 16);
+    expect(roundTrip.height, 24);
+
+    image.dispose();
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('Texture.fromImage shares storage with the source image', () async {
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    final ui.Canvas canvas = ui.Canvas(recorder);
+    canvas.drawPaint(ui.Paint()..color = const ui.Color(0xFFFF0000));
+    final ui.Picture picture = recorder.endRecording();
+    final ui.Image image = await picture.toImage(8, 8);
+    picture.dispose();
+
+    final gpu.Texture texture = gpu.Texture.fromImage(gpu.gpuContext, image);
+    // Disposing the source image must not invalidate the wrapper, which holds
+    // its own reference to the shared texture. Reading the texture back as an
+    // image exercises the native texture (not the cached Dart fields).
+    image.dispose();
+    expect(texture.isValid, true);
+    final ui.Image roundTrip = texture.asImage();
+    expect(roundTrip.width, 8);
+    expect(roundTrip.height, 8);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
   test('Texture.asImage throws when not shader readable', () async {
     final gpu.Texture texture = gpu.gpuContext.createTexture(
       gpu.StorageMode.hostVisible,

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -898,14 +898,14 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('Texture.fromImage wraps a ui.Image without a copy', () async {
-    final ui.PictureRecorder recorder = ui.PictureRecorder();
-    final ui.Canvas canvas = ui.Canvas(recorder);
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
     canvas.drawPaint(ui.Paint()..color = const ui.Color(0xFF00FF00));
     final ui.Picture picture = recorder.endRecording();
     final ui.Image image = await picture.toImage(16, 24);
     picture.dispose();
 
-    final gpu.Texture texture = gpu.Texture.fromImage(gpu.gpuContext, image);
+    final texture = gpu.Texture.fromImage(gpu.gpuContext, image);
     expect(texture.width, 16);
     expect(texture.height, 24);
     expect(texture.sampleCount, 1);
@@ -926,14 +926,14 @@ void main() async {
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
   test('Texture.fromImage shares storage with the source image', () async {
-    final ui.PictureRecorder recorder = ui.PictureRecorder();
-    final ui.Canvas canvas = ui.Canvas(recorder);
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
     canvas.drawPaint(ui.Paint()..color = const ui.Color(0xFFFF0000));
     final ui.Picture picture = recorder.endRecording();
     final ui.Image image = await picture.toImage(8, 8);
     picture.dispose();
 
-    final gpu.Texture texture = gpu.Texture.fromImage(gpu.gpuContext, image);
+    final texture = gpu.Texture.fromImage(gpu.gpuContext, image);
     // Disposing the source image must not invalidate the wrapper, which holds
     // its own reference to the shared texture. Reading the texture back as an
     // image exercises the native texture (not the cached Dart fields).


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/188246

Adds `Texture.fromImage`, the inverse of `Texture.asImage`. It wraps the GPU texture that backs a `ui.Image` as a Flutter GPU `Texture` without copying any pixel data.

Getting widget content into a Flutter GPU texture currently needs a full CPU round trip (rasterize, read back with `toByteData`, then upload into a new texture). The `ui.Image` returned by `toImage` already holds a GPU resident texture on the same context Flutter GPU renders with, so the readback and the upload are wasted work. `Texture.fromImage` reads the texture metadata from the descriptor and shares the underlying texture, so neither copy is needed.

Notes

- Use an image from the asynchronous `RepaintBoundary.toImage` or `Picture.toImage`. A `toImageSync` image rasterizes asynchronously and may not have a texture yet, in which case this throws.
- The wrapped texture is meant for sampling. It reflects the usage of the source texture and is not guaranteed to be usable as a render pass attachment.
- The wrapper holds its own reference to the shared texture, so it stays valid after the source `ui.Image` is disposed.


https://github.com/user-attachments/assets/c4d164f8-6d18-4d77-bf02-12fb83a8faf7

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
