### PR TITLE
[macOS] Bound frames in flight to protect Impeller per-frame GPU buffers

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERSURFACE_H_
 
 #import <Cocoa/Cocoa.h>
+#import <Metal/Metal.h>
 
 #import "flutter/shell/platform/embedder/embedder.h"
 
@@ -34,6 +35,8 @@
 @property(readonly, nonatomic, nonnull) IOSurfaceRef ioSurface;
 @property(readonly, nonatomic) CGSize size;
 @property(readonly, nonatomic) int64_t textureId;
+// The Metal texture backed by ioSurface that the engine renders into.
+@property(readonly, nonatomic, nonnull) id<MTLTexture> texture;
 // Whether the surface is currently in use by the compositor.
 @property(readonly, nonatomic) BOOL isInUse;
 // Whether the surface was created with wide gamut enabled.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h
@@ -35,7 +35,7 @@
 @property(readonly, nonatomic, nonnull) IOSurfaceRef ioSurface;
 @property(readonly, nonatomic) CGSize size;
 @property(readonly, nonatomic) int64_t textureId;
-// The Metal texture backed by ioSurface that the engine renders into.
+// Metal texture that the engine renders into, backed by ioSurface.
 @property(readonly, nonatomic, nonnull) id<MTLTexture> texture;
 // Whether the surface is currently in use by the compositor.
 @property(readonly, nonatomic) BOOL isInUse;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.mm
@@ -34,6 +34,10 @@
   return reinterpret_cast<int64_t>(_texture);
 }
 
+- (id<MTLTexture>)texture {
+  return _texture;
+}
+
 - (BOOL)isInUse {
   return _isInUseOverride || IOSurfaceIsInUse(_ioSurface);
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
@@ -122,6 +122,12 @@
 @property(readonly, nonatomic, nonnull) NSArray<FlutterSurface*>* frontSurfaces;
 @property(readonly, nonatomic, nonnull) NSArray<CALayer*>* layers;
 
+/**
+ * Blocks until the GPU has completed all previously presented frames. Used
+ * for tests.
+ */
+- (void)waitForAllFramesInFlight;
+
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERSURFACEMANAGER_H_

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
@@ -128,6 +128,12 @@
  */
 - (void)waitForAllFramesInFlight;
 
+/**
+ * Skips the fence blit during present. The blit is the only GPU work in unit
+ * tests and would keep surfaces marked in use. Used for tests.
+ */
+@property(readwrite, nonatomic) BOOL disableFenceBlitForTesting;
+
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERSURFACEMANAGER_H_

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -30,6 +30,8 @@ static const intptr_t kMaxFramesInFlight = 3;
 
   // 1x1 target for the fence blit in presentSurfaces.
   id<MTLTexture> _fenceScratchTexture;
+
+  BOOL _disableFenceBlitForTesting;
   CALayer* _containingLayer;
   __weak id<FlutterSurfaceManagerDelegate> _delegate;
   BOOL _wideGamut;
@@ -161,6 +163,14 @@ static void UpdateContentSubLayers(CALayer* layer,
   }
 }
 
+- (BOOL)disableFenceBlitForTesting {
+  return _disableFenceBlitForTesting;
+}
+
+- (void)setDisableFenceBlitForTesting:(BOOL)value {
+  _disableFenceBlitForTesting = value;
+}
+
 - (NSArray*)frontSurfaces {
   return _frontSurfaces;
 }
