### PR TITLE
Preserve Tooltip semantics when disabled by TooltipVisibility

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -554,6 +554,14 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
         ignorePointer: widget.ignorePointer ?? widget.message != null,
         child: effectiveChild,
       );
+    } else {
+      // A TooltipVisibility ancestor has disabled the tooltip overlay and its
+      // triggers, but the message should still be reported to assistive
+      // technology, matching what RawTooltip does when the tooltip is enabled.
+      effectiveChild = Semantics(
+        tooltip: excludeFromSemantics ? null : _tooltipMessage,
+        child: effectiveChild,
+      );
     }
 
     return effectiveChild;

--- a/packages/flutter/test/material/tooltip_visibility_test.dart
+++ b/packages/flutter/test/material/tooltip_visibility_test.dart
@@ -189,6 +189,56 @@ void main() {
     await tester.pump();
     expect(find.text(tooltipText), findsOneWidget);
   });
+
+  testWidgets('Tooltip contributes semantics when in TooltipVisibility with visible = false', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/189062.
+    final SemanticsHandle handle = tester.ensureSemantics();
+    const childKey = Key('child');
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: TooltipVisibility(
+          visible: false,
+          child: Tooltip(
+            message: tooltipText,
+            child: SizedBox(key: childKey, width: 100.0, height: 100.0),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSemantics(find.byKey(childKey)), containsSemantics(tooltip: tooltipText));
+    handle.dispose();
+  });
+
+  testWidgets(
+    'Tooltip in TooltipVisibility with visible = false contributes no semantics when excluded',
+    (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      const childKey = Key('child');
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: TooltipVisibility(
+            visible: false,
+            child: Tooltip(
+              message: tooltipText,
+              excludeFromSemantics: true,
+              child: SizedBox(key: childKey, width: 100.0, height: 100.0),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.byKey(childKey)),
+        isNot(containsSemantics(tooltip: tooltipText)),
+      );
+      handle.dispose();
+    },
+  );
 }
 
 Future<void> setWidgetForTooltipMode(


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

`TooltipVisibility(visible: false)` is documented to "only visually" disable tooltips while it "continues to provide any semantic information that is provided". Since the `RawTooltip` refactor (#177678), `TooltipState.build` skips the `RawTooltip` wrapper entirely when the tooltip is disabled. Because the `Semantics(tooltip:)` annotation now lives inside `RawTooltip`, it is dropped along with it, so assistive technologies stop announcing the tooltip message — for example, an `IconButton` with `tooltip: 'Add'` under `TooltipVisibility(visible: false)` is announced as just "button". Before that refactor, the `Semantics` wrapper was applied unconditionally and only gesture handling was gated on visibility.

This change restores the documented behavior: when a `TooltipVisibility` ancestor disables the tooltip, the child is still wrapped in the same `Semantics(tooltip:)` annotation that `RawTooltip` applies when the tooltip is enabled, honoring `excludeFromSemantics`. It adds a regression test that fails without the fix, plus a test verifying that `excludeFromSemantics: true` still suppresses the semantics when the tooltip is disabled.

Fixes https://github.com/flutter/flutter/issues/189062

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
