### PR TITLE
Fix drop-through skipping a DragTarget stacked under a refusing one (#187543)

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -904,8 +904,11 @@ class _DragAvatar<T extends Object> extends Drag {
 
     final List<_DragTargetState<Object>> targets = _getDragTargets(result.path).toList();
 
+    // Require equal length: a longer `targets` means a new target (e.g. one
+    // stacked beneath a refusing target) is now under the pointer and must be
+    // entered, not skipped. https://github.com/flutter/flutter/issues/187543
     var listsMatch = false;
-    if (targets.length >= _enteredTargets.length && _enteredTargets.isNotEmpty) {
+    if (targets.length == _enteredTargets.length && _enteredTargets.isNotEmpty) {
       listsMatch = true;
       final Iterator<_DragTargetState<Object>> iterator = targets.iterator;
       for (var i = 0; i < _enteredTargets.length; i += 1) {

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -511,6 +511,92 @@ void main() {
     events.clear();
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/187543
+  //
+  // A drag refused by the upper target must fall through to an accepting target
+  // stacked beneath it once they overlap. The upper target uses an IgnorePointer
+  // so it does not occlude the lower one.
+  testWidgets('Drag and drop - drops through a refusing target to an accepting one beneath it', (
+    WidgetTester tester,
+  ) async {
+    var bottomAccepted = 0;
+    var topAccepted = 0;
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: <Widget>[
+            const Draggable<int>(data: 10, feedback: Text('Dragging'), child: Text('Source')),
+            SizedBox(
+              key: const Key('field'),
+              height: 200.0,
+              width: 200.0,
+              child: Stack(
+                children: <Widget>[
+                  // Lower target: accepts, occupies the lower-right area.
+                  Positioned(
+                    left: 50,
+                    bottom: 50,
+                    child: DragTarget<int>(
+                      builder: (BuildContext context, List<int?> data, List<dynamic> rejects) {
+                        return const SizedBox(height: 100.0, width: 100.0);
+                      },
+                      onWillAcceptWithDetails: (DragTargetDetails<int> _) => true,
+                      onAcceptWithDetails: (DragTargetDetails<int> details) {
+                        bottomAccepted += details.data;
+                      },
+                    ),
+                  ),
+                  // Upper target: refuses, occupies the upper-left area and
+                  // overlaps the lower target. IgnorePointer keeps its content
+                  // from occluding the target beneath it.
+                  Positioned(
+                    left: 0,
+                    top: 0,
+                    child: DragTarget<int>(
+                      builder: (BuildContext context, List<int?> data, List<dynamic> rejects) {
+                        return const IgnorePointer(child: SizedBox(height: 100.0, width: 100.0));
+                      },
+                      onWillAcceptWithDetails: (DragTargetDetails<int> _) => false,
+                      onAcceptWithDetails: (DragTargetDetails<int> details) {
+                        topAccepted += details.data;
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final Offset fieldOrigin = tester.getTopLeft(find.byKey(const Key('field')));
+    final Offset firstLocation = tester.getCenter(find.text('Source'));
+    final Offset secondLocation =
+        fieldOrigin + const Offset(20, 20); // over the refusing target only
+    final Offset thirdLocation =
+        fieldOrigin + const Offset(75, 75); // over the overlap of both targets
+
+    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    await tester.pump();
+
+    // Over the refusing target only: nothing is accepted.
+    await gesture.moveTo(secondLocation);
+    await tester.pump();
+
+    // Move into the overlap so the accepting target below is now under the
+    // pointer, then release there.
+    await gesture.moveTo(thirdLocation);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(bottomAccepted, 10);
+    expect(topAccepted, 0);
+  });
+
   testWidgets('Drag and drop - tapping button', (WidgetTester tester) async {
     final events = <String>[];
     Offset firstLocation, secondLocation;


### PR DESCRIPTION
The `listsMatch` check in `_DragAvatar.updateDrag` treated a longer entered-targets list as unchanged as long as its prefix still matched. So when a drag moved from a refusing target into an overlap with an accepting target stacked beneath it, the lower target was never entered and couldn't receive the drop. This PR requires the two lists to be the same length before treating them as unchanged, so the newly-overlapped target is entered normally.

Fixes #187543 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md