### PR TITLE
Fix broken listener code in WindowScope

### DIFF
--- a/packages/flutter/lib/src/widgets/_window.dart
+++ b/packages/flutter/lib/src/widgets/_window.dart
@@ -2179,9 +2179,9 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
     return _isFullscreenValue(controller);
   }
 
-  // Computes the value of the [_WindowControllerAspect.title] aspect for the
-  // given [controller]. Controllers that do not support titles report an empty
-  // string.
+  /// Computes the value of the [_WindowControllerAspect.title] aspect for the
+  /// given [controller]. Controllers that do not support titles report an empty
+  /// string.
   static String _titleValue(BaseWindowController controller) => switch (controller) {
     RegularWindowController() => controller.title,
     DialogWindowController() => controller.title,
@@ -2200,9 +2200,9 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
     SatelliteWindowController() => controller.isActivated,
   };
 
-  // Computes the value of the [_WindowControllerAspect.maximized] aspect for the
-  // given [controller]. Controllers that do not support maximization report
-  // false.
+  /// Computes the value of the [_WindowControllerAspect.maximized] aspect for the
+  /// given [controller]. Controllers that do not support maximization report
+  /// false.
   static bool _isMaximizedValue(BaseWindowController controller) => switch (controller) {
     RegularWindowController() => controller.isMaximized,
     DialogWindowController() => false,
@@ -2211,9 +2211,9 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
     SatelliteWindowController() => false,
   };
 
-  // Computes the value of the [_WindowControllerAspect.minimized] aspect for the
-  // given [controller]. Controllers that do not support minimization report
-  // false.
+  /// Computes the value of the [_WindowControllerAspect.minimized] aspect for the
+  /// given [controller]. Controllers that do not support minimization report
+  /// false.
   static bool _isMinimizedValue(BaseWindowController controller) => switch (controller) {
     RegularWindowController() => controller.isMinimized,
     DialogWindowController() => controller.isMinimized,
@@ -2222,9 +2222,9 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
     SatelliteWindowController() => false,
   };
 
-  // Computes the value of the [_WindowControllerAspect.fullscreen] aspect for
-  // the given [controller]. Controllers that do not support fullscreen report
-  // false.
+  /// Computes the value of the [_WindowControllerAspect.fullscreen] aspect for
+  /// the given [controller]. Controllers that do not support fullscreen report
+  /// false.
   static bool _isFullscreenValue(BaseWindowController controller) => switch (controller) {
     RegularWindowController() => controller.isFullscreen,
     DialogWindowController() => false,

--- a/packages/flutter/lib/src/widgets/_window.dart
+++ b/packages/flutter/lib/src/widgets/_window.dart
@@ -1889,11 +1889,34 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
   ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
-  WindowScope({super.key, required this.controller, required super.child}) {
+  WindowScope({super.key, required this.controller, required super.child})
+    : _contentSize = controller.contentSize,
+      _title = _titleValue(controller),
+      _isActivated = _isActivatedValue(controller),
+      _isMaximized = _isMaximizedValue(controller),
+      _isMinimized = _isMinimizedValue(controller),
+      _isFullscreen = _isFullscreenValue(controller) {
     if (!isWindowingEnabled) {
       throw UnsupportedError(_kWindowingDisabledErrorMessage);
     }
   }
+
+  // A snapshot of the aspect values captured from [controller] at construction
+  // time.
+  //
+  // The window widgets rebuild this [WindowScope] with the same [controller]
+  // instance whenever the controller notifies its listeners. Because the
+  // controller is the same object across rebuilds, comparing the live
+  // controller against itself in [updateShouldNotify] and
+  // [updateShouldNotifyDependent] would never detect a change. Capturing the
+  // values here means the old and new widgets hold independent snapshots that
+  // can be compared to detect which aspects changed.
+  final Size _contentSize;
+  final String _title;
+  final bool _isActivated;
+  final bool _isMaximized;
+  final bool _isMinimized;
+  final bool _isFullscreen;
 
   /// The controller associated with this window.
   ///
@@ -1987,14 +2010,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
   /// * [of], which returns the [BaseWindowController] associated with the window.
   @internal
   static String titleOf(BuildContext context) {
-    final BaseWindowController controller = _of(context, _WindowControllerAspect.title);
-    return switch (controller) {
-      RegularWindowController() => controller.title,
-      DialogWindowController() => controller.title,
-      TooltipWindowController() => '',
-      PopupWindowController() => '',
-      SatelliteWindowController() => controller.title,
-    };
+    return _titleValue(_of(context, _WindowControllerAspect.title));
   }
 
   /// Returns title of the nearest [WindowScope], or null if not found.
@@ -2012,13 +2028,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       return null;
     }
 
-    return switch (controller) {
-      RegularWindowController() => controller.title,
-      DialogWindowController() => controller.title,
-      TooltipWindowController() => '',
-      PopupWindowController() => '',
-      SatelliteWindowController() => controller.title,
-    };
+    return _titleValue(controller);
   }
 
   /// Returns the activation status of the nearest [WindowScope].
@@ -2036,14 +2046,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
   /// * [of], which returns the [BaseWindowController] associated with the window.
   @internal
   static bool isActivatedOf(BuildContext context) {
-    final BaseWindowController controller = _of(context, _WindowControllerAspect.activated);
-    return switch (controller) {
-      RegularWindowController() => controller.isActivated,
-      DialogWindowController() => controller.isActivated,
-      TooltipWindowController() => false,
-      PopupWindowController() => controller.isActivated,
-      SatelliteWindowController() => controller.isActivated,
-    };
+    return _isActivatedValue(_of(context, _WindowControllerAspect.activated));
   }
 
   /// Returns the activation status of the nearest [WindowScope],
@@ -2062,13 +2065,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       return null;
     }
 
-    return switch (controller) {
-      RegularWindowController() => controller.isActivated,
-      DialogWindowController() => controller.isActivated,
-      TooltipWindowController() => false,
-      PopupWindowController() => controller.isActivated,
-      SatelliteWindowController() => controller.isActivated,
-    };
+    return _isActivatedValue(controller);
   }
 
   /// Returns the minimization status of the nearest [WindowScope].
@@ -2086,14 +2083,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
   /// * [of], which returns the [BaseWindowController] associated with the window.
   @internal
   static bool isMinimizedOf(BuildContext context) {
-    final BaseWindowController controller = _of(context, _WindowControllerAspect.minimized);
-    return switch (controller) {
-      RegularWindowController() => controller.isMinimized,
-      DialogWindowController() => controller.isMinimized,
-      TooltipWindowController() => false,
-      PopupWindowController() => false,
-      SatelliteWindowController() => false,
-    };
+    return _isMinimizedValue(_of(context, _WindowControllerAspect.minimized));
   }
 
   /// Returns the minimization status of the nearest [WindowScope],
@@ -2112,13 +2102,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       return null;
     }
 
-    return switch (controller) {
-      RegularWindowController() => controller.isMinimized,
-      DialogWindowController() => controller.isMinimized,
-      TooltipWindowController() => false,
-      PopupWindowController() => false,
-      SatelliteWindowController() => false,
-    };
+    return _isMinimizedValue(controller);
   }
 
   /// Returns the maximization status of the nearest [WindowScope].
@@ -2136,14 +2120,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
   /// * [of], which returns the [BaseWindowController] associated with the window.
   @internal
   static bool isMaximizedOf(BuildContext context) {
-    final BaseWindowController controller = _of(context, _WindowControllerAspect.maximized);
-    return switch (controller) {
-      RegularWindowController() => controller.isMaximized,
-      DialogWindowController() => false,
-      TooltipWindowController() => false,
-      PopupWindowController() => false,
-      SatelliteWindowController() => false,
-    };
+    return _isMaximizedValue(_of(context, _WindowControllerAspect.maximized));
   }
 
   /// Returns the maximization status of the nearest [WindowScope],
@@ -2162,13 +2139,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       return null;
     }
 
-    return switch (controller) {
-      RegularWindowController() => controller.isMaximized,
-      DialogWindowController() => false,
-      TooltipWindowController() => false,
-      PopupWindowController() => false,
-      SatelliteWindowController() => false,
-    };
+    return _isMaximizedValue(controller);
   }
 
   /// Returns the fullscreen status of the nearest [WindowScope].
@@ -2186,15 +2157,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
   /// * [of], which returns the [BaseWindowController] associated with the window.
   @internal
   static bool isFullscreenOf(BuildContext context) {
-    final BaseWindowController controller = _of(context, _WindowControllerAspect.fullscreen);
-
-    return switch (controller) {
-      RegularWindowController() => controller.isFullscreen,
-      DialogWindowController() => false,
-      TooltipWindowController() => false,
-      PopupWindowController() => false,
-      SatelliteWindowController() => false,
-    };
+    return _isFullscreenValue(_of(context, _WindowControllerAspect.fullscreen));
   }
 
   /// Returns the fullscreen status of the nearest [WindowScope],
@@ -2213,14 +2176,62 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       return null;
     }
 
-    return switch (controller) {
-      RegularWindowController() => controller.isFullscreen,
-      DialogWindowController() => false,
-      TooltipWindowController() => false,
-      PopupWindowController() => false,
-      SatelliteWindowController() => false,
-    };
+    return _isFullscreenValue(controller);
   }
