### PR TITLE
[web] Fix semantic text field automation

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -2,10 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:ui/ui.dart' as ui;
 
 import '../dom.dart';
 import '../platform_dispatcher.dart';
+import '../services/message_codecs.dart';
 import '../text_editing/input_type.dart';
 import '../text_editing/text_editing.dart';
 import 'semantics.dart';
@@ -307,6 +310,25 @@ class SemanticTextField extends SemanticRole {
       'blur',
       createDomEventListener((DomEvent event) {
         SemanticsTextEditingStrategy._instance?.deactivate(this);
+      }),
+    );
+    editableElement.addEventListener(
+      'input',
+      createDomEventListener((DomEvent event) {
+        final String value = EditingState.fromDomElement(editableElement).text;
+        // Browser autofill and automation may edit the semantic DOM input
+        // before it is driving Flutter's text editing channel.
+        if (SemanticsTextEditingStrategy._instance?.activeTextField == this ||
+            !semanticsObject.hasAction(ui.SemanticsAction.setText)) {
+          return;
+        }
+        final ByteData? encodedValue = const StandardMessageCodec().encodeMessage(value);
+        EnginePlatformDispatcher.instance.invokeOnSemanticsAction(
+          viewId,
+          semanticsObject.id,
+          ui.SemanticsAction.setText,
+          encodedValue,
+        );
       }),
     );
   }

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -106,6 +106,120 @@ void testMain() {
       expect(inputElement.getAttribute('aria-required'), isNull);
     });
 