@@ -272,7 +282,7 @@ static CGSize GetRequiredFrameSize(NSArray<FlutterSurfacePresentInfo*>* surfaces
   // Read a pixel of each surface so that hazard tracking orders this command
   // buffer after the frame's rendering. An empty command buffer has no
   // dependencies and may complete before the rendering does.
-  if (surfaces.count > 0) {
+  if (surfaces.count > 0 && !_disableFenceBlitForTesting) {
     id<MTLTexture> first = surfaces.firstObject.surface.texture;
     if (_fenceScratchTexture == nil || _fenceScratchTexture.pixelFormat != first.pixelFormat) {
       MTLTextureDescriptor* descriptor =

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -11,12 +11,33 @@
 #include "flutter/fml/logging.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h"
 
+// Maximum number of frames that may be scheduled on the GPU but not yet
+// completed at the time a new frame is presented. Impeller's per-frame
+// transient buffers (impeller::HostBuffer) cycle an arena of
+// impeller::kHostBufferArenaSize (4) entries; one entry is consumed by the
+// frame currently being recorded, so at most 3 additional frames may be in
+// flight before an arena entry is reused while the GPU is still reading it.
+// Other platforms get an equivalent bound from their display surfaces (for
+// example CAMetalLayer's drawable pool on iOS), but the IOSurface-based
+// macOS compositor provides none.
+// See https://github.com/flutter/flutter/issues/184091.
+static const intptr_t kMaxFramesInFlight = 3;
+
 @implementation FlutterSurfacePresentInfo
 @end
 
 @interface FlutterSurfaceManager () {
   id<MTLDevice> _device;
   id<MTLCommandQueue> _commandQueue;
+
+  // Limits the number of frames scheduled but not yet completed on the GPU
+  // to kMaxFramesInFlight. Waited on (raster thread) before presenting a
+  // frame, signaled from the frame command buffer's completion handler.
+  dispatch_semaphore_t _frameSemaphore;
+
+  // 1x1 destination for the fence blit in presentSurfaces. Recreated if the
+  // surface pixel format changes (e.g. wide gamut).
+  id<MTLTexture> _fenceScratchTexture;
   CALayer* _containingLayer;
   __weak id<FlutterSurfaceManagerDelegate> _delegate;
   BOOL _wideGamut;
@@ -116,6 +137,7 @@ static void UpdateContentSubLayers(CALayer* layer,
     _backBufferCache = [[FlutterBackBufferCache alloc] init];
     _frontSurfaces = [NSMutableArray array];
     _layers = [NSMutableArray array];
+    _frameSemaphore = dispatch_semaphore_create(kMaxFramesInFlight);
   }
   return self;
 }
@@ -136,6 +158,15 @@ static void UpdateContentSubLayers(CALayer* layer,
 
 - (FlutterBackBufferCache*)backBufferCache {
   return _backBufferCache;
+}
+
+- (void)waitForAllFramesInFlight {
+  for (intptr_t i = 0; i < kMaxFramesInFlight; i++) {
+    dispatch_semaphore_wait(_frameSemaphore, DISPATCH_TIME_FOREVER);
+  }
+  for (intptr_t i = 0; i < kMaxFramesInFlight; i++) {
+    dispatch_semaphore_signal(_frameSemaphore);
+  }
 }
 
 - (NSArray*)frontSurfaces {
@@ -242,7 +273,49 @@ static CGSize GetRequiredFrameSize(NSArray<FlutterSurfacePresentInfo*>* surfaces
 - (void)presentSurfaces:(NSArray<FlutterSurfacePresentInfo*>*)surfaces
                  atTime:(CFTimeInterval)presentationTime
                  notify:(dispatch_block_t)notify {
+  // Apply backpressure when the GPU falls more than kMaxFramesInFlight frames
+  // behind. The frame's rendering command buffers are already committed at
+  // this point, so blocking here only delays presentation and the recording
+  // of subsequent frames. It never blocks while the GPU keeps up.
+  dispatch_semaphore_wait(_frameSemaphore, DISPATCH_TIME_FOREVER);
+
   id<MTLCommandBuffer> commandBuffer = [_commandQueue commandBuffer];
+  // Read one pixel of each presented surface so Metal's hazard tracking
+  // serializes this command buffer behind all of the frame's rendering into
+  // those surfaces. Without this the buffer is empty, has no dependencies,
+  // and can complete while the frame's rendering is still executing, which
+  // would make the completion handler below meaningless as a frame fence.
+  if (surfaces.count > 0) {
+    id<MTLTexture> first = surfaces.firstObject.surface.texture;
+    if (_fenceScratchTexture == nil || _fenceScratchTexture.pixelFormat != first.pixelFormat) {
+      MTLTextureDescriptor* descriptor =
+          [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:first.pixelFormat
+                                                             width:1
+                                                            height:1
+                                                         mipmapped:NO];
+      descriptor.storageMode = MTLStorageModePrivate;
+      _fenceScratchTexture = [_device newTextureWithDescriptor:descriptor];
+    }
+    id<MTLBlitCommandEncoder> blit = [commandBuffer blitCommandEncoder];
+    for (FlutterSurfacePresentInfo* info in surfaces) {
+      if (info.surface.texture.pixelFormat != _fenceScratchTexture.pixelFormat) {
+        continue;
+      }
+      [blit copyFromTexture:info.surface.texture
+                sourceSlice:0
+                sourceLevel:0
+               sourceOrigin:MTLOriginMake(0, 0, 0)
+                 sourceSize:MTLSizeMake(1, 1, 1)
+                  toTexture:_fenceScratchTexture
+           destinationSlice:0
+           destinationLevel:0
+          destinationOrigin:MTLOriginMake(0, 0, 0)];
+    }
+    [blit endEncoding];
+  }
+  [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
+    dispatch_semaphore_signal(_frameSemaphore);
+  }];
   [commandBuffer commit];
   [commandBuffer waitUntilScheduled];
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -11,15 +11,10 @@
 #include "flutter/fml/logging.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h"
 
-// Maximum number of frames that may be scheduled on the GPU but not yet
-// completed at the time a new frame is presented. Impeller's per-frame
-// transient buffers (impeller::HostBuffer) cycle an arena of
-// impeller::kHostBufferArenaSize (4) entries; one entry is consumed by the
-// frame currently being recorded, so at most 3 additional frames may be in
-// flight before an arena entry is reused while the GPU is still reading it.
-// Other platforms get an equivalent bound from their display surfaces (for
-// example CAMetalLayer's drawable pool on iOS), but the IOSurface-based
-// macOS compositor provides none.
+// Maximum number of scheduled but incomplete frames. Impeller reuses
+// per-frame transient buffers (impeller::HostBuffer) after
+// impeller::kHostBufferArenaSize (4) resets, so deeper pipelining corrupts
+// buffers the GPU is still reading.
 // See https://github.com/flutter/flutter/issues/184091.
 static const intptr_t kMaxFramesInFlight = 3;
 
@@ -30,13 +25,10 @@ static const intptr_t kMaxFramesInFlight = 3;
   id<MTLDevice> _device;
   id<MTLCommandQueue> _commandQueue;
 
-  // Limits the number of frames scheduled but not yet completed on the GPU
-  // to kMaxFramesInFlight. Waited on (raster thread) before presenting a
-  // frame, signaled from the frame command buffer's completion handler.
+  // Enforces kMaxFramesInFlight. Signaled when a presented frame completes.
   dispatch_semaphore_t _frameSemaphore;
 
-  // 1x1 destination for the fence blit in presentSurfaces. Recreated if the
-  // surface pixel format changes (e.g. wide gamut).
+  // 1x1 target for the fence blit in presentSurfaces.
   id<MTLTexture> _fenceScratchTexture;
   CALayer* _containingLayer;
   __weak id<FlutterSurfaceManagerDelegate> _delegate;
@@ -273,18 +265,13 @@ static CGSize GetRequiredFrameSize(NSArray<FlutterSurfacePresentInfo*>* surfaces
 - (void)presentSurfaces:(NSArray<FlutterSurfacePresentInfo*>*)surfaces
                  atTime:(CFTimeInterval)presentationTime
                  notify:(dispatch_block_t)notify {
-  // Apply backpressure when the GPU falls more than kMaxFramesInFlight frames
-  // behind. The frame's rendering command buffers are already committed at
-  // this point, so blocking here only delays presentation and the recording
-  // of subsequent frames. It never blocks while the GPU keeps up.
+  // Block until fewer than kMaxFramesInFlight frames are pending on the GPU.
   dispatch_semaphore_wait(_frameSemaphore, DISPATCH_TIME_FOREVER);
 
   id<MTLCommandBuffer> commandBuffer = [_commandQueue commandBuffer];
-  // Read one pixel of each presented surface so Metal's hazard tracking
-  // serializes this command buffer behind all of the frame's rendering into
-  // those surfaces. Without this the buffer is empty, has no dependencies,
-  // and can complete while the frame's rendering is still executing, which
-  // would make the completion handler below meaningless as a frame fence.
+  // Read a pixel of each surface so that hazard tracking orders this command
+  // buffer after the frame's rendering. An empty command buffer has no
+  // dependencies and may complete before the rendering does.
   if (surfaces.count > 0) {
     id<MTLTexture> first = surfaces.firstObject.surface.texture;
     if (_fenceScratchTexture == nil || _fenceScratchTexture.pixelFormat != first.pixelFormat) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
@@ -44,11 +44,16 @@ static FlutterSurfaceManager* CreateSurfaceManager(TestView* testView, BOOL enab
   id<MTLDevice> device = MTLCreateSystemDefaultDevice();
   id<MTLCommandQueue> commandQueue = [device newCommandQueue];
   CALayer* layer = reinterpret_cast<CALayer*>(testView.layer);
-  return [[FlutterSurfaceManager alloc] initWithDevice:device
-                                          commandQueue:commandQueue
-                                                 layer:layer
-                                              delegate:testView
-                                             wideGamut:enableWideGamut];
+  FlutterSurfaceManager* surfaceManager =
+      [[FlutterSurfaceManager alloc] initWithDevice:device
+                                       commandQueue:commandQueue
+                                              layer:layer
+                                           delegate:testView
+                                          wideGamut:enableWideGamut];
+  // The fence blit would be the only GPU work touching surfaces in these
+  // tests and would keep them marked in use, breaking cache expectations.
+  surfaceManager.disableFenceBlitForTesting = YES;
+  return surfaceManager;
 }
 
 static FlutterSurfacePresentInfo* CreatePresentInfo(
@@ -178,28 +183,38 @@ TEST(FlutterSurfaceManager, BackingStoreCacheSurfaceStuckInUse) {
   auto surface1 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
 
   [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface1) ] atTime:0 notify:nil];
-  [surfaceManager waitForAllFramesInFlight];
   // Pretend that compositor is holding on to the surface. The surface will be kept
   // in cache until the age of kSurfaceEvictionAge is reached, and then evicted.
   surface1.isInUseOverride = YES;
 
   auto surface2 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
   [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface2) ] atTime:0 notify:nil];
-  [surfaceManager waitForAllFramesInFlight];
   EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
 
   for (int i = 0; i < 30 /* kSurfaceEvictionAge */ - 1; ++i) {
     auto surface3 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
     [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface3) ] atTime:0 notify:nil];
-    [surfaceManager waitForAllFramesInFlight];
     EXPECT_EQ(surfaceManager.backBufferCache.count, 2ul);
   }
 
   auto surface4 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
   [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface4) ] atTime:0 notify:nil];
-  [surfaceManager waitForAllFramesInFlight];
   // Surface in use should bet old enough at this point to be evicted.
   EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
+}
+
+TEST(FlutterSurfaceManager, PresentsAreFencedAndBounded) {
+  TestView* testView = [[TestView alloc] init];
+  FlutterSurfaceManager* surfaceManager = CreateSurfaceManager(testView);
+  surfaceManager.disableFenceBlitForTesting = NO;
+
+  // Presenting more frames than the in-flight limit must not deadlock, and
+  // all frames must eventually complete.
+  for (int i = 0; i < 10; ++i) {
+    auto surface = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+    [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface) ] atTime:0 notify:nil];
+  }
+  [surfaceManager waitForAllFramesInFlight];
 }
 
 inline bool operator==(const CGRect& lhs, const CGRect& rhs) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
@@ -178,22 +178,26 @@ TEST(FlutterSurfaceManager, BackingStoreCacheSurfaceStuckInUse) {
   auto surface1 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
 
   [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface1) ] atTime:0 notify:nil];
