### PR TITLE
[flutter_tools] Fix macOS ExFAT SSD AppleDouble deletion race

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -12,6 +12,7 @@ import 'package:logging/logging.dart' as logging;
 import 'package:package_config/package_config_types.dart';
 
 import '../../base/common.dart';
+import '../../base/error_handling_io.dart';
 import '../../base/file_system.dart';
 import '../../base/logger.dart';
 import '../../base/platform.dart';
@@ -831,7 +832,15 @@ Future<List<File>> _copyNativeCodeAssetsForOS(
     targetDir.createSync(recursive: true);
   }
   await for (final FileSystemEntity entity in targetDir.list()) {
-    await entity.delete(recursive: true);
+    try {
+      await entity.delete(recursive: true);
+    } on FileSystemException catch (e) {
+      // Ignore if the file was already deleted by another process (e.g. macOS metadata)
+      final int? errorCode = e.osError?.errorCode;
+      if (errorCode != kSystemCodeCannotFindFile && errorCode != kSystemCodePathNotFound) {
+        rethrow;
+      }
+    }
   }
 
   if (assetTargetLocations.isEmpty) {

--- a/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
@@ -510,6 +510,11 @@ class ErrorThrowingFileSystem extends ForwardingFileSystem {
       errorCodeToThrow: errorCodeToThrow,
     );
   }
+
+  @override
+  File file(dynamic path) {
+    return ErrorThrowingFile(this, delegate.file(path), errorCodeToThrow: errorCodeToThrow);
+  }
 }
 
 class ErrorThrowingDirectory extends ForwardingFileSystemEntity<Directory, io.Directory>
@@ -550,7 +555,16 @@ class ErrorThrowingDirectory extends ForwardingFileSystemEntity<Directory, io.Di
       ErrorThrowingFile(_fileSystem, delegate, errorCodeToThrow: errorCodeToThrow);
 
   @override
-  Link wrapLink(io.Link delegate) => delegate as Link;
+  Link wrapLink(io.Link delegate) => _fileSystem.link(delegate.path);
+
+  @override
+  Future<Directory> delete({bool recursive = false}) async {
+    throw FileSystemException(
+      'Mock deletion error',
+      path,
+      io.OSError('Mock OS Error', errorCodeToThrow),
+    );
+  }
 
   @override
   Stream<FileSystemEntity> list({bool recursive = false, bool followLinks = true}) {
@@ -586,10 +600,10 @@ class ErrorThrowingFile extends ForwardingFileSystemEntity<File, io.File> with F
       ErrorThrowingFile(_fileSystem, delegate, errorCodeToThrow: errorCodeToThrow);
 
   @override
-  Directory wrapDirectory(io.Directory delegate) => delegate as Directory;
+  Directory wrapDirectory(io.Directory delegate) => _fileSystem.directory(delegate.path);
 
   @override
-  Link wrapLink(io.Link delegate) => delegate as Link;
+  Link wrapLink(io.Link delegate) => _fileSystem.link(delegate.path);
 
   @override
   Future<File> delete({bool recursive = false}) async {

--- a/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' as io;
 import 'package:code_assets/code_assets.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -393,6 +394,95 @@ CMAKE_LINKER:FILEPATH=/usr/bin/ld.ldd
       expect(target.didSetCCompilerConfig, isTrue);
     },
   );