+
+  // Computes the value of the [_WindowControllerAspect.title] aspect for the
+  // given [controller]. Controllers that do not support titles report an empty
+  // string.
+  static String _titleValue(BaseWindowController controller) => switch (controller) {
+    RegularWindowController() => controller.title,
+    DialogWindowController() => controller.title,
+    TooltipWindowController() => '',
+    PopupWindowController() => '',
+    SatelliteWindowController() => controller.title,
+  };
+
+  // Computes the value of the [_WindowControllerAspect.activated] aspect for the
+  // given [controller]. Controllers that do not support activation report false.
+  static bool _isActivatedValue(BaseWindowController controller) => switch (controller) {
+    RegularWindowController() => controller.isActivated,
+    DialogWindowController() => controller.isActivated,
+    TooltipWindowController() => false,
+    PopupWindowController() => controller.isActivated,
+    SatelliteWindowController() => controller.isActivated,
+  };
+
+  // Computes the value of the [_WindowControllerAspect.maximized] aspect for the
+  // given [controller]. Controllers that do not support maximization report
+  // false.
+  static bool _isMaximizedValue(BaseWindowController controller) => switch (controller) {
+    RegularWindowController() => controller.isMaximized,
+    DialogWindowController() => false,
+    TooltipWindowController() => false,
+    PopupWindowController() => false,
+    SatelliteWindowController() => false,
+  };
+
+  // Computes the value of the [_WindowControllerAspect.minimized] aspect for the
+  // given [controller]. Controllers that do not support minimization report
+  // false.
+  static bool _isMinimizedValue(BaseWindowController controller) => switch (controller) {
+    RegularWindowController() => controller.isMinimized,
+    DialogWindowController() => controller.isMinimized,
+    TooltipWindowController() => false,
+    PopupWindowController() => false,
+    SatelliteWindowController() => false,
+  };
+
+  // Computes the value of the [_WindowControllerAspect.fullscreen] aspect for
+  // the given [controller]. Controllers that do not support fullscreen report
+  // false.
+  static bool _isFullscreenValue(BaseWindowController controller) => switch (controller) {
+    RegularWindowController() => controller.isFullscreen,
+    DialogWindowController() => false,
+    TooltipWindowController() => false,
+    PopupWindowController() => false,
+    SatelliteWindowController() => false,
+  };
 
   static BaseWindowController _of(BuildContext context, [_WindowControllerAspect? aspect]) {
     if (!isWindowingEnabled) {
@@ -2265,7 +2276,15 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
   @override
-  bool updateShouldNotify(WindowScope oldWidget) => controller != oldWidget.controller;
+  bool updateShouldNotify(WindowScope oldWidget) {
+    return controller != oldWidget.controller ||
+        _contentSize != oldWidget._contentSize ||
+        _title != oldWidget._title ||
+        _isActivated != oldWidget._isActivated ||
+        _isMaximized != oldWidget._isMaximized ||
+        _isMinimized != oldWidget._isMinimized ||
+        _isFullscreen != oldWidget._isFullscreen;
+  }
 
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
@@ -2275,59 +2294,12 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       (Object dependency) =>
           dependency is _WindowControllerAspect &&
           switch (dependency) {
-            _WindowControllerAspect.contentSize =>
-              controller.contentSize != oldWidget.controller.contentSize,
-            _WindowControllerAspect.title => switch (controller) {
-              final RegularWindowController regular =>
-                regular.title != (oldWidget.controller as RegularWindowController).title,
-              final DialogWindowController dialog =>
-                dialog.title != (oldWidget.controller as DialogWindowController).title,
-              TooltipWindowController() => false,
-              PopupWindowController() => false,
-              final SatelliteWindowController satellite =>
-                satellite.title != (oldWidget.controller as SatelliteWindowController).title,
-            },
-            _WindowControllerAspect.activated => switch (controller) {
-              final RegularWindowController regular =>
-                regular.isActivated !=
-                    (oldWidget.controller as RegularWindowController).isActivated,
-              final DialogWindowController dialog =>
-                dialog.isActivated != (oldWidget.controller as DialogWindowController).isActivated,
-              TooltipWindowController() => false,
-              final PopupWindowController popup =>
-                popup.isActivated != (oldWidget.controller as PopupWindowController).isActivated,
-              final SatelliteWindowController satellite =>
-                satellite.isActivated !=
-                    (oldWidget.controller as SatelliteWindowController).isActivated,
-            },
-            _WindowControllerAspect.maximized => switch (controller) {
-              final RegularWindowController regular =>
-                regular.isMaximized !=
-                    (oldWidget.controller as RegularWindowController).isMaximized,
-              DialogWindowController() => false,
-              TooltipWindowController() => false,
-              PopupWindowController() => false,
-              SatelliteWindowController() => false,
-            },
-            _WindowControllerAspect.minimized => switch (controller) {
-              final RegularWindowController regular =>
-                regular.isMinimized !=
-                    (oldWidget.controller as RegularWindowController).isMinimized,
-              final DialogWindowController dialog =>
-                dialog.isMinimized != (oldWidget.controller as DialogWindowController).isMinimized,
-              TooltipWindowController() => false,
-              PopupWindowController() => false,
-              SatelliteWindowController() => false,
-            },
-            _WindowControllerAspect.fullscreen => switch (controller) {
-              final RegularWindowController regular =>
-                regular.isFullscreen !=
-                    (oldWidget.controller as RegularWindowController).isFullscreen,
-              DialogWindowController() => false,
-              TooltipWindowController() => false,
-              PopupWindowController() => false,
-              SatelliteWindowController() => false,
-            },
+            _WindowControllerAspect.contentSize => _contentSize != oldWidget._contentSize,
+            _WindowControllerAspect.title => _title != oldWidget._title,
+            _WindowControllerAspect.activated => _isActivated != oldWidget._isActivated,
+            _WindowControllerAspect.maximized => _isMaximized != oldWidget._isMaximized,
+            _WindowControllerAspect.minimized => _isMinimized != oldWidget._isMinimized,
+            _WindowControllerAspect.fullscreen => _isFullscreen != oldWidget._isFullscreen,
           },
     );
   }

