### PR TITLE
[flutter_tools] Fix test flakiness in widget_preview_detection_test.dart

### DIFF
--- a/packages/flutter_tools/test/integration.shard/widget_preview_detection_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_detection_test.dart
@@ -55,6 +55,15 @@ void main() {
         dtdUri: dtdUri,
       );
 
+      final reloadCompleter = Completer<void>();
+      final StreamSubscription<String> reloadSub = stream.listen((String msg) {
+        if (msg.contains('Triggering reload based on update to script:')) {
+          if (!reloadCompleter.isCompleted) {
+            reloadCompleter.complete();
+          }
+        }
+      });
+
       final File newFile = tempDir.childDirectory('lib').childFile('new_preview.dart');
       newFile.createSync(recursive: true);
       newFile.writeAsStringSync('''
@@ -64,13 +73,6 @@ import 'package:flutter/widget_previews.dart';
 @Preview()
 Widget myNewPreview() => Container();
 ''');
-
-      final reloadCompleter = Completer<void>();
-      final StreamSubscription<String> reloadSub = stream.listen((String msg) {
-        if (msg.contains('Triggering reload based on update to script:')) {
-          reloadCompleter.complete();
-        }
-      });
       await reloadCompleter.future.timeout(
         const Duration(seconds: 60),
         onTimeout: () => throw StateError('Timed out waiting for reload message in LSP test!'),
@@ -96,6 +98,15 @@ Widget myNewPreview() => Container();
         dtdUri: dtdUri,
       );
 
+      final initReloadCompleter = Completer<void>();
+      final StreamSubscription<String> initReloadSub = stream.listen((String msg) {
+        if (msg.contains('Triggering reload based on update to script:')) {
+          if (!initReloadCompleter.isCompleted) {
+            initReloadCompleter.complete();
+          }
+        }
+      });
+
       final File removeFile = tempDir.childDirectory('lib').childFile('remove_preview.dart');
       removeFile.createSync(recursive: true);
       removeFile.writeAsStringSync('''
@@ -105,13 +116,6 @@ import 'package:flutter/widget_previews.dart';
 @Preview()
 Widget myRemovePreview() => Container();
 ''');
