### PR TITLE
Forward showDragHandle from showCupertinoSheet to CupertinoSheetRoute

### DIFF
--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -204,6 +204,7 @@ Future<T?> showCupertinoSheet<T>({
       scrollableBuilder: scrollableBuilder,
       settings: settings,
       enableDrag: enableDrag,
+      showDragHandle: showDragHandle,
       topGap: topGap,
     );
 
@@ -248,6 +249,7 @@ Future<T?> showCupertinoSheet<T>({
           ),
       settings: settings,
       enableDrag: enableDrag,
+      showDragHandle: showDragHandle,
       topGap: topGap,
     );
     return Navigator.of(context, rootNavigator: true).push<T>(route);

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -164,6 +164,97 @@ void main() {
     expect(sheetContentOffset.dy, greaterThan(dragHandleOffset.dy));
   });
 
+  testWidgets('showCupertinoSheet forwards showDragHandle to the sheet', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey scaffoldKey = GlobalKey();
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          key: scaffoldKey,
+          child: Center(
+            child: Column(
+              children: <Widget>[
+                const Text('Page 1'),
+                CupertinoButton(
+                  onPressed: () {
+                    showCupertinoSheet<void>(
+                      context: scaffoldKey.currentContext!,
+                      pageBuilder: (BuildContext context) {
+                        return const CupertinoPageScaffold(child: Text('Page 2'));
+                      },
+                      showDragHandle: true,
+                    );
+                  },
+                  child: const Text('Push Page 2'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Page 2'), findsNothing);
+
+    await tester.tap(find.text('Push Page 2'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Page 2'), findsOneWidget);
+    final Finder dragHandleFinder = find.byWidgetPredicate((Widget widget) {
+      return widget is DecoratedBox &&
+          widget.decoration is ShapeDecoration &&
+          (widget.decoration as ShapeDecoration).color == CupertinoColors.tertiaryLabel;
+    });
+    expect(dragHandleFinder, findsOneWidget);
+  });
+
+  testWidgets('showCupertinoSheet forwards showDragHandle with nested navigation', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey scaffoldKey = GlobalKey();
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          key: scaffoldKey,
+          child: Center(
+            child: Column(
+              children: <Widget>[
+                const Text('Page 1'),
+                CupertinoButton(
+                  onPressed: () {
+                    showCupertinoSheet<void>(
+                      context: scaffoldKey.currentContext!,
+                      useNestedNavigation: true,
+                      pageBuilder: (BuildContext context) {
+                        return const CupertinoPageScaffold(child: Text('Page 2'));
+                      },
+                      showDragHandle: true,
+                    );
+                  },
+                  child: const Text('Push Page 2'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Push Page 2'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Page 2'), findsOneWidget);
+    final Finder dragHandleFinder = find.byWidgetPredicate((Widget widget) {
+      return widget is DecoratedBox &&
+          widget.decoration is ShapeDecoration &&
+          (widget.decoration as ShapeDecoration).color == CupertinoColors.tertiaryLabel;
+    });
+    expect(dragHandleFinder, findsOneWidget);
+  });
+
   testWidgets('Previous route moves slight downward when sheet route is pushed', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -181,7 +181,7 @@ void main() {
                   onPressed: () {
                     showCupertinoSheet<void>(
                       context: scaffoldKey.currentContext!,
-                      pageBuilder: (BuildContext context) {
+                      scrollableBuilder: (BuildContext context, ScrollController controller) {
                         return const CupertinoPageScaffold(child: Text('Page 2'));
                       },
                       showDragHandle: true,
@@ -228,7 +228,7 @@ void main() {
                     showCupertinoSheet<void>(
                       context: scaffoldKey.currentContext!,
                       useNestedNavigation: true,
-                      pageBuilder: (BuildContext context) {
+                      scrollableBuilder: (BuildContext context, ScrollController controller) {
                         return const CupertinoPageScaffold(child: Text('Page 2'));
                       },
                       showDragHandle: true,


### PR DESCRIPTION
## Description

`showCupertinoSheet` accepted a `showDragHandle` argument but never forwarded
it to the `CupertinoSheetRoute` it creates, so the flag was silently ignored
in both the default and nested-navigation code paths. This PR forwards
`showDragHandle` to the route in both cases.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/187693

## Tests

Added two widget tests in `sheet_test.dart` that call `showCupertinoSheet`
with `showDragHandle: true` and assert the drag handle is shown — one for the
default path and one for `useNestedNavigation: true`. Both fail before this
change and pass after.

_Disclosure: this change was prepared with AI-assisted tooling. I have
reviewed and understand the full change and take responsibility for it._

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.