### PR TITLE
[Impeller] Fix potential overflow when allocating buffers at the next power of two size

### DIFF
--- a/engine/src/flutter/impeller/base/BUILD.gn
+++ b/engine/src/flutter/impeller/base/BUILD.gn
@@ -40,6 +40,7 @@ impeller_component("base_unittests") {
   testonly = true
   sources = [
     "allocation_size_unittests.cc",
+    "allocation_unittests.cc",
     "base_unittests.cc",
   ]
   deps = [

--- a/engine/src/flutter/impeller/base/BUILD.gn
+++ b/engine/src/flutter/impeller/base/BUILD.gn
@@ -32,6 +32,8 @@ impeller_component("base") {
   ]
 
   deps = [ "//flutter/fml" ]
+
+  public_deps = [ "//third_party/abseil-cpp/absl/status:statusor" ]
 }
 
 impeller_component("base_unittests") {

--- a/engine/src/flutter/impeller/base/allocation.cc
+++ b/engine/src/flutter/impeller/base/allocation.cc
@@ -40,7 +40,7 @@ bool Allocation::Truncate(Bytes length, bool npot) {
 }
 
 absl::StatusOr<uint64_t> Allocation::NextPowerOfTwoSize(uint64_t x) {
-  if (x > static_cast<uint64_t>(1) << 63) {
+  if (x > (static_cast<uint64_t>(1) << 63)) {
     return absl::InvalidArgumentError("Out of range");
   }
   if (x == 0) {

--- a/engine/src/flutter/impeller/base/allocation.cc
+++ b/engine/src/flutter/impeller/base/allocation.cc
@@ -34,11 +34,15 @@ bool Allocation::Truncate(Bytes length, bool npot) {
   if (!reserved) {
     return false;
   }
+  FML_CHECK(reserved_ >= length);
   length_ = length;
   return true;
 }
 
-uint32_t Allocation::NextPowerOfTwoSize(uint32_t x) {
+absl::StatusOr<uint64_t> Allocation::NextPowerOfTwoSize(uint64_t x) {
+  if (x > static_cast<uint64_t>(1) << 63) {
+    return absl::InvalidArgumentError("Out of range");
+  }
   if (x == 0) {
     return 1;
   }
@@ -50,6 +54,7 @@ uint32_t Allocation::NextPowerOfTwoSize(uint32_t x) {
   x |= x >> 4;
   x |= x >> 8;
   x |= x >> 16;
+  x |= x >> 32;
 
   return x + 1;
 }
@@ -57,7 +62,12 @@ uint32_t Allocation::NextPowerOfTwoSize(uint32_t x) {
 bool Allocation::ReserveNPOT(Bytes reserved) {
   // Reserve at least one page of data.
   reserved = std::max(Bytes{4096u}, reserved);
-  return Reserve(Bytes{NextPowerOfTwoSize(reserved.GetByteSize())});
+  absl::StatusOr<uint64_t> npot_size =
+      NextPowerOfTwoSize(reserved.GetByteSize());
+  if (!npot_size.ok()) {
+    return false;
+  }
+  return Reserve(Bytes{*npot_size});
 }
 
 bool Allocation::Reserve(Bytes reserved) {

--- a/engine/src/flutter/impeller/base/allocation.h
+++ b/engine/src/flutter/impeller/base/allocation.h
@@ -79,7 +79,7 @@ class Allocation {
   ///
   /// @param[in]  x     The size.
   ///
-  /// @return     The next power of two of x.
+  /// @return     The smallest power of two that is greater than or equal to x.
   ///
   static absl::StatusOr<uint64_t> NextPowerOfTwoSize(uint64_t x);
 

--- a/engine/src/flutter/impeller/base/allocation.h
+++ b/engine/src/flutter/impeller/base/allocation.h
@@ -10,6 +10,7 @@
 
 #include "flutter/fml/mapping.h"
 #include "impeller/base/allocation_size.h"
+#include "third_party/abseil-cpp/absl/status/statusor.h"
 
 namespace impeller {
 
@@ -80,7 +81,7 @@ class Allocation {
   ///
   /// @return     The next power of two of x.
   ///
-  static uint32_t NextPowerOfTwoSize(uint32_t x);
+  static absl::StatusOr<uint64_t> NextPowerOfTwoSize(uint64_t x);
 
  private:
   uint8_t* buffer_ = nullptr;

--- a/engine/src/flutter/impeller/base/allocation_size.h
+++ b/engine/src/flutter/impeller/base/allocation_size.h
@@ -126,7 +126,15 @@ class AllocationSize {
   uint64_t bytes_ = {};
 };
 
-using Bytes = AllocationSize<1u>;
+class Bytes : public AllocationSize<1u> {
+ public:
+  constexpr Bytes() = default;
+
+  // Do not do arithmetic when constructing Bytes in order to avoid overflow
+  // or precision loss.
+  explicit constexpr Bytes(uint64_t size)
+      : AllocationSize(size, FromBytesTag::kFromBytes) {}
+};
 
 using KiloBytes = AllocationSize<1'000u>;
 using MegaBytes = AllocationSize<1'000u * 1'000u>;

--- a/engine/src/flutter/impeller/base/allocation_size.h
+++ b/engine/src/flutter/impeller/base/allocation_size.h
@@ -134,6 +134,10 @@ class Bytes : public AllocationSize<1u> {
   // or precision loss.
   explicit constexpr Bytes(uint64_t size)
       : AllocationSize(size, FromBytesTag::kFromBytes) {}
+
+  // Allow implicit conversion from the base class to support arithmetic
+  // operations.
+  constexpr Bytes(AllocationSize<1u> size) : AllocationSize(size) {}
 };
 
 using KiloBytes = AllocationSize<1'000u>;

--- a/engine/src/flutter/impeller/base/allocation_size.h
+++ b/engine/src/flutter/impeller/base/allocation_size.h
@@ -137,7 +137,7 @@ class Bytes : public AllocationSize<1u> {
 
   // Allow implicit conversion from the base class to support arithmetic
   // operations.
-  constexpr Bytes(AllocationSize<1u> size) : AllocationSize(size) {}
+  explicit constexpr Bytes(AllocationSize<1u> size) : AllocationSize(size) {}
 };
 
 using KiloBytes = AllocationSize<1'000u>;

--- a/engine/src/flutter/impeller/base/allocation_size_unittests.cc
+++ b/engine/src/flutter/impeller/base/allocation_size_unittests.cc
@@ -109,16 +109,16 @@ TEST(AllocationSizeTest, CanPerformSimpleArithmetic) {
 
 TEST(AllocationSizeTest, CanConstructWithArith) {
   {
-    Bytes a(1u);
-    ASSERT_EQ(a.GetByteSize(), 1u);
+    KiloBytes a(1u);
+    ASSERT_EQ(a.GetByteSize(), 1000u);
   }
   {
-    Bytes a(1.5);
-    ASSERT_EQ(a.GetByteSize(), 2u);
+    KiloBytes a(1.5);
+    ASSERT_EQ(a.GetByteSize(), 2000u);
   }
   {
-    Bytes a(1.5f);
-    ASSERT_EQ(a.GetByteSize(), 2u);
+    KiloBytes a(1.5f);
+    ASSERT_EQ(a.GetByteSize(), 2000u);
   }
 }
 

--- a/engine/src/flutter/impeller/base/allocation_unittests.cc
+++ b/engine/src/flutter/impeller/base/allocation_unittests.cc
@@ -31,6 +31,11 @@ TEST(AllocationTest, ReserveNPOTPotentialOverflow) {
   // Try allocations with sizes around the maximum 32-bit value.
   allocate_and_write((1ULL << 32) + 1);
   allocate_and_write((1ULL << 32) - 1);
+
+  // Test that an allocation size that is out of range fails immediately.
+  Allocation max_allocation;
+  EXPECT_FALSE(
+      max_allocation.Truncate(Bytes{std::numeric_limits<uint64_t>::max()}));
 }
 
 TEST(AllocationTest, NextPowerOfTwoSize) {

--- a/engine/src/flutter/impeller/base/allocation_unittests.cc
+++ b/engine/src/flutter/impeller/base/allocation_unittests.cc
@@ -1,0 +1,49 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <cstring>
+#include <limits>
+
+#include "flutter/testing/testing.h"
+#include "impeller/base/allocation.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(AllocationTest, ReserveNPOTPotentialOverflow) {
+  std::vector<uint8_t> data(64, 0xff);
+
+  auto allocate_and_write = [&](uint64_t size) {
+    Allocation allocation;
+
+    // Allocate a buffer with the size rounded up to the next power of two.
+    if (!allocation.Truncate(Bytes{size})) {
+      // Not enough memory available.
+      return;
+    }
+
+    // If the allocation succeeded, then check that writes are safe.
+    memcpy(allocation.GetBuffer(), data.data(), data.size());
+    EXPECT_EQ(memcmp(allocation.GetBuffer(), data.data(), data.size()), 0);
+  };
+
+  // Try allocations with sizes around the maximum 32-bit value.
+  allocate_and_write((1ULL << 32) + 1);
+  allocate_and_write((1ULL << 32) - 1);
+}
+
+TEST(AllocationTest, NextPowerOfTwoSize) {
+  EXPECT_EQ(*Allocation::NextPowerOfTwoSize((1ULL << 32) - 1), 1ULL << 32);
+  EXPECT_EQ(*Allocation::NextPowerOfTwoSize((1ULL << 32) + 1), 1ULL << 33);
+  EXPECT_EQ(*Allocation::NextPowerOfTwoSize(1ULL << 63), 1ULL << 63);
+  EXPECT_EQ(Allocation::NextPowerOfTwoSize((1ULL << 63) + 1).status().code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(Allocation::NextPowerOfTwoSize(std::numeric_limits<uint64_t>::max())
+                .status()
+                .code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/engine/src/flutter/impeller/base/base_unittests.cc
+++ b/engine/src/flutter/impeller/base/base_unittests.cc
@@ -2,11 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <cstring>
-#include <limits>
-
 #include "flutter/testing/testing.h"
-#include "impeller/base/allocation.h"
 #include "impeller/base/mask.h"
 #include "impeller/base/promise.h"
 #include "impeller/base/strings.h"
@@ -442,40 +438,6 @@ TEST(BaseTest, CanUseTypedMasks) {
     ASSERT_FALSE(x > m);
     ASSERT_FALSE(x >= m);
   }
-}
-
-TEST(AllocationTest, ReserveNPOTPotentialOverflow) {
-  std::vector<uint8_t> data(64, 0xff);
-
-  auto allocate_and_write = [&](uint64_t size) {
-    Allocation allocation;
-
-    // Allocate a buffer with the size rounded up to the next power of two.
-    if (!allocation.Truncate(Bytes{size})) {
-      // Not enough memory available.
-      return;
-    }
-
-    // If the allocation succeeded, then check that writes are safe.
-    memcpy(allocation.GetBuffer(), data.data(), data.size());
-    EXPECT_EQ(memcmp(allocation.GetBuffer(), data.data(), data.size()), 0);
-  };
-
-  // Try allocations with sizes around the maximum 32-bit value.
-  allocate_and_write((1ULL << 32) + 1);
-  allocate_and_write((1ULL << 32) - 1);
-}
-
-TEST(AllocationTest, NextPowerOfTwoSize) {
-  EXPECT_EQ(*Allocation::NextPowerOfTwoSize((1ULL << 32) - 1), 1ULL << 32);
-  EXPECT_EQ(*Allocation::NextPowerOfTwoSize((1ULL << 32) + 1), 1ULL << 33);
-  EXPECT_EQ(*Allocation::NextPowerOfTwoSize(1ULL << 63), 1ULL << 63);
-  EXPECT_EQ(Allocation::NextPowerOfTwoSize((1ULL << 63) + 1).status().code(),
-            absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(Allocation::NextPowerOfTwoSize(std::numeric_limits<uint64_t>::max())
-                .status()
-                .code(),
-            absl::StatusCode::kInvalidArgument);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/base/base_unittests.cc
+++ b/engine/src/flutter/impeller/base/base_unittests.cc
@@ -2,7 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <cstring>
+#include <limits>
+
 #include "flutter/testing/testing.h"
+#include "impeller/base/allocation.h"
 #include "impeller/base/mask.h"
 #include "impeller/base/promise.h"
 #include "impeller/base/strings.h"
@@ -438,6 +442,40 @@ TEST(BaseTest, CanUseTypedMasks) {
     ASSERT_FALSE(x > m);
     ASSERT_FALSE(x >= m);
   }
+}
+
+TEST(AllocationTest, ReserveNPOTPotentialOverflow) {
+  std::vector<uint8_t> data(64, 0xff);
+
+  auto allocate_and_write = [&](uint64_t size) {
+    Allocation allocation;
+
+    // Allocate a buffer with the size rounded up to the next power of two.
+    if (!allocation.Truncate(Bytes{size})) {
+      // Not enough memory available.
+      return;
+    }
+
+    // If the allocation succeeded, then check that writes are safe.
+    memcpy(allocation.GetBuffer(), data.data(), data.size());
+    EXPECT_EQ(memcmp(allocation.GetBuffer(), data.data(), data.size()), 0);
+  };
+
+  // Try allocations with sizes around the maximum 32-bit value.
+  allocate_and_write((1ULL << 32) + 1);
+  allocate_and_write((1ULL << 32) - 1);
+}
+
+TEST(AllocationTest, NextPowerOfTwoSize) {
+  EXPECT_EQ(*Allocation::NextPowerOfTwoSize((1ULL << 32) - 1), 1ULL << 32);
+  EXPECT_EQ(*Allocation::NextPowerOfTwoSize((1ULL << 32) + 1), 1ULL << 33);
+  EXPECT_EQ(*Allocation::NextPowerOfTwoSize(1ULL << 63), 1ULL << 63);
+  EXPECT_EQ(Allocation::NextPowerOfTwoSize((1ULL << 63) + 1).status().code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(Allocation::NextPowerOfTwoSize(std::numeric_limits<uint64_t>::max())
+                .status()
+                .code(),
+            absl::StatusCode::kInvalidArgument);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/playground/image/decompressed_image.cc
+++ b/engine/src/flutter/impeller/playground/image/decompressed_image.cc
@@ -75,7 +75,7 @@ DecompressedImage DecompressedImage::ConvertToRGBA() const {
   }
 
   auto rgba_allocation = std::make_shared<Allocation>();
-  if (!rgba_allocation->Truncate(Bytes{size_.Area() * 4u}, false)) {
+  if (!rgba_allocation->Truncate(Bytes(size_.Area() * 4u), false)) {
     return {};
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -441,7 +441,7 @@ std::string ProcTableGLES::GetProgramInfoLogString(GLuint program) const {
 
   length = std::min<GLint>(length, 1024);
   Allocation allocation;
-  if (!allocation.Truncate(Bytes{length}, false)) {
+  if (!allocation.Truncate(Bytes(length), false)) {
     return "";
   }
   GetProgramInfoLog(program,  // program

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -618,7 +618,7 @@ Bytes AllocatorVK::DebugGetHeapUsage() const {
     const VmaBudget& budget = budgets[i];
     total_usage += budget.usage;
   }
-  return Bytes{static_cast<double>(total_usage)};
+  return Bytes{total_usage};
 }
 
 void AllocatorVK::DebugTraceMemoryStatistics() const {


### PR DESCRIPTION
Allocation::NextPowerOfTwoSize will now use 64-bit integers and will check for inputs that are out of range.

See b/521829269