### PR TITLE
Skip locked issues in no-response check

### DIFF
--- a/.github/scripts/no-response.js
+++ b/.github/scripts/no-response.js
@@ -100,6 +100,11 @@ Thanks for your contribution.`;
     // Stale check
     if (issue.state === 'open') {
       if (labeledAt < closeDate) {
+        if (issue.locked) {
+          console.log(`Skipping #${issue.number} because the conversation is locked.`);
+          continue;
+        }
+
         console.log(`Closing #${issue.number} due to no response.`);
         const body = isPr ? prCloseComment : issueCloseComment;
         if (body) {


### PR DESCRIPTION
Avoid closing stale issues or PRs when the conversation is locked. The script now logs and skips locked items instead of throwing and unhandled error and failing the job.

Part of https://github.com/flutter/flutter/issues/178913