### PR TITLE
Update lock-threads dependency to 6.0.2

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'flutter/flutter' }}
     steps:
-      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c  # v6.0.2
         with:
           process-only: 'issues'
           github-token: ${{ github.token }}

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'flutter/flutter' }}
     steps:
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c
         with:
           process-only: 'issues'
           github-token: ${{ github.token }}


### PR DESCRIPTION
- Fixes Lock Threads workflow failure where github-token input exceeded action constraints
- Bump lock-threads 6.0.0 to 6.0.2

part of https://github.com/flutter/flutter/issues/178913