### PR TITLE
Consolidate android_hardware_smoke_test instrumented tests to run both Vulkan and OpenGL ES in one APK...

### DIFF
--- a/dev/integration_tests/android_hardware_smoke_test/README.md
+++ b/dev/integration_tests/android_hardware_smoke_test/README.md
@@ -83,6 +83,17 @@ This mode is used to execute visual assertions locally on your PC or in CI pipel
     --no-dds
   ```
 
+* **Command to run using a locally compiled engine**:
+  If you have modified the engine codebase locally, specify your target engine and host configs:
+  ```sh
+  flutter drive -v \
+    --local-engine=android_debug_unopt_arm64 \
+    --local-engine-host=host_debug_unopt_arm64 \
+    --driver=test_driver/driver_test.dart \
+    --target=integration_test/integration_test_wrapper.dart \
+    --no-dds
+  ```
+
 * **Command to capture/update reference golden baselines**:
   Running with `UPDATE_GOLDENS=true` writes or overwrites the local PNG baselines under `test_driver/goldens/` on the host.
 
@@ -101,7 +112,7 @@ This mode is used to execute visual assertions locally on your PC or in CI pipel
 
 > [!IMPORTANT]
 > **Asset Bundling Precondition**:
-> Because instrumented tests run completely standalone on the device, they compare pixels against baseline images bundled as read-only assets inside the APK. You **must** first generate the local baselines under `test_driver/goldens/` using the **Host-Driven Driver Mode (with `UPDATE_GOLDENS=true`)** before compiling and building the instrumented APK.
+> Because the instrumented tests will run both backends sequentially in a single execution, they compare pixels against baseline images bundled as read-only assets inside the APK. You **must** generate local baselines under `test_driver/goldens/` for **both** backend variants (Vulkan and OpenGL ES) using the **Host-Driven Driver Mode (with `UPDATE_GOLDENS=true`)** before compiling and building the instrumented APK.
 
 * **Command to compile and run the native JUnit suite**:
   ```sh
