### PR TITLE
[WIP] Fix OverlayPortal accessibility tree crash and layout on macOS

### DIFF
--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -7,6 +7,7 @@
 #include <functional>
 #include <utility>
 
+#include "flutter/shell/platform/embedder/embedder_struct_macros.h"
 #include "flutter/third_party/accessibility/ax/ax_tree_manager_map.h"
 #include "flutter/third_party/accessibility/ax/ax_tree_update.h"
 #include "flutter/third_party/accessibility/base/logging.h"
@@ -18,6 +19,14 @@ constexpr int kHasScrollingAction =
     FlutterSemanticsAction::kFlutterSemanticsActionScrollRight |
     FlutterSemanticsAction::kFlutterSemanticsActionScrollUp |
     FlutterSemanticsAction::kFlutterSemanticsActionScrollDown;
+
+std::unique_ptr<gfx::Transform> CreateTransform(
+    const FlutterTransformation& transform) {
+  return std::make_unique<gfx::Transform>(
+      transform.scaleX, transform.skewX, transform.transX, 0, transform.skewY,
+      transform.scaleY, transform.transY, 0, transform.pers0, transform.pers1,
+      transform.pers2, 0, 0, 0, 0, 0);
+}
 
 // AccessibilityBridge
 AccessibilityBridge::AccessibilityBridge()