+    test('sends setText for inactive semantic text field input changes', () {
+      final dispatchedActions = <ui.SemanticsActionEvent>[];
+      ui.PlatformDispatcher.instance.onSemanticsActionEvent = (ui.SemanticsActionEvent event) {
+        dispatchedActions.add(event);
+      };
+      addTearDown(() {
+        ui.PlatformDispatcher.instance.onSemanticsActionEvent = null;
+      });
+
+      final SemanticsObject textFieldSemantics = createTextFieldSemantics(
+        value: '',
+        hasSetText: true,
+      );
+      final textFieldRole = textFieldSemantics.semanticRole! as SemanticTextField;
+      final inputElement = textFieldRole.editableElement as DomHTMLInputElement;
+
+      inputElement.value = 'hello@example.com';
+      inputElement.dispatchEvent(createDomEvent('Event', 'input'));
+
+      final ui.SemanticsActionEvent setTextAction = dispatchedActions.singleWhere(
+        (ui.SemanticsActionEvent event) => event.type == ui.SemanticsAction.setText,
+      );
+      expect(setTextAction.nodeId, textFieldSemantics.id);
+      expect(
+        const StandardMessageCodec().decodeMessage(setTextAction.arguments! as ByteData),
+        'hello@example.com',
+      );
+    });
+
+    test('skips setText for inactive semantic text fields without setText action', () {
+      final dispatchedActions = <ui.SemanticsActionEvent>[];
+      ui.PlatformDispatcher.instance.onSemanticsActionEvent = (ui.SemanticsActionEvent event) {
+        dispatchedActions.add(event);
+      };
+      addTearDown(() {
+        ui.PlatformDispatcher.instance.onSemanticsActionEvent = null;
+      });
+
+      final SemanticsObject textFieldSemantics = createTextFieldSemantics(value: '');
+      final textFieldRole = textFieldSemantics.semanticRole! as SemanticTextField;
+      final inputElement = textFieldRole.editableElement as DomHTMLInputElement;
+
+      inputElement.value = 'hello@example.com';
+      inputElement.dispatchEvent(createDomEvent('Event', 'input'));
+
+      expect(
+        dispatchedActions,
+        isNot(
+          contains(
+            isA<ui.SemanticsActionEvent>().having(
+              (ui.SemanticsActionEvent event) => event.type,
+              'type',
+              ui.SemanticsAction.setText,
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('uses text editing callback for active semantic text field input changes', () {
+      final dispatchedActions = <ui.SemanticsActionEvent>[];
+      ui.PlatformDispatcher.instance.onSemanticsActionEvent = (ui.SemanticsActionEvent event) {
+        dispatchedActions.add(event);
+      };
+      addTearDown(() {
+        ui.PlatformDispatcher.instance.onSemanticsActionEvent = null;
+      });
+      final editingStates = <EditingState>[];
+      strategy.enable(
+        singlelineConfig,
+        onChange: (EditingState? editingState, _) {
+          if (editingState != null) {
+            editingStates.add(editingState);
+          }
+        },
+        onAction: (_) {},
+      );
+
+      final SemanticsObject textFieldSemantics = createTextFieldSemantics(
+        value: '',
+        isFocused: true,
+        hasSetText: true,
+      );
+      final textFieldRole = textFieldSemantics.semanticRole! as SemanticTextField;
+      final inputElement = textFieldRole.editableElement as DomHTMLInputElement;
+
+      inputElement.value = 'hello@example.com';
+      inputElement.dispatchEvent(createDomEvent('Event', 'input'));
+
+      expect(editingStates.single.text, 'hello@example.com');
+      expect(
+        dispatchedActions,
+        isNot(
+          contains(
+            isA<ui.SemanticsActionEvent>().having(
+              (ui.SemanticsActionEvent event) => event.type,
+              'type',
+              ui.SemanticsAction.setText,
+            ),
+          ),
+        ),
+      );
+      expect(
+        dispatchedActions,
+        contains(
+          isA<ui.SemanticsActionEvent>().having(
+            (ui.SemanticsActionEvent event) => event.type,
+            'type',
+            ui.SemanticsAction.focus,
+          ),
+        ),
+      );
+    });
+
     test('renders a password field', () {
       createTextFieldSemantics(value: 'secret', isObscured: true);
 
@@ -628,6 +742,7 @@ SemanticsObject createTextFieldSemantics({
   int textSelectionBase = 0,
   int textSelectionExtent = 0,
   ui.SemanticsInputType inputType = ui.SemanticsInputType.text,
+  bool hasSetText = false,
 }) {
   final tester = SemanticsTester(owner());
   tester.updateNode(
@@ -646,6 +761,7 @@ SemanticsObject createTextFieldSemantics({
           : (isRequired ? ui.Tristate.isTrue : ui.Tristate.isFalse),
     ),
     hasTap: true,
+    hasSetText: hasSetText,
     rect: rect,
     textDirection: ui.TextDirection.ltr,
     textSelectionBase: textSelectionBase,

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1387,7 +1387,9 @@ class RenderEditable extends RenderBox
       config.onSetSelection = _handleSetSelection;
     }
 
-    if (hasFocus && !readOnly) {
+    // Browser autofill and automation can ask to set text before the focus
+    // update has settled, so expose setText early on web.
+    if (!readOnly && (kIsWeb || hasFocus)) {
       config.onSetText = _handleSetText;
     }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -112,9 +112,8 @@ typedef SemanticsUpdateCallback = void Function(SemanticsUpdate update);
 ///
 /// Use [ChildSemanticsConfigurationsResultBuilder] to generate the return
 /// value.
-typedef ChildSemanticsConfigurationsDelegate = ChildSemanticsConfigurationsResult Function(
-  List<SemanticsConfiguration>,
-);
+typedef ChildSemanticsConfigurationsDelegate =
+    ChildSemanticsConfigurationsResult Function(List<SemanticsConfiguration>);
 
 /// Controls how accessibility focus is blocked.
 ///
@@ -6716,12 +6715,18 @@ class SemanticsConfiguration {
   SemanticsFlags _flags = SemanticsFlags.none;
 
   bool get _hasExplicitRole {
+    if (_hasNonTextFieldExplicitRole) {
+      return true;
+    }
+    return _flags.isTextField;
+  }
+
+  bool get _hasNonTextFieldExplicitRole {
     if (_role != SemanticsRole.none) {
       return true;
     }
-    if (_flags.isTextField ||
-        // In non web platforms, the header is a trait.
-        (_flags.isHeader && kIsWeb) ||
+    // In non web platforms, the header is a trait.
+    if ((_flags.isHeader && kIsWeb) ||
         _flags.isSlider ||
         _flags.isLink ||
         _flags.scopesRoute ||
@@ -6730,6 +6735,15 @@ class SemanticsConfiguration {
       return true;
     }
     return false;
+  }
+
+  bool _hasConflictingFlags(SemanticsConfiguration other) {
+    if (!_flags.hasConflictingFlags(other._flags)) {
+      return false;
+    }
+    final SemanticsFlags flags = _flags.copyWith(isTextField: false);
+    final SemanticsFlags otherFlags = other._flags.copyWith(isTextField: false);
+    return flags.hasConflictingFlags(otherFlags);
   }
 
   // CONFIGURATION COMBINATION LOGIC
@@ -6755,7 +6769,7 @@ class SemanticsConfiguration {
     if (_actionsAsBits & other._actionsAsBits != 0) {
       return false;
     }
-    if (_flags.hasConflictingFlags(other._flags)) {
+    if (_hasConflictingFlags(other)) {
       return false;
     }
 
@@ -6774,7 +6788,9 @@ class SemanticsConfiguration {
     if (_localeForSubtree != other._localeForSubtree) {
       return false;
     }
-    if (_hasExplicitRole && other._hasExplicitRole) {
+    if (_hasExplicitRole &&
+        other._hasExplicitRole &&
+        (_hasNonTextFieldExplicitRole || other._hasNonTextFieldExplicitRole)) {
       return false;
     }
     if (_hitTestBehavior != ui.SemanticsHitTestBehavior.defer ||

--- a/packages/flutter/test/material/text_field_semantics_merge_test.dart
+++ b/packages/flutter/test/material/text_field_semantics_merge_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../widgets/semantics_tester.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    debugResetSemanticsIdCounter();
+  });
+
+  testWidgets('Semantics label merges with editable text field semantics', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Semantics(
+            label: 'Login_email',
+            textField: true,
+            child: TextField(
+              controller: controller,
+              decoration: const InputDecoration(hintText: 'Email'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Iterable<SemanticsNode> textFields = tester.semantics
+        .simulatedAccessibilityTraversal()
+        .where((SemanticsNode node) => node.getSemanticsData().hasFlag(SemanticsFlag.isTextField));
+
+    expect(textFields, hasLength(1));
+    expect(
+      textFields.single.getSemanticsData(),
+      matchesSemantics(
+        label: 'Login_email\nEmail',
+        isTextField: true,
+        isFocusable: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        hasTapAction: true,
+        hasFocusAction: true,
+        hasSetTextAction: kIsWeb,
+        inputType: ui.SemanticsInputType.text,
+        textDirection: TextDirection.ltr,
+      ),
+    );
+
+    semantics.dispose();
+  });
+}

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -1079,6 +1079,28 @@ void main() {
     expect(copy.label, 'test');
   });
 
+  test('SemanticsConfiguration treats repeated text field roles as compatible', () {
+    final wrapper = SemanticsConfiguration()
+      ..label = 'Login_email'
+      ..isTextField = true;
+    final editable = SemanticsConfiguration()
+      ..label = 'Email'
+      ..isTextField = true
+      ..onSetText = (String value) {};
+
+    expect(wrapper.isCompatibleWith(editable), isTrue);
+
+    final link = SemanticsConfiguration()
+      ..label = 'Terms'
+      ..isLink = true;
+    expect(wrapper.isCompatibleWith(link), isFalse);
+
+    final otherEditable = SemanticsConfiguration()
+      ..isTextField = true
+      ..onSetText = (String value) {};
+    expect(editable.isCompatibleWith(otherEditable), isFalse);
+  });
+
   test('SemanticsConfiguration.copy() preserves all hitTestBehavior values', () {
     final deferConfig = SemanticsConfiguration();
     expect(deferConfig.copy().hitTestBehavior, SemanticsHitTestBehavior.defer);

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4664,6 +4664,13 @@ void main() {
       ),
     );
 
+    if (kIsWeb) {
+      expect(
+        semantics,
+        includesNodeWith(value: 'test', actions: <SemanticsAction>[SemanticsAction.setText]),
+      );
+    }
+
     focusNode.requestFocus();
     await tester.pump();
 
@@ -4720,6 +4727,71 @@ void main() {
           SemanticsAction.setText,
         ],
       ),
+    );
+
+    semantics.dispose();
+  });
+
+  testWidgets('can set text with a11y means before focus on web', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    controller.text = 'hello';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditableText(
+          backgroundCursorColor: Colors.grey,
+          controller: controller,
+          focusNode: focusNode,
+          style: textStyle,
+          cursorColor: cursorColor,
+        ),
+      ),
+    );
+
+    expect(
+      semantics,
+      includesNodeWith(value: 'hello', actions: <SemanticsAction>[SemanticsAction.setText]),
+    );
+    final SemanticsNode node = find.semantics.byValue('hello').evaluate().first;
+    expect(focusNode.hasFocus, isFalse);
+    expect(controller.text, 'hello');
+
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(
+      node.id,
+      SemanticsAction.setText,
+      'how are you',
+    );
+
+    expect(controller.text, 'how are you');
+    expect(focusNode.hasFocus, isFalse);
+
+    semantics.dispose();
+  }, skip: !kIsWeb);
+
+  testWidgets('read-only editable text does not expose setText before focus', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+
+    controller.text = 'hello';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditableText(
+          backgroundCursorColor: Colors.grey,
+          controller: controller,
+          focusNode: focusNode,
+          readOnly: true,
+          style: textStyle,
+          cursorColor: cursorColor,
+        ),
+      ),
+    );
+
+    expect(
+      semantics,
+      isNot(includesNodeWith(value: 'hello', actions: <SemanticsAction>[SemanticsAction.setText])),
     );
 
     semantics.dispose();


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
