### PR TITLE
Fix TreeSliver first node clipping during expand/collapse animation

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_tree.dart
+++ b/packages/flutter/lib/src/rendering/sliver_tree.dart
@@ -375,7 +375,7 @@ class RenderTreeSliver extends RenderSliverVariedExtentList {
       // parentIndex is always a real animating node (the unclipped first
       // segment is already painted), so its extent is added even when it is
       // index 0. Otherwise the clip starts at the parent's leading edge and its
-      // children paint over it. See https://github.com/flutter/flutter/issues/188305.
+      // children paint over it.
       final int parentIndex = math.max(segment.leadingIndex - 1, 0);
       final double leadingOffset =
           indexToLayoutOffset(0.0, parentIndex) + itemExtentBuilder(parentIndex, layoutDimensions)!;

--- a/packages/flutter/lib/src/rendering/sliver_tree.dart
+++ b/packages/flutter/lib/src/rendering/sliver_tree.dart
@@ -371,10 +371,14 @@ class RenderTreeSliver extends RenderSliverVariedExtentList {
       // leadingIndex), and the trailing edge of the trailing index. We cannot
       // rely on the leading edge of the leading index, because it is currently
       // moving.
+      //
+      // parentIndex is always a real animating node (the unclipped first
+      // segment is already painted), so its extent is added even when it is
+      // index 0. Otherwise the clip starts at the parent's leading edge and its
+      // children paint over it. See https://github.com/flutter/flutter/issues/188305.
       final int parentIndex = math.max(segment.leadingIndex - 1, 0);
       final double leadingOffset =
-          indexToLayoutOffset(0.0, parentIndex) +
-          (parentIndex == 0 ? 0.0 : itemExtentBuilder(parentIndex, layoutDimensions)!);
+          indexToLayoutOffset(0.0, parentIndex) + itemExtentBuilder(parentIndex, layoutDimensions)!;
       final double trailingOffset =
           indexToLayoutOffset(0.0, segment.trailingIndex) +
           itemExtentBuilder(segment.trailingIndex, layoutDimensions)!;

--- a/packages/flutter/test/widgets/sliver_tree_test.dart
+++ b/packages/flutter/test/widgets/sliver_tree_test.dart
@@ -1007,11 +1007,11 @@ void main() {
     expect(tester.getTopLeft(find.byType(ColoredBox)), const Offset(0, -5));
   });
 
-  // Regression test for https://github.com/flutter/flutter/issues/188305.
-  // While a node expands, its children must be clipped beneath the node (at the
-  // node's trailing edge) - including the first node, which used to clip at its
-  // leading edge and let its children paint over it.
   group('Animating node clips children below its trailing edge', () {
+    // Regression test for https://github.com/flutter/flutter/issues/188305.
+    // While a node expands, its children must be clipped beneath the node (at the
+    // node's trailing edge) - including the first node, which used to clip at its
+    // leading edge and let its children paint over it.
     const rowExtent = 40.0;
     const animationDuration = Duration(seconds: 1);
 
@@ -1084,9 +1084,9 @@ void main() {
       await tester.pump();
       await tester.pump(animationDuration ~/ 2); // Mid-animation.
 
-      final RenderTreeSliver renderTree = tester.allRenderObjects
-          .whereType<RenderTreeSliver>()
-          .first;
+      final RenderTreeSliver renderTree = tester.renderObject<RenderTreeSliver>(
+        find.byType(TreeSliver<String>),
+      );
       final List<double> clipTops = recordedClipTops(renderTree);
       // One row down (the node's trailing edge), not at the top (0.0).
       expect(clipTops, isNotEmpty);
@@ -1102,9 +1102,9 @@ void main() {
       await tester.pump();
       await tester.pump(animationDuration ~/ 2); // Mid-animation.
 
-      final RenderTreeSliver renderTree = tester.allRenderObjects
-          .whereType<RenderTreeSliver>()
-          .first;
+      final RenderTreeSliver renderTree = tester.renderObject<RenderTreeSliver>(
+        find.byType(TreeSliver<String>),
+      );
       final List<double> clipTops = recordedClipTops(renderTree);
       // The second node is at index 1, so its trailing edge is two rows down.
       expect(clipTops, isNotEmpty);

--- a/packages/flutter/test/widgets/sliver_tree_test.dart
+++ b/packages/flutter/test/widgets/sliver_tree_test.dart
@@ -1006,4 +1006,110 @@ void main() {
     await expectLater(find.byKey(key), matchesGoldenFile('sliver_tree.scrolling.1.png'));
     expect(tester.getTopLeft(find.byType(ColoredBox)), const Offset(0, -5));
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/188305.
+  // While a node expands, its children must be clipped beneath the node (at the
+  // node's trailing edge) - including the first node, which used to clip at its
+  // leading edge and let its children paint over it.
+  group('Animating node clips children below its trailing edge', () {
+    const rowExtent = 40.0;
+    const animationDuration = Duration(seconds: 1);
+
+    // The top edge of every clip rect the sliver paints.
+    List<double> recordedClipTops(RenderObject renderObject) {
+      final tops = <double>[];
+      final canvas = TestRecordingCanvas();
+      final context = TestRecordingPaintingContext(canvas);
+      renderObject.paint(context, Offset.zero);
+      for (final RecordedInvocation recorded in canvas.invocations) {
+        if (recorded.invocation.memberName == #clipRect) {
+          tops.add((recorded.invocation.positionalArguments[0] as Rect).top);
+        }
+      }
+      return tops;
+    }
+
+    Widget buildTree(TreeSliverController controller) {
+      final tree = <TreeSliverNode<String>>[
+        TreeSliverNode<String>(
+          'First',
+          children: <TreeSliverNode<String>>[
+            TreeSliverNode<String>('First:0'),
+            TreeSliverNode<String>('First:1'),
+          ],
+        ),
+        TreeSliverNode<String>(
+          'Second',
+          children: <TreeSliverNode<String>>[
+            TreeSliverNode<String>('Second:0'),
+            TreeSliverNode<String>('Second:1'),
+          ],
+        ),
+      ];
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            TreeSliver<String>(
+              tree: tree,
+              controller: controller,
+              treeRowExtentBuilder: (_, _) => rowExtent,
+              toggleAnimationStyle: const AnimationStyle(
+                curve: Curves.linear,
+                duration: animationDuration,
+              ),
+              treeNodeBuilder:
+                  (
+                    BuildContext context,
+                    TreeSliverNode<Object?> node,
+                    AnimationStyle animationStyle,
+                  ) {
+                    return GestureDetector(
+                      behavior: HitTestBehavior.translucent,
+                      onTap: () => controller.toggleNode(node),
+                      child: TreeSliver.defaultTreeNodeBuilder(context, node, animationStyle),
+                    );
+                  },
+            ),
+          ],
+        ),
+      );
+    }
+
+    testWidgets('first node (index 0) clips at its trailing edge', (WidgetTester tester) async {
+      final controller = TreeSliverController();
+      await tester.pumpWidget(buildTree(controller));
+
+      await tester.tap(find.text('First'));
+      await tester.pump();
+      await tester.pump(animationDuration ~/ 2); // Mid-animation.
+
+      final RenderTreeSliver renderTree = tester.allRenderObjects
+          .whereType<RenderTreeSliver>()
+          .first;
+      final List<double> clipTops = recordedClipTops(renderTree);
+      // One row down (the node's trailing edge), not at the top (0.0).
+      expect(clipTops, isNotEmpty);
+      expect(clipTops, contains(rowExtent));
+      expect(clipTops, isNot(contains(0.0)));
+    });
+
+    testWidgets('non-first node (index 1) clips at its trailing edge', (WidgetTester tester) async {
+      final controller = TreeSliverController();
+      await tester.pumpWidget(buildTree(controller));
+
+      await tester.tap(find.text('Second'));
+      await tester.pump();
+      await tester.pump(animationDuration ~/ 2); // Mid-animation.
+
+      final RenderTreeSliver renderTree = tester.allRenderObjects
+          .whereType<RenderTreeSliver>()
+          .first;
+      final List<double> clipTops = recordedClipTops(renderTree);
+      // The second node is at index 1, so its trailing edge is two rows down.
+      expect(clipTops, isNotEmpty);
+      expect(clipTops, contains(rowExtent * 2));
+      expect(clipTops, isNot(contains(0.0)));
+    });
+  });
 }


### PR DESCRIPTION
## Description

While a `TreeSliver` node expands/collapses, its children should be clipped beneath the node (at the node's trailing edge). This worked for every node except the first: node index 0 clipped at its *leading* edge, so its children painted over the node during the animation.

The cause was a special case in `RenderTreeSliver.paint` that conflated "no parent" with "parent is index 0":

```dart
(parentIndex == 0 ? 0.0 : itemExtentBuilder(parentIndex, layoutDimensions)!)
```

This branch only runs for the clipped segments after the first (the first segment is painted unclipped beforehand), so `parentIndex` is always a real animating parent whose extent must be added — including index 0. The fix always adds the parent's extent.

## Demo

Video showing the bug and the fix:

https://github.com/user-attachments/assets/db19c35c-c249-4a92-afde-5fb1e6f9f2fb

## Related Issues

Fixes https://github.com/flutter/flutter/issues/188305

## Tests

I added the following tests:

Regression tests in `sliver_tree_test.dart` that pump the toggle animation to its midpoint and assert the clip-rect top edge:
- First node (index 0) clips at its trailing edge (`rowExtent`), not `0.0`.
- Non-first node (index 1) clips at its trailing edge (`rowExtent * 2`), confirming no regression for other nodes.



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


