### PR TITLE
Fix null terminator in input truncates clipboard

### DIFF
--- a/engine/src/flutter/fml/platform/win/wstring_conversion.cc
+++ b/engine/src/flutter/fml/platform/win/wstring_conversion.cc
@@ -15,12 +15,12 @@ using WideStringConverter =
 
 std::string WideStringToUtf8(const std::wstring_view str) {
   WideStringConverter converter;
-  return converter.to_bytes(str.data());
+  return converter.to_bytes(str.data(), str.data() + str.size());
 }
 
 std::wstring Utf8ToWideString(const std::string_view str) {
   WideStringConverter converter;
-  return converter.from_bytes(str.data());
+  return converter.from_bytes(str.data(), str.data() + str.size());
 }
 
 std::u16string WideStringToUtf16(const std::wstring_view str) {

--- a/engine/src/flutter/shell/platform/windows/platform_handler.cc
+++ b/engine/src/flutter/shell/platform/windows/platform_handler.cc
@@ -341,7 +341,7 @@ void PlatformHandler::GetHasStrings(
 }
 
 void PlatformHandler::SetPlainText(
-    const std::string& text,
+    const std::string_view text,
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
   std::unique_ptr<ScopedClipboardInterface> clipboard =
       scoped_clipboard_provider_();
@@ -353,7 +353,9 @@ void PlatformHandler::SetPlainText(
     result->Error(kClipboardError, "Unable to open clipboard", error_code);
     return;
   }
-  int set_result = clipboard->SetString(fml::Utf8ToWideString(text));
+  std::wstring clipboard_text = fml::Utf8ToWideString(text);
+  std::replace(clipboard_text.begin(), clipboard_text.end(), L'\0', L'\uFFFD');
+  int set_result = clipboard->SetString(clipboard_text);
   if (set_result != kErrorSuccess) {
     rapidjson::Document error_code;
     error_code.SetInt(set_result);
@@ -504,7 +506,9 @@ void PlatformHandler::HandleMethodCall(
       result->Error(kClipboardError, kUnknownClipboardFormatMessage);
       return;
     }
-    SetPlainText(itr->value.GetString(), std::move(result));
+    SetPlainText(
+        std::string_view(itr->value.GetString(), itr->value.GetStringLength()),
+        std::move(result));
   } else if (method.compare(kPlaySoundMethod) == 0) {
     // Only one string argument is expected.
     const rapidjson::Value& sound_type = method_call.arguments()[0];

--- a/engine/src/flutter/shell/platform/windows/platform_handler.cc
+++ b/engine/src/flutter/shell/platform/windows/platform_handler.cc
@@ -354,6 +354,8 @@ void PlatformHandler::SetPlainText(
     return;
   }
   std::wstring clipboard_text = fml::Utf8ToWideString(text);
+  // Windows clipboard strings are null-terminated, so an embedded null
+  // character causes other applications to paste only the text before it.
   std::replace(clipboard_text.begin(), clipboard_text.end(), L'\0', L'\uFFFD');
   int set_result = clipboard->SetString(clipboard_text);
   if (set_result != kErrorSuccess) {

--- a/engine/src/flutter/shell/platform/windows/platform_handler.cc
+++ b/engine/src/flutter/shell/platform/windows/platform_handler.cc
@@ -341,7 +341,7 @@ void PlatformHandler::GetHasStrings(
 }
 
 void PlatformHandler::SetPlainText(
-    const std::string_view text,
+    std::string_view text,
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
   std::unique_ptr<ScopedClipboardInterface> clipboard =
       scoped_clipboard_provider_();

--- a/engine/src/flutter/shell/platform/windows/platform_handler.h
+++ b/engine/src/flutter/shell/platform/windows/platform_handler.h
@@ -69,7 +69,7 @@ class PlatformHandler {
   // Sets the clipboard's plain text to |text|, and reports the result (either
   // an error, or null for success) to |result|.
   virtual void SetPlainText(
-      const std::string& text,
+      const std::string_view text,
       std::unique_ptr<MethodResult<rapidjson::Document>> result);
 
   virtual void SystemSoundPlay(

--- a/engine/src/flutter/shell/platform/windows/platform_handler.h
+++ b/engine/src/flutter/shell/platform/windows/platform_handler.h
@@ -69,7 +69,7 @@ class PlatformHandler {
   // Sets the clipboard's plain text to |text|, and reports the result (either
   // an error, or null for success) to |result|.
   virtual void SetPlainText(
-      const std::string_view text,
+      std::string_view text,
       std::unique_ptr<MethodResult<rapidjson::Document>> result);
 
   virtual void SystemSoundPlay(

--- a/engine/src/flutter/shell/platform/windows/platform_handler_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/platform_handler_unittests.cc
@@ -82,7 +82,7 @@ class MockPlatformHandler : public PlatformHandler {
               (override));
   MOCK_METHOD(void,
               SetPlainText,
-              (const std::string&,
+              (const std::string_view,
                std::unique_ptr<MethodResult<rapidjson::Document>>),
               (override));
   MOCK_METHOD(void,

--- a/engine/src/flutter/shell/platform/windows/platform_handler_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/platform_handler_unittests.cc
@@ -85,7 +85,7 @@ class MockPlatformHandler : public PlatformHandler {
               (override));
   MOCK_METHOD(void,
               SetPlainText,
-              (const std::string_view,
+              (std::string_view,
                std::unique_ptr<MethodResult<rapidjson::Document>>),
               (override));
   MOCK_METHOD(void,

--- a/engine/src/flutter/shell/platform/windows/platform_handler_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/platform_handler_unittests.cc
@@ -38,6 +38,9 @@ static constexpr char kClipboardHasStringsFakeContentTypeMessage[] =
     "{\"method\":\"Clipboard.hasStrings\",\"args\":\"text/madeupcontenttype\"}";
 static constexpr char kClipboardSetDataMessage[] =
     "{\"method\":\"Clipboard.setData\",\"args\":{\"text\":\"hello\"}}";
+static constexpr char kClipboardSetDataNullTerminatorMessage[] =
+    "{\"method\":\"Clipboard.setData\",\"args\":{\"text\":"
+    "\"hello\\u0000world\"}}";
 static constexpr char kClipboardSetDataNullTextMessage[] =
     "{\"method\":\"Clipboard.setData\",\"args\":{\"text\":null}}";
 static constexpr char kClipboardSetDataUnknownTypeMessage[] =
@@ -354,6 +357,33 @@ TEST_F(PlatformHandlerTest, ClipboardSetData) {
 
   std::string result =
       SimulatePlatformMessage(&messenger, kClipboardSetDataMessage);
+
+  EXPECT_EQ(result, "[null]");
+}
+
+// Regression test for https://github.com/flutter/flutter/issues/162226.
+TEST_F(PlatformHandlerTest, ClipboardSetDataReplacesNullTerminators) {
+  UseHeadlessEngine();
+
+  TestBinaryMessenger messenger;
+  PlatformHandler platform_handler(&messenger, engine(), []() {
+    auto clipboard = std::make_unique<MockScopedClipboard>();
+
+    EXPECT_CALL(*clipboard.get(), Open)
+        .Times(1)
+        .WillOnce(Return(kErrorSuccess));
+    EXPECT_CALL(*clipboard.get(), SetString)
+        .Times(1)
+        .WillOnce([](std::wstring string) {
+          EXPECT_EQ(string, L"hello\uFFFDworld");
+          return kErrorSuccess;
+        });
+
+    return clipboard;
+  });
+
+  std::string result = SimulatePlatformMessage(
+      &messenger, kClipboardSetDataNullTerminatorMessage);
 
   EXPECT_EQ(result, "[null]");
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Closes https://github.com/flutter/flutter/issues/162226.

Sadly win32 doesn't allow `\0` characters inside the `CF_UNICODETEXT` clipboard. To prevent it, I replaced the null terminator with the `\uFFFD` (replacement character: https://www.compart.com/en/unicode/U+FFFD).
I replaced the string type to a string view to also store the size on the way so it doesn't break on the way if there are null terminators.

~~Currently a draft since I don't have tests yet.~~

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
