### PR TITLE
[Flutter GPU] Honor the enable argument in RenderPass.setDepthWriteEnable

### DIFF
--- a/engine/src/flutter/lib/gpu/BUILD.gn
+++ b/engine/src/flutter/lib/gpu/BUILD.gn
@@ -88,6 +88,7 @@ if (enable_unittests && !is_fuchsia) {
 
     sources = [
       "command_buffer_unittests.cc",
+      "render_pass_unittests.cc",
       "shader_library_unittests.cc",
     ]
 

--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -561,7 +561,7 @@ void InternalFlutterGpu_RenderPass_SetDepthWriteEnable(
     flutter::gpu::RenderPass* wrapper,
     bool enable) {
   auto& depth = wrapper->GetDepthAttachmentDescriptor();
-  depth.depth_write_enabled = true;
+  depth.depth_write_enabled = enable;
 }
 
 void InternalFlutterGpu_RenderPass_SetDepthCompareOperation(

--- a/engine/src/flutter/lib/gpu/render_pass_unittests.cc
+++ b/engine/src/flutter/lib/gpu/render_pass_unittests.cc
@@ -4,8 +4,9 @@
 
 #include "flutter/lib/gpu/render_pass.h"
 
-#include "flutter/fml/memory/ref_ptr.h"
 #include "gtest/gtest.h"
+
+#include "fml/memory/ref_ptr.h"
 
 namespace flutter::gpu {
 namespace {

--- a/engine/src/flutter/lib/gpu/render_pass_unittests.cc
+++ b/engine/src/flutter/lib/gpu/render_pass_unittests.cc
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/gpu/render_pass.h"
+
+#include "flutter/fml/memory/ref_ptr.h"
+#include "gtest/gtest.h"
+
+namespace flutter::gpu {
+namespace {
+
+// Regression test for https://github.com/flutter/flutter/issues/188712:
+// SetDepthWriteEnable must honor its argument. It previously ignored the
+// argument and always enabled depth writes, so disabling depth writes (for
+// example to keep overlapping translucent draws from self-occluding) had no
+// effect.
+TEST(FlutterGpuRenderPassTest, SetDepthWriteEnableHonorsArgument) {
+  auto render_pass = fml::MakeRefCounted<RenderPass>();
+
+  InternalFlutterGpu_RenderPass_SetDepthWriteEnable(render_pass.get(), true);
+  EXPECT_TRUE(render_pass->GetDepthAttachmentDescriptor().depth_write_enabled);
+
+  InternalFlutterGpu_RenderPass_SetDepthWriteEnable(render_pass.get(), false);
+  EXPECT_FALSE(render_pass->GetDepthAttachmentDescriptor().depth_write_enabled);
+}
+
+}  // namespace
+}  // namespace flutter::gpu


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/188712

Honors the `enable` argument in `RenderPass.setDepthWriteEnable`. The native binding `InternalFlutterGpu_RenderPass_SetDepthWriteEnable` ignored its argument and always set `depth_write_enabled` to `true`, so `RenderPass.setDepthWriteEnable(false)` was a no-op and depth writes could not be disabled for any Flutter GPU draw.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
