### PR TITLE
Add import of `dart:_js_interop_wasm` in sdk rewriter tool

### DIFF
--- a/engine/src/flutter/web_sdk/sdk_rewriter.dart
+++ b/engine/src/flutter/web_sdk/sdk_rewriter.dart
@@ -210,6 +210,7 @@ List<String> getExtraImportsForLibrary(String libraryName) {
   }
   if (libraryName == 'skwasm_impl') {
     extraImports.add("import 'dart:_wasm';");
+    extraImports.add("import 'dart:_js_interop_wasm';");
   }
   return extraImports;
 }

--- a/engine/src/flutter/web_sdk/test/sdk_rewriter_test.dart
+++ b/engine/src/flutter/web_sdk/test/sdk_rewriter_test.dart
@@ -171,6 +171,7 @@ void printSomething() {
       "import 'dart:_web_test_fonts';",
       "import 'dart:_web_locale_keymap' as locale_keymap;",
       "import 'dart:_wasm';",
+      "import 'dart:_js_interop_wasm';",
     ]);
 
     // Other libraries (should not have extra imports).


### PR DESCRIPTION
This is a follow-up for [0] which should unblock landing [1] (which currently fails with g3 roll error).

[0] https://github.com/flutter/flutter/pull/186974
[1] https://dart-review.googlesource.com/c/sdk/+/505960