### PR TITLE
Fix dereference of nullptr in the moved-to-rect signal in the Linux embedder

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_window_monitor.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_window_monitor.cc
@@ -59,6 +59,13 @@ static void moved_to_rect_cb(FlWindowMonitor* self,
                              GdkRectangle* final_rect,
                              gboolean flipped_x,
                              gboolean flipped_y) {
+  // According to the documentation, the final_rect can be null
+  // if the backend can't obtain it.
+  // Reference: https://docs.gtk.org/gdk3/signal.Window.moved-to-rect.html
+  if (final_rect == nullptr) {
+    return;
+  }
+
   flutter::IsolateScope scope(self->isolate);
   self->on_moved_to_rect(final_rect->x, final_rect->y, final_rect->width,
                          final_rect->height);


### PR DESCRIPTION
## What's new?
- Per the docs, `final_rect` can be nullptr. We should handle that case. I figured this out with `layer_shell.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

