### PR TITLE
In AndroidImageGenerator, check that the destination pixel buffer has sufficient capacity for the decoded data

### DIFF
--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -44,6 +44,7 @@ executable("flutter_shell_native_unittests") {
   testonly = true
   sources = [
     "android_context_gl_impeller_unittests.cc",
+    "android_image_generator_unittests.cc",
     "android_shell_holder_unittests.cc",
     "apk_asset_provider_unittests.cc",
     "flutter_shell_native_unittests.cc",

--- a/engine/src/flutter/shell/platform/android/android_image_generator.cc
+++ b/engine/src/flutter/shell/platform/android/android_image_generator.cc
@@ -79,6 +79,9 @@ bool AndroidImageGenerator::GetPixels(const SkImageInfo& info,
   // API level 30+ once it's updated to do symbol lookups and not get
   // preprocessed out in Skia. This will allow for avoiding this copy in
   // cases where the result image doesn't need to be resized.
+  if (software_decoded_data_->size() > info.computeByteSize(row_bytes)) {
+    return false;
+  }
   memcpy(pixels, software_decoded_data_->data(),
          software_decoded_data_->size());
   return true;
@@ -186,6 +189,18 @@ std::shared_ptr<ImageGenerator> AndroidImageGenerator::MakeFromData(
   }
 
   return nullptr;
+}
+
+std::shared_ptr<AndroidImageGenerator> AndroidImageGenerator::MakeForTesting(
+    const SkImageInfo& header_info,
+    sk_sp<SkData> decoded_data) {
+  std::shared_ptr<AndroidImageGenerator> generator(
+      new AndroidImageGenerator(SkData::MakeEmpty()));
+  generator->image_info_ = header_info;
+  generator->software_decoded_data_ = std::move(decoded_data);
+  generator->header_decoded_latch_.Signal();
+  generator->fully_decoded_latch_.Signal();
+  return generator;
 }
 
 void AndroidImageGenerator::NativeImageHeaderCallback(JNIEnv* env,

--- a/engine/src/flutter/shell/platform/android/android_image_generator.cc
+++ b/engine/src/flutter/shell/platform/android/android_image_generator.cc
@@ -80,7 +80,7 @@ bool AndroidImageGenerator::GetPixels(const SkImageInfo& info,
   // preprocessed out in Skia. This will allow for avoiding this copy in
   // cases where the result image doesn't need to be resized.
   size_t pixels_size = info.computeByteSize(row_bytes);
-  if (pixels_size < software_decoded_data_->size() || pixels_size == SIZE_MAX) {
+  if (pixels_size == SIZE_MAX || pixels_size < software_decoded_data_->size()) {
     return false;
   }
   memcpy(pixels, software_decoded_data_->data(),

--- a/engine/src/flutter/shell/platform/android/android_image_generator.cc
+++ b/engine/src/flutter/shell/platform/android/android_image_generator.cc
@@ -79,7 +79,8 @@ bool AndroidImageGenerator::GetPixels(const SkImageInfo& info,
   // API level 30+ once it's updated to do symbol lookups and not get
   // preprocessed out in Skia. This will allow for avoiding this copy in
   // cases where the result image doesn't need to be resized.
-  if (software_decoded_data_->size() > info.computeByteSize(row_bytes)) {
+  size_t pixels_size = info.computeByteSize(row_bytes);
+  if (pixels_size < software_decoded_data_->size() || pixels_size == SIZE_MAX) {
     return false;
   }
   memcpy(pixels, software_decoded_data_->data(),

--- a/engine/src/flutter/shell/platform/android/android_image_generator.h
+++ b/engine/src/flutter/shell/platform/android/android_image_generator.h
@@ -14,6 +14,10 @@
 
 namespace flutter {
 
+namespace testing {
+FML_TEST_CLASS(AndroidImageGenerator, HeaderDecodeDimensionMismatch);
+}
+
 class AndroidImageGenerator : public ImageGenerator {
  private:
   explicit AndroidImageGenerator(sk_sp<SkData> buffer);
@@ -59,6 +63,9 @@ class AndroidImageGenerator : public ImageGenerator {
                                         int height);
 
  private:
+  FML_FRIEND_TEST(testing::AndroidImageGenerator,
+                  HeaderDecodeDimensionMismatch);
+
   sk_sp<SkData> data_;
   sk_sp<SkData> software_decoded_data_;
 
@@ -70,6 +77,10 @@ class AndroidImageGenerator : public ImageGenerator {
 
   /// Blocks until the image has been fully decoded.
   fml::ManualResetWaitableEvent fully_decoded_latch_;
+
+  static std::shared_ptr<AndroidImageGenerator> MakeForTesting(
+      const SkImageInfo& header_info,
+      sk_sp<SkData> decoded_data);
 
   void DoDecodeImage();
 

--- a/engine/src/flutter/shell/platform/android/android_image_generator_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/android_image_generator_unittests.cc
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/android/android_image_generator.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+TEST(AndroidImageGenerator, HeaderDecodeDimensionMismatch) {
+  constexpr int kHeaderW = 2;
+  constexpr int kHeaderH = 2;
+  SkImageInfo header_info = SkImageInfo::Make(
+      kHeaderW, kHeaderH, kRGBA_8888_SkColorType, kPremul_SkAlphaType);
+
+  constexpr int kDecodedW = 64;
+  constexpr int kDecodedH = 64;
+  sk_sp<SkData> decoded =
+      SkData::MakeZeroInitialized(kDecodedW * kDecodedH * sizeof(uint32_t));
+
+  // Create an AndroidImageGenerator where the dimensions in the header
+  // ImageInfo do not match the dimensions of the decoded data.
+  auto gen =
+      AndroidImageGenerator::MakeForTesting(header_info, std::move(decoded));
+
+  ASSERT_EQ(gen->GetInfo().dimensions(), SkISize(kHeaderW, kHeaderH));
+
+  // AndroidImageGenerator should detect that the buffer size derived from the
+  // SkImageInfo is insufficent for the decoded data.
+  sk_sp<SkImage> image = gen->GetImage();
+  EXPECT_EQ(image, nullptr);
+}
+
+}  // namespace testing
+}  // namespace flutter


### PR DESCRIPTION
See b/521831466