@@ -112,14 +123,44 @@ This mode is used to execute visual assertions locally on your PC or in CI pipel
     -s
   ```
 
+* **Command to compile and run using a locally compiled engine**:
+  When testing changes made to the Flutter Engine codebase, you must compile your engine changes first (see [Debugging the engine](file:///Users/awolff/Projects/andywolff/flutter/docs/engine/Debugging-the-engine.md#running-a-flutter-app-with-a-local-engine)).
+  
+  Since running Gradle directly bypasses the `flutter` CLI tool, you must manually populate a Maven-layout directory with your local engine's `.jar` and `.pom` artifacts so that Gradle can resolve them:
+  
+  1. Assemble a local Maven directory structure and copy the artifacts (replace `<COMMIT_HASH>` with your engine repo's current commit). (Optional) Add `/local_maven_repo/` to your local `android/.gitignore` file to prevent tracking it:
+     ```sh
+     VERSION="1.0.0-<COMMIT_HASH>"
+     REPO="dev/integration_tests/android_hardware_smoke_test/android/local_maven_repo"
+     OUT_DIR="engine/src/out/android_debug_unopt_arm64"
+     
+     mkdir -p "$REPO/io/flutter/flutter_embedding_debug/$VERSION"
+     mkdir -p "$REPO/io/flutter/arm64_v8a_debug/$VERSION"
+     
+     cp "$OUT_DIR/flutter_embedding_debug.jar" "$REPO/io/flutter/flutter_embedding_debug/$VERSION/flutter_embedding_debug-$VERSION.jar"
+     cp "$OUT_DIR/flutter_embedding_debug.pom" "$REPO/io/flutter/flutter_embedding_debug/$VERSION/flutter_embedding_debug-$VERSION.pom"
+     cp "$OUT_DIR/arm64_v8a_debug.jar" "$REPO/io/flutter/arm64_v8a_debug/$VERSION/arm64_v8a_debug-$VERSION.jar"
+     cp "$OUT_DIR/arm64_v8a_debug.pom" "$REPO/io/flutter/arm64_v8a_debug/$VERSION/arm64_v8a_debug-$VERSION.pom"
+     ```
+  
+  2. Execute the Gradle connected test command, passing the local repository and engine paths:
+     ```sh
+     cd android
+     ./gradlew :app:connectedDebugAndroidTest \
+       -Pandroid.testInstrumentationRunnerArguments.class=com.example.android_hardware_smoke_test.FlutterActivityTest \
+       -Plocal-engine-repo=local_maven_repo \
+       -Plocal-engine-out=../../../../engine/src/out/android_debug_unopt_arm64 \
+       -Plocal-engine-host-out=../../../../engine/src/out/host_debug_unopt_arm64 \
+       -s
+     ```
+
 > [!NOTE]
-> **Statically Compiled Single Source of Truth**:
-> The app's compiled `AndroidManifest.xml` `<meta-data>` tag is the single source of truth for the graphics backend configuration under **both** Instrumented On-Device Mode (OEM) and Host-Driven Driver Mode (CI).
+> **Dynamic Backend Override**:
+> Under **Instrumented On-Device Mode (OEM)**, the native JUnit runner (`FlutterActivityTest.kt`) automatically executes both the Vulkan and OpenGL ES variants of each test method in a single run. It does this by launching the Activity programmatically with an intent extra designating the target backend, which dynamically overrides the statically compiled `AndroidManifest.xml` backend metadata tag.
 >
-> * **Instrumented On-Device Mode (OEM)**: The native Java JUnit harness (`FlutterActivityTest.java`) reads this value dynamically using the `PackageManager` API and routes it to Dart.
-> * **Host-Driven Driver Mode (CI / Host)**: The Dart app queries the native Android embedder via a custom `MethodChannel` to self-discover its compiled backend and self-reports it to the host test script inside its JSON reply payload, completely eliminating the need for environment variables on the host PC.
+> * **Host-Driven Driver Mode (CI / Host)**: The compiled `AndroidManifest.xml` backend configuration remains the single source of truth and is automatically queried via a custom `MethodChannel` to self-discover its compiled backend.
 >
-> To switch the active graphics backend manually for local runs, open `android/app/src/main/AndroidManifest.xml` and update the `io.flutter.embedding.android.ImpellerBackend` value:
+> To switch the active graphics backend manually for host-driven driver runs, open `android/app/src/main/AndroidManifest.xml` and update the `io.flutter.embedding.android.ImpellerBackend` value:
 >
 > ```xml
 > <!-- Enable Vulkan: -->

--- a/dev/integration_tests/android_hardware_smoke_test/android/app/src/androidTest/java/com/example/android_hardware_smoke_test/FlutterActivityTest.kt
+++ b/dev/integration_tests/android_hardware_smoke_test/android/app/src/androidTest/java/com/example/android_hardware_smoke_test/FlutterActivityTest.kt
@@ -6,12 +6,12 @@
 
 package com.example.android_hardware_smoke_test
 
+import android.content.Intent
 import android.graphics.Bitmap
 import android.util.Base64
 import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.rules.ActivityScenarioRule
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.flutter.embedding.engine.FlutterEngineCache
 import org.json.JSONObject
