### PR TITLE
Add OverlayPortal.overlayChildLayoutBuilder sample

### DIFF
--- a/examples/api/lib/widgets/overlay/overlay_portal.1.dart
+++ b/examples/api/lib/widgets/overlay/overlay_portal.1.dart
@@ -1,0 +1,73 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+/// Flutter code sample for [OverlayPortal.overlayChildLayoutBuilder].
+
+void main() => runApp(const OverlayPortalLayoutBuilderExampleApp());
+
+class OverlayPortalLayoutBuilderExampleApp extends StatelessWidget {
+  const OverlayPortalLayoutBuilderExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WidgetsApp(
+      color: const Color(0xFFFFFFFF),
+      home: const OverlayPortalLayoutBuilderExample(),
+      pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) =>
+          PageRouteBuilder<T>(
+            settings: settings,
+            pageBuilder: (BuildContext context, _, _) => builder(context),
+          ),
+    );
+  }
+}
+
+class OverlayPortalLayoutBuilderExample extends StatefulWidget {
+  const OverlayPortalLayoutBuilderExample({super.key});
+
+  @override
+  State<OverlayPortalLayoutBuilderExample> createState() =>
+      _OverlayPortalLayoutBuilderExampleState();
+}
+
+class _OverlayPortalLayoutBuilderExampleState
+    extends State<OverlayPortalLayoutBuilderExample> {
+  final OverlayPortalController _controller = OverlayPortalController();
+
+  Widget _buildOverlay(BuildContext context, OverlayChildLayoutInfo info) {
+    // Clone the anchor's paint transform and translate it downward by the
+    // anchor's height, so the overlay child appears just below the anchor.
+    final Matrix4 belowAnchor = info.childPaintTransform.clone()
+      ..translateByDouble(0.0, info.childSize.height, 0.0, 1.0);
+
+    return Transform(
+      transform: belowAnchor,
+      child: Align(
+        alignment: .topLeft,
+        child: Container(
+          color: const Color(0xFFFFE57F),
+          padding: const .all(8),
+          child: const Text('Hello from the overlay!'),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: OverlayPortal.overlayChildLayoutBuilder(
+        controller: _controller,
+        overlayChildBuilder: _buildOverlay,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: _controller.toggle,
+          child: const Text('Press me'),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/lib/widgets/overlay/overlay_portal.1.dart
+++ b/examples/api/lib/widgets/overlay/overlay_portal.1.dart
@@ -46,7 +46,7 @@ class _OverlayPortalLayoutBuilderExampleState
           // Translate the child widget's local coordinates to the overlay's
           // coordinate space. This assumes the child paint transform is invertible
           // (e.g., not a transform that collapses the child to a line or point),
-          // otherwise the resulting childRect would be NaN.
+          // otherwise the resulting childRect would contain NaN.
           final Rect childRect = MatrixUtils.transformRect(
             info.childPaintTransform,
             Offset.zero & info.childSize,

--- a/examples/api/lib/widgets/overlay/overlay_portal.1.dart
+++ b/examples/api/lib/widgets/overlay/overlay_portal.1.dart
@@ -38,13 +38,14 @@ class _OverlayPortalLayoutBuilderExampleState
   final OverlayPortalController _controller = OverlayPortalController();
 
   Widget _buildOverlay(BuildContext context, OverlayChildLayoutInfo info) {
-    // Clone the anchor's paint transform and translate it downward by the
-    // anchor's height, so the overlay child appears just below the anchor.
-    final Matrix4 belowAnchor = info.childPaintTransform.clone()
-      ..translateByDouble(0.0, info.childSize.height, 0.0, 1.0);
+    final Offset childOffset = MatrixUtils.transformPoint(
+      info.childPaintTransform,
+      Offset.zero,
+    );
 
-    return Transform(
-      transform: belowAnchor,
+    return Positioned(
+      left: childOffset.dx,
+      top: childOffset.dy + info.childSize.height,
       child: Align(
         alignment: .topLeft,
         child: Container(

--- a/examples/api/lib/widgets/overlay/overlay_portal.1.dart
+++ b/examples/api/lib/widgets/overlay/overlay_portal.1.dart
@@ -37,32 +37,31 @@ class _OverlayPortalLayoutBuilderExampleState
     extends State<OverlayPortalLayoutBuilderExample> {
   final OverlayPortalController _controller = OverlayPortalController();
 
-  Widget _buildOverlay(BuildContext context, OverlayChildLayoutInfo info) {
-    final Offset childOffset = MatrixUtils.transformPoint(
-      info.childPaintTransform,
-      Offset.zero,
-    );
-
-    return Positioned(
-      left: childOffset.dx,
-      top: childOffset.dy + info.childSize.height,
-      child: Align(
-        alignment: .topLeft,
-        child: Container(
-          color: const Color(0xFFFFE57F),
-          padding: const .all(8),
-          child: const Text('Hello from the overlay!'),
-        ),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Center(
       child: OverlayPortal.overlayChildLayoutBuilder(
         controller: _controller,
-        overlayChildBuilder: _buildOverlay,
+        overlayChildBuilder: (BuildContext context, OverlayChildLayoutInfo info) {
+          // Translate the child widget's local coordinates to the overlay's
+          // coordinate space. This assumes the child paint transform is invertible
+          // (e.g., not a transform that collapses the child to a line or point),
+          // otherwise the resulting childRect would be NaN.
+          final Rect childRect = MatrixUtils.transformRect(
+            info.childPaintTransform,
+            Offset.zero & info.childSize,
+          );
+
+          return Positioned(
+            left: childRect.left,
+            top: childRect.bottom,
+            child: Container(
+              color: const Color(0xFFFFE57F),
+              padding: const .all(8),
+              child: const Text('Hello from the overlay!'),
+            ),
+          );
+        },
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: _controller.toggle,

--- a/examples/api/test/widgets/overlay/overlay_portal.1_test.dart
+++ b/examples/api/test/widgets/overlay/overlay_portal.1_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_api_samples/widgets/overlay/overlay_portal.1.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows anchor and hides overlay initially', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const example.OverlayPortalLayoutBuilderExampleApp(),
+    );
+
+    expect(find.text('Press me'), findsOneWidget);
+    expect(find.text('Hello from the overlay!'), findsNothing);
+  });
+
+  testWidgets('tapping anchor shows overlay below it', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const example.OverlayPortalLayoutBuilderExampleApp(),
+    );
+
+    await tester.tap(find.text('Press me'));
+    await tester.pump();
+
+    expect(find.text('Hello from the overlay!'), findsOneWidget);
+
+    final Rect anchorRect = tester.getRect(
+      find.ancestor(
+        of: find.text('Press me'),
+        matching: find.byType(GestureDetector),
+      ),
+    );
+    final Rect overlayRect = tester.getRect(
+      find.ancestor(
+        of: find.text('Hello from the overlay!'),
+        matching: find.byType(Container),
+      ),
+    );
+
+    expect(overlayRect.top, anchorRect.bottom);
+    expect(overlayRect.left, anchorRect.left);
+  });
+
+  testWidgets('tapping anchor again hides the overlay', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const example.OverlayPortalLayoutBuilderExampleApp(),
+    );
+
+    await tester.tap(find.text('Press me'));
+    await tester.pump();
+    expect(find.text('Hello from the overlay!'), findsOneWidget);
+
+    await tester.tap(find.text('Press me'));
+    await tester.pump();
+    expect(find.text('Hello from the overlay!'), findsNothing);
+  });
+}

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -1907,6 +1907,13 @@ class OverlayPortal extends StatefulWidget {
   /// at the same time resize itself base on how close it is to the edges of
   /// the [Overlay].
   ///
+  /// {@tool dartpad}
+  /// This example uses [OverlayPortal.overlayChildLayoutBuilder] to build a
+  /// tooltip that becomes visible when the user taps on the [child] widget.
+  ///
+  /// ** See code in examples/api/lib/widgets/overlay/overlay_portal.1.dart **
+  /// {@end-tool}
+  ///
   /// The `overlayChildBuilder` callback is called during layout. To ensure the
   /// paint transform of [OverlayPortal.child] in relation to the target
   /// [Overlay] is up-to-date by then, all [RenderObject]s between the


### PR DESCRIPTION
This mirrors the existing `OverlayPortal` example:

https://github.com/flutter/flutter/blob/master/examples/api/lib/widgets/overlay/overlay_portal.0.dart#L1-L58

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.