### PR TITLE
Use correct titlebar on linux

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_application.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_application.cc
@@ -57,18 +57,26 @@ static GtkWindow* fl_application_create_window(FlApplication* self,
   // desktop).
   // If running on X and not using GNOME then just use a traditional title bar
   // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
+  // If running on Wayland then use XDG_CURRENT_DESKTOP, as the window manager
+  // name is only available on X.
+  gboolean use_header_bar = FALSE;
 #ifdef GDK_WINDOWING_X11
   GdkScreen* screen = gtk_window_get_screen(GTK_WINDOW(window));
   if (GDK_IS_X11_SCREEN(screen)) {
     const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
+    if (g_strcmp0(wm_name, "GNOME Shell") == 0) {
+      use_header_bar = TRUE;
+    }
+  } else
+#endif
+  {
+    const gchar* current_desktop = g_getenv("XDG_CURRENT_DESKTOP");
+    if (current_desktop != nullptr) {
+      g_auto(GStrv) desktops = g_strsplit(current_desktop, ":", -1);
+      use_header_bar = g_strv_contains(
+          reinterpret_cast<const gchar* const*>(desktops), "GNOME");
     }
   }
-#endif
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));

--- a/engine/src/flutter/shell/platform/linux/fl_application.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_application.cc
@@ -73,8 +73,7 @@ static GtkWindow* fl_application_create_window(FlApplication* self,
     const gchar* current_desktop = g_getenv("XDG_CURRENT_DESKTOP");
     if (current_desktop != nullptr) {
       g_auto(GStrv) desktops = g_strsplit(current_desktop, ":", -1);
-      use_header_bar = g_strv_contains(
-          reinterpret_cast<const gchar* const*>(desktops), "GNOME");
+      use_header_bar = g_strv_contains(desktops, "GNOME");
     }
   }
   if (use_header_bar) {

--- a/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
+++ b/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
@@ -30,18 +30,26 @@ static void my_application_activate(GApplication* application) {
   // desktop).
   // If running on X and not using GNOME then just use a traditional title bar
   // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
+  // If running on Wayland then use XDG_CURRENT_DESKTOP, as the window manager
+  // name is only available on X.
+  gboolean use_header_bar = FALSE;
 #ifdef GDK_WINDOWING_X11
   GdkScreen* screen = gtk_window_get_screen(window);
   if (GDK_IS_X11_SCREEN(screen)) {
     const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
+    if (g_strcmp0(wm_name, "GNOME Shell") == 0) {
+      use_header_bar = TRUE;
+    }
+  } else
+#endif
+  {
+    const gchar* current_desktop = g_getenv("XDG_CURRENT_DESKTOP");
+    if (current_desktop != nullptr) {
+      g_auto(GStrv) desktops = g_strsplit(current_desktop, ":", -1);
+      use_header_bar = g_strv_contains(
+          reinterpret_cast<const gchar* const*>(desktops), "GNOME");
     }
   }
-#endif
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));

--- a/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
+++ b/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
@@ -46,8 +46,7 @@ static void my_application_activate(GApplication* application) {
     const gchar* current_desktop = g_getenv("XDG_CURRENT_DESKTOP");
     if (current_desktop != nullptr) {
       g_auto(GStrv) desktops = g_strsplit(current_desktop, ":", -1);
-      use_header_bar = g_strv_contains(
-          reinterpret_cast<const gchar* const*>(desktops), "GNOME");
+      use_header_bar = g_strv_contains(desktops, "GNOME");
     }
   }
   if (use_header_bar) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Closes https://github.com/flutter/flutter/issues/111453.

Tested on my flutter input demo:
<img width="1962" height="1161" alt="Screenshot_20260708_182819" src="https://github.com/user-attachments/assets/9a24038c-c7e5-4dce-90df-220ac10911c5" />
https://github.com/CodeDoctorDE/flutter-input-demo/commit/0d7b012b8b5ed3cb47d3fa56e5722e1e3687f60a

I changed the `my_application.cc.tmpl` for wayland to look for the gnome desktop and if not, it uses the system title bar. I also changed the `fl_application.cc` to match the tmpl changes
I'm currently not sure how I should write tests for a tmpl file. I also rather have added it somewhere in the engine so users don't need to recreate the files.

**Currently a draft since I cannot have more than 2 prs open**

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
