### PR TITLE
ci: extract wait-for-engine-build logic into a reusable composite action

### DIFF
--- a/.github/actions/wait-for-engine-build/action.yml
+++ b/.github/actions/wait-for-engine-build/action.yml
@@ -18,12 +18,19 @@ runs:
     - name: Check Engine Changes
       id: check_engine
       shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        PUSH_BEFORE_SHA: ${{ github.event.before }}
       run: |
         # 1. Determine local base tracking SHA
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
-          BASE_REF="${{ github.event.pull_request.base.sha }}"
-        elif [ "${{ github.event_name }}" = "merge_group" ]; then
-          BASE_REF="${{ github.event.merge_group.base_sha }}"
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          BASE_REF="$PR_BASE_SHA"
+        elif [ "$EVENT_NAME" = "merge_group" ]; then
+          BASE_REF="$MERGE_GROUP_BASE_SHA"
+        elif [ "$EVENT_NAME" = "push" ] && [ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+          BASE_REF="$PUSH_BEFORE_SHA"
         else
           BASE_REF="origin/master"
         fi
@@ -36,7 +43,7 @@ runs:
         echo "$CHANGED_FILES"
 
         # 3. Check if any file matches engine pattern using the helper script:
-        if [ "$(echo "$CHANGED_FILES" | .github/scripts/did_engine_change.sh)" = "true" ]; then
+        if [ "$(printf '%s\n' "$CHANGED_FILES" | .github/scripts/did_engine_change.sh)" = "true" ]; then
           echo "Engine file changed - forced to wait for check-name: '${{ inputs.check-name }}', check-regexp: '${{ inputs.check-regexp }}'"
           echo "changed=true" >> "$GITHUB_OUTPUT"
         else

--- a/.github/actions/wait-for-engine-build/action.yml
+++ b/.github/actions/wait-for-engine-build/action.yml
@@ -1,0 +1,66 @@
+name: 'Wait for Engine Build'
+description: 'Wait for an engine build and redirect engine.version if engine files changed'
+inputs:
+  github-token:
+    description: 'GitHub token'
+    required: true
+  check-name:
+    description: 'The name of the check to wait on'
+    required: false
+    default: 'Linux linux_host_engine'
+  check-regexp:
+    description: 'Filter checks using regex pattern'
+    required: false
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - name: Check Engine Changes
+      id: check_engine
+      shell: bash
+      run: |
+        # 1. Determine local base tracking SHA
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          BASE_REF="${{ github.event.pull_request.base.sha }}"
+        elif [ "${{ github.event_name }}" = "merge_group" ]; then
+          BASE_REF="${{ github.event.merge_group.base_sha }}"
+        else
+          BASE_REF="origin/master"
+        fi
+
+        echo "Comparing against base SHA: $BASE_REF"
+
+        # 2. Get the changed files using the helper script
+        CHANGED_FILES=$(.github/scripts/git_files_changed.sh "$BASE_REF")
+        echo "Changed files in this branch:"
+        echo "$CHANGED_FILES"
+
+        # 3. Check if any file matches engine pattern using the helper script:
+        if [ "$(echo "$CHANGED_FILES" | .github/scripts/did_engine_change.sh)" = "true" ]; then
+          echo "Engine file changed - forced to wait for check-name: '${{ inputs.check-name }}', check-regexp: '${{ inputs.check-regexp }}'"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Note: lewagon/wait-on-check-action has a limit of 100 checks (pagination).
+    # Consider writing an API endpoint on flutter/cocoon that returns the status of an array of checks.
+    - name: Wait for test check-in
+      if: steps.check_engine.outputs.changed == 'true' && env.ACT != 'true'
+      uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        check-name: ${{ inputs.check-name }}
+        check-regexp: ${{ inputs.check-regexp }}
+        repo-token: ${{ inputs.github-token }}
+        wait-interval: 30 # seconds
+        checks-discovery-timeout: 3600 # Wait up to 1 hour for LUCI to register the check
+        allowed-conclusions: success,neutral
+        verbose: false
+
+    - name: Redirect engine.version
+      if: steps.check_engine.outputs.changed == 'true' && github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        echo "FLUTTER_REALM=flutter_archives_v2" >> $GITHUB_ENV
+        echo "FLUTTER_PREBUILT_ENGINE_VERSION=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV

--- a/.github/workflows/tree-analyze.yml
+++ b/.github/workflows/tree-analyze.yml
@@ -26,50 +26,10 @@ jobs:
         if: env.ACT
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Check Engine Changes
-        id: check_engine
-        run: |
-          # 1. Determine local base tracking SHA
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF="${{ github.event.pull_request.base.sha }}"
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            BASE_REF="${{ github.event.merge_group.base_sha }}"
-          else
-            BASE_REF="origin/master"
-          fi
-
-          echo "Comparing against base SHA: $BASE_REF"
-
-          # 2. Get the changed files using the helper script
-          CHANGED_FILES=$(.github/scripts/git_files_changed.sh "$BASE_REF")
-          echo "Changed files in this branch:"
-          echo "$CHANGED_FILES"
-
-          # 3. Check if any file matches engine pattern using the helper script:
-          if [ "$(echo "$CHANGED_FILES" | .github/scripts/did_engine_change.sh)" = "true" ]; then
-            echo "Engine file changed - forced to wait for Linux linux_host_engine"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Wait for test check-in
-        if: steps.check_engine.outputs.changed == 'true' && env.ACT != 'true'
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800
+      - name: Wait for Engine Build
+        uses: ./.github/actions/wait-for-engine-build
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          check-name: 'Linux linux_host_engine'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30 # seconds
-          checks-discovery-timeout: 3600 # Wait up to 1 hour for LUCI to register the check
-          allowed-conclusions: success,neutral
-          verbose: false
-
-      - name: Redirect engine.version
-        if: steps.check_engine.outputs.changed == 'true' && github.event_name == 'pull_request'
-        run: |
-          echo "FLUTTER_REALM=flutter_archives_v2" >> $GITHUB_ENV
-          echo "FLUTTER_PREBUILT_ENGINE_VERSION=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: ./.github/actions/composite-flutter-setup
 


### PR DESCRIPTION
Extracted the reusable bits of waiting for engine presubmits from `tree-analyze.yml` into a new reusable composite GitHub Action at `.github/actions/wait-for-engine-build`.

further improvements: move away from `lewagon/wait-on-check-action` by creating an API endpoint on Cocoon that blends

fixes: #188663
