### PR TITLE
[flutter_tools] Tell user how to skip the device prompt with -d

### DIFF
--- a/packages/flutter_tools/lib/src/runner/target_devices.dart
+++ b/packages/flutter_tools/lib/src/runner/target_devices.dart
@@ -24,6 +24,8 @@ const _wirelesslyConnectedDevicesMessage = 'Wirelessly connected devices:';
 
 String _chooseDeviceOptionMessage(int option, String name, String deviceId) =>
     '[$option]: $name ($deviceId)';
+String _skipPromptHintMessage(String deviceId) =>
+    'To skip this prompt next time, specify the device with "-d $deviceId".';
 String _foundMultipleSpecifiedDevicesMessage(String deviceId) =>
     'Found multiple devices with name or id matching $deviceId:';
 String _foundSpecifiedDevicesMessage(int count, String deviceId) =>
@@ -347,7 +349,9 @@ class TargetDevices {
     if (userInput.toLowerCase() == 'q') {
       throwToolExit('');
     }
-    return devices[int.parse(userInput) - 1];
+    final Device chosenDevice = devices[int.parse(userInput) - 1];
+    _logger.printStatus(_skipPromptHintMessage(chosenDevice.id));
+    return chosenDevice;
   }
 
   void _displayDeviceOptions(List<Device> devices) {
@@ -721,6 +725,8 @@ class TargetDevicesWithExtendedWirelessDeviceDiscovery extends TargetDevices {
     // Update the [DeviceManager.specifiedDeviceId] so that the user will not
     // be prompted again.
     _deviceManager.specifiedDeviceId = chosenDevice.id;
+
+    _logger.printStatus(_skipPromptHintMessage(chosenDevice.id));
 
     return <Device>[chosenDevice];
   }

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -669,6 +669,7 @@ target-device-5 (wireless) (mobile) • xxx • android • Android 10
 
 [1]: target-device-1 (xxx)
 [2]: target-device-5 (wireless) (xxx)
+To skip this prompt next time, specify the device with "-d xxx".
 '''),
             );
             expect(devices, <Device>[wirelessAndroidDevice1]);
@@ -694,12 +695,29 @@ target-device-1 (mobile) • xxx • android • Android 10
 target-device-2 (mobile) • xxx • android • Android 10
 [1]: target-device-1 (xxx)
 [2]: target-device-2 (xxx)
+To skip this prompt next time, specify the device with "-d xxx".
 '''),
             );
             expect(devices, <Device>[attachedAndroidDevice1]);
             expect(deviceManager.androidDiscoverer.devicesCalled, 2);
             expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
             expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
+
+          testUsingContext('tells user how to skip the prompt after choosing a device', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedAndroidDevice2,
+            ];
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
+
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(devices, <Device>[attachedAndroidDevice1]);
+            expect(
+              logger.statusText,
+              contains('To skip this prompt next time, specify the device with "-d xxx".'),
+            );
           }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
 
           testUsingContext('can select the eleventh attached device', () async {
@@ -743,6 +761,7 @@ target-device-6 (wireless) (mobile) • xxx • android • Android 10
 
 [1]: target-device-5 (wireless) (xxx)
 [2]: target-device-6 (wireless) (xxx)
+To skip this prompt next time, specify the device with "-d xxx".
 '''),
             );
             expect(devices, <Device>[wirelessAndroidDevice1]);
@@ -879,6 +898,7 @@ target-device-8 (wireless) (mobile) • xxx • android • Android 10
 [2]: target-device-4 (xxx)
 [3]: target-device-5 (wireless) (xxx)
 [4]: target-device-8 (wireless) (xxx)
+To skip this prompt next time, specify the device with "-d xxx".
 '''),
             );
             expect(devices, <Device>[attachedUnsupportedForProjectAndroidDevice]);
@@ -904,6 +924,7 @@ target-device-1 (mobile) • xxx • android • Android 10
 target-device-2 (mobile) • xxx • android • Android 10
 [1]: target-device-1 (xxx)
 [2]: target-device-2 (xxx)
+To skip this prompt next time, specify the device with "-d xxx".
 '''),
             );
             expect(devices, <Device>[attachedAndroidDevice1]);
@@ -932,6 +953,7 @@ target-device-6 (wireless) (mobile) • xxx • android • Android 10
 
 [1]: target-device-5 (wireless) (xxx)
 [2]: target-device-6 (wireless) (xxx)
+To skip this prompt next time, specify the device with "-d xxx".
 '''),
             );
             expect(devices, <Device>[wirelessAndroidDevice1]);
@@ -1736,7 +1758,8 @@ target-device-9 (mobile) • xxx • ios • iOS 16
 No wireless devices were found.
 
 [1]: target-device-9 (xxx)
-Please choose one (or "q" to quit): '''),
+Please choose one (or "q" to quit): To skip this prompt next time, specify the device with "-d xxx".
+'''),
             );
             expect(devices, <Device>[nonEphemeralDevice]);
             expect(deviceManager.iosDiscoverer.devicesCalled, 2);
@@ -1782,7 +1805,8 @@ target-device-9 (mobile) • xxx • ios • iOS 16
 No wireless devices were found.
 
 [1]: target-device-9 (xxx)
