### PR TITLE
[CP-Beta] Raise Warn Version to AGP 9+

### DIFF
--- a/dev/benchmarks/multiple_flutters/android/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/build.gradle
@@ -4,13 +4,13 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "2.2.0"
+    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.0'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Do not place your application dependencies here; they belong

--- a/dev/benchmarks/multiple_flutters/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/benchmarks/multiple_flutters/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Feb 24 15:28:21 EST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
+++ b/dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
@@ -17,14 +17,13 @@ import 'package:flutter_devicelab/framework/framework.dart';
 // (*) - support range defined in packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts.
 List<VersionTuple> versionTuples = <VersionTuple>[
   // Minimum supported
-  VersionTuple(agpVersion: '8.6.0', gradleVersion: '8.7', kotlinVersion: '2.0.0'),
-  // Template
   VersionTuple(agpVersion: '8.11.1', gradleVersion: '8.14', kotlinVersion: '2.2.20'),
-  // Max known
-  VersionTuple(agpVersion: '8.13.0', gradleVersion: '9.1.0', kotlinVersion: '2.2.20'),
+  // Template and max known
+  // TODO(jesswon): Separate max known once there exists a newer one: https://github.com/flutter/flutter/issues/189112.
+  VersionTuple(agpVersion: '9.1.0', gradleVersion: '9.3.1', kotlinVersion: '2.4.0'),
   /* Others */
-  VersionTuple(agpVersion: '8.7.0', gradleVersion: '8.9', kotlinVersion: '2.1.0'),
-  VersionTuple(agpVersion: '8.9.0', gradleVersion: '8.11.1', kotlinVersion: '2.2.0'),
+  VersionTuple(agpVersion: '8.11.1', gradleVersion: '8.14', kotlinVersion: '2.2.20'),
+  VersionTuple(agpVersion: '8.12.0', gradleVersion: '8.14', kotlinVersion: '2.2.20'),
 ]; // Max length is 7 entries until this test is split See https://github.com/flutter/flutter/issues/167495.
 
 Future<void> main() async {

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.0'
+        classpath 'com.android.tools.build:gradle:8.11.1'
     }
 }
 

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/dev/integration_tests/pure_android_host_apps/android_custom_host_app/build.gradle
+++ b/dev/integration_tests/pure_android_host_apps/android_custom_host_app/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.0'
+        classpath 'com.android.tools.build:gradle:8.11.1'
     }
 }
 

