### PR TITLE
Clear text input handler widget on view dispose

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_text_input_handler.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_text_input_handler.cc
@@ -336,6 +336,12 @@ static void update_im_cursor_position(FlTextInputHandler* self) {
     return;
   }
 
+  // Cannot compute a position without a widget (e.g. after the view is
+  // disposed).
+  if (self->widget == nullptr) {
+    return;
+  }
+
   // Transform the x, y positions of the cursor from local coordinates to
   // Flutter view coordinates.
   gint x = self->composing_rect.x * self->editabletext_transform[0][0] +

--- a/engine/src/flutter/shell/platform/linux/fl_text_input_handler.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_text_input_handler.cc
@@ -480,8 +480,9 @@ void fl_text_input_handler_set_widget(FlTextInputHandler* self,
                                       GtkWidget* widget) {
   g_return_if_fail(FL_IS_TEXT_INPUT_HANDLER(self));
   self->widget = widget;
-  gtk_im_context_set_client_window(self->im_context,
-                                   gtk_widget_get_window(self->widget));
+  gtk_im_context_set_client_window(
+      self->im_context,
+      widget != nullptr ? gtk_widget_get_window(widget) : nullptr);
 }
 
 GtkWidget* fl_text_input_handler_get_widget(FlTextInputHandler* self) {

--- a/engine/src/flutter/shell/platform/linux/fl_text_input_handler_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_text_input_handler_test.cc
@@ -586,6 +586,10 @@ TEST_F(FlTextInputHandlerTest, SurroundingText) {
 }
 
 TEST_F(FlTextInputHandlerTest, SetMarkedTextRect) {
+  GtkWidget* window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  g_object_ref_sink(window);
+  fl_text_input_handler_set_widget(handler, window);
+
   g_signal_emit_by_name(fl_text_input_handler_get_im_context(handler),
                         "preedit-start", nullptr);
 
@@ -668,6 +672,36 @@ TEST_F(FlTextInputHandlerTest, SetMarkedTextRect) {
         EXPECT_TRUE(fl_value_equal(fl_method_success_response_get_result(
                                        FL_METHOD_SUCCESS_RESPONSE(response)),
                                    expected_result));
+      },
+      &called);
+  EXPECT_TRUE(called);
+
+  fl_text_input_handler_set_widget(handler, nullptr);
+  g_object_unref(window);
+}
+
+// Updating the marked text rect with no widget set (e.g. after the view is
+// disposed) must not crash. https://github.com/flutter/flutter/issues/188657
+TEST_F(FlTextInputHandlerTest, SetMarkedTextRectWithoutWidget) {
+  g_signal_emit_by_name(fl_text_input_handler_get_im_context(handler),
+                        "preedit-start", nullptr);
+
+  EXPECT_CALL(mock_gtk, gtk_widget_translate_coordinates).Times(0);
+
+  g_autoptr(FlValue) rect = build_map({
+      {"x", fl_value_new_float(1)},
+      {"y", fl_value_new_float(2)},
+      {"width", fl_value_new_float(3)},
+      {"height", fl_value_new_float(4)},
+  });
+  gboolean called = FALSE;
+  fl_mock_binary_messenger_invoke_json_method(
+      messenger, "flutter/textinput", "TextInput.setMarkedTextRect", rect,
+      [](FlMockBinaryMessenger* messenger, FlMethodResponse* response,
+         gpointer user_data) {
+        gboolean* called = static_cast<gboolean*>(user_data);
+        *called = TRUE;
+        EXPECT_TRUE(FL_IS_METHOD_SUCCESS_RESPONSE(response));
       },
       &called);
   EXPECT_TRUE(called);

--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -474,6 +474,16 @@ static void fl_view_dispose(GObject* object) {
   g_clear_object(&self->zoom_gesture);
   g_clear_object(&self->rotate_gesture);
   if (self->engine != nullptr) {
+    // If this view holds the text input focus, clear the handler's widget
+    // pointer so it does not dangle once this view is finalized.
+    FlTextInputHandler* text_input_handler =
+        fl_engine_get_text_input_handler(self->engine);
+    if (text_input_handler != nullptr &&
+        fl_text_input_handler_get_widget(text_input_handler) ==
+            GTK_WIDGET(self)) {
+      fl_text_input_handler_set_widget(text_input_handler, nullptr);
+    }
+
     // Release the view ID from the engine.
     fl_engine_remove_view(self->engine, self->view_id, nullptr, nullptr,
                           nullptr);

--- a/engine/src/flutter/shell/platform/linux/fl_view_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view_test.cc
@@ -8,6 +8,7 @@
 
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
+#include "flutter/shell/platform/linux/fl_text_input_handler.h"
 #include "flutter/shell/platform/linux/fl_view_private.h"
 #include "flutter/shell/platform/linux/testing/fl_test.h"
 #include "flutter/shell/platform/linux/testing/fl_test_gtk_logs.h"
@@ -43,6 +44,27 @@ TEST_F(FlViewTest, StateUpdateDoesNotHappenInInit) {
       (GLogLevelFlags)0x0);
 
   (void)view;
+}
+
+// Disposing a view that holds the text input focus clears the handler's
+// widget pointer so it does not dangle.
+// https://github.com/flutter/flutter/issues/188657
+TEST_F(FlViewTest, DisposeClearsTextInputWidget) {
+  FlView* view = fl_view_new(project);
+  g_object_ref_sink(view);
+  g_autoptr(FlEngine) engine =
+      FL_ENGINE(g_object_ref(fl_view_get_engine(view)));
+  StartEngine(engine);
+  FlTextInputHandler* handler = fl_engine_get_text_input_handler(engine);
+
+  // Give the view text input focus.
+  fl_text_input_handler_set_widget(handler, GTK_WIDGET(view));
+  EXPECT_EQ(fl_text_input_handler_get_widget(handler), GTK_WIDGET(view));
+
+  // Destroy the view while the engine and handler persist.
+  g_object_unref(view);
+
+  EXPECT_EQ(fl_text_input_handler_get_widget(handler), nullptr);
 }
 
 // FIXME(robert-ancell): Disabling this test as it requires the FlView


### PR DESCRIPTION
When an FlView holding the text input focus is destroyed, the text input handler kept a dangling pointer to the view, causing a crash. Clear the handler's widget in fl_view_dispose and make set_widget null-safe.

Fixes https://github.com/flutter/flutter/issues/188657