+  [surfaceManager waitForAllFramesInFlight];
   // Pretend that compositor is holding on to the surface. The surface will be kept
   // in cache until the age of kSurfaceEvictionAge is reached, and then evicted.
   surface1.isInUseOverride = YES;
 
   auto surface2 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
   [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface2) ] atTime:0 notify:nil];
+  [surfaceManager waitForAllFramesInFlight];
   EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
 
   for (int i = 0; i < 30 /* kSurfaceEvictionAge */ - 1; ++i) {
     auto surface3 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
     [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface3) ] atTime:0 notify:nil];
+    [surfaceManager waitForAllFramesInFlight];
     EXPECT_EQ(surfaceManager.backBufferCache.count, 2ul);
   }
 
   auto surface4 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
   [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface4) ] atTime:0 notify:nil];
+  [surfaceManager waitForAllFramesInFlight];
   // Surface in use should bet old enough at this point to be evicted.
   EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/184091.

On macOS, nothing limits how far the raster thread can run ahead of the GPU. Impeller's per-frame transient buffers cycle an arena of kHostBufferArenaSize (4) entries, so on GPU-heavy workloads the pipeline can run more than 4 frames deep and an arena entry gets overwritten while an earlier frame is still reading it, causing intermittent rendering corruption. Other platforms get this bound from their display surfaces, for example CAMetalLayer's drawable pool on iOS.

This adds a counting semaphore to FlutterSurfaceManager that caps scheduled-but-incomplete frames at 3, released from a completion handler on the present command buffer. That buffer now also encodes a 1x1 blit reading each presented surface, since an empty command buffer has no dependencies and can complete before the frame's rendering finishes. The wait only engages when the GPU is already more than 3 frames behind, so light workloads are unaffected.

The BackingStoreCacheSurfaceStuckInUse test now drains in-flight frames between presents, since the fence blit briefly keeps presented surfaces marked in use.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
