### PR TITLE
Support cross-browser web macrobenchmark runs

### DIFF
--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -445,18 +445,21 @@ class BlinkFrame {
   BlinkTraceEvent? endMeasuredFrame;
 }
 
-/// Takes a list of events that have non-null [BlinkTraceEvent.tdur] computes
-/// their average as a [Duration] value.
+/// Takes a list of events that have a non-null [BlinkTraceEvent.tdur] or
+/// [BlinkTraceEvent.dur] and computes their average as a [Duration] value.
 Duration _computeAverageDuration(List<BlinkTraceEvent> events) {
-  // Compute the sum of "tdur" fields of the last _kMeasuredSampleCount events.
+  // Compute the sum of trace duration fields of the last _kMeasuredSampleCount
+  // events. Chrome versions can report duration-only frame events, so fall
+  // back to "dur" when thread duration is not present.
   final double sum = events.skip(math.max(events.length - _kMeasuredSampleCount, 0)).fold(0.0, (
     double previousValue,
     BlinkTraceEvent event,
   ) {
-    if (event.tdur == null) {
-      throw FormatException('Trace event lacks "tdur" field: $event');
+    final int? duration = event.tdur ?? event.dur;
+    if (duration == null) {
+      throw FormatException('Trace event lacks duration field: $event');
     }
-    return previousValue + event.tdur!;
+    return previousValue + duration;
   });
   final int sampleCount = math.min(events.length, _kMeasuredSampleCount);
   return Duration(microseconds: sum ~/ sampleCount);
@@ -500,7 +503,8 @@ class BlinkTraceEvent {
       tid = _readInt(json, 'tid'),
       ts = _readInt(json, 'ts'),
       tts = _readInt(json, 'tts'),
-      tdur = _readInt(json, 'tdur');
+      tdur = _readInt(json, 'tdur'),
+      dur = _readInt(json, 'dur');
 
   /// Event-specific data.
   final Map<String, dynamic> args;
@@ -528,6 +532,9 @@ class BlinkTraceEvent {
 
   /// Event duration in microseconds.
   final int? tdur;
+
+  /// Wall-clock event duration in microseconds.
+  final int? dur;
 
   /// A "begin frame" event contains all of the scripting time of an animation
   /// frame (JavaScript, WebAssembly), plus a negligible amount of internal
@@ -590,7 +597,8 @@ class BlinkTraceEvent {
       'tid: $tid, '
       'ts: $ts, '
       'tts: $tts, '
-      'tdur: $tdur)';
+      'tdur: $tdur, '
+      'dur: $dur)';
 }
 
 /// Read an integer out of [json] stored under [key].

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -26,6 +26,9 @@ const int chromeDebugPort = 10000;
 /// The port at which the benchmark's app is being served.
 const int benchmarksAppPort = 10001;
 
+/// The port at which SafariDriver listens during local cross-browser runs.
+const int safariDriverPort = 10002;
+
 typedef WebBenchmarkOptions = ({
   bool useWasm,
   bool forceSingleThreadedSkwasm,
@@ -34,9 +37,44 @@ typedef WebBenchmarkOptions = ({
   String buildMode,
 });
 
+enum _BenchmarkBrowser { chrome, safari, firefox }
+
+List<String>? _parseBenchmarkFilter(String? rawFilter) {
+  if (rawFilter == null || rawFilter.trim().isEmpty) {
+    return null;
+  }
+  return rawFilter
+      .split(',')
+      .map((String benchmark) => benchmark.trim())
+      .where((String benchmark) => benchmark.isNotEmpty)
+      .toList();
+}
+
+_BenchmarkBrowser _readBenchmarkBrowser() {
+  final String rawBrowser = io.Platform.environment['WEB_BENCHMARK_BROWSER'] ?? 'chrome';
+  return switch (rawBrowser.toLowerCase()) {
+    'chrome' => _BenchmarkBrowser.chrome,
+    'safari' => _BenchmarkBrowser.safari,
+    'firefox' => _BenchmarkBrowser.firefox,
+    _ => throw ArgumentError.value(
+      rawBrowser,
+      'WEB_BENCHMARK_BROWSER',
+      'Expected chrome, safari, or firefox',
+    ),
+  };
+}
+
 Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
   // Reduce logging level. Otherwise, package:webkit_inspection_protocol is way too spammy.
   Logger.root.level = Level.INFO;
+  final List<String>? benchmarkFilter = _parseBenchmarkFilter(
+    io.Platform.environment['WEB_BENCHMARKS'],
+  );
+  final _BenchmarkBrowser benchmarkBrowser = _readBenchmarkBrowser();
+  final useChromeTracing = benchmarkBrowser == _BenchmarkBrowser.chrome;
+  if (benchmarkOptions.useDdc && benchmarkBrowser != _BenchmarkBrowser.chrome) {
+    throw UnsupportedError('DDC web benchmarks still require Chrome.');
+  }
   final String macrobenchmarksDirectory = path.join(
     flutterDirectory.path,
     'dev',
@@ -125,6 +163,7 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
     // Sometime one wins. Other times, the other wins.
     Future<Chrome>? whenChromeIsReady;
     Chrome? chrome;
+    _LaunchedBenchmarkBrowser? launchedBrowser;
     late io.HttpServer server;
     var cascade = Cascade();
     List<Map<String, dynamic>>? latestPerformanceTrace;
@@ -144,7 +183,9 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
     cascade = cascade.add((Request request) async {
       final String requestContents = await request.readAsString();
       try {
-        chrome ??= await whenChromeIsReady;
+        if (useChromeTracing) {
+          chrome ??= await whenChromeIsReady;
+        }
         if (request.method == 'OPTIONS') {
           return Response.ok('', headers: requestHeaders);
         }
@@ -175,10 +216,16 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
           collectedProfiles.add(profile);
           return Response.ok('Profile received', headers: requestHeaders);
         } else if (request.requestedUri.path.endsWith('/start-performance-tracing')) {
+          if (!useChromeTracing) {
+            return Response.ok('Performance tracing skipped', headers: requestHeaders);
+          }
           latestPerformanceTrace = null;
           await chrome!.beginRecordingPerformance(request.requestedUri.queryParameters['label']!);
           return Response.ok('Started performance tracing', headers: requestHeaders);
         } else if (request.requestedUri.path.endsWith('/stop-performance-tracing')) {
+          if (!useChromeTracing) {
+            return Response.ok('Performance tracing skipped', headers: requestHeaders);
+          }
           latestPerformanceTrace = await chrome!.endRecordingPerformance();
           return Response.ok('Stopped performance tracing', headers: requestHeaders);
         } else if (request.requestedUri.path.endsWith('/on-error')) {
@@ -189,7 +236,25 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
           return Response.ok('', headers: requestHeaders);
         } else if (request.requestedUri.path.endsWith('/next-benchmark')) {
           if (benchmarks == null) {
-            benchmarks = (json.decode(requestContents) as List<dynamic>).cast<String>();
+            final List<String> availableBenchmarks = (json.decode(requestContents) as List<dynamic>)
+                .cast<String>();
+            if (benchmarkFilter != null) {
+              final List<String> missingBenchmarks = benchmarkFilter
+                  .where((String benchmark) => !availableBenchmarks.contains(benchmark))
+                  .toList();
+              if (missingBenchmarks.isNotEmpty) {
+                throw ArgumentError.value(
+                  missingBenchmarks.join(', '),
+                  'WEB_BENCHMARKS',
+                  'Unknown benchmark(s)',
+                );
+              }
+              benchmarks = availableBenchmarks
+                  .where((String benchmark) => benchmarkFilter.contains(benchmark))
+                  .toList();
+            } else {
+              benchmarks = availableBenchmarks;
+            }
             benchmarkIterator = benchmarks!.iterator;
           }
           if (benchmarkIterator.moveNext()) {
@@ -252,20 +317,31 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
         enableWasmGC: benchmarkOptions.useWasm,
       );
 
-      print('Launching Chrome.');
+      if (benchmarkBrowser == _BenchmarkBrowser.chrome) {
+        print('Launching Chrome.');
 
-      if (benchmarkOptions.useDdc) {
-        // DDC reuses the existing Chrome connection spawned via 'flutter run'.
-        whenChromeIsReady = Chrome.connect(
-          flutterRunProcess!,
-          options,
-          onError: (String error) {
-            profileData.completeError(Exception(error));
-          },
-          workingDirectory: cwd,
-        );
+        if (benchmarkOptions.useDdc) {
+          // DDC reuses the existing Chrome connection spawned via 'flutter run'.
+          whenChromeIsReady = Chrome.connect(
+            flutterRunProcess!,
+            options,
+            onError: (String error) {
+              profileData.completeError(Exception(error));
+            },
+            workingDirectory: cwd,
+          );
+        } else {
+          whenChromeIsReady = Chrome.launch(
+            options,
+            onError: (String error) {
+              profileData.completeError(Exception(error));
+            },
+            workingDirectory: cwd,
+          );
+        }
       } else {
-        whenChromeIsReady = Chrome.launch(
+        launchedBrowser = await _LaunchedBenchmarkBrowser.launch(
+          benchmarkBrowser,
           options,
           onError: (String error) {
             profileData.completeError(Exception(error));
@@ -316,6 +392,7 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
     } finally {
       unawaited(server.close());
       chrome?.stop();
+      await launchedBrowser?.stop();
       if (flutterRunProcess != null) {
         // Sending a SIGINT/SIGTERM to the process here isn't reliable because [process] is
         // the shell (flutter is a shell script) and doesn't pass the signal on.
@@ -334,6 +411,253 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
       }
     }
   });
+}
+
+class _LaunchedBenchmarkBrowser {
+  _LaunchedBenchmarkBrowser._({this.process, this.safariSession});
+
+  static Future<_LaunchedBenchmarkBrowser> launch(
+    _BenchmarkBrowser browser,
+    ChromeOptions options, {
+    required ChromeErrorCallback onError,
+    required String workingDirectory,
+  }) async {
+    return switch (browser) {
+      _BenchmarkBrowser.chrome => throw ArgumentError('Use Chrome.launch for Chrome benchmarks.'),
+      _BenchmarkBrowser.safari => _launchSafari(
+        options,
+        onError: onError,
+        workingDirectory: workingDirectory,
+      ),
+      _BenchmarkBrowser.firefox => _launchFirefox(
+        options,
+        onError: onError,
+        workingDirectory: workingDirectory,
+      ),
+    };
+  }
+
+  final io.Process? process;
+  final _SafariWebDriverSession? safariSession;
+  bool _isStopped = false;
+
+  Future<void> stop() async {
+    _isStopped = true;
+    await safariSession?.stop();
+    process?.kill();
+  }
+
+  static Future<_LaunchedBenchmarkBrowser> _launchFirefox(
+    ChromeOptions options, {
+    required ChromeErrorCallback onError,
+    required String workingDirectory,
+  }) async {
+    final String? url = options.url;
+    final String? userDataDirectory = options.userDataDirectory;
+    if (url == null || userDataDirectory == null) {
+      throw ArgumentError('Firefox benchmarks require a URL and user data directory.');
+    }
+    final String executable = _findFirefoxExecutable();
+    final args = <String>[
+      '--new-instance',
+      '--profile',
+      userDataDirectory,
+      '--width',
+      '${options.windowWidth}',
+      '--height',
+      '${options.windowHeight}',
+      url,
+    ];
+    print('Launching Firefox: $executable ${args.join(' ')}');
+    final io.Process process = await io.Process.start(
+      executable,
+      args,
+      workingDirectory: workingDirectory,
+    );
+    final launched = _LaunchedBenchmarkBrowser._(process: process);
+    process.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((String line) {
+      print('[FIREFOX STDOUT]: $line');
+    });
+    process.stderr.transform(utf8.decoder).transform(const LineSplitter()).listen((String line) {
+      print('[FIREFOX STDERR]: $line');
+    });
+    unawaited(
+      process.exitCode.then((int exitCode) {
+        if (!launched._isStopped) {
+          onError('Firefox process exited prematurely with exit code $exitCode');
+        }
+      }),
+    );
+    return launched;
+  }
+
+  static Future<_LaunchedBenchmarkBrowser> _launchSafari(
+    ChromeOptions options, {
+    required ChromeErrorCallback onError,
+    required String workingDirectory,
+  }) async {
+    final String? url = options.url;
+    if (url == null) {
+      throw ArgumentError('Safari benchmarks require a URL.');
+    }
+    if (!io.Platform.isMacOS) {
+      throw UnsupportedError('Safari benchmarks are only supported on macOS.');
+    }
+    print('Launching Safari via safaridriver.');
+    final _SafariWebDriverSession session = await _SafariWebDriverSession.start(
+      url,
+      onError: onError,
+      workingDirectory: workingDirectory,
+    );
+    return _LaunchedBenchmarkBrowser._(safariSession: session);
+  }
+}
+
+String _findFirefoxExecutable() {
+  const macOSFirefoxPath = '/Applications/Firefox.app/Contents/MacOS/firefox';
+  if (io.File(macOSFirefoxPath).existsSync()) {
+    return macOSFirefoxPath;
+  }
+  return 'firefox';
+}
+
+class _SafariWebDriverSession {
+  _SafariWebDriverSession._(this._driverProcess, this._sessionId, this._onError) {
+    unawaited(
+      _driverProcess.exitCode.then((int exitCode) {
+        if (!_isStopped) {
+          _onError('safaridriver exited prematurely with exit code $exitCode');
+        }
+      }),
+    );
+  }
+
+  static Future<_SafariWebDriverSession> start(
+    String url, {
+    required ChromeErrorCallback onError,
+    required String workingDirectory,
+  }) async {
+    final io.Process driverProcess = await io.Process.start(_findSafariDriverExecutable(), <String>[
+      '--port',
+      '$safariDriverPort',
+    ], workingDirectory: workingDirectory);
+    driverProcess.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((
+      String line,
+    ) {
+      print('[SAFARIDRIVER STDOUT]: $line');
+    });
+    driverProcess.stderr.transform(utf8.decoder).transform(const LineSplitter()).listen((
+      String line,
+    ) {
+      print('[SAFARIDRIVER STDERR]: $line');
+    });
+
+    try {
+      await _waitForWebDriverStatus();
+      final String sessionId = await _createSession();
+      final session = _SafariWebDriverSession._(driverProcess, sessionId, onError);
+      await session._navigate(url);
+      return session;
+    } catch (_) {
+      driverProcess.kill();
+      rethrow;
+    }
+  }
+
+  final io.Process _driverProcess;
+  final String _sessionId;
+  final ChromeErrorCallback _onError;
+  bool _isStopped = false;
+
+  Future<void> stop() async {
+    _isStopped = true;
+    try {
+      await _webdriverRequest('DELETE', '/session/$_sessionId');
+    } catch (error) {
+      print('Failed to stop Safari WebDriver session: $error');
+    }
+    _driverProcess.kill();
+  }
+
+  static Future<void> _waitForWebDriverStatus() async {
+    final stopwatch = Stopwatch()..start();
+    Object? lastError;
+    while (stopwatch.elapsed < const Duration(seconds: 10)) {
+      try {
+        await _webdriverRequest('GET', '/status');
+        return;
+      } catch (error) {
+        lastError = error;
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }
+    }
+    throw StateError('safaridriver did not become ready: $lastError');
+  }
+
+  static Future<String> _createSession() async {
+    final Map<String, dynamic> response = await _webdriverRequest(
+      'POST',
+      '/session',
+      body: <String, dynamic>{
+        'capabilities': <String, dynamic>{
+          'alwaysMatch': <String, dynamic>{'browserName': 'safari'},
+        },
+      },
+    );
+    final value = response['value'] as Map<String, dynamic>;
+    return value['sessionId'] as String;
+  }
+
+  Future<void> _navigate(String url) async {
+    await _webdriverRequest(
+      'POST',
+      '/session/$_sessionId/url',
+      body: <String, dynamic>{'url': url},
+    );
+  }
+
+  static Future<Map<String, dynamic>> _webdriverRequest(
+    String method,
+    String path, {
+    Map<String, dynamic>? body,
+  }) async {
+    final Uri uri = Uri.parse('http://localhost:$safariDriverPort$path');
+    final client = io.HttpClient();
+    try {
+      final io.HttpClientRequest request = await client.openUrl(method, uri);
+      request.headers.contentType = io.ContentType.json;
+      if (body != null) {
+        request.write(json.encode(body));
+      }
+      final io.HttpClientResponse response = await request.close();
+      final String responseBody = await utf8.decoder.bind(response).join();
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw io.HttpException(
+          'WebDriver $method $path failed with ${response.statusCode}: $responseBody',
+          uri: uri,
+        );
+      }
+      if (responseBody.isEmpty) {
+        return <String, dynamic>{};
+      }
+      return json.decode(responseBody) as Map<String, dynamic>;
+    } finally {
+      client.close();
+    }
+  }
+}
+
+String _findSafariDriverExecutable() {
+  const candidates = <String>[
+    '/usr/bin/safaridriver',
+    '/System/Cryptexes/App/usr/bin/safaridriver',
+  ];
+  for (final candidate in candidates) {
+    if (io.File(candidate).existsSync()) {
+      return candidate;
+    }
+  }
+  return 'safaridriver';
 }
 
 Handler createBuildDirectoryHandler(String buildDirectoryPath) {

--- a/dev/devicelab/test/framework/browser_test.dart
+++ b/dev/devicelab/test/framework/browser_test.dart
@@ -45,4 +45,49 @@ void main() {
       expect(anotherUnrelated.isEndMeasuredFrame, isFalse);
     });
   });
+
+  test('BlinkTraceSummary falls back to duration when thread duration is absent', () {
+    final Map<String, dynamic> beginMeasuredFrame = _event(beginMeasuredFrameJson_89plus, ts: 100);
+    final Map<String, dynamic> beginFrame = _event(
+      beginMainFrameJson_89plus,
+      ts: 110,
+      duration: 6000,
+      removeThreadDuration: true,
+    );
+    final Map<String, dynamic> endMeasuredFrame = _event(endMeasuredFrameJson_89plus, ts: 120);
+    final Map<String, dynamic> updateLifecycle = _event(
+      updateLifecycleJson_89plus,
+      ts: 130,
+      duration: 250,
+      removeThreadDuration: true,
+    );
+
+    final BlinkTraceSummary? summary = BlinkTraceSummary.fromJson(<Map<String, dynamic>>[
+      beginMeasuredFrame,
+      beginFrame,
+      endMeasuredFrame,
+      updateLifecycle,
+    ]);
+
+    expect(summary!.averageBeginFrameTime, const Duration(microseconds: 6000));
+    expect(summary.averageUpdateLifecyclePhasesTime, const Duration(microseconds: 250));
+    expect(summary.averageTotalUIFrameTime, const Duration(microseconds: 6250));
+  });
+}
+
+Map<String, dynamic> _event(
+  Map<String, Object?> event, {
+  required int ts,
+  int? duration,
+  bool removeThreadDuration = false,
+}) {
+  final result = Map<String, dynamic>.from(event);
+  result['ts'] = ts;
+  if (duration != null) {
+    result['dur'] = duration;
+  }
+  if (removeThreadDuration) {
+    result.remove('tdur');
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary

Adds local cross-browser execution support to the existing web macrobenchmark task:

- `WEB_BENCHMARK_BROWSER=chrome|firefox|safari` selects the browser.
- `WEB_BENCHMARKS=bench_a,bench_b` optionally limits a run to specific benchmarks.
- Firefox launches with an isolated temporary profile.
- Safari launches through `safaridriver`.
- Non-Chrome runs skip the Chrome DevTools tracing endpoints while still collecting the app-reported benchmark profile metrics.

This also updates Blink trace parsing to fall back from `tdur` to `dur` when newer Chrome trace events do not include thread duration, with a regression test.

## Why

Related to flutter/flutter#187660 and follow-up measurement work around Skwasm on Safari and Firefox.

The current web macrobenchmark task is Chrome-centered. That makes it hard to compare CanvasKit, normal Skwasm, and single-threaded Skwasm on the browsers where Skwasm policy decisions are most uncertain.

This PR is intentionally measurement infrastructure only. It does not change the default renderer policy and does not enable Skwasm by default on Safari or Firefox.

## Relationship to #188614

flutter/flutter#188614 is the artifact-proof PR: it lets tests force `normal`, `heavy`, or `auto` Skwasm and verify which Skwasm-family files actually loaded.

This PR is the measurement-helper PR: it lets the existing macrobenchmark runner execute in Chrome, Firefox, or Safari.

The two PRs are complementary but independent. Neither PR is the Safari/WebKit performance solution by itself.

## Policy notes

- Chrome should keep the existing normal Skwasm direction; the local macrobenchmarks still show clear Skwasm wins.
- Firefox does not currently justify forcing single-threaded Skwasm as default. ST remains diagnostic only.
- Safari remains the main open problem. The next Safari work should separate artifact policy (`normal`/`heavy`/`auto`) from presentation strategy, especially retained/tiled or small-dirty presentation.

## Measurement notes

Chrome keeps the existing DevTools tracing path and can still report `totalUiFrame.average`.

Firefox and Safari do not have that Chrome tracing path here, so their runs collect the benchmark profile metrics reported by the Flutter app, such as `drawFrameDuration.average`. This is enough for local A/B comparison, but it is not claiming trace parity with Chrome.

Safari requires WebDriver support to be enabled locally, for example with `safaridriver --enable`.

## Verification

- `dart analyze lib/tasks/web_benchmarks.dart lib/framework/browser.dart test/framework/browser_test.dart`
- `dart --packages=/private/tmp/flutter-pr-188614/.dart_tool/package_config.json /private/tmp/flutter-pr-188614-pub-cache/hosted/pub.dev/test-1.31.1/bin/test.dart test/framework/browser_test.dart`

`flutter test` through the wrapper was not used for the final local test run because this isolated checkout tried to refresh Flutter tool dependencies from pub.dev. The test above uses the existing workspace package config and does not contact pub.dev.
