### PR TITLE
iOS: clean up swiftc.py after migration to target triples

### DIFF
--- a/engine/src/build/toolchain/darwin/swiftc.py
+++ b/engine/src/build/toolchain/darwin/swiftc.py
@@ -345,7 +345,7 @@ def fix_generated_header(header_path, output_path, src_dir, gen_dir):
       header_file.write(line)
 
 
-def invoke_swift_compiler(args, extras_args, build_cache_dir, output_file_map, target_triple):
+def invoke_swift_compiler(args, extras_args, build_cache_dir, output_file_map):
   """Invokes Swift compiler to compile module according to `args`.
 
   The `build_cache_dir` and `output_file_map` should be path to existing
@@ -378,7 +378,7 @@ def invoke_swift_compiler(args, extras_args, build_cache_dir, output_file_map, t
       '-sdk',
       args.sdk_path,
       '-target',
-      target_triple,
+      args.target_triple,
       '-swift-version',
       args.swift_version,
       '-c',
@@ -419,7 +419,7 @@ def invoke_swift_compiler(args, extras_args, build_cache_dir, output_file_map, t
 
   # Handle -I, -F, -isystem, -Fsystem and -D arguments.
   for (attr_name, forwarder) in ARGUMENT_FORWARDER_FOR_ATTR:
-    forwarder.forward(swiftc_args, getattr(args, attr_name), target_triple)
+    forwarder.forward(swiftc_args, getattr(args, attr_name), args.target_triple)
 
   # Handle -whole-module-optimization flag.
   num_threads = max(1, multiprocessing.cpu_count() // 2)
@@ -523,7 +523,7 @@ def generate_depfile(args, output_file_map):
       stream.write(f'{output}: {" ".join(sorted(inputs))}\n')
 
 
-def compile_module(args, extras_args, build_signature, target_triple):
+def compile_module(args, extras_args, build_signature):
   """Compiles Swift module according to `args`."""
   for path in (args.target_out_dir, os.path.dirname(args.header_path)):
     ensure_directory(path)
@@ -541,8 +541,7 @@ def compile_module(args, extras_args, build_signature, target_triple):
     invoke_swift_compiler(args,
                           extras_args,
                           build_cache_dir=build_cache_dir,
-                          output_file_map=output_file_map_path,
-                          target_triple=target_triple)
+                          output_file_map=output_file_map_path)
 
   # Generate the depfile.
   generate_depfile(args, output_file_map)
@@ -608,6 +607,7 @@ def main(args):
 
   parser.add_argument('-target',
                       required=True,
+                      dest='target_triple',
                       help='target triple (e.g. "arm64-apple-ios14.0")')
 
   parser.add_argument('-sdk',
@@ -656,7 +656,7 @@ def main(args):
 
   parsed, extras = parser.parse_known_args(args)
 
-  compile_module(parsed, extras, build_signature(os.environ, args), parsed.target)
+  compile_module(parsed, extras, build_signature(os.environ, args))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In https://github.com/flutter/flutter/pull/189174, we migrated back to using target triples in swiftc.py in order to more closely mirror the commandline interface to `swiftc` itself.

This is a followup that cleans up some extra function parameters that are no longer necessary now that we're getting the target triple in args.

This cleans up a few remaining diffs from the reversion of the target triple splitting from https://github.com/flutter/flutter/pull/185712/changes#diff-d57f937ed2d743b17635dd069689072eba124f649f307228915c25d55b19ed62.

No test changes since this is a refactor with no semantic change. The test is the build (and transitively, all the tests it builds and runs).

Issue: https://github.com/flutter/flutter/issues/185741


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
