### PR TITLE
Fix `TabBar` assertion to allow `indicatorWeight: 0` with a themed `indicator`

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1038,8 +1038,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
     this.tabAlignment,
     this.textScaler,
     this.indicatorAnimation,
-  }) : _isPrimary = true,
-       assert(indicator != null || (indicatorWeight > 0.0));
+  }) : _isPrimary = true;
 
   /// Creates a Material Design secondary tab bar.
   ///
@@ -1094,8 +1093,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
     this.tabAlignment,
     this.textScaler,
     this.indicatorAnimation,
-  }) : _isPrimary = false,
-       assert(indicator != null || (indicatorWeight > 0.0));
+  }) : _isPrimary = false;
 
   /// Typically a list of two or more [Tab] widgets.
   ///
@@ -1592,6 +1590,12 @@ class _TabBarState extends State<TabBar> {
     if (tabBarTheme.indicator != null) {
       return tabBarTheme.indicator!;
     }
+    assert(
+      widget.indicatorWeight > 0.0,
+      'The indicatorWeight must be greater than 0 when the TabBar '
+      'draws its default underline indicator (i.e. when no indicator is '
+      'provided by the TabBar or the TabBarTheme).',
+    );
 
     Color color = widget.indicatorColor ?? tabBarTheme.indicatorColor ?? _defaults.indicatorColor!;
     // ThemeData tries to avoid this by having indicatorColor avoid being the

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1149,7 +1149,8 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// If [ThemeData.useMaterial3] is false, the default value is 2.0.
   ///
   /// If [indicator] is specified or provided from [TabBarThemeData],
-  /// this property is ignored.
+  /// this property is ignored. Otherwise, when drawing the default underline
+  /// indicator, the value of this parameter must be greater than zero.
   final double indicatorWeight;
 
   /// The padding for the indicator.
@@ -1590,12 +1591,24 @@ class _TabBarState extends State<TabBar> {
     if (tabBarTheme.indicator != null) {
       return tabBarTheme.indicator!;
     }
-    assert(
-      widget.indicatorWeight > 0.0,
-      'The indicatorWeight must be greater than 0 when the TabBar '
-      'draws its default underline indicator (i.e. when no indicator is '
-      'provided by the TabBar or the TabBarTheme).',
-    );
+    assert(() {
+      if (widget.indicatorWeight <= 0.0) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('Invalid indicatorWeight for TabBar.'),
+          ErrorDescription(
+            'The indicatorWeight must be greater than zero when the TabBar '
+            'draws its default underline indicator, that is when no indicator '
+            'is provided by the TabBar or the TabBarTheme.',
+          ),
+          ErrorHint(
+            'To fix this, set indicatorWeight to a value greater than zero, '
+            'or provide an indicator with the TabBar.indicator or '
+            'TabBarThemeData.indicator property.',
+          ),
+        ]);
+      }
+      return true;
+    }());
 
     Color color = widget.indicatorColor ?? tabBarTheme.indicatorColor ?? _defaults.indicatorColor!;
     // ThemeData tries to avoid this by having indicatorColor avoid being the

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -3646,6 +3646,101 @@ void main() {
     );
   });
 
