### PR TITLE
[test cross imports] More test/rendering + flutter_test/test fixes

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -208,7 +208,6 @@ class TestsCrossImportChecker {
     'packages/flutter_test/test/controller_test.dart',
     'packages/flutter_test/test/recording_canvas_test.dart',
     'packages/flutter_test/test/test_text_input_test.dart',
-    'packages/flutter_test/test/multi_view_accessibility_test.dart',
   };
 
   static final Set<String> _knownCrossImports = {

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -200,7 +200,6 @@ class TestsCrossImportChecker {
     'packages/flutter_test/test/utils/memory_leak_tests.dart',
     'packages/flutter_test/test/widget_tester_test.dart',
     'packages/flutter_test/test/live_widget_controller_test.dart',
-    'packages/flutter_test/test/live_binding_test.dart',
     'packages/flutter_test/test/accessibility_test.dart',
     'packages/flutter_test/test/finders_test.dart',
     'packages/flutter_test/test/controller_test.dart',

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -199,7 +199,6 @@ class TestsCrossImportChecker {
     'packages/flutter_test/test/all_elements_test.dart',
     'packages/flutter_test/test/utils/memory_leak_tests.dart',
     'packages/flutter_test/test/widget_tester_test.dart',
-    'packages/flutter_test/test/bindings_test.dart',
     'packages/flutter_test/test/live_widget_controller_test.dart',
     'packages/flutter_test/test/live_binding_test.dart',
     'packages/flutter_test/test/accessibility_test.dart',

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -207,7 +207,6 @@ class TestsCrossImportChecker {
     'packages/flutter_test/test/finders_test.dart',
     'packages/flutter_test/test/controller_test.dart',
     'packages/flutter_test/test/recording_canvas_test.dart',
-    'packages/flutter_test/test/test_text_input_test.dart',
   };
 
   static final Set<String> _knownCrossImports = {

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -162,11 +162,6 @@ class TestsCrossImportChecker {
   static final Set<String> knownRenderingCrossImports = <String>{
     'packages/flutter/test/rendering/aligning_shifted_box_baseline_test.dart',
     'packages/flutter/test/rendering/localized_fonts_test.dart',
-    'packages/flutter/test/rendering/box_test.dart',
-    'packages/flutter/test/rendering/pipeline_owner_tree_test.dart',
-    'packages/flutter/test/rendering/proxy_getters_and_setters_test.dart',
-    'packages/flutter/test/rendering/proxy_box_test.dart',
-    'packages/flutter/test/rendering/object_test.dart',
   };
   static final Set<String> knownSchedulerCrossImports = <String>{};
   static final Set<String> knownSemanticsCrossImports = <String>{};

--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -199,7 +199,6 @@ class TestsCrossImportChecker {
     'packages/flutter_test/test/all_elements_test.dart',
     'packages/flutter_test/test/utils/memory_leak_tests.dart',
     'packages/flutter_test/test/widget_tester_test.dart',
-    'packages/flutter_test/test/display_test.dart',
     'packages/flutter_test/test/bindings_test.dart',
     'packages/flutter_test/test/live_widget_controller_test.dart',
     'packages/flutter_test/test/live_binding_test.dart',

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'rendering_tester.dart';
@@ -84,14 +84,23 @@ void main() {
 
   test('should size to render view', () {
     final RenderBox root = RenderDecoratedBox(
-      decoration: BoxDecoration(
-        color: const Color(0xFF00FF00),
+      decoration: const BoxDecoration(
+        color: Color(0xFF00FF00),
         gradient: RadialGradient(
           center: Alignment.topLeft,
           radius: 1.8,
-          colors: <Color>[Colors.yellow[500]!, Colors.blue[500]!],
+          colors: <Color>[Color(0xFFFF00FF), Color(0xFFFFFF00)],
         ),
-        boxShadow: kElevationToShadow[3],
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            offset: Offset(0.0, 3.0),
+            blurRadius: 3.0,
+            spreadRadius: -2.0,
+            color: Color(0x33000000),
+          ),
+          BoxShadow(offset: Offset(0.0, 3.0), blurRadius: 4.0, color: Color(0x24000000)),
+          BoxShadow(offset: Offset(0.0, 1.0), blurRadius: 8.0, color: Color(0x1F000000)),
+        ],
       ),
     );
     layout(root);

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -5,8 +5,8 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 

--- a/packages/flutter/test/rendering/pipeline_owner_tree_test.dart
+++ b/packages/flutter/test/rendering/pipeline_owner_tree_test.dart
@@ -4,8 +4,8 @@
 
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -5,8 +5,8 @@
 import 'dart:ui' as ui show Gradient, Image, ImageFilter;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'rendering_tester.dart';

--- a/packages/flutter/test/rendering/proxy_getters_and_setters_test.dart
+++ b/packages/flutter/test/rendering/proxy_getters_and_setters_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -55,13 +54,13 @@ void main() {
   test('RenderShaderMask getters and setters', () {
     Shader callback1(Rect bounds) {
       assert(false); // The test should not call this.
-      const gradient = LinearGradient(colors: <Color>[Colors.red]);
+      const gradient = LinearGradient(colors: <Color>[Color(0xFFFF0000)]);
       return gradient.createShader(Rect.zero);
     }
 
     Shader callback2(Rect bounds) {
       assert(false); // The test should not call this.
-      const gradient = LinearGradient(colors: <Color>[Colors.blue]);
+      const gradient = LinearGradient(colors: <Color>[Color(0xFF0000FF)]);
       return gradient.createShader(Rect.zero);
     }
 

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -12,8 +12,8 @@ library;
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -71,9 +71,10 @@ void main() {
   testWidgets('timeStamp should be accurate to microsecond precision', (WidgetTester tester) async {
     final WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
 
-    await tester.pumpWidget(const CircularProgressIndicator());
+    await tester.pumpWidget(const SizedBox());
 
     final Duration timeStampBefore = widgetsBinding.currentSystemFrameTimeStamp;
+    tester.binding.scheduleFrame();
     await tester.pump(const Duration(microseconds: 12345));
     final Duration timeStampAfter = widgetsBinding.currentSystemFrameTimeStamp;
 

--- a/packages/flutter_test/test/display_test.dart
+++ b/packages/flutter_test/test/display_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter_test/test/live_binding_test.dart
+++ b/packages/flutter_test/test/live_binding_test.dart
@@ -3,15 +3,42 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // This file is for testings that require a `LiveTestWidgetsFlutterBinding`
 void main() {
+  PageRoute<T> defaultPageRouteBuilder<T>(RouteSettings settings, WidgetBuilder builder) {
+    return PageRouteBuilder<T>(
+      settings: settings,
+      pageBuilder:
+          (
+            BuildContext context,
+            Animation<double> animation,
+            Animation<double> secondaryAnimation,
+          ) => builder(context),
+      transitionsBuilder:
+          (
+            BuildContext context,
+            Animation<double> animation,
+            Animation<double> secondaryAnimation,
+            Widget child,
+          ) => child,
+    );
+  }
+
+  Widget buildTestApp({required Widget child}) {
+    return WidgetsApp(
+      color: const Color(0xFFFFFFFF),
+      pageRouteBuilder: defaultPageRouteBuilder,
+      home: SizedBox.expand(child: Center(child: child)),
+    );
+  }
+
   final binding = LiveTestWidgetsFlutterBinding();
   testWidgets('Input PointerAddedEvent', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: Text('Test')));
+    await tester.pumpWidget(buildTestApp(child: const Text('Test')));
     await tester.pump();
     final TestGesture gesture = await tester.createGesture();
     // This mimics the start of a gesture as seen on a device, where inputs
@@ -23,8 +50,8 @@ void main() {
   testWidgets('Input PointerHoverEvent', (WidgetTester tester) async {
     PointerHoverEvent? hoverEvent;
     await tester.pumpWidget(
-      MaterialApp(
-        home: MouseRegion(
+      buildTestApp(
+        child: MouseRegion(
           child: const Text('Test'),
           onHover: (PointerHoverEvent event) {
             hoverEvent = event;
@@ -44,14 +71,12 @@ void main() {
   testWidgets('hitTesting works when using setSurfaceSize', (WidgetTester tester) async {
     var invocations = 0;
     await tester.pumpWidget(
-      MaterialApp(
-        home: Center(
-          child: GestureDetector(
-            onTap: () {
-              invocations++;
-            },
-            child: const Text('Test'),
-          ),
+      buildTestApp(
+        child: GestureDetector(
+          onTap: () {
+            invocations++;
+          },
+          child: const Text('Test'),
         ),
       ),
     );
@@ -75,7 +100,7 @@ void main() {
 
   testWidgets('setSurfaceSize works', (WidgetTester tester) async {
     addTearDown(binding.resetLayers);
-    await tester.pumpWidget(const MaterialApp(home: Center(child: Text('Test'))));
+    await tester.pumpWidget(buildTestApp(child: const Text('Test')));
 
     final Size windowCenter = tester.view.physicalSize / tester.view.devicePixelRatio / 2;
     final double windowCenterX = windowCenter.width;

--- a/packages/flutter_test/test/multi_view_accessibility_test.dart
+++ b/packages/flutter_test/test/multi_view_accessibility_test.dart
@@ -10,6 +10,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'multi_view_testing.dart';
 
 void main() {
+  const kYellow = Color(0xFFFFEB3B);
+  const kYellowAccent = Color(0xFFFFFF00);
+
   testWidgets('Detects tap targets in all views', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     await pumpViews(
@@ -66,19 +69,19 @@ void main() {
         Container(
           width: 200.0,
           height: 200.0,
-          color: const Color(0xFFFFEB3B),
+          color: kYellow,
           child: const Text(
             'this is a test',
-            style: TextStyle(fontSize: 14.0, color: Color(0xFFFFFF00)),
+            style: TextStyle(fontSize: 14.0, color: kYellowAccent),
           ),
         ),
         Container(
           width: 200.0,
           height: 200.0,
-          color: const Color(0xFFFFEB3B),
+          color: kYellow,
           child: const Text(
             'this is a test',
-            style: TextStyle(fontSize: 25.0, color: Color(0xFFFFFF00)),
+            style: TextStyle(fontSize: 25.0, color: kYellowAccent),
           ),
         ),
       ],

--- a/packages/flutter_test/test/multi_view_accessibility_test.dart
+++ b/packages/flutter_test/test/multi_view_accessibility_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'multi_view_testing.dart';
@@ -66,19 +66,19 @@ void main() {
         Container(
           width: 200.0,
           height: 200.0,
-          color: Colors.yellow,
+          color: const Color(0xFFFFEB3B),
           child: const Text(
             'this is a test',
-            style: TextStyle(fontSize: 14.0, color: Colors.yellowAccent),
+            style: TextStyle(fontSize: 14.0, color: Color(0xFFFFFF00)),
           ),
         ),
         Container(
           width: 200.0,
           height: 200.0,
-          color: Colors.yellow,
+          color: const Color(0xFFFFEB3B),
           child: const Text(
             'this is a test',
-            style: TextStyle(fontSize: 25.0, color: Colors.yellowAccent),
+            style: TextStyle(fontSize: 25.0, color: Color(0xFFFFFF00)),
           ),
         ),
       ],

--- a/packages/flutter_test/test/test_text_input_test.dart
+++ b/packages/flutter_test/test/test_text_input_test.dart
@@ -2,21 +2,56 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=20210721"
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  PageRoute<T> defaultPageRouteBuilder<T>(RouteSettings settings, WidgetBuilder builder) {
+    return PageRouteBuilder<T>(
+      settings: settings,
+      pageBuilder:
+          (
+            BuildContext context,
+            Animation<double> animation,
+            Animation<double> secondaryAnimation,
+          ) => builder(context),
+      transitionsBuilder:
+          (
+            BuildContext context,
+            Animation<double> animation,
+            Animation<double> secondaryAnimation,
+            Widget child,
+          ) => child,
+    );
+  }
+
+  Widget buildTestApp({required TextEditingController controller, required FocusNode focusNode}) {
+    return WidgetsApp(
+      color: const Color(0xFFFFFFFF),
+      pageRouteBuilder: defaultPageRouteBuilder,
+      home: SizedBox.expand(
+        child: Center(
+          child: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(),
+            cursorColor: const Color(0xFFFF0000),
+            backgroundCursorColor: const Color(0xFFFAFAFA),
+          ),
+        ),
+      ),
+    );
+  }
+
   testWidgets('enterText works', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: Material(child: TextField())));
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(buildTestApp(controller: controller, focusNode: focusNode));
 
     final EditableTextState state = tester.state(find.byType(EditableText));
     expect(state.textEditingValue.text, '');
@@ -38,11 +73,15 @@ void main() {
       'receiveAction() forwards exception when exception occurs during action processing',
       (WidgetTester tester) async {
         // Setup a widget that can receive focus so that we can open the keyboard.
-        const Widget widget = MaterialApp(home: Material(child: TextField()));
-        await tester.pumpWidget(widget);
+        final controller = TextEditingController();
+        addTearDown(controller.dispose);
+        final focusNode = FocusNode();
+        addTearDown(focusNode.dispose);
+
+        await tester.pumpWidget(buildTestApp(controller: controller, focusNode: focusNode));
 
         // Keyboard must be shown for receiveAction() to function.
-        await tester.showKeyboard(find.byType(TextField));
+        await tester.showKeyboard(find.byType(EditableText));
 
         // Register a handler for the text input channel that throws an error. This
         // error should be reported within a PlatformException by TestTextInput.
@@ -110,39 +149,35 @@ void main() {
   // between tests.
   // Regression test for https://github.com/flutter/flutter/issues/171491.
   for (var i = 0; i < 2; i++) {
-    testWidgets(
-      'keyboard shortcut handling is cleared between tests (${i + 1}/2)',
-      (WidgetTester tester) async {
-        final client = _PerformSelectorInputClient();
+    testWidgets('keyboard shortcut handling is cleared between tests (${i + 1}/2)', (
+      WidgetTester tester,
+    ) async {
+      final client = _PerformSelectorInputClient();
 
-        final focusNode = FocusNode();
-        addTearDown(focusNode.dispose);
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
 
-        await tester.pumpWidget(
-          Directionality(
-            textDirection: TextDirection.ltr,
-            child: Scaffold(
-              body: Focus(focusNode: focusNode, autofocus: true, child: Container()),
-            ),
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: SizedBox.expand(
+            child: Focus(focusNode: focusNode, autofocus: true, child: Container()),
           ),
-        );
+        ),
+      );
 
-        final TextInputConnection connection = TextInput.attach(
-          client,
-          const TextInputConfiguration(),
-        );
-        addTearDown(() {
-          connection.close();
-        });
-        connection.show();
+      final TextInputConnection connection = TextInput.attach(
+        client,
+        const TextInputConfiguration(),
+      );
+      addTearDown(connection.close);
+      connection.show();
 
-        // Press the left arrow, which should trigger a "moveLeft:" selector call.
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft, platform: 'macos');
+      // Press the left arrow, which should trigger a "moveLeft:" selector call.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft, platform: 'macos');
 
-        expect(client.performSelectorCalled, isTrue);
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.macOS),
-    );
+      expect(client.performSelectorCalled, isTrue);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
   }
 }
 


### PR DESCRIPTION
This PR fixes some more cross imports in tests:

- `packages/flutter/test/rendering/box_test.dart`
- `packages/flutter/test/rendering/pipeline_owner_tree_test.dart`
- `packages/flutter/test/rendering/proxy_getters_and_setters_test.dart`
- `packages/flutter/test/rendering/proxy_box_test.dart`
- `packages/flutter/test/rendering/object_test.dart`
- `packages/flutter_test/test/display_test.dart`
- `packages/flutter_test/test/bindings_test.dart`
- `packages/flutter_test/test/live_binding_test.dart`
- `packages/flutter_test/test/test_text_input_test.dart`
- `packages/flutter_test/test/multi_view_accessibility_test.dart`

Part of https://github.com/flutter/flutter/issues/177415

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
