### PR TITLE
[Impeller] Guard optional FlatBuffer fields on the runtime shader load path

### DIFF
--- a/engine/src/flutter/impeller/runtime_stage/runtime_stage.cc
+++ b/engine/src/flutter/impeller/runtime_stage/runtime_stage.cc
@@ -70,6 +70,13 @@ absl::StatusOr<RuntimeStage> RuntimeStage::Create(
   if (!runtime_stage) {
     return absl::InvalidArgumentError("Runtime stage is null.");
   }
+  // The runtime stage FlatBuffer schema marks these fields optional, so the
+  // structural VerifyRuntimeStagesBuffer() does not guarantee they are present.
+  // Guard against a malformed (but structurally-valid) stage that omits them.
+  if (runtime_stage->entrypoint() == nullptr ||
+      runtime_stage->shader() == nullptr) {
+    return absl::InvalidArgumentError("Runtime stage is missing required data.");
+  }
 
   RuntimeStage stage(payload);
   stage.stage_ = ToShaderStage(runtime_stage->stage());

--- a/engine/src/flutter/lib/gpu/shader_library.cc
+++ b/engine/src/flutter/lib/gpu/shader_library.cc
@@ -222,10 +222,22 @@ static ShaderLibrary::ShaderMap ParseShaderBundle(
     return shader_map;
   }
 
+  if (bundle->shaders() == nullptr) {
+    return shader_map;
+  }
+
   for (const auto* bundled_shader : *bundle->shaders()) {
+    // The shader bundle FlatBuffer schema marks every field as optional, so the
+    // structural VerifyShaderBundleBuffer() above does not guarantee these
+    // sub-fields are present. Guard the ones this loop dereferences to avoid a
+    // null dereference on a malformed (but structurally-valid) bundle.
+    if (bundled_shader->name() == nullptr) {
+      continue;
+    }
     const impeller::fb::shaderbundle::BackendShader* backend_shader =
         GetShaderBackend(backend_type, bundled_shader);
-    if (!backend_shader) {
+    if (!backend_shader || backend_shader->shader() == nullptr ||
+        backend_shader->entrypoint() == nullptr) {
       VALIDATION_LOG << "Failed to unpack shader \""
                      << bundled_shader->name()->c_str() << "\" from bundle.";
       continue;

--- a/engine/src/flutter/lib/gpu/shader_library_unittests.cc
+++ b/engine/src/flutter/lib/gpu/shader_library_unittests.cc
@@ -71,6 +71,23 @@ static std::shared_ptr<std::vector<uint8_t>> BuildCorruptBundle() {
   return data;
 }
 
+// Builds a structurally-valid shader bundle that omits the optional `shaders`
+// vector entirely, so bundle->shaders() returns nullptr. Mirrors
+// BuildValidEmptyBundle but never calls add_shaders().
+static std::shared_ptr<std::vector<uint8_t>> BuildBundleWithoutShaders() {
+  flatbuffers::FlatBufferBuilder builder;
+  impeller::fb::shaderbundle::ShaderBundleBuilder bundle_builder(builder);
+  bundle_builder.add_format_version(static_cast<uint32_t>(
+      impeller::fb::shaderbundle::ShaderBundleFormatVersion::kVersion));
+  // Intentionally do NOT call add_shaders(): the field is optional in the
+  // schema, so it is absent and bundle->shaders() == nullptr.
+  auto bundle = bundle_builder.Finish();
+  builder.Finish(bundle, impeller::fb::shaderbundle::ShaderBundleIdentifier());
+  return std::make_shared<std::vector<uint8_t>>(
+      builder.GetBufferPointer(),
+      builder.GetBufferPointer() + builder.GetSize());
+}
+
 // Sanity check on the test fixtures themselves: the corrupt buffer carries the
 // expected identifier (so it reaches the new verification) while failing
 // structural verification, and the valid buffer passes both.
@@ -160,6 +177,33 @@ TEST(FlutterGpuShaderLibraryTest,
       impeller::Context::BackendType::kMetal, CreateMappingFromVector(valid),
       "test_bundle");
   EXPECT_FALSE(library);
+}
+
+// Regression: the shader-bundle FlatBuffer schema marks the `shaders` vector as
+// optional, so a structurally-valid bundle can omit it, making bundle->shaders()
+// return nullptr. ParseShaderBundle() must not dereference the null vector -- it
+// should behave the same as a bundle with a present-but-empty shaders vector
+// rather than crashing.
+TEST(FlutterGpuShaderLibraryTest, MakeFromFlatbufferHandlesMissingShadersVector) {
+  auto without_shaders = BuildBundleWithoutShaders();
+  // The omitted optional field still passes structural verification.
+  {
+    flatbuffers::Verifier verifier(without_shaders->data(),
+                                   without_shaders->size());
+    EXPECT_TRUE(
+        impeller::fb::shaderbundle::VerifyShaderBundleBuffer(verifier));
+  }
+  // Loading it must not crash (prior to the guard this dereferenced
+  // *bundle->shaders() with shaders() == nullptr) and must match the behavior of
+  // the present-but-empty bundle.
+  auto library_missing = ShaderLibrary::MakeFromFlatbuffer(
+      impeller::Context::BackendType::kMetal,
+      CreateMappingFromVector(without_shaders), "missing_shaders_bundle");
+  auto library_empty = ShaderLibrary::MakeFromFlatbuffer(
+      impeller::Context::BackendType::kMetal,
+      CreateMappingFromVector(BuildValidEmptyBundle()), "empty_bundle");
+  EXPECT_EQ(static_cast<bool>(library_missing),
+            static_cast<bool>(library_empty));
 }
 
 }  // namespace testing


### PR DESCRIPTION
The shader-bundle (`shader_bundle.fbs`) and runtime-stage (`runtime_stage.fbs`) FlatBuffer schemas mark every field as optional. The structural `VerifyShaderBundleBuffer()` / `VerifyRuntimeStagesBuffer()` checks only guarantee that *present* offsets are in-bounds — they do not require any field to exist, so an omitted optional table/string/vector field makes the generated accessor return `nullptr`.

`ParseShaderBundle()` (`lib/gpu/shader_library.cc`) and `RuntimeStage::Create()` (`impeller/runtime_stage/runtime_stage.cc`) then dereference several of these without a null check:
- `*bundle->shaders()`, `bundled_shader->name()`, `backend_shader->shader()`, `backend_shader->entrypoint()`
- `runtime_stage->entrypoint()`, `runtime_stage->shader()`

So a structurally-valid but malformed `.shaderbundle` / runtime-stage blob — loaded from an untrusted asset via `ShaderLibrary.fromAsset` / `FragmentProgram.fromAsset` — crashes the engine with a null-pointer dereference.

This guards the fields these load paths dereference (skipping the malformed shader, or returning an error), mirroring the existing element-level null guards already present for `backend_shader`, `uniform_structs`, and `uniform_textures`. Follow-up hardening to the FlatBuffer verification already added for these paths.

Note: I could not build the full engine locally; the change is limited to added null guards matching the surrounding style.
