### PR TITLE
Bump version for lock-threads workflow

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'flutter/flutter' }}
     steps:
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c
         with:
           process-only: 'issues'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           # Number of days of inactivity before a closed issue is locked.
           issue-inactive-days: '14'
           issue-comment: >

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7
         with:
           process-only: 'issues'
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           # Number of days of inactivity before a closed issue is locked.
           issue-inactive-days: '14'
           issue-comment: >


### PR DESCRIPTION
- Fixes Lock Threads workflow failure where github-token input exceeded action constraints
- 6.0.0 to 6.0.2

part of https://github.com/flutter/flutter/issues/178913