### PR TITLE
Print a warning in `flutter doctor` when running on Intel Macs

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -42,6 +42,11 @@ import 'windows/visual_studio_validator.dart';
 import 'windows/windows_version_validator.dart';
 import 'windows/windows_workflow.dart';
 
+const _kIntelMacWarning = ValidationMessage.hint(
+  'Flutter is deprecating support for Intel-based Macs. '
+  'A future version of Flutter will require an Apple Silicon Mac to build applications.',
+);
+
 abstract class DoctorValidatorsProvider {
   // Allow tests to construct a [_DefaultDoctorValidatorsProvider] with explicit
   // [FeatureFlags].
@@ -86,7 +91,7 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
       return _validators!;
     }
     final proxyValidator = ProxyValidator(platform: platform);
-    _validators = <DoctorValidator>[
+    return _validators = <DoctorValidator>[
       FlutterValidator(
         fileSystem: globals.fs,
         platform: globals.platform,
@@ -146,7 +151,6 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
         httpClient: globals.httpClientFactory?.call() ?? HttpClient(),
       ),
     ];
-    return _validators!;
   }
 
   @override
@@ -514,7 +518,9 @@ class FlutterValidator extends DoctorValidator {
 
   @override
   Future<ValidationResult> validateImpl() async {
-    final messages = <ValidationMessage>[];
+    final messages = <ValidationMessage>[
+      if (_operatingSystemUtils.hostPlatform == .darwin_x64) _kIntelMacWarning,
+    ];
     String? versionChannel;
     String? frameworkVersion;
 
@@ -593,7 +599,7 @@ class FlutterValidator extends DoctorValidator {
       messages.add(ValidationMessage.error(buffer.toString()));
     }
 
-    ValidationType valid;
+    final ValidationType valid;
     if (messages.every((ValidationMessage message) => message.isInformation)) {
       valid = ValidationType.success;
     } else {

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -715,6 +715,90 @@ void main() {
       ),
     );
   });
