### PR TITLE
Do not report a caret inside a surrogate pair to the platform IME

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4017,7 +4017,8 @@ class EditableTextState extends State<EditableText>
     if (_batchEditDepth > 0 || !_hasInputConnection) {
       return;
     }
-    final TextEditingValue localValue = _value;
+    // Never report a caret inside a surrogate pair to the IME, the IME might incorrectly split inside the pair.
+    final TextEditingValue localValue = _snapSelectionOffSurrogatePairs(_value);
     if (localValue == _lastKnownRemoteTextEditingValue) {
       return;
     }
@@ -4107,7 +4108,8 @@ class EditableTextState extends State<EditableText>
       return;
     }
     if (!_hasInputConnection) {
-      final TextEditingValue localValue = _value;
+      // Never report a caret inside a surrogate pair to the IME, the IME might incorrectly split inside the pair.
+      final TextEditingValue localValue = _snapSelectionOffSurrogatePairs(_value);
 
       // When _needsAutofill == true && currentAutofillScope == null, autofill
       // is allowed but saving the user input from the text field is
@@ -4185,11 +4187,13 @@ class EditableTextState extends State<EditableText>
         TextInput.attach(this, _effectiveAutofillClient.textInputConfiguration);
     _textInputConnection = newConnection;
 
+    // Never report a caret inside a surrogate pair to the IME, the IME might incorrectly split inside the pair.
+    final TextEditingValue localValue = _snapSelectionOffSurrogatePairs(_value);
     newConnection
       ..show()
       ..updateStyle(_getTextInputStyle(context))
-      ..setEditingState(_value);
-    _lastKnownRemoteTextEditingValue = _value;
+      ..setEditingState(localValue);
+    _lastKnownRemoteTextEditingValue = localValue;
   }
 
   @override
@@ -4697,6 +4701,52 @@ class EditableTextState extends State<EditableText>
         ),
       );
     }
+  }
+
+  /// Returns [offset] moved forward to just past a UTF-16 surrogate pair if it falls between the
+  /// pair's two code units; otherwise returns it unchanged. The returned offset is never inside a
+  /// surrogate pair.
+  ///
+  /// The pair is left by its trailing edge (offset + 1), not its leading edge (offset - 1), so a
+  /// caret that lands inside an emoji's glyph ends up *after* the emoji rather than before it. That
+  /// matches where a tap inside a trailing emoji was aiming and keeps a following backspace able to
+  /// delete the emoji; in a right-to-left field the leading edge is on the visual right, where
+  /// snapping there would strand the caret before the emoji instead. Either edge keeps the pair from
+  /// being split, so this choice only affects where the caret lands. offset + 1 is always valid
+  /// here: a low surrogate at [offset] guarantees offset < text.length.
+  static int _offsetOffSurrogatePair(String text, int offset) {
+    if (offset <= 0 || offset >= text.length) {
+      return offset;
+    }
+    final int prev = text.codeUnitAt(offset - 1);
+    final int next = text.codeUnitAt(offset);
+    // High surrogates occupy U+D800..U+DBFF and low surrogates U+DC00..U+DFFF; a high unit
+    // immediately followed by a low unit forms one code point, so [offset] sits inside that pair.
+    final bool insidePair = prev >= 0xD800 && prev <= 0xDBFF && next >= 0xDC00 && next <= 0xDFFF;
+    return insidePair ? offset + 1 : offset;
+  }
+
+  /// Snaps both selection endpoints off any surrogate-pair interior. A selection endpoint that
+  /// sits between the two halves of a surrogate pair lets a later edit split the pair into lone
+  /// surrogates, which corrupts the text as it crosses the platform input channel (each lone half
+  /// is encoded as '?') and throws "string is not well-formed UTF-16" from ParagraphBuilder when
+  /// the text is painted.
+  ///
+  /// See https://github.com/flutter/flutter/issues/188713.
+  static TextEditingValue _snapSelectionOffSurrogatePairs(TextEditingValue value) {
+    final TextSelection selection = value.selection;
+    if (!selection.isValid) {
+      return value;
+    }
+    final String text = value.text;
+    final int base = _offsetOffSurrogatePair(text, selection.baseOffset);
+    final int extent = _offsetOffSurrogatePair(text, selection.extentOffset);
+    if (base == selection.baseOffset && extent == selection.extentOffset) {
+      return value;
+    }
+    return value.copyWith(
+      selection: selection.copyWith(baseOffset: base, extentOffset: extent),
+    );
   }
 
   @pragma('vm:notify-debugger-on-exception')

