### PR TITLE
Decouple Cupertino's dartDoc imports of Material

### DIFF
--- a/packages/flutter/lib/src/cupertino/adaptive_text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/adaptive_text_selection_toolbar.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-library;
-
 import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -158,7 +155,7 @@ class CupertinoAdaptiveTextSelectionToolbar extends StatelessWidget {
          onShare: null, // See https://github.com/flutter/flutter/issues/141775.
        );
 
-  /// {@macro flutter.material.AdaptiveTextSelectionToolbar.anchors}
+  /// The location on which to anchor the menu.
   final TextSelectionToolbarAnchors anchors;
 
   /// The children of the toolbar, typically buttons.

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-/// @docImport 'package:flutter/services.dart';
-///
 /// @docImport 'page_scaffold.dart';
 /// @docImport 'tab_view.dart';
 library;
@@ -51,7 +48,7 @@ import 'theme.dart';
 /// The [CupertinoApp] widget isn't a required ancestor for other Cupertino
 /// widgets, but many Cupertino widgets could depend on the [CupertinoTheme]
 /// widget, which the [CupertinoApp] composes. If you use Material widgets, a
-/// [MaterialApp] also creates the needed dependencies for Cupertino widgets.
+/// [MaterialApp](https://api.flutter.dev/flutter/material/MaterialApp-class.html) also creates the needed dependencies for Cupertino widgets.
 ///
 /// {@template flutter.cupertino.CupertinoApp.defaultSelectionStyle}
 /// The [CupertinoApp] automatically creates a [DefaultSelectionStyle] with
@@ -420,7 +417,12 @@ class CupertinoApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.restorationScopeId}
   final String? restorationScopeId;
 
-  /// {@macro flutter.material.materialApp.scrollBehavior}
+  /// The default [ScrollBehavior] for the application.
+  ///
+  /// [ScrollBehavior]s describe how [Scrollable] widgets behave. Providing
+  /// a [ScrollBehavior] can set the default [ScrollPhysics] across
+  /// an application, and manage [Scrollable] decorations like [Scrollbar]s and
+  /// [GlowingOverscrollIndicator]s.
   ///
   /// When null, defaults to [CupertinoScrollBehavior].
   ///

--- a/packages/flutter/lib/src/cupertino/checkbox.dart
+++ b/packages/flutter/lib/src/cupertino/checkbox.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'slider.dart';
 /// @docImport 'switch.dart';
 library;
@@ -81,7 +79,7 @@ const List<double> _kDisabledDarkGradientOpacities = <double>[0.08, 0.14];
 ///
 /// See also:
 ///
-///  * [Checkbox], the Material Design equivalent.
+///  * [Checkbox](https://api.flutter.dev/flutter/material/Checkbox-class.html), the Material Design equivalent.
 ///  * [CupertinoSwitch], a widget with semantics similar to [CupertinoCheckbox].
 ///  * [CupertinoSlider], for selecting a value in a range.
 ///  * <https://developer.apple.com/design/human-interface-guidelines/components/selection-and-input/toggles/>

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'button.dart';
 /// @docImport 'nav_bar.dart';
 library;
