### PR TITLE
Add --disable-service-origin-check flag and forward through runner

### DIFF
--- a/engine/src/flutter/common/settings.h
+++ b/engine/src/flutter/common/settings.h
@@ -201,6 +201,10 @@ struct Settings {
   // the VM service.
   bool disable_service_auth_codes = true;
 
+  // Determines whether origin and host checks are required to communicate with
+  // the VM service.
+  bool disable_service_origin_check = false;
+
   // Determine whether the vmservice should fallback to automatic port selection
   // after failing to bind to a specified port.
   bool enable_service_port_fallback = false;

--- a/engine/src/flutter/runtime/dart_isolate.cc
+++ b/engine/src/flutter/runtime/dart_isolate.cc
@@ -1023,7 +1023,7 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
           settings.vm_service_host,            // server IP address
           settings.vm_service_port,            // server VM service port
           tonic::DartState::HandleLibraryTag,  // embedder library tag handler
-          false,  //  disable websocket origin check
+          settings.disable_service_origin_check,  // disable websocket origin check
           settings.disable_service_auth_codes,  // disable VM service auth codes
           settings.enable_service_port_fallback,  // enable fallback to port 0
                                                   // when bind fails.

--- a/engine/src/flutter/shell/common/switch_defs.h
+++ b/engine/src/flutter/shell/common/switch_defs.h
@@ -126,6 +126,10 @@ DEF_SWITCH(DisableServiceAuthCodes,
            "disable-service-auth-codes",
            "Disable the requirement for authentication codes for communicating"
            " with the VM service.")
+DEF_SWITCH(DisableServiceOriginCheck,
+           "disable-service-origin-check",
+           "Disable the requirement for origin and host checks for communicating"
+           " with the VM service.")
 DEF_SWITCH(EnableServicePortFallback,
            "enable-service-port-fallback",
            "Allow the VM service to fallback to automatic port selection if"

--- a/engine/src/flutter/shell/common/switches.cc
+++ b/engine/src/flutter/shell/common/switches.cc
@@ -277,6 +277,11 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
   settings.disable_service_auth_codes =
       command_line.HasOption(FlagForSwitch(Switch::DisableServiceAuthCodes));
 
+  // Disable need for origin and host checks for VM service communication, if
+  // specified.
+  settings.disable_service_origin_check =
+      command_line.HasOption(FlagForSwitch(Switch::DisableServiceOriginCheck));
+
   // Allow fallback to automatic port selection if binding to a specified port
   // fails.
   settings.enable_service_port_fallback =

--- a/engine/src/flutter/shell/common/switches_unittests.cc
+++ b/engine/src/flutter/shell/common/switches_unittests.cc
@@ -139,6 +139,23 @@ TEST(SwitchesTest, ProfileStartup) {
   }
 }
 
+TEST(SwitchesTest, DisableServiceOriginCheck) {
+  {
+    fml::CommandLine command_line = fml::CommandLineFromInitializerList(
+        {"command", "--disable-service-origin-check"});
+    EXPECT_TRUE(command_line.HasOption("disable-service-origin-check"));
+    Settings settings = SettingsFromCommandLine(command_line);
+    EXPECT_EQ(settings.disable_service_origin_check, true);
+  }
+  {
+    // default
+    fml::CommandLine command_line =
+        fml::CommandLineFromInitializerList({"command"});
+    Settings settings = SettingsFromCommandLine(command_line);
+    EXPECT_EQ(settings.disable_service_origin_check, false);
+  }
+}
+
 #if !FLUTTER_RELEASE
 TEST(SwitchesTest, EnableAsserts) {
   fml::CommandLine command_line = fml::CommandLineFromInitializerList(


### PR DESCRIPTION
    ### Purpose
    When Dart SDK CL 515120 is relanded, the VM Service will enforce strict WebSocket origin and host header verification by
  default. While local loopback connections are unaffected, remote web sockets and device emulators require a mechanism to
  disable origin verification.

    This change implements the minimal C++ engine runtime switch `--disable-service-origin-check` required to accommodate
  embedded device testing setups (such as Fuchsia emulators in Google3):
    - Added `DisableServiceOriginCheck` switch and `Settings.disable_service_origin_check` in `switch_defs.h`, `switches.cc`,
  and `settings.h`.
    - Forwarded the setting into parameter 4 of `DartServiceIsolate::Startup` in `dart_isolate.cc`.
    - Added unit test `TEST(SwitchesTest, DisableServiceOriginCheck)` in `switches_unittests.cc` verifying command-line switch
  parsing and default values.

    When running embedded apps on target devices (e.g. in Fuchsia testing setups), passing `--disable-service-origin-check` in
  `--flutter_flags` allows test tools and remote debuggers to connect without hitting HTTP 403 Forbidden errors.

    ### Related Issues
    * Fixes b/528429998

    ### Pre-launch Checklist
    - [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
    - [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
    - [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
    - [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
    - [x] I signed the [CLA].
    - [x] I listed at least one issue that this PR fixes in the description above.
    - [x] I updated/added relevant documentation (doc comments with `///`).
    - [x] I added new tests to check the change I am making, or this PR is [test-exempt].
    - [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
    - [x] All existing and new tests are passing.