### PR TITLE
Move WindowManager outside of WidgetsApp

### DIFF
--- a/examples/api/lib/widgets/windows/window_manager.0.dart
+++ b/examples/api/lib/widgets/windows/window_manager.0.dart
@@ -17,7 +17,12 @@ void main() {
     );
     runWidget(
       WindowManager(
-        child: RegularWindow(controller: controller, child: const MainWindow()),
+        initialWindows: [
+          WindowEntry(
+            controller: controller,
+            builder: (context) => const MainWindow(),
+          ),
+        ],
       ),
     );
   } on UnsupportedError catch (e) {

--- a/examples/multiple_windows/lib/app/dialog_window_content.dart
+++ b/examples/multiple_windows/lib/app/dialog_window_content.dart
@@ -19,9 +19,8 @@ class DialogWindowContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final WindowSettings windowSettings = WindowSettingsAccessor.of(context);
 
-    return Overlay.wrap(
-      alwaysSizeToContent: true,
-      child: FocusScope(
+    return MaterialApp(
+      home: FocusScope(
         autofocus: true,
         child: IntrinsicWidth(
           child: Material(

--- a/examples/multiple_windows/lib/app/main_window.dart
+++ b/examples/multiple_windows/lib/app/main_window.dart
@@ -94,7 +94,7 @@ class _WindowsTable extends StatelessWidget {
   }
 
   List<DataRow> _buildRows(WindowRegistry windowRegistry, BuildContext context) {
-    final List<DataRow> rows = [_buildRow(mainWindow, context)];
+    final List<DataRow> rows = [];
     for (final WindowEntry entry in windowRegistry.windows) {
       final BaseWindowController controller = entry.controller;
       rows.add(_buildRow(controller, context));

--- a/examples/multiple_windows/lib/app/popup_button.dart
+++ b/examples/multiple_windows/lib/app/popup_button.dart
@@ -32,7 +32,7 @@ class _PopupButtonState extends State<PopupButton> {
     super.dispose();
   }
 
-  void _onPressed(WindowRegistry windowRegistry, WindowSettings windowSettings) {
+  void _onPressed(WindowSettings windowSettings) {
     // Toggle popup visibility.
     if (_popupWindowEntry != null) {
       _popupWindowEntry!.controller.destroy();
@@ -50,7 +50,6 @@ class _PopupButtonState extends State<PopupButton> {
         positioner: windowSettings.positioner,
         delegate: _PopupWindowControllerDelegate(
           onDestroyed: () {
-            windowRegistry.unregister(entry);
             tracker.dispose();
             if (mounted) {
               setState(() {
@@ -66,7 +65,6 @@ class _PopupButtonState extends State<PopupButton> {
         controller: controller,
         builder: (BuildContext context) => PopupWindowContent(controller: controller),
       );
-      windowRegistry.register(entry);
       tracker.onGlobalRectChange = (rect) {
         controller.updatePosition(anchorRect: rect);
       };
@@ -79,13 +77,20 @@ class _PopupButtonState extends State<PopupButton> {
 
   @override
   Widget build(BuildContext context) {
-    final WindowRegistry windowManager = WindowRegistry.of(context);
     final WindowSettings windowSettings = WindowSettingsAccessor.of(context);
 
     return OutlinedButton(
       key: _popupButtonKey,
-      onPressed: () => _onPressed(windowManager, windowSettings),
-      child: Text(_popupWindowEntry != null ? 'Hide Popup' : 'Show Popup'),
+      onPressed: () => _onPressed(windowSettings),
+      child: ViewAnchor(
+        view: _popupWindowEntry != null
+            ? View(
+                view: _popupWindowEntry!.controller.rootView,
+                child: Builder(builder: _popupWindowEntry!.builder),
+              )
+            : null,
+        child: Text(_popupWindowEntry != null ? 'Hide Popup' : 'Show Popup'),
+      ),
     );
   }
 }

--- a/examples/multiple_windows/lib/app/regular_window_content.dart
+++ b/examples/multiple_windows/lib/app/regular_window_content.dart
@@ -49,9 +49,8 @@ class _RegularWindowContentState extends State<RegularWindowContent> {
     final double dpr = MediaQuery.of(context).devicePixelRatio;
     final Size windowSize = WindowScope.contentSizeOf(context);
 
-    return Overlay.wrap(
-      alwaysSizeToContent: true,
-      child: IntrinsicWidth(
+    return MaterialApp(
+      home: IntrinsicWidth(
         child: Material(
           child: Column(
             mainAxisSize: .min,

--- a/examples/multiple_windows/lib/app/tooltip_button.dart
+++ b/examples/multiple_windows/lib/app/tooltip_button.dart
@@ -5,8 +5,6 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
 

--- a/examples/multiple_windows/lib/app/tooltip_button.dart
+++ b/examples/multiple_windows/lib/app/tooltip_button.dart
@@ -5,6 +5,8 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
 
@@ -32,7 +34,7 @@ class _TooltipButtonState extends State<TooltipButton> {
     super.dispose();
   }
 
-  void _onPressed(WindowRegistry windowRegistry, WindowSettings windowSettings) {
+  void _onPressed(WindowSettings windowSettings) {
     // Toggle tooltip visibility.
     if (_tooltipEntry != null) {
       _tooltipEntry!.controller.destroy();
@@ -50,7 +52,6 @@ class _TooltipButtonState extends State<TooltipButton> {
         positioner: windowSettings.positioner,
         delegate: _TooltipWindowControllerDelegate(
           onDestroyed: () {
-            windowRegistry.unregister(entry);
             tracker.dispose();
             if (mounted) {
               setState(() {
@@ -66,7 +67,6 @@ class _TooltipButtonState extends State<TooltipButton> {
         controller: controller,
         builder: (BuildContext context) => TooltipWindowContent(controller: controller),
       );
-      windowRegistry.register(entry);
       tracker.onGlobalRectChange = (rect) {
         controller.updatePosition(anchorRect: rect);
       };
@@ -79,13 +79,20 @@ class _TooltipButtonState extends State<TooltipButton> {
 
   @override
   Widget build(BuildContext context) {
-    final WindowRegistry windowManager = WindowRegistry.of(context);
     final WindowSettings windowSettings = WindowSettingsAccessor.of(context);
 
     return OutlinedButton(
       key: _tooltipButtonKey,
-      onPressed: () => _onPressed(windowManager, windowSettings),
-      child: Text(_tooltipEntry != null ? 'Hide Tooltip' : 'Show Tooltip'),
+      onPressed: () => _onPressed(windowSettings),
+      child: ViewAnchor(
+        view: _tooltipEntry != null
+            ? View(
+                view: _tooltipEntry!.controller.rootView,
+                child: Builder(builder: _tooltipEntry!.builder),
+              )
+            : null,
+        child: Text(_tooltipEntry != null ? 'Hide Tooltip' : 'Show Tooltip'),
+      ),
     );
   }
 }

--- a/examples/multiple_windows/lib/main.dart
+++ b/examples/multiple_windows/lib/main.dart
@@ -51,9 +51,13 @@ class _MultiWindowAppState extends State<MultiWindowApp> {
   Widget build(BuildContext context) {
     return WindowSettingsAccessor(
       windowSettings: settings,
-      child: RegularWindow(
-        controller: controller,
-        child: MaterialApp(home: MainWindow(controller: controller)),
+      child: WindowManager(
+        initialWindows: [
+          WindowEntry(
+            controller: controller,
+            builder: (context) => MaterialApp(home: MainWindow(controller: controller)),
+          ),
+        ],
       ),
     );
   }

--- a/packages/flutter/lib/src/widgets/_window.dart
+++ b/packages/flutter/lib/src/widgets/_window.dart
@@ -2516,6 +2516,7 @@ class WindowManager extends StatefulWidget {
   @internal
   const WindowManager({super.key, required this.initialWindows});
 
+/// The initial windows to be registered and managed by this window manager.
   final List<WindowEntry> initialWindows;
 
   @override

--- a/packages/flutter/lib/src/widgets/_window.dart
+++ b/packages/flutter/lib/src/widgets/_window.dart
@@ -2514,10 +2514,9 @@ class WindowManager extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
-  const WindowManager({super.key, required this.child});
+  const WindowManager({super.key, required this.initialWindows});
 
-  /// The child widget of the window manager.
-  final Widget child;
+  final List<WindowEntry> initialWindows;
 
   @override
   State<WindowManager> createState() => _WindowManagerState();
@@ -2527,11 +2526,13 @@ class _WindowManagerState extends State<WindowManager> {
   final WindowRegistry _registry = WindowRegistry();
 
   @override
-  Widget build(BuildContext context) {
-    if (!isWindowingEnabled) {
-      return widget.child;
-    }
+  void initState() {
+    super.initState();
+    widget.initialWindows.forEach(_registry.register);
+  }
 
+  @override
+  Widget build(BuildContext context) {
     return _WindowRegistryScope(
       registry: _registry,
       child: ListenableBuilder(
@@ -2562,17 +2563,8 @@ class _WindowManagerState extends State<WindowManager> {
             };
           }).toList();
 
-          final FlutterView? view = View.maybeOf(context);
-          if (view == null) {
-            return ViewCollection(views: subViews);
-          }
-
-          return ViewAnchor(
-            view: subViews.isNotEmpty ? ViewCollection(views: subViews) : null,
-            child: child!,
-          );
+          return ViewCollection(views: subViews);
         },
-        child: widget.child,
       ),
     );
   }

--- a/packages/flutter/lib/src/widgets/_window.dart
+++ b/packages/flutter/lib/src/widgets/_window.dart
@@ -2516,7 +2516,7 @@ class WindowManager extends StatefulWidget {
   @internal
   const WindowManager({super.key, required this.initialWindows});
 
-/// The initial windows to be registered and managed by this window manager.
+  /// The initial windows to be registered and managed by this window manager.
   final List<WindowEntry> initialWindows;
 
   @override

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -15,8 +15,6 @@ import 'dart:collection' show HashMap;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import '../foundation/_features.dart' show isWindowingEnabled;
-import '_window.dart' show WindowManager;
 
 import 'actions.dart';
 import 'banner.dart';

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1730,10 +1730,6 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
       result = routing!;
     }
 
-    if (isWindowingEnabled) {
-      result = WindowManager(child: result);
-    }
-
     if (widget.textStyle != null) {
       result = DefaultTextStyle(style: widget.textStyle!, child: result);
     }

--- a/packages/flutter/lib/src/widgets/dialog.dart
+++ b/packages/flutter/lib/src/widgets/dialog.dart
@@ -2,24 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
-
-import '../foundation/_features.dart' show isWindowingEnabled;
-
-import '_window.dart'
-    show
-        BaseWindowController,
-        DialogWindowController,
-        DialogWindowControllerDelegate,
-        WindowEntry,
-        WindowRegistry,
-        WindowScope;
-
 import 'basic.dart';
 import 'debug.dart';
 import 'framework.dart';
 import 'navigator.dart';
-import 'overlay.dart';
 import 'routes.dart';
 
 /// A builder for a route that takes the build context and the widget intended
@@ -78,27 +64,6 @@ Future<T?> showRawDialog<T>({
 
   final NavigatorState navigator = Navigator.of(context, rootNavigator: useRootNavigator);
 
-  final WindowRegistry? windowRegistry = WindowRegistry.maybeOf(context);
-  if (windowRegistry != null && isWindowingEnabled) {
-    try {
-      final Size? parentSize = WindowScope.maybeContentSizeOf(context);
-      return navigator.push<T>(
-        _DialogWindowRoute<T>(
-          builder: builder,
-          parentController: WindowScope.maybeOf(context),
-          context: context,
-          settings: routeSettings,
-          size: fullscreenDialog ? parentSize : null,
-        ),
-      );
-    } on UnsupportedError catch (error, stacktrace) {
-      // Fallback to normal dialog route if windowing is not supported.
-      FlutterError.reportError(
-        FlutterErrorDetails(exception: error, library: 'widgets library', stack: stacktrace),
-      );
-    }
-  }
-
   final Route<T> route =
       routeBuilder?.call(context, builder) ??
       RawDialogRoute<T>(
@@ -113,87 +78,4 @@ Future<T?> showRawDialog<T>({
       );
 
   return navigator.push<T>(route);
-}
-
-class _DialogWindowDelegate extends DialogWindowControllerDelegate {
-  _DialogWindowDelegate(this.route);
-
-  final _DialogWindowRoute<dynamic> route;
-
-  @override
-  void onWindowCloseRequested(DialogWindowController controller) {
-    route.navigator?.pop();
-  }
-}
-
-class _DialogWindowRoute<T> extends Route<T> {
-  _DialogWindowRoute({
-    required this.builder,
-    required this.parentController,
-    required BuildContext context,
-    super.settings,
-    Size? size,
-  }) : _registry = WindowRegistry.maybeOf(context) {
-    _controller = size != null
-        ? DialogWindowController(
-            parent: parentController,
-            title: 'Dialog',
-            delegate: _DialogWindowDelegate(this),
-            size: size,
-          )
-        : DialogWindowController.sizedToContent(
-            parent: parentController,
-            title: 'Dialog',
-            delegate: _DialogWindowDelegate(this),
-          );
-  }
-
-  final WidgetBuilder builder;
-  final BaseWindowController? parentController;
-  final WindowRegistry? _registry;
-  DialogWindowController? _controller;
-  WindowEntry? _entry;
-  late final List<OverlayEntry> _overlayEntries;
-
-  @override
-  List<OverlayEntry> get overlayEntries => _overlayEntries;
-
-  @override
-  void install() {
-    super.install();
-
-    // Create a minimal transparent overlay entry to satisfy Navigator requirements.
-    // The actual dialog content is rendered through ViewAnchor, not through this overlay.
-    _overlayEntries = <OverlayEntry>[
-      OverlayEntry(builder: (BuildContext context) => const SizedBox.shrink()),
-    ];
-
-    final NavigatorState? nav = navigator;
-    final BuildContext? routeContext = nav?.context;
-    if (routeContext != null && nav != null) {
-      _entry = WindowEntry(controller: _controller!, builder: builder);
-      _registry?.register(_entry!);
-    }
-  }
-
-  @override
-  TickerFuture didPush() {
-    return super.didPush();
-  }
-
-  @override
-  bool didPop(T? result) {
-    if (_entry != null) {
-      _registry?.unregister(_entry!);
-    }
-    _controller?.destroy();
-    return super.didPop(result);
-  }
-
-  @override
-  void dispose() {
-    _controller?.dispose();
-    _controller = null;
-    super.dispose();
-  }
 }


### PR DESCRIPTION
This is a prototype branch for moving `WindowManager` outside of `WidgetsApp`.

Our current approach where first window is "blessed" and other windows are anchored inside first window hierarchy is causing multiple issues:
- Only the first window has navigator
- Secondary windows focus zones are inside primary window focus zone so it is always focused.
- Widget inspector only works in primary window

In general there is no reason for one window to be special. Normally for a desktop application all windows should be equal. The closest we can get to this is to give each top level window its own Widgets/MaterialApp. While this duplicates some elements that should normally be shared, arguably it behaves better than doing what we do right now.

Ideally we'd want to split the App widget into shared and per window parts, but that will be a much bigger change.

With this branch the top level Dialog/Regular window have each their own MaterialApp widget and separate focus trees, solving the issues above.

 `Popup` and `Tooltip` window work and are anchored at proper place in window hierarchy (they should not be top level window). However we might want to consider a convenience Widget to anchoring these instead of using `ViewAnchor` + `View`.

Screenshot of example app running in this mode - notice the Debug banner and widget inspector buttons in each window.

<img width="900" height="800" alt="Screenshot 2026-07-01 at 5 48 13 PM" src="https://github.com/user-attachments/assets/bbb6e646-e9d8-4618-9702-19afe0749b11" />