--- a/packages/flutter/test/widgets/windowing_test.dart
+++ b/packages/flutter/test/widgets/windowing_test.dart
@@ -202,6 +202,70 @@ class _StubSatelliteWindowController extends SatelliteWindowController {
   void destroy() {}
 }
 
+// A controller that mutates its aspect values and notifies listeners, used to
+// verify that dependents rebuild when the controller notifies even though the
+// same controller instance is reused across rebuilds.
+class _MutableRegularWindowController extends RegularWindowController {
+  _MutableRegularWindowController(WidgetTester tester) : super.empty() {
+    rootView = FakeView(tester.view);
+  }
+
+  Size _contentSize = Size.zero;
+  bool _activated = false;
+  bool _maximized = false;
+
+  @override
+  Size get contentSize => _contentSize;
+
+  @override
+  String get title => 'Mutable Window';
+
+  @override
+  bool get isActivated => _activated;
+
+  @override
+  bool get isMaximized => _maximized;
+
+  @override
+  bool get isMinimized => false;
+
+  @override
+  bool get isFullscreen => false;
+
+  @override
+  void setSize(Size size) {
+    _contentSize = size;
+    notifyListeners();
+  }
+
+  @override
+  void setConstraints(BoxConstraints constraints) {}
+
+  @override
+  void setTitle(String title) {}
+
+  @override
+  void activate() {
+    _activated = true;
+    notifyListeners();
+  }
+
+  @override
+  void setMaximized(bool maximized) {
+    _maximized = maximized;
+    notifyListeners();
+  }
+
+  @override
+  void setMinimized(bool minimized) {}
+
+  @override
+  void setFullscreen(bool fullscreen, {Display? display}) {}
+
+  @override
+  void destroy() {}
+}
+
 void main() {
   group('Windowing', () {
     group('isWindowingEnabled is false', () {
@@ -1783,6 +1847,33 @@ void main() {
         );
 
         expect(isFullscreen, equals(false));
+      });
+
+      testWidgets('Dependent rebuilds when an aspect changes and the controller notifies', (
+        WidgetTester tester,
+      ) async {
+        final controller = _MutableRegularWindowController(tester);
+        addTearDown(controller.dispose);
+        final observed = <bool>[];
+        await tester.pumpWidget(
+          wrapWithView: false,
+          RegularWindow(
+            controller: controller,
+            child: Builder(
+              builder: (BuildContext context) {
+                observed.add(WindowScope.isActivatedOf(context));
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+
+        expect(observed, <bool>[false]);
+
+        controller.activate();
+        await tester.pump();
+
+        expect(observed, <bool>[false, true]);
       });
 
       testWidgets('SatelliteWindow does not throw', (WidgetTester tester) async {


### PR DESCRIPTION
## What's new?
WindowScope is an InheritedModel that is rebuilt with the same controller instance whenever the controller notifies its listeners. Its updateShouldNotify and updateShouldNotifyDependent compared the live controller's values against oldWidget.controller's values, but since the controller is the same object across rebuilds, those comparisons were always false and dependents never rebuilt.

Capture a snapshot of each aspect value in the WindowScope constructor so the old and new widgets hold independent values that can be compared to detect which aspects changed. The per-aspect value computations are extracted into static helpers shared with the *Of accessors.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
