### PR TITLE
Support DynamicLibrary.codeAsset in Flutter

### DIFF
--- a/dev/devicelab/lib/tasks/native_assets_test.dart
+++ b/dev/devicelab/lib/tasks/native_assets_test.dart
@@ -181,7 +181,8 @@ Future<Directory> createTestProject(String packageName, Directory tempDirectory)
   await _pinDependencies(File(path.join(packageDirectory.path, 'pubspec.yaml')));
   await _pinDependencies(File(path.join(packageDirectory.path, 'example', 'pubspec.yaml')));
 
-  await _addIntegrationTest(packageDirectory.uri.resolve('example/'), _packageName);
+  await _addCodeAssetOpenHelper(packageDirectory, packageName);
+  await _addIntegrationTest(packageDirectory.uri.resolve('example/'), packageName);
 
   await exec(_flutterBin, <String>['pub', 'get'], workingDirectory: packageDirectory.path);
 
@@ -192,6 +193,43 @@ Future<void> _pinDependencies(File pubspecFile) async {
   final String oldPubspec = await pubspecFile.readAsString();
   final String newPubspec = oldPubspec.replaceAll(': ^', ': ');
   await pubspecFile.writeAsString(newPubspec);
+}
+
+Future<void> _addCodeAssetOpenHelper(Directory packageDirectory, String packageName) async {
+  final dartFile = File(path.join(packageDirectory.path, 'lib', '$packageName.dart'));
+  final String oldDartFile = await dartFile.readAsString();
+  final String lineEnding = oldDartFile.contains('\r\n') ? '\r\n' : '\n';
+  final String withFfiImport = oldDartFile.replaceFirst(
+    "import 'dart:async';",
+    "import 'dart:async';${lineEnding}import 'dart:ffi';",
+  );
+  if (withFfiImport == oldDartFile) {
+    throw StateError('Failed to add dart:ffi import to ${dartFile.path}');
+  }
+  final String newDartFile = withFfiImport.replaceFirst(
+    'int sum(int a, int b) => bindings.sum(a, b);',
+    '''
+int sum(int a, int b) => bindings.sum(a, b);
+
+/// Invokes `sum` by explicitly opening the generated code asset.
+int sumWithCodeAsset(int a, int b) {
+  final DynamicLibrary library = DynamicLibrary.codeAsset(
+    'package:$packageName/${packageName}_bindings_generated.dart',
+  );
+  try {
+    final int Function(int, int) sum = library.lookupFunction<
+        IntPtr Function(IntPtr, IntPtr), int Function(int, int)>('sum');
+    return sum(a, b);
+  } finally {
+    library.close();
+  }
+}
+''',
+  );
+  if (newDartFile == withFfiImport) {
+    throw StateError('Failed to add sumWithCodeAsset to ${dartFile.path}');
+  }
+  await dartFile.writeAsString(newDartFile);
 }
 
 Future<T> inTempDir<T>(Future<T> Function(Directory tempDirectory) fun) async {
@@ -222,6 +260,7 @@ Future<void> _addIntegrationTest(Uri exampleDirectory, String packageName) async
     ..createSync(recursive: true)
     ..writeAsStringSync('''
 import 'package:flutter_test/flutter_test.dart';
+import 'package:$packageName/$packageName.dart' as native_assets;
 import 'package:${packageName}_example/main.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -235,6 +274,7 @@ void main() {
 
       // Verify the native function was called.
       expect(find.text('sum(1, 2) = 3'), findsOneWidget);
+      expect(native_assets.sumWithCodeAsset(2, 3), 5);
     });
   });
 }

--- a/dev/devicelab/lib/tasks/native_assets_test.dart
+++ b/dev/devicelab/lib/tasks/native_assets_test.dart
@@ -181,7 +181,8 @@ Future<Directory> createTestProject(String packageName, Directory tempDirectory)
   await _pinDependencies(File(path.join(packageDirectory.path, 'pubspec.yaml')));
   await _pinDependencies(File(path.join(packageDirectory.path, 'example', 'pubspec.yaml')));
 
-  await _addIntegrationTest(packageDirectory.uri.resolve('example/'), _packageName);
+  await _addCodeAssetOpenHelper(packageDirectory, packageName);
+  await _addIntegrationTest(packageDirectory.uri.resolve('example/'), packageName);
 
   await exec(_flutterBin, <String>['pub', 'get'], workingDirectory: packageDirectory.path);
 
@@ -192,6 +193,43 @@ Future<void> _pinDependencies(File pubspecFile) async {
   final String oldPubspec = await pubspecFile.readAsString();
   final String newPubspec = oldPubspec.replaceAll(': ^', ': ');
   await pubspecFile.writeAsString(newPubspec);
+}
+
+Future<void> _addCodeAssetOpenHelper(Directory packageDirectory, String packageName) async {
+  final dartFile = File(path.join(packageDirectory.path, 'lib', '$packageName.dart'));
+  final String oldDartFile = await dartFile.readAsString();
+  final lineEnding = oldDartFile.contains('\r\n') ? '\r\n' : '\n';
+  final String withFfiImport = oldDartFile.replaceFirst(
+    "import 'dart:async';",
+    "import 'dart:async';${lineEnding}import 'dart:ffi';",
+  );
+  if (withFfiImport == oldDartFile) {
+    throw StateError('Failed to add dart:ffi import to ${dartFile.path}');
+  }
+  final String newDartFile = withFfiImport.replaceFirst(
+    'int sum(int a, int b) => bindings.sum(a, b);',
+    '''
+int sum(int a, int b) => bindings.sum(a, b);
+
+/// Invokes `sum` by explicitly opening the generated code asset.
+int sumWithCodeAsset(int a, int b) {
+  final library = DynamicLibrary.codeAsset(
+    'package:$packageName/${packageName}_bindings_generated.dart',
+  );
+  try {
+    final sum = library.lookupFunction<
+        IntPtr Function(IntPtr, IntPtr), int Function(int, int)>('sum');
+    return sum(a, b);
+  } finally {
+    library.close();
+  }
+}
+''',
+  );
+  if (newDartFile == withFfiImport) {
+    throw StateError('Failed to add sumWithCodeAsset to ${dartFile.path}');
+  }
+  await dartFile.writeAsString(newDartFile);
 }
 
 Future<T> inTempDir<T>(Future<T> Function(Directory tempDirectory) fun) async {
@@ -222,6 +260,7 @@ Future<void> _addIntegrationTest(Uri exampleDirectory, String packageName) async
     ..createSync(recursive: true)
     ..writeAsStringSync('''
 import 'package:flutter_test/flutter_test.dart';
+import 'package:$packageName/$packageName.dart' as native_assets;
 import 'package:${packageName}_example/main.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -235,6 +274,7 @@ void main() {
 
       // Verify the native function was called.
       expect(find.text('sum(1, 2) = 3'), findsOneWidget);
+      expect(native_assets.sumWithCodeAsset(2, 3), 5);
     });
   });
 }