--- a/dev/integration_tests/pure_android_host_apps/android_custom_host_app/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/integration_tests/pure_android_host_apps/android_custom_host_app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Feb 18 12:03:21 EST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
@@ -91,22 +91,22 @@ object DependencyVersionChecker {
     // Advice for maintainers for other areas of code that are impacted are documented
     // in packages/flutter_tools/lib/src/android/README.md.
 
-    @VisibleForTesting internal val warnGradleVersion: Version = Version(8, 14, 0)
+    @VisibleForTesting internal val warnGradleVersion: Version = Version(9, 1, 0)
 
-    @VisibleForTesting internal val errorGradleVersion: Version = Version(8, 7, 0)
+    @VisibleForTesting internal val errorGradleVersion: Version = Version(8, 14, 0)
 
     // Java error and warn should align with packages/flutter_tools/lib/src/android/gradle_utils.dart.
     @VisibleForTesting internal val warnJavaVersion: JavaVersion = JavaVersion.VERSION_17
 
     @VisibleForTesting internal val errorJavaVersion: JavaVersion = JavaVersion.VERSION_17
 
-    @VisibleForTesting internal val warnAGPVersion: AndroidPluginVersion = AndroidPluginVersion(8, 11, 1)
+    @VisibleForTesting internal val warnAGPVersion: AndroidPluginVersion = AndroidPluginVersion(9, 0, 1)
 
-    @VisibleForTesting internal val errorAGPVersion: AndroidPluginVersion = AndroidPluginVersion(8, 6, 0)
+    @VisibleForTesting internal val errorAGPVersion: AndroidPluginVersion = AndroidPluginVersion(8, 11, 1)
 
-    @VisibleForTesting internal val warnKGPVersion: Version = Version(2, 2, 20)
+    @VisibleForTesting internal val warnKGPVersion: Version = Version(2, 3, 20)
 
-    @VisibleForTesting internal val errorKGPVersion: Version = Version(2, 0, 0)
+    @VisibleForTesting internal val errorKGPVersion: Version = Version(2, 2, 20)
 
     // If this value is changed, then make sure to change the documentation on https://docs.flutter.dev/reference/supported-platforms
     // Non inclusive.

--- a/packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
@@ -52,12 +52,10 @@ private const val FAKE_PROJECT_ROOT_DIR = "/fake/root/dir"
 
 // The following values will need to be modified when the corresponding "warn$DepName" versions
 // are updated in DependencyVersionChecker.kt
-// These values should also match the flutter create template values.
-// In //packages/flutter_tools/lib/src/android/gradle_utils.dart
-private const val SUPPORTED_GRADLE_VERSION: String = "9.3.1"
+private const val SUPPORTED_GRADLE_VERSION: String = "9.1.0"
 private val SUPPORTED_JAVA_VERSION: JavaVersion = JavaVersion.VERSION_17
-private val SUPPORTED_AGP_VERSION: AndroidPluginVersion = AndroidPluginVersion(9, 1, 0)
-private const val SUPPORTED_KGP_VERSION: String = "2.4.0"
+private val SUPPORTED_AGP_VERSION: AndroidPluginVersion = AndroidPluginVersion(9, 0, 1)
+private const val SUPPORTED_KGP_VERSION: String = "2.3.20"
 private val SUPPORTED_SDK_VERSION: MinSdkVersion = MinSdkVersion("release", 30)
 
 class DependencyVersionCheckerTest {
@@ -82,7 +80,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `AGP version in error range results in DependencyValidationException`() {
-        val exampleErrorAgpVersion = AndroidPluginVersion(8, 5, 0)
+        val exampleErrorAgpVersion = AndroidPluginVersion(8, 11, 0)
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(agpVersion = exampleErrorAgpVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra
@@ -104,7 +102,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `AGP version in warn range results in warning logs`() {
-        val exampleWarnAgpVersion = AndroidPluginVersion(8, 10, 0)
+        val exampleWarnAgpVersion = AndroidPluginVersion(8, 11, 1)
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(agpVersion = exampleWarnAgpVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra
@@ -128,7 +126,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `KGP version in error range results in DependencyValidationException`() {
-        val exampleErrorKgpVersion = "1.9.20"
+        val exampleErrorKgpVersion = "2.0.0"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(kgpVersion = exampleErrorKgpVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra
@@ -152,7 +150,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `KGP version in warn range results in warning logs`() {
-        val exampleWarnKgpVersion = "2.2.0"
+        val exampleWarnKgpVersion = "2.2.20"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(kgpVersion = exampleWarnKgpVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra
@@ -203,7 +201,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `Gradle version in error range results in DependencyValidationException`() {
-        val exampleErrorGradleVersion = "8.6.0"
+        val exampleErrorGradleVersion = "8.13.0"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(gradleVersion = exampleErrorGradleVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra
@@ -226,7 +224,7 @@ class DependencyVersionCheckerTest {
 
     @Test
     fun `Gradle version in warn range results in warning logs`() {
-        val exampleWarnGradleVersion = "8.12.0"
+        val exampleWarnGradleVersion = "8.14.0"
         val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(gradleVersion = exampleWarnGradleVersion)
 
         val mockExtraPropertiesExtension = mockProject.extra

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -1122,9 +1122,9 @@ String getGradleVersionFor(String agpV) {
     GradleForAgp(agpMin: '8.8.0', agpMax: '8.8.99', minRequiredGradle: '8.10.2'),
     GradleForAgp(agpMin: '8.9.0', agpMax: '8.9.99', minRequiredGradle: '8.11.1'),
     GradleForAgp(agpMin: '8.10.0', agpMax: '8.10.99', minRequiredGradle: '8.11.1'),
-    GradleForAgp(agpMin: '8.11.0', agpMax: '8.11.99', minRequiredGradle: '8.13'),
-    GradleForAgp(agpMin: '8.12.0', agpMax: '8.12.99', minRequiredGradle: '8.13'),
-    GradleForAgp(agpMin: '8.13.0', agpMax: '8.13.99', minRequiredGradle: '8.13'),
+    GradleForAgp(agpMin: '8.11.0', agpMax: '8.11.99', minRequiredGradle: '8.14'),
+    GradleForAgp(agpMin: '8.12.0', agpMax: '8.12.99', minRequiredGradle: '8.14'),
+    GradleForAgp(agpMin: '8.13.0', agpMax: '8.13.99', minRequiredGradle: '8.14'),
     GradleForAgp(agpMin: '9.0', agpMax: '9.0.99', minRequiredGradle: '9.1.0'),
     GradleForAgp(agpMin: '9.1.0', agpMax: '9.1.99', minRequiredGradle: '9.3.1'),
     // Assume if AGP is newer than this code knows about return the highest gradle

--- a/packages/flutter_tools/test/android_java17_integration.shard/android_dependency_version_checking_test.dart
+++ b/packages/flutter_tools/test/android_java17_integration.shard/android_dependency_version_checking_test.dart
@@ -25,7 +25,7 @@ void main() {
   testUsingContext('AGP version out of "warn" support band but in "error" band builds '
       'successfully and prints warning', () async {
     final versionTuple = VersionTuple(
-      agpVersion: '8.7.0',
+      agpVersion: '8.12.0',
       gradleVersion: '8.14',
       kotlinVersion: '2.2.20',
     );
@@ -42,7 +42,7 @@ void main() {
     // Create a new flutter project.
     final versionTuple = VersionTuple(
       agpVersion: '8.11.1',
-      gradleVersion: '8.13',
+      gradleVersion: '8.14',
       kotlinVersion: '2.2.20',
     );
     final ProcessResult result = await buildFlutterApkWithSpecifiedDependencyVersions(
@@ -56,9 +56,9 @@ void main() {
   testUsingContext('Kotlin version out of "warn" support band but in "error" band builds '
       'successfully and prints warning', () async {
     final versionTuple = VersionTuple(
-      agpVersion: '8.7.0',
+      agpVersion: '8.11.1',
       gradleVersion: '8.14',
-      kotlinVersion: '2.1.20',
+      kotlinVersion: '2.3.0',
     );
     final ProcessResult result = await buildFlutterApkWithSpecifiedDependencyVersions(
       versions: versionTuple,
@@ -71,9 +71,9 @@ void main() {
 
   testUsingContext('No logs are printed when suppression flag is passed', () async {
     final versionTuple = VersionTuple(
-      agpVersion: '8.6.0',
-      gradleVersion: '8.7',
-      kotlinVersion: '2.0.0',
+      agpVersion: '8.11.1',
+      gradleVersion: '8.14',
+      kotlinVersion: '2.2.20',
     );
     final ProcessResult result = await buildFlutterApkWithSpecifiedDependencyVersions(
       versions: versionTuple,

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -1494,9 +1494,9 @@ allprojects {
       expect(getGradleVersionFor('8.8'), '8.10.2');
       expect(getGradleVersionFor('8.9'), '8.11.1');
       expect(getGradleVersionFor('8.10'), '8.11.1');
-      expect(getGradleVersionFor('8.11'), '8.13');
-      expect(getGradleVersionFor('8.12'), '8.13');
-      expect(getGradleVersionFor('8.13'), '8.13');
+      expect(getGradleVersionFor('8.11'), '8.14');
+      expect(getGradleVersionFor('8.12'), '8.14');
+      expect(getGradleVersionFor('8.13'), '8.14');
       expect(getGradleVersionFor('9.0.1'), '9.1.0');
       expect(getGradleVersionFor('9.1.0'), '9.3.1');
     });

--- a/packages/flutter_tools/test/integration.shard/android_gradle_legacy_flutter_plugins_strings_in_comments_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_legacy_flutter_plugins_strings_in_comments_test.dart
@@ -70,8 +70,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
@@ -111,8 +111,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.9.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app", ":component1"


### PR DESCRIPTION
This was a manual cherry pick of https://github.com/flutter/flutter/pull/189109 and of https://github.com/flutter/flutter/pull/189229.

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/189228

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)?
Does it impact development (ex. flutter doctor crashes when Android Studio is installed),
or the shipping of production apps (the app crashes on launch).
This information is for domain experts and release engineers to understand the consequences of saying yes or no to the cherry pick.

This affects all Flutter Android apps and add-to-app integrations below the new warn and error version thresholds. Apps below the warn version will successfully build with warning logs urging an upgrade. Apps below the error version will fail to build and receive logs to upgrade.

New Warn Version
AGP: 9.0.1
Gradle: 9.1.0
KGP: 2.3.20

New Error Version
AGP: 8.11.1
Gradle: 8.14
KGP: 2.2.20

### Changelog Description:
Explain this cherry pick:
* In one line that is accessible to most Flutter developers.
* That describes the state prior to the fix.
* That includes which platforms are impacted.
See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples.

< Replace with changelog description here >
[flutter/189383](https://github.com/flutter/flutter/issues/186100): When building Flutter Android apps and add-to-app modules using AGP < 9, the tool does not prompt developers to upgrade to AGP 9+ or log Built-in Kotlin migration warnings.

### Workaround:
Is there a workaround for this issue?

This change must be made. More develoeprs should upgrade to AGP 9+ to receive Built-in Kotlin migration warnings. To urge more developers to migrate to AGP 9+, we must raise the warn version to AGP 9+ to urge a larger chunk of our developers to migrate to AGP 9+. This must be done in this release because we don't have many Flutter releases left before AGP 10 releases.

### Risk:
What is the risk level of this cherry-pick?

  - [ ] Low
  - [x] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?
To validate the new warn version:
- `flutter create` a new app
- change versions to just below the warn version AGP: 9.0.1, Gradle: 9.1.0 KGP: 2.3.20 in settings.gradle.kts
- `flutter build apk` and the build is successful but you will see logs urging you to upgrade.
- change versions to the warn version GP: 9.0.1, Gradle: 9.1.0 KGP: 2.3.20 in settings.gradle.kts
-`flutter build apk` and the build is successful and you will see no logs

To validate the new error version:
- change versions to just below the error version AGP: 8.11.1, Gradle: 8.14 KGP: 2.2.20 in settings.gradle.kts
- `flutter build apk` and the build will fail and you will see logs urging you to upgrade.
- change versions to the error version  AGP: 8.11.1, Gradle: 8.14 KGP: 2.2.20 in settings.gradle.kts
-`flutter build apk` and the build is successful and you will see no logs

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
