### PR TITLE
Fix TabBar indicatorWeight assertion with themed indicator

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1038,8 +1038,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
     this.tabAlignment,
     this.textScaler,
     this.indicatorAnimation,
-  }) : _isPrimary = true,
-       assert(indicator != null || (indicatorWeight > 0.0));
+  }) : _isPrimary = true;
 
   /// Creates a Material Design secondary tab bar.
   ///
@@ -1094,8 +1093,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
     this.tabAlignment,
     this.textScaler,
     this.indicatorAnimation,
-  }) : _isPrimary = false,
-       assert(indicator != null || (indicatorWeight > 0.0));
+  }) : _isPrimary = false;
 
   /// Typically a list of two or more [Tab] widgets.
   ///
@@ -1139,7 +1137,8 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
 
   /// The thickness of the line that appears below the selected tab.
   ///
-  /// The value of this parameter must be greater than zero.
+  /// When using the default underline indicator, the value of this parameter
+  /// must be greater than zero.
   ///
   /// If [ThemeData.useMaterial3] is true and [TabBar] is used to create a
   /// primary tab bar, the default value is 3.0. If the provided value is less
@@ -1948,6 +1947,20 @@ class _TabBarState extends State<TabBar> {
     return true;
   }
 
+  bool _debugIndicatorWeightIsValid(TabBarThemeData tabBarTheme) {
+    assert(() {
+      if (widget.indicator == null &&
+          tabBarTheme.indicator == null &&
+          widget.indicatorWeight <= 0.0) {
+        throw FlutterError(
+          'indicatorWeight must be greater than zero when TabBar uses the default indicator.',
+        );
+      }
+      return true;
+    }());
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
@@ -1957,6 +1970,7 @@ class _TabBarState extends State<TabBar> {
     final TabAlignment effectiveTabAlignment =
         widget.tabAlignment ?? tabBarTheme.tabAlignment ?? _defaults.tabAlignment!;
     assert(_debugTabAlignmentIsValid(effectiveTabAlignment));
+    assert(_debugIndicatorWeightIsValid(tabBarTheme));
 
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     if (_controller!.length == 0) {

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -3623,21 +3623,30 @@ void main() {
   ) async {
     const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
 
-    Widget buildFrame({required bool secondary}) {
-      return boilerplate(
+    await tester.pumpWidget(
+      boilerplate(
         child: DefaultTabController(
           length: tabs.length,
-          child: secondary
-              ? const TabBar.secondary(indicatorWeight: 0.0, tabs: tabs)
-              : const TabBar(indicatorWeight: 0.0, tabs: tabs),
+          child: const TabBar(indicatorWeight: 0.0, tabs: tabs),
         ),
-      );
-    }
-
-    await tester.pumpWidget(buildFrame(secondary: false));
+      ),
+    );
     expect(tester.takeException(), isAssertionError);
+  });
 
-    await tester.pumpWidget(buildFrame(secondary: true));
+  testWidgets('TabBar.secondary asserts zero indicatorWeight with default indicator', (
+    WidgetTester tester,
+  ) async {
+    const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: DefaultTabController(
+          length: tabs.length,
+          child: const TabBar.secondary(indicatorWeight: 0.0, tabs: tabs),
+        ),
+      ),
+    );
     expect(tester.takeException(), isAssertionError);
   });
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -3578,6 +3578,69 @@ void main() {
     );
   });
 
+  testWidgets('TabBar accepts zero indicatorWeight with themed indicator', (
+    WidgetTester tester,
+  ) async {
+    const indicatorColor = Color(0xFF00FF00);
+    const indicator = BoxDecoration(color: indicatorColor);
+    const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
+
+    Widget buildFrame({required bool secondary}) {
+      return boilerplate(
+        tabBarTheme: const TabBarThemeData(
+          indicator: indicator,
+          indicatorSize: TabBarIndicatorSize.tab,
+        ),
+        child: Container(
+          alignment: Alignment.topLeft,
+          child: DefaultTabController(
+            length: tabs.length,
+            child: secondary
+                ? const TabBar.secondary(indicatorWeight: 0.0, tabs: tabs)
+                : const TabBar(indicatorWeight: 0.0, tabs: tabs),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(secondary: false));
+
+    expect(tester.takeException(), isNull);
+    final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    expect(tabBarBox.size.height, 46.0);
+    expect(
+      tabBarBox,
+      paints..rect(rect: const Rect.fromLTRB(0.0, 0.0, 400.0, 46.0), color: indicatorColor),
+    );
+
+    await tester.pumpWidget(buildFrame(secondary: true));
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('TabBar asserts zero indicatorWeight with default indicator', (
+    WidgetTester tester,
+  ) async {
+    const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
+
+    Widget buildFrame({required bool secondary}) {
+      return boilerplate(
+        child: DefaultTabController(
+          length: tabs.length,
+          child: secondary
+              ? const TabBar.secondary(indicatorWeight: 0.0, tabs: tabs)
+              : const TabBar(indicatorWeight: 0.0, tabs: tabs),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(secondary: false));
+    expect(tester.takeException(), isAssertionError);
+
+    await tester.pumpWidget(buildFrame(secondary: true));
+    expect(tester.takeException(), isAssertionError);
+  });
+
   testWidgets('TabBar with custom indicator and indicatorPadding (RTL)', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Fixes #188837

This updates TabBar validation so indicatorWeight: 0 is accepted when the effective indicator is supplied by TabBarThemeData.indicator.

Added a regression test covering a themed indicator with indicatorWeight: 0.