-Please choose one (or "q" to quit): '''),
+Please choose one (or "q" to quit): To skip this prompt next time, specify the device with "-d xxx".
+'''),
             );
             expect(devices, <Device>[nonEphemeralDevice]);
           }, overrides: <Type, Generator>{AnsiTerminal: () => terminal});
@@ -2133,7 +2157,8 @@ target-device-5 (wireless) (mobile) • xxx • ios • iOS 16
 [1]: target-device-1 (xxx)
 [2]: target-device-2 (xxx)
 [3]: target-device-5 (wireless) (xxx)
-Please choose one (or "q" to quit): '''),
+Please choose one (or "q" to quit): To skip this prompt next time, specify the device with "-d xxx".
+'''),
             );
             expect(devices, <Device>[connectedWirelessIOSDevice1]);
             expect(deviceManager.iosDiscoverer.devicesCalled, 2);
@@ -2173,7 +2198,8 @@ No wireless devices were found.
 
 [1]: target-device-1 (xxx)
 [2]: target-device-2 (xxx)
-Please choose one (or "q" to quit): '''),
+Please choose one (or "q" to quit): To skip this prompt next time, specify the device with "-d xxx".
+'''),
             );
             expect(devices, <Device>[attachedIOSDevice2]);
             expect(deviceManager.iosDiscoverer.devicesCalled, 2);
@@ -2210,6 +2236,7 @@ target-device-6 (wireless) (mobile) • xxx • ios • iOS 16
 
 [1]: target-device-5 (wireless) (xxx)
 [2]: target-device-6 (wireless) (xxx)
+To skip this prompt next time, specify the device with "-d xxx".
 '''),
             );
             expect(devices, <Device>[connectedWirelessIOSDevice1]);
@@ -2258,6 +2285,7 @@ target-device-5 (wireless) (mobile) • xxx • ios • iOS 16
 [1]: target-device-1 (xxx)
 [2]: target-device-2 (xxx)
 [3]: target-device-5 (wireless) (xxx)
+To skip this prompt next time, specify the device with "-d xxx".
 '''),
               );
               expect(devices, <Device>[attachedIOSDevice1]);
@@ -2315,7 +2343,8 @@ target-device-2 (mobile) • xxx • ios • iOS 16
 
 [1]: target-device-1 (xxx)
 [2]: target-device-2 (xxx)
-Please choose one (or "q" to quit): '''),
+Please choose one (or "q" to quit): To skip this prompt next time, specify the device with "-d xxx".
+'''),
               );
 
               expect(devices, <Device>[attachedIOSDevice2]);
@@ -2371,7 +2400,8 @@ target-device-5 (wireless) (mobile) • xxx • ios • iOS 16
 [1]: target-device-1 (xxx)
 [2]: target-device-2 (xxx)
 [3]: target-device-5 (wireless) (xxx)
-Please choose one (or "q" to quit): '''),
+Please choose one (or "q" to quit): To skip this prompt next time, specify the device with "-d xxx".
+'''),
               );
 
               expect(devices, <Device>[attachedIOSDevice2]);
@@ -2560,7 +2590,8 @@ target-device-8 (wireless) (mobile) • xxx • ios • iOS 16
 [2]: target-device-4 (xxx)
 [3]: target-device-5 (wireless) (xxx)
 [4]: target-device-8 (wireless) (xxx)
-Please choose one (or "q" to quit): '''),
+Please choose one (or "q" to quit): To skip this prompt next time, specify the device with "-d xxx".
+'''),
             );
             expect(devices, <Device>[connectedWirelessIOSDevice1]);
             expect(deviceManager.iosDiscoverer.devicesCalled, 3);
@@ -2600,7 +2631,8 @@ No wireless devices were found.
 
 [1]: target-device-1 (xxx)
 [2]: target-device-2 (xxx)
-Please choose one (or "q" to quit): '''),
+Please choose one (or "q" to quit): To skip this prompt next time, specify the device with "-d xxx".
+'''),
             );
             expect(devices, <Device>[attachedIOSDevice2]);
             expect(deviceManager.iosDiscoverer.devicesCalled, 3);
@@ -2635,6 +2667,7 @@ target-device-6 (wireless) (mobile) • xxx • ios • iOS 16
 
 [1]: target-device-5 (wireless) (xxx)
 [2]: target-device-6 (wireless) (xxx)
+To skip this prompt next time, specify the device with "-d xxx".
 '''),
             );
             expect(devices, <Device>[connectedWirelessIOSDevice1]);


### PR DESCRIPTION
## Description

When `flutter run` (or any command) finds multiple devices and no `-d`/`--device-id` was given, it interactively prompts the user to choose one. After a device is chosen, this PR prints a short hint telling the user how to skip the prompt next time by passing the chosen device id with `-d <device-id>`.

Example:
```
[1]: iPhone 15 (00008030-...)
[2]: macOS (macos)
Please choose one (or "q" to quit): 1
To skip this prompt next time, specify the device with "-d 00008030-...".
```

The hint is shown for both the standard interactive selection path and the extended wireless-device selection path.

Fixes https://github.com/flutter/flutter/issues/63541

## Tests

- Added a new test verifying the hint is printed after a device is chosen.
- Updated existing `target_devices_test.dart` snapshot expectations to include the hint line for the interactive-selection cases.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests