### PR TITLE
Add support for inverted stylus on web

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -69,6 +69,10 @@ const int _stylusDeviceId = -4;
 const int _kPrimaryMouseButton = 0x1;
 const int _kSecondaryMouseButton = 0x2;
 const int _kMiddleMouseButton = 0x4;
+const int _kStylusContact = 0x1;
+const int _kPrimaryStylusButton = 0x2;
+const int _kSecondaryStylusButton = 0x4;
+const int _kHtmlPenEraserButton = 0x20;
 
 int _nthButton(int n) => 0x1 << n;
 
@@ -887,113 +891,179 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
 
 @immutable
 class _SanitizedDetails {
-  const _SanitizedDetails({required this.buttons, required this.change});
+  const _SanitizedDetails({required this.buttons, required this.change, required this.kind});
 
   final ui.PointerChange change;
   final int buttons;
+  final ui.PointerDeviceKind kind;
 
   @override
-  String toString() => '$runtimeType(change: $change, buttons: $buttons)';
+  String toString() => '$runtimeType(change: $change, buttons: $buttons, kind: $kind)';
 }
 
 class _ButtonSanitizer {
   int _pressedButtons = 0;
+  ui.PointerDeviceKind? _pressedKind;
 
   /// Transform [DomPointerEvent.buttons] to Flutter's PointerEvent buttons.
-  int _htmlButtonsToFlutterButtons(int buttons) {
+  int _htmlButtonsToFlutterButtons(int buttons, ui.PointerDeviceKind kind) {
+    if (kind == ui.PointerDeviceKind.stylus && buttons & _kHtmlPenEraserButton != 0) {
+      return (buttons & _kStylusContact) |
+          (buttons & _kPrimaryStylusButton) |
+          _kSecondaryStylusButton;
+    }
     // Flutter's button definition conveniently matches that of JavaScript
     // from primary button (0x1) to forward button (0x10), which allows us to
     // avoid transforming it bit by bit.
     return buttons & _kButtonsMask;
   }
 
+  ui.PointerDeviceKind _htmlButtonsToPointerKind(int buttons, ui.PointerDeviceKind kind) {
+    if (kind == ui.PointerDeviceKind.stylus && buttons & _kHtmlPenEraserButton != 0) {
+      return ui.PointerDeviceKind.invertedStylus;
+    }
+    return kind;
+  }
+
   /// Given [DomPointerEvent.button] and [DomPointerEvent.buttons], tries to
   /// infer the correct value for Flutter buttons.
-  int _inferDownFlutterButtons(int button, int buttons) {
+  int _inferDownFlutterButtons(int button, int buttons, ui.PointerDeviceKind kind) {
     if (buttons == 0 && button > -1) {
       // In some cases, the browser sends `buttons:0` in a down event. In such
       // case, we try to infer the value from `button`.
       buttons = convertButtonToButtons(button);
     }
-    return _htmlButtonsToFlutterButtons(buttons);
+    return _htmlButtonsToFlutterButtons(buttons, kind);
   }
 
-  _SanitizedDetails sanitizeDownEvent({required int button, required int buttons}) {
+  _SanitizedDetails sanitizeDownEvent({
+    required int button,
+    required int buttons,
+    required ui.PointerDeviceKind kind,
+  }) {
     // If the pointer is already down, we just send a move event with the new
     // `buttons` value.
     if (_pressedButtons != 0) {
-      return sanitizeMoveEvent(buttons: buttons);
+      return sanitizeMoveEvent(buttons: buttons, kind: kind);
     }
 
-    _pressedButtons = _inferDownFlutterButtons(button, buttons);
+    _pressedButtons = _inferDownFlutterButtons(button, buttons, kind);
+    _pressedKind = _htmlButtonsToPointerKind(buttons, kind);
 
-    return _SanitizedDetails(change: ui.PointerChange.down, buttons: _pressedButtons);
+    return _SanitizedDetails(
+      change: ui.PointerChange.down,
+      buttons: _pressedButtons,
+      kind: _pressedKind!,
+    );
   }
 
-  _SanitizedDetails sanitizeMoveEvent({required int buttons}) {
-    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons);
+  _SanitizedDetails sanitizeMoveEvent({required int buttons, required ui.PointerDeviceKind kind}) {
+    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons, kind);
     // This could happen when the user clicks RMB then moves the mouse quickly.
     // The brower sends a move event with `buttons:2` even though there's no
     // buttons down yet.
     if (_pressedButtons == 0 && newPressedButtons != 0) {
-      return _SanitizedDetails(change: ui.PointerChange.hover, buttons: _pressedButtons);
+      return _SanitizedDetails(
+        change: ui.PointerChange.hover,
+        buttons: _pressedButtons,
+        kind: _htmlButtonsToPointerKind(buttons, kind),
+      );
     }
 
     _pressedButtons = newPressedButtons;
+    _pressedKind = _pressedButtons == 0 ? null : _htmlButtonsToPointerKind(buttons, kind);
 
     return _SanitizedDetails(
       change: _pressedButtons == 0 ? ui.PointerChange.hover : ui.PointerChange.move,
       buttons: _pressedButtons,
+      kind: _pressedKind ?? _htmlButtonsToPointerKind(buttons, kind),
     );
   }
 
-  _SanitizedDetails? sanitizeMissingRightClickUp({required int buttons}) {
-    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons);
+  _SanitizedDetails? sanitizeMissingRightClickUp({
+    required int buttons,
+    required ui.PointerDeviceKind kind,
+  }) {
+    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons, kind);
     // This could happen when RMB is clicked and released but no pointerup
     // event was received because context menu was shown.
     if (_pressedButtons != 0 && newPressedButtons == 0) {
+      final ui.PointerDeviceKind sanitizedKind =
+          _pressedKind ?? _htmlButtonsToPointerKind(buttons, kind);
       _pressedButtons = 0;
-      return _SanitizedDetails(change: ui.PointerChange.up, buttons: _pressedButtons);
+      _pressedKind = null;
+      return _SanitizedDetails(
+        change: ui.PointerChange.up,
+        buttons: _pressedButtons,
+        kind: sanitizedKind,
+      );
     }
     return null;
   }
 
-  _SanitizedDetails? sanitizeLeaveEvent({required int buttons}) {
-    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons);
+  _SanitizedDetails? sanitizeLeaveEvent({
+    required int buttons,
+    required ui.PointerDeviceKind kind,
+  }) {
+    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons, kind);
 
     // The move event already handles the case where the pointer is currently
     // down, in which case handling the leave event as well is superfluous.
     if (newPressedButtons == 0) {
       _pressedButtons = 0;
+      _pressedKind = null;
 
-      return _SanitizedDetails(change: ui.PointerChange.hover, buttons: _pressedButtons);
+      return _SanitizedDetails(
+        change: ui.PointerChange.hover,
+        buttons: _pressedButtons,
+        kind: _htmlButtonsToPointerKind(buttons, kind),
+      );
     }
 
     return null;
   }
 
-  _SanitizedDetails? sanitizeUpEvent({required int? buttons}) {
+  _SanitizedDetails? sanitizeUpEvent({required int? buttons, required ui.PointerDeviceKind kind}) {
     // The pointer could have been released by a `pointerout` event, in which
     // case `pointerup` should have no effect.
     if (_pressedButtons == 0) {
       return null;
     }
 
-    _pressedButtons = _htmlButtonsToFlutterButtons(buttons ?? 0);
+    final int htmlButtons = buttons ?? 0;
+    _pressedButtons = _htmlButtonsToFlutterButtons(htmlButtons, kind);
 
     if (_pressedButtons == 0) {
+      final ui.PointerDeviceKind sanitizedKind =
+          _pressedKind ?? _htmlButtonsToPointerKind(htmlButtons, kind);
+      _pressedKind = null;
       // All buttons have been released.
-      return _SanitizedDetails(change: ui.PointerChange.up, buttons: _pressedButtons);
+      return _SanitizedDetails(
+        change: ui.PointerChange.up,
+        buttons: _pressedButtons,
+        kind: sanitizedKind,
+      );
     } else {
+      _pressedKind = _htmlButtonsToPointerKind(htmlButtons, kind);
       // There are still some unreleased buttons, we shouldn't send an up event
       // yet. Instead we send a move event to update the position of the pointer.
-      return _SanitizedDetails(change: ui.PointerChange.move, buttons: _pressedButtons);
+      return _SanitizedDetails(
+        change: ui.PointerChange.move,
+        buttons: _pressedButtons,
+        kind: _htmlButtonsToPointerKind(htmlButtons, kind),
+      );
     }
   }
 
-  _SanitizedDetails sanitizeCancelEvent() {
+  _SanitizedDetails sanitizeCancelEvent({required ui.PointerDeviceKind kind}) {
+    final ui.PointerDeviceKind sanitizedKind = _pressedKind ?? kind;
     _pressedButtons = 0;
-    return _SanitizedDetails(change: ui.PointerChange.cancel, buttons: _pressedButtons);
+    _pressedKind = null;
+    return _SanitizedDetails(
+      change: ui.PointerChange.cancel,
+      buttons: _pressedButtons,
+      kind: sanitizedKind,
+    );
   }
 }
 
@@ -1057,11 +1127,13 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
   @override
   void setup() {
     _addPointerEventListener(_viewTarget, 'pointerdown', (DomPointerEvent event) {
+      final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
       final int device = _getPointerId(event);
       final pointerData = <ui.PointerData>[];
       final _ButtonSanitizer sanitizer = _ensureSanitizer(device);
       final _SanitizedDetails? up = sanitizer.sanitizeMissingRightClickUp(
         buttons: event.buttons!.toInt(),
+        kind: kind,
       );
       if (up != null) {
         _convertEventsToPointerData(data: pointerData, event: event, details: up);
@@ -1069,6 +1141,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       final _SanitizedDetails down = sanitizer.sanitizeDownEvent(
         button: event.button.toInt(),
         buttons: event.buttons!.toInt(),
+        kind: kind,
       );
       _convertEventsToPointerData(data: pointerData, event: event, details: down);
       _callback(event, pointerData);
@@ -1104,6 +1177,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     // TODO(dkwingsmt): Investigate whether we can configure the behavior for
     // `_viewTarget`. https://github.com/flutter/flutter/issues/157968
     _addPointerEventListener(_globalTarget, 'pointermove', (DomPointerEvent moveEvent) {
+      final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(moveEvent.pointerType!);
       final int device = _getPointerId(moveEvent);
       final _ButtonSanitizer sanitizer = _ensureSanitizer(device);
       final pointerData = <ui.PointerData>[];
@@ -1111,6 +1185,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       for (final event in expandedEvents) {
         final _SanitizedDetails? up = sanitizer.sanitizeMissingRightClickUp(
           buttons: event.buttons!.toInt(),
+          kind: kind,
         );
         if (up != null) {
           _convertEventsToPointerData(
@@ -1121,7 +1196,10 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
             eventTarget: moveEvent.target,
           );
         }
-        final _SanitizedDetails move = sanitizer.sanitizeMoveEvent(buttons: event.buttons!.toInt());
+        final _SanitizedDetails move = sanitizer.sanitizeMoveEvent(
+          buttons: event.buttons!.toInt(),
+          kind: kind,
+        );
         _convertEventsToPointerData(
           data: pointerData,
           event: event,
@@ -1134,11 +1212,13 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     });
 
     _addPointerEventListener(_viewTarget, 'pointerleave', (DomPointerEvent event) {
+      final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
       final int device = _getPointerId(event);
       final _ButtonSanitizer sanitizer = _ensureSanitizer(device);
       final pointerData = <ui.PointerData>[];
       final _SanitizedDetails? details = sanitizer.sanitizeLeaveEvent(
         buttons: event.buttons!.toInt(),
+        kind: kind,
       );
       if (details != null) {
         _convertEventsToPointerData(data: pointerData, event: event, details: details);
@@ -1148,12 +1228,13 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
 
     // TODO(dit): This must happen in the flutterViewElement, https://github.com/flutter/flutter/issues/116561
     _addPointerEventListener(_globalTarget, 'pointerup', (DomPointerEvent event) {
+      final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
       final int device = _getPointerId(event);
       if (_hasSanitizer(device)) {
         final pointerData = <ui.PointerData>[];
         final _SanitizedDetails? details = _getSanitizer(
           device,
-        ).sanitizeUpEvent(buttons: event.buttons?.toInt());
+        ).sanitizeUpEvent(buttons: event.buttons?.toInt(), kind: kind);
         _removePointerIfUnhoverable(event);
         if (details != null) {
           _convertEventsToPointerData(data: pointerData, event: event, details: details);
@@ -1167,10 +1248,11 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     // A browser fires cancel event if it concludes the pointer will no longer
     // be able to generate events (example: device is deactivated)
     _addPointerEventListener(_viewTarget, 'pointercancel', (DomPointerEvent event) {
+      final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
       final int device = _getPointerId(event);
       if (_hasSanitizer(device)) {
         final pointerData = <ui.PointerData>[];
-        final _SanitizedDetails details = _getSanitizer(device).sanitizeCancelEvent();
+        final _SanitizedDetails details = _getSanitizer(device).sanitizeCancelEvent(kind: kind);
         _removePointerIfUnhoverable(event);
         _convertEventsToPointerData(data: pointerData, event: event, details: details);
         _callback(event, pointerData);
@@ -1194,7 +1276,6 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     int? pointerId,
     DomEventTarget? eventTarget,
   }) {
-    final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
     final double tilt = _computeHighestTilt(event);
     final Duration timeStamp = _BaseAdapter._eventTimeStampToDuration(event.timeStamp!);
     final num? pressure = event.pressure;
@@ -1204,7 +1285,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       viewId: _view.viewId,
       change: details.change,
       timeStamp: timeStamp,
-      kind: kind,
+      kind: details.kind,
       signalKind: ui.PointerSignalKind.none,
       device: pointerId ?? _getPointerId(event),
       physicalX: offset.dx * _view.devicePixelRatio,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -70,8 +70,6 @@ const int _kPrimaryMouseButton = 0x1;
 const int _kSecondaryMouseButton = 0x2;
 const int _kMiddleMouseButton = 0x4;
 const int _kStylusContact = 0x1;
-const int _kPrimaryStylusButton = 0x2;
-const int _kSecondaryStylusButton = 0x4;
 const int _kHtmlPenEraserButton = 0x20;
 
 int _nthButton(int n) => 0x1 << n;
@@ -922,9 +920,7 @@ class _ButtonSanitizer {
   /// Transform [DomPointerEvent.buttons] to Flutter's PointerEvent buttons.
   int _htmlButtonsToFlutterButtons(int buttons, ui.PointerDeviceKind kind) {
     if (kind == ui.PointerDeviceKind.stylus && buttons & _kHtmlPenEraserButton != 0) {
-      return (buttons & _kStylusContact) |
-          (buttons & _kPrimaryStylusButton) |
-          _kSecondaryStylusButton;
+      buttons = (buttons & ~_kHtmlPenEraserButton) | _kStylusContact;
     }
     // Flutter's button definition conveniently matches that of JavaScript
     // from primary button (0x1) to forward button (0x10), which allows us to
@@ -939,15 +935,13 @@ class _ButtonSanitizer {
     return kind;
   }
 
-  /// Given [DomPointerEvent.button] and [DomPointerEvent.buttons], tries to
-  /// infer the correct value for Flutter buttons.
-  int _inferDownFlutterButtons(int button, int buttons, ui.PointerDeviceKind kind) {
+  int _inferDownHtmlButtons(int button, int buttons) {
     if (buttons == 0 && button > -1) {
       // In some cases, the browser sends `buttons:0` in a down event. In such
       // case, we try to infer the value from `button`.
-      buttons = convertButtonToButtons(button);
+      return convertButtonToButtons(button);
     }
-    return _htmlButtonsToFlutterButtons(buttons, kind);
+    return buttons;
   }
 
   _SanitizedDetails sanitizeDownEvent({
@@ -961,8 +955,9 @@ class _ButtonSanitizer {
       return sanitizeMoveEvent(buttons: buttons, kind: kind);
     }
 
-    _pressedButtons = _inferDownFlutterButtons(button, buttons, kind);
-    _pressedKind = _htmlButtonsToPointerKind(buttons, kind);
+    final int htmlButtons = _inferDownHtmlButtons(button, buttons);
+    _pressedButtons = _htmlButtonsToFlutterButtons(htmlButtons, kind);
+    _pressedKind = _htmlButtonsToPointerKind(htmlButtons, kind);
 
     return _SanitizedDetails(
       change: ui.PointerChange.down,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -69,6 +69,10 @@ const int _stylusDeviceId = -4;
 const int _kPrimaryMouseButton = 0x1;
 const int _kSecondaryMouseButton = 0x2;
 const int _kMiddleMouseButton = 0x4;
+const int _kStylusContact = 0x1;
+const int _kPrimaryStylusButton = 0x2;
+const int _kSecondaryStylusButton = 0x4;
+const int _kHtmlPenEraserButton = 0x20;
 
 int _nthButton(int n) => 0x1 << n;
 
@@ -901,113 +905,179 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
 
 @immutable
 class _SanitizedDetails {
-  const _SanitizedDetails({required this.buttons, required this.change});
+  const _SanitizedDetails({required this.buttons, required this.change, required this.kind});
 
   final ui.PointerChange change;
   final int buttons;
+  final ui.PointerDeviceKind kind;
 
   @override
-  String toString() => '$runtimeType(change: $change, buttons: $buttons)';
+  String toString() => '$runtimeType(change: $change, buttons: $buttons, kind: $kind)';
 }
 
 class _ButtonSanitizer {
   int _pressedButtons = 0;
+  ui.PointerDeviceKind? _pressedKind;
 
   /// Transform [DomPointerEvent.buttons] to Flutter's PointerEvent buttons.
-  int _htmlButtonsToFlutterButtons(int buttons) {
+  int _htmlButtonsToFlutterButtons(int buttons, ui.PointerDeviceKind kind) {
+    if (kind == ui.PointerDeviceKind.stylus && buttons & _kHtmlPenEraserButton != 0) {
+      return (buttons & _kStylusContact) |
+          (buttons & _kPrimaryStylusButton) |
+          _kSecondaryStylusButton;
+    }
     // Flutter's button definition conveniently matches that of JavaScript
     // from primary button (0x1) to forward button (0x10), which allows us to
     // avoid transforming it bit by bit.
     return buttons & _kButtonsMask;
   }
 
+  ui.PointerDeviceKind _htmlButtonsToPointerKind(int buttons, ui.PointerDeviceKind kind) {
+    if (kind == ui.PointerDeviceKind.stylus && buttons & _kHtmlPenEraserButton != 0) {
+      return ui.PointerDeviceKind.invertedStylus;
+    }
+    return kind;
+  }
+
   /// Given [DomPointerEvent.button] and [DomPointerEvent.buttons], tries to
   /// infer the correct value for Flutter buttons.
-  int _inferDownFlutterButtons(int button, int buttons) {
+  int _inferDownFlutterButtons(int button, int buttons, ui.PointerDeviceKind kind) {
     if (buttons == 0 && button > -1) {
       // In some cases, the browser sends `buttons:0` in a down event. In such
       // case, we try to infer the value from `button`.
       buttons = convertButtonToButtons(button);
     }
-    return _htmlButtonsToFlutterButtons(buttons);
+    return _htmlButtonsToFlutterButtons(buttons, kind);
   }
 
-  _SanitizedDetails sanitizeDownEvent({required int button, required int buttons}) {
+  _SanitizedDetails sanitizeDownEvent({
+    required int button,
+    required int buttons,
+    required ui.PointerDeviceKind kind,
+  }) {
     // If the pointer is already down, we just send a move event with the new
     // `buttons` value.
     if (_pressedButtons != 0) {
-      return sanitizeMoveEvent(buttons: buttons);
+      return sanitizeMoveEvent(buttons: buttons, kind: kind);
     }
 
-    _pressedButtons = _inferDownFlutterButtons(button, buttons);
+    _pressedButtons = _inferDownFlutterButtons(button, buttons, kind);
+    _pressedKind = _htmlButtonsToPointerKind(buttons, kind);
 
-    return _SanitizedDetails(change: ui.PointerChange.down, buttons: _pressedButtons);
+    return _SanitizedDetails(
+      change: ui.PointerChange.down,
+      buttons: _pressedButtons,
+      kind: _pressedKind!,
+    );
   }
 
-  _SanitizedDetails sanitizeMoveEvent({required int buttons}) {
-    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons);
+  _SanitizedDetails sanitizeMoveEvent({required int buttons, required ui.PointerDeviceKind kind}) {
+    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons, kind);
     // This could happen when the user clicks RMB then moves the mouse quickly.
     // The brower sends a move event with `buttons:2` even though there's no
     // buttons down yet.
     if (_pressedButtons == 0 && newPressedButtons != 0) {
-      return _SanitizedDetails(change: ui.PointerChange.hover, buttons: _pressedButtons);
+      return _SanitizedDetails(
+        change: ui.PointerChange.hover,
+        buttons: _pressedButtons,
+        kind: _htmlButtonsToPointerKind(buttons, kind),
+      );
     }
 
     _pressedButtons = newPressedButtons;
+    _pressedKind = _pressedButtons == 0 ? null : _htmlButtonsToPointerKind(buttons, kind);
 
     return _SanitizedDetails(
       change: _pressedButtons == 0 ? ui.PointerChange.hover : ui.PointerChange.move,
       buttons: _pressedButtons,
+      kind: _pressedKind ?? _htmlButtonsToPointerKind(buttons, kind),
     );
   }
 
-  _SanitizedDetails? sanitizeMissingRightClickUp({required int buttons}) {
-    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons);
+  _SanitizedDetails? sanitizeMissingRightClickUp({
+    required int buttons,
+    required ui.PointerDeviceKind kind,
+  }) {
+    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons, kind);
     // This could happen when RMB is clicked and released but no pointerup
     // event was received because context menu was shown.
     if (_pressedButtons != 0 && newPressedButtons == 0) {
+      final ui.PointerDeviceKind sanitizedKind =
+          _pressedKind ?? _htmlButtonsToPointerKind(buttons, kind);
       _pressedButtons = 0;
-      return _SanitizedDetails(change: ui.PointerChange.up, buttons: _pressedButtons);
+      _pressedKind = null;
+      return _SanitizedDetails(
+        change: ui.PointerChange.up,
+        buttons: _pressedButtons,
+        kind: sanitizedKind,
+      );
     }
     return null;
   }
 
-  _SanitizedDetails? sanitizeLeaveEvent({required int buttons}) {
-    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons);
+  _SanitizedDetails? sanitizeLeaveEvent({
+    required int buttons,
+    required ui.PointerDeviceKind kind,
+  }) {
+    final int newPressedButtons = _htmlButtonsToFlutterButtons(buttons, kind);
 
     // The move event already handles the case where the pointer is currently
     // down, in which case handling the leave event as well is superfluous.
     if (newPressedButtons == 0) {
       _pressedButtons = 0;
+      _pressedKind = null;
 
-      return _SanitizedDetails(change: ui.PointerChange.hover, buttons: _pressedButtons);
+      return _SanitizedDetails(
+        change: ui.PointerChange.hover,
+        buttons: _pressedButtons,
+        kind: _htmlButtonsToPointerKind(buttons, kind),
+      );
     }
 
     return null;
   }
 
-  _SanitizedDetails? sanitizeUpEvent({required int? buttons}) {
+  _SanitizedDetails? sanitizeUpEvent({required int? buttons, required ui.PointerDeviceKind kind}) {
     // The pointer could have been released by a `pointerout` event, in which
     // case `pointerup` should have no effect.
     if (_pressedButtons == 0) {
       return null;
     }
 
-    _pressedButtons = _htmlButtonsToFlutterButtons(buttons ?? 0);
+    final int htmlButtons = buttons ?? 0;
+    _pressedButtons = _htmlButtonsToFlutterButtons(htmlButtons, kind);
 
     if (_pressedButtons == 0) {
+      final ui.PointerDeviceKind sanitizedKind =
+          _pressedKind ?? _htmlButtonsToPointerKind(htmlButtons, kind);
+      _pressedKind = null;
       // All buttons have been released.
-      return _SanitizedDetails(change: ui.PointerChange.up, buttons: _pressedButtons);
+      return _SanitizedDetails(
+        change: ui.PointerChange.up,
+        buttons: _pressedButtons,
+        kind: sanitizedKind,
+      );
     } else {
+      _pressedKind = _htmlButtonsToPointerKind(htmlButtons, kind);
       // There are still some unreleased buttons, we shouldn't send an up event
       // yet. Instead we send a move event to update the position of the pointer.
-      return _SanitizedDetails(change: ui.PointerChange.move, buttons: _pressedButtons);
+      return _SanitizedDetails(
+        change: ui.PointerChange.move,
+        buttons: _pressedButtons,
+        kind: _htmlButtonsToPointerKind(htmlButtons, kind),
+      );
     }
   }
 
-  _SanitizedDetails sanitizeCancelEvent() {
+  _SanitizedDetails sanitizeCancelEvent({required ui.PointerDeviceKind kind}) {
+    final ui.PointerDeviceKind sanitizedKind = _pressedKind ?? kind;
     _pressedButtons = 0;
-    return _SanitizedDetails(change: ui.PointerChange.cancel, buttons: _pressedButtons);
+    _pressedKind = null;
+    return _SanitizedDetails(
+      change: ui.PointerChange.cancel,
+      buttons: _pressedButtons,
+      kind: sanitizedKind,
+    );
   }
 }
 
@@ -1080,11 +1150,13 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
   @override
   void setup() {
     _addPointerEventListener(_viewTarget, 'pointerdown', (DomPointerEvent event) {
+      final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
       final int device = _getPointerId(event);
       final pointerData = <ui.PointerData>[];
       final _ButtonSanitizer sanitizer = _ensureSanitizer(device);
       final _SanitizedDetails? up = sanitizer.sanitizeMissingRightClickUp(
         buttons: event.buttons!.toInt(),
+        kind: kind,
       );
       if (up != null) {
         _convertEventsToPointerData(data: pointerData, event: event, details: up);
@@ -1092,6 +1164,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       final _SanitizedDetails down = sanitizer.sanitizeDownEvent(
         button: event.button.toInt(),
         buttons: event.buttons!.toInt(),
+        kind: kind,
       );
       _convertEventsToPointerData(data: pointerData, event: event, details: down);
       if (event.pointerType == 'touch') {
@@ -1130,6 +1203,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     // TODO(dkwingsmt): Investigate whether we can configure the behavior for
     // `_viewTarget`. https://github.com/flutter/flutter/issues/157968
     _addPointerEventListener(_globalTarget, 'pointermove', (DomPointerEvent moveEvent) {
+      final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(moveEvent.pointerType!);
       final int device = _getPointerId(moveEvent);
       final _ButtonSanitizer sanitizer = _ensureSanitizer(device);
       final pointerData = <ui.PointerData>[];
@@ -1137,6 +1211,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       for (final event in expandedEvents) {
         final _SanitizedDetails? up = sanitizer.sanitizeMissingRightClickUp(
           buttons: event.buttons!.toInt(),
+          kind: kind,
         );
         if (up != null) {
           _convertEventsToPointerData(
@@ -1147,7 +1222,10 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
             eventTarget: moveEvent.target,
           );
         }
-        final _SanitizedDetails move = sanitizer.sanitizeMoveEvent(buttons: event.buttons!.toInt());
+        final _SanitizedDetails move = sanitizer.sanitizeMoveEvent(
+          buttons: event.buttons!.toInt(),
+          kind: kind,
+        );
         _convertEventsToPointerData(
           data: pointerData,
           event: event,
@@ -1160,11 +1238,13 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     });
 
     _addPointerEventListener(_viewTarget, 'pointerleave', (DomPointerEvent event) {
+      final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
       final int device = _getPointerId(event);
       final _ButtonSanitizer sanitizer = _ensureSanitizer(device);
       final pointerData = <ui.PointerData>[];
       final _SanitizedDetails? details = sanitizer.sanitizeLeaveEvent(
         buttons: event.buttons!.toInt(),
+        kind: kind,
       );
       if (details != null) {
         _convertEventsToPointerData(data: pointerData, event: event, details: details);
@@ -1174,12 +1254,13 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
 
     // TODO(dit): This must happen in the flutterViewElement, https://github.com/flutter/flutter/issues/116561
     _addPointerEventListener(_globalTarget, 'pointerup', (DomPointerEvent event) {
+      final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
       final int device = _getPointerId(event);
       if (_hasSanitizer(device)) {
         final pointerData = <ui.PointerData>[];
         final _SanitizedDetails? details = _getSanitizer(
           device,
-        ).sanitizeUpEvent(buttons: event.buttons?.toInt());
+        ).sanitizeUpEvent(buttons: event.buttons?.toInt(), kind: kind);
         _removePointerIfUnhoverable(event);
         if (details != null) {
           _convertEventsToPointerData(data: pointerData, event: event, details: details);
@@ -1193,10 +1274,11 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     // A browser fires cancel event if it concludes the pointer will no longer
     // be able to generate events (example: device is deactivated)
     _addPointerEventListener(_viewTarget, 'pointercancel', (DomPointerEvent event) {
+      final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
       final int device = _getPointerId(event);
       if (_hasSanitizer(device)) {
         final pointerData = <ui.PointerData>[];
-        final _SanitizedDetails details = _getSanitizer(device).sanitizeCancelEvent();
+        final _SanitizedDetails details = _getSanitizer(device).sanitizeCancelEvent(kind: kind);
         _removePointerIfUnhoverable(event);
         _convertEventsToPointerData(data: pointerData, event: event, details: details);
         _callback(event, pointerData);
@@ -1289,7 +1371,6 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     int? pointerId,
     DomEventTarget? eventTarget,
   }) {
-    final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
     final double tilt = _computeHighestTilt(event);
     final Duration timeStamp = _BaseAdapter._eventTimeStampToDuration(event.timeStamp!);
     final num? pressure = event.pressure;
@@ -1299,7 +1380,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       viewId: _view.viewId,
       change: details.change,
       timeStamp: timeStamp,
-      kind: kind,
+      kind: details.kind,
       signalKind: ui.PointerSignalKind.none,
       device: pointerId ?? _getPointerId(event),
       physicalX: offset.dx * _view.devicePixelRatio,

--- a/engine/src/flutter/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -2237,6 +2237,47 @@ void testMain() {
     packets.clear();
   });
 
+  test('handles stylus eraser touches as inverted stylus', () {
+    final context = _PointerEventContext();
+
+    final packets = <ui.PointerDataPacket>[];
+    ui.PlatformDispatcher.instance.onPointerDataPacket = (ui.PointerDataPacket packet) {
+      packets.add(packet);
+    };
+
+    rootElement.dispatchEvent(
+      context.stylusTouchDown(pointerId: 100, buttons: 0x32, clientX: 5.0, clientY: 100.0),
+    );
+    expect(packets, hasLength(1));
+    expect(packets[0].data, hasLength(2));
+    expect(packets[0].data[0].change, equals(ui.PointerChange.add));
+    expect(packets[0].data[0].kind, equals(ui.PointerDeviceKind.invertedStylus));
+    expect(packets[0].data[1].change, equals(ui.PointerChange.down));
+    expect(packets[0].data[1].kind, equals(ui.PointerDeviceKind.invertedStylus));
+    expect(packets[0].data[1].buttons, equals(0x6));
+    packets.clear();
+
+    rootElement.dispatchEvent(
+      context.stylusTouchMove(pointerId: 100, buttons: 0x32, clientX: 10.0, clientY: 105.0),
+    );
+    expect(packets, hasLength(1));
+    expect(packets[0].data, hasLength(1));
+    expect(packets[0].data[0].change, equals(ui.PointerChange.move));
+    expect(packets[0].data[0].kind, equals(ui.PointerDeviceKind.invertedStylus));
+    expect(packets[0].data[0].buttons, equals(0x6));
+    packets.clear();
+
+    rootElement.dispatchEvent(
+      context.stylusTouchUp(pointerId: 100, buttons: 0, clientX: 10.0, clientY: 105.0),
+    );
+    expect(packets, hasLength(1));
+    expect(packets[0].data, hasLength(1));
+    expect(packets[0].data[0].change, equals(ui.PointerChange.up));
+    expect(packets[0].data[0].kind, equals(ui.PointerDeviceKind.invertedStylus));
+    expect(packets[0].data[0].buttons, equals(0));
+    packets.clear();
+  });
+
   // MULTIPOINTER ADAPTERS
 
   test('treats each pointer separately', () {
@@ -3631,6 +3672,22 @@ class _PointerEventContext extends _BasicEventContext
       pointer: pointerId,
       buttons: buttons,
       button: 0,
+      clientX: clientX,
+      clientY: clientY,
+      pointerType: 'pen',
+    );
+  }
+
+  DomEvent stylusTouchMove({
+    double? clientX,
+    double? clientY,
+    int? buttons,
+    int? pointerId = 1000,
+  }) {
+    return _moveWithFullDetails(
+      pointer: pointerId,
+      buttons: buttons,
+      button: _kNoButtonChange,
       clientX: clientX,
       clientY: clientY,
       pointerType: 'pen',

--- a/engine/src/flutter/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -2282,7 +2282,7 @@ void testMain() {
     };
 
     rootElement.dispatchEvent(
-      context.stylusTouchDown(pointerId: 100, buttons: 0x32, clientX: 5.0, clientY: 100.0),
+      context.stylusTouchDown(pointerId: 100, buttons: 0x20, clientX: 5.0, clientY: 100.0),
     );
     expect(packets, hasLength(1));
     expect(packets[0].data, hasLength(2));
@@ -2290,17 +2290,17 @@ void testMain() {
     expect(packets[0].data[0].kind, equals(ui.PointerDeviceKind.invertedStylus));
     expect(packets[0].data[1].change, equals(ui.PointerChange.down));
     expect(packets[0].data[1].kind, equals(ui.PointerDeviceKind.invertedStylus));
-    expect(packets[0].data[1].buttons, equals(0x6));
+    expect(packets[0].data[1].buttons, equals(0x1));
     packets.clear();
 
     rootElement.dispatchEvent(
-      context.stylusTouchMove(pointerId: 100, buttons: 0x32, clientX: 10.0, clientY: 105.0),
+      context.stylusTouchMove(pointerId: 100, buttons: 0x20, clientX: 10.0, clientY: 105.0),
     );
     expect(packets, hasLength(1));
     expect(packets[0].data, hasLength(1));
     expect(packets[0].data[0].change, equals(ui.PointerChange.move));
     expect(packets[0].data[0].kind, equals(ui.PointerDeviceKind.invertedStylus));
-    expect(packets[0].data[0].buttons, equals(0x6));
+    expect(packets[0].data[0].buttons, equals(0x1));
     packets.clear();
 
     rootElement.dispatchEvent(
@@ -2312,6 +2312,46 @@ void testMain() {
     expect(packets[0].data[0].kind, equals(ui.PointerDeviceKind.invertedStylus));
     expect(packets[0].data[0].buttons, equals(0));
     packets.clear();
+  });
+
+  test('preserves stylus barrel button with eraser contact', () {
+    final context = _PointerEventContext();
+
+    final packets = <ui.PointerDataPacket>[];
+    ui.PlatformDispatcher.instance.onPointerDataPacket = (ui.PointerDataPacket packet) {
+      packets.add(packet);
+    };
+
+    rootElement.dispatchEvent(
+      context.stylusTouchDown(pointerId: 102, buttons: 0x22, clientX: 5.0, clientY: 100.0),
+    );
+    expect(packets[0].data.last.kind, equals(ui.PointerDeviceKind.invertedStylus));
+    expect(packets[0].data.last.buttons, equals(0x3));
+    packets.clear();
+
+    rootElement.dispatchEvent(
+      context.stylusTouchUp(pointerId: 102, buttons: 0, clientX: 5.0, clientY: 100.0),
+    );
+    expect(packets[0].data.single.change, equals(ui.PointerChange.up));
+    expect(packets[0].data.single.kind, equals(ui.PointerDeviceKind.invertedStylus));
+  });
+
+  test('does not treat the pen eraser bit as inverted stylus for mouse', () {
+    final context = _PointerEventContext();
+
+    final packets = <ui.PointerDataPacket>[];
+    ui.PlatformDispatcher.instance.onPointerDataPacket = (ui.PointerDataPacket packet) {
+      packets.add(packet);
+    };
+
+    rootElement.dispatchEvent(context.mouseDown(button: 5, buttons: 0x20));
+    expect(packets[0].data.last.kind, equals(ui.PointerDeviceKind.mouse));
+    expect(packets[0].data.last.buttons, equals(0x20));
+    packets.clear();
+
+    rootElement.dispatchEvent(context.mouseUp(button: 5, buttons: 0));
+    expect(packets[0].data.last.change, equals(ui.PointerChange.up));
+    expect(packets[0].data.last.kind, equals(ui.PointerDeviceKind.mouse));
   });
 
   // MULTIPOINTER ADAPTERS

--- a/engine/src/flutter/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -2273,6 +2273,47 @@ void testMain() {
     packets.clear();
   });
 
+  test('handles stylus eraser touches as inverted stylus', () {
+    final context = _PointerEventContext();
+
+    final packets = <ui.PointerDataPacket>[];
+    ui.PlatformDispatcher.instance.onPointerDataPacket = (ui.PointerDataPacket packet) {
+      packets.add(packet);
+    };
+
+    rootElement.dispatchEvent(
+      context.stylusTouchDown(pointerId: 100, buttons: 0x32, clientX: 5.0, clientY: 100.0),
+    );
+    expect(packets, hasLength(1));
+    expect(packets[0].data, hasLength(2));
+    expect(packets[0].data[0].change, equals(ui.PointerChange.add));
+    expect(packets[0].data[0].kind, equals(ui.PointerDeviceKind.invertedStylus));
+    expect(packets[0].data[1].change, equals(ui.PointerChange.down));
+    expect(packets[0].data[1].kind, equals(ui.PointerDeviceKind.invertedStylus));
+    expect(packets[0].data[1].buttons, equals(0x6));
+    packets.clear();
+
+    rootElement.dispatchEvent(
+      context.stylusTouchMove(pointerId: 100, buttons: 0x32, clientX: 10.0, clientY: 105.0),
+    );
+    expect(packets, hasLength(1));
+    expect(packets[0].data, hasLength(1));
+    expect(packets[0].data[0].change, equals(ui.PointerChange.move));
+    expect(packets[0].data[0].kind, equals(ui.PointerDeviceKind.invertedStylus));
+    expect(packets[0].data[0].buttons, equals(0x6));
+    packets.clear();
+
+    rootElement.dispatchEvent(
+      context.stylusTouchUp(pointerId: 100, buttons: 0, clientX: 10.0, clientY: 105.0),
+    );
+    expect(packets, hasLength(1));
+    expect(packets[0].data, hasLength(1));
+    expect(packets[0].data[0].change, equals(ui.PointerChange.up));
+    expect(packets[0].data[0].kind, equals(ui.PointerDeviceKind.invertedStylus));
+    expect(packets[0].data[0].buttons, equals(0));
+    packets.clear();
+  });
+
   // MULTIPOINTER ADAPTERS
 
   test('treats each pointer separately', () {
@@ -3972,6 +4013,22 @@ class _PointerEventContext extends _BasicEventContext
       pointer: pointerId,
       buttons: buttons,
       button: 0,
+      clientX: clientX,
+      clientY: clientY,
+      pointerType: 'pen',
+    );
+  }
+
+  DomEvent stylusTouchMove({
+    double? clientX,
+    double? clientY,
+    int? buttons,
+    int? pointerId = 1000,
+  }) {
+    return _moveWithFullDetails(
+      pointer: pointerId,
+      buttons: buttons,
+      button: _kNoButtonChange,
       clientX: clientX,
       clientY: clientY,
       pointerType: 'pen',


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Closes #187532.

Flutter incorrectly sees `0b100000` as button instead of the indication of the eraser (also called inveredStylus).

This pr fixes it by saving the kind in the current _SanitizedDetails and calculating the kind in the sanitization.

Tested on my flutter input demo (which i also used in my windows stylus prs and linux stylus pr).

See: https://github.com/CodeDoctorDE/flutter-input-demo/tree/0d7b012b8b5ed3cb47d3fa56e5722e1e3687f60a.

<img width="1575" height="1571" alt="Screenshot_20260709_200710" src="https://github.com/user-attachments/assets/bd53ea39-b321-476e-a6ab-f767abc7f19b" />

**Currently in draft since I cannot have more than 2 prs and the issue is currently in triage**


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
