### PR TITLE
[Impeller] Render COLR/CPAL color text as vector paths

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1973,6 +1973,45 @@ static constexpr Scalar kMaxTextScale = 250;
 void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
                            Point position,
                            const Paint& paint) {
+  // Color (COLR) text: draw each glyph's color layers as vector paths so the
+  // text stays crisp at any scale. The color glyph atlas (used otherwise)
+  // rasterizes at a capped size and softens/pixelates when scaled. Monochrome
+  // text gets the analogous treatment via the GetPath() branch below.
+  if (text_frame->HasColor()) {
+    std::vector<ColorGlyphLayer> color_layers = text_frame->GetColorPaths();
+    if (!color_layers.empty()) {
+      // A drawText op is budgeted exactly one depth slot by the DisplayList
+      // (AUTO_DEPTH_WATCHER(1u) in dl_dispatcher.cc), so all layers must share
+      // it: the first draw takes the slot and the rest stack on top of it via
+      // reuse_depth, composited in submission order (same pattern
+      // BlurStyle::kSolid uses to draw its solid shape atop its blur). Opaque
+      // same-depth draws resolve first-wins via the depth buffer, so layers
+      // are painted front-to-back: topmost COLR layer first, base glyph last.
+      Save(1);
+      Concat(Matrix::MakeTranslation(position));
+      bool first_layer = true;
+      for (auto it = color_layers.rbegin(); it != color_layers.rend(); ++it) {
+        const ColorGlyphLayer& layer = *it;
+        Paint layer_paint = paint;
+        layer_paint.style = Paint::Style::kFill;
+        layer_paint.color_source = nullptr;  // fill with the layer's own color
+        layer_paint.color =
+            layer.use_foreground_color
+                ? paint.color
+                : layer.color.WithAlpha(layer.color.alpha * paint.color.alpha);
+        Entity entity;
+        entity.SetTransform(GetCurrentTransform());
+        entity.SetBlendMode(layer_paint.blend_mode);
+        FillPathGeometry geom(layer.path);
+        AddRenderEntityWithFiltersToCurrentPass(entity, &geom, layer_paint,
+                                                /*reuse_depth=*/!first_layer);
+        first_layer = false;
+      }
+      Restore();
+      return;
+    }
+  }
+
   Scalar max_scale = GetCurrentTransform().GetMaxBasisLengthXY();
   if (max_scale * text_frame->GetFont().GetMetrics().point_size >
       kMaxTextScale) {

--- a/engine/src/flutter/impeller/display_list/canvas_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/canvas_unittests.cc
@@ -19,6 +19,7 @@
 #include "impeller/playground/playground.h"
 #include "impeller/playground/widgets.h"
 #include "impeller/renderer/render_target.h"
+#include "impeller/typographer/text_frame.h"
 #include "third_party/abseil-cpp/absl/status/status_matchers.h"
 
 namespace impeller {
@@ -126,6 +127,41 @@ TEST_P(AiksTest, CanvasCanPushPopCTM) {
   ASSERT_EQ(canvas->GetSaveCount(), 1u);
   ASSERT_MATRIX_NEAR(canvas->GetCurrentTransform(),
                      Matrix::MakeTranslation({100.0, 100.0, 0.0}));
+}
+
+TEST_P(AiksTest, DrawColorTextFrameConsumesOneDepthSlot) {
+  ContentContext& context = GetContentContext();
+  auto canvas = CreateTestCanvas(context);
+
+  // A COLR text frame whose color layers are produced by the creator, the
+  // same way the Skia typographer backend supplies them.
+  auto make_color_frame = []() {
+    std::vector<TextRun> runs;
+    return std::make_shared<TextFrame>(
+        runs, Rect::MakeLTRB(0, 0, 20, 20), /*has_color=*/true,
+        /*path_creator=*/PathCreator{},
+        /*color_path_creator=*/[]() {
+          std::vector<ColorGlyphLayer> layers(3);
+          layers[0].path = flutter::DlPath::MakeRectLTRB(0, 0, 10, 10);
+          layers[0].use_foreground_color = true;
+          layers[1].path = flutter::DlPath::MakeRectLTRB(2, 2, 8, 8);
+          layers[1].color = Color::Red();
+          layers[2].path = flutter::DlPath::MakeRectLTRB(4, 4, 6, 6);
+          layers[2].color = Color::Green();
+          return layers;
+        });
+  };
+
+  // The DisplayList budgets exactly one depth slot per drawText op
+  // (AUTO_DEPTH_WATCHER(1u) in dl_dispatcher.cc), so drawing all of a color
+  // frame's layers must consume exactly one depth slot regardless of the
+  // layer count.
+  uint64_t depth_before = canvas->GetOpDepth();
+  canvas->DrawTextFrame(make_color_frame(), Point(0, 0), Paint{});
+  EXPECT_EQ(canvas->GetOpDepth(), depth_before + 1u);
+
+  canvas->DrawTextFrame(make_color_frame(), Point(20, 0), Paint{});
+  EXPECT_EQ(canvas->GetOpDepth(), depth_before + 2u);
 }
 
 TEST_P(AiksTest, CanvasCTMCanBeUpdated) {

--- a/engine/src/flutter/impeller/typographer/backends/skia/text_frame_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/text_frame_skia.cc
@@ -278,7 +278,15 @@ std::shared_ptr<TextFrame> MakeTextFrameFromTextBlobSkia(
           ColrV0 colr = ParseColrV0(colr_data);
           std::vector<Color> palette = ParseCpalPalette0(cpal_data);
 
-          SkStrikeSpec strike_spec = SkStrikeSpec::MakeWithNoDevice(run.font());
+          // Fetch outlines unhinted with linear metrics: these paths are
+          // rendered as scalable vectors, and grid-fitting (e.g. FreeType on
+          // Android) displaces the base glyph and its color layers by
+          // different amounts, which reads as a visible misalignment once
+          // zoomed. (CoreText never hints, so this is a no-op on iOS/macOS.)
+          SkFont path_font = run.font();
+          path_font.setHinting(SkFontHinting::kNone);
+          path_font.setLinearMetrics(true);
+          SkStrikeSpec strike_spec = SkStrikeSpec::MakeWithNoDevice(path_font);
           SkBulkGlyphMetricsAndPaths paths{strike_spec};
 
           const SkGlyphID* glyph_ids = run.glyphs();

--- a/engine/src/flutter/impeller/typographer/backends/skia/text_frame_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/text_frame_skia.cc
@@ -12,10 +12,14 @@
 #include "impeller/typographer/backends/skia/typeface_skia.h"
 #include "impeller/typographer/font.h"
 #include "impeller/typographer/glyph.h"
+#include "third_party/skia/include/core/SkData.h"
 #include "third_party/skia/include/core/SkFont.h"
 #include "third_party/skia/include/core/SkFontMetrics.h"
+#include "third_party/skia/include/core/SkMatrix.h"
 #include "third_party/skia/include/core/SkPaint.h"
+#include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkRect.h"
+#include "third_party/skia/include/core/SkTypeface.h"
 #include "third_party/skia/modules/skparagraph/include/Paragraph.h"  // nogncheck
 #include "third_party/skia/src/core/SkStrikeSpec.h"    // nogncheck
 #include "third_party/skia/src/core/SkTextBlobPriv.h"  // nogncheck
@@ -41,6 +45,163 @@ static Font ToFont(const SkTextBlobRunIterator& run, AxisAlignment alignment) {
 static Rect ToRect(const SkRect& rect) {
   return Rect::MakeLTRB(rect.fLeft, rect.fTop, rect.fRight, rect.fBottom);
 }
+
+namespace {
+
+// Minimal big-endian OpenType readers for the COLR (v0) and CPAL tables.
+// iOS uses the CoreText backend, which rasterizes the *composite* color glyph
+// to a bitmap and never exposes COLR layers as vector data. But COLRv0 layers
+// are just references to ordinary glyphs whose outlines CoreText *does*
+// provide, so we parse the tables ourselves and render each layer as a colored
+// path.
+uint16_t ReadU16(const uint8_t* p) {
+  return static_cast<uint16_t>((static_cast<uint16_t>(p[0]) << 8) | p[1]);
+}
+uint32_t ReadU32(const uint8_t* p) {
+  return (static_cast<uint32_t>(p[0]) << 24) |
+         (static_cast<uint32_t>(p[1]) << 16) |
+         (static_cast<uint32_t>(p[2]) << 8) | static_cast<uint32_t>(p[3]);
+}
+
+// The first (index 0) CPAL palette, as impeller Colors. Empty if unavailable.
+std::vector<Color> ParseCpalPalette0(const sk_sp<SkData>& data) {
+  if (!data || data->size() < 14) {
+    return {};
+  }
+  const uint8_t* b = data->bytes();
+  const size_t size = data->size();
+  uint16_t num_palette_entries = ReadU16(b + 2);
+  uint16_t num_palettes = ReadU16(b + 4);
+  uint16_t num_color_records = ReadU16(b + 6);
+  uint32_t color_records_offset = ReadU32(b + 8);
+  if (num_palettes == 0) {
+    return {};
+  }
+  // colorRecordIndices[] starts at offset 12 (u16 each); palette 0 is the
+  // first.
+  uint16_t first_record = ReadU16(b + 12);
+  std::vector<Color> colors;
+  colors.reserve(num_palette_entries);
+  for (uint16_t i = 0; i < num_palette_entries; i++) {
+    uint32_t rec = first_record + i;
+    if (rec >= num_color_records) {
+      break;
+    }
+    size_t off = color_records_offset + static_cast<size_t>(rec) * 4;
+    if (off + 4 > size) {
+      break;
+    }
+    // CPAL color records are stored BGRA, 8 bits each.
+    Scalar blue = b[off + 0] / 255.0f;
+    Scalar green = b[off + 1] / 255.0f;
+    Scalar red = b[off + 2] / 255.0f;
+    Scalar alpha = b[off + 3] / 255.0f;
+    colors.push_back(Color(red, green, blue, alpha));
+  }
+  return colors;
+}
+
+// A parsed COLR (v0) table header; layer records are read on demand.
+struct ColrV0 {
+  const uint8_t* data = nullptr;
+  size_t size = 0;
+  uint16_t num_base_glyph_records = 0;
+  uint32_t base_glyph_records_offset = 0;
+  uint32_t layer_records_offset = 0;
+  uint16_t num_layer_records = 0;
+  bool ok = false;
+};
+
+ColrV0 ParseColrV0(const sk_sp<SkData>& data) {
+  ColrV0 c;
+  if (!data || data->size() < 14) {
+    return c;
+  }
+  const uint8_t* b = data->bytes();
+  // Only the v0 base/layer records are handled (v1 keeps them at the same
+  // offsets, so v1 fonts still get their v0 layers rendered).
+  c.data = b;
+  c.size = data->size();
+  c.num_base_glyph_records = ReadU16(b + 2);
+  c.base_glyph_records_offset = ReadU32(b + 4);
+  c.layer_records_offset = ReadU32(b + 8);
+  c.num_layer_records = ReadU16(b + 12);
+  c.ok = true;
+  return c;
+}
+
+// Binary-search the (glyphID-sorted) base glyph records for `glyph_id`.
+bool FindColrLayers(const ColrV0& c,
+                    uint16_t glyph_id,
+                    uint16_t* first_layer,
+                    uint16_t* num_layers) {
+  if (!c.ok || c.num_base_glyph_records == 0) {
+    return false;
+  }
+  int lo = 0;
+  int hi = static_cast<int>(c.num_base_glyph_records) - 1;
+  while (lo <= hi) {
+    int mid = (lo + hi) / 2;
+    size_t off = c.base_glyph_records_offset + static_cast<size_t>(mid) * 6;
+    if (off + 6 > c.size) {
+      return false;
+    }
+    uint16_t gid = ReadU16(c.data + off);
+    if (gid == glyph_id) {
+      *first_layer = ReadU16(c.data + off + 2);
+      *num_layers = ReadU16(c.data + off + 4);
+      return true;
+    }
+    if (gid < glyph_id) {
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return false;
+}
+
+bool GetColrLayerRecord(const ColrV0& c,
+                        uint16_t layer_index,
+                        uint16_t* glyph_id,
+                        uint16_t* palette_index) {
+  if (layer_index >= c.num_layer_records) {
+    return false;
+  }
+  size_t off = c.layer_records_offset + static_cast<size_t>(layer_index) * 4;
+  if (off + 4 > c.size) {
+    return false;
+  }
+  *glyph_id = ReadU16(c.data + off);
+  *palette_index = ReadU16(c.data + off + 2);
+  return true;
+}
+
+// Appends `glyph_id`'s outline (translated to `pos`) as a layer filled with
+// `color` (or the foreground color when `use_foreground`).
+void AppendGlyphPath(SkBulkGlyphMetricsAndPaths& paths,
+                     SkGlyphID glyph_id,
+                     SkPoint pos,
+                     Color color,
+                     bool use_foreground,
+                     std::vector<ColorGlyphLayer>* out) {
+  SkSpan<const SkGlyph*> span = paths.glyphs(SkSpan(&glyph_id, 1));
+  if (span.empty() || span[0] == nullptr) {
+    return;
+  }
+  const SkPath* path = span[0]->path();
+  if (path == nullptr || path->isEmpty()) {
+    return;
+  }
+  SkPath moved = path->makeTransform(SkMatrix::Translate(pos.x(), pos.y()));
+  ColorGlyphLayer layer;
+  layer.path = flutter::DlPath(moved);
+  layer.color = color;
+  layer.use_foreground_color = use_foreground;
+  out->push_back(std::move(layer));
+}
+
+}  // namespace
 
 std::shared_ptr<TextFrame> MakeTextFrameFromTextBlobSkia(
     const sk_sp<SkTextBlob>& blob) {
@@ -96,6 +257,63 @@ std::shared_ptr<TextFrame> MakeTextFrameFromTextBlobSkia(
         SkPath transformed = path.makeTransform(
             SkMatrix::Translate(blob->bounds().left(), blob->bounds().top()));
         return flutter::DlPath(transformed);
+      },
+      [blob]() -> std::vector<ColorGlyphLayer> {
+        // Build per-layer colored vector paths for every glyph in the frame so
+        // COLR text can be drawn as paths (crisp at any scale) instead of the
+        // color glyph atlas. See ColorGlyphLayer / TextFrame::GetColorPaths.
+        std::vector<ColorGlyphLayer> layers;
+        for (SkTextBlobRunIterator run(blob.get()); !run.done(); run.next()) {
+          if (run.positioning() != SkTextBlobRunIterator::kFull_Positioning) {
+            continue;
+          }
+          SkTypeface* typeface = run.font().getTypeface();
+          if (typeface == nullptr) {
+            continue;
+          }
+          sk_sp<SkData> colr_data =
+              typeface->copyTableData(SkSetFourByteTag('C', 'O', 'L', 'R'));
+          sk_sp<SkData> cpal_data =
+              typeface->copyTableData(SkSetFourByteTag('C', 'P', 'A', 'L'));
+          ColrV0 colr = ParseColrV0(colr_data);
+          std::vector<Color> palette = ParseCpalPalette0(cpal_data);
+
+          SkStrikeSpec strike_spec = SkStrikeSpec::MakeWithNoDevice(run.font());
+          SkBulkGlyphMetricsAndPaths paths{strike_spec};
+
+          const SkGlyphID* glyph_ids = run.glyphs();
+          const SkPoint* points = run.points();
+          for (uint32_t i = 0; i < run.glyphCount(); i++) {
+            SkGlyphID gid = glyph_ids[i];
+            SkPoint pos = points[i];
+            uint16_t first_layer = 0;
+            uint16_t num_layers = 0;
+            bool found =
+                colr.ok && FindColrLayers(colr, gid, &first_layer, &num_layers);
+            if (found && num_layers > 0) {
+              for (uint16_t l = 0; l < num_layers; l++) {
+                uint16_t layer_gid = 0;
+                uint16_t palette_index = 0;
+                if (!GetColrLayerRecord(colr, first_layer + l, &layer_gid,
+                                        &palette_index)) {
+                  continue;
+                }
+                bool use_foreground =
+                    palette_index == 0xFFFF || palette_index >= palette.size();
+                Color color =
+                    use_foreground ? Color::Black() : palette[palette_index];
+                AppendGlyphPath(paths, layer_gid, pos, color, use_foreground,
+                                &layers);
+              }
+            } else {
+              // Non-color glyph inside a color frame: draw its own outline in
+              // the foreground (paint) color.
+              AppendGlyphPath(paths, gid, pos, Color::Black(),
+                              /*use_foreground=*/true, &layers);
+            }
+          }
+        }
+        return layers;
       });
 }
 

--- a/engine/src/flutter/impeller/typographer/text_frame.cc
+++ b/engine/src/flutter/impeller/typographer/text_frame.cc
@@ -16,11 +16,13 @@ TextFrame::TextFrame() = default;
 TextFrame::TextFrame(std::vector<TextRun>& runs,
                      Rect bounds,
                      bool has_color,
-                     const PathCreator& path_creator)
+                     const PathCreator& path_creator,
+                     const ColorPathCreator& color_path_creator)
     : runs_(std::move(runs)),
       bounds_(bounds),
       has_color_(has_color),
-      path_creator_(path_creator) {}
+      path_creator_(path_creator),
+      color_path_creator_(color_path_creator) {}
 
 TextFrame::~TextFrame() = default;
 
@@ -116,6 +118,13 @@ fml::StatusOr<flutter::DlPath> TextFrame::GetPath() const {
     return path_creator_();
   }
   return fml::Status(fml::StatusCode::kCancelled, "no path creator specified.");
+}
+
+std::vector<ColorGlyphLayer> TextFrame::GetColorPaths() const {
+  if (color_path_creator_) {
+    return color_path_creator_();
+  }
+  return {};
 }
 
 const Font& TextFrame::GetFont() const {

--- a/engine/src/flutter/impeller/typographer/text_frame.h
+++ b/engine/src/flutter/impeller/typographer/text_frame.h
@@ -10,6 +10,7 @@
 
 #include "flutter/display_list/geometry/dl_path.h"
 #include "fml/status_or.h"
+#include "impeller/geometry/color.h"
 #include "impeller/geometry/rational.h"
 #include "impeller/typographer/glyph.h"
 #include "impeller/typographer/glyph_atlas.h"
@@ -18,6 +19,19 @@
 namespace impeller {
 
 using PathCreator = std::function<fml::StatusOr<flutter::DlPath>()>;
+
+//------------------------------------------------------------------------------
+/// @brief      A single vector layer of a COLR/CPAL color glyph: an outline
+///             plus the CPAL color it should be filled with.
+struct ColorGlyphLayer {
+  flutter::DlPath path;
+  Color color;
+  /// When true, fill with the current paint color instead of [color] (COLR
+  /// palette index 0xFFFF = "text foreground color").
+  bool use_foreground_color = false;
+};
+
+using ColorPathCreator = std::function<std::vector<ColorGlyphLayer>()>;
 
 //------------------------------------------------------------------------------
 /// @brief      Represents a collection of shaped text runs.
@@ -31,7 +45,8 @@ class TextFrame {
   TextFrame(std::vector<TextRun>& runs,
             Rect bounds,
             bool has_color,
-            const PathCreator& path_creator = {});
+            const PathCreator& path_creator = {},
+            const ColorPathCreator& color_path_creator = {});
 
   ~TextFrame();
 
@@ -92,6 +107,13 @@ class TextFrame {
 
   fml::StatusOr<flutter::DlPath> GetPath() const;
 
+  //----------------------------------------------------------------------------
+  /// @brief      For a COLR/CPAL color text frame, the per-glyph color layer
+  ///             outlines (see [ColorGlyphLayer]). Empty if this frame has no
+  ///             color path data available (e.g. non-color text, or a color
+  ///             format other than COLRv0).
+  std::vector<ColorGlyphLayer> GetColorPaths() const;
+
   /// @brief Toggle the platform-specific contrast and gamma correction in the
   ///        fragment shader.
   ///
@@ -110,6 +132,7 @@ class TextFrame {
   Rect bounds_;
   bool has_color_;
   const PathCreator path_creator_;
+  const ColorPathCreator color_path_creator_;
   std::optional<bool> enable_gamma_correction_ = std::nullopt;
 };
 

--- a/engine/src/flutter/impeller/typographer/typographer_unittests.cc
+++ b/engine/src/flutter/impeller/typographer/typographer_unittests.cc
@@ -78,6 +78,46 @@ TEST_P(TypographerTest, CanConvertTextBlob) {
   }
 }
 
+TEST_P(TypographerTest, TextFrameReturnsColorPathsFromCreator) {
+  std::vector<TextRun> runs;
+  TextFrame frame(runs, Rect::MakeLTRB(0, 0, 10, 10), /*has_color=*/true,
+                  /*path_creator=*/{},
+                  /*color_path_creator=*/[]() {
+                    std::vector<ColorGlyphLayer> layers(2);
+                    layers[0].use_foreground_color = true;
+                    layers[1].color = Color::Red();
+                    return layers;
+                  });
+  std::vector<ColorGlyphLayer> layers = frame.GetColorPaths();
+  ASSERT_EQ(layers.size(), 2u);
+  EXPECT_TRUE(layers[0].use_foreground_color);
+  EXPECT_FALSE(layers[1].use_foreground_color);
+  EXPECT_EQ(layers[1].color, Color::Red());
+}
+
+TEST_P(TypographerTest, TextFrameWithoutColorPathCreatorHasNoColorPaths) {
+  TextFrame frame;
+  EXPECT_TRUE(frame.GetColorPaths().empty());
+}
+
+TEST_P(TypographerTest, NonColrColorFontHasNoColorPaths) {
+#if FML_OS_MACOSX
+  auto mapping = flutter::testing::OpenFixtureAsSkData("Apple Color Emoji.ttc");
+#else
+  auto mapping = flutter::testing::OpenFixtureAsSkData("NotoColorEmoji.ttf");
+#endif
+  ASSERT_TRUE(mapping);
+  sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
+  SkFont emoji_font(font_mgr->makeFromData(mapping), 50.0);
+  auto frame = MakeTextFrameFromTextBlobSkia(
+      SkTextBlob::MakeFromString("😀 ", emoji_font));
+  ASSERT_TRUE(frame->HasColor());
+  // Bitmap emoji formats (CBDT/sbix) carry no COLRv0 layer list, so color
+  // path extraction must come back empty and rendering falls back to the
+  // color glyph atlas.
+  EXPECT_TRUE(frame->GetColorPaths().empty());
+}
+
 TEST_P(TypographerTest, CanCreateRenderContext) {
   auto context = TypographerContextSkia::Make();
   ASSERT_TRUE(context && context->IsValid());


### PR DESCRIPTION
Color (COLR/CPAL) text is currently pinned to a rasterized color glyph atlas capped at a small max scale (`kMaximumTextScale = 48`), so it goes soft/pixelated when scaled or zoomed while adjacent monochrome text — which already has a vector-path fallback above a scale threshold (`kMaxTextScale = 250` in `Canvas::DrawTextFrame`) — stays sharp.

This affects any app rendering a COLR/CPAL color font via Impeller: multicolor icon/emoji-style fonts, brand-colored icon fonts, or fonts that encode markup as glyph color. One concrete example that surfaced this: Quran apps that use COLR-colored fonts to render *tajweed* (pronunciation-rule annotations expressed as colored letters) — the colors go soft under zoom while the surrounding black text stays crisp.

COLRv0 layers are just references to ordinary glyphs, whose outlines are already available from the font. This PR adds a color branch to `Canvas::DrawTextFrame` that draws each glyph's COLR layers as colored vector paths instead of falling back to the bitmap atlas, matching the sharpness monochrome text already gets.

## What changed

- `impeller/typographer/text_frame.h` / `.cc`: `TextFrame` gains an optional `ColorPathCreator` that produces per-layer `(outline, CPAL color)` pairs (`ColorGlyphLayer`), and a `GetColorPaths()` accessor.
- `impeller/typographer/backends/skia/text_frame_skia.cc`: parses the COLR (v0) base/layer records and CPAL palette 0 directly from the typeface (Skia doesn't currently expose per-layer COLR paths itself), and builds a `ColorGlyphLayer` per `(glyph, layer)` using the glyph's own outline (translated into position). Layer outlines are fetched from an **unhinted strike with linear metrics** — grid-fitting (e.g. FreeType on Android) displaces the base glyph and its color layers by different amounts, which is magnified by the text scale and reads as visible misalignment; canonical unhinted outlines are the right source for arbitrarily-scaled vector rendering (no-op on CoreText, which never hints).
- `impeller/display_list/canvas.cc`: `DrawTextFrame` draws the color layers within a **single** Impeller depth-budget slot, matching the 1-depth-per-`drawText`-op budget the `DisplayList` allocates for this op — the first layer's draw takes the slot, the rest reuse it (`reuse_depth`), the same pattern `BlurStyle::kSolid` already uses to draw a solid shape atop its blur. Opaque same-depth draws resolve first-wins via the depth buffer, so layers are painted front-to-back (topmost COLR layer first, base glyph last) to composite correctly.

## Important: companion Skia changes needed

Skia's font backends set `neverRequestPath` on color glyphs, which blocks the outline fetches this PR relies on. Two small backend changes are needed in Skia (**separate, non-GitHub** — Skia reviews via Gerrit at skia-review.googlesource.com):

1. **CoreText (`SkScalerContext_mac_ct.cpp`), affects iOS/macOS:** CoreText disables outline generation *font-wide* (not per-glyph) for any typeface containing color glyphs, so `SkBulkGlyphMetricsAndPaths` returns null paths for the COLR layer glyphs even though `CTFontCreatePathForGlyph` produces them correctly.
2. **FreeType (`SkFontHost_FreeType.cpp`), affects Android/Linux:** the COLRv0 branch sets `neverRequestPath = true` on the *base composite glyph* — but in many COLRv0 fonts, layer 0 *is* the base glyph ID (foreground layer), so its outline fetch fails and the base letterform is dropped. COLRv0 base glyphs have valid outlines of their own; the fix scopes `neverRequestPath` to non-COLRv0 formats (bitmap/SVG/COLRv1) only.

Without these, `GetColorPaths()` returns incomplete/empty layers and this PR falls back to the existing atlas path (regression-free, but no sharpness improvement on the affected platform). I'm preparing both hunks for a Skia Gerrit CL and will link it here; happy to take guidance on sequencing.

## Testing

Manually verified end-to-end on physical devices against a locally-built engine (this PR's changes + the Skia patches above), using a Quran app's tajweed-colored Hafs font as the test case:

- **iPhone (Impeller/Metal):** COLR text renders as crisp vector paths at high zoom (previously visibly pixelated), correct per-layer palette colors, no depth-budget violations (verified with `USE_DEPTH_WATCHER` debug checks enabled).
- **Android, Samsung Galaxy S24+ (Impeller/Vulkan):** same result — sharp vector color text at any zoom, layers exactly aligned with base glyphs.

Engine unit tests included (all passing locally on the Metal backend):

- `typographer_unittests.cc`: `TextFrame::GetColorPaths` returns creator-supplied layers with colors/foreground flags intact and is empty without a creator; a color font without COLRv0 layers (the existing CBDT/sbix emoji fixtures) produces no color paths, preserving the atlas fallback.
- `canvas_unittests.cc`: `DrawTextFrame` consumes exactly **one** depth slot for a color frame regardless of layer count — this is the regression guard for the depth-budget overflow.

A positive end-to-end COLRv0 test (blob → parsed layers with real palette colors) needs a COLRv0 fixture font, which doesn't currently exist in the tree (`NotoColorEmoji.ttf` is CBDT, `Apple Color Emoji.ttc` is sbix) — happy to add a small COLRv0 test font as a fixture if reviewers want that covered.

Fixes #188904.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA]. **(pending — will sign before this is ready for review)**
- [ ] All existing and new tests are passing. **(not yet run against CI; manually verified on-device as described above)**

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/flutter/blob/main/engine/src/flutter/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/blob/main/docs/engine/testing/Testing-the-engine.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
