### PR TITLE
[tool] Enable record_use experiment by default on all channels

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -224,7 +224,9 @@ const recordUse = Feature(
   name: 'record use experiment',
   configSetting: 'enable-record-use',
   environmentOverride: 'FLUTTER_RECORD_USE',
-  master: FeatureChannelSetting(available: true),
+  master: FeatureChannelSetting(available: true, enabledByDefault: true),
+  beta: FeatureChannelSetting(available: true, enabledByDefault: true),
+  stable: FeatureChannelSetting(available: true, enabledByDefault: true),
 );
 
 /// Enable Swift Package Manager as a darwin dependency manager.

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
@@ -96,6 +96,8 @@ name: my_app
           '-DFLUTTER_WEB_USE_SKWASM=true',
           '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
           '--extra-compiler-option=--depfile=${environment.buildDir.childFile('dart2wasm.d').path}',
+          '--recorded-uses=${environment.buildDir.childFile('recorded_uses_wasm.json').path}',
+          '--enable-experiment=record-use',
           '-O0',
           '--no-strip-wasm',
           '--no-minify',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -39,6 +39,8 @@ const _kStandardFlutterWebDefines = <String>[
   '-DFLUTTER_WEB_USE_SKIA=true',
   '-DFLUTTER_WEB_USE_SKWASM=false',
   '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
+  '--write-resources',
+  '--enable-experiment=record-use',
 ];
 
 const _kDart2WasmLinuxArgs = <String>[
@@ -1338,6 +1340,8 @@ _flutter.loader.load();
                           ],
                           '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
                           '--extra-compiler-option=--depfile=${depFile.absolute.path}',
+                          '--recorded-uses=${environment.buildDir.childFile('recorded_uses_wasm.json').absolute.path}',
+                          '--enable-experiment=record-use',
                           '-O$expectedLevel',
                           if (strip && buildMode == 'release')
                             '--strip-wasm'

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -204,6 +204,7 @@ void main() {
   testUsingContext(
     'NativeAssets with an asset',
     overrides: <Type, Generator>{
+      FeatureFlags: () => TestFeatureFlags(isNativeAssetsEnabled: true),
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
         // Create the framework dylib.
         FakeCommand(


### PR DESCRIPTION
With https://github.com/dart-lang/sdk/commit/58ca1208b235673ac0b0f46c6e98a41ced1a7964 the last record use change is in for the stable release. So lets flip the flag.