+
+  testWithoutContext('FlutterValidator shows a warning message on Intel Macs', () async {
+    final flutterVersion = FakeFlutterVersion(frameworkVersion: '1.0.0', branch: 'beta');
+    final fileSystem = MemoryFileSystem.test();
+    final artifacts = Artifacts.test();
+    final flutterValidator = FlutterValidator(
+      platform: FakePlatform(
+        operatingSystem: 'macos',
+        localeName: 'en_US.UTF-8',
+        environment: <String, String>{},
+      ),
+      flutterVersion: () => flutterVersion,
+      devToolsVersion: () => '2.8.0',
+      artifacts: artifacts,
+      fileSystem: fileSystem,
+      flutterRoot: () => '/sdk/flutter',
+      operatingSystemUtils: FakeOperatingSystemUtils(
+        name: 'macOS',
+        hostPlatform: HostPlatform.darwin_x64,
+        fs: fileSystem,
+      ),
+      processManager: FakeProcessManager.any(),
+      featureFlags: TestFeatureFlags(),
+    );
+
+    expect(
+      await flutterValidator.validate(),
+      _matchDoctorValidation(
+        validationType: ValidationType.partial,
+        statusInfo: 'Channel beta, 1.0.0, on macOS, locale en_US.UTF-8',
+        messages: contains(
+          const ValidationMessage.hint(
+            'Flutter is deprecating support for Intel-based Macs. '
+            'A future version of Flutter will require an Apple Silicon Mac to build applications.',
+          ),
+        ),
+      ),
+    );
+  });
+
+  testWithoutContext(
+    'FlutterValidator does not show a warning message on Apple Silicon Macs',
+    () async {
+      final flutterVersion = FakeFlutterVersion(frameworkVersion: '1.0.0', branch: 'beta');
+      final fileSystem = MemoryFileSystem.test();
+      final artifacts = Artifacts.test();
+      final flutterValidator = FlutterValidator(
+        platform: FakePlatform(
+          operatingSystem: 'macos',
+          localeName: 'en_US.UTF-8',
+          environment: <String, String>{},
+        ),
+        flutterVersion: () => flutterVersion,
+        devToolsVersion: () => '2.8.0',
+        artifacts: artifacts,
+        fileSystem: fileSystem,
+        flutterRoot: () => '/sdk/flutter',
+        operatingSystemUtils: FakeOperatingSystemUtils(
+          name: 'macOS',
+          hostPlatform: HostPlatform.darwin_arm64,
+          fs: fileSystem,
+        ),
+        processManager: FakeProcessManager.any(),
+        featureFlags: TestFeatureFlags(),
+      );
+
+      expect(
+        await flutterValidator.validate(),
+        _matchDoctorValidation(
+          validationType: ValidationType.success,
+          statusInfo: 'Channel beta, 1.0.0, on macOS, locale en_US.UTF-8',
+          messages: isNot(
+            contains(
+              isA<ValidationMessage>().having(
+                (ValidationMessage message) => message.message,
+                'message',
+                contains('Flutter is deprecating support for Intel-based Macs'),
+              ),
+            ),
+          ),
+        ),
+      );
+    },
+  );
 }
 
 class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -29,6 +29,12 @@ Matcher _matchDoctorValidation({
       .having((ValidationResult result) => result.messages, 'messages', messages);
 }
 
+Matcher _first(Object matcher) => const TypeMatcher<Iterable<Object?>>().having(
+  (Iterable<Object?> element) => element.first,
+  'first',
+  matcher,
+);
+
 void main() {
   testWithoutContext('FlutterValidator shows an error message if gen_snapshot is '
       'downloaded and exits with code 1', () async {
@@ -745,7 +751,7 @@ void main() {
       _matchDoctorValidation(
         validationType: ValidationType.partial,
         statusInfo: 'Channel beta, 1.0.0, on macOS, locale en_US.UTF-8',
-        messages: contains(
+        messages: _first(
           const ValidationMessage.hint(
             'Flutter is deprecating support for Intel-based Macs. '
             'A future version of Flutter will require an Apple Silicon Mac to build applications.',
@@ -754,51 +760,6 @@ void main() {
       ),
     );
   });
-
-  testWithoutContext(
-    'FlutterValidator does not show a warning message on Apple Silicon Macs',
-    () async {
-      final flutterVersion = FakeFlutterVersion(frameworkVersion: '1.0.0', branch: 'beta');
-      final fileSystem = MemoryFileSystem.test();
-      final artifacts = Artifacts.test();
-      final flutterValidator = FlutterValidator(
-        platform: FakePlatform(
-          operatingSystem: 'macos',
-          localeName: 'en_US.UTF-8',
-          environment: <String, String>{},
-        ),
-        flutterVersion: () => flutterVersion,
-        devToolsVersion: () => '2.8.0',
-        artifacts: artifacts,
-        fileSystem: fileSystem,
-        flutterRoot: () => '/sdk/flutter',
-        operatingSystemUtils: FakeOperatingSystemUtils(
-          name: 'macOS',
-          hostPlatform: HostPlatform.darwin_arm64,
-          fs: fileSystem,
-        ),
-        processManager: FakeProcessManager.any(),
-        featureFlags: TestFeatureFlags(),
-      );
-
-      expect(
-        await flutterValidator.validate(),
-        _matchDoctorValidation(
-          validationType: ValidationType.success,
-          statusInfo: 'Channel beta, 1.0.0, on macOS, locale en_US.UTF-8',
-          messages: isNot(
-            contains(
-              isA<ValidationMessage>().having(
-                (ValidationMessage message) => message.message,
-                'message',
-                contains('Flutter is deprecating support for Intel-based Macs'),
-              ),
-            ),
-          ),
-        ),
-      );
-    },
-  );
 }
 
 class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/188330. Shows this on `flutter doctor`:

<img width="1034" height="44" alt="Screenshot 2026-06-29 at 4 46 17 PM" src="https://github.com/user-attachments/assets/1af20058-7163-4046-ac43-ed9394b8371e" />


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
