### PR TITLE
Catch error if decoding state restoration data fails

### DIFF
--- a/packages/flutter/lib/src/services/restoration.dart
+++ b/packages/flutter/lib/src/services/restoration.dart
@@ -325,7 +325,20 @@ class RestorationManager extends ChangeNotifier {
       return null;
     }
     final ByteData encoded = data.buffer.asByteData(data.offsetInBytes, data.lengthInBytes);
-    return const StandardMessageCodec().decodeMessage(encoded) as Map<Object?, Object?>?;
+    try {
+      return const StandardMessageCodec().decodeMessage(encoded) as Map<Object?, Object?>?;
+    } catch (exception, stack) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: exception,
+          stack: stack,
+          library: 'services library',
+          context: ErrorDescription('during restoration data decoding from the engine'),
+        ),
+      );
+
+      return null;
+    }
   }
 
   Uint8List _encodeRestorationData(Map<Object?, Object?> data) {

--- a/packages/flutter/test/services/restoration_test.dart
+++ b/packages/flutter/test/services/restoration_test.dart
@@ -355,7 +355,7 @@ void main() {
 
   testWidgets('handles decoding errors gracefully', (WidgetTester tester) async {
     final result = Completer<Map<dynamic, dynamic>>();
-    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
       SystemChannels.restoration,
       (MethodCall call) => result.future,
     );
@@ -395,7 +395,7 @@ Map<dynamic, dynamic> _createCorruptedRestorationData({int truncateBy = 1}) {
   final Map<dynamic, dynamic> valid = _createEncodedRestorationData1();
   final validBytes = valid['data'] as Uint8List;
 
-  final corrupted = Uint8List.fromList(validBytes.sublist(0, validBytes.length - truncateBy));
+  final Uint8List corrupted = validBytes.sublist(0, validBytes.length - truncateBy);
 
   return <dynamic, dynamic>{'enabled': true, 'data': corrupted};
 }

--- a/packages/flutter/test/services/restoration_test.dart
+++ b/packages/flutter/test/services/restoration_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -351,6 +352,35 @@ void main() {
       isTrue,
     );
   });
+
+  testWidgets('handles decoding errors gracefully', (WidgetTester tester) async {
+    final result = Completer<Map<dynamic, dynamic>>();
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.restoration,
+      (MethodCall call) => result.future,
+    );
+
+    final manager = RestorationManager();
+    addTearDown(manager.dispose);
+
+    FlutterErrorDetails? reportedError;
+    final FlutterExceptionHandler? originalOnError = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) => reportedError = details;
+    addTearDown(() => FlutterError.onError = originalOnError);
+
+    RestorationBucket? rootBucket;
+    manager.rootBucket.then((RestorationBucket? bucket) => rootBucket = bucket);
+    result.complete(_createCorruptedRestorationData());
+    await tester.pump();
+
+    expect(reportedError, isNotNull);
+    expect(reportedError!.exception, isNotNull);
+    expect(reportedError!.library, 'services library');
+    expect(reportedError!.context.toString(), contains('restoration data decoding'));
+    expect(rootBucket, isNotNull);
+    expect(rootBucket!.contains('value1'), isFalse);
+    expect(rootBucket!.read<int>('value1'), isNull);
+  });
 }
 
 Future<void> _pushDataFromEngine(Map<dynamic, dynamic> data) async {
@@ -359,6 +389,15 @@ Future<void> _pushDataFromEngine(Map<dynamic, dynamic> data) async {
     const StandardMethodCodec().encodeMethodCall(MethodCall('push', data)),
     (_) {},
   );
+}
+
+Map<dynamic, dynamic> _createCorruptedRestorationData({int truncateBy = 1}) {
+  final Map<dynamic, dynamic> valid = _createEncodedRestorationData1();
+  final validBytes = valid['data'] as Uint8List;
+
+  final corrupted = Uint8List.fromList(validBytes.sublist(0, validBytes.length - truncateBy));
+
+  return <dynamic, dynamic>{'enabled': true, 'data': corrupted};
 }
 
 Map<dynamic, dynamic> _createEncodedRestorationData1() {

--- a/packages/flutter/test/services/restoration_test.dart
+++ b/packages/flutter/test/services/restoration_test.dart
@@ -359,6 +359,12 @@ void main() {
       SystemChannels.restoration,
       (MethodCall call) => result.future,
     );
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.restoration,
+        null,
+      );
+    });
 
     final manager = RestorationManager();
     addTearDown(manager.dispose);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Add a try-catch block to catch any errors happening when calling StandardMessageCodec().decodeMessage() for state restoration

Fixes https://github.com/flutter/flutter/issues/147456

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
