### PR TITLE
[Impeller] Recycle HostBuffer arena entries only after GPU completion

### DIFF
--- a/engine/src/flutter/impeller/core/BUILD.gn
+++ b/engine/src/flutter/impeller/core/BUILD.gn
@@ -16,6 +16,8 @@ impeller_component("core") {
     "device_buffer_descriptor.h",
     "formats.cc",
     "formats.h",
+    "gpu_submission_tracker.cc",
+    "gpu_submission_tracker.h",
     "host_buffer.cc",
     "host_buffer.h",
     "idle_waiter.h",

--- a/engine/src/flutter/impeller/core/gpu_submission_tracker.cc
+++ b/engine/src/flutter/impeller/core/gpu_submission_tracker.cc
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/core/gpu_submission_tracker.h"
+
+namespace impeller {
+
+uint64_t GpuSubmissionTracker::RecordSubmission() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  uint64_t id = ++last_id_;
+  pending_.insert(id);
+  return id;
+}
+
+void GpuSubmissionTracker::RecordCompletion(uint64_t id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  pending_.erase(id);
+}
+
+uint64_t GpuSubmissionTracker::CompletedThrough() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (pending_.empty()) {
+    return last_id_;
+  }
+  return *pending_.begin() - 1;
+}
+
+uint64_t GpuSubmissionTracker::LatestSubmission() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return last_id_;
+}
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/core/gpu_submission_tracker.cc
+++ b/engine/src/flutter/impeller/core/gpu_submission_tracker.cc
@@ -9,14 +9,14 @@
 namespace impeller {
 
 uint64_t GpuSubmissionTracker::RecordSubmission() {
-  std::lock_guard<std::mutex> lock(mutex_);
+  Lock lock(mutex_);
   uint64_t id = ++last_id_;
   pending_.push_back(id);
   return id;
 }
 
 void GpuSubmissionTracker::RecordCompletion(uint64_t id) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  Lock lock(mutex_);
   auto it = std::lower_bound(pending_.begin(), pending_.end(), id);
   if (it != pending_.end() && *it == id) {
     pending_.erase(it);
@@ -24,7 +24,7 @@ void GpuSubmissionTracker::RecordCompletion(uint64_t id) {
 }
 
 uint64_t GpuSubmissionTracker::CompletedThrough() const {
-  std::lock_guard<std::mutex> lock(mutex_);
+  Lock lock(mutex_);
   if (pending_.empty()) {
     return last_id_;
   }
@@ -32,7 +32,7 @@ uint64_t GpuSubmissionTracker::CompletedThrough() const {
 }
 
 uint64_t GpuSubmissionTracker::LatestSubmission() const {
-  std::lock_guard<std::mutex> lock(mutex_);
+  Lock lock(mutex_);
   return last_id_;
 }
 

--- a/engine/src/flutter/impeller/core/gpu_submission_tracker.cc
+++ b/engine/src/flutter/impeller/core/gpu_submission_tracker.cc
@@ -4,18 +4,23 @@
 
 #include "impeller/core/gpu_submission_tracker.h"
 
+#include <algorithm>
+
 namespace impeller {
 
 uint64_t GpuSubmissionTracker::RecordSubmission() {
   std::lock_guard<std::mutex> lock(mutex_);
   uint64_t id = ++last_id_;
-  pending_.insert(id);
+  pending_.push_back(id);
   return id;
 }
 
 void GpuSubmissionTracker::RecordCompletion(uint64_t id) {
   std::lock_guard<std::mutex> lock(mutex_);
-  pending_.erase(id);
+  auto it = std::lower_bound(pending_.begin(), pending_.end(), id);
+  if (it != pending_.end() && *it == id) {
+    pending_.erase(it);
+  }
 }
 
 uint64_t GpuSubmissionTracker::CompletedThrough() const {
@@ -23,7 +28,7 @@ uint64_t GpuSubmissionTracker::CompletedThrough() const {
   if (pending_.empty()) {
     return last_id_;
   }
-  return *pending_.begin() - 1;
+  return pending_.front() - 1;
 }
 
 uint64_t GpuSubmissionTracker::LatestSubmission() const {

--- a/engine/src/flutter/impeller/core/gpu_submission_tracker.h
+++ b/engine/src/flutter/impeller/core/gpu_submission_tracker.h
@@ -9,6 +9,8 @@
 #include <mutex>
 #include <vector>
 
+#include "impeller/base/thread_safety.h"
+
 namespace impeller {
 
 /// @brief Tracks GPU completion of submitted command buffers as a monotonic
@@ -38,11 +40,11 @@ class GpuSubmissionTracker {
 
  private:
   mutable std::mutex mutex_;
-  uint64_t last_id_ = 0;
+  uint64_t last_id_ IPLR_GUARDED_BY(mutex_) = 0;
   // Sorted, since ids are recorded in increasing order. The pending count
   // tracks GPU queue depth and stays small, so erasure is cheap and steady
   // state performs no heap allocation.
-  std::vector<uint64_t> pending_;
+  std::vector<uint64_t> pending_ IPLR_GUARDED_BY(mutex_);
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/core/gpu_submission_tracker.h
+++ b/engine/src/flutter/impeller/core/gpu_submission_tracker.h
@@ -6,10 +6,9 @@
 #define FLUTTER_IMPELLER_CORE_GPU_SUBMISSION_TRACKER_H_
 
 #include <cstdint>
-#include <mutex>
 #include <vector>
 
-#include "impeller/base/thread_safety.h"
+#include "impeller/base/thread.h"
 
 namespace impeller {
 
@@ -39,7 +38,7 @@ class GpuSubmissionTracker {
   uint64_t LatestSubmission() const;
 
  private:
-  mutable std::mutex mutex_;
+  mutable Mutex mutex_;
   uint64_t last_id_ IPLR_GUARDED_BY(mutex_) = 0;
   // Sorted, since ids are recorded in increasing order. The pending count
   // tracks GPU queue depth and stays small, so erasure is cheap and steady

--- a/engine/src/flutter/impeller/core/gpu_submission_tracker.h
+++ b/engine/src/flutter/impeller/core/gpu_submission_tracker.h
@@ -7,7 +7,7 @@
 
 #include <cstdint>
 #include <mutex>
-#include <set>
+#include <vector>
 
 namespace impeller {
 
@@ -39,7 +39,10 @@ class GpuSubmissionTracker {
  private:
   mutable std::mutex mutex_;
   uint64_t last_id_ = 0;
-  std::set<uint64_t> pending_;
+  // Sorted, since ids are recorded in increasing order. The pending count
+  // tracks GPU queue depth and stays small, so erasure is cheap and steady
+  // state performs no heap allocation.
+  std::vector<uint64_t> pending_;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/core/gpu_submission_tracker.h
+++ b/engine/src/flutter/impeller/core/gpu_submission_tracker.h
@@ -1,0 +1,47 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_CORE_GPU_SUBMISSION_TRACKER_H_
+#define FLUTTER_IMPELLER_CORE_GPU_SUBMISSION_TRACKER_H_
+
+#include <cstdint>
+#include <mutex>
+#include <set>
+
+namespace impeller {
+
+/// @brief Tracks GPU completion of submitted command buffers as a monotonic
+///        watermark.
+///
+/// Backends record an id for each submitted command buffer and mark it from
+/// the command buffer's completion callback. Consumers compare ids against
+/// [CompletedThrough] to find out whether the GPU is done with all work
+/// submitted up to a point in time, regardless of the order in which
+/// individual command buffers complete.
+///
+/// All methods are thread safe.
+class GpuSubmissionTracker {
+ public:
+  /// Records a command buffer submission and returns its id.
+  uint64_t RecordSubmission();
+
+  /// Marks a previously recorded submission as completed by the GPU.
+  void RecordCompletion(uint64_t id);
+
+  /// Returns the highest id such that all submissions with ids up to and
+  /// including it have completed.
+  uint64_t CompletedThrough() const;
+
+  /// Returns the id of the most recent submission.
+  uint64_t LatestSubmission() const;
+
+ private:
+  mutable std::mutex mutex_;
+  uint64_t last_id_ = 0;
+  std::set<uint64_t> pending_;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_CORE_GPU_SUBMISSION_TRACKER_H_

--- a/engine/src/flutter/impeller/core/host_buffer.cc
+++ b/engine/src/flutter/impeller/core/host_buffer.cc
@@ -21,16 +21,21 @@ constexpr size_t kAllocatorBlockSize = 1024000;  // 1024 Kb.
 std::shared_ptr<HostBuffer> HostBuffer::Create(
     const std::shared_ptr<Allocator>& allocator,
     const std::shared_ptr<const IdleWaiter>& idle_waiter,
-    size_t minimum_uniform_alignment) {
+    size_t minimum_uniform_alignment,
+    std::shared_ptr<const GpuSubmissionTracker> submission_tracker) {
   return std::shared_ptr<HostBuffer>(
-      new HostBuffer(allocator, idle_waiter, minimum_uniform_alignment));
+      new HostBuffer(allocator, idle_waiter, minimum_uniform_alignment,
+                     std::move(submission_tracker)));
 }
 
-HostBuffer::HostBuffer(const std::shared_ptr<Allocator>& allocator,
-                       const std::shared_ptr<const IdleWaiter>& idle_waiter,
-                       size_t minimum_uniform_alignment)
+HostBuffer::HostBuffer(
+    const std::shared_ptr<Allocator>& allocator,
+    const std::shared_ptr<const IdleWaiter>& idle_waiter,
+    size_t minimum_uniform_alignment,
+    std::shared_ptr<const GpuSubmissionTracker> submission_tracker)
     : allocator_(allocator),
       idle_waiter_(idle_waiter),
+      submission_tracker_(std::move(submission_tracker)),
       minimum_uniform_alignment_(minimum_uniform_alignment) {
   DeviceBufferDescriptor desc;
   desc.size = kAllocatorBlockSize;
@@ -233,9 +238,42 @@ void HostBuffer::Reset() {
     device_buffers_[frame_index_].pop_back();
   }
 
+  if (submission_tracker_) {
+    // Everything submitted so far may reference this entry's buffers.
+    entry_stamps_[frame_index_] = submission_tracker_->LatestSubmission();
+  }
+
   offset_ = 0u;
   current_buffer_ = 0u;
   frame_index_ = (frame_index_ + 1) % kHostBufferArenaSize;
+
+  if (submission_tracker_) {
+    uint64_t completed = submission_tracker_->CompletedThrough();
+
+    // Release retired buffers the GPU has completed with.
+    std::erase_if(retired_buffers_, [completed](const auto& retired) {
+      return retired.first <= completed;
+    });
+
+    // If the GPU may still be reading the next entry's buffers, retire them
+    // and start the entry over with a fresh allocation. Otherwise writes
+    // below would race the reads of an incomplete earlier frame.
+    if (entry_stamps_[frame_index_] > completed) {
+      DeviceBufferDescriptor desc;
+      desc.size = kAllocatorBlockSize;
+      desc.storage_mode = StorageMode::kHostVisible;
+      std::shared_ptr<DeviceBuffer> buffer = allocator_->CreateBuffer(desc);
+      if (buffer) {
+        retired_buffers_.emplace_back(entry_stamps_[frame_index_],
+                                      std::move(device_buffers_[frame_index_]));
+        device_buffers_[frame_index_].clear();
+        device_buffers_[frame_index_].push_back(std::move(buffer));
+        entry_stamps_[frame_index_] = 0;
+      } else {
+        VALIDATION_LOG << "Failed to replace an in-flight host buffer entry.";
+      }
+    }
+  }
 }
 
 size_t HostBuffer::GetMinimumUniformAlignment() const {

--- a/engine/src/flutter/impeller/core/host_buffer.cc
+++ b/engine/src/flutter/impeller/core/host_buffer.cc
@@ -247,33 +247,36 @@ void HostBuffer::Reset() {
   current_buffer_ = 0u;
   frame_index_ = (frame_index_ + 1) % kHostBufferArenaSize;
 
-  if (submission_tracker_) {
-    uint64_t completed = submission_tracker_->CompletedThrough();
-
-    // Release retired buffers the GPU has completed with.
-    std::erase_if(retired_buffers_, [completed](const auto& retired) {
-      return retired.first <= completed;
-    });
-
-    // If the GPU may still be reading the next entry's buffers, retire them
-    // and start the entry over with a fresh allocation. Otherwise writes
-    // below would race the reads of an incomplete earlier frame.
-    if (entry_stamps_[frame_index_] > completed) {
-      DeviceBufferDescriptor desc;
-      desc.size = kAllocatorBlockSize;
-      desc.storage_mode = StorageMode::kHostVisible;
-      std::shared_ptr<DeviceBuffer> buffer = allocator_->CreateBuffer(desc);
-      if (buffer) {
-        retired_buffers_.emplace_back(entry_stamps_[frame_index_],
-                                      std::move(device_buffers_[frame_index_]));
-        device_buffers_[frame_index_].clear();
-        device_buffers_[frame_index_].push_back(std::move(buffer));
-        entry_stamps_[frame_index_] = 0;
-      } else {
-        VALIDATION_LOG << "Failed to replace an in-flight host buffer entry.";
-      }
-    }
+  if (!submission_tracker_) {
+    return;
   }
+  uint64_t completed = submission_tracker_->CompletedThrough();
+
+  // Release retired buffers the GPU has completed with.
+  std::erase_if(retired_buffers_, [completed](const auto& retired) {
+    return retired.first <= completed;
+  });
+
+  if (entry_stamps_[frame_index_] <= completed) {
+    return;
+  }
+
+  // The GPU may still be reading the next entry's buffers. Retire them and
+  // start the entry over with a fresh allocation, since reusing them would
+  // race the reads of an incomplete earlier frame.
+  DeviceBufferDescriptor desc;
+  desc.size = kAllocatorBlockSize;
+  desc.storage_mode = StorageMode::kHostVisible;
+  std::shared_ptr<DeviceBuffer> buffer = allocator_->CreateBuffer(desc);
+  if (!buffer) {
+    VALIDATION_LOG << "Failed to replace an in-flight host buffer entry.";
+    return;
+  }
+  retired_buffers_.emplace_back(entry_stamps_[frame_index_],
+                                std::move(device_buffers_[frame_index_]));
+  device_buffers_[frame_index_].clear();
+  device_buffers_[frame_index_].push_back(std::move(buffer));
+  entry_stamps_[frame_index_] = 0;
 }
 
 size_t HostBuffer::GetMinimumUniformAlignment() const {

--- a/engine/src/flutter/impeller/core/host_buffer.h
+++ b/engine/src/flutter/impeller/core/host_buffer.h
@@ -10,9 +10,12 @@
 #include <functional>
 #include <memory>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "impeller/core/allocator.h"
 #include "impeller/core/buffer_view.h"
+#include "impeller/core/gpu_submission_tracker.h"
 
 namespace impeller {
 
@@ -23,12 +26,19 @@ static const constexpr size_t kHostBufferArenaSize = 4u;
 /// allocations.
 ///
 /// These are reset per-frame.
+///
+/// The buffers of an arena entry are reused kHostBufferArenaSize resets
+/// after they were written. Nothing guarantees that few frames are in
+/// flight, so with a [GpuSubmissionTracker] the reuse is made safe. Entries
+/// whose GPU work has not completed by the time they come up for reuse are
+/// kept alive off to the side and replaced with fresh allocations.
 class HostBuffer {
  public:
   static std::shared_ptr<HostBuffer> Create(
       const std::shared_ptr<Allocator>& allocator,
       const std::shared_ptr<const IdleWaiter>& idle_waiter,
-      size_t minimum_uniform_alignment);
+      size_t minimum_uniform_alignment,
+      std::shared_ptr<const GpuSubmissionTracker> submission_tracker = nullptr);
 
   ~HostBuffer();
 
@@ -157,9 +167,11 @@ class HostBuffer {
 
   [[nodiscard]] BufferView Emplace(const void* buffer, size_t length);
 
-  explicit HostBuffer(const std::shared_ptr<Allocator>& allocator,
-                      const std::shared_ptr<const IdleWaiter>& idle_waiter,
-                      size_t minimum_uniform_alignment);
+  explicit HostBuffer(
+      const std::shared_ptr<Allocator>& allocator,
+      const std::shared_ptr<const IdleWaiter>& idle_waiter,
+      size_t minimum_uniform_alignment,
+      std::shared_ptr<const GpuSubmissionTracker> submission_tracker);
 
   HostBuffer(const HostBuffer&) = delete;
 
@@ -167,8 +179,16 @@ class HostBuffer {
 
   std::shared_ptr<Allocator> allocator_;
   std::shared_ptr<const IdleWaiter> idle_waiter_;
+  std::shared_ptr<const GpuSubmissionTracker> submission_tracker_;
   std::array<std::vector<std::shared_ptr<DeviceBuffer>>, kHostBufferArenaSize>
       device_buffers_;
+  // Per-entry id of the last GPU submission that may reference the entry's
+  // buffers.
+  std::array<uint64_t, kHostBufferArenaSize> entry_stamps_ = {};
+  // Buffers pulled out of reuse because the GPU had not completed with them,
+  // keyed by the submission id to outlive.
+  std::vector<std::pair<uint64_t, std::vector<std::shared_ptr<DeviceBuffer>>>>
+      retired_buffers_;
   size_t current_buffer_ = 0u;
   size_t offset_ = 0u;
   size_t frame_index_ = 0u;

--- a/engine/src/flutter/impeller/entity/contents/content_context.cc
+++ b/engine/src/flutter/impeller/entity/contents/content_context.cc
@@ -566,7 +566,8 @@ ContentContext::ContentContext(
       data_host_buffer_(HostBuffer::Create(
           context_->GetResourceAllocator(),
           context_->GetIdleWaiter(),
-          context_->GetCapabilities()->GetMinimumUniformAlignment())),
+          context_->GetCapabilities()->GetMinimumUniformAlignment(),
+          context_->GetSubmissionTracker())),
       text_shadow_cache_(std::make_unique<TextShadowCache>()) {
   if (!context_ || !context_->IsValid()) {
     return;
@@ -580,7 +581,8 @@ ContentContext::ContentContext(
       context_->GetCapabilities()->NeedsPartitionedHostBuffer()
           ? HostBuffer::Create(
                 context_->GetResourceAllocator(), context_->GetIdleWaiter(),
-                context_->GetCapabilities()->GetMinimumUniformAlignment())
+                context_->GetCapabilities()->GetMinimumUniformAlignment(),
+                context_->GetSubmissionTracker())
           : data_host_buffer_;
   {
     TextureDescriptor desc;

--- a/engine/src/flutter/impeller/entity/contents/host_buffer_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/host_buffer_unittests.cc
@@ -219,6 +219,61 @@ class FailingAllocator : public Allocator {
   std::shared_ptr<Allocator> delegate_;
 };
 
+TEST(GpuSubmissionTrackerTest, WatermarkHandlesOutOfOrderCompletion) {
+  GpuSubmissionTracker tracker;
+  EXPECT_EQ(tracker.CompletedThrough(), 0u);
+  uint64_t a = tracker.RecordSubmission();
+  uint64_t b = tracker.RecordSubmission();
+  uint64_t c = tracker.RecordSubmission();
+  EXPECT_EQ(tracker.LatestSubmission(), c);
+
+  tracker.RecordCompletion(b);
+  EXPECT_EQ(tracker.CompletedThrough(), 0u);
+  tracker.RecordCompletion(a);
+  EXPECT_EQ(tracker.CompletedThrough(), b);
+  tracker.RecordCompletion(c);
+  EXPECT_EQ(tracker.CompletedThrough(), c);
+}
+
+TEST_P(HostBufferTest, PendingEntriesAreReplacedNotReused) {
+  auto tracker = std::make_shared<GpuSubmissionTracker>();
+  auto buffer = HostBuffer::Create(GetContext()->GetResourceAllocator(),
+                                   GetContext()->GetIdleWaiter(), 256, tracker);
+
+  // Write to the first arena entry and pretend its GPU work never completes.
+  const DeviceBuffer* first_entry = buffer->EmplaceUniform(0.0f).GetBuffer();
+  uint64_t pending = tracker->RecordSubmission();
+  for (size_t i = 0; i < kHostBufferArenaSize; i++) {
+    buffer->Reset();
+  }
+
+  // The entry must be replaced with a fresh allocation.
+  EXPECT_NE(buffer->EmplaceUniform(0.0f).GetBuffer(), first_entry);
+
+  // Once completed, entries are reused in place.
+  tracker->RecordCompletion(pending);
+  const DeviceBuffer* second_entry = buffer->EmplaceUniform(0.0f).GetBuffer();
+  for (size_t i = 0; i < kHostBufferArenaSize; i++) {
+    buffer->Reset();
+  }
+  EXPECT_EQ(buffer->EmplaceUniform(0.0f).GetBuffer(), second_entry);
+}
+
+TEST_P(HostBufferTest, CompletedEntriesAreReusedWithoutTrackerChurn) {
+  auto tracker = std::make_shared<GpuSubmissionTracker>();
+  auto buffer = HostBuffer::Create(GetContext()->GetResourceAllocator(),
+                                   GetContext()->GetIdleWaiter(), 256, tracker);
+
+  // Simulate frames whose GPU work completes promptly. Entries must be
+  // reused, not replaced.
+  const DeviceBuffer* entry = buffer->EmplaceUniform(0.0f).GetBuffer();
+  for (size_t i = 0; i < kHostBufferArenaSize * 3; i++) {
+    tracker->RecordCompletion(tracker->RecordSubmission());
+    buffer->Reset();
+  }
+  EXPECT_EQ(buffer->EmplaceUniform(0.0f).GetBuffer(), entry);
+}
+
 TEST_P(HostBufferTest, EmplaceWithFailingAllocationDoesntCrash) {
   ScopedValidationDisable disable;
   std::shared_ptr<FailingAllocator> allocator =

--- a/engine/src/flutter/impeller/renderer/backend/gles/command_buffer_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/command_buffer_gles.cc
@@ -9,6 +9,7 @@
 
 #include "impeller/base/config.h"
 #include "impeller/renderer/backend/gles/blit_pass_gles.h"
+#include "impeller/renderer/backend/gles/context_gles.h"
 #include "impeller/renderer/backend/gles/render_pass_gles.h"
 
 namespace impeller {
@@ -72,8 +73,21 @@ bool CommandBufferGLES::IsValid() const {
 // |CommandBuffer|
 bool CommandBufferGLES::OnSubmitCommands(bool block_on_schedule,
                                          CompletionCallback callback) {
+  // The reactor consumes commands on the GL thread and GL synchronizes
+  // buffer reuse implicitly, so submissions are tracked at reactor
+  // consumption granularity rather than GPU completion.
+  std::shared_ptr<GpuSubmissionTracker> tracker;
+  uint64_t submission_id = 0;
+  if (auto context = context_.lock()) {
+    tracker = ContextGLES::Cast(*context).GetMutableSubmissionTracker();
+    submission_id = tracker->RecordSubmission();
+  }
+
   if (reactor_->CanReactOnCurrentThread()) {
     const auto result = reactor_->React();
+    if (tracker) {
+      tracker->RecordCompletion(submission_id);
+    }
     if (callback) {
       callback(result ? CommandBuffer::Status::kCompleted
                       : CommandBuffer::Status::kError);
@@ -83,17 +97,25 @@ bool CommandBufferGLES::OnSubmitCommands(bool block_on_schedule,
 
   // Submission is accepted even when no GL context is current yet. The
   // reactor keeps previously encoded operations queued on this thread.
-  if (!callback) {
-    return true;
+  std::shared_ptr<DeferredCompletionCallback> deferred_callback;
+  if (callback) {
+    deferred_callback =
+        std::make_shared<DeferredCompletionCallback>(std::move(callback));
   }
-
-  auto deferred_callback =
-      std::make_shared<DeferredCompletionCallback>(std::move(callback));
   if (!reactor_->AddOperation(
-          [deferred_callback](const ReactorGLES& reactor) {
-            deferred_callback->Complete();
+          [deferred_callback, tracker,
+           submission_id](const ReactorGLES& reactor) {
+            if (tracker) {
+              tracker->RecordCompletion(submission_id);
+            }
+            if (deferred_callback) {
+              deferred_callback->Complete();
+            }
           },
           /*defer=*/true)) {
+    if (tracker) {
+      tracker->RecordCompletion(submission_id);
+    }
     return false;
   }
   return true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/context_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/context_gles.cc
@@ -121,6 +121,16 @@ std::shared_ptr<Allocator> ContextGLES::GetResourceAllocator() const {
   return resource_allocator_;
 }
 
+std::shared_ptr<const GpuSubmissionTracker> ContextGLES::GetSubmissionTracker()
+    const {
+  return submission_tracker_;
+}
+
+const std::shared_ptr<GpuSubmissionTracker>&
+ContextGLES::GetMutableSubmissionTracker() const {
+  return submission_tracker_;
+}
+
 // |Context|
 std::shared_ptr<ShaderLibrary> ContextGLES::GetShaderLibrary() const {
   return shader_library_;

--- a/engine/src/flutter/impeller/renderer/backend/gles/context_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/context_gles.h
@@ -47,6 +47,8 @@ class ContextGLES final : public Context,
 
  private:
   std::shared_ptr<ReactorGLES> reactor_;
+  std::shared_ptr<GpuSubmissionTracker> submission_tracker_ =
+      std::make_shared<GpuSubmissionTracker>();
   std::shared_ptr<ShaderLibraryGLES> shader_library_;
   std::shared_ptr<PipelineLibraryGLES> pipeline_library_;
   std::shared_ptr<SamplerLibraryGLES> sampler_library_;
@@ -74,6 +76,14 @@ class ContextGLES final : public Context,
 
   // |Context|
   std::shared_ptr<Allocator> GetResourceAllocator() const override;
+
+  // |Context|
+  std::shared_ptr<const GpuSubmissionTracker> GetSubmissionTracker()
+      const override;
+
+  // Mutable tracker for command buffer submission bookkeeping.
+  const std::shared_ptr<GpuSubmissionTracker>& GetMutableSubmissionTracker()
+      const;
 
   // |Context|
   std::shared_ptr<ShaderLibrary> GetShaderLibrary() const override;

--- a/engine/src/flutter/impeller/renderer/backend/gles/context_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/context_gles.h
@@ -45,6 +45,10 @@ class ContextGLES final : public Context,
 
   std::shared_ptr<GPUTracerGLES> GetGPUTracer() const { return gpu_tracer_; }
 
+  // Mutable tracker for command buffer submission bookkeeping.
+  const std::shared_ptr<GpuSubmissionTracker>& GetMutableSubmissionTracker()
+      const;
+
  private:
   std::shared_ptr<ReactorGLES> reactor_;
   std::shared_ptr<GpuSubmissionTracker> submission_tracker_ =
@@ -80,10 +84,6 @@ class ContextGLES final : public Context,
   // |Context|
   std::shared_ptr<const GpuSubmissionTracker> GetSubmissionTracker()
       const override;
-
-  // Mutable tracker for command buffer submission bookkeeping.
-  const std::shared_ptr<GpuSubmissionTracker>& GetMutableSubmissionTracker()
-      const;
 
   // |Context|
   std::shared_ptr<ShaderLibrary> GetShaderLibrary() const override;

--- a/engine/src/flutter/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -171,6 +171,15 @@ bool CommandBufferMTL::OnSubmitCommands(bool block_on_schedule,
 #ifdef IMPELLER_DEBUG
   ContextMTL::Cast(*context).GetGPUTracer()->RecordCmdBuffer(buffer_);
 #endif  // IMPELLER_DEBUG
+
+  // Copied so the block keeps the tracker alive past context teardown.
+  std::shared_ptr<GpuSubmissionTracker> tracker =
+      ContextMTL::Cast(*context).GetMutableSubmissionTracker();
+  uint64_t submission_id = tracker->RecordSubmission();
+  [buffer_ addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
+    tracker->RecordCompletion(submission_id);
+  }];
+
   if (callback) {
     [buffer_
         addCompletedHandler:^(id<MTLCommandBuffer> buffer) {

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.h
@@ -104,6 +104,14 @@ class ContextMTL final : public Context,
   std::shared_ptr<Allocator> GetResourceAllocator() const override;
 
   // |Context|
+  std::shared_ptr<const GpuSubmissionTracker> GetSubmissionTracker()
+      const override;
+
+  // Mutable tracker for command buffer submission bookkeeping.
+  const std::shared_ptr<GpuSubmissionTracker>& GetMutableSubmissionTracker()
+      const;
+
+  // |Context|
   std::shared_ptr<ShaderLibrary> GetShaderLibrary() const override;
 
   // |Context|
@@ -176,6 +184,8 @@ class ContextMTL final : public Context,
   std::shared_ptr<AllocatorMTL> resource_allocator_;
   std::shared_ptr<const Capabilities> device_capabilities_;
   std::shared_ptr<const fml::SyncSwitch> is_gpu_disabled_sync_switch_;
+  std::shared_ptr<GpuSubmissionTracker> submission_tracker_ =
+      std::make_shared<GpuSubmissionTracker>();
   Mutex tasks_awaiting_gpu_mutex_;
   std::deque<PendingTasks> tasks_awaiting_gpu_
       IPLR_GUARDED_BY(tasks_awaiting_gpu_mutex_);

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -394,6 +394,16 @@ std::shared_ptr<Allocator> ContextMTL::GetResourceAllocator() const {
   return resource_allocator_;
 }
 
+std::shared_ptr<const GpuSubmissionTracker> ContextMTL::GetSubmissionTracker()
+    const {
+  return submission_tracker_;
+}
+
+const std::shared_ptr<GpuSubmissionTracker>&
+ContextMTL::GetMutableSubmissionTracker() const {
+  return submission_tracker_;
+}
+
 id<MTLDevice> ContextMTL::GetMTLDevice() const {
   return device_;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
@@ -75,13 +75,18 @@ fml::Status CommandQueueVK::Submit(
     return fml::Status();
   };
 
+  std::shared_ptr<GpuSubmissionTracker> tracker =
+      context->GetMutableSubmissionTracker();
+  uint64_t submission_id = tracker->RecordSubmission();
+
   // This will be called later when the command completes.
-  auto fence_complete_callback = [completion_callback,
+  auto fence_complete_callback = [completion_callback, tracker, submission_id,
                                   tracked_objects =
                                       std::move(tracked_objects)]() mutable {
     // Ensure tracked objects are destructed before calling any final
     // callbacks.
     tracked_objects.clear();
+    tracker->RecordCompletion(submission_id);
     if (completion_callback) {
       completion_callback(CommandBuffer::Status::kCompleted);
     }
@@ -92,6 +97,7 @@ fml::Status CommandQueueVK::Submit(
   auto fence_status = context->GetFenceWaiter()->AddFence(
       std::move(fence), submit_callback, std::move(fence_complete_callback));
   if (!fence_status.ok()) {
+    tracker->RecordCompletion(submission_id);
     return fence_status;
   }
   reset.Release();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -524,6 +524,16 @@ std::shared_ptr<Allocator> ContextVK::GetResourceAllocator() const {
   return allocator_;
 }
 
+std::shared_ptr<const GpuSubmissionTracker> ContextVK::GetSubmissionTracker()
+    const {
+  return submission_tracker_;
+}
+
+const std::shared_ptr<GpuSubmissionTracker>&
+ContextVK::GetMutableSubmissionTracker() const {
+  return submission_tracker_;
+}
+
 std::shared_ptr<ShaderLibrary> ContextVK::GetShaderLibrary() const {
   return shader_library_;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
@@ -119,6 +119,14 @@ class ContextVK final : public Context,
   std::shared_ptr<Allocator> GetResourceAllocator() const override;
 
   // |Context|
+  std::shared_ptr<const GpuSubmissionTracker> GetSubmissionTracker()
+      const override;
+
+  // Mutable tracker for command buffer submission bookkeeping.
+  const std::shared_ptr<GpuSubmissionTracker>& GetMutableSubmissionTracker()
+      const;
+
+  // |Context|
   std::shared_ptr<ShaderLibrary> GetShaderLibrary() const override;
 
   // |Context|
@@ -280,6 +288,8 @@ class ContextVK final : public Context,
   QueuesVK queues_;
   std::shared_ptr<const Capabilities> device_capabilities_;
   std::shared_ptr<FenceWaiterVK> fence_waiter_;
+  std::shared_ptr<GpuSubmissionTracker> submission_tracker_ =
+      std::make_shared<GpuSubmissionTracker>();
   std::shared_ptr<ResourceManagerVK> resource_manager_;
   std::shared_ptr<DescriptorPoolRecyclerVK> descriptor_pool_recycler_;
   std::shared_ptr<CommandPoolRecyclerVK> command_pool_recycler_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
@@ -65,6 +65,10 @@ class ContextVK final : public Context,
                         public BackendCast<ContextVK, Context>,
                         public std::enable_shared_from_this<ContextVK> {
  public:
+  // Mutable tracker for command buffer submission bookkeeping.
+  const std::shared_ptr<GpuSubmissionTracker>& GetMutableSubmissionTracker()
+      const;
+
   /// Embedder Stuff
   struct EmbedderData {
     VkInstance instance;
@@ -121,10 +125,6 @@ class ContextVK final : public Context,
   // |Context|
   std::shared_ptr<const GpuSubmissionTracker> GetSubmissionTracker()
       const override;
-
-  // Mutable tracker for command buffer submission bookkeeping.
-  const std::shared_ptr<GpuSubmissionTracker>& GetMutableSubmissionTracker()
-      const;
 
   // |Context|
   std::shared_ptr<ShaderLibrary> GetShaderLibrary() const override;

--- a/engine/src/flutter/impeller/renderer/context.cc
+++ b/engine/src/flutter/impeller/renderer/context.cc
@@ -43,6 +43,14 @@ std::shared_ptr<const IdleWaiter> Context::GetIdleWaiter() const {
   return nullptr;
 }
 
+std::shared_ptr<const GpuSubmissionTracker> Context::GetSubmissionTracker()
+    const {
+  // TODO(https://github.com/flutter/flutter/issues/184091): Wire submission
+  // tracking for the Vulkan and GLES backends. Their swapchains bound frames
+  // in flight today, so HostBuffer reuse keeps the previous behavior there.
+  return nullptr;
+}
+
 void Context::ResetThreadLocalState() const {
   // Nothing to do.
 }

--- a/engine/src/flutter/impeller/renderer/context.cc
+++ b/engine/src/flutter/impeller/renderer/context.cc
@@ -45,9 +45,6 @@ std::shared_ptr<const IdleWaiter> Context::GetIdleWaiter() const {
 
 std::shared_ptr<const GpuSubmissionTracker> Context::GetSubmissionTracker()
     const {
-  // TODO(https://github.com/flutter/flutter/issues/184091): Wire submission
-  // tracking for the Vulkan and GLES backends. Their swapchains bound frames
-  // in flight today, so HostBuffer reuse keeps the previous behavior there.
   return nullptr;
 }
 

--- a/engine/src/flutter/impeller/renderer/context.h
+++ b/engine/src/flutter/impeller/renderer/context.h
@@ -14,6 +14,7 @@
 #include "impeller/base/thread_safety.h"
 #include "impeller/core/allocator.h"
 #include "impeller/core/formats.h"
+#include "impeller/core/gpu_submission_tracker.h"
 #include "impeller/renderer/capabilities.h"
 #include "impeller/renderer/command_queue.h"
 #include "impeller/renderer/sampler_library.h"
@@ -248,6 +249,15 @@ class Context {
   virtual bool AddTrackingFence(const std::shared_ptr<Texture>& texture) const;
 
   virtual std::shared_ptr<const IdleWaiter> GetIdleWaiter() const;
+
+  //----------------------------------------------------------------------------
+  /// @brief Returns the tracker recording GPU completion of command buffer
+  ///        submissions, or nullptr if the backend does not provide one.
+  ///
+  /// Used by per-frame transient allocators to avoid reusing memory the GPU
+  /// is still reading.
+  virtual std::shared_ptr<const GpuSubmissionTracker> GetSubmissionTracker()
+      const;
 
   //----------------------------------------------------------------------------
   /// Resets any thread local state that may interfere with embedders.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/184091.

HostBuffer reuses each arena entry kHostBufferArenaSize (4) resets after it was written, assuming no more than 4 frames are ever in flight. Nothing enforces that assumption. On macOS the embedder applies no frame backpressure, so GPU-heavy workloads run the pipeline deeper than the arena and per-frame uniform and vertex data is overwritten while the GPU is still reading it, corrupting rendering.

This makes reuse completion-aware. Each backend context records command buffer submissions and completions in a monotonic watermark, and HostBuffer::Reset retires entries whose GPU work has not yet completed (keeping their buffers alive until it has) and starts them over with fresh allocations. Deep pipelines now cost transient memory instead of correctness, and the memory drains back once the GPU catches up.

Metal tracks completion via command buffer completed handlers and Vulkan via the fence waiter. GLES tracks at reactor consumption granularity, since GL synchronizes buffer reuse implicitly and provides no equivalent completion signal there.

Before fix (repro: https://github.com/flutter/flutter/issues/184091#issuecomment-4881949695):

https://github.com/user-attachments/assets/ef49ab50-8273-4571-a759-bf4d8285a372

After fix:

https://github.com/user-attachments/assets/450eadf4-6165-47bb-83df-68a51c274e65

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
