### PR TITLE
Provide guided migration logs when iOS app crashes on simulator

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -67,7 +67,6 @@ In the meantime, we recommend these temporary workarounds:
   profile mode via --release or --profile flags.
 ════════════════════════════════════════════════════════════════════════════════''';
 
-@visibleForTesting
 const String kUISceneMigrationRequiredError = '''
 ════════════════════════════════════════════════════════════════════════════════
 Your iOS app has not been migrated to the UIScene lifecycle.
@@ -847,21 +846,6 @@ class IOSDevice extends Device {
   }
 
   Future<void> _addLogInterceptors(SharedIOSDeviceLogReader deviceLogReader) async {
-    final String? uisceneWarning = globals.userMessages.uiSceneMigrationWarning;
-    if (uisceneWarning != null) {
-      final uisceneWarningInterceptor = LogInterceptor(
-        identifier: 'uiscene_requirement',
-        pattern: RegExp(
-          '`UIScene` lifecycle will soon be required|This process does not adopt UIScene lifecycle',
-        ),
-        action: () {
-          globals.printWarning(uisceneWarning);
-        },
-        excludeFromStream: true,
-      );
-      deviceLogReader.addLogInterceptor(uisceneWarningInterceptor);
-    }
-
     final uisceneCrashInterceptor = LogInterceptor(
       identifier: 'uiscene_crash',
       pattern: RegExp(r'UIScene life\s?cycle is required'),

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -67,6 +67,8 @@ In the meantime, we recommend these temporary workarounds:
   profile mode via --release or --profile flags.
 ════════════════════════════════════════════════════════════════════════════════''';
 
+/// The error message shown when an iOS app fails to launch because it has not
+/// been migrated to the UIScene lifecycle.
 const String kUISceneMigrationRequiredError = '''
 ════════════════════════════════════════════════════════════════════════════════
 Your iOS app has not been migrated to the UIScene lifecycle.
@@ -860,6 +862,7 @@ class IOSDevice extends Device {
       );
       deviceLogReader.addLogInterceptor(uisceneWarningInterceptor);
     }
+
     final uisceneCrashInterceptor = LogInterceptor(
       identifier: 'uiscene_crash',
       pattern: RegExp(r'UIScene life\s?cycle is required'),

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -846,6 +846,20 @@ class IOSDevice extends Device {
   }
 
   Future<void> _addLogInterceptors(SharedIOSDeviceLogReader deviceLogReader) async {
+    final String? uisceneWarning = globals.userMessages.uiSceneMigrationWarning;
+    if (uisceneWarning != null) {
+      final uisceneWarningInterceptor = LogInterceptor(
+        identifier: 'uiscene_requirement',
+        pattern: RegExp(
+          '`UIScene` lifecycle will soon be required|This process does not adopt UIScene lifecycle',
+        ),
+        action: () {
+          globals.printWarning(uisceneWarning);
+        },
+        excludeFromStream: true,
+      );
+      deviceLogReader.addLogInterceptor(uisceneWarningInterceptor);
+    }
     final uisceneCrashInterceptor = LogInterceptor(
       identifier: 'uiscene_crash',
       pattern: RegExp(r'UIScene life\s?cycle is required'),

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -783,6 +783,7 @@ Future<Process> launchDeviceUnifiedLogging(IOSSimulator device, String? appName)
       'senderImagePath ENDSWITH "/Flutter"',
       'senderImagePath ENDSWITH "/libswiftCore.dylib"',
       'processImageUUID == senderImageUUID',
+      'eventMessage CONTAINS "UIScene life cycle is required"',
       'eventMessage CONTAINS "`UIScene` lifecycle will soon be required"',
       'eventMessage CONTAINS "This process does not adopt UIScene lifecycle."',
     ]),
@@ -824,7 +825,17 @@ Future<Process?> launchSystemLogTool(IOSSimulator device) async {
 }
 
 class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
-  _IOSSimulatorLogReader(this.device, IOSApp? app) : _appName = app?.name?.replaceAll('.app', '');
+  _IOSSimulatorLogReader(this.device, IOSApp? app) : _appName = app?.name?.replaceAll('.app', '') {
+    final uisceneCrashInterceptor = LogInterceptor(
+      identifier: 'uiscene_crash',
+      pattern: RegExp(r'UIScene life\s?cycle is required'),
+      action: () {
+        throwToolExit(kUISceneMigrationRequiredError);
+      },
+      excludeFromStream: false,
+    );
+    addLogInterceptor(uisceneCrashInterceptor);
+  }
 
   final IOSSimulator device;
 

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -15,6 +18,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwarder.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/application_package.dart';
+import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
@@ -485,7 +489,9 @@ void main() {
             'eventType = logEvent AND '
             'processImagePath ENDSWITH "My Super Awesome App" AND '
             '(senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" OR processImageUUID == senderImageUUID '
-            'OR eventMessage CONTAINS "`UIScene` lifecycle will soon be required" OR eventMessage CONTAINS "This process does not adopt UIScene lifecycle.") AND '
+            'OR eventMessage CONTAINS "UIScene life cycle is required" '
+            'OR eventMessage CONTAINS "`UIScene` lifecycle will soon be required" '
+            'OR eventMessage CONTAINS "This process does not adopt UIScene lifecycle.") AND '
             'NOT(eventMessage CONTAINS ": could not find icon for representation -> com.apple.") AND '
             'NOT(eventMessage BEGINSWITH "assertion failed: ") AND '
             'NOT(eventMessage CONTAINS " libxpc.dylib ")';
@@ -528,7 +534,9 @@ void main() {
         const expectedPredicate =
             'eventType = logEvent AND '
             '(senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" OR processImageUUID == senderImageUUID '
-            'OR eventMessage CONTAINS "`UIScene` lifecycle will soon be required" OR eventMessage CONTAINS "This process does not adopt UIScene lifecycle.") AND '
+            'OR eventMessage CONTAINS "UIScene life cycle is required" '
+            'OR eventMessage CONTAINS "`UIScene` lifecycle will soon be required" '
+            'OR eventMessage CONTAINS "This process does not adopt UIScene lifecycle.") AND '
             'NOT(eventMessage CONTAINS ": could not find icon for representation -> com.apple.") AND '
             'NOT(eventMessage BEGINSWITH "assertion failed: ") AND '
             'NOT(eventMessage CONTAINS " libxpc.dylib ")';
@@ -743,9 +751,11 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           const logPredicate =
               'eventType = logEvent AND processImagePath ENDSWITH "My Super Awesome App" '
               'AND (senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" '
-              'OR processImageUUID == senderImageUUID OR eventMessage CONTAINS "`UIScene` lifecycle'
-              ' will soon be required" OR eventMessage CONTAINS "This process does not adopt UIScene '
-              'lifecycle.") AND NOT(eventMessage CONTAINS ": could not find icon '
+              'OR processImageUUID == senderImageUUID '
+              'OR eventMessage CONTAINS "UIScene life cycle is required" '
+              'OR eventMessage CONTAINS "`UIScene` lifecycle will soon be required" '
+              'OR eventMessage CONTAINS "This process does not adopt UIScene lifecycle.") '
+              'AND NOT(eventMessage CONTAINS ": could not find icon '
               'for representation -> com.apple.") AND NOT(eventMessage BEGINSWITH "assertion failed: ") '
               'AND NOT(eventMessage CONTAINS " libxpc.dylib ")';
           fakeProcessManager.addCommand(
@@ -805,14 +815,87 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
       );
 
       testUsingContext(
+        'log reader throws ToolExit when UIScene error message is detected',
+        () async {
+          const logPredicate =
+              'eventType = logEvent AND processImagePath ENDSWITH "My Super Awesome App" '
+              'AND (senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" '
+              'OR processImageUUID == senderImageUUID '
+              'OR eventMessage CONTAINS "UIScene life cycle is required" '
+              'OR eventMessage CONTAINS "`UIScene` lifecycle will soon be required" '
+              'OR eventMessage CONTAINS "This process does not adopt UIScene lifecycle.") '
+              'AND NOT(eventMessage CONTAINS ": could not find icon '
+              'for representation -> com.apple.") AND NOT(eventMessage BEGINSWITH "assertion failed: ") '
+              'AND NOT(eventMessage CONTAINS " libxpc.dylib ")';
+          fakeProcessManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'xcrun',
+                'simctl',
+                'spawn',
+                '123456',
+                'log',
+                'stream',
+                '--style',
+                'json',
+                '--predicate',
+                logPredicate,
+              ],
+              stdout:
+                  '},{\n'
+                  '  "traceID" : 37579774151491588,\n'
+                  '  "eventMessage" : "UIScene life cycle is required",\n'
+                  '  "eventType" : "logEvent"\n'
+                  '},{\n',
+            ),
+          );
+
+          final device = IOSSimulator(
+            '123456',
+            name: 'iPhone 11',
+            simulatorCategory: 'iOS 11.0',
+            simControl: simControl,
+            logger: logger,
+          );
+          final DeviceLogReader logReader = device.getLogReader(
+            app: await BuildableIOSApp.fromProject(mockIosProject, null),
+          );
+
+          final completer = Completer<void>();
+          runZonedGuarded<void>(
+            () {
+              logReader.logLines.listen((_) {});
+            },
+            (Object error, StackTrace stack) {
+              expect(error, isA<ToolExit>());
+              expect(error.toString(), contains(kUISceneMigrationRequiredError));
+              completer.complete();
+            },
+          );
+
+          await completer.future;
+          expect(fakeProcessManager, hasNoRemainingExpectations);
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => fakeProcessManager,
+          FileSystem: () => fileSystem,
+          Platform: () => osx,
+          Xcode: () => xcode,
+          Logger: () => logger,
+        },
+      );
+
+      testUsingContext(
         'log reader handles bad output',
         () async {
           const logPredicate =
               'eventType = logEvent AND processImagePath ENDSWITH "My Super Awesome App" '
               'AND (senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" '
-              'OR processImageUUID == senderImageUUID OR eventMessage CONTAINS "`UIScene` lifecycle '
-              'will soon be required" OR eventMessage CONTAINS "This process does not adopt UIScene '
-              'lifecycle.") AND NOT(eventMessage CONTAINS ": could not find icon '
+              'OR processImageUUID == senderImageUUID '
+              'OR eventMessage CONTAINS "UIScene life cycle is required" '
+              'OR eventMessage CONTAINS "`UIScene` lifecycle will soon be required" '
+              'OR eventMessage CONTAINS "This process does not adopt UIScene lifecycle.") '
+              'AND NOT(eventMessage CONTAINS ": could not find icon '
               'for representation -> com.apple.") AND NOT(eventMessage BEGINSWITH "assertion failed: ") '
               'AND NOT(eventMessage CONTAINS " libxpc.dylib ")';
           fakeProcessManager.addCommand(


### PR DESCRIPTION
When an unmigrated iOS app runs on iOS 27+, it immediately crashes on launch because the `UIScene` lifecycle is required.

Part II of https://github.com/flutter/flutter/pull/188556

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

Fixes https://github.com/flutter/flutter/issues/187758

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
