### PR TITLE
[web] Add Skwasm artifact variant test support

### DIFF
--- a/engine/src/flutter/lib/web_ui/dev/felt_config.dart
+++ b/engine/src/flutter/lib/web_ui/dev/felt_config.dart
@@ -34,6 +34,8 @@ class TestBundle {
 
 enum CanvasKitVariant { full, chromium }
 
+enum SkwasmVariant { auto, normal, heavy }
+
 enum BrowserName { chrome, edge, firefox, safari }
 
 class RunConfiguration {
@@ -42,6 +44,7 @@ class RunConfiguration {
     this.browser,
     this.browserFlags,
     this.variant,
+    this.skwasmVariant,
     this.crossOriginIsolated,
     this.forceSingleThreadedSkwasm,
     this.enableWebParagraph,
@@ -53,6 +56,7 @@ class RunConfiguration {
   final BrowserName browser;
   final List<String> browserFlags;
   final CanvasKitVariant? variant;
+  final SkwasmVariant? skwasmVariant;
   final bool crossOriginIsolated;
   final bool forceSingleThreadedSkwasm;
   final bool enableWebParagraph;
@@ -66,18 +70,21 @@ class ArtifactDependencies {
     required this.canvasKit,
     required this.canvasKitChromium,
     required this.skwasm,
+    required this.wimp,
   });
 
   ArtifactDependencies.none()
     : canvasKitWebParagraph = false,
       canvasKit = false,
       canvasKitChromium = false,
-      skwasm = false;
+      skwasm = false,
+      wimp = false;
 
   final bool canvasKitWebParagraph;
   final bool canvasKit;
   final bool canvasKitChromium;
   final bool skwasm;
+  final bool wimp;
 
   ArtifactDependencies operator |(ArtifactDependencies other) {
     return ArtifactDependencies(
@@ -85,6 +92,7 @@ class ArtifactDependencies {
       canvasKit: canvasKit || other.canvasKit,
       canvasKitChromium: canvasKitChromium || other.canvasKitChromium,
       skwasm: skwasm || other.skwasm,
+      wimp: wimp || other.wimp,
     );
   }
 
@@ -94,6 +102,7 @@ class ArtifactDependencies {
       canvasKit: canvasKit && other.canvasKit,
       canvasKitChromium: canvasKitChromium && other.canvasKitChromium,
       skwasm: skwasm && other.skwasm,
+      wimp: wimp && other.wimp,
     );
   }
 }
@@ -191,6 +200,10 @@ class FeltConfig {
       final CanvasKitVariant? variant = variantNode == null
           ? null
           : CanvasKitVariant.values.byName(variantNode as String);
+      final dynamic skwasmVariantNode = runConfigYaml['skwasm-variant'];
+      final SkwasmVariant? skwasmVariant = skwasmVariantNode == null
+          ? null
+          : SkwasmVariant.values.byName(skwasmVariantNode as String);
       final bool crossOriginIsolated = runConfigYaml['cross-origin-isolated'] as bool? ?? false;
       final bool forceSingleThreadedSkwasm =
           runConfigYaml['force-single-threaded-skwasm'] as bool? ?? false;
@@ -202,6 +215,7 @@ class FeltConfig {
         browser,
         browserFlags,
         variant,
+        skwasmVariant,
         crossOriginIsolated,
         forceSingleThreadedSkwasm,
         enableWebParagraph,
@@ -237,6 +251,7 @@ class FeltConfig {
       var canvasKit = false;
       var canvasKitChromium = false;
       var skwasm = false;
+      var wimp = false;
       final dynamic depsNode = testSuiteYaml['artifact-deps'];
       if (depsNode != null) {
         for (final dynamic dep in depsNode as YamlList) {
@@ -261,6 +276,11 @@ class FeltConfig {
                 throw AssertionError('Artifact dep $dep listed twice in suite $name.');
               }
               skwasm = true;
+            case 'wimp':
+              if (wimp) {
+                throw AssertionError('Artifact dep $dep listed twice in suite $name.');
+              }
+              wimp = true;
             default:
               throw AssertionError('Unrecognized artifact dependency: $dep');
           }
@@ -271,6 +291,7 @@ class FeltConfig {
         canvasKit: canvasKit,
         canvasKitChromium: canvasKitChromium,
         skwasm: skwasm,
+        wimp: wimp,
       );
       final bool enableCi = (testSuiteYaml['enable-ci'] as bool?) ?? true;
       final suite = TestSuite(name, bundle, runConfig, artifactDeps, enableCi);

--- a/engine/src/flutter/lib/web_ui/dev/felt_config_test.dart
+++ b/engine/src/flutter/lib/web_ui/dev/felt_config_test.dart
@@ -1,0 +1,132 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:test/test.dart';
+
+import 'felt_config.dart';
+
+void main() {
+  test('parses optional skwasm variant from run config', () {
+    final io.File configFile = _writeConfig('''
+compile-configs:
+  - name: dart2wasm-skwasm
+    compiler: dart2wasm
+    renderer: skwasm
+
+test-sets:
+  - name: skwasm
+    directory: skwasm
+
+test-bundles:
+  - name: dart2wasm-skwasm-skwasm
+    test-set: skwasm
+    compile-configs: dart2wasm-skwasm
+
+run-configs:
+  - name: safari-coi-wasm-normal
+    browser: safari
+    canvaskit-variant: full
+    cross-origin-isolated: true
+    skwasm-variant: normal
+    wasm-allow-list:
+      webkit: true
+
+test-suites:
+  - name: safari-dart2wasm-skwasm-skwasm
+    test-bundle: dart2wasm-skwasm-skwasm
+    run-config: safari-coi-wasm-normal
+    artifact-deps: [ skwasm ]
+''');
+    addTearDown(() => configFile.parent.deleteSync(recursive: true));
+
+    final config = FeltConfig.fromFile(configFile.path);
+
+    expect(config.runConfigs.single.skwasmVariant, SkwasmVariant.normal);
+  });
+
+  test('leaves skwasm variant unset by default', () {
+    final io.File configFile = _writeConfig('''
+compile-configs:
+  - name: dart2wasm-skwasm
+    compiler: dart2wasm
+    renderer: skwasm
+
+test-sets:
+  - name: skwasm
+    directory: skwasm
+
+test-bundles:
+  - name: dart2wasm-skwasm-skwasm
+    test-set: skwasm
+    compile-configs: dart2wasm-skwasm
+
+run-configs:
+  - name: safari-coi-wasm
+    browser: safari
+    canvaskit-variant: full
+    cross-origin-isolated: true
+    wasm-allow-list:
+      webkit: true
+
+test-suites:
+  - name: safari-dart2wasm-skwasm-skwasm
+    test-bundle: dart2wasm-skwasm-skwasm
+    run-config: safari-coi-wasm
+    artifact-deps: [ skwasm ]
+''');
+    addTearDown(() => configFile.parent.deleteSync(recursive: true));
+
+    final config = FeltConfig.fromFile(configFile.path);
+
+    expect(config.runConfigs.single.skwasmVariant, isNull);
+  });
+
+  test('parses wimp artifact dependency separately from skwasm', () {
+    final io.File configFile = _writeConfig('''
+compile-configs:
+  - name: dart2wasm-skwasm
+    compiler: dart2wasm
+    renderer: skwasm
+
+test-sets:
+  - name: skwasm
+    directory: skwasm
+
+test-bundles:
+  - name: dart2wasm-skwasm-skwasm
+    test-set: skwasm
+    compile-configs: dart2wasm-skwasm
+
+run-configs:
+  - name: chrome-wimp
+    browser: chrome
+    canvaskit-variant: chromium
+    cross-origin-isolated: true
+    enable-wimp: true
+
+test-suites:
+  - name: chrome-dart2wasm-wimp-skwasm
+    test-bundle: dart2wasm-skwasm-skwasm
+    run-config: chrome-wimp
+    artifact-deps: [ skwasm, wimp ]
+''');
+    addTearDown(() => configFile.parent.deleteSync(recursive: true));
+
+    final ArtifactDependencies artifactDependencies = FeltConfig.fromFile(
+      configFile.path,
+    ).testSuites.single.artifactDependencies;
+
+    expect(artifactDependencies.skwasm, isTrue);
+    expect(artifactDependencies.wimp, isTrue);
+  });
+}
+
+io.File _writeConfig(String contents) {
+  final io.Directory directory = io.Directory.systemTemp.createTempSync('felt_config_test.');
+  final file = io.File('${directory.path}/felt_config.yaml');
+  file.writeAsStringSync(contents);
+  return file;
+}

--- a/engine/src/flutter/lib/web_ui/dev/steps/copy_artifacts_step.dart
+++ b/engine/src/flutter/lib/web_ui/dev/steps/copy_artifacts_step.dart
@@ -136,6 +136,9 @@ class CopyArtifactsStep implements PipelineStep {
       copied.add('Skwasm');
       await copyWasmLibrary('skwasm', skwasmSourceDirectory, 'canvaskit');
       await copyWasmLibrary('skwasm_heavy', skwasmHeavySourceDirectory, 'canvaskit');
+    }
+    if (artifactDeps.wimp) {
+      copied.add('Wimp');
       await copyWasmLibrary('wimp', skwasmSourceDirectory, 'canvaskit');
     }
     print('Copied artifacts: ${copied.join(', ')}');

--- a/engine/src/flutter/lib/web_ui/dev/test_platform.dart
+++ b/engine/src/flutter/lib/web_ui/dev/test_platform.dart
@@ -509,6 +509,9 @@ class BrowserPlatform extends PlatformPlugin {
       final String buildConfigsString = suite.testBundle.compileConfigs
           .map((CompileConfiguration config) => _makeBuildConfigString(scriptBase, config))
           .join(',\n');
+      final skwasmVariantConfig = suite.runConfig.skwasmVariant == null
+          ? ''
+          : '      skwasmVariant: "${suite.runConfig.skwasmVariant!.name}",\n';
       final bootstrapScript =
           '''
 <script>
@@ -524,6 +527,10 @@ class BrowserPlatform extends PlatformPlugin {
       $buildConfigsString
     ]
   };
+  window._flutterTestConfig = {
+    enableWimp: ${suite.runConfig.enableWimp},
+    skwasmVariant: ${jsonEncode(suite.runConfig.skwasmVariant?.name)},
+  };
 </script>
 <script src="/flutter_js/flutter.js"></script>
 <script>
@@ -532,7 +539,7 @@ class BrowserPlatform extends PlatformPlugin {
       canvasKitVariant: "${getCanvasKitVariant()}",
       canvasKitBaseUrl: "/canvaskit",
       forceSingleThreadedSkwasm: ${suite.runConfig.forceSingleThreadedSkwasm},
-      wasmAllowList: ${jsonEncode(suite.runConfig.wasmAllowList)},
+$skwasmVariantConfig      wasmAllowList: ${jsonEncode(suite.runConfig.wasmAllowList)},
       preferWebParagraph: ${suite.runConfig.enableWebParagraph},
       enableWimp: ${suite.runConfig.enableWimp},
     },

--- a/engine/src/flutter/lib/web_ui/dev/test_runner.dart
+++ b/engine/src/flutter/lib/web_ui/dev/test_runner.dart
@@ -363,6 +363,9 @@ class TestCommand extends Command<bool> with ArgUtils<bool> {
       if (artifacts.skwasm) {
         print('  skwasm'.ansiYellow);
       }
+      if (artifacts.wimp) {
+        print('  wimp'.ansiYellow);
+      }
     }
     if (isList) {
       return true;

--- a/engine/src/flutter/lib/web_ui/flutter_js/src/skwasm_loader.js
+++ b/engine/src/flutter/lib/web_ui/flutter_js/src/skwasm_loader.js
@@ -5,11 +5,20 @@
 import { createWasmInstantiator } from "./instantiate_wasm.js";
 import { resolveUrlWithSegments } from "./utils.js";
 
-export const loadSkwasm = async (deps, config, browserEnvironment, baseUrl) => {
+export const resolveSkwasmFileStem = (config, browserEnvironment) => {
+  const standardFileStem = config.enableWimp ? 'wimp' : 'skwasm';
+  switch (config.skwasmVariant) {
+    case 'normal':
+      return standardFileStem;
+    case 'heavy':
+      return 'skwasm_heavy';
+  }
   const needsHeavy = (!browserEnvironment.hasImageCodecs || !browserEnvironment.hasChromiumBreakIterators)
-  const fileStem = needsHeavy
-     ? 'skwasm_heavy'
-     : (config.enableWimp ? 'wimp' : 'skwasm');
+  return needsHeavy ? 'skwasm_heavy' : standardFileStem;
+}
+
+export const loadSkwasm = async (deps, config, browserEnvironment, baseUrl) => {
+  const fileStem = resolveSkwasmFileStem(config, browserEnvironment);
   const rawSkwasmUrl = resolveUrlWithSegments(baseUrl, `${fileStem}.js`)
   let skwasmUrl = rawSkwasmUrl;
   if (deps.flutterTT.policy) {

--- a/engine/src/flutter/lib/web_ui/flutter_js/src/types.d.ts
+++ b/engine/src/flutter/lib/web_ui/flutter_js/src/types.d.ts
@@ -50,6 +50,11 @@ type CanvasKitVariant =
   "full" |
   "chromium";
 
+type SkwasmVariant =
+  "auto" |
+  "normal" |
+  "heavy";
+
 type WasmAllowList = {
   [k in BrowserEngine]?: boolean;
 }
@@ -58,6 +63,11 @@ export interface FlutterConfiguration {
   assetBase?: string;
   canvasKitBaseUrl?: string;
   canvasKitVariant?: CanvasKitVariant;
+  /**
+   * Selects the Skwasm runtime artifact. Defaults to "auto", which chooses
+   * "heavy" when browser feature detection requires it.
+   */
+  skwasmVariant?: SkwasmVariant;
   renderer?: WebRenderer;
   preferWebParagraph?: boolean;
   enableWimp?: boolean;

--- a/engine/src/flutter/lib/web_ui/test/felt_config.yaml
+++ b/engine/src/flutter/lib/web_ui/test/felt_config.yaml
@@ -130,6 +130,21 @@ run-configs:
     wasm-allow-list:
       gecko: true
 
+  - name: firefox-coi-wasm
+    browser: firefox
+    canvaskit-variant: full
+    cross-origin-isolated: true
+    wasm-allow-list:
+      gecko: true
+
+  - name: firefox-coi-wasm-normal
+    browser: firefox
+    canvaskit-variant: full
+    cross-origin-isolated: true
+    skwasm-variant: normal
+    wasm-allow-list:
+      gecko: true
+
   - name: safari
     browser: safari
     canvaskit-variant: full
@@ -137,6 +152,21 @@ run-configs:
   - name: safari-wasm
     browser: safari
     canvaskit-variant: full
+    wasm-allow-list:
+      webkit: true
+
+  - name: safari-coi-wasm
+    browser: safari
+    canvaskit-variant: full
+    cross-origin-isolated: true
+    wasm-allow-list:
+      webkit: true
+
+  - name: safari-coi-wasm-normal
+    browser: safari
+    canvaskit-variant: full
+    cross-origin-isolated: true
+    skwasm-variant: normal
     wasm-allow-list:
       webkit: true
 
@@ -150,12 +180,12 @@ test-suites:
   - name: chrome-dart2wasm-wimp-ui
     test-bundle: dart2wasm-skwasm-ui
     run-config: chrome-wimp
-    artifact-deps: [ skwasm ]
+    artifact-deps: [ skwasm, wimp ]
 
   - name: chrome-dart2wasm-wimp-skwasm
     test-bundle: dart2wasm-skwasm-skwasm
     run-config: chrome-wimp
-    artifact-deps: [ skwasm ]
+    artifact-deps: [ skwasm, wimp ]
 
   - name: chrome-dart2js-canvaskit-engine
     test-bundle: dart2js-canvaskit-engine
@@ -228,6 +258,12 @@ test-suites:
     artifact-deps: [ skwasm ]
     enable-ci: false
 
+  - name: firefox-dart2wasm-skwasm-skwasm
+    test-bundle: dart2wasm-skwasm-skwasm
+    run-config: firefox-coi-wasm-normal
+    artifact-deps: [ skwasm ]
+    enable-ci: false
+
   - name: safari-dart2js-canvaskit-engine
     test-bundle: dart2js-canvaskit-engine
     run-config: safari
@@ -252,6 +288,12 @@ test-suites:
   - name: safari-dart2wasm-skwasm-ui
     test-bundle: dart2wasm-skwasm-ui
     run-config: safari-wasm
+    artifact-deps: [ skwasm ]
+    enable-ci: false
+
+  - name: safari-dart2wasm-skwasm-skwasm
+    test-bundle: dart2wasm-skwasm-skwasm
+    run-config: safari-coi-wasm-normal
     artifact-deps: [ skwasm ]
     enable-ci: false
 

--- a/engine/src/flutter/lib/web_ui/test/skwasm/artifact_loading_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/skwasm/artifact_loading_test.dart
@@ -1,0 +1,89 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine/dom.dart';
+
+@JS('_flutterTestConfig')
+external JSObject get flutterTestConfig;
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  test('loads the expected Skwasm artifact for this suite', () {
+    final List<String> loadedResourceNames = getLoadedResourceNames();
+    final String? expectedFileStem = getExpectedSkwasmFileStem();
+
+    if (expectedFileStem == null) {
+      expect(
+        loadedResourceNames.any(isSkwasmArtifact),
+        isTrue,
+        reason: 'The Skwasm test suite should load a Skwasm-family artifact.',
+      );
+    } else {
+      expect(
+        loadedResourceNames,
+        contains(endsWith('/canvaskit/$expectedFileStem.js')),
+        reason: 'The Skwasm test suite should load the expected JS artifact.',
+      );
+      expect(
+        loadedResourceNames,
+        contains(endsWith('/canvaskit/$expectedFileStem.wasm')),
+        reason: 'The Skwasm test suite should load the expected Wasm artifact.',
+      );
+      for (final fileStem in <String>['skwasm', 'skwasm_heavy', 'wimp']) {
+        if (fileStem == expectedFileStem) {
+          continue;
+        }
+        expect(
+          loadedResourceNames.any((String name) => name.contains('/canvaskit/$fileStem.')),
+          isFalse,
+          reason: 'The Skwasm test suite should not silently load $fileStem.',
+        );
+      }
+    }
+    expect(
+      loadedResourceNames.any((String name) => name.contains('/canvaskit/canvaskit.')),
+      isFalse,
+      reason: 'The Skwasm suite should not silently fall back to CanvasKit.',
+    );
+  });
+}
+
+List<String> getLoadedResourceNames() {
+  final JSArray<JSAny?> entries = domWindow.performance.callMethod<JSArray<JSAny?>>(
+    'getEntriesByType'.toJS,
+    'resource'.toJS,
+  );
+  return entries.toDart.map((JSAny? entry) {
+    return (entry! as JSObject).getProperty<JSString>('name'.toJS).toDart;
+  }).toList();
+}
+
+String? getExpectedSkwasmFileStem() {
+  final bool enableWimp = flutterTestConfig.getProperty<JSBoolean>('enableWimp'.toJS).toDart;
+  if (enableWimp) {
+    return 'wimp';
+  }
+  final String? skwasmVariant = flutterTestConfig
+      .getProperty<JSString?>('skwasmVariant'.toJS)
+      ?.toDart;
+  return switch (skwasmVariant) {
+    'normal' => 'skwasm',
+    'heavy' => 'skwasm_heavy',
+    _ => null,
+  };
+}
+
+bool isSkwasmArtifact(String name) {
+  return name.contains('/canvaskit/skwasm.') ||
+      name.contains('/canvaskit/skwasm_heavy.') ||
+      name.contains('/canvaskit/wimp.');
+}


### PR DESCRIPTION
## Summary

Adds explicit Skwasm artifact selection and browser-test coverage for Safari and Firefox.

The new tests prove which Skwasm artifact was loaded and verify that the run did not silently fall back to CanvasKit.

## Why now

#188797 fixed the stock `RenderCanvas` CSS-size drift observed on Safari, and the corresponding issue #188723 is now closed.

With that specific rendering blocker addressed, the next gap is artifact-level confidence. Safari and Firefox automatically select `skwasm_heavy`, but existing tests do not prove which runtime files were loaded. This makes it possible to accidentally measure another Skwasm variant, Wimp, or a CanvasKit fallback.

This PR makes that selection explicit and testable.

## Changes

- Adds `skwasmVariant` with `auto`, `normal`, and `heavy` options.
- Adds Felt support for selecting a Skwasm variant.
- Adds non-CI Safari and Firefox Skwasm suites.
- Verifies that the expected Skwasm JavaScript and Wasm files were loaded.
- Verifies that other Skwasm variants and CanvasKit were not loaded.
- Tracks Wimp artifacts separately so Skwasm-only suites do not copy or depend on them.

The default remains `auto`; existing production selection behavior is unchanged.

## Local validation

A three-pass local macrobenchmark comparison used the same SDK and browser harness for CanvasKit and Skwasm. The metric is `drawFrameDuration.average`; lower is better.

| Browser | Artifact selected | Card | Lazy text | Wrapbox |
| --- | --- | ---: | ---: | ---: |
| Chrome | `skwasm` | 1.69× faster | 1.46× faster | 1.92× faster |
| Firefox | `skwasm_heavy` | 1.37× faster | 1.48× faster | 1.28× faster |
| Safari | `skwasm_heavy` | 2.26× faster | 1.75× faster | 2.56× faster |

The selected artifact was recorded on every run, and the direction did not change across the three passes.

A controlled variant check also showed why this proof matters: forcing normal `skwasm` on Safari or Firefox fails during text layout because `Intl.v8BreakIterator` is unavailable. `skwasm_heavy` includes the required text-segmentation data and runs successfully.

These are local results supporting the test infrastructure in this PR. They are not a default-enablement or CI-readiness claim.

## Scope

This PR does not:

- enable Skwasm by default on Safari or Firefox;
- change the rendering or presentation path;
- add Safari or Firefox Skwasm suites to CI.

Related: #178893, #188797.

## Tests

- `dart analyze test/skwasm/artifact_loading_test.dart dev/felt_config.dart dev/felt_config_test.dart dev/test_platform.dart dev/test_runner.dart dev/steps/copy_artifacts_step.dart`
- `dart test dev/felt_config_test.dart`
- `./dev/felt test --suite=firefox-dart2wasm-skwasm-skwasm --suite=safari-dart2wasm-skwasm-skwasm test/skwasm/artifact_loading_test.dart`