-
-      final initReloadCompleter = Completer<void>();
-      final StreamSubscription<String> initReloadSub = stream.listen((String msg) {
-        if (msg.contains('Triggering reload based on update to script:')) {
-          initReloadCompleter.complete();
-        }
-      });
       await initReloadCompleter.future.timeout(
         const Duration(seconds: 60),
         onTimeout: () =>
@@ -121,14 +125,16 @@ Widget myRemovePreview() => Container();
 
       await waitForPreviews(dtdConnection);
 
-      removeFile.deleteSync();
-
       final deleteReloadCompleter = Completer<void>();
       final StreamSubscription<String> deleteReloadSub = stream.listen((String msg) {
         if (msg.contains('Triggering reload based on update to script:')) {
-          deleteReloadCompleter.complete();
+          if (!deleteReloadCompleter.isCompleted) {
+            deleteReloadCompleter.complete();
+          }
         }
       });
+
+      removeFile.deleteSync();
       await deleteReloadCompleter.future.timeout(
         const Duration(seconds: 60),
         onTimeout: () =>
@@ -164,6 +170,15 @@ Widget myRemovePreview() => Container();
         dtdUri: dtdUri,
       );
 
+      final initReloadCompleter = Completer<void>();
+      final StreamSubscription<String> initReloadSub = stream.listen((String msg) {
+        if (msg.contains('Triggering reload based on update to script:')) {
+          if (!initReloadCompleter.isCompleted) {
+            initReloadCompleter.complete();
+          }
+        }
+      });
+
       final File modifyFile = tempDir.childDirectory('lib').childFile('modify_preview.dart');
       modifyFile.createSync(recursive: true);
       modifyFile.writeAsStringSync('''
@@ -173,13 +188,6 @@ import 'package:flutter/widget_previews.dart';
 @Preview(name: 'Initial')
 Widget myModifyPreview() => Container();
 ''');
-
-      final initReloadCompleter = Completer<void>();
-      final StreamSubscription<String> initReloadSub = stream.listen((String msg) {
-        if (msg.contains('Triggering reload based on update to script:')) {
-          initReloadCompleter.complete();
-        }
-      });
       await initReloadCompleter.future.timeout(
         const Duration(seconds: 60),
         onTimeout: () =>
@@ -189,6 +197,15 @@ Widget myModifyPreview() => Container();
 
       await waitForPreviews(dtdConnection);
 
+      final modifyReloadCompleter = Completer<void>();
+      final StreamSubscription<String> modifyReloadSub = stream.listen((String msg) {
+        if (msg.contains('Triggering reload based on update to script:')) {
+          if (!modifyReloadCompleter.isCompleted) {
+            modifyReloadCompleter.complete();
+          }
+        }
+      });
+
       modifyFile.writeAsStringSync('''
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
@@ -196,13 +213,6 @@ import 'package:flutter/widget_previews.dart';
 @Preview(name: 'Updated')
 Widget myModifyPreview() => Container();
 ''');
-
-      final modifyReloadCompleter = Completer<void>();
-      final StreamSubscription<String> modifyReloadSub = stream.listen((String msg) {
-        if (msg.contains('Triggering reload based on update to script:')) {
-          modifyReloadCompleter.complete();
-        }
-      });
       await modifyReloadCompleter.future.timeout(
         const Duration(seconds: 60),
         onTimeout: () =>
@@ -233,6 +243,15 @@ Widget myModifyPreview() => Container();
         dtdUri: dtdUri,
       );
 
+      final reloadCompleter = Completer<void>();
+      final StreamSubscription<String> reloadSub = stream.listen((String msg) {
+        if (msg.contains('Triggering reload based on update to script:')) {
+          if (!reloadCompleter.isCompleted) {
+            reloadCompleter.complete();
+          }
+        }
+      });
+
       final File libFile = tempDir.childDirectory('lib').childFile('my_library.dart');
       final File partFile = tempDir.childDirectory('lib').childFile('my_part.dart');
 
@@ -254,13 +273,6 @@ import 'package:flutter/widget_previews.dart';
 @Preview()
 Widget myPartPreview() => Container();
 ''');
-
-      final reloadCompleter = Completer<void>();
-      final StreamSubscription<String> reloadSub = stream.listen((String msg) {
-        if (msg.contains('Triggering reload based on update to script:')) {
-          reloadCompleter.complete();
-        }
-      });
       await reloadCompleter.future.timeout(
         const Duration(seconds: 60),
         onTimeout: () => throw StateError('Timed out waiting for reload message in Parts test!'),

--- a/packages/flutter_tools/test/integration.shard/widget_preview_detection_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_detection_test.dart
@@ -56,11 +56,13 @@ void main() {
       );
 
       final reloadCompleter = Completer<void>();
-      final StreamSubscription<String> reloadSub = stream.listen((String msg) {
+      late final StreamSubscription<String> reloadSub;
+      reloadSub = stream.listen((String msg) {
         if (msg.contains('Triggering reload based on update to script:')) {
           if (!reloadCompleter.isCompleted) {
             reloadCompleter.complete();
           }
+          reloadSub.cancel();
         }
       });
 
@@ -99,11 +101,13 @@ Widget myNewPreview() => Container();
       );
 
       final initReloadCompleter = Completer<void>();
-      final StreamSubscription<String> initReloadSub = stream.listen((String msg) {
+      late final StreamSubscription<String> initReloadSub;
+      initReloadSub = stream.listen((String msg) {
         if (msg.contains('Triggering reload based on update to script:')) {
           if (!initReloadCompleter.isCompleted) {
             initReloadCompleter.complete();
           }
+          initReloadSub.cancel();
         }
       });
 
@@ -171,11 +175,13 @@ Widget myRemovePreview() => Container();
       );
 
       final initReloadCompleter = Completer<void>();
-      final StreamSubscription<String> initReloadSub = stream.listen((String msg) {
+      late final StreamSubscription<String> initReloadSub;
+      initReloadSub = stream.listen((String msg) {
         if (msg.contains('Triggering reload based on update to script:')) {
           if (!initReloadCompleter.isCompleted) {
             initReloadCompleter.complete();
           }
+          initReloadSub.cancel();
         }
       });
 
@@ -244,11 +250,13 @@ Widget myModifyPreview() => Container();
       );
 
       final reloadCompleter = Completer<void>();
-      final StreamSubscription<String> reloadSub = stream.listen((String msg) {
+      late final StreamSubscription<String> reloadSub;
+      reloadSub = stream.listen((String msg) {
         if (msg.contains('Triggering reload based on update to script:')) {
           if (!reloadCompleter.isCompleted) {
             reloadCompleter.complete();
           }
+          reloadSub.cancel();
         }
       });
 


### PR DESCRIPTION
Moves the `stream.listen` setup and `Completer` initialization BEFORE the filesystem modifications (e.g. `deleteSync()`, `writeAsStringSync()`, `createSync()`) in all test cases to prevent race conditions during the reload detection. Also adds a `!completer.isCompleted` guard when completing.

Fixes https://github.com/flutter/flutter/issues/185991
