### PR TITLE
[ios,macos] Update swiftc.py flags to match swiftc

### DIFF
--- a/engine/src/build/config/darwin/BUILD.gn
+++ b/engine/src/build/config/darwin/BUILD.gn
@@ -48,20 +48,15 @@ config("compiler") {
   # when their commandline changes). Nothing should ever read this define.
   #defines = [ "CR_XCODE_VERSION=$xcode_version" ]
 
+  _target_triple =
+      "$darwin_target_arch-$_triplet_os$_deployment_target$darwin_target_sim"
+
   swiftflags = [
     "-sdk",
     _sdk_root,
-    "--target-cpu",
-    current_cpu,
-    "--target-os",
-    _triplet_os,
-    "--deployment-target",
-    _deployment_target,
+    "-target",
+    _target_triple,
     "-swift-version",
     _swift_version,
   ]
-
-  if (use_ios_simulator) {
-    swiftflags += [ "--use-simulator" ]
-  }
 }

--- a/engine/src/build/config/darwin/darwin_sdk.gni
+++ b/engine/src/build/config/darwin/darwin_sdk.gni
@@ -176,3 +176,12 @@ if (is_ios) {
     }
   }
 }
+
+darwin_target_arch = current_cpu
+if (darwin_target_arch == "x64") {
+  darwin_target_arch = "x86_64"
+}
+darwin_target_sim = ""
+if (is_ios && use_ios_simulator) {
+  darwin_target_sim = "-simulator"
+}

--- a/engine/src/build/toolchain/darwin/swiftc.py
+++ b/engine/src/build/toolchain/darwin/swiftc.py
@@ -404,9 +404,9 @@ def invoke_swift_compiler(args, extras_args, build_cache_dir, output_file_map, t
       ensure_directory(os.path.join(build_cache_dir, 'PrecompiledHeaders')),
   ]
 
-  # Handle optional -bridge-header flag.
-  if args.bridge_header:
-    swiftc_args.extend(('-import-objc-header', args.bridge_header))
+  # Handle optional -import-objc-header flag.
+  if args.import_objc_header:
+    swiftc_args.extend(('-import-objc-header', args.import_objc_header))
 
   # Handle swift const values extraction.
   swiftc_args.extend(['-emit-const-values'])
@@ -552,7 +552,7 @@ def main(args):
   parser = argparse.ArgumentParser(allow_abbrev=False, add_help=False)
 
   # Required arguments.
-  parser.add_argument('--module-name',
+  parser.add_argument('-module-name',
                       required=True,
                       help='name of the Swift module')
 
@@ -572,7 +572,7 @@ def main(args):
                       required=True,
                       help='path to the generated header file')
 
-  parser.add_argument('--bridge-header',
+  parser.add_argument('-import-objc-header',
                       required=True,
                       help='path to the Objective-C bridge header file')
 
@@ -606,23 +606,9 @@ def main(args):
                       action='store_true',
                       help='enable whole module optimisation')
 
-  parser.add_argument('--target-cpu',
+  parser.add_argument('-target',
                       required=True,
-                      choices=['x64', 'arm64'],
-                      help='target CPU architecture (e.g. "arm64", "x64")')
-
-  parser.add_argument('--target-os',
-                      required=True,
-                      help='target OS name (e.g. "apple-ios", "apple-macos")')
-
-  parser.add_argument('--deployment-target',
-                      required=True,
-                      help='target deployment version (e.g. "13.0", "15.6")')
-
-  parser.add_argument('--use-simulator',
-                      default=False,
-                      action='store_true',
-                      help='targeting the simulator')
+                      help='target triple (e.g. "arm64-apple-ios14.0")')
 
   parser.add_argument('-sdk',
                       required=True,
@@ -670,11 +656,7 @@ def main(args):
 
   parsed, extras = parser.parse_known_args(args)
 
-  cpu = 'x86_64' if parsed.target_cpu == 'x64' else parsed.target_cpu
-  simulator = '-simulator' if parsed.use_simulator else ''
-  target_triple = f'{cpu}-{parsed.target_os}{parsed.deployment_target}{simulator}'
-
-  compile_module(parsed, extras, build_signature(os.environ, args), target_triple)
+  compile_module(parsed, extras, build_signature(os.environ, args), parsed.target)
 
 
 if __name__ == '__main__':

--- a/engine/src/build/toolchain/mac/BUILD.gn
+++ b/engine/src/build/toolchain/mac/BUILD.gn
@@ -225,9 +225,7 @@ template("mac_toolchain") {
       # The list of outputs and partial_outputs change whether the whole
       # module optimization is enabled or not.
       if (swift_whole_module_optimization) {
-        outputs += [
-          "$_output_dir/{{module_name}}.swiftconstvalues",
-        ]
+        outputs += [ "$_output_dir/{{module_name}}.swiftconstvalues" ]
       } else {
         outputs += [ "$_output_dir/{{module_name}}.priors" ]
         partial_outputs += [
@@ -320,11 +318,11 @@ template("mac_toolchain") {
               root_build_dir)
 
       command =
-          "$_env_vars $python_path $_tool --module-name {{module_name}} " +
+          "$_env_vars $python_path $_tool -module-name {{module_name}} " +
           "--header-path $_header_path --target-out-dir $_output_dir " +
           "--const-gather-protocols-file $_const_gather_protocols_file " +
           "--depfile-path $depfile --src-dir $_src_dir --gen-dir $_gen_dir " +
-          "--bridge-header {{bridge_header}} {{include_dirs}} " +
+          "-import-objc-header {{bridge_header}} {{include_dirs}} " +
           "{{module_dirs}} {{swiftflags}} {{inputs}}$_extra_flags"
 
       description = "SWIFT $_output_dir/{{module_name}}.swiftmodule"

--- a/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
@@ -35,8 +35,8 @@ config("test_config") {
   if (is_ios) {
     _platform_path = ios_platform_path
     swiftflags += [
-      "--deployment-target",
-      ios_testing_deployment_target,
+      "-target",
+      "$darwin_target_arch-apple-ios$ios_testing_deployment_target$darwin_target_sim",
     ]
     cflags += [ "-mios-simulator-version-min=$ios_testing_deployment_target" ]
     ldflags += [ "-mios-simulator-version-min=$ios_testing_deployment_target" ]


### PR DESCRIPTION
This updates flag names in the swiftc.py build wrapper and GN rules to match underlying swiftc counterparts (-module-name, -import-objc-header, and -target). This eliminates the finer-grained custom flags we had been using for convenience.

This also deduplicates the LLVM target triple mapping and iOS simulator suffix rules into darwin_sdk.gni, so they're shared between default and test configurations.

This is pre-factoring that will simplify downstream compile_commands.json post-processing in an upcoming patch that adds SourceKit LSP support for Swift.

No test changes because the test is the build itself (as well as existing tests).

Issue: https://github.com/flutter/flutter/issues/185741

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
