### PR TITLE
Recommend `OverlayPortal.overlayChildLayoutBuilder` over Target-Follower

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2303,8 +2303,10 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   // currently allowed to mutate, and a boolean indicating whether this
   // RenderObject is allowed to mutate.
   //
-  // This method must only be called during layout as mutations are always allowed
-  // before layout.
+  // This method must only be called during layout, as mutations are always
+  // allowed before layout. A null return value indicates another render subtree
+  // is actively performing layout and, in the process, illegally mutating this
+  // RenderObject's subtree.
   (RenderObject, bool)? get _debugClosestMutationRoot {
     return switch (this) {
       // This subtree is being mutated in a layout callback.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1991,7 +1991,7 @@ class CompositedTransformTarget extends SingleChildRenderObjectWidget {
 /// [CompositedTransformFollower] and [CompositedTransformTarget] are
 /// incompatible with [OverlayPortal.overlayChildLayoutBuilder] thus must not
 /// be used together. Consider using the [OverlayPortal.overlayChildLayoutBuilder]
-/// API instead to achieve a similar target-following effect, while also allowing
+/// API instead to achieve a similar target-following effect, while allowing
 /// the follower to be sized and positioned dynamically based on the target's
 /// size and position.
 /// {@endtemplate}

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1989,7 +1989,7 @@ class CompositedTransformTarget extends SingleChildRenderObjectWidget {
 ///
 /// {@template flutter.widgets.CompositedTransformFollower.overlayPortal}
 /// [CompositedTransformFollower] and [CompositedTransformTarget] are
-/// incompatible with [OverlayPortal.overlayChildLayoutBuilder] thus must not
+/// incompatible with [OverlayPortal.overlayChildLayoutBuilder] and thus must not
 /// be used together. Consider using the [OverlayPortal.overlayChildLayoutBuilder]
 /// API instead to achieve a similar target-following effect, while allowing
 /// the follower to be sized and positioned dynamically based on the target's

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1934,6 +1934,8 @@ class Transform extends SingleChildRenderObjectWidget {
 /// The [CompositedTransformTarget] must come earlier in the paint order than
 /// any linked [CompositedTransformFollower]s.
 ///
+/// {@macro flutter.widgets.CompositedTransformFollower.overlayPortal}
+///
 /// See also:
 ///
 ///  * [CompositedTransformFollower], the widget that can target this one.
@@ -1984,6 +1986,15 @@ class CompositedTransformTarget extends SingleChildRenderObjectWidget {
 /// hittable. If the parent covers the screen, this is trivially achievable, so
 /// this widget is usually used as the root of an [OverlayEntry] in an app-wide
 /// [Overlay] (e.g. as created by the [MaterialApp] widget's [Navigator]).
+///
+/// {@template flutter.widgets.CompositedTransformFollower.overlayPortal}
+/// [CompositedTransformFollower] and [CompositedTransformTarget] are
+/// incompatible with [OverlayPortal.overlayChildLayoutBuilder] thus must not
+/// be used together. Consider using the [OverlayPortal.overlayChildLayoutBuilder]
+/// API instead to achieve a similar target-following effect, while also allowing
+/// the follower to be sized and positioned dynamically based on the target's
+/// size and position.
+/// {@endtemplate}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1940,6 +1940,9 @@ class Transform extends SingleChildRenderObjectWidget {
 ///
 ///  * [CompositedTransformFollower], the widget that can target this one.
 ///  * [LeaderLayer], the layer that implements this widget's logic.
+///  * [OverlayPortal.overlayChildLayoutBuilder], which achieves a similar
+///    target-following effect, but also allows the follower to be sized and
+///    positioned dynamically based on the target's size and position.
 class CompositedTransformTarget extends SingleChildRenderObjectWidget {
   /// Creates a composited transform target widget.
   ///
@@ -1989,11 +1992,9 @@ class CompositedTransformTarget extends SingleChildRenderObjectWidget {
 ///
 /// {@template flutter.widgets.CompositedTransformFollower.overlayPortal}
 /// [CompositedTransformFollower] and [CompositedTransformTarget] are
-/// incompatible with [OverlayPortal.overlayChildLayoutBuilder] and thus must not
-/// be used together. Consider using the [OverlayPortal.overlayChildLayoutBuilder]
-/// API instead to achieve a similar target-following effect, while allowing
-/// the follower to be sized and positioned dynamically based on the target's
-/// size and position.
+/// incompatible with [OverlayPortal.overlayChildLayoutBuilder] and thus
+/// must not be used together. Consider using
+/// [OverlayPortal.overlayChildLayoutBuilder] instead
 /// {@endtemplate}
 ///
 /// See also:
@@ -2001,6 +2002,9 @@ class CompositedTransformTarget extends SingleChildRenderObjectWidget {
 ///  * [CompositedTransformTarget], the widget that this widget can target.
 ///  * [FollowerLayer], the layer that implements this widget's logic.
 ///  * [Transform], which applies an arbitrary transform to a child.
+///  * [OverlayPortal.overlayChildLayoutBuilder], which achieves a similar
+///    target-following effect, but also allows the follower to be sized and
+///    positioned dynamically based on the target's size and position.
 class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   /// Creates a composited transform target widget.
   ///


### PR DESCRIPTION
Also document that these 2 APIs are not compatible.

With the doc change I would like to discourage the use of `CompositedTransformTarget` and `CompositedTransformFollower` since their competing API `OverlayPortal.overlayChildLayoutBuilder` is generally more powerful but unfortunately is also incompatible with  `CompositedTransformTarget` and `CompositedTransformFollower`. Existing `CompositedTransformTarget` and `CompositedTransformFollower` usages in apps may throw when we port framework widgets to the new API.

I thought about introducing a convenience `OverlayPortal` constructor that can be used as drop-in replacement of `CompositedTransformTarget` and `CompositedTransformFollower`
but it seems to me that always following the `target` without resizing or re-positioning is not a common use case: in most cases you'd want to adjust the follower to stay in the viewport when the target moves too close to the edge.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
