### PR TITLE
Adds semantics role check to isSemantics and matchesSemantics

### DIFF
--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -689,6 +689,7 @@ Matcher matchesSemantics({
   ui.SemanticsInputType? inputType,
   String? maxValue,
   String? minValue,
+  ui.SemanticsRole? role,
   // Flags //
   bool hasCheckedState = false,
   bool isChecked = false,
@@ -776,6 +777,7 @@ Matcher matchesSemantics({
     inputType: inputType,
     minValue: minValue,
     maxValue: maxValue,
+    role: role,
     // Flags
     hasCheckedState: hasCheckedState,
     isChecked: isChecked,
@@ -1090,6 +1092,7 @@ Matcher isSemantics({
   ui.SemanticsInputType? inputType,
   String? maxValue,
   String? minValue,
+  ui.SemanticsRole? role,
   // Flags
   bool? hasCheckedState,
   bool? isChecked,
@@ -1177,6 +1180,7 @@ Matcher isSemantics({
     inputType: inputType,
     minValue: minValue,
     maxValue: maxValue,
+    role: role,
     // Flags
     hasCheckedState: hasCheckedState,
     isChecked: isChecked,
@@ -2642,6 +2646,7 @@ class _MatchesSemanticsData extends Matcher {
     required this.inputType,
     required this.minValue,
     required this.maxValue,
+    required this.role,
     // Flags
     required bool? hasCheckedState,
     required bool? isChecked,
@@ -2791,6 +2796,7 @@ class _MatchesSemanticsData extends Matcher {
   final SemanticsValidationResult? validationResult;
   final String? maxValue;
   final String? minValue;
+  final ui.SemanticsRole? role;
 
   /// There are three possible states for these two maps:
   ///
@@ -2909,6 +2915,9 @@ class _MatchesSemanticsData extends Matcher {
     }
     if (maxValue != null) {
       description.add(' with maxValue: $maxValue');
+    }
+    if (role != null) {
+      description.add(' with role: $role');
     }
     if (children != null) {
       description.add(' with children:\n  ');
@@ -3074,6 +3083,9 @@ class _MatchesSemanticsData extends Matcher {
     }
     if (maxValue != null && maxValue != data.maxValue) {
       return failWithDescription(matchState, 'maxValue was: ${data.maxValue}');
+    }
+    if (role != null && role != data.role) {
+      return failWithDescription(matchState, 'role was: ${data.role}');
     }
     if (actions.isNotEmpty) {
       final unexpectedActions = <SemanticsAction>[];

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -614,7 +614,6 @@ void main() {
 
   group('matchesSemanticsData', () {
     testWidgets('matches SemanticsData', (WidgetTester tester) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
       const key = Key('semantics');
       await tester.pumpWidget(
         Semantics(
@@ -713,8 +712,6 @@ void main() {
           ),
         ),
       );
-
-      handle.dispose();
     });
 
     testWidgets('Can match all semantics flags and actions', (WidgetTester tester) async {
@@ -831,7 +828,6 @@ void main() {
     });
 
     testWidgets('Can match child semantics', (WidgetTester tester) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
       const key = Key('a');
       await tester.pumpWidget(
         Semantics(
@@ -853,12 +849,9 @@ void main() {
           children: <Matcher>[matchesSemantics(label: 'Bar', textDirection: TextDirection.ltr)],
         ),
       );
-      handle.dispose();
     });
 
     testWidgets('failure does not throw unexpected errors', (WidgetTester tester) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
-
       const key = Key('semantics');
       await tester.pumpWidget(
         Semantics(
@@ -913,7 +906,6 @@ void main() {
       );
 
       expect(failedExpectation, throwsA(isA<TestFailure>()));
-      handle.dispose();
     });
 
     testWidgets('matchesSemantics captures NBSP in failure descriptions', (
@@ -1281,8 +1273,6 @@ void main() {
 
   group('isSemantics', () {
     testWidgets('matches SemanticsData', (WidgetTester tester) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
-
       const key = Key('semantics');
       await tester.pumpWidget(
         Semantics(
@@ -1381,7 +1371,6 @@ void main() {
         ),
         reason: 'onTapHint "scans" should not have matched "scan".',
       );
-      handle.dispose();
     });
 
     testWidgets('can match all semantics flags and actions enabled', (WidgetTester tester) async {
@@ -1710,7 +1699,6 @@ void main() {
     });
 
     testWidgets('can match child semantics', (WidgetTester tester) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
       const key = Key('a');
       await tester.pumpWidget(
         Semantics(
@@ -1732,11 +1720,8 @@ void main() {
           children: <Matcher>[isSemantics(label: 'Bar', textDirection: TextDirection.ltr)],
         ),
       );
-
-      handle.dispose();
     });
     testWidgets('can match validation result', (WidgetTester tester) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
       const key = Key('a');
       await tester.pumpWidget(
         Semantics(
@@ -1756,12 +1741,9 @@ void main() {
           textDirection: TextDirection.ltr,
         ),
       );
-
-      handle.dispose();
     });
 
     testWidgets('can ignore validation result', (WidgetTester tester) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
       const key = Key('a');
       await tester.pumpWidget(
         Semantics(
@@ -1775,8 +1757,60 @@ void main() {
       // It is important that validationResult is passed as null to isSemantics,
       // because this is testing that null means "ignore the validation result value".
       expect(node, isSemantics(label: 'Foo', textDirection: TextDirection.ltr));
+    });
 
-      handle.dispose();
+    testWidgets('can match role', (WidgetTester tester) async {
+      const key = Key('a');
+      await tester.pumpWidget(
+        Semantics(
+          key: key,
+          label: 'Foo',
+          role: ui.SemanticsRole.dialog,
+          textDirection: TextDirection.ltr,
+        ),
+      );
+      final SemanticsNode node = tester.getSemantics(find.byKey(key));
+
+      expect(
+        node,
+        isSemantics(label: 'Foo', role: ui.SemanticsRole.dialog, textDirection: TextDirection.ltr),
+      );
+    });
+
+    testWidgets('can ignore role', (WidgetTester tester) async {
+      const key = Key('a');
+      await tester.pumpWidget(
+        Semantics(
+          key: key,
+          label: 'Foo',
+          role: ui.SemanticsRole.dialog,
+          textDirection: TextDirection.ltr,
+        ),
+      );
+      final SemanticsNode node = tester.getSemantics(find.byKey(key));
+      expect(node, isSemantics(label: 'Foo', textDirection: TextDirection.ltr));
+    });
+
+    testWidgets('can match role with matchesSemantics', (WidgetTester tester) async {
+      const key = Key('a');
+      await tester.pumpWidget(
+        Semantics(
+          key: key,
+          label: 'Foo',
+          role: ui.SemanticsRole.dialog,
+          textDirection: TextDirection.ltr,
+        ),
+      );
+      final SemanticsNode node = tester.getSemantics(find.byKey(key));
+
+      expect(
+        node,
+        matchesSemantics(
+          label: 'Foo',
+          role: ui.SemanticsRole.dialog,
+          textDirection: TextDirection.ltr,
+        ),
+      );
     });
 
     testWidgets('can match only custom actions', (WidgetTester tester) async {
@@ -1822,8 +1856,6 @@ void main() {
     });
 
     testWidgets('failure does not throw unexpected errors', (WidgetTester tester) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
-
       const key = Key('semantics');
       await tester.pumpWidget(
         Semantics(
@@ -1875,7 +1907,6 @@ void main() {
       );
 
       expect(failedExpectation, throwsA(isA<TestFailure>()));
-      handle.dispose();
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

as title

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
