### PR TITLE
UberSDF thin roundrect handling

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_path_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_path_unittests.cc
@@ -375,6 +375,21 @@ TEST_P(AiksTest, DrawLinesWithFilledRects) {
   });
 }
 
+TEST_P(AiksTest, DrawLinesWithFilledRoundRects) {
+  DrawLinesTest(this, [](DisplayListBuilder& builder, const DlPaint& paint,
+                         Point p0, Point p1, Scalar width) {
+    DlPaint fill_paint = paint;
+    fill_paint.setDrawStyle(DlDrawStyle::kFill);
+    Scalar length = p0.GetDistance(p1);
+    Point center = {(p0.x + p1.x) * 0.5f, (p0.y + p1.y) * 0.5f};
+    builder.DrawRoundRect(
+        DlRoundRect::MakeRectRadius(
+            DlRect::MakeEllipseBounds(center, Size(length, width) * 0.5f),
+            width * 0.5f),
+        fill_paint);
+  });
+}
+
 TEST_P(AiksTest, CanRenderTightConicPath) {
   DisplayListBuilder builder;
   builder.Scale(GetContentScale().x, GetContentScale().y);

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -833,47 +833,25 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
       IsCompatibleWithSDFRendering(paint)) {
-    Vector2 transform_scaling = GetCurrentTransform().GetBasisScaleXY();
-    if (transform_scaling.x <= 0.0f || transform_scaling.y <= 0.0f) {
-      // Rectangle is scaled to 0 and doesn't need to be drawn.
-      return;
-    }
-
     Rect effective_rect = rect;
     Color effective_color = paint.color;
 
-    // Expand very small/thin rectangles to have a minimum 1 pixel width/height.
-    // Rectangles that are scaled up to meet this minimum get their alpha scaled
-    // down by the same ratio to maintain visual consistency.
-    //
-    // This only applies to filled rectangles with no perspective transform.
-    if (paint.style == Paint::Style::kFill &&
-        !GetCurrentTransform().HasPerspective2D()) {
-      // Convert local rectangle size to device pixel size.
-      Vector2 rect_pixel_size = Vector2(rect.GetSize()) * transform_scaling;
+    if (paint.style == Paint::Style::kFill) {
+      effective_rect = UpscaledRect(rect);
 
-      // Expand rect pixel size dimensions to a 1.0 minimum.
-      Vector2 expanded_rect_pixel_size =
-          rect_pixel_size.Max(Vector2(1.0f, 1.0f));
-
-      // Calculate the alpha scaling as the ratio of the original rectangle to
-      // the expanded rectangle.
-      Scalar alpha_scaling = (rect_pixel_size.x / expanded_rect_pixel_size.x) *
-                             (rect_pixel_size.y / expanded_rect_pixel_size.y);
-
-      if (alpha_scaling <= kEhCloseEnough) {
-        // Rect is effectively invisible and doesn't need to be drawn.
+      if (effective_rect.IsEmpty()) {
+        // Rect is effectively invisible. Don't need to draw anything.
         return;
       }
-
-      // Convert expanded rectangle from pixel size back to local size.
-      Vector2 expanded_rect_local_size =
-          Vector2(expanded_rect_pixel_size / transform_scaling);
-
-      effective_rect = Rect::MakeEllipseBounds(rect.GetCenter(),
-                                               expanded_rect_local_size * 0.5f);
-      effective_color =
-          effective_color.WithAlpha(effective_color.alpha * alpha_scaling);
+      if (effective_rect != rect) {
+        Scalar alpha_scaling = rect.Area() / effective_rect.Area();
+        if (alpha_scaling < kEhCloseEnough) {
+          // Rect is effectively invisible. Don't need to draw anything.
+          return;
+        }
+        effective_color =
+            paint.color.WithAlpha(paint.color.alpha * alpha_scaling);
+      }
     }
 
     auto params = UberSDFParameters::MakeRect(
@@ -1015,6 +993,36 @@ void Canvas::DrawRoundRect(const RoundRect& round_rect, const Paint& paint) {
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
       IsCompatibleWithSDFRendering(paint) && radii.AreAllCornersCircular()) {
+    if (paint.style == Paint::Style::kFill) {
+      Rect rrect_bounds = round_rect.GetBounds();
+      Rect upscaled_bounds = UpscaledRect(rrect_bounds);
+
+      if (upscaled_bounds.IsEmpty()) {
+        // Rect is effectively invisible. Don't need to draw anything.
+        return;
+      }
+
+      if (upscaled_bounds != rrect_bounds) {
+        // The rrect is upscaled to 1 pixel minimum dimensions.
+        Scalar alpha_scaling = rrect_bounds.Area() / upscaled_bounds.Area();
+        if (alpha_scaling < kEhCloseEnough) {
+          // Rect is effectively invisible. Don't need to draw anything.
+          return;
+        }
+        Color effective_color =
+            paint.color.WithAlpha(paint.color.alpha * alpha_scaling);
+
+        // At a 1-pixel size, the rounded corners can be ignored. Draw a regular
+        // rect matching the upscaled bounds.
+        auto params = UberSDFParameters::MakeRect(
+            /*color=*/effective_color,
+            /*rect=*/upscaled_bounds,
+            /*stroke=*/std::nullopt);
+        AddRenderSDFEntityToCurrentPass(paint, params);
+        return;
+      }
+    }
+
     auto params = UberSDFParameters::MakeRoundedRect(
         /*color=*/paint.color,
         /*rect=*/round_rect.GetBounds(),
@@ -2551,6 +2559,39 @@ bool Canvas::IsCompatibleWithSDFRendering(const Paint& paint) {
     case BlendMode::kLuminosity:
       return true;
   }
+}
+
+Rect Canvas::UpscaledRect(const Rect& rect) const {
+  if (rect.IsEmpty() || GetCurrentTransform().HasPerspective2D()) {
+    // Minimum rect scaling not applicable for empty rects or when using a
+    // perspective transform. Return the unmodified input rect.
+    return rect;
+  }
+
+  Vector2 transform_scaling = GetCurrentTransform().GetBasisScaleXY();
+  if (transform_scaling.x <= 0.0f || transform_scaling.y <= 0.0f) {
+    // Rectangle is scaled to 0. Return an empty rectangle.
+    return Rect();
+  }
+
+  // Convert local rectangle size to device size (pixels).
+  Vector2 rect_device_size = Vector2(rect.GetSize()) * transform_scaling;
+
+  // Expand rect pixel size dimensions to a 1.0 minimum.
+  Vector2 expanded_rect_device_size = rect_device_size.Max(Vector2(1.0f, 1.0f));
+
+  if (expanded_rect_device_size == rect_device_size) {
+    // Minimum rect scaling not applicable - rectangle is already large enough.
+    // Return the unmodified rectangle.
+    return rect;
+  }
+
+  // Convert expanded rectangle from pixel size back to local size.
+  Vector2 expanded_rect_local_size =
+      Vector2(expanded_rect_device_size / transform_scaling);
+
+  return Rect::MakeEllipseBounds(rect.GetCenter(),
+                                 expanded_rect_local_size * 0.5f);
 }
 
 LazyRenderingConfig::LazyRenderingConfig(

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -2577,7 +2577,7 @@ Rect Canvas::UpscaledRect(const Rect& rect) const {
   // Convert local rectangle size to device size (pixels).
   Vector2 rect_device_size = Vector2(rect.GetSize()) * transform_scaling;
 
-  // Expand rect pixel size dimensions to a 1.0 minimum.
+  // Expand rect device size dimensions to a 1.0 minimum.
   Vector2 expanded_rect_device_size = rect_device_size.Max(Vector2(1.0f, 1.0f));
 
   if (expanded_rect_device_size == rect_device_size) {
@@ -2586,7 +2586,7 @@ Rect Canvas::UpscaledRect(const Rect& rect) const {
     return rect;
   }
 
-  // Convert expanded rectangle from pixel size back to local size.
+  // Convert expanded rectangle from device size back to local size.
   Vector2 expanded_rect_local_size =
       Vector2(expanded_rect_device_size / transform_scaling);
 

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -283,6 +283,15 @@ class Canvas {
   /// Visible for testing.
   static bool IsCompatibleWithSDFRendering(const Paint& paint);
 
+  /// Returns the input rectangle upscaled to have a minimum 1 pixel width and
+  /// height when rendered with the canvas' current transform.
+  ///
+  /// If the rectangle is effectively invisible, the returned rectangle will be
+  /// empty.
+  ///
+  /// Visible for testing.
+  Rect UpscaledRect(const Rect& rect) const;
+
  private:
   class BlurShape {
    public:

--- a/engine/src/flutter/impeller/display_list/canvas_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/canvas_unittests.cc
@@ -545,6 +545,81 @@ TEST_P(AiksTest, BlendModeCompatibilityWithSDFRendering) {
   }
 }
 
+TEST_P(AiksTest, UpscaledRectReturnsEmptyForEmptyRect) {
+  ContentContext& context = GetContentContext();
+  auto canvas = CreateTestCanvas(context);
+
+  Rect empty_rect = Rect::MakeXYWH(0, 0, 0, 10);
+  EXPECT_TRUE(canvas->UpscaledRect(empty_rect).IsEmpty());
+}
+
+TEST_P(AiksTest, UpscaledRectReturnsUnmodifiedWithPerspective) {
+  ContentContext& context = GetContentContext();
+  auto canvas = CreateTestCanvas(context);
+
+  canvas->Transform(Matrix::MakePerspective(Degrees(60), 1, 1, 100));
+  ASSERT_TRUE(canvas->GetCurrentTransform().HasPerspective2D());
+
+  Rect subpixel_rect = Rect::MakeXYWH(10, 10, 0.1f, 0.1f);
+  EXPECT_EQ(canvas->UpscaledRect(subpixel_rect), subpixel_rect);
+}
+
+TEST_P(AiksTest, UpscaledRectReturnsEmptyWhenScaledToZero) {
+  ContentContext& context = GetContentContext();
+  auto canvas = CreateTestCanvas(context);
+
+  canvas->Scale(Vector3(0.0f, 1.0f));
+  Rect rect = Rect::MakeXYWH(0, 0, 10, 10);
+  EXPECT_TRUE(canvas->UpscaledRect(rect).IsEmpty());
+}
+
+TEST_P(AiksTest, UpscaledRectReturnsUnmodifiedWhenLargeEnough) {
+  ContentContext& context = GetContentContext();
+  auto canvas = CreateTestCanvas(context);
+
+  Rect rect = Rect::MakeXYWH(0, 0, 10, 20);
+  EXPECT_EQ(canvas->UpscaledRect(rect), rect);
+
+  canvas->Scale(Vector3(0.5f, 0.5f));
+  EXPECT_EQ(canvas->UpscaledRect(rect), rect);
+}
+
+TEST_P(AiksTest, UpscaledRectExpandsSubPixelRectWithUnscaledCanvas) {
+  ContentContext& context = GetContentContext();
+  auto canvas = CreateTestCanvas(context);
+
+  Point center = Point();
+  Size size = Size(0.2f, 10.0f);
+  Rect rect = Rect::MakeEllipseBounds(center, size * 0.5f);
+
+  Rect upscaled = canvas->UpscaledRect(rect);
+
+  Size expected_size = Size(1.0f, 10.0f);
+  Rect expected = Rect::MakeEllipseBounds(center, expected_size * 0.5f);
+  EXPECT_RECT_NEAR(upscaled, expected);
+}
+
+TEST_P(AiksTest, UpscaledRectExpandsSubPixelRectWithScaledCanvas) {
+  ContentContext& context = GetContentContext();
+  auto canvas = CreateTestCanvas(context);
+
+  // Canvas is scaled by 2x in the X direction and 4x in the Y direction.
+  canvas->Scale(Vector3(2.0f, 4.0f));
+
+  Point center = Point();
+  Size size = Size(0.2f, 10.0f);
+  Rect rect = Rect::MakeEllipseBounds(center, size * 0.5f);
+
+  Rect upscaled = canvas->UpscaledRect(rect);
+
+  // Rect's device size is (0.2 * 2, 10.0 * 4) = (0.4, 40.0) pixels.
+  // It's expanded to (1.0, 40.0) pixels.
+  // In local space, this corresponds to (1.0 / 2.0, 40.0 / 4.0) = (0.5, 10.0).
+  Size expected_local_size = Size(0.5f, 10.0f);
+  Rect expected = Rect::MakeEllipseBounds(center, expected_local_size * 0.5f);
+  EXPECT_RECT_NEAR(upscaled, expected);
+}
+
 TEST(CanvasTest, NonAntialiasedPaintIncompatibleWithSDFRendering) {
   Paint paint;
   paint.anti_alias = false;

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -156,6 +156,36 @@ float rectPixelSize(vec2 p) {
   return (distance.x < distance.y) ? device_pixel_size.x : device_pixel_size.y;
 }
 
+// Special case pixel size calculation for rounded rectangles, similar to
+// `rectPixelSize` for regular rectangles.
+float roundRectPixelSize(vec2 p) {
+  // The change in local coordinates per horizontal device pixel (device_dx)
+  // and vertical device pixel (device_dy).
+  vec2 device_dx = dFdx(v_position);
+  vec2 device_dy = dFdy(v_position);
+  // The size of a device pixel in terms of local coordinates.
+  vec2 device_pixel_size = vec2(length(vec2(device_dx.x, device_dy.x)),
+                                length(vec2(device_dx.y, device_dy.y)));
+
+  // Select the corner radius for the quadrant of p.
+  vec4 r = frag_info.radii;
+  r.xy = (p.x > 0.0) ? r.xy : r.zw;
+  float radius = (p.y > 0.0) ? r.x : r.y;
+
+  // Vector from corner circle center to abs(p).
+  vec2 corner_center = frag_info.size - radius;
+  vec2 q = abs(p) - corner_center;
+
+  // If in the rounded corner arc, blend X and Y pixel sizes along the normal.
+  if (q.x > 0.0 && q.y > 0.0) {
+    return length(normalize(q) * device_pixel_size);
+  }
+
+  // Otherwise, we are closer to a straight edge. Get pixel size in the
+  // direction perpendicular to the closer edge.
+  return (q.x > q.y) ? device_pixel_size.x : device_pixel_size.y;
+}
+
 float pixelSize(float sdf) {
   vec2 gradient = vec2(dFdx(sdf), dFdy(sdf));
   return length(gradient);
@@ -174,7 +204,9 @@ vec2 filledSDF(vec2 p) {
   } else if (frag_info.type < 2.5) {  // Oval
     sdf = distanceFromOval(p, frag_info.size);
   } else if (frag_info.type < 3.5) {  // Rounded Rect
+    // RoundRect has its own separate logic for calculating pixel size.
     sdf = distanceFromRoundedRect(p, frag_info.size, frag_info.radii);
+    return vec2(sdf, roundRectPixelSize(p));
   } else {  // Symmetric Rounded Superellipse
     sdf = distanceFromRoundedSuperellipse(
         p, frag_info.superellipse_degree, frag_info.superellipse_semi_axis,

--- a/engine/src/flutter/impeller/tools/malioc.json
+++ b/engine/src/flutter/impeller/tools/malioc.json
@@ -8869,7 +8869,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 33,
+          "fp16_arithmetic": 32,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -8912,10 +8912,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              12.5,
-              12.5,
-              4.21875,
-              11.375,
+              13.375,
+              13.375,
+              4.65625,
+              12.625,
               0.0,
               0.25,
               0.0
@@ -8962,9 +8962,9 @@
               "arithmetic"
             ],
             "total_cycles": [
-              92.33333587646484,
+              102.33333587646484,
               3.0,
-              12.0
+              16.0
             ]
           },
           "thread_occupancy": 100,
@@ -12277,7 +12277,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 37,
+          "fp16_arithmetic": 36,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -12317,13 +12317,13 @@
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_fma"
+              "arith_sfu"
             ],
             "total_cycles": [
-              11.4375,
-              11.4375,
-              4.612500190734863,
-              11.375,
+              12.625,
+              12.125,
+              4.800000190734863,
+              12.625,
               0.0,
               0.25,
               0.0
@@ -12331,7 +12331,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 48,
+          "uniform_registers_used": 50,
           "work_registers_used": 32
         }
       }


### PR DESCRIPTION
This fixes thin UberSDF roundrect drawing, in the same way that https://github.com/flutter/flutter/pull/188821 fixed it for normal rects.

Prerequisite for using UberSDF for lines.

- Factors out some of the rect-upscaling code in DrawRect to an UpscaleRect helper function, so it can be shared by DrawRect and DrawRoundRect.
- Adds a roundRectPixelSize function in uber_sdf.frag, similar to rectPixelSize but for round rects.
- Adds unit tests for UpscaleRect, and a new golden tests for "DrawLinesWithFilledRoundRects"

## Screenshot

### DrawLinesWithFilledRoundRects

Before:
<img width="1024" height="800" alt="roundrect ubersdf before" src="https://github.com/user-attachments/assets/c490318f-0579-4425-82ec-ca5a7fd51d89" />

After:
<img width="1024" height="800" alt="roundrect ubersdf after" src="https://github.com/user-attachments/assets/cd7bc780-fbc8-46aa-a034-6a9c1db69ad9" />

## Video

### DrawLinesWithFilledRoundRects

Before:

https://github.com/user-attachments/assets/612af65d-bce5-45d2-a1aa-7636a60f3254

After:

https://github.com/user-attachments/assets/4090d72c-eba9-4e28-8c8a-495bcce9b82b


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
