### PR TITLE
Replace All Flutter Tooling Usages of Internal Gradle APIs

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -261,7 +261,7 @@ class FlutterPlugin @Inject constructor(
     }
 
     private fun getExecutableNameForPlatform(baseExecutableName: String): String {
-        val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+        val isWindows = System.getProperty("os.name")?.startsWith("Windows", ignoreCase = true) == true
         return if (isWindows) "$baseExecutableName.bat" else baseExecutableName
     }
 

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -26,7 +26,6 @@ import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.Directory
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.process.ExecOperations
 import java.io.File
@@ -259,8 +258,10 @@ class FlutterPlugin : Plugin<Project> {
         )
     }
 
-    private fun getExecutableNameForPlatform(baseExecutableName: String): String =
-        if (OperatingSystem.current().isWindows) "$baseExecutableName.bat" else baseExecutableName
+    private fun getExecutableNameForPlatform(baseExecutableName: String): String {
+        val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+        return if (isWindows) "$baseExecutableName.bat" else baseExecutableName
+    }
 
     private fun resolveFlutterSdkProperty(defaultValue: String?): String? {
         val propertyName = "flutter.sdk"

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -26,14 +26,16 @@ import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.Directory
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.process.ExecOperations
 import java.io.File
+import javax.inject.Inject
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 import java.util.Properties
 
-class FlutterPlugin : Plugin<Project> {
+class FlutterPlugin @Inject constructor(
+    private val execOperations: ExecOperations
+) : Plugin<Project> {
     private var project: Project? = null
     private var flutterRoot: File? = null
     private var flutterExecutable: File? = null
@@ -281,8 +283,7 @@ class FlutterPlugin : Plugin<Project> {
                 rootProject.subprojects.forEach { subproject ->
                     val gradlew: String =
                         getExecutableNameForPlatform("${rootProject.projectDir}/gradlew")
-                    val execOps = rootProject.serviceOf<ExecOperations>()
-                    execOps.exec {
+                    execOperations.exec {
                         workingDir(rootProject.projectDir)
                         executable(gradlew)
                         args(":${subproject.name}:dependencies", "--write-locks")

--- a/packages/flutter_tools/gradle/src/main/kotlin/tasks/BaseFlutterTask.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/tasks/BaseFlutterTask.kt
@@ -10,6 +10,8 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFiles
 import java.io.File
+import javax.inject.Inject
+import org.gradle.process.ExecOperations
 
 // IMPORTANT: Do not add logic to the methods in this class directly,
 // instead add logic to [BaseFlutterTaskHelper].
@@ -19,6 +21,9 @@ import java.io.File
  * so this class delegates all logic to [BaseFlutterTaskHelper].
  */
 open class BaseFlutterTask : DefaultTask() {
+    @get:Inject
+    open val execOperations: ExecOperations
+        get() = throw UnsupportedOperationException()
     @Internal
     var flutterRoot: File? = null
 

--- a/packages/flutter_tools/gradle/src/main/kotlin/tasks/BaseFlutterTaskHelper.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/tasks/BaseFlutterTaskHelper.kt
@@ -9,8 +9,8 @@ import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.OutputFiles
-import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.process.ExecOperations
 import org.gradle.process.ExecSpec
 
@@ -155,7 +155,7 @@ object BaseFlutterTaskHelper {
     fun buildBundle(baseFlutterTask: BaseFlutterTask) {
         checkPreConditions(baseFlutterTask)
         baseFlutterTask.logging.captureStandardError(LogLevel.ERROR)
-        val execOps = baseFlutterTask.project.serviceOf<ExecOperations>()
+        val execOps = baseFlutterTask.execOperations
         execOps.exec(createExecSpecActionFromTask(baseFlutterTask = baseFlutterTask))
     }
 }

--- a/packages/flutter_tools/gradle/src/test/kotlin/DeeplinkTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/DeeplinkTest.kt
@@ -4,9 +4,9 @@
 
 package com.flutter.gradle
 
-import org.gradle.internal.impldep.org.junit.Assert.assertThrows
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -41,7 +41,7 @@ class DeeplinkTest {
         val deeplink1 = Deeplink("scheme1", "host1", "path1", IntentFilterCheck())
         val deeplink2 = null
 
-        assertThrows(NullPointerException::class.java) { deeplink1.equals(deeplink2) }
+        assertFailsWith<NullPointerException> { deeplink1.equals(deeplink2) }
     }
 
     @Test

--- a/packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
@@ -43,7 +43,7 @@ import org.gradle.api.Task
 import org.gradle.api.logging.Logger
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.tasks.TaskContainer
-import org.gradle.internal.extensions.core.extra
+
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -65,7 +65,7 @@ class DependencyVersionCheckerTest {
     fun `Template versions are considered supported`() {
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions()
 
-        val mockExtraPropertiesExtension = mockProject.extra
+        val mockExtraPropertiesExtension = mockProject.extensions.extraProperties
         every { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false) } returns Unit
         val mockLogger = mockProject.logger
         every { mockLogger.error(any()) } returns Unit
@@ -85,7 +85,7 @@ class DependencyVersionCheckerTest {
         val exampleErrorAgpVersion = AndroidPluginVersion(8, 5, 0)
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(agpVersion = exampleErrorAgpVersion)
 
-        val mockExtraPropertiesExtension = mockProject.extra
+        val mockExtraPropertiesExtension = mockProject.extensions.extraProperties
         every { mockExtraPropertiesExtension.set(any(), any()) } returns Unit
 
         val dependencyValidationException =
@@ -107,7 +107,7 @@ class DependencyVersionCheckerTest {
         val exampleWarnAgpVersion = AndroidPluginVersion(8, 10, 0)
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(agpVersion = exampleWarnAgpVersion)
 
-        val mockExtraPropertiesExtension = mockProject.extra
+        val mockExtraPropertiesExtension = mockProject.extensions.extraProperties
         every { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false) } returns Unit
         val mockLogger = mockProject.logger
         every { mockLogger.error(any()) } returns Unit
@@ -131,7 +131,7 @@ class DependencyVersionCheckerTest {
         val exampleErrorKgpVersion = "1.9.20"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(kgpVersion = exampleErrorKgpVersion)
 
-        val mockExtraPropertiesExtension = mockProject.extra
+        val mockExtraPropertiesExtension = mockProject.extensions.extraProperties
         every { mockExtraPropertiesExtension.set(any(), any()) } returns Unit
 
         val dependencyValidationException =
@@ -155,7 +155,7 @@ class DependencyVersionCheckerTest {
         val exampleWarnKgpVersion = "2.2.0"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(kgpVersion = exampleWarnKgpVersion)
 
-        val mockExtraPropertiesExtension = mockProject.extra
+        val mockExtraPropertiesExtension = mockProject.extensions.extraProperties
         every { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false) } returns Unit
         val mockLogger = mockProject.logger
         every { mockLogger.error(any()) } returns Unit
@@ -181,7 +181,7 @@ class DependencyVersionCheckerTest {
         val exampleErrorJavaVersion = JavaVersion.VERSION_16
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(javaVersion = exampleErrorJavaVersion)
 
-        val mockExtraPropertiesExtension = mockProject.extra
+        val mockExtraPropertiesExtension = mockProject.extensions.extraProperties
         every { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false) } returns Unit
         every { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true) } returns Unit
         val mockLogger = mockProject.logger
@@ -206,7 +206,7 @@ class DependencyVersionCheckerTest {
         val exampleErrorGradleVersion = "8.6.0"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(gradleVersion = exampleErrorGradleVersion)
 
-        val mockExtraPropertiesExtension = mockProject.extra
+        val mockExtraPropertiesExtension = mockProject.extensions.extraProperties
         every { mockExtraPropertiesExtension.set(any(), any()) } returns Unit
 
         val dependencyValidationException =
@@ -229,7 +229,7 @@ class DependencyVersionCheckerTest {
         val exampleWarnGradleVersion = "8.12.0"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(gradleVersion = exampleWarnGradleVersion)
 
-        val mockExtraPropertiesExtension = mockProject.extra
+        val mockExtraPropertiesExtension = mockProject.extensions.extraProperties
         every { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false) } returns Unit
         val mockLogger = mockProject.logger
         every { mockLogger.error(any()) } returns Unit
@@ -262,7 +262,7 @@ class DependencyVersionCheckerTest {
                     )
             )
 
-        val mockExtraPropertiesExtension = mockProject.extra
+        val mockExtraPropertiesExtension = mockProject.extensions.extraProperties
         every {
             mockExtraPropertiesExtension.set(
                 OUT_OF_SUPPORT_RANGE_PROPERTY,
@@ -311,7 +311,7 @@ class DependencyVersionCheckerTest {
                     )
             )
 
-        val mockExtraPropertiesExtension = mockProject.extra
+        val mockExtraPropertiesExtension = mockProject.extensions.extraProperties
         val mockLogger = mockProject.logger
         every { mockExtraPropertiesExtension.set(any(), any()) } returns Unit
         every { mockLogger.error(any()) } returns Unit
@@ -450,7 +450,7 @@ private object MockProjectFactory {
 
         // Extra properties extension
         val mockExtraPropertiesExtension = mockk<ExtraPropertiesExtension>()
-        every { mockProject.extra } returns mockExtraPropertiesExtension
+        every { mockProject.extensions.extraProperties } returns mockExtraPropertiesExtension
 
         // Project path
         every { mockProject.rootDir.path } returns FAKE_PROJECT_ROOT_DIR

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginTest.kt
@@ -26,6 +26,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.process.ExecOperations
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.io.TempDir
@@ -119,7 +120,7 @@ class FlutterPluginTest {
         // mock method calls that are invoked by the args to NativePluginLoaderReflectionBridge
         every { project.extraProperties } returns mockk()
         every { project.file(flutterExtension.source!!) } returns mockk()
-        val flutterPlugin = FlutterPlugin()
+        val flutterPlugin = FlutterPlugin(mockk<ExecOperations>())
         flutterPlugin.apply(project)
 
         verify { project.tasks.register("generateLockfiles", any()) }
@@ -304,7 +305,7 @@ class FlutterPluginTest {
         every {
             taskContainer.named(any<String>())
         } returns mockTaskProvider
-        val flutterPlugin = FlutterPlugin()
+        val flutterPlugin = FlutterPlugin(mockk<ExecOperations>())
         flutterPlugin.apply(project)
 
         copyTaskActionCaptor.captured.execute(copyTask)

--- a/packages/flutter_tools/gradle/src/test/kotlin/tasks/BaseFlutterTaskHelperTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/tasks/BaseFlutterTaskHelperTest.kt
@@ -13,7 +13,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.logging.LoggingManager
-import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.process.ExecOperations
 import org.gradle.process.ExecSpec
 import org.gradle.process.ProcessForkOptions
@@ -349,9 +348,7 @@ class BaseFlutterTaskHelperTest {
         val baseFlutterTask = mockk<BaseFlutterTask>()
         val mockLoggingManager = mockk<LoggingManager>()
         val mockFile = mockk<File>()
-        // Mocking the serviceOf() extension below requires us to specify this internal type
-        // unfortunately.
-        val mockProject = mockk<org.gradle.api.internal.project.ProjectInternal>()
+        val mockProject = mockk<Project>()
 
         // When baseFlutterTask.sourceDir is null, an exception is thrown. We mock its return value
         // before creating a BaseFlutterTaskHelper object.
@@ -362,9 +359,7 @@ class BaseFlutterTaskHelperTest {
         every { mockLoggingManager.captureStandardError(any()) } returns mockLoggingManager
         every { baseFlutterTask.project } returns mockProject
         val mockExecOperations = mockk<ExecOperations>()
-        every {
-            mockProject.serviceOf<ExecOperations>()
-        } returns mockExecOperations
+        every { baseFlutterTask.execOperations } returns mockExecOperations
         every { mockExecOperations.exec(any<Action<ExecSpec>>()) } returns mockk()
 
         BaseFlutterTaskHelper.buildBundle(baseFlutterTask)


### PR DESCRIPTION
Update all usages of internal Gradle APIs in Flutter tooling to only use public apis.

Fixes https://github.com/flutter/flutter/issues/188755

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
