### PR TITLE
[flutter_tools] Track asset transformer dependencies for hot reload (Reland #187947)

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -57,15 +57,18 @@ class DepfileService {
   /// Parse the depfile contents from [file].
   ///
   /// If the syntax is invalid, returns an empty [Depfile].
-  Depfile parse(File file) {
+  ///
+  /// If [baseDirectory] is provided, any relative paths in the depfile
+  /// will be resolved relative to it.
+  Depfile parse(File file, [Directory? baseDirectory]) {
     final String contents = file.readAsStringSync();
     final List<String> colonSeparated = contents.split(': ');
     if (colonSeparated.length != 2) {
       _logger.printError('Invalid depfile: ${file.path}');
       return const Depfile(<File>[], <File>[]);
     }
-    final List<File> inputs = _processList(colonSeparated[1].trim());
-    final List<File> outputs = _processList(colonSeparated[0].trim());
+    final List<File> inputs = _processList(colonSeparated[1].trim(), baseDirectory);
+    final List<File> outputs = _processList(colonSeparated[0].trim(), baseDirectory);
     return Depfile(inputs, outputs);
   }
 
@@ -100,12 +103,12 @@ class DepfileService {
     }
   }
 
-  List<File> _processList(String rawText) {
+  List<File> _processList(String rawText, [Directory? baseDirectory]) {
     return rawText
         // Put every file on right-hand side on the separate line
         .replaceAllMapped(_separatorExpr, (Match match) => '${match.group(1)}\n')
         .split('\n')
-        // Expand escape sequences, so that '\ ', for example,ß becomes ' '
+        // Expand escape sequences, so that '\ ', for example, becomes ' '
         .map<String>(
           (String path) =>
               path.replaceAllMapped(_escapeExpr, (Match match) => match.group(1)!).trim(),
@@ -115,7 +118,14 @@ class DepfileService {
         // be resilient to the outputs of other tools which write or user edits to depfiles.
         .toSet()
         // Normalize the path before creating a file object.
-        .map((String path) => _fileSystem.file(_fileSystem.path.normalize(path)))
+        .map((String path) {
+          if (baseDirectory != null && _fileSystem.path.isRelative(path)) {
+            return _fileSystem.file(
+              _fileSystem.path.normalize(_fileSystem.path.join(baseDirectory.path, path)),
+            );
+          }
+          return _fileSystem.file(_fileSystem.path.normalize(path));
+        })
         .toList();
   }
 }

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -135,7 +135,7 @@ Future<Depfile> copyAssets(
             case AssetKind.regular:
               if (entry.value.transformers.isNotEmpty) {
                 transformResource = await transformPool.request();
-                final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
+                final AssetTransformationResult result = await assetTransformer.transformAsset(
                   asset: content.file as File,
                   outputPath: file.path,
                   workingDirectory: environment.projectDir.path,
@@ -143,12 +143,13 @@ Future<Depfile> copyAssets(
                   logger: environment.logger,
                 );
                 doCopy = false;
-                if (failure != null) {
+                if (result.failure != null) {
                   throwToolExit(
                     'User-defined transformation of asset "${entry.key}" failed.\n'
-                    '${failure.message}',
+                    '${result.failure!.message}',
                   );
                 }
+                inputs.addAll(result.dependencies);
               }
             case AssetKind.font:
               doCopy = !await iconTreeShaker.subsetFont(
@@ -162,19 +163,20 @@ Future<Depfile> copyAssets(
               if (entry.value.transformers.isNotEmpty) {
                 transformResource = await transformPool.request();
                 final transformedShaderSourcePath = '${file.path}.transformed';
-                final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
+                final AssetTransformationResult result = await assetTransformer.transformAsset(
                   asset: inputToCompiler,
                   outputPath: transformedShaderSourcePath,
                   workingDirectory: environment.projectDir.path,
                   transformerEntries: entry.value.transformers,
                   logger: environment.logger,
                 );
-                if (failure != null) {
+                if (result.failure != null) {
                   throwToolExit(
                     'User-defined transformation of shader "${entry.key}" failed.\n'
-                    '${failure.message}',
+                    '${result.failure!.message}',
                   );
                 }
+                inputs.addAll(result.dependencies);
                 inputToCompiler = environment.fileSystem.file(transformedShaderSourcePath);
               }
 

--- a/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
@@ -15,6 +15,7 @@ import '../../build_info.dart';
 import '../../devfs.dart';
 import '../../flutter_manifest.dart';
 import '../build_system.dart';
+import '../depfile.dart';
 
 /// Applies a series of user-specified asset-transforming packages to an asset file.
 final class AssetTransformer {
@@ -46,7 +47,7 @@ final class AssetTransformer {
 
   /// Applies, in sequence, a list of transformers to an [asset] and then copies
   /// the output to [outputPath].
-  Future<AssetTransformationFailure?> transformAsset({
+  Future<AssetTransformationResult> transformAsset({
     required File asset,
     required String outputPath,
     required String workingDirectory,
@@ -69,10 +70,11 @@ final class AssetTransformer {
     await asset.copy(tempInputFile.path);
     File tempOutputFile = nextTempFile();
 
+    final allDependencies = <File>[];
     final stopwatch = Stopwatch()..start();
     try {
       for (final (int i, AssetTransformerEntry transformer) in transformerEntries.indexed) {
-        final AssetTransformationFailure? transformerFailure = await _applyTransformer(
+        final AssetTransformationResult transformerResult = await _applyTransformer(
           asset: tempInputFile,
           output: tempOutputFile,
           transformer: transformer,
@@ -80,9 +82,10 @@ final class AssetTransformer {
           logger: logger,
         );
 
-        if (transformerFailure != null) {
-          return AssetTransformationFailure(transformerFailure.message);
+        if (transformerResult.failure != null) {
+          return AssetTransformationResult(failure: transformerResult.failure);
         }
+        allDependencies.addAll(transformerResult.dependencies);
 
         ErrorHandlingFileSystem.deleteIfExists(tempInputFile);
         if (i == transformerEntries.length - 1) {
@@ -101,60 +104,80 @@ final class AssetTransformer {
       ErrorHandlingFileSystem.deleteIfExists(tempDirectory, recursive: true);
     }
 
-    return null;
+    final String tempDirPath = tempDirectory.path;
+    final List<File> filteredDependencies = allDependencies
+        .where((File file) => !_fileSystem.path.isWithin(tempDirPath, file.path))
+        .toList();
+
+    return AssetTransformationResult(dependencies: filteredDependencies);
   }
 
-  Future<AssetTransformationFailure?> _applyTransformer({
+  Future<AssetTransformationResult> _applyTransformer({
     required File asset,
     required File output,
     required AssetTransformerEntry transformer,
     required String workingDirectory,
     required Logger logger,
   }) async {
-    final transformerArguments = <String>[
-      '--input=${asset.absolute.path}',
-      '--output=${output.absolute.path}',
+    final command = <String>[
+      _dartBinaryPath,
+      'run',
+      transformer.package,
+      '--input=${asset.path}',
+      '--output=${output.path}',
       ...transformer.args,
     ];
 
-    final command = <String>[_dartBinaryPath, 'run', transformer.package, ...transformerArguments];
-
-    // Delete the output file if it already exists for whatever reason.
-    // With this, we can check for the existence of the file after transformation
-    // to make sure the transformer produced an output file.
-    ErrorHandlingFileSystem.deleteIfExists(output);
-
-    logger.printTrace("Transforming asset using command '${command.join(' ')}'");
     final ProcessResult result = await _processManager.run(
       command,
       workingDirectory: workingDirectory,
-      environment: <String, String>{AssetTransformer.buildModeEnvVar: _buildMode.cliName},
+      environment: <String, String>{buildModeEnvVar: _buildMode.cliName},
     );
+
     final stdout = result.stdout as String;
     final stderr = result.stderr as String;
 
     if (result.exitCode != 0) {
-      return AssetTransformationFailure(
-        'Transformer process terminated with non-zero exit code: ${result.exitCode}\n'
-        'Transformer package: ${transformer.package}\n'
-        'Full command: ${command.join(' ')}\n'
-        'stdout:\n$stdout\n'
-        'stderr:\n$stderr',
+      return AssetTransformationResult(
+        failure: AssetTransformationFailure(
+          'Transformer process terminated with non-zero exit code: ${result.exitCode}\n'
+          'Transformer package: ${transformer.package}\n'
+          'Full command: ${command.join(' ')}\n'
+          'stdout:\n$stdout\n'
+          'stderr:\n$stderr',
+        ),
       );
     }
 
     if (!_fileSystem.file(output).existsSync()) {
-      return AssetTransformationFailure(
-        'Asset transformer ${transformer.package} did not produce an output file.\n'
-        'Input file provided to transformer: "${asset.path}"\n'
-        'Expected output file at: "${output.absolute.path}"\n'
-        'Full command: ${command.join(' ')}\n'
-        'stdout:\n$stdout\n'
-        'stderr:\n$stderr',
+      return AssetTransformationResult(
+        failure: AssetTransformationFailure(
+          'Asset transformer ${transformer.package} did not produce an output file.\n'
+          'Input file provided to transformer: "${asset.path}"\n'
+          'Expected output file at: "${output.absolute.path}"\n'
+          'Full command: ${command.join(' ')}\n'
+          'stdout:\n$stdout\n'
+          'stderr:\n$stderr',
+        ),
       );
     }
 
-    return null;
+    var dependencies = <File>[];
+    final File depfile = _fileSystem.file('${output.path}.d');
+    if (depfile.existsSync()) {
+      try {
+        final depfileService = DepfileService(logger: logger, fileSystem: _fileSystem);
+        final Depfile parsedDepfile = depfileService.parse(
+          depfile,
+          _fileSystem.directory(workingDirectory),
+        );
+        dependencies = parsedDepfile.inputs;
+      } on Exception catch (e) {
+        logger.printTrace('Failed to parse depfile: $e');
+      }
+    }
+
+    return AssetTransformationResult(dependencies: dependencies);
   }
 }
 
@@ -173,6 +196,16 @@ final class DevelopmentAssetTransformer {
   final _transformationPool = Pool(4);
   final Logger _logger;
 
+  final Map<String, Set<Uri>> _dependencies = <String, Set<Uri>>{};
+
+  /// The dependencies registered by transformers, indexed by asset key.
+  Map<String, Set<Uri>> get dependencies => _dependencies;
+
+  /// Removes dependencies for assets that are no longer active.
+  void pruneDependencies(Set<String> activeAssetKeys) {
+    _dependencies.removeWhere((String key, _) => !activeAssetKeys.contains(key));
+  }
+
   /// Re-transforms an asset and returns a [DevFSContent] that should be synced
   /// to the attached device in its place.
   ///
@@ -184,12 +217,12 @@ final class DevelopmentAssetTransformer {
     required String workingDirectory,
   }) async {
     final File output = _fileSystem.systemTempDirectory.childFile(
-      'retransformerInput-$inputAssetKey',
+      'retransformerOutput-$inputAssetKey',
     );
     ErrorHandlingFileSystem.deleteIfExists(output);
     File? inputFile;
     var cleanupInput = false;
-    Uint8List result;
+    Uint8List resultBytes;
     PoolResource? resource;
     try {
       resource = await _transformationPool.request();
@@ -200,18 +233,21 @@ final class DevelopmentAssetTransformer {
         inputFile.writeAsBytesSync(await inputAssetContent.contentsAsBytes());
         cleanupInput = true;
       }
-      final AssetTransformationFailure? failure = await _transformer.transformAsset(
+      final AssetTransformationResult transformationResult = await _transformer.transformAsset(
         asset: inputFile,
         outputPath: output.path,
         transformerEntries: transformerEntries,
         workingDirectory: workingDirectory,
         logger: _logger,
       );
-      if (failure != null) {
-        _logger.printError(failure.message);
+      if (transformationResult.failure != null) {
+        _logger.printError(transformationResult.failure!.message);
         return null;
       }
-      result = output.readAsBytesSync();
+      _dependencies[inputAssetKey] = transformationResult.dependencies
+          .map((File f) => f.absolute.uri)
+          .toSet();
+      resultBytes = output.readAsBytesSync();
     } finally {
       resource?.release();
       ErrorHandlingFileSystem.deleteIfExists(output);
@@ -219,7 +255,7 @@ final class DevelopmentAssetTransformer {
         ErrorHandlingFileSystem.deleteIfExists(inputFile);
       }
     }
-    return DevFSByteContent(result);
+    return DevFSByteContent(resultBytes);
   }
 }
 
@@ -227,4 +263,11 @@ final class AssetTransformationFailure {
   const AssetTransformationFailure(this.message);
 
   final String message;
+}
+
+final class AssetTransformationResult {
+  const AssetTransformationResult({this.failure, this.dependencies = const <File>[]});
+
+  final AssetTransformationFailure? failure;
+  final List<File> dependencies;
 }

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -188,7 +188,7 @@ Future<void> writeBundle(
               if (entry.value.transformers.isEmpty) {
                 break;
               }
-              final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
+              final AssetTransformationResult result = await assetTransformer.transformAsset(
                 asset: input,
                 outputPath: file.path,
                 workingDirectory: projectDir.path,
@@ -196,10 +196,10 @@ Future<void> writeBundle(
                 logger: logger,
               );
               doCopy = false;
-              if (failure != null) {
+              if (result.failure != null) {
                 throwToolExit(
                   'User-defined transformation of asset "${entry.key}" failed.\n'
-                  '${failure.message}',
+                  '${result.failure!.message}',
                 );
               }
             case AssetKind.font:
@@ -208,17 +208,17 @@ Future<void> writeBundle(
               var inputToCompiler = input;
               if (entry.value.transformers.isNotEmpty) {
                 final transformedShaderSourcePath = '${file.path}.transformed';
-                final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
+                final AssetTransformationResult result = await assetTransformer.transformAsset(
                   asset: inputToCompiler,
                   outputPath: transformedShaderSourcePath,
                   workingDirectory: projectDir.path,
                   transformerEntries: entry.value.transformers,
                   logger: logger,
                 );
-                if (failure != null) {
+                if (result.failure != null) {
                   throwToolExit(
                     'User-defined transformation of shader "${entry.key}" failed.\n'
-                    '${failure.message}',
+                    '${result.failure!.message}',
                   );
                 }
                 inputToCompiler = fileSystem.file(transformedShaderSourcePath);

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -642,9 +642,11 @@ class DevFS {
           assetPathsToEvict: assetPathsToEvict,
           shaderPathsToEvict: shaderPathsToEvict,
           bundleFirstUpload: bundleFirstUpload,
+          invalidatedFiles: invalidatedFiles,
           onFontManifestUpdated: () => didUpdateFontManifest = true,
         );
         syncedBytes += bundleSyncedBytes;
+        _assetTransformer.pruneDependencies(bundle.entries.keys.toSet());
       } on Exception catch (err, stackTrace) {
         _logger.printError('Error updating bundle: $err');
         _logger.printTrace('$stackTrace');
@@ -663,7 +665,10 @@ class DevFS {
     _previousCompiled = lastCompiled;
     lastCompiled = candidateCompileTime;
     // list of sources that needs to be monitored are in [compilerOutput.sources]
-    sources = compilerOutput.sources;
+    sources = <Uri>{
+      ...compilerOutput.sources,
+      ..._assetTransformer.dependencies.values.expand((Set<Uri> uris) => uris),
+    }.toList();
     //
     // Don't send full kernel file that would overwrite what VM already
     // started loading from.
@@ -717,23 +722,30 @@ class DevFS {
     required Set<String> assetPathsToEvict,
     required Set<String> shaderPathsToEvict,
     required bool bundleFirstUpload,
+    List<Uri> invalidatedFiles = const <Uri>[],
     bool syncAllAssetsOnFirstUpload = false,
     void Function()? onFontManifestUpdated,
   }) async {
-    if (bundleFirstUpload && !syncAllAssetsOnFirstUpload) {
-      for (final AssetBundleEntry entry in bundle.entries.values) {
-        entry.content.markClean();
-      }
-      return 0;
-    }
-
     final String assetBuildDirPrefix = _asUriPath(fileSystem, assetDirectory);
     final pendingAssetBuilds = <Future<void>>[];
     var syncedBytes = 0;
 
+    final Set<Uri> invalidatedSet = invalidatedFiles.toSet();
     final syncedEntries = <AssetBundleEntry>[];
     bundle.entries.forEach((String archivePath, AssetBundleEntry entry) {
-      if (!bundleFirstUpload && !entry.content.isModified) {
+      final bool hasTransformers = entry.transformers.isNotEmpty;
+      final bool skipSync = bundleFirstUpload && !syncAllAssetsOnFirstUpload && !hasTransformers;
+
+      if (skipSync) {
+        entry.content.markClean();
+        return;
+      }
+
+      final bool isEntryModified = entry.content.isModified;
+      final Set<Uri>? deps = assetTransformer.dependencies[archivePath];
+      final bool hasInvalidatedDependencies = deps != null && deps.any(invalidatedSet.contains);
+
+      if (!bundleFirstUpload && !isEntryModified && !hasInvalidatedDependencies) {
         return;
       }
       syncedEntries.add(entry);
@@ -766,12 +778,14 @@ class DevFS {
               }
               content = transformed;
             }
-            final DevFSContent? compiled = await shaderCompiler.recompileShader(content);
-            if (compiled == null) {
-              throw DevFSShaderCompilationException(archivePath, 'Failed to compile shader');
+            if (!bundleFirstUpload || syncAllAssetsOnFirstUpload) {
+              final DevFSContent? compiled = await shaderCompiler.recompileShader(content);
+              if (compiled == null) {
+                throw DevFSShaderCompilationException(archivePath, 'Failed to compile shader');
+              }
+              dirtyEntries[deviceUri] = compiled;
+              syncedBytes += compiled.size;
             }
-            dirtyEntries[deviceUri] = compiled;
-            syncedBytes += compiled.size;
             if (!bundleFirstUpload) {
               shaderPathsToEvict.add(archivePath);
             }
@@ -793,8 +807,10 @@ class DevFS {
             if (content == null) {
               throw AssetTransformationException(archivePath, 'Failed to transform asset');
             }
-            dirtyEntries[deviceUri] = content;
-            syncedBytes += content.size;
+            if (!bundleFirstUpload || syncAllAssetsOnFirstUpload) {
+              dirtyEntries[deviceUri] = content;
+              syncedBytes += content.size;
+            }
             if (!bundleFirstUpload) {
               assetPathsToEvict.add(archivePath);
             }

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -381,10 +381,12 @@ class WebDevFS implements DevFS {
           assetPathsToEvict: _assetPathsToEvict,
           shaderPathsToEvict: _shaderPathsToEvict,
           bundleFirstUpload: bundleFirstUpload,
+          invalidatedFiles: invalidatedFiles,
           syncAllAssetsOnFirstUpload: true,
           onFontManifestUpdated: () => didUpdateFontManifest = true,
         );
         syncedBytes += bundleSyncedBytes;
+        _assetTransformer.pruneDependencies(bundle.entries.keys.toSet());
       } on Exception catch (err, stackTrace) {
         logger.printError('Error updating bundle: $err');
         logger.printTrace('$stackTrace');
@@ -438,7 +440,10 @@ class WebDevFS implements DevFS {
     // Only update the last compiled time if we successfully compiled.
     lastCompiled = candidateCompileTime;
     // list of sources that needs to be monitored are in [compilerOutput.sources]
-    sources = compilerOutput.sources;
+    sources = <Uri>{
+      ...compilerOutput.sources,
+      ..._assetTransformer.dependencies.values.expand((Set<Uri> uris) => uris),
+    }.toList();
     late File codeFile;
     File manifestFile;
     File sourcemapFile;

--- a/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
@@ -29,6 +29,18 @@ a.txt: b.txt
     expect(depfile.outputs.single.path, 'a.txt');
   });
 
+  testWithoutContext('Can parse depfile with relative paths and baseDirectory', () {
+    final Directory baseDirectory = fileSystem.directory('project')..createSync();
+    final File depfileSource = fileSystem.file('example.d')
+      ..writeAsStringSync('''
+relative/a.txt: relative/b.txt
+''');
+    final Depfile depfile = depfileService.parse(depfileSource, baseDirectory);
+
+    expect(depfile.inputs.single.path, fileSystem.path.join('project', 'relative', 'b.txt'));
+    expect(depfile.outputs.single.path, fileSystem.path.join('project', 'relative', 'a.txt'));
+  });
+
   testWithoutContext('Can parse depfile with multiple inputs', () {
     final File depfileSource = fileSystem.file('example.d')
       ..writeAsStringSync('''
@@ -141,7 +153,6 @@ C:\\a1.txt C:\\a2/a3.txt: C:\\b1.txt C:\\b2/b3.txt
       ..writeAsStringSync(r'''
 a.txt
   : b.txt    c.txt
-
 
 ''');
     final Depfile depfile = depfileService.parse(depfileSource);

--- a/packages/flutter_tools/test/general.shard/build_system/targets/asset_transformer_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/asset_transformer_test.dart
@@ -28,7 +28,7 @@ void main() {
 
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
-        command: <String>[
+        command: <Pattern>[
           artifacts.getArtifactPath(Artifact.engineDartBinary),
           'run',
           'my_copy_transformer',
@@ -59,7 +59,7 @@ void main() {
       buildMode: BuildMode.debug,
     );
 
-    final AssetTransformationFailure? transformationFailure = await transformer.transformAsset(
+    final AssetTransformationResult result = await transformer.transformAsset(
       asset: asset,
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
@@ -72,7 +72,7 @@ void main() {
       logger: logger,
     );
 
-    expect(transformationFailure, isNull, reason: logger.errorText);
+    expect(result.failure, isNull, reason: logger.errorText);
     expect(processManager, hasNoRemainingExpectations);
     expect(fileSystem.file(outputPath).readAsStringSync(), 'hello world');
     expect(
@@ -94,7 +94,7 @@ void main() {
       final String dartBinaryPath = artifacts.getArtifactPath(Artifact.engineDartBinary);
       final processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
-          command: <String>[
+          command: <Pattern>[
             dartBinaryPath,
             'run',
             'my_copy_transformer',
@@ -122,7 +122,7 @@ void main() {
         buildMode: BuildMode.debug,
       );
 
-      final AssetTransformationFailure? failure = await transformer.transformAsset(
+      final AssetTransformationResult result = await transformer.transformAsset(
         asset: asset,
         outputPath: outputPath,
         workingDirectory: fileSystem.currentDirectory.path,
@@ -134,15 +134,19 @@ void main() {
 
       expect(asset, exists);
       expect(processManager, hasNoRemainingExpectations);
-      expect(failure, isNotNull);
-      expect(failure!.message, '''
-Transformer process terminated with non-zero exit code: 1
-Transformer package: my_copy_transformer
-Full command: $dartBinaryPath run my_copy_transformer --input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt --output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt
-stdout:
-Beginning transformation
-stderr:
-Something went wrong''');
+      expect(result.failure, isNotNull);
+      expect(
+        result.failure!.message,
+        matches(
+          'Transformer process terminated with non-zero exit code: 1\n'
+          'Transformer package: my_copy_transformer\n'
+          'Full command: $dartBinaryPath run my_copy_transformer --input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt --output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt\n'
+          'stdout:\n'
+          'Beginning transformation\n'
+          'stderr:\n'
+          'Something went wrong',
+        ),
+      );
       expect(
         fileSystem.directory('.tmp_rand0').listSync(),
         isEmpty,
@@ -163,7 +167,7 @@ Something went wrong''');
       final String dartBinaryPath = artifacts.getArtifactPath(Artifact.engineDartBinary);
       final processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
-          command: <String>[
+          command: <Pattern>[
             dartBinaryPath,
             'run',
             'my_transformer',
@@ -184,7 +188,7 @@ Something went wrong''');
         buildMode: BuildMode.debug,
       );
 
-      final AssetTransformationFailure? failure = await transformer.transformAsset(
+      final AssetTransformationResult result = await transformer.transformAsset(
         asset: asset,
         outputPath: outputPath,
         workingDirectory: fileSystem.currentDirectory.path,
@@ -195,16 +199,20 @@ Something went wrong''');
       );
 
       expect(processManager, hasNoRemainingExpectations);
-      expect(failure, isNotNull);
-      expect(failure!.message, '''
-Asset transformer my_transformer did not produce an output file.
-Input file provided to transformer: "/.tmp_rand0/rand0/asset.txt-transformOutput0.txt"
-Expected output file at: "/.tmp_rand0/rand0/asset.txt-transformOutput1.txt"
-Full command: $dartBinaryPath run my_transformer --input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt --output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt
-stdout:
-
-stderr:
-Transformation failed, but I forgot to exit with a non-zero code.''');
+      expect(result.failure, isNotNull);
+      expect(
+        result.failure!.message,
+        matches(
+          'Asset transformer my_transformer did not produce an output file.\n'
+          'Input file provided to transformer: "/.tmp_rand0/rand0/asset.txt-transformOutput0.txt"\n'
+          'Expected output file at: "/.tmp_rand0/rand0/asset.txt-transformOutput1.txt"\n'
+          'Full command: $dartBinaryPath run my_transformer --input=/.tmp_rand0/rand0/asset.txt-transformOutput0.txt --output=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt\n'
+          'stdout:\n'
+          '\n'
+          'stderr:\n'
+          'Transformation failed, but I forgot to exit with a non-zero code.',
+        ),
+      );
       expect(
         fileSystem.directory('.tmp_rand0').listSync(),
         isEmpty,
@@ -225,7 +233,7 @@ Transformation failed, but I forgot to exit with a non-zero code.''');
     final String dartBinaryPath = artifacts.getArtifactPath(Artifact.engineDartBinary);
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
-        command: <String>[
+        command: <Pattern>[
           dartBinaryPath,
           'run',
           'my_lowercase_transformer',
@@ -246,7 +254,7 @@ Transformation failed, but I forgot to exit with a non-zero code.''');
         },
       ),
       FakeCommand(
-        command: <String>[
+        command: <Pattern>[
           dartBinaryPath,
           'run',
           'my_distance_from_ascii_a_transformer',
@@ -281,7 +289,7 @@ Transformation failed, but I forgot to exit with a non-zero code.''');
       buildMode: BuildMode.debug,
     );
 
-    final AssetTransformationFailure? failure = await transformer.transformAsset(
+    final AssetTransformationResult result = await transformer.transformAsset(
       asset: asset,
       outputPath: outputPath,
       workingDirectory: fileSystem.currentDirectory.path,
@@ -296,7 +304,7 @@ Transformation failed, but I forgot to exit with a non-zero code.''');
     );
 
     expect(processManager, hasNoRemainingExpectations);
-    expect(failure, isNull);
+    expect(result.failure, isNull);
     expect(fileSystem.file(outputPath).readAsStringSync(), '012');
     expect(
       fileSystem.directory('.tmp_rand0').listSync(),
@@ -319,7 +327,7 @@ Transformation failed, but I forgot to exit with a non-zero code.''');
       final String dartBinaryPath = artifacts.getArtifactPath(Artifact.engineDartBinary);
       final processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
-          command: <String>[
+          command: <Pattern>[
             dartBinaryPath,
             'run',
             'my_lowercase_transformer',
@@ -342,7 +350,7 @@ Transformation failed, but I forgot to exit with a non-zero code.''');
           },
         ),
         FakeCommand(
-          command: <String>[
+          command: <Pattern>[
             dartBinaryPath,
             'run',
             'my_distance_from_ascii_a_transformer',
@@ -364,7 +372,7 @@ Transformation failed, but I forgot to exit with a non-zero code.''');
         buildMode: BuildMode.debug,
       );
 
-      final AssetTransformationFailure? failure = await transformer.transformAsset(
+      final AssetTransformationResult result = await transformer.transformAsset(
         asset: asset,
         outputPath: outputPath,
         workingDirectory: fileSystem.currentDirectory.path,
@@ -378,16 +386,20 @@ Transformation failed, but I forgot to exit with a non-zero code.''');
         logger: BufferLogger.test(),
       );
 
-      expect(failure, isNotNull);
-      expect(failure!.message, '''
-Asset transformer my_distance_from_ascii_a_transformer did not produce an output file.
-Input file provided to transformer: "/.tmp_rand0/rand0/asset.txt-transformOutput1.txt"
-Expected output file at: "/.tmp_rand0/rand0/asset.txt-transformOutput2.txt"
-Full command: Artifact.engineDartBinary run my_distance_from_ascii_a_transformer --input=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt --output=/.tmp_rand0/rand0/asset.txt-transformOutput2.txt
-stdout:
-
-stderr:
-Transformation failed, but I forgot to exit with a non-zero code.''');
+      expect(result.failure, isNotNull);
+      expect(
+        result.failure!.message,
+        matches(
+          'Asset transformer my_distance_from_ascii_a_transformer did not produce an output file.\n'
+          'Input file provided to transformer: "/.tmp_rand0/rand0/asset.txt-transformOutput1.txt"\n'
+          'Expected output file at: "/.tmp_rand0/rand0/asset.txt-transformOutput2.txt"\n'
+          'Full command: Artifact.engineDartBinary run my_distance_from_ascii_a_transformer --input=/.tmp_rand0/rand0/asset.txt-transformOutput1.txt --output=/.tmp_rand0/rand0/asset.txt-transformOutput2.txt\n'
+          'stdout:\n'
+          '\n'
+          'stderr:\n'
+          'Transformation failed, but I forgot to exit with a non-zero code.',
+        ),
+      );
       expect(processManager, hasNoRemainingExpectations);
       expect(fileSystem.file(outputPath), isNot(exists));
       expect(
@@ -397,4 +409,74 @@ Transformation failed, but I forgot to exit with a non-zero code.''');
       );
     },
   );
+
+  testWithoutContext('Parses depfile and returns dependencies', () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final logger = BufferLogger.test();
+    final artifacts = Artifacts.test();
+
+    final File asset = fileSystem.file('asset.txt')
+      ..createSync()
+      ..writeAsStringSync('hello world');
+    const outputPath = 'output.txt';
+    final File depfileInput = fileSystem.file('depfile_input.txt')..createSync();
+
+    final String dartBinaryPath = artifacts.getArtifactPath(Artifact.engineDartBinary);
+    final processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(
+        command: <Pattern>[
+          dartBinaryPath,
+          'run',
+          'my_transformer',
+          RegExp(r'--input=.*'),
+          RegExp(r'--output=.*'),
+        ],
+        onRun: (List<String> args) {
+          final String inputArg = args.firstWhere((String arg) => arg.startsWith('--input='));
+          final String outputArg = args.firstWhere((String arg) => arg.startsWith('--output='));
+
+          final String inputPath = inputArg.substring('--input='.length);
+          final String outputPath = outputArg.substring('--output='.length);
+
+          final File depfile = fileSystem.file('$outputPath.d');
+
+          fileSystem.file(inputPath).copySync(outputPath);
+          depfile.writeAsStringSync(
+            '${fileSystem.file(outputPath).absolute.path}: '
+            '${fileSystem.file(inputPath).absolute.path} '
+            '${depfileInput.absolute.path}',
+          );
+        },
+      ),
+    ]);
+
+    final transformer = AssetTransformer(
+      processManager: processManager,
+      fileSystem: fileSystem,
+      dartBinaryPath: dartBinaryPath,
+      buildMode: BuildMode.debug,
+    );
+
+    final AssetTransformationResult result = await transformer.transformAsset(
+      asset: asset,
+      outputPath: outputPath,
+      workingDirectory: fileSystem.currentDirectory.path,
+      transformerEntries: <AssetTransformerEntry>[
+        const AssetTransformerEntry(package: 'my_transformer', args: <String>[]),
+      ],
+      logger: logger,
+    );
+
+    expect(result.failure, isNull, reason: logger.errorText);
+    expect(processManager, hasNoRemainingExpectations);
+    expect(fileSystem.file(outputPath).readAsStringSync(), 'hello world');
+    expect(result.dependencies, hasLength(1));
+    expect(result.dependencies.first.path, depfileInput.absolute.path);
+
+    expect(
+      fileSystem.directory('.tmp_rand0').listSync(),
+      isEmpty,
+      reason: 'Transformer did not clean up after itself.',
+    );
+  });
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -978,11 +978,12 @@ flutter:
         userMessages: UserMessages(),
       );
 
+      final processManager = FakeProcessManager.list(
+        List<FakeCommand>.filled(assetsToTransform, transformerCommand, growable: true),
+      );
       final environment = Environment.test(
         fileSystem.currentDirectory,
-        processManager: FakeProcessManager.list(
-          List<FakeCommand>.filled(assetsToTransform, transformerCommand, growable: true),
-        ),
+        processManager: processManager,
         artifacts: Artifacts.test(),
         fileSystem: fileSystem,
         logger: logger,
@@ -1023,8 +1024,9 @@ flutter:
       markTransformDone.complete();
       await waitFor;
 
-      expect(inputFilePaths.toSet(), hasLength(4));
-      expect(outputFilePaths.toSet(), hasLength(4));
+      expect(inputFilePaths, hasLength(5));
+      expect(outputFilePaths, hasLength(5));
+      expect(processManager, hasNoRemainingExpectations);
     },
     overrides: <Type, Generator>{
       Platform: () => FakePlatform(numberOfProcessors: 4),


### PR DESCRIPTION
**Reland of #187947** (reverted in #188751)

This is a reland of the previously reverted PR #187947. The failure in Mac `web_tool_tests` that triggered the revert was determined to be an unrelated flake. Specifically, the test failed in build [29841](https://ci.chromium.org/ui/b/8725838089301019649) (which also failed in 29846 without the PR).

Original description:
[flutter_tools] Track asset transformer dependencies for hot reload

Allow asset transformers to register additional input dependencies for hot reload by passing a `--depfile` flag to the transformer subprocess and parsing the resulting Ninja-format depfile.

Key changes:
- `AssetTransformer` now passes `--depfile` and parses it using `DepfileService`, returning dependencies in a new `AssetTransformationResult`.
- `DevelopmentAssetTransformer` tracks these dependencies and provides them to `DevFS`.
- `DevFS.updateBundle` does not skip transformed assets on startup, running the transformer to collect dependencies but optimizing by not uploading them to the device unless requested (e.g., for Web).
- `DevFS.updateBundle` checks if any tracked dependencies are invalidated and triggers re-transformation.
- `DevFS.update` and `WebDevFS.update` append collected dependencies to the watched `sources` set.
- `copyAssets` build target collects and adds these dependencies to its inputs to ensure correct rebuilds.
- Added unit and integration tests to verify the behavior.

Fixes https://github.com/flutter/flutter/issues/187051
