### PR TITLE
[Linux] Fix FlCompositorOpenGL.pixels comment

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -28,7 +28,7 @@ struct _FlCompositorOpenGL {
   // Last rendered frame.
   FlFramebuffer* framebuffer;
 
-  // Last rendered frame pixels (only set if shareable is TRUE).
+  // Last rendered frame pixels (only set if shareable is FALSE).
   uint8_t* pixels;
 
   // Shader program used to composite layers.


### PR DESCRIPTION
The pixels buffer is only populated when shareable is FALSE, not TRUE.
