### PR TITLE
Free compositor in view renderer finalize to avoid use-after-free

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_view_renderer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view_renderer.cc
@@ -172,15 +172,28 @@ static void fl_view_renderer_dispose(GObject* object) {
   FlViewRenderer* self = FL_VIEW_RENDERER(object);
 
   g_clear_object(&self->render_context);
-  g_clear_object(&self->compositor);
   g_clear_object(&self->engine);
   g_clear_pointer(&self->background_color, gdk_rgba_free);
 
   G_OBJECT_CLASS(fl_view_renderer_parent_class)->dispose(object);
 }
 
+static void fl_view_renderer_finalize(GObject* object) {
+  FlViewRenderer* self = FL_VIEW_RENDERER(object);
+
+  // The compositor is released here rather than in dispose() so it outlives a
+  // forced dispose (e.g. gtk_widget_destroy()) and is only freed once the last
+  // reference is dropped. This keeps it alive for the raster thread, which
+  // holds a strong reference on the view (and thus this renderer) while
+  // presenting.
+  g_clear_object(&self->compositor);
+
+  G_OBJECT_CLASS(fl_view_renderer_parent_class)->finalize(object);
+}
+
 static void fl_view_renderer_class_init(FlViewRendererClass* klass) {
   G_OBJECT_CLASS(klass)->dispose = fl_view_renderer_dispose;
+  G_OBJECT_CLASS(klass)->finalize = fl_view_renderer_finalize;
 
   GtkWidgetClass* widget_class = GTK_WIDGET_CLASS(klass);
   widget_class->realize = fl_view_renderer_realize;


### PR DESCRIPTION
A forced dispose (gtk_widget_destroy) runs even while the raster thread holds a strong reference on the view and is presenting onto the compositor. Releasing the compositor in dispose could free it mid-present, causing a use-after-free. Move the release to finalize so it lives until the last reference (held transitively by the raster thread) is dropped.

Fixes https://github.com/flutter/flutter/issues/188659