+  testWidgets('TabBar accepts indicatorWeight: 0 when the indicator comes from TabBarThemeData', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/188837.
+    // A themed indicator supplies the decoration, so indicatorWeight: 0 must not
+    // trip the default-underline assertion.
+    const indicatorColor = Color(0xFF00FF00);
+    const Decoration indicator = BoxDecoration(color: indicatorColor);
+    const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
+
+    Widget buildFrame({required bool secondary}) {
+      return boilerplate(
+        useMaterial3: false,
+        tabBarTheme: const TabBarThemeData(
+          indicator: indicator,
+          indicatorSize: TabBarIndicatorSize.tab,
+        ),
+        child: Container(
+          alignment: Alignment.topLeft,
+          child: DefaultTabController(
+            length: tabs.length,
+            child: secondary
+                ? TabBar.secondary(indicatorWeight: 0.0, tabs: tabs)
+                : TabBar(indicatorWeight: 0.0, tabs: tabs),
+          ),
+        ),
+      );
+    }
+
+    // Primary TabBar: no assertion is thrown and the themed indicator is painted.
+    await tester.pumpWidget(buildFrame(secondary: false));
+    expect(tester.takeException(), isNull);
+
+    final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    // 46 = _kTabHeight(46) with no weight added by the zero indicatorWeight.
+    expect(tabBarBox.size.height, 46.0);
+    expect(
+      tabBarBox,
+      paints..rect(rect: const Rect.fromLTRB(0.0, 0.0, 400.0, 46.0), color: indicatorColor),
+    );
+
+    // Secondary TabBar: also accepts a zero indicatorWeight with a themed indicator.
+    await tester.pumpWidget(buildFrame(secondary: true));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('TabBar accepts indicatorWeight: 0 when the indicator is provided on the widget', (
+    WidgetTester tester,
+  ) async {
+    const Decoration indicator = BoxDecoration(color: Color(0xFF00FF00));
+    const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
+
+    await tester.pumpWidget(
+      boilerplate(
+        useMaterial3: false,
+        child: DefaultTabController(
+          length: tabs.length,
+          child: const TabBar(indicator: indicator, indicatorWeight: 0.0, tabs: tabs),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('TabBar asserts indicatorWeight: 0 with the default underline indicator', (
+    WidgetTester tester,
+  ) async {
+    // With no indicator on the widget or the theme, the TabBar falls back to the
+    // default underline indicator, which requires a positive indicatorWeight.
+    const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
+
+    await tester.pumpWidget(
+      boilerplate(
+        useMaterial3: false,
+        child: DefaultTabController(
+          length: tabs.length,
+          child: TabBar(indicatorWeight: 0.0, tabs: tabs),
+        ),
+      ),
+    );
+    expect(tester.takeException(), isAssertionError);
+
+    await tester.pumpWidget(
+      boilerplate(
+        useMaterial3: false,
+        child: DefaultTabController(
+          length: tabs.length,
+          child: TabBar.secondary(indicatorWeight: 0.0, tabs: tabs),
+        ),
+      ),
+    );
+    expect(tester.takeException(), isAssertionError);
+  });
+
   testWidgets('TabBar with custom indicator - directional indicatorPadding (LTR)', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -3668,8 +3668,8 @@ void main() {
           child: DefaultTabController(
             length: tabs.length,
             child: secondary
-                ? TabBar.secondary(indicatorWeight: 0.0, tabs: tabs)
-                : TabBar(indicatorWeight: 0.0, tabs: tabs),
+                ? const TabBar.secondary(indicatorWeight: 0.0, tabs: tabs)
+                : const TabBar(indicatorWeight: 0.0, tabs: tabs),
           ),
         ),
       );
@@ -3711,34 +3711,39 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('TabBar asserts indicatorWeight: 0 with the default underline indicator', (
+  testWidgets('TabBar throws indicatorWeight: 0 with the default underline indicator', (
     WidgetTester tester,
   ) async {
     // With no indicator on the widget or the theme, the TabBar falls back to the
     // default underline indicator, which requires a positive indicatorWeight.
     const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
+    final Matcher throwsInvalidIndicatorWeightError = isFlutterError.having(
+      (FlutterError error) => error.message,
+      'message',
+      contains('Invalid indicatorWeight for TabBar.'),
+    );
 
     await tester.pumpWidget(
       boilerplate(
         useMaterial3: false,
         child: DefaultTabController(
           length: tabs.length,
-          child: TabBar(indicatorWeight: 0.0, tabs: tabs),
+          child: const TabBar(indicatorWeight: 0.0, tabs: tabs),
         ),
       ),
     );
-    expect(tester.takeException(), isAssertionError);
+    expect(tester.takeException(), throwsInvalidIndicatorWeightError);
 
     await tester.pumpWidget(
       boilerplate(
         useMaterial3: false,
         child: DefaultTabController(
           length: tabs.length,
-          child: TabBar.secondary(indicatorWeight: 0.0, tabs: tabs),
+          child: const TabBar.secondary(indicatorWeight: 0.0, tabs: tabs),
         ),
       ),
     );
-    expect(tester.takeException(), isAssertionError);
+    expect(tester.takeException(), throwsInvalidIndicatorWeightError);
   });
 
   testWidgets('TabBar with custom indicator - directional indicatorPadding (LTR)', (

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -3651,14 +3651,13 @@ void main() {
   ) async {
     // Regression test for https://github.com/flutter/flutter/issues/188837.
     // A themed indicator supplies the decoration, so indicatorWeight: 0 must not
-    // trip the default-underline assertion.
+    // throw the default-underline assertion.
     const indicatorColor = Color(0xFF00FF00);
     const Decoration indicator = BoxDecoration(color: indicatorColor);
     const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
 
     Widget buildFrame({required bool secondary}) {
       return boilerplate(
-        useMaterial3: false,
         tabBarTheme: const TabBarThemeData(
           indicator: indicator,
           indicatorSize: TabBarIndicatorSize.tab,
@@ -3700,7 +3699,6 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
-        useMaterial3: false,
         child: DefaultTabController(
           length: tabs.length,
           child: const TabBar(indicator: indicator, indicatorWeight: 0.0, tabs: tabs),
@@ -3725,7 +3723,6 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
-        useMaterial3: false,
         child: DefaultTabController(
           length: tabs.length,
           child: const TabBar(indicatorWeight: 0.0, tabs: tabs),
@@ -3736,7 +3733,6 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
-        useMaterial3: false,
         child: DefaultTabController(
           length: tabs.length,
           child: const TabBar.secondary(indicatorWeight: 0.0, tabs: tabs),

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -3712,7 +3712,8 @@ void main() {
 
   testWidgets(
     'TabBar throws indicatorWeight: 0 with the default underline indicator',
-    experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
+    experimentalLeakTesting: LeakTesting.settings
+        .withIgnoredAll(), // leaking by design because of exception
     (WidgetTester tester) async {
       // With no indicator on the widget or the theme, the TabBar falls back to the
       // default underline indicator, which requires a positive indicatorWeight.

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../widgets/feedback_tester.dart';
 import '../widgets/semantics_tester.dart';
@@ -3709,38 +3710,40 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('TabBar throws indicatorWeight: 0 with the default underline indicator', (
-    WidgetTester tester,
-  ) async {
-    // With no indicator on the widget or the theme, the TabBar falls back to the
-    // default underline indicator, which requires a positive indicatorWeight.
-    const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
-    final Matcher throwsInvalidIndicatorWeightError = isFlutterError.having(
-      (FlutterError error) => error.message,
-      'message',
-      contains('Invalid indicatorWeight for TabBar.'),
-    );
+  testWidgets(
+    'TabBar throws indicatorWeight: 0 with the default underline indicator',
+    experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
+    (WidgetTester tester) async {
+      // With no indicator on the widget or the theme, the TabBar falls back to the
+      // default underline indicator, which requires a positive indicatorWeight.
+      const tabs = <Widget>[Tab(text: 'A'), Tab(text: 'B')];
+      final Matcher throwsInvalidIndicatorWeightError = isFlutterError.having(
+        (FlutterError error) => error.message,
+        'message',
+        contains('Invalid indicatorWeight for TabBar.'),
+      );
 
-    await tester.pumpWidget(
-      boilerplate(
-        child: DefaultTabController(
-          length: tabs.length,
-          child: const TabBar(indicatorWeight: 0.0, tabs: tabs),
+      await tester.pumpWidget(
+        boilerplate(
+          child: DefaultTabController(
+            length: tabs.length,
+            child: const TabBar(indicatorWeight: 0.0, tabs: tabs),
+          ),
         ),
-      ),
-    );
-    expect(tester.takeException(), throwsInvalidIndicatorWeightError);
+      );
+      expect(tester.takeException(), throwsInvalidIndicatorWeightError);
 
-    await tester.pumpWidget(
-      boilerplate(
-        child: DefaultTabController(
-          length: tabs.length,
-          child: const TabBar.secondary(indicatorWeight: 0.0, tabs: tabs),
+      await tester.pumpWidget(
+        boilerplate(
+          child: DefaultTabController(
+            length: tabs.length,
+            child: const TabBar.secondary(indicatorWeight: 0.0, tabs: tabs),
+          ),
         ),
-      ),
-    );
-    expect(tester.takeException(), throwsInvalidIndicatorWeightError);
-  });
+      );
+      expect(tester.takeException(), throwsInvalidIndicatorWeightError);
+    },
+  );
 
   testWidgets('TabBar with custom indicator - directional indicatorPadding (LTR)', (
     WidgetTester tester,


### PR DESCRIPTION
This PR moves the assertion that checks `indicator != null || (indicatorWeight > 0.0)` from the `TabBar` constructors into the `Decoration _getIndicator(TabBarIndicatorSize indicatorSize)` method. During the first phase of creating the `TabBar` widget, Dart just fills in the fields, there is no `BuildContext` available yet, so the widget has no way of access the `TabBarTheme` via `context.dependOnInheritedWidgetOfExactType<TabBarTheme>()`. As a result, the constructor's assertion can only see the `indicator` passed directly to the widget, and it fails even when a valid indicator is supplied through the `TabBarTheme`.
 
By moving the assertion into the method mentionned above, which runs at build time, the `TabBar` now has access to the `TabBarTheme` and can validate the `indicator` correctly, accepting `indicatorWeight: 0` when a themed indicator is present, while still asserting when the default underline indicator is used.

Fixes #188837

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.