@@ -71,6 +80,7 @@ void AccessibilityBridge::CommitUpdates() {
   // Second, apply the pending node updates. This also moves reparented nodes to
   // their new parents if needed.
   ui::AXTreeUpdate update{.tree_data = tree_->data()};
+  UpdateHitTestParentIds();
 
   // Figure out update order, ui::AXTree only accepts update in tree order,
   // where parent node must come before the child node in
@@ -81,18 +91,22 @@ void AccessibilityBridge::CommitUpdates() {
   // before child updates. If the root is in the update, it is guaranteed to
   // be the first node of the last list.
   std::vector<std::vector<SemanticsNode>> results;
+  std::unordered_set<int32_t> update_node_ids;
   while (!pending_semantics_node_updates_.empty()) {
     auto begin = pending_semantics_node_updates_.begin();
     SemanticsNode target = begin->second;
     std::vector<SemanticsNode> sub_tree_list;
     GetSubTreeList(target, sub_tree_list);
+    for (const SemanticsNode& node : sub_tree_list) {
+      update_node_ids.insert(node.id);
+    }
     results.push_back(sub_tree_list);
     pending_semantics_node_updates_.erase(begin);
   }
 
   for (size_t i = results.size(); i > 0; i--) {
     for (const SemanticsNode& node : results[i - 1]) {
-      ConvertFlutterUpdate(node, update);
+      ConvertFlutterUpdate(node, update_node_ids, update);
     }
   }
 
@@ -201,8 +215,9 @@ void AccessibilityBridge::OnAtomicUpdateFinished(
   for (const auto& change : changes) {
     ui::AXNode* node = change.node;
     const ui::AXNodeData& data = node->data();
-    AccessibilityNodeId offset_container_id = -1;
-    if (node->parent()) {
+    AccessibilityNodeId offset_container_id =
+        data.relative_bounds.offset_container_id;
+    if (offset_container_id == ui::AXNode::kInvalidAXID && node->parent()) {
       offset_container_id = node->parent()->id();
     }
     node->SetLocation(offset_container_id, data.relative_bounds.bounds,
@@ -230,10 +245,13 @@ AccessibilityBridge::CreateRemoveReparentedNodesUpdate() {
         continue;
       }
 
-      // This pending update moves the current child node.
-      // That new child must have a corresponding pending update.
-      assert(pending_semantics_node_updates_.find(child_id) !=
-             pending_semantics_node_updates_.end());
+      // This pending update moves the current child node. If the new child
+      // does not have node data in the same pending update, AXTree cannot
+      // re-add it under the new parent in this atomic update.
+      if (pending_semantics_node_updates_.find(child_id) ==
+          pending_semantics_node_updates_.end()) {
+        continue;
+      }
 
       // Create an update to remove the child from its previous parent.
       int32_t parent_id = child->parent()->id();
@@ -266,6 +284,22 @@ AccessibilityBridge::CreateRemoveReparentedNodesUpdate() {
   return update;
 }
 
+void AccessibilityBridge::UpdateHitTestParentIds() {
+  for (const auto& node_update : pending_semantics_node_updates_) {
+    for (auto iter = hit_test_parent_ids_.begin();
+         iter != hit_test_parent_ids_.end();) {
+      if (iter->second == node_update.first) {
+        iter = hit_test_parent_ids_.erase(iter);
+      } else {
+        iter++;
+      }
+    }
+    for (int32_t child_id : node_update.second.children_in_hit_test_order) {
+      hit_test_parent_ids_[child_id] = node_update.first;
+    }
+  }
+}
+
 // Private method.
 void AccessibilityBridge::GetSubTreeList(const SemanticsNode& target,
                                          std::vector<SemanticsNode>& result) {
@@ -280,8 +314,10 @@ void AccessibilityBridge::GetSubTreeList(const SemanticsNode& target,
   }
 }
 
-void AccessibilityBridge::ConvertFlutterUpdate(const SemanticsNode& node,
-                                               ui::AXTreeUpdate& tree_update) {
+void AccessibilityBridge::ConvertFlutterUpdate(
+    const SemanticsNode& node,
+    const std::unordered_set<int32_t>& update_node_ids,
+    ui::AXTreeUpdate& tree_update) {
   ui::AXNodeData node_data;
   node_data.id = node.id;
   SetRoleFromFlutterUpdate(node_data, node);
@@ -298,13 +334,19 @@ void AccessibilityBridge::ConvertFlutterUpdate(const SemanticsNode& node,
   node_data.relative_bounds.bounds.SetRect(node.rect.left, node.rect.top,
                                            node.rect.right - node.rect.left,
                                            node.rect.bottom - node.rect.top);
-  node_data.relative_bounds.transform = std::make_unique<gfx::Transform>(
-      node.transform.scaleX, node.transform.skewX, node.transform.transX, 0,
-      node.transform.skewY, node.transform.scaleY, node.transform.transY, 0,
-      node.transform.pers0, node.transform.pers1, node.transform.pers2, 0, 0, 0,
-      0, 0);
+  auto hit_test_parent_iter = hit_test_parent_ids_.find(node.id);
+  if (hit_test_parent_iter != hit_test_parent_ids_.end()) {
+    node_data.relative_bounds.offset_container_id =
+        hit_test_parent_iter->second;
+    node_data.relative_bounds.transform =
+        CreateTransform(node.hit_test_transform);
+  } else {
+    node_data.relative_bounds.transform = CreateTransform(node.transform);
+  }
   for (auto child : node.children_in_traversal_order) {
-    node_data.child_ids.push_back(child);
+    if (tree_->GetFromId(child) || update_node_ids.contains(child)) {
+      node_data.child_ids.push_back(child);
+    }
   }
   SetTreeData(node, tree_update);
   tree_update.nodes.push_back(node_data);
@@ -622,10 +664,24 @@ AccessibilityBridge::FromFlutterSemanticsNode(
   result.text_direction = flutter_node.text_direction;
   result.rect = flutter_node.rect;
   result.transform = flutter_node.transform;
+  const FlutterSemanticsNode2* flutter_node_ptr = &flutter_node;
+  result.hit_test_transform =
+      STRUCT_HAS_MEMBER(flutter_node_ptr, hit_test_transform)
+          ? flutter_node.hit_test_transform
+          : flutter_node.transform;
   if (flutter_node.child_count > 0) {
     result.children_in_traversal_order = std::vector<int32_t>(
         flutter_node.children_in_traversal_order,
         flutter_node.children_in_traversal_order + flutter_node.child_count);
+  }
+  const size_t hit_test_child_count =
+      STRUCT_HAS_MEMBER(flutter_node_ptr, hit_test_child_count)
+          ? flutter_node.hit_test_child_count
+          : flutter_node.child_count;
+  if (hit_test_child_count > 0 && flutter_node.children_in_hit_test_order) {
+    result.children_in_hit_test_order = std::vector<int32_t>(
+        flutter_node.children_in_hit_test_order,
+        flutter_node.children_in_hit_test_order + hit_test_child_count);
   }
   if (flutter_node.custom_accessibility_actions_count > 0) {
     result.custom_accessibility_actions = std::vector<int32_t>(

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.h
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_COMMON_ACCESSIBILITY_BRIDGE_H_
 
 #include <unordered_map>
+#include <unordered_set>
 
 #include "flutter/fml/mapping.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -179,7 +180,9 @@ class AccessibilityBridge
     FlutterTextDirection text_direction;
     FlutterRect rect;
     FlutterTransformation transform;
+    FlutterTransformation hit_test_transform;
     std::vector<int32_t> children_in_traversal_order;
+    std::vector<int32_t> children_in_hit_test_order;
     std::vector<int32_t> custom_accessibility_actions;
     int32_t heading_level;
     std::string identifier;
@@ -201,6 +204,7 @@ class AccessibilityBridge
   std::unordered_map<int32_t, SemanticsNode> pending_semantics_node_updates_;
   std::unordered_map<int32_t, SemanticsCustomAction>
       pending_semantics_custom_action_updates_;
+  std::unordered_map<int32_t, AccessibilityNodeId> hit_test_parent_ids_;
   AccessibilityNodeId last_focused_id_ = ui::AXNode::kInvalidAXID;
 
   void InitAXTree(const ui::AXTreeUpdate& initial_state);
@@ -211,7 +215,9 @@ class AccessibilityBridge
 
   void GetSubTreeList(const SemanticsNode& target,
                       std::vector<SemanticsNode>& result);
+  void UpdateHitTestParentIds();
   void ConvertFlutterUpdate(const SemanticsNode& node,
+                            const std::unordered_set<int32_t>& update_node_ids,
                             ui::AXTreeUpdate& tree_update);
   void SetRoleFromFlutterUpdate(ui::AXNodeData& node_data,
                                 const SemanticsNode& node);

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
@@ -563,6 +563,40 @@ TEST(AccessibilityBridgeTest, CanReparentNodeWithChild) {
               Contains(ui::AXEventGenerator::Event::ROLE_CHANGED).Times(1));
 }
 
+// Verify that a traversal parent update cannot corrupt AXTree if the update
+// names a grafted child whose node data is unavailable in the same batch.
+TEST(AccessibilityBridgeTest, SkipsUnavailableTraversalChild) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+
+  const int32_t root_id = 0;
+  const int32_t portal_id = 1;
+  const int32_t overlay_child_id = 4;
+
+  std::vector<int32_t> root_children{portal_id};
+  FlutterSemanticsNode2 root =
+      CreateSemanticsNode(root_id, "root", &root_children);
+  FlutterSemanticsNode2 portal = CreateSemanticsNode(portal_id, "portal");
+
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(portal);
+  bridge->CommitUpdates();
+  ASSERT_TRUE(bridge->GetTree()->error().empty());
+
+  std::vector<int32_t> portal_children{overlay_child_id};
+  portal.child_count = portal_children.size();
+  portal.children_in_traversal_order = portal_children.data();
+
+  bridge->AddFlutterSemanticsNodeUpdate(portal);
+  bridge->CommitUpdates();
+
+  EXPECT_TRUE(bridge->GetTree()->error().empty());
+  auto portal_node =
+      bridge->GetFlutterPlatformNodeDelegateFromID(portal_id).lock();
+  ASSERT_TRUE(portal_node);
+  EXPECT_EQ(portal_node->GetChildCount(), 0);
+}
+
 TEST(AccessibilityBridgeTest, AXTreeManagerTest) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();

--- a/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -43,7 +43,7 @@ TEST(FlutterPlatformNodeDelegateTest, NodeDelegateHasUniqueId) {
 TEST(FlutterPlatformNodeDelegateTest, canPerfomActions) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   root.id = 0;
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   flags.is_text_field = true;
@@ -92,7 +92,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetAXNode) {
   // Set up a flutter accessibility node.
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   root.id = 0;
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   flags.is_text_field = true;
@@ -122,7 +122,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -140,7 +140,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
-  FlutterSemanticsNode2 child1;
+  FlutterSemanticsNode2 child1{};
   child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";
@@ -173,7 +173,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -191,7 +191,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
-  FlutterSemanticsNode2 child1;
+  FlutterSemanticsNode2 child1{};
   child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";
@@ -272,11 +272,87 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   EXPECT_EQ(result, false);
 }
 
+TEST(FlutterPlatformNodeDelegateTest,
+     canCalculateBoundsWithHitTestTransformParent) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsFlags flags = FlutterSemanticsFlags{};
+  constexpr FlutterTransformation kIdentity = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+  constexpr FlutterTransformation kTraversalChildTransform = {1, 0, 100, 0, 1,
+                                                              0, 0, 0,   1};
+  constexpr FlutterTransformation kHitTestParentTransform = {1, 0, 200, 0, 1,
+                                                             0, 0, 0,   1};
+  constexpr FlutterTransformation kHitTestChildTransform = {1, 0, 25, 0, 1,
+                                                            0, 0, 0,  1};
+
+  std::vector<int32_t> root_traversal_children{1, 2};
+  std::vector<int32_t> root_hit_test_children{2};
+  FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};
+  root.label = "root";
+  root.flags2 = &flags;
+  root.rect = {0, 0, 400, 400};
+  root.transform = kIdentity;
+  root.hit_test_transform = kIdentity;
+  root.child_count = root_traversal_children.size();
+  root.children_in_traversal_order = root_traversal_children.data();
+  root.hit_test_child_count = root_hit_test_children.size();
+  root.children_in_hit_test_order = root_hit_test_children.data();
+
+  std::vector<int32_t> traversal_parent_children{3};
+  FlutterSemanticsNode2 traversal_parent{sizeof(FlutterSemanticsNode2), 1};
+  traversal_parent.label = "traversal parent";
+  traversal_parent.flags2 = &flags;
+  traversal_parent.rect = {0, 0, 400, 400};
+  traversal_parent.transform = kIdentity;
+  traversal_parent.hit_test_transform = kIdentity;
+  traversal_parent.child_count = traversal_parent_children.size();
+  traversal_parent.children_in_traversal_order =
+      traversal_parent_children.data();
+  traversal_parent.hit_test_child_count = 0;
+
+  std::vector<int32_t> hit_test_parent_children{3};
+  FlutterSemanticsNode2 hit_test_parent{sizeof(FlutterSemanticsNode2), 2};
+  hit_test_parent.label = "hit-test parent";
+  hit_test_parent.flags2 = &flags;
+  hit_test_parent.rect = {0, 0, 400, 400};
+  hit_test_parent.transform = kHitTestParentTransform;
+  hit_test_parent.hit_test_transform = kHitTestParentTransform;
+  hit_test_parent.child_count = 0;
+  hit_test_parent.hit_test_child_count = hit_test_parent_children.size();
+  hit_test_parent.children_in_hit_test_order = hit_test_parent_children.data();
+
+  FlutterSemanticsNode2 overlay_child{sizeof(FlutterSemanticsNode2), 3};
+  overlay_child.label = "overlay child";
+  overlay_child.flags2 = &flags;
+  overlay_child.rect = {0, 0, 10, 10};
+  overlay_child.transform = kTraversalChildTransform;
+  overlay_child.hit_test_transform = kHitTestChildTransform;
+
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(traversal_parent);
+  bridge->AddFlutterSemanticsNodeUpdate(hit_test_parent);
+  bridge->AddFlutterSemanticsNodeUpdate(overlay_child);
+
+  bridge->CommitUpdates();
+  auto overlay_node = bridge->GetFlutterPlatformNodeDelegateFromID(3).lock();
+  ASSERT_TRUE(overlay_node);
+  bool offscreen = false;
+  gfx::RectF bounds =
+      overlay_node->GetOwnerBridge().lock()->RelativeToGlobalBounds(
+          overlay_node->GetAXNode(), offscreen, true);
+
+  EXPECT_EQ(overlay_node->GetData().relative_bounds.offset_container_id, 2);
+  EXPECT_EQ(bounds.x(), 225);
+  EXPECT_EQ(bounds.y(), 0);
+  EXPECT_EQ(bounds.width(), 10);
+  EXPECT_EQ(bounds.height(), 10);
+}
+
 TEST(FlutterPlatformNodeDelegateTest, selfIsLowestPlatformAncestor) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -301,7 +377,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -317,7 +393,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
-  FlutterSemanticsNode2 child1;
+  FlutterSemanticsNode2 child1{};
   child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -98,7 +98,7 @@ TEST_F(AccessibilityBridgeMacWindowTest, SendsAccessibilityCreateNotificationFlu
   engine.semanticsEnabled = YES;
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   root.id = 0;
   root.flags2 = &flags;
@@ -159,7 +159,7 @@ TEST_F(AccessibilityBridgeMacWindowTest, NonZeroRootNodeId) {
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
 
-  FlutterSemanticsNode2 node1;
+  FlutterSemanticsNode2 node1{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   std::vector<int32_t> node1_children{2};
   node1.id = 1;
@@ -180,7 +180,7 @@ TEST_F(AccessibilityBridgeMacWindowTest, NonZeroRootNodeId) {
   node1.custom_accessibility_actions_count = 0;
   node1.identifier = "";
 
-  FlutterSemanticsNode2 node2;
+  FlutterSemanticsNode2 node2{};
   node2.id = 2;
   node2.flags2 = &flags;
   // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
@@ -227,7 +227,7 @@ TEST_F(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhe
   engine.semanticsEnabled = YES;
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   root.id = 0;
   root.flags2 = &flags;
@@ -276,7 +276,7 @@ TEST_F(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhe
   engine.semanticsEnabled = YES;
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   root.id = 0;
   root.flags2 = &flags;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -328,7 +328,7 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   engine.semanticsEnabled = YES;
   EXPECT_TRUE(enabled_called);
   // Send flutter semantics updates.
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   FlutterSemanticsFlags child_flags = FlutterSemanticsFlags{0};
   root.id = 0;
@@ -349,7 +349,7 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   root.custom_accessibility_actions_count = 0;
   root.identifier = "";
 
-  FlutterSemanticsNode2 child1;
+  FlutterSemanticsNode2 child1{};
   child1.id = 1;
   child1.flags2 = &child_flags;
   // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
@@ -424,7 +424,7 @@ TEST_F(FlutterEngineTest, CanToggleAccessibilityWhenHeadless) {
   engine.semanticsEnabled = YES;
   EXPECT_TRUE(enabled_called);
   // Send flutter semantics updates.
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   FlutterSemanticsFlags child_flags = FlutterSemanticsFlags{0};
   root.id = 0;
@@ -444,7 +444,7 @@ TEST_F(FlutterEngineTest, CanToggleAccessibilityWhenHeadless) {
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
 
-  FlutterSemanticsNode2 child1;
+  FlutterSemanticsNode2 child1{};
   child1.id = 1;
   child1.flags2 = &child_flags;
   // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -35,7 +35,7 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   root.id = 0;
   root.flags2 = &flags;
@@ -73,7 +73,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{.is_text_field = true, .is_read_only = true};
   root.id = 0;
   root.flags2 = &flags;
@@ -116,7 +116,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{.is_text_field = true, .is_read_only = true};
   root.id = 0;
   root.flags2 = &flags;
@@ -164,7 +164,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{};
   root.flags2 = &flags;
   root.id = 0;
@@ -181,7 +181,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   root.identifier = "";
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
-  FlutterSemanticsNode2 child1;
+  FlutterSemanticsNode2 child1{};
   FlutterSemanticsFlags child_flags = FlutterSemanticsFlags{};
   child1.flags2 = &child_flags;
   child1.id = 1;
@@ -245,7 +245,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
 
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   FlutterSemanticsFlags child_flags = FlutterSemanticsFlags{.is_text_field = true};
   root.id = 0;
@@ -270,7 +270,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   double rectSize = 50;
   double transformFactor = 0.5;
 
-  FlutterSemanticsNode2 child1;
+  FlutterSemanticsNode2 child1{};
   child1.id = 1;
   child1.flags2 = &child_flags;
   // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
@@ -327,7 +327,7 @@ TEST(FlutterPlatformNodeDelegateMac, ChangingFlagsUpdatesNativeViewAccessible) {
 
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{};
   root.id = 0;
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   root.flags2 = &flags;
@@ -351,7 +351,7 @@ TEST(FlutterPlatformNodeDelegateMac, ChangingFlagsUpdatesNativeViewAccessible) {
   double rectSize = 50;
   double transformFactor = 0.5;
 
-  FlutterSemanticsNode2 child1;
+  FlutterSemanticsNode2 child1{};
   FlutterSemanticsFlags child_flags = FlutterSemanticsFlags{0};
   child1.flags2 = &child_flags;
   child1.id = 1;

--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -1631,11 +1631,14 @@ typedef struct {
   /// The transform from this node's coordinate system to its parent's
   /// coordinate system.
   FlutterTransformation transform;
-  /// The number of children this node has.
+  /// The number of children this node has in traversal order.
   size_t child_count;
   /// Array of child node IDs in traversal order. Has length `child_count`.
   const int32_t* children_in_traversal_order;
   /// Array of child node IDs in hit test order. Has length `child_count`.
+  ///
+  /// @deprecated     Use `hit_test_child_count` as the length for this array
+  ///                 when the field is available.
   const int32_t* children_in_hit_test_order;
   /// The number of custom accessibility action associated with this node.
   size_t custom_accessibility_actions_count;
@@ -1714,11 +1717,12 @@ typedef struct {
   /// The transform from this node's coordinate system to its parent's
   /// coordinate system.
   FlutterTransformation transform;
-  /// The number of children this node has.
+  /// The number of children this node has in traversal order.
   size_t child_count;
   /// Array of child node IDs in traversal order. Has length `child_count`.
   const int32_t* children_in_traversal_order;
-  /// Array of child node IDs in hit test order. Has length `child_count`.
+  /// Array of child node IDs in hit test order. Has length
+  /// `hit_test_child_count`.
   const int32_t* children_in_hit_test_order;
   /// The number of custom accessibility action associated with this node.
   size_t custom_accessibility_actions_count;
@@ -1767,6 +1771,11 @@ typedef struct {
   /// This is usually used for UI testing with tools that work by querying the
   /// native accessibility, like UI Automator, XCUITest, or Appium.
   const char* identifier;
+  /// The transform from this node's coordinate system to its hit-test parent's
+  /// coordinate system.
+  FlutterTransformation hit_test_transform;
+  /// The number of children this node has in hit-test order.
+  size_t hit_test_child_count;
 } FlutterSemanticsNode2;
 
 /// `FlutterSemanticsCustomAction` ID used as a sentinel to signal the end of a

--- a/engine/src/flutter/shell/platform/embedder/embedder_semantics_update.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_semantics_update.cc
@@ -5,6 +5,15 @@
 #include "flutter/shell/platform/embedder/embedder_semantics_update.h"
 
 namespace {
+FlutterTransformation ToFlutterTransformation(const SkM44& value) {
+  SkMatrix transform = value.asM33();
+  return {transform.get(SkMatrix::kMScaleX), transform.get(SkMatrix::kMSkewX),
+          transform.get(SkMatrix::kMTransX), transform.get(SkMatrix::kMSkewY),
+          transform.get(SkMatrix::kMScaleY), transform.get(SkMatrix::kMTransY),
+          transform.get(SkMatrix::kMPersp0), transform.get(SkMatrix::kMPersp1),
+          transform.get(SkMatrix::kMPersp2)};
+}
+
 FlutterCheckState ToFlutterCheckState(flutter::SemanticsCheckState state) {
   switch (state) {
     case flutter::SemanticsCheckState::kNone:
@@ -187,13 +196,8 @@ FlutterSemanticsFlag SemanticsFlagsToInt(const SemanticsFlags& flags) {
 }
 
 void EmbedderSemanticsUpdate::AddNode(const SemanticsNode& node) {
-  SkMatrix transform = node.transform.asM33();
-  FlutterTransformation flutter_transform{
-      transform.get(SkMatrix::kMScaleX), transform.get(SkMatrix::kMSkewX),
-      transform.get(SkMatrix::kMTransX), transform.get(SkMatrix::kMSkewY),
-      transform.get(SkMatrix::kMScaleY), transform.get(SkMatrix::kMTransY),
-      transform.get(SkMatrix::kMPersp0), transform.get(SkMatrix::kMPersp1),
-      transform.get(SkMatrix::kMPersp2)};
+  FlutterTransformation flutter_transform =
+      ToFlutterTransformation(node.transform);
 
   // Do not add new members to FlutterSemanticsNode.
   // This would break the forward compatibility of FlutterSemanticsUpdate.
@@ -284,13 +288,10 @@ EmbedderSemanticsUpdate2::EmbedderSemanticsUpdate2(
 EmbedderSemanticsUpdate2::~EmbedderSemanticsUpdate2() {}
 
 void EmbedderSemanticsUpdate2::AddNode(const SemanticsNode& node) {
-  SkMatrix transform = node.transform.asM33();
-  FlutterTransformation flutter_transform{
-      transform.get(SkMatrix::kMScaleX), transform.get(SkMatrix::kMSkewX),
-      transform.get(SkMatrix::kMTransX), transform.get(SkMatrix::kMSkewY),
-      transform.get(SkMatrix::kMScaleY), transform.get(SkMatrix::kMTransY),
-      transform.get(SkMatrix::kMPersp0), transform.get(SkMatrix::kMPersp1),
-      transform.get(SkMatrix::kMPersp2)};
+  FlutterTransformation flutter_transform =
+      ToFlutterTransformation(node.transform);
+  FlutterTransformation flutter_hit_test_transform =
+      ToFlutterTransformation(node.hitTestTransform);
 
   auto label_attributes = CreateStringAttributes(node.labelAttributes);
   auto hint_attributes = CreateStringAttributes(node.hintAttributes);
@@ -344,6 +345,8 @@ void EmbedderSemanticsUpdate2::AddNode(const SemanticsNode& node) {
       flags_.back().get(),
       node.headingLevel,
       node.identifier.c_str(),
+      flutter_hit_test_transform,
+      node.childrenInHitTestOrder.size(),
   });
 }
 

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -161,6 +161,15 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingV3Callbacks) {
           ASSERT_EQ(7.0, node->transform.pers0);
           ASSERT_EQ(8.0, node->transform.pers1);
           ASSERT_EQ(9.0, node->transform.pers2);
+          ASSERT_EQ(1.0, node->hit_test_transform.scaleX);
+          ASSERT_EQ(2.0, node->hit_test_transform.skewX);
+          ASSERT_EQ(3.0, node->hit_test_transform.transX);
+          ASSERT_EQ(4.0, node->hit_test_transform.skewY);
+          ASSERT_EQ(5.0, node->hit_test_transform.scaleY);
+          ASSERT_EQ(6.0, node->hit_test_transform.transY);
+          ASSERT_EQ(7.0, node->hit_test_transform.pers0);
+          ASSERT_EQ(8.0, node->hit_test_transform.pers1);
+          ASSERT_EQ(9.0, node->hit_test_transform.pers2);
           ASSERT_EQ(std::strncmp(kTooltip, node->tooltip, sizeof(kTooltip) - 1),
                     0);
           ASSERT_EQ(node->heading_level, 0);
@@ -837,6 +846,15 @@ TEST_F(EmbedderA11yTest, A11yTreesAreConsistentWithMultipleViews) {
           ASSERT_EQ(7.0, node->transform.pers0);
           ASSERT_EQ(8.0, node->transform.pers1);
           ASSERT_EQ(9.0, node->transform.pers2);
+          ASSERT_EQ(1.0, node->hit_test_transform.scaleX);
+          ASSERT_EQ(2.0, node->hit_test_transform.skewX);
+          ASSERT_EQ(3.0, node->hit_test_transform.transX);
+          ASSERT_EQ(4.0, node->hit_test_transform.skewY);
+          ASSERT_EQ(5.0, node->hit_test_transform.scaleY);
+          ASSERT_EQ(6.0, node->hit_test_transform.transY);
+          ASSERT_EQ(7.0, node->hit_test_transform.pers0);
+          ASSERT_EQ(8.0, node->hit_test_transform.pers1);
+          ASSERT_EQ(9.0, node->hit_test_transform.pers2);
           ASSERT_EQ(std::strncmp(kTooltip, node->tooltip, sizeof(kTooltip) - 1),
                     0);
         }


### PR DESCRIPTION
Just WIP. Not ready to review.

### Description
This PR fixes a critical crash in the macOS desktop accessibility bridge (common bridge) when using `OverlayPortal`.
1. It avoids committing traversal children to the `AXTreeUpdate` until their node data is available in the transaction batch, preventing `Failed to update ui::AXTree` errors.
2. It corrects bounds offset and coordinate mapping for virtually grafted nodes by using their physical hit-test parents and transforms as the layout offset container instead of their logical traversal parents.

### Tests
- Added `AccessibilityBridgeTest.SkipsUnavailableTraversalChild`
- Added `FlutterPlatformNodeDelegateTest.canCalculateBoundsWithHitTestTransformParent`