@@ -68,7 +66,7 @@ abstract final class CupertinoColors {
   ///
   /// See also:
   ///
-  ///  * [Colors.white], the same color, in the Material Design palette.
+  ///  * [Colors.white](https://api.flutter.dev/flutter/material/Colors/white-constant.html), the same color, in the Material Design palette.
   ///  * [black], opaque black in the [CupertinoColors] palette.
   static const Color white = Color(0xFFFFFFFF);
 
@@ -78,7 +76,7 @@ abstract final class CupertinoColors {
   ///
   /// See also:
   ///
-  ///  * [Colors.black], the same color, in the Material Design palette.
+  ///  * [Colors.black](https://api.flutter.dev/flutter/material/Colors/black-constant.html), the same color, in the Material Design palette.
   ///  * [white], opaque white in the [CupertinoColors] palette.
   static const Color black = Color(0xFF000000);
 
@@ -86,7 +84,7 @@ abstract final class CupertinoColors {
   ///
   /// See also:
   ///
-  ///  * [Colors.transparent], the same color, in the Material Design palette.
+  ///  * [Colors.transparent](https://api.flutter.dev/flutter/material/Colors/transparent-constant.html), the same color, in the Material Design palette.
   static const Color transparent = Color(0x00000000);
 
   /// Used in iOS 10 for light background fills such as the chat bubble background.

--- a/packages/flutter/lib/src/cupertino/constants.dart
+++ b/packages/flutter/lib/src/cupertino/constants.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'checkbox.dart';
 /// @docImport 'radio.dart';
 /// @docImport 'switch.dart';
@@ -24,7 +22,7 @@ import 'button.dart';
 ///
 /// See also:
 ///
-///  * [kMinInteractiveDimension]
+///  * [kMinInteractiveDimension](https://api.flutter.dev/flutter/material/kMinInteractiveDimension-constant.html)
 ///  * <https://developer.apple.com/ios/human-interface-guidelines/visual-design/adaptivity-and-layout/>
 const double kMinInteractiveDimensionCupertino = 44.0;
 

--- a/packages/flutter/lib/src/cupertino/desktop_text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection_toolbar.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'adaptive_text_selection_toolbar.dart';
 /// @docImport 'desktop_text_selection_toolbar_button.dart';
 library;
@@ -86,10 +84,15 @@ class CupertinoDesktopTextSelectionToolbar extends StatelessWidget {
     ];
   }
 
-  /// {@macro flutter.material.DesktopTextSelectionToolbar.anchor}
+  /// The point where the toolbar will attempt to position itself as closely as
+  /// possible.
   final Offset anchor;
 
-  /// {@macro flutter.material.TextSelectionToolbar.children}
+  /// The children that will be displayed in the text selection toolbar.
+  ///
+  /// Typically these are buttons.
+  ///
+  /// Must not be empty.
   ///
   /// See also:
   ///   * [CupertinoDesktopTextSelectionToolbarButton], which builds a default

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'button.dart';
 /// @docImport 'route.dart';
 library;
@@ -283,10 +281,16 @@ class CupertinoAlertDialog extends StatefulWidget {
   ///    section when it is long.
   final ScrollController? actionScrollController;
 
-  /// {@macro flutter.material.dialog.insetAnimationDuration}
+  /// The duration of the animation to show when the system keyboard intrudes
+  /// into the space that the dialog is placed in.
+  ///
+  /// Defaults to 100 milliseconds.
   final Duration insetAnimationDuration;
 
-  /// {@macro flutter.material.dialog.insetAnimationCurve}
+  /// The curve to use for the animation shown when the system keyboard intrudes
+  /// into the space that the dialog is placed in.
+  ///
+  /// Defaults to [Curves.decelerate].
   final Curve insetAnimationCurve;
 
   @override

--- a/packages/flutter/lib/src/cupertino/expansion_tile.dart
+++ b/packages/flutter/lib/src/cupertino/expansion_tile.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'list_section.dart';
 library;
 
@@ -67,7 +65,7 @@ enum ExpansionTileTransitionMode {
 ///
 /// See also:
 ///
-///  * [ExpansionTile], the Material Design equivalent.
+///  * [ExpansionTile](https://api.flutter.dev/flutter/material/ExpansionTile-class.html), the Material Design equivalent.
 ///  * [CupertinoListSection], useful for creating an expansion tile [child].
 ///  * [CupertinoListTile], the header of a [CupertinoExpansionTile].
 ///  * <https://developer.apple.com/design/human-interface-guidelines/disclosure-controls/>

--- a/packages/flutter/lib/src/cupertino/list_tile.dart
+++ b/packages/flutter/lib/src/cupertino/list_tile.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'button.dart';
 /// @docImport 'list_section.dart';
 /// @docImport 'switch.dart';
@@ -49,7 +47,7 @@ enum _CupertinoListTileType { base, notched }
 
 /// An iOS-style list tile.
 ///
-/// The [CupertinoListTile] is a Cupertino equivalent of Material [ListTile].
+/// The [CupertinoListTile] is a Cupertino equivalent of Material [ListTile](https://api.flutter.dev/flutter/material/ListTile-class.html).
 /// It comes in two forms, an old-fashioned edge-to-edge variant known from iOS
 /// Settings app and in a new, "Inset Grouped" form, known from either iOS Notes
 /// or Reminders app. The first is constructed using default constructor, and
@@ -89,7 +87,7 @@ enum _CupertinoListTileType { base, notched }
 ///
 ///  * [CupertinoListSection], an iOS-style list that is a typical container for
 ///    [CupertinoListTile].
-///  * [ListTile], a Material Design list tile.
+///  * [ListTile](https://api.flutter.dev/flutter/material/ListTile-class.html), a Material Design list tile.
 class CupertinoListTile extends StatefulWidget {
   /// Creates an edge-to-edge iOS-style list tile like the tiles in iOS Settings
   /// app.

--- a/packages/flutter/lib/src/cupertino/magnifier.dart
+++ b/packages/flutter/lib/src/cupertino/magnifier.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-library;
-
 import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/lib/src/cupertino/menu_anchor.dart
+++ b/packages/flutter/lib/src/cupertino/menu_anchor.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-library;
-
 import 'dart:collection';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
@@ -1782,7 +1779,10 @@ class CupertinoMenuItem extends StatelessWidget implements CupertinoMenuEntry {
   /// pointer event, which is always between frames.
   final ValueChanged<bool>? onHover;
 
-  /// {@macro flutter.material.inkwell.onFocusChange}
+  /// Handler called when the focus changes.
+  ///
+  /// Called with true if this widget's node gains focus, and false if it loses
+  /// focus.
   final ValueChanged<bool>? onFocusChange;
 
   /// Whether hovering should request focus for this widget.

--- a/packages/flutter/lib/src/cupertino/radio.dart
+++ b/packages/flutter/lib/src/cupertino/radio.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'checkbox.dart';
 /// @docImport 'slider.dart';
 /// @docImport 'switch.dart';
@@ -129,14 +127,28 @@ class CupertinoRadio<T> extends StatefulWidget {
   /// {@macro flutter.widget.RawRadio.value}
   final T value;
 
-  /// {@macro flutter.material.Radio.groupValue}
+  /// The currently selected value for a group of radio buttons.
+  ///
+  /// This radio button is considered selected if its [value] matches the
+  /// [groupValue].
+  ///
+  /// This is deprecated, use [RadioGroup] to manage group value instead.
   @Deprecated(
     'Use a RadioGroup ancestor to manage group value instead. '
     'This feature was deprecated after v3.32.0-0.0.pre.',
   )
   final T? groupValue;
 
-  /// {@macro flutter.material.Radio.onChanged}
+  /// Called when the user selects this radio button.
+  ///
+  /// The radio button passes [value] as a parameter to this callback. The radio
+  /// button does not actually change state until the parent widget rebuilds the
+  /// radio button with the new [groupValue].
+  ///
+  /// If null, the radio button will be displayed as disabled.
+  ///
+  /// The provided callback will not be invoked if this radio button is already
+  /// selected and [toggleable] is not set to true.
   ///
   /// For example:
   ///
@@ -220,7 +232,17 @@ class CupertinoRadio<T> extends StatefulWidget {
   /// [RadioGroupRegistry].
   final RadioGroupRegistry<T>? groupRegistry;
 
-  /// {@macro flutter.material.Radio.enabled}
+  /// Whether this widget is interactive.
+  ///
+  /// If not provided, this widget will be interactable if one of the following
+  /// is true:
+  ///
+  /// * A [onChanged] is provided.
+  /// * Having a [RadioGroup] with the same type T above this widget.
+  /// * A [groupRegistry] is provided.
+  ///
+  /// If this is set to true, one of the above condition must also be true.
+  /// Otherwise, an assertion error is thrown.
   final bool? enabled;
 
   @override

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'app.dart';
 /// @docImport 'nav_bar.dart';
 library;
@@ -280,8 +278,8 @@ typedef RefreshCallback = Future<void> Function();
 ///  * [CustomScrollView], a typical sliver holding scroll view this control
 ///    should go into.
 ///  * <https://developer.apple.com/ios/human-interface-guidelines/controls/refresh-content-controls/>
-///  * [RefreshIndicator], a Material Design version of the pull-to-refresh
-///    paradigm. This widget works differently than [RefreshIndicator] because
+///  * [RefreshIndicator](https://api.flutter.dev/flutter/material/RefreshIndicator-class.html), a Material Design version of the pull-to-refresh
+///    paradigm. This widget works differently than [RefreshIndicator](https://api.flutter.dev/flutter/material/RefreshIndicator-class.html) because
 ///    instead of being an overlay on top of the scrollable, the
 ///    [CupertinoSliverRefreshControl] is part of the scrollable and actively occupies
 ///    scrollable space.

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -4,7 +4,6 @@
 
 /// @docImport 'dart:ui';
 ///
-/// @docImport 'package:flutter/material.dart';
 /// @docImport 'package:flutter/services.dart';
 ///
 /// @docImport 'app.dart';
@@ -224,7 +223,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   /// See also:
   ///
   ///  * [CupertinoPageTransitionsBuilder], which uses this method to define a
-  ///    [PageTransitionsBuilder] for the [PageTransitionsTheme].
+  ///    [PageTransitionsBuilder] for the [PageTransitionsTheme](https://api.flutter.dev/flutter/material/PageTransitionsTheme-class.html).
   static Widget buildPageTransitions<T>(
     PageRoute<T> route,
     BuildContext context,
@@ -1368,7 +1367,8 @@ Widget _buildCupertinoDialogTransitions(
 /// By default, `useRootNavigator` is `true` and the dialog route created by
 /// this method is pushed to the root navigator.
 ///
-/// {@macro flutter.material.dialog.requestFocus}
+/// The `requestFocus` argument is used to specify whether the dialog should
+/// request focus when shown.
 /// {@macro flutter.widgets.navigator.Route.requestFocus}
 ///
 /// {@macro flutter.widgets.RawDialogRoute}
@@ -1565,10 +1565,10 @@ class CupertinoDialogRoute<T> extends RawDialogRoute<T> {
 ///    Cupertino apps.
 ///  * [CupertinoPageTransition], the widget that implements the iOS page
 ///    transition animation.
-///  * [MaterialPageRoute], an adaptive [PageRoute] that can use this builder
-///    through [PageTransitionsTheme].
-///  * [PageTransitionsTheme], which defines the page transitions used by
-///    [MaterialPageRoute] for different target platforms.
+///  * [MaterialPageRoute](https://api.flutter.dev/flutter/material/MaterialPageRoute-class.html), an adaptive [PageRoute] that can use this builder
+///    through [PageTransitionsTheme](https://api.flutter.dev/flutter/material/PageTransitionsTheme-class.html).
+///  * [PageTransitionsTheme](https://api.flutter.dev/flutter/material/PageTransitionsTheme-class.html), which defines the page transitions used by
+///    [MaterialPageRoute](https://api.flutter.dev/flutter/material/MaterialPageRoute-class.html) for different target platforms.
 class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
   /// Constructs a page transition animation that matches the iOS transition.
   const CupertinoPageTransitionsBuilder();

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-library;
-
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -65,7 +62,7 @@ const double _kScrollbarCrossAxisMargin = 3.0;
 ///
 ///  * [ListView], which displays a linear, scrollable list of children.
 ///  * [GridView], which displays a 2 dimensional, scrollable array of children.
-///  * [Scrollbar], a Material Design scrollbar.
+///  * [Scrollbar](https://api.flutter.dev/flutter/material/Scrollbar-class.html), a Material Design scrollbar.
 ///  * [RawScrollbar], a basic scrollbar that fades in and out, extended
 ///    by this class to add more animations and behaviors.
 class CupertinoScrollbar extends RawScrollbar {

--- a/packages/flutter/lib/src/cupertino/spell_check_suggestions_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/spell_check_suggestions_toolbar.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-library;
-
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart' show SelectionChangedCause, SuggestionSpan;
 import 'package:flutter/widgets.dart';
@@ -23,7 +20,7 @@ const int _kMaxSuggestions = 3;
 /// readjusts to fit above bottom view insets.
 ///
 /// See also:
-///  * [SpellCheckSuggestionsToolbar], which is similar but for both the
+///  * [SpellCheckSuggestionsToolbar](https://api.flutter.dev/flutter/material/SpellCheckSuggestionsToolbar-class.html), which is similar but for both the
 ///    Material and Cupertino libraries.
 class CupertinoSpellCheckSuggestionsToolbar extends StatelessWidget {
   /// Constructs a [CupertinoSpellCheckSuggestionsToolbar].

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -7,8 +7,6 @@
 // bool _lights = false;
 // void setState(VoidCallback fn) { }
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'list_tile.dart';
 library;
 
@@ -277,16 +275,18 @@ class CupertinoSwitch extends StatefulWidget {
   /// (or [Color.fromARGB(255, 255, 255, 255)] in high contrast) when null.
   final Color? offLabelColor;
 
-  /// {@macro flutter.material.switch.activeThumbImage}
+  /// An image to use on the thumb of this switch when the switch is on.
   final ImageProvider? activeThumbImage;
 
-  /// {@macro flutter.material.switch.onActiveThumbImageError}
+  /// An optional error callback for errors emitted when loading
+  /// [activeThumbImage].
   final ImageErrorListener? onActiveThumbImageError;
 
-  /// {@macro flutter.material.switch.inactiveThumbImage}
+  /// An image to use on the thumb of this switch when the switch is off.
   final ImageProvider? inactiveThumbImage;
 
-  /// {@macro flutter.material.switch.onInactiveThumbImageError}
+  /// An optional error callback for errors emitted when loading
+  /// [inactiveThumbImage].
   final ImageErrorListener? onInactiveThumbImageError;
 
   /// The outline color of this [CupertinoSwitch]'s track.

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-library;
-
 import 'dart:math' as math;
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 
@@ -161,7 +158,10 @@ class _CupertinoTextFieldSelectionGestureDetectorBuilder
 /// rounded rectangle border around the text field. If you set the [decoration]
 /// property to null, the decoration will be removed entirely.
 ///
-/// {@macro flutter.material.textfield.wantKeepAlive}
+/// When the widget has focus, it will prevent itself from disposing via its
+/// underlying [EditableText]'s [AutomaticKeepAliveClientMixin.wantKeepAlive] in
+/// order to avoid losing the selection. Removing the focus will allow it to be
+/// disposed.
 ///
 /// Remember to call [TextEditingController.dispose] when it is no longer
 /// needed. This will ensure we discard any resources used by the object.
@@ -602,7 +602,16 @@ class CupertinoTextField extends StatefulWidget {
   )
   final ToolbarOptions? toolbarOptions;
 
-  /// {@macro flutter.material.InputDecorator.textAlignVertical}
+  /// How the text should be aligned vertically.
+  ///
+  /// Determines the alignment of the baseline within the available space of
+  /// the input (typically a TextField). For example, TextAlignVertical.top will
+  /// place the baseline such that the text, and any attached decoration like
+  /// prefix and suffix, is as close to the top of the input as possible without
+  /// overflowing. The heights of the prefix and suffix are similarly included
+  /// for other alignment values. If the height is greater than the height
+  /// available, then the prefix and suffix will be allowed to overflow first
+  /// before the text scrolls.
   final TextAlignVertical? textAlignVertical;
 
   /// {@macro flutter.widgets.editableText.textDirection}
@@ -772,19 +781,53 @@ class CupertinoTextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.selectionEnabled}
   bool get selectionEnabled => enableInteractiveSelection;
 
-  /// {@macro flutter.material.textfield.onTap}
+  /// Called for the first tap in a series of taps.
+  ///
+  /// The text field builds a [GestureDetector] to handle input events like tap,
+  /// to trigger focus requests, to move the caret, adjust the selection, etc.
+  /// Handling some of those events by wrapping the text field with a competing
+  /// GestureDetector is problematic.
+  ///
+  /// To unconditionally handle taps, without interfering with the text field's
+  /// internal gesture detector, provide this callback.
+  ///
+  /// If the text field is created with [enabled] false, taps will not be
+  /// recognized.
+  ///
+  /// To be notified when the text field gains or loses the focus, provide a
+  /// [focusNode] and add a listener to that.
+  ///
+  /// To listen to arbitrary pointer events without competing with the
+  /// text field's internal gesture detector, use a [Listener].
   final GestureTapCallback? onTap;
 
   /// {@macro flutter.widgets.editableText.autofillHints}
   /// {@macro flutter.services.AutofillConfiguration.autofillHints}
   final Iterable<String>? autofillHints;
 
-  /// {@macro flutter.material.Material.clipBehavior}
+  /// The content will be clipped (or not) according to this option.
+  ///
+  /// See the enum [Clip] for details of all possible options and their common
+  /// use cases.
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
-  /// {@macro flutter.material.textfield.restorationId}
+  /// Restoration ID to save and restore the state of the text field.
+  ///
+  /// If non-null, the text field will persist and restore its current scroll
+  /// offset and - if no [controller] has been provided - the content of the
+  /// text field. If a [controller] has been provided, it is the responsibility
+  /// of the owner of that controller to persist and restore it, e.g. by using
+  /// a [RestorableTextEditingController].
+  ///
+  /// The state of this widget is persisted in a [RestorationBucket] claimed
+  /// from the surrounding [RestorationScope] using the provided restoration ID.
+  ///
+  /// See also:
+  ///
+  ///  * [RestorationManager], which explains how state restoration works in
+  ///    Flutter.
   final String? restorationId;
 
   /// {@macro flutter.widgets.editableText.scribbleEnabled}
@@ -852,7 +895,7 @@ class CupertinoTextField extends StatefulWidget {
   /// See also:
   ///  * [SpellCheckConfiguration.misspelledTextStyle], the style configured to
   ///    mark misspelled words with.
-  ///  * [TextField.materialMisspelledTextStyle], the style configured
+  ///  * [TextField.materialMisspelledTextStyle](https://api.flutter.dev/flutter/material/TextField/materialMisspelledTextStyle-constant.html), the style configured
   ///    to mark misspelled words with in the Material style.
   static const TextStyle cupertinoMisspelledTextStyle = TextStyle(
     decoration: TextDecoration.underline,

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-library;
-
 import 'dart:collection';
 import 'dart:math' as math show pi;
 import 'dart:ui' as ui;
@@ -97,20 +94,31 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
     this.toolbarBuilder = _defaultToolbarBuilder,
   }) : assert(children.length > 0);
 
-  /// {@macro flutter.material.TextSelectionToolbar.anchorAbove}
+  /// The focal point above which the toolbar attempts to position itself.
+  ///
+  /// If there is not enough room above before reaching the top of the screen,
+  /// then the toolbar will position itself below [anchorBelow].
   final Offset anchorAbove;
 
-  /// {@macro flutter.material.TextSelectionToolbar.anchorBelow}
+  /// The focal point below which the toolbar attempts to position itself, if it
+  /// doesn't fit above [anchorAbove].
   final Offset anchorBelow;
 
-  /// {@macro flutter.material.TextSelectionToolbar.children}
+  /// The children that will be displayed in the text selection toolbar.
+  ///
+  /// Typically these are buttons.
+  ///
+  /// Must not be empty.
   ///
   /// See also:
   ///   * [CupertinoTextSelectionToolbarButton], which builds a default
   ///     Cupertino-style text selection toolbar text button.
   final List<Widget> children;
 
-  /// {@macro flutter.material.TextSelectionToolbar.toolbarBuilder}
+  /// Builds the toolbar container.
+  ///
+  /// Useful for customizing the high-level background of the toolbar. The given
+  /// child Widget will contain all of the [children].
   ///
   /// The given anchor and isAbove can be used to position an arrow, as in the
   /// default Cupertino toolbar.

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/material.dart';
-///
 /// @docImport 'app.dart';
 /// @docImport 'button.dart';
 /// @docImport 'switch.dart';
@@ -51,8 +49,8 @@ const _CupertinoThemeDefaults _kDefaultTheme = _CupertinoThemeDefaults(
 ///  * [CupertinoThemeData], specifies the theme's visual styling.
 ///  * [CupertinoApp], which will automatically add a [CupertinoTheme] based on the
 ///    value of [CupertinoApp.theme].
-///  * [Theme], a Material theme which will automatically add a [CupertinoTheme]
-///    with a [CupertinoThemeData] derived from the Material [ThemeData].
+///  * [Theme](https://api.flutter.dev/flutter/material/Theme-class.html), a Material theme which will automatically add a [CupertinoTheme]
+///    with a [CupertinoThemeData] derived from the Material [ThemeData](https://api.flutter.dev/flutter/material/ThemeData-class.html).
 class CupertinoTheme extends StatelessWidget {
   /// Creates a [CupertinoTheme] to change descendant Cupertino widgets' styling.
   const CupertinoTheme({super.key, required this.data, required this.child});
@@ -169,8 +167,8 @@ class InheritedCupertinoTheme extends InheritedTheme {
 /// See also:
 ///
 ///  * [CupertinoTheme], in which this [CupertinoThemeData] is inserted.
-///  * [ThemeData], a Material equivalent that also configures Cupertino
-///    styling via a [CupertinoThemeData] subclass [MaterialBasedCupertinoThemeData].
+///  * [ThemeData](https://api.flutter.dev/flutter/material/ThemeData-class.html), a Material equivalent that also configures Cupertino
+///    styling via a [CupertinoThemeData] subclass [MaterialBasedCupertinoThemeData](https://api.flutter.dev/flutter/material/MaterialBasedCupertinoThemeData-class.html).
 @immutable
 class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable {
   /// Creates a [CupertinoTheme] styling specification.
@@ -414,7 +412,7 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
 /// Unlike [CupertinoThemeData] instances of this class do not return default
 /// values for properties that have been left unspecified in the constructor.
 /// Instead, unspecified properties will return null. This is used by
-/// Material's [ThemeData.cupertinoOverrideTheme].
+/// Material's [ThemeData.cupertinoOverrideTheme](https://api.flutter.dev/flutter/material/ThemeData/cupertinoOverrideTheme.html).
 ///
 /// See also:
 ///
@@ -442,13 +440,13 @@ class NoDefaultCupertinoThemeData {
   /// take precedence over the ambient [MediaQueryData.platformBrightness], when
   /// determining the brightness of descendant Cupertino widgets.
   ///
-  /// If coming from a Material [Theme] and unspecified, [brightness] will be
-  /// derived from the Material [ThemeData]'s [brightness].
+  /// If coming from a Material [Theme](https://api.flutter.dev/flutter/material/Theme-class.html) and unspecified, [brightness] will be
+  /// derived from the Material [ThemeData](https://api.flutter.dev/flutter/material/ThemeData-class.html)'s [brightness].
   ///
   /// See also:
   ///
-  ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
-  ///    [brightness] to its Material [Theme] parent if it's unspecified.
+  ///  * [MaterialBasedCupertinoThemeData](https://api.flutter.dev/flutter/material/MaterialBasedCupertinoThemeData-class.html), a [CupertinoThemeData] that defers
+  ///    [brightness] to its Material [Theme](https://api.flutter.dev/flutter/material/Theme-class.html) parent if it's unspecified.
   ///
   ///  * [CupertinoTheme.brightnessOf], a method used to retrieve the overall
   ///    [Brightness] from a [BuildContext], for Cupertino widgets.
@@ -459,16 +457,16 @@ class NoDefaultCupertinoThemeData {
   /// This color is generally used on text and icons in buttons and tappable
   /// elements. Defaults to [CupertinoColors.activeBlue].
   ///
-  /// If coming from a Material [Theme] and unspecified, [primaryColor] will be
-  /// derived from the Material [ThemeData]'s `colorScheme.primary`. However, in
+  /// If coming from a Material [Theme](https://api.flutter.dev/flutter/material/Theme-class.html) and unspecified, [primaryColor] will be
+  /// derived from the Material [ThemeData](https://api.flutter.dev/flutter/material/ThemeData-class.html)'s `colorScheme.primary`. However, in
   /// iOS styling, the [primaryColor] is more sparsely used than in Material
   /// Design where the [primaryColor] can appear on non-interactive surfaces like
   /// the [AppBar] background, [TextField] borders etc.
   ///
   /// See also:
   ///
-  ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
-  ///    [primaryColor] to its Material [Theme] parent if it's unspecified.
+  ///  * [MaterialBasedCupertinoThemeData](https://api.flutter.dev/flutter/material/MaterialBasedCupertinoThemeData-class.html), a [CupertinoThemeData] that defers
+  ///    [primaryColor] to its Material [Theme](https://api.flutter.dev/flutter/material/Theme-class.html) parent if it's unspecified.
   final Color? primaryColor;
 
   /// A color that must be easy to see when rendered on a [primaryColor] background.
@@ -476,13 +474,13 @@ class NoDefaultCupertinoThemeData {
   /// For example, this color is used for a [CupertinoButton]'s text and icons
   /// when the button's background is [primaryColor].
   ///
-  /// If coming from a Material [Theme] and unspecified, [primaryContrastingColor]
-  /// will be derived from the Material [ThemeData]'s `colorScheme.onPrimary`.
+  /// If coming from a Material [Theme](https://api.flutter.dev/flutter/material/Theme-class.html) and unspecified, [primaryContrastingColor]
+  /// will be derived from the Material [ThemeData](https://api.flutter.dev/flutter/material/ThemeData-class.html)'s `colorScheme.onPrimary`.
   ///
   /// See also:
   ///
-  ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
-  ///    [primaryContrastingColor] to its Material [Theme] parent if it's unspecified.
+  ///  * [MaterialBasedCupertinoThemeData](https://api.flutter.dev/flutter/material/MaterialBasedCupertinoThemeData-class.html), a [CupertinoThemeData] that defers
+  ///    [primaryContrastingColor] to its Material [Theme](https://api.flutter.dev/flutter/material/Theme-class.html) parent if it's unspecified.
   final Color? primaryContrastingColor;
 
   /// Text styles used by Cupertino widgets.


### PR DESCRIPTION
Fixes #187911

Decouples `packages/flutter/lib/src/cupertino` from `material.dart` by:
- Removing `/// @docImport 'package:flutter/material.dart';` across 20 files.
- Inlining doc macros that referenced Material templates.
- Replacing unresolved bracketed links to Material classes (e.g. `[Scrollbar]`, `[ListTile]`) with explicit API URL links.
- Cleaning up now-unnecessary `library;` statements.

Verified via `dart analyze --fatal-infos` and `dart format`.