+
+  group('installCodeAssets deletion race', () {
+    testUsingContext(
+      'ignores errorCode 2 and 3 when deleting entities',
+      overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
+      () async {
+        final File packageConfig = environment.projectDir.childFile(
+          '.dart_tool/package_config.json',
+        );
+        await packageConfig.parent.create();
+        await packageConfig.create();
+
+        final File directSoFile = environment.projectDir.childFile('direct.so');
+        directSoFile.writeAsBytesSync(<int>[]);
+
+        CodeAsset makeCodeAsset(String name, LinkMode linkMode, [Uri? file]) =>
+            CodeAsset(package: 'bar', name: name, linkMode: linkMode, file: file);
+
+        final environmentDefines = <String, String>{kBuildMode: BuildMode.release.cliName};
+        final codeAssets = <CodeAsset>[
+          makeCodeAsset('malloc', DynamicLoadingBundled(), directSoFile.uri),
+        ];
+
+        final DartHooksResult dartHookResult = await runFlutterSpecificHooks(
+          environmentDefines: environmentDefines,
+          targetPlatform: TargetPlatform.linux_x64,
+          projectUri: projectUri,
+          fileSystem: fileSystem,
+          buildRunner: FakeFlutterNativeAssetsBuildRunner(
+            packagesWithNativeAssetsResult: <String>['bar'],
+            buildResult: FakeFlutterNativeAssetsBuilderResult.fromAssets(codeAssets: codeAssets),
+          ),
+          buildCodeAssets: const BuildCodeAssetsOptions(appBuildDirectory: null),
+          buildDataAssets: true,
+          recordedUsesFile: null,
+        );
+
+        final errorFs2 = ErrorThrowingFileSystem(fileSystem, errorCodeToThrow: 2);
+        final Uri nonFlutterTesterAssetUri = environment.buildDir
+            .childFile('native_assets.json')
+            .uri;
+        final Directory targetDirectory = environment.buildDir.childDirectory('native_assets');
+
+        // Populate targetDirectory with a file so entity.delete gets called.
+        final File existingFile = targetDirectory.childFile('existing.so');
+        await existingFile.create(recursive: true);
+
+        // Should not throw since error code is 2
+        await installCodeAssets(
+          dartHookResult: dartHookResult,
+          environmentDefines: environmentDefines,
+          targetPlatform: TargetPlatform.linux_x64,
+          projectUri: projectUri,
+          fileSystem: errorFs2,
+          nativeAssetsFileUri: nonFlutterTesterAssetUri,
+          targetUri: targetDirectory.uri,
+        );
+
+        final errorFs3 = ErrorThrowingFileSystem(fileSystem, errorCodeToThrow: 3);
+        await existingFile.create(recursive: true);
+        // Should not throw since error code is 3
+        await installCodeAssets(
+          dartHookResult: dartHookResult,
+          environmentDefines: environmentDefines,
+          targetPlatform: TargetPlatform.linux_x64,
+          projectUri: projectUri,
+          fileSystem: errorFs3,
+          nativeAssetsFileUri: nonFlutterTesterAssetUri,
+          targetUri: targetDirectory.uri,
+        );
+
+        final errorFs5 = ErrorThrowingFileSystem(fileSystem, errorCodeToThrow: 5);
+        await existingFile.create(recursive: true);
+        // Should throw since error code is 5
+        expect(
+          () => installCodeAssets(
+            dartHookResult: dartHookResult,
+            environmentDefines: environmentDefines,
+            targetPlatform: TargetPlatform.linux_x64,
+            projectUri: projectUri,
+            fileSystem: errorFs5,
+            nativeAssetsFileUri: nonFlutterTesterAssetUri,
+            targetUri: targetDirectory.uri,
+          ),
+          throwsA(isA<FileSystemException>()),
+        );
+      },
+    );
+  });
 }
 
 class _SetCCompilerConfigTarget extends FakeFlutterNativeAssetsBuildRunner {
@@ -404,5 +494,109 @@ class _SetCCompilerConfigTarget extends FakeFlutterNativeAssetsBuildRunner {
   Future<void> setCCompilerConfig(CodeAssetTarget target) async {
     await target.setCCompilerConfig();
     didSetCCompilerConfig = true;
+  }
+}
+
+class ErrorThrowingFileSystem extends ForwardingFileSystem {
+  ErrorThrowingFileSystem(super.delegate, {required this.errorCodeToThrow});
+
+  final int errorCodeToThrow;
+
+  @override
+  Directory directory(dynamic path) {
+    return ErrorThrowingDirectory(
+      this,
+      delegate.directory(path),
+      errorCodeToThrow: errorCodeToThrow,
+    );
+  }
+}
+
+class ErrorThrowingDirectory extends ForwardingFileSystemEntity<Directory, io.Directory>
+    with ForwardingDirectory<Directory> {
+  ErrorThrowingDirectory(this._fileSystem, this.delegate, {required this.errorCodeToThrow});
+
+  final ErrorThrowingFileSystem _fileSystem;
+
+  @override
+  final io.Directory delegate;
+
+  final int errorCodeToThrow;
+
+  @override
+  FileSystem get fileSystem => _fileSystem;
+
+  @override
+  Directory childDirectory(String basename) {
+    return fileSystem.directory(fileSystem.path.join(path, basename));
+  }
+
+  @override
+  File childFile(String basename) {
+    return fileSystem.file(fileSystem.path.join(path, basename));
+  }
+
+  @override
+  Link childLink(String basename) {
+    return fileSystem.link(fileSystem.path.join(path, basename));
+  }
+
+  @override
+  Directory wrapDirectory(io.Directory delegate) =>
+      ErrorThrowingDirectory(_fileSystem, delegate, errorCodeToThrow: errorCodeToThrow);
+
+  @override
+  File wrapFile(io.File delegate) =>
+      ErrorThrowingFile(_fileSystem, delegate, errorCodeToThrow: errorCodeToThrow);
+
+  @override
+  Link wrapLink(io.Link delegate) => delegate as Link;
+
+  @override
+  Stream<FileSystemEntity> list({bool recursive = false, bool followLinks = true}) {
+    return delegate.list(recursive: recursive, followLinks: followLinks).map((
+      io.FileSystemEntity entity,
+    ) {
+      if (entity is io.File) {
+        return ErrorThrowingFile(_fileSystem, entity, errorCodeToThrow: errorCodeToThrow);
+      }
+      if (entity is io.Directory) {
+        return ErrorThrowingDirectory(_fileSystem, entity, errorCodeToThrow: errorCodeToThrow);
+      }
+      throw UnimplementedError('Link not supported');
+    });
+  }
+}
+
+class ErrorThrowingFile extends ForwardingFileSystemEntity<File, io.File> with ForwardingFile {
+  ErrorThrowingFile(this._fileSystem, this.delegate, {required this.errorCodeToThrow});
+
+  final ErrorThrowingFileSystem _fileSystem;
+
+  @override
+  final io.File delegate;
+
+  final int errorCodeToThrow;
+
+  @override
+  FileSystem get fileSystem => _fileSystem;
+
+  @override
+  File wrapFile(io.File delegate) =>
+      ErrorThrowingFile(_fileSystem, delegate, errorCodeToThrow: errorCodeToThrow);
+
+  @override
+  Directory wrapDirectory(io.Directory delegate) => delegate as Directory;
+
+  @override
+  Link wrapLink(io.Link delegate) => delegate as Link;
+
+  @override
+  Future<File> delete({bool recursive = false}) async {
+    throw FileSystemException(
+      'Mock deletion error',
+      path,
+      io.OSError('Mock OS Error', errorCodeToThrow),
+    );
   }
 }


### PR DESCRIPTION
This PR fixes one of the top crashers identified in the Flutter 3.44.4 stable release, which causes build failures on macOS when projects are run from external drives (such as ExFAT/FAT32 SSDs).

### Root Cause
During build code assets cleanup on macOS, the tool lists the target build directory and deletes all files one-by-one. On external drives, macOS automatically creates hidden metadata files prefixed with `._` (AppleDouble files). When deleting files, a race condition occurs where the macOS filesystem automatically deletes these metadata files before `flutter_tools` can, causing `entity.delete(recursive: true)` to fail with a fatal `PathNotFoundException` (OS Error 2 or 3).

### Solution
1. Wrapped the asynchronous deletion loop in `packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart` in a try-catch block.
2. Safely ignore `kSystemCodeCannotFindFile` (error code 2) and `kSystemCodePathNotFound` (error code 3), allowing the build to proceed. Other filesystem exceptions are correctly rethrown.
3. Added a new unit test suite in `packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart` using a custom mock filesystem (`ErrorThrowingFileSystem`) to verify that the target error codes are safely ignored while other errors (like Access Denied) are still caught and rethrown.

Fixes https://github.com/flutter/flutter/issues/188631