--- a/engine/src/flutter/assets/native_assets.cc
+++ b/engine/src/flutter/assets/native_assets.cc
@@ -118,6 +118,12 @@ std::vector<std::string> NativeAssetsManager::LookupNativeAsset(
   return parsed_mapping_[as_string];
 }
 
+bool NativeAssetsManager::ContainsNativeAsset(std::string_view asset_id) const {
+  // Cpp17 does not support unordered_map lookup with std::string_view on a
+  // std::string key.
+  return parsed_mapping_.find(std::string(asset_id)) != parsed_mapping_.end();
+}
+
 std::string NativeAssetsManager::AvailableNativeAssets() {
   if (parsed_mapping_.empty()) {
     return std::string("No available native assets.");

--- a/engine/src/flutter/assets/native_assets.h
+++ b/engine/src/flutter/assets/native_assets.h
@@ -34,6 +34,9 @@ class NativeAssetsManager {
   // `["system", "libsqlite3.so"]`.
   std::vector<std::string> LookupNativeAsset(std::string_view asset_id);
 
+  // Returns whether [asset_id] is present in the native assets mapping.
+  bool ContainsNativeAsset(std::string_view asset_id) const;
+
   // Lists the available asset ids.
   //
   // Used when a user tries to look up an asset with an ID that does not exist

--- a/engine/src/flutter/assets/native_assets_unittests.cc
+++ b/engine/src/flutter/assets/native_assets_unittests.cc
@@ -69,6 +69,7 @@ TEST(NativeAssetsManagerTest, NoAvailableAssets) {
   NativeAssetsManager manager;
   std::string available_assets = manager.AvailableNativeAssets();
   ASSERT_EQ(available_assets, "No available native assets.");
+  ASSERT_FALSE(manager.ContainsNativeAsset("non_existing_asset"));
 }
 
 TEST(NativeAssetsManagerTest, NativeAssetsManifestParsing) {
@@ -80,6 +81,10 @@ TEST(NativeAssetsManagerTest, NativeAssetsManifestParsing) {
   ASSERT_EQ(available_assets,
             "Available native assets: "
             "package:my_package/my_package_bindings_generated.dart.");
+
+  ASSERT_TRUE(manager.ContainsNativeAsset(
+      "package:my_package/my_package_bindings_generated.dart"));
+  ASSERT_FALSE(manager.ContainsNativeAsset("non_existing_asset"));
 
   std::vector<std::string> existing_asset = manager.LookupNativeAsset(
       "package:my_package/my_package_bindings_generated.dart");

--- a/engine/src/flutter/runtime/dart_isolate.cc
+++ b/engine/src/flutter/runtime/dart_isolate.cc
@@ -5,6 +5,7 @@
 #include "flutter/runtime/dart_isolate.h"
 
 #include <cstdlib>
+#include <string>
 #include <utility>
 
 #include "flutter/fml/logging.h"
@@ -1200,12 +1201,47 @@ static void* NativeAssetsDlopenRelative(const char* path, char** error) {
                                                  error);
 }
 
-static void* NativeAssetsDlopen(const char* asset_id, char** error) {
+static void SetNativeAssetsError(char** error, const std::string& message) {
+  if (error == nullptr) {
+    return;
+  }
+  *error = fml::strdup(message.c_str());
+}
+
+static void SetNativeAssetUnavailableError(
+    const char* asset_id,
+    NativeAssetsManager* native_assets_manager,
+    char** error) {
+  std::string message = "Native asset '";
+  message.append(asset_id);
+  message.append("' is unavailable. ");
+  if (native_assets_manager == nullptr) {
+    message.append("No available native assets.");
+  } else {
+    message.append(native_assets_manager->AvailableNativeAssets());
+  }
+  SetNativeAssetsError(error, message);
+}
+
+static void SetNativeAssetInvalidMappingError(const char* asset_id,
+                                              const std::string& path_type,
+                                              char** error) {
+  std::string message = "Native asset '";
+  message.append(asset_id);
+  message.append("' has invalid mapping for path type '");
+  message.append(path_type);
+  message.append("'.");
+  SetNativeAssetsError(error, message);
+}
+
+static void* NativeAssetsDlopenV2(const char* asset_id, char** error) {
+  FML_DCHECK(asset_id != nullptr);
   auto* isolate_group_data =
       static_cast<std::shared_ptr<DartIsolateGroupData>*>(
           Dart_CurrentIsolateGroupData());
   auto native_assets_manager = (*isolate_group_data)->GetNativeAssetsManager();
   if (native_assets_manager == nullptr) {
+    SetNativeAssetUnavailableError(asset_id, nullptr, error);
     return nullptr;
   }
 
@@ -1213,11 +1249,12 @@ static void* NativeAssetsDlopen(const char* asset_id, char** error) {
       native_assets_manager->LookupNativeAsset(asset_id);
   if (asset_path.size() == 0) {
     // The asset id was not in the mapping.
+    SetNativeAssetUnavailableError(asset_id, native_assets_manager.get(),
+                                   error);
     return nullptr;
   }
 
   auto& path_type = asset_path[0];
-  std::string path;
   static constexpr const char* kAbsolute = "absolute";
   static constexpr const char* kExecutable = "executable";
   static constexpr const char* kProcess = "process";
@@ -1225,21 +1262,26 @@ static void* NativeAssetsDlopen(const char* asset_id, char** error) {
   static constexpr const char* kSystem = "system";
   if (path_type == kAbsolute || path_type == kRelative ||
       path_type == kSystem) {
-    path = asset_path[1];
+    if (asset_path.size() < 2) {
+      SetNativeAssetInvalidMappingError(asset_id, path_type, error);
+      return nullptr;
+    }
   }
 
   if (path_type == kAbsolute) {
-    return dart::bin::NativeAssets::DlopenAbsolute(path.c_str(), error);
+    return dart::bin::NativeAssets::DlopenAbsolute(asset_path[1].c_str(),
+                                                   error);
   } else if (path_type == kRelative) {
-    return NativeAssetsDlopenRelative(path.c_str(), error);
+    return NativeAssetsDlopenRelative(asset_path[1].c_str(), error);
   } else if (path_type == kSystem) {
-    return dart::bin::NativeAssets::DlopenSystem(path.c_str(), error);
+    return dart::bin::NativeAssets::DlopenSystem(asset_path[1].c_str(), error);
   } else if (path_type == kProcess) {
     return dart::bin::NativeAssets::DlopenProcess(error);
   } else if (path_type == kExecutable) {
     return dart::bin::NativeAssets::DlopenExecutable(error);
   }
 
+  SetNativeAssetInvalidMappingError(asset_id, path_type, error);
   return nullptr;
 }
 
@@ -1257,15 +1299,9 @@ static char* NativeAssetsAvailableAssets() {
 static void InitDartFFIForIsolateGroup() {
   NativeAssetsApi native_assets;
   memset(&native_assets, 0, sizeof(native_assets));
-  // TODO(dacoharkes): Remove after flutter_tools stops kernel embedding.
-  native_assets.dlopen_absolute = &dart::bin::NativeAssets::DlopenAbsolute;
-  native_assets.dlopen_relative = &NativeAssetsDlopenRelative;
-  native_assets.dlopen_system = &dart::bin::NativeAssets::DlopenSystem;
-  native_assets.dlopen_executable = &dart::bin::NativeAssets::DlopenExecutable;
-  native_assets.dlopen_process = &dart::bin::NativeAssets::DlopenProcess;
-  // TODO(dacoharkes): End todo.
   native_assets.dlsym = &dart::bin::NativeAssets::Dlsym;
-  native_assets.dlopen = &NativeAssetsDlopen;
+  native_assets.dlclose = &dart::bin::NativeAssets::Dlclose;
+  native_assets.dlopen_v2 = &NativeAssetsDlopenV2;
   native_assets.available_assets = &NativeAssetsAvailableAssets;
   Dart_InitializeNativeAssetsResolver(&native_assets);
 };

--- a/engine/src/flutter/runtime/dart_isolate.cc
+++ b/engine/src/flutter/runtime/dart_isolate.cc
@@ -5,6 +5,7 @@
 #include "flutter/runtime/dart_isolate.h"
 
 #include <cstdlib>
+#include <string>
 #include <utility>
 
 #include "flutter/fml/logging.h"
@@ -1200,24 +1201,64 @@ static void* NativeAssetsDlopenRelative(const char* path, char** error) {
                                                  error);
 }
 
-static void* NativeAssetsDlopen(const char* asset_id, char** error) {
+static void SetNativeAssetsError(char** error, const std::string& message) {
+  if (error == nullptr) {
+    return;
+  }
+  *error = fml::strdup(message.c_str());
+}
+
+static void SetNativeAssetUnavailableError(const char* asset_id, char** error) {
+  std::string message = "Native asset '";
+  message.append(asset_id);
+  message.append("' is unavailable. No available native assets.");
+  SetNativeAssetsError(error, message);
+}
+
+static void SetNativeAssetInvalidMappingError(const char* asset_id,
+                                              const std::string& path_type,
+                                              char** error) {
+  std::string message = "Native asset '";
+  message.append(asset_id);
+  if (path_type.empty()) {
+    message.append("' has an empty mapping.");
+  } else {
+    message.append("' has invalid mapping for path type '");
+    message.append(path_type);
+    message.append("'.");
+  }
+  SetNativeAssetsError(error, message);
+}
+
+static bool NativeAssetsContainsAsset(const char* asset_id) {
+  FML_DCHECK(asset_id != nullptr);
+  auto* isolate_group_data =
+      static_cast<std::shared_ptr<DartIsolateGroupData>*>(
+          Dart_CurrentIsolateGroupData());
+  auto native_assets_manager = (*isolate_group_data)->GetNativeAssetsManager();
+  return native_assets_manager != nullptr &&
+         native_assets_manager->ContainsNativeAsset(asset_id);
+}
+
+static void* NativeAssetsDlopenAsset(const char* asset_id, char** error) {
+  FML_DCHECK(asset_id != nullptr);
   auto* isolate_group_data =
       static_cast<std::shared_ptr<DartIsolateGroupData>*>(
           Dart_CurrentIsolateGroupData());
   auto native_assets_manager = (*isolate_group_data)->GetNativeAssetsManager();
   if (native_assets_manager == nullptr) {
+    SetNativeAssetUnavailableError(asset_id, error);
     return nullptr;
   }
 
   std::vector<std::string> asset_path =
       native_assets_manager->LookupNativeAsset(asset_id);
-  if (asset_path.size() == 0) {
-    // The asset id was not in the mapping.
+  if (asset_path.empty()) {
+    SetNativeAssetInvalidMappingError(asset_id, "", error);
     return nullptr;
   }
 
   auto& path_type = asset_path[0];
-  std::string path;
   static constexpr const char* kAbsolute = "absolute";
   static constexpr const char* kExecutable = "executable";
   static constexpr const char* kProcess = "process";
@@ -1225,21 +1266,26 @@ static void* NativeAssetsDlopen(const char* asset_id, char** error) {
   static constexpr const char* kSystem = "system";
   if (path_type == kAbsolute || path_type == kRelative ||
       path_type == kSystem) {
-    path = asset_path[1];
+    if (asset_path.size() < 2) {
+      SetNativeAssetInvalidMappingError(asset_id, path_type, error);
+      return nullptr;
+    }
   }
 
   if (path_type == kAbsolute) {
-    return dart::bin::NativeAssets::DlopenAbsolute(path.c_str(), error);
+    return dart::bin::NativeAssets::DlopenAbsolute(asset_path[1].c_str(),
+                                                   error);
   } else if (path_type == kRelative) {
-    return NativeAssetsDlopenRelative(path.c_str(), error);
+    return NativeAssetsDlopenRelative(asset_path[1].c_str(), error);
   } else if (path_type == kSystem) {
-    return dart::bin::NativeAssets::DlopenSystem(path.c_str(), error);
+    return dart::bin::NativeAssets::DlopenSystem(asset_path[1].c_str(), error);
   } else if (path_type == kProcess) {
     return dart::bin::NativeAssets::DlopenProcess(error);
   } else if (path_type == kExecutable) {
     return dart::bin::NativeAssets::DlopenExecutable(error);
   }
 
+  SetNativeAssetInvalidMappingError(asset_id, path_type, error);
   return nullptr;
 }
 
@@ -1248,8 +1294,10 @@ static char* NativeAssetsAvailableAssets() {
       static_cast<std::shared_ptr<DartIsolateGroupData>*>(
           Dart_CurrentIsolateGroupData());
   auto native_assets_manager = (*isolate_group_data)->GetNativeAssetsManager();
-  FML_DCHECK(native_assets_manager != nullptr);
-  auto available_assets = native_assets_manager->AvailableNativeAssets();
+  std::string available_assets = "No available native assets.";
+  if (native_assets_manager != nullptr) {
+    available_assets = native_assets_manager->AvailableNativeAssets();
+  }
   auto* result = fml::strdup(available_assets.c_str());
   return result;
 }
@@ -1257,15 +1305,16 @@ static char* NativeAssetsAvailableAssets() {
 static void InitDartFFIForIsolateGroup() {
   NativeAssetsApi native_assets;
   memset(&native_assets, 0, sizeof(native_assets));
-  // TODO(dacoharkes): Remove after flutter_tools stops kernel embedding.
+  // TODO(dacoharkes): Remove after Flutter stops kernel embedding in g3.
   native_assets.dlopen_absolute = &dart::bin::NativeAssets::DlopenAbsolute;
   native_assets.dlopen_relative = &NativeAssetsDlopenRelative;
   native_assets.dlopen_system = &dart::bin::NativeAssets::DlopenSystem;
   native_assets.dlopen_executable = &dart::bin::NativeAssets::DlopenExecutable;
   native_assets.dlopen_process = &dart::bin::NativeAssets::DlopenProcess;
-  // TODO(dacoharkes): End todo.
   native_assets.dlsym = &dart::bin::NativeAssets::Dlsym;
-  native_assets.dlopen = &NativeAssetsDlopen;
+  native_assets.dlclose = &dart::bin::NativeAssets::Dlclose;
+  native_assets.contains_asset = &NativeAssetsContainsAsset;
+  native_assets.dlopen_asset = &NativeAssetsDlopenAsset;
   native_assets.available_assets = &NativeAssetsAvailableAssets;
   Dart_InitializeNativeAssetsResolver(&native_assets);
 };

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_flutter_run_test.dart
@@ -45,6 +45,8 @@ void main() {
         await inTempDir((Directory tempDirectory) async {
           final Directory packageDirectory = await createTestProject(packageName, tempDirectory);
           final Directory exampleDirectory = packageDirectory.childDirectory('example');
+          await addCodeAssetOpenHelper(packageName, packageDirectory);
+          await addCodeAssetCallToExampleApp(packageName, packageDirectory);
 
           final ProcessTestResult result = await runFlutter(
             <String>['run', '-d$device', '--$buildMode'],

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_flutter_run_test.dart
@@ -14,7 +14,7 @@ library;
 import 'package:file/file.dart';
 
 import '../../src/common.dart';
-import '../test_utils.dart' show platform;
+import '../test_utils.dart' show getLocalEngineArguments, platform;
 import '../transition_test_utils.dart';
 import 'native_assets_test_utils.dart';
 
@@ -45,9 +45,11 @@ void main() {
         await inTempDir((Directory tempDirectory) async {
           final Directory packageDirectory = await createTestProject(packageName, tempDirectory);
           final Directory exampleDirectory = packageDirectory.childDirectory('example');
+          await addCodeAssetOpenHelper(packageName, packageDirectory);
+          await addCodeAssetCallToExampleApp(packageName, packageDirectory);
 
           final ProcessTestResult result = await runFlutter(
-            <String>['run', '-d$device', '--$buildMode'],
+            <String>[...getLocalEngineArguments(), 'run', '-d$device', '--$buildMode'],
             exampleDirectory.path,
             <Transition>[
               Multiple.contains(

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
@@ -138,6 +138,117 @@ import '${packageName}_bindings_generated.dart' as bindings;
   await dartFile.writeAsString(dartFileNew2);
 }
 
+Future<void> addCodeAssetOpenHelper(
+  String packageName,
+  Directory packageDirectory,
+) async {
+  final File dartFile = packageDirectory.childDirectory('lib').childFile('$packageName.dart');
+  final String dartFileOld = await dartFile.readAsString();
+  final String lineEnding = dartFileOld.contains('\r\n') ? '\r\n' : '\n';
+  final String dartFileWithFfiImport = dartFileOld.replaceFirst(
+    "import 'dart:async';",
+    "import 'dart:async';${lineEnding}import 'dart:ffi';",
+  );
+  expect(dartFileWithFfiImport, isNot(dartFileOld));
+
+  const String generatedSumDeclaration = 'int sum(int a, int b) => bindings.sum(a, b);';
+  const String linkedSumDeclaration =
+      'int sum(int a, int b) => bindings.sum(a, b) + l.difference(2, 1) - 1;';
+  final String sumDeclaration = dartFileWithFfiImport.contains(linkedSumDeclaration)
+      ? linkedSumDeclaration
+      : generatedSumDeclaration;
+  final String dartFileNew = dartFileWithFfiImport.replaceFirst(
+    sumDeclaration,
+    '''
+$sumDeclaration
+
+/// Invokes `sum` by explicitly opening the generated code asset.
+int sumWithCodeAsset(int a, int b) {
+  final DynamicLibrary library = DynamicLibrary.codeAsset(
+    'package:$packageName/${packageName}_bindings_generated.dart',
+  );
+  try {
+    final int Function(int, int) sum = library.lookupFunction<
+        IntPtr Function(IntPtr, IntPtr), int Function(int, int)>('sum');
+    return sum(a, b);
+  } finally {
+    library.close();
+  }
+}
+''',
+  );
+  expect(dartFileNew, isNot(dartFileWithFfiImport));
+  await dartFile.writeAsString(dartFileNew);
+}
+
+Future<void> addCodeAssetCallToExampleApp(
+  String packageName,
+  Directory packageDirectory,
+) async {
+  final File dartFile = packageDirectory
+      .childDirectory('example')
+      .childDirectory('lib')
+      .childFile('main.dart');
+  final String dartFileOld = (await dartFile.readAsString()).replaceAll('\r\n', '\n');
+  final String dartFileWithResultField = dartFileOld.replaceFirst(
+    '''
+  late int sumResult;
+  late Future<int> sumAsyncResult;
+''',
+    '''
+  late int sumResult;
+  late int sumWithCodeAssetResult;
+  late Future<int> sumAsyncResult;
+''',
+  );
+  expect(dartFileWithResultField, isNot(dartFileOld));
+
+  final String dartFileWithCodeAssetCall = dartFileWithResultField.replaceFirst(
+    '''
+    sumResult = $packageName.sum(1, 2);
+    sumAsyncResult = $packageName.sumAsync(3, 4);
+''',
+    '''
+    sumResult = $packageName.sum(1, 2);
+    sumWithCodeAssetResult = $packageName.sumWithCodeAsset(2, 3);
+    if (sumWithCodeAssetResult != 5) {
+      throw StateError(
+        'Expected sumWithCodeAsset(2, 3) to be 5, got \$sumWithCodeAssetResult',
+      );
+    }
+    sumAsyncResult = $packageName.sumAsync(3, 4);
+''',
+  );
+  expect(dartFileWithCodeAssetCall, isNot(dartFileWithResultField));
+
+  final String dartFileNew = dartFileWithCodeAssetCall.replaceFirst(
+    '''
+                Text(
+                  'sum(1, 2) = \$sumResult',
+                  style: textStyle,
+                  textAlign: .center,
+                ),
+                spacerSmall,
+''',
+    '''
+                Text(
+                  'sum(1, 2) = \$sumResult',
+                  style: textStyle,
+                  textAlign: .center,
+                ),
+                spacerSmall,
+                Text(
+                  'sumWithCodeAsset(2, 3) = \$sumWithCodeAssetResult',
+                  style: textStyle,
+                  textAlign: .center,
+                ),
+                spacerSmall,
+''',
+  );
+  expect(dartFileNew, isNot(dartFileWithCodeAssetCall));
+  await dartFile.writeAsString(dartFileNew);
+}
+
 /// Adds a user-define to the pubspec of the package and the example project.
 ///
 /// The build hook will fail if the user-define is not set. So, we don't have to

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
@@ -146,6 +146,108 @@ import '${packageName}_bindings_generated.dart' as bindings;
   await dartFile.writeAsString(dartFileNew2);
 }
 
+Future<void> addCodeAssetOpenHelper(String packageName, Directory packageDirectory) async {
+  final File dartFile = packageDirectory.childDirectory('lib').childFile('$packageName.dart');
+  final String dartFileOld = await dartFile.readAsString();
+  final lineEnding = dartFileOld.contains('\r\n') ? '\r\n' : '\n';
+  final String dartFileWithFfiImport = dartFileOld.replaceFirst(
+    "import 'dart:async';",
+    "import 'dart:async';${lineEnding}import 'dart:ffi';",
+  );
+  expect(dartFileWithFfiImport, isNot(dartFileOld));
+
+  const generatedSumDeclaration = 'int sum(int a, int b) => bindings.sum(a, b);';
+  const linkedSumDeclaration =
+      'int sum(int a, int b) => bindings.sum(a, b) + l.difference(2, 1) - 1;';
+  final sumDeclaration = dartFileWithFfiImport.contains(linkedSumDeclaration)
+      ? linkedSumDeclaration
+      : generatedSumDeclaration;
+  final String dartFileNew = dartFileWithFfiImport.replaceFirst(sumDeclaration, '''
+$sumDeclaration
+
+/// Invokes `sum` by explicitly opening the generated code asset.
+int sumWithCodeAsset(int a, int b) {
+  final library = DynamicLibrary.codeAsset(
+    'package:$packageName/${packageName}_bindings_generated.dart',
+  );
+  try {
+    final sum = library.lookupFunction<
+        IntPtr Function(IntPtr, IntPtr), int Function(int, int)>('sum');
+    return sum(a, b);
+  } finally {
+    library.close();
+  }
+}
+''');
+  expect(dartFileNew, isNot(dartFileWithFfiImport));
+  await dartFile.writeAsString(dartFileNew);
+}
+
+Future<void> addCodeAssetCallToExampleApp(String packageName, Directory packageDirectory) async {
+  final File dartFile = packageDirectory
+      .childDirectory('example')
+      .childDirectory('lib')
+      .childFile('main.dart');
+  final String dartFileOld = (await dartFile.readAsString()).replaceAll('\r\n', '\n');
+  final String dartFileWithResultField = dartFileOld.replaceFirst(
+    '''
+  late int sumResult;
+  late Future<int> sumAsyncResult;
+''',
+    '''
+  late int sumResult;
+  late int sumWithCodeAssetResult;
+  late Future<int> sumAsyncResult;
+''',
+  );
+  expect(dartFileWithResultField, isNot(dartFileOld));
+
+  final String dartFileWithCodeAssetCall = dartFileWithResultField.replaceFirst(
+    '''
+    sumResult = $packageName.sum(1, 2);
+    sumAsyncResult = $packageName.sumAsync(3, 4);
+''',
+    '''
+    sumResult = $packageName.sum(1, 2);
+    sumWithCodeAssetResult = $packageName.sumWithCodeAsset(2, 3);
+    if (sumWithCodeAssetResult != 5) {
+      throw StateError(
+        'Expected sumWithCodeAsset(2, 3) to be 5, got \$sumWithCodeAssetResult',
+      );
+    }
+    sumAsyncResult = $packageName.sumAsync(3, 4);
+''',
+  );
+  expect(dartFileWithCodeAssetCall, isNot(dartFileWithResultField));
+
+  final String dartFileNew = dartFileWithCodeAssetCall.replaceFirst(
+    r'''
+                Text(
+                  'sum(1, 2) = $sumResult',
+                  style: textStyle,
+                  textAlign: .center,
+                ),
+                spacerSmall,
+''',
+    r'''
+                Text(
+                  'sum(1, 2) = $sumResult',
+                  style: textStyle,
+                  textAlign: .center,
+                ),
+                spacerSmall,
+                Text(
+                  'sumWithCodeAsset(2, 3) = $sumWithCodeAssetResult',
+                  style: textStyle,
+                  textAlign: .center,
+                ),
+                spacerSmall,
+''',
+  );
+  expect(dartFileNew, isNot(dartFileWithCodeAssetCall));
+  await dartFile.writeAsString(dartFileNew);
+}
+
 /// Adds a user-define to the pubspec of the package and the example project.
 ///
 /// The build hook will fail if the user-define is not set. So, we don't have to


### PR DESCRIPTION
Registers the Flutter native-assets callbacks required by `DynamicLibrary.codeAsset` while preserving `@Native` process fallback.

The required Dart change landed in https://github.com/dart-lang/sdk/commit/eb5d7983230621e9f09ea54500008ff4259fd50a.

Verified with a local engine for flutter-tester and Linux desktop debug, including hot reload and hot restart.

cc: @dcharkes