### PR TITLE
Fix potential race condtion in android_semantics_integration_test

### DIFF
--- a/dev/integration_tests/android_semantics_testing/integration_test/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/integration_test/main_test.dart
@@ -67,19 +67,22 @@ Future<void> main() async {
   group('AccessibilityBridge', () {
     group('TextField', () {
       Future<void> prepareTextField(WidgetTester tester) async {
-        app.main();
-        await tester.pumpAndSettle();
-        await tester.tap(find.text(textFieldRoute));
-        await tester.pumpAndSettle();
-
         // The text selection menu and related semantics vary depending on if
         // the clipboard contents are pasteable. Copy some text into the
         // clipboard to make sure these tests always run with pasteable content
         // in the clipboard.
+        //
+        // This MUST be called before the text field is initialized (before app.main
+        // and navigation) to avoid a race condition with EditableText's initial
+        // asynchronous clipboard status query during initState.
+        //
         // Ideally this should test the case where there is nothing on the
         // clipboard as well, but there is no reliable way to clear the
         // clipboard on Android devices.
         await setClipboard('Hello World');
+        app.main();
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(textFieldRoute));
         await tester.pumpAndSettle();
       }
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->
editable text initstate reads the clipboard status and won't get updated later, so it is possible the initstate finishes before the test set clipboard. I reverse the order to fix the race condition

fixes https://github.com/flutter/flutter/issues/188101

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