@@ -19,19 +19,28 @@ import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestName
 import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
 import java.io.ByteArrayOutputStream
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-@RunWith(AndroidJUnit4::class)
-class FlutterActivityTest {
+@RunWith(Parameterized::class)
+class FlutterActivityTest(
+    private val backend: String
+) {
     companion object {
         private const val TAG = "FlutterActivityTest"
         private const val SCREENSHOT_CAPTURE_DELAY_MS = 200L
         private const val DIAGNOSTIC_WARNING_DELAY_SEC = 5L
         private const val TEST_TIMEOUT_SEC = 60L
+
+        @JvmStatic
+        @Parameters(name = "{0}")
+        fun backends(): Collection<Array<Any>> = listOf(arrayOf("vulkan"), arrayOf("opengles"))
 
         @JvmStatic
         @AfterClass
@@ -44,7 +53,14 @@ class FlutterActivityTest {
         }
     }
 
-    @get:Rule val rule = ActivityScenarioRule(MainActivity::class.java)
+    @get:Rule val rule =
+        ActivityScenarioRule<MainActivity>(
+            Intent(InstrumentationRegistry.getInstrumentation().targetContext, MainActivity::class.java).apply {
+                putExtra("backend", backend)
+            }
+        )
+
+    @get:Rule val testNameRule = TestName()
 
     /**
      * Common test body for executing a test on the device by sending a command to the Flutter

--- a/dev/integration_tests/android_hardware_smoke_test/android/app/src/androidTest/java/com/example/android_hardware_smoke_test/FlutterActivityTest.kt
+++ b/dev/integration_tests/android_hardware_smoke_test/android/app/src/androidTest/java/com/example/android_hardware_smoke_test/FlutterActivityTest.kt
@@ -13,7 +13,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import io.flutter.embedding.engine.FlutterEngineCache
 import org.json.JSONObject
+import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -30,6 +32,16 @@ class FlutterActivityTest {
         private const val SCREENSHOT_CAPTURE_DELAY_MS = 200L
         private const val DIAGNOSTIC_WARNING_DELAY_SEC = 5L
         private const val TEST_TIMEOUT_SEC = 60L
+
+        @JvmStatic
+        @AfterClass
+        fun tearDownClass() {
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                val engine = FlutterEngineCache.getInstance().get("smoke_test_engine")
+                engine?.destroy()
+                FlutterEngineCache.getInstance().remove("smoke_test_engine")
+            }
+        }
     }
 
     @get:Rule val rule = ActivityScenarioRule(MainActivity::class.java)

--- a/dev/integration_tests/android_hardware_smoke_test/android/app/src/main/kotlin/com/example/android_hardware_smoke_test/MainActivity.kt
+++ b/dev/integration_tests/android_hardware_smoke_test/android/app/src/main/kotlin/com/example/android_hardware_smoke_test/MainActivity.kt
@@ -24,21 +24,30 @@ class MainActivity : FlutterActivity() {
     var messageChannel: BasicMessageChannel<Any>? = null
     private var impellerBackend = "vulkan"
 
-    override fun provideFlutterEngine(context: Context): FlutterEngine {
-        var backend = "vulkan"
-        try {
-            val appInfo =
-                context.packageManager.getApplicationInfo(
-                    context.packageName,
-                    PackageManager.GET_META_DATA
-                )
-            val manifestBackend = appInfo.metaData?.getString("io.flutter.embedding.android.ImpellerBackend")
-            if (!manifestBackend.isNullOrEmpty()) {
-                backend = manifestBackend
+    // Resolves the Impeller backend to run: queries the intent parameter first,
+    // falls back to AndroidManifest metadata next, and defaults to Vulkan.
+    private fun getImpellerBackend(context: Context): String {
+        var backend = intent.getStringExtra("backend")
+        if (backend.isNullOrEmpty()) {
+            try {
+                val appInfo =
+                    context.packageManager.getApplicationInfo(
+                        context.packageName,
+                        PackageManager.GET_META_DATA
+                    )
+                val manifestBackend = appInfo.metaData?.getString("io.flutter.embedding.android.ImpellerBackend")
+                if (!manifestBackend.isNullOrEmpty()) {
+                    backend = manifestBackend
+                }
+            } catch (e: PackageManager.NameNotFoundException) {
+                Log.e(TAG, "Failed to read PackageManager metadata: ${e.message}")
             }
-        } catch (e: PackageManager.NameNotFoundException) {
-            Log.e(TAG, "Failed to read PackageManager metadata: ${e.message}")
         }
+        return if (backend.isNullOrEmpty()) "vulkan" else backend
+    }
+
+    override fun provideFlutterEngine(context: Context): FlutterEngine {
+        val backend = getImpellerBackend(context)
 
         // Cache the engine.
         // This both speeds up the test execution and avoids teardown crashes
@@ -49,30 +58,20 @@ class MainActivity : FlutterActivity() {
         if (backend == "vulkan") {
             var engine = FlutterEngineCache.getInstance().get("smoke_test_engine")
             if (engine == null) {
-                engine = FlutterEngine(context)
+                val shellArgs = arrayOf("--enable-impeller", "--impeller-backend=vulkan")
+                engine = FlutterEngine(context, shellArgs)
                 FlutterEngineCache.getInstance().put("smoke_test_engine", engine)
             }
             return engine
         }
-        return FlutterEngine(context)
+        val shellArgs = arrayOf("--enable-impeller", "--impeller-backend=opengles")
+        return FlutterEngine(context, shellArgs)
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
-        try {
-            val appInfo =
-                packageManager.getApplicationInfo(
-                    packageName,
-                    PackageManager.GET_META_DATA
-                )
-            val manifestBackend = appInfo.metaData?.getString("io.flutter.embedding.android.ImpellerBackend")
-            if (!manifestBackend.isNullOrEmpty()) {
-                impellerBackend = manifestBackend
-            }
-        } catch (e: PackageManager.NameNotFoundException) {
-            Log.e(TAG, "Failed to read PackageManager metadata: ${e.message}")
-        }
+        impellerBackend = getImpellerBackend(this)
 
         messageChannel =
             BasicMessageChannel(

--- a/dev/integration_tests/android_hardware_smoke_test/android/app/src/main/kotlin/com/example/android_hardware_smoke_test/MainActivity.kt
+++ b/dev/integration_tests/android_hardware_smoke_test/android/app/src/main/kotlin/com/example/android_hardware_smoke_test/MainActivity.kt
@@ -2,11 +2,13 @@
 
 package com.example.android_hardware_smoke_test
 
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.plugin.common.BasicMessageChannel
 import io.flutter.plugin.common.JSONMessageCodec
 import io.flutter.plugin.common.MethodChannel
@@ -16,10 +18,44 @@ class MainActivity : FlutterActivity() {
         private const val TAG = "MainActivity"
         const val CHANNEL_NAME = "com.example.android_hardware_smoke_test/test_channel"
         private const val METHOD_CHANNEL_NAME = "com.example.android_hardware_smoke_test/native_support"
+        private var lastConfiguredEngine: FlutterEngine? = null
     }
 
     var messageChannel: BasicMessageChannel<Any>? = null
     private var impellerBackend = "vulkan"
+
+    override fun provideFlutterEngine(context: Context): FlutterEngine {
+        var backend = "vulkan"
+        try {
+            val appInfo =
+                context.packageManager.getApplicationInfo(
+                    context.packageName,
+                    PackageManager.GET_META_DATA
+                )
+            val manifestBackend = appInfo.metaData?.getString("io.flutter.embedding.android.ImpellerBackend")
+            if (!manifestBackend.isNullOrEmpty()) {
+                backend = manifestBackend
+            }
+        } catch (e: PackageManager.NameNotFoundException) {
+            Log.e(TAG, "Failed to read PackageManager metadata: ${e.message}")
+        }
+
+        // Cache the engine.
+        // This both speeds up the test execution and avoids teardown crashes
+        // which can occur on certain GPU drivers.
+        // We only want to do this for Vulkan backend because those teardown
+        // crashes are specific to Vulkan, and OpenGLES can crash when
+        // creating a surface/window with a cached engine.
+        if (backend == "vulkan") {
+            var engine = FlutterEngineCache.getInstance().get("smoke_test_engine")
+            if (engine == null) {
+                engine = FlutterEngine(context)
+                FlutterEngineCache.getInstance().put("smoke_test_engine", engine)
+            }
+            return engine
+        }
+        return FlutterEngine(context)
+    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -45,13 +81,16 @@ class MainActivity : FlutterActivity() {
                 JSONMessageCodec.INSTANCE
             )
 
-        flutterEngine
-            .platformViewsController
-            .registry
-            .registerViewFactory(
-                "com.example.android_hardware_smoke_test/native_text_view",
-                NativeTextViewFactory()
-            )
+        if (flutterEngine != lastConfiguredEngine) {
+            flutterEngine
+                .platformViewsController
+                .registry
+                .registerViewFactory(
+                    "com.example.android_hardware_smoke_test/native_text_view",
+                    NativeTextViewFactory()
+                )
+            lastConfiguredEngine = flutterEngine
+        }
 
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, METHOD_CHANNEL_NAME)
             .setMethodCallHandler { call, result ->

--- a/dev/integration_tests/android_hardware_smoke_test/android/app/test_result_embedder.gradle.kts
+++ b/dev/integration_tests/android_hardware_smoke_test/android/app/test_result_embedder.gradle.kts
@@ -116,14 +116,28 @@ tasks.register("embedTestResultImages") {
                     for (test in discoveredTests) {
                         val testName = test.testName
                         val fileName = test.fileName
-                        val targetCell = "<td>$testName</td>"
+                        val baseName = fileName.substringBefore(".")
+                        val hasVariant = fileName.count { it == '.' } > 1
+                        val targetCell = "<td>$baseName</td>"
+
                         if (htmlContent.contains(targetCell)) {
                             htmlContent =
                                 htmlContent.replace(
                                     targetCell,
-                                    "<td>$testName<br/><img src=\"test_result_images/$fileName\" width=\"300\" style=\"border: 2px solid #ccc; margin-top: 10px;\" /><br/><span style=\"font-size: 12px; color: #555; font-style: italic;\">Result Image: $fileName</span></td>"
+                                    "<td>$baseName<br/><img src=\"test_result_images/$fileName\" width=\"300\" style=\"border: 2px solid #ccc; margin-top: 10px;\" /><br/><span style=\"font-size: 12px; color: #555; font-style: italic;\">Result Image: $fileName</span></td>"
                                 )
                             modified = true
+                        } else if (hasVariant) {
+                            val variant = fileName.substringAfter(".").substringBefore(".")
+                            val parameterizedCell = "<td>$baseName[$variant]</td>"
+                            if (htmlContent.contains(parameterizedCell)) {
+                                htmlContent =
+                                    htmlContent.replace(
+                                        parameterizedCell,
+                                        "<td>$baseName[$variant]<br/><img src=\"test_result_images/$fileName\" width=\"300\" style=\"border: 2px solid #ccc; margin-top: 10px;\" /><br/><span style=\"font-size: 12px; color: #555; font-style: italic;\">Result Image: $fileName</span></td>"
+                                    )
+                                modified = true
+                            }
                         }
                     }
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -406,7 +406,7 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
     // is already attached to a native shell. In that case, the Java FlutterEngine is created around
     // an existing shell.
     if (!flutterJNI.isAttached()) {
-      attachToJni();
+      attachToJni(dartVmArgs);
     }
 
     this.renderer = new FlutterRenderer(flutterJNI);
@@ -434,9 +434,13 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
     this.pluginRegistry.add(processTextPlugin);
   }
 
-  private void attachToJni() {
+  private void attachToJni(@Nullable String[] shellArgs) {
     Log.v(TAG, "Attaching to JNI.");
-    flutterJNI.attachToNative();
+    if (shellArgs != null && shellArgs.length > 0) {
+      flutterJNI.attachToNative(shellArgs);
+    } else {
+      flutterJNI.attachToNative();
+    }
 
     if (!isAttachedToJni()) {
       throw new RuntimeException("FlutterEngine failed to attach to its native Object reference.");

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -412,22 +412,27 @@ public class FlutterJNI {
    */
   @UiThread
   public void attachToNative() {
+    attachToNative(null);
+  }
+
+  @UiThread
+  public void attachToNative(@Nullable String[] shellArgs) {
     ensureRunningOnMainThread();
     ensureNotAttachedToNative();
     shellHolderLock.writeLock().lock();
     try {
-      nativeShellHolderId = performNativeAttach(this);
+      nativeShellHolderId = performNativeAttach(this, shellArgs);
     } finally {
       shellHolderLock.writeLock().unlock();
     }
   }
 
   @VisibleForTesting
-  public long performNativeAttach(@NonNull FlutterJNI flutterJNI) {
-    return nativeAttach(flutterJNI);
+  public long performNativeAttach(@NonNull FlutterJNI flutterJNI, @Nullable String[] shellArgs) {
+    return nativeAttach(flutterJNI, shellArgs);
   }
 
-  private native long nativeAttach(@NonNull FlutterJNI flutterJNI);
+  private native long nativeAttach(@NonNull FlutterJNI flutterJNI, @Nullable String[] shellArgs);
 
   /**
    * Spawns a new FlutterJNI instance from the current instance.

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -182,13 +182,34 @@ static jfieldID g_path_fill_type_winding_field = nullptr;
 static jfieldID g_path_fill_type_even_odd_field = nullptr;
 
 // Called By Java
-static jlong AttachJNI(JNIEnv* env, jclass clazz, jobject flutterJNI) {
+static jlong AttachJNI(JNIEnv* env,
+                       jclass clazz,
+                       jobject flutterJNI,
+                       jobjectArray jargs) {
   fml::jni::JavaObjectWeakGlobalRef java_object(env, flutterJNI);
   std::shared_ptr<PlatformViewAndroidJNI> jni_facade =
       std::make_shared<PlatformViewAndroidJNIImpl>(java_object);
-  auto shell_holder = std::make_unique<AndroidShellHolder>(
-      FlutterMain::Get().GetSettings(), jni_facade,
-      FlutterMain::Get().GetAndroidRenderingAPI());
+
+  auto settings = FlutterMain::Get().GetSettings();
+  flutter::AndroidRenderingAPI rendering_api =
+      FlutterMain::Get().GetAndroidRenderingAPI();
+
+  if (jargs != nullptr) {
+    std::vector<std::string> args = fml::jni::StringArrayToVector(env, jargs);
+    for (const auto& arg : args) {
+      if (arg == "--impeller-backend=opengles") {
+        rendering_api = flutter::AndroidRenderingAPI::kImpellerOpenGLES;
+      } else if (arg == "--impeller-backend=vulkan") {
+        rendering_api = flutter::AndroidRenderingAPI::kImpellerVulkan;
+      }
+      if (arg.compare(0, 19, "--impeller-backend=") == 0) {
+        settings.requested_rendering_backend = arg.substr(19);
+      }
+    }
+  }
+
+  auto shell_holder =
+      std::make_unique<AndroidShellHolder>(settings, jni_facade, rendering_api);
   if (shell_holder->IsValid()) {
     return reinterpret_cast<jlong>(shell_holder.release());
   } else {
@@ -739,7 +760,8 @@ bool RegisterApi(JNIEnv* env) {
       // Start of methods from FlutterJNI
       {
           .name = "nativeAttach",
-          .signature = "(Lio/flutter/embedding/engine/FlutterJNI;)J",
+          .signature =
+              "(Lio/flutter/embedding/engine/FlutterJNI;[Ljava/lang/String;)J",
           .fnPtr = reinterpret_cast<void*>(&AttachJNI),
       },
       {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -389,4 +389,27 @@ public class FlutterEngineTest {
     assertNotNull(pluginBindingCaptor.getValue());
     assertEquals(mockGroup, pluginBindingCaptor.getValue().getEngineGroup());
   }
+
+  @Test
+  public void itPassesShellArgsToNativeAttach() {
+    FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
+    String[] shellArgs = new String[] {"--enable-impeller", "--impeller-backend=opengles"};
+
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) throws Throwable {
+                jniAttached = true;
+                return null;
+              }
+            })
+        .when(flutterJNI)
+        .attachToNative(shellArgs);
+
+    new FlutterEngine(
+        ctx, mockFlutterLoader, flutterJNI, new PlatformViewsController(), shellArgs, true);
+
+    verify(flutterJNI).attachToNative(shellArgs);
+    verify(flutterJNI, never()).attachToNative();
+  }
 }


### PR DESCRIPTION
... and update engine to enable this

Improvement related to https://github.com/flutter/flutter/issues/182123

Consolidate the `android_hardware_smoke_test` connected instrumented tests so that they execute both Vulkan and OpenGL ES backend tests sequentially in a single APK run. A single APK run is desirable because it simplifies delivery to hardware manufacturers so they can run the test suite.

However, that was impossible because the Flutter Engine JNI initializes with either vulkan or impeller once per app lifetime. To remove that restriction, this PR updates the Java and C++ layers in the Android platform embedder to (only when present to avoid breaking change) forward and parse a shell argument which selects impeller backend. It also adds a test to cover this.

Verified with a local engine build. Also added instructions for running the android instrumented tests against a local engine build.

NOTE: this builds on PR https://github.com/flutter/flutter/pull/189026, I'll clean it up after that merges

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