--- a/packages/flutter/test/widgets/editable_text_surrogate_pair_test.dart
+++ b/packages/flutter/test/widgets/editable_text_surrogate_pair_test.dart
@@ -1,0 +1,146 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Regression test for https://github.com/flutter/flutter/issues/188713
+//
+// EditableText must never report a caret that sits inside a UTF-16 surrogate pair to the platform
+// text input plugin (IME). If it does, the IME inserts a character at that offset and splits the
+// pair into lone surrogates, which corrupt as the editing value crosses the input channel (each
+// lone half is encoded as '?') and crash ParagraphBuilder on paint ("string is not well-formed
+// UTF-16"). The value sent over the channel is now snapped off the pair. Flutter's internal,
+// framework-side cursor behavior (which already handles mid-grapheme deletes) is intentionally
+// left unchanged.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'widgets_app_tester.dart';
+
+/// Whether [value] contains a UTF-16 surrogate code unit that is not part of a valid high-low pair.
+bool _hasLoneSurrogate(String value) {
+  final List<int> codeUnits = value.codeUnits;
+  for (var i = 0; i < codeUnits.length; i++) {
+    final int codeUnit = codeUnits[i];
+    if (codeUnit >= 0xD800 && codeUnit <= 0xDBFF) {
+      // A high surrogate must be immediately followed by a low surrogate.
+      if (i + 1 >= codeUnits.length ||
+          !(codeUnits[i + 1] >= 0xDC00 && codeUnits[i + 1] <= 0xDFFF)) {
+        return true;
+      }
+      i++;
+    } else if (codeUnit >= 0xDC00 && codeUnit <= 0xDFFF) {
+      // A low surrogate not preceded by a high surrogate.
+      return true;
+    }
+  }
+  return false;
+}
+
+void main() {
+  // 'a😓b' -> code units [0061, D83D, DE13, 0062]; offset 2 is between D83D and DE13.
+  const text = 'a😓b';
+
+  /// Pumps an autofocused [EditableText] driven by [controller] and [focusNode] inside a minimal
+  /// [TestWidgetsApp] (no Material), and opens its input connection so
+  /// [WidgetTester.testTextInput] sees its state.
+  Future<void> pumpEditable(
+    WidgetTester tester,
+    TextEditingController controller,
+    FocusNode focusNode,
+  ) async {
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: EditableText(
+          controller: controller,
+          focusNode: focusNode,
+          style: const TextStyle(),
+          cursorColor: const Color(0xFF000000),
+          backgroundCursorColor: const Color(0xFF000000),
+          autofocus: true,
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets(
+    'a caret inside a surrogate pair is snapped off the pair before being sent to the IME',
+    (WidgetTester tester) async {
+      final controller = TextEditingController(text: text);
+      addTearDown(controller.dispose);
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      await pumpEditable(tester, controller, focusNode);
+
+      // The platform reports a caret inside the surrogate pair (offset 2).
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(text: text, selection: TextSelection.collapsed(offset: 2)),
+      );
+      await tester.pump();
+
+      // Framework-internal cursor behavior is intentionally unchanged.
+      expect(controller.selection.baseOffset, 2);
+
+      // But the value sent back over the input channel is snapped past the pair end (offset 3), so it
+      // never sits inside the pair.
+      expect(tester.testTextInput.editingState!['selectionBase'], 3);
+      expect(tester.testTextInput.editingState!['selectionExtent'], 3);
+    },
+  );
+
+  testWidgets('with the clamped IME caret, the next insert does not split the emoji or crash', (
+    WidgetTester tester,
+  ) async {
+    final controller = TextEditingController(text: text);
+    addTearDown(controller.dispose);
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await pumpEditable(tester, controller, focusNode);
+
+    tester.testTextInput.updateEditingValue(
+      const TextEditingValue(text: text, selection: TextSelection.collapsed(offset: 2)),
+    );
+    await tester.pump();
+    final imeCaret = tester.testTextInput.editingState!['selectionBase'] as int;
+    expect(imeCaret, 3);
+
+    // The IME inserts a character at the offset the framework reported to it.
+    tester.testTextInput.updateEditingValue(
+      TextEditingValue(
+        text: text.replaceRange(imeCaret, imeCaret, 'x'),
+        selection: TextSelection.collapsed(offset: imeCaret + 1),
+      ),
+    );
+    await tester.pump();
+
+    expect(_hasLoneSurrogate(controller.text), isFalse);
+    expect(controller.text.contains('😓'), isTrue);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('boundary carets are left unchanged (only the pair interior is clamped)', (
+    WidgetTester tester,
+  ) async {
+    final controller = TextEditingController(text: text);
+    addTearDown(controller.dispose);
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await pumpEditable(tester, controller, focusNode);
+
+    for (final offset in <int>[0, 1, 3, 4]) {
+      tester.testTextInput.updateEditingValue(
+        TextEditingValue(
+          text: text,
+          selection: TextSelection.collapsed(offset: offset),
+        ),
+      );
+      await tester.pump();
+      expect(
+        controller.selection.baseOffset,
+        offset,
+        reason: 'boundary offset $offset must be kept',
+      );
+    }
+  });
+}


### PR DESCRIPTION
### Description

`EditableText` forwards its selection to the platform text input plugin verbatim. When a collapsed
caret (or a selection endpoint) sits **between the two UTF-16 code units of a surrogate pair**, the
IME inserts a character at that offset and splits the pair into two lone surrogates. The resulting
editing value then:

- corrupts as it crosses the platform input channel — on Android the engine's UTF-8 encoder
  replaces each lone surrogate with `?`, so a single emoji becomes `??`; and
- throws `ArgumentError: string is not well-formed UTF-16` from `ParagraphBuilder.addText` when the
  field is painted.

This change snaps the selection off any surrogate-pair interior **before the editing state is sent
to the platform**, at every `setEditingState` site (`_updateRemoteEditingValueIfNeeded`,
`_openInputConnection`, `_restartConnectionIfNeeded`). The IME therefore never inserts inside a pair.

The selection is snapped to the **trailing edge** of the pair (`offset + 1`), not the leading edge, so
a caret that lands inside a trailing emoji's glyph ends up *after* the emoji — where a following
backspace deletes the emoji. Snapping to the leading edge would instead strand the caret before the
emoji and delete the wrong character; this is most visible in right-to-left text, where the leading
edge is on the visual right. Either edge prevents the split, so the choice only affects where the
caret lands.

The framework-internal cursor behavior is intentionally **not** changed: a caret may still be placed
mid-grapheme inside the framework (e.g. on obscured text), and existing grapheme-aware deletion
continues to work. Only what is reported to the platform IME is constrained, which is the minimal
change that prevents the data loss.

Root-cause and reproduction details, including a standalone `flutter test` repro that reproduces on
stable 3.44.4 and 3.24.0, are in the linked issue.

### Tests

Adds `packages/flutter/test/widgets/editable_text_surrogate_pair_test.dart`:

- a caret reported inside a surrogate pair is snapped off the pair before being sent to the IME (and
  the framework-internal selection is left unchanged);
- with the clamped IME caret, the next insert does not split the emoji or crash;
- boundary carets are left unchanged.

Locally on 3.44.4 the new test passes, and `editable_text_test.dart` and `material/text_field_test.dart`
pass with no regressions (including the existing "manually placing the cursor in the middle of a code
point" test, which is intentionally left unchanged).

### Related Issues

Fixes https://github.com/flutter/flutter/issues/188713

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

