### PR TITLE
Stop running most Mac x64 builders that have Mac ARM equivalents on master

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3899,6 +3899,9 @@ targets:
   - name: Mac_x64 build_tests_1_5
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       add_recipes_cq: "true"
@@ -3918,6 +3921,9 @@ targets:
   - name: Mac_x64 build_tests_2_5
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       add_recipes_cq: "true"
@@ -3937,6 +3943,9 @@ targets:
   - name: Mac_x64 build_tests_3_5
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       add_recipes_cq: "true"
@@ -3956,6 +3965,9 @@ targets:
   - name: Mac_x64 build_tests_4_5
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       add_recipes_cq: "true"
@@ -3975,6 +3987,9 @@ targets:
   - name: Mac_x64 build_tests_5_5
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       add_recipes_cq: "true"
@@ -4271,6 +4286,9 @@ targets:
   - name: Mac_x64 framework_tests_misc
     recipe: flutter/flutter_drone
     timeout: 60
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     properties:
       dependencies: >-
         [
@@ -4573,6 +4591,9 @@ targets:
   - name: Mac_x64 plugin_lint_mac
     recipe: devicelab/devicelab_drone
     timeout: 60
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     properties:
       dependencies: >-
         [
@@ -4695,6 +4716,9 @@ targets:
   - name: Mac_x64 tool_host_cross_arch_tests
     recipe: flutter/flutter_drone
     timeout: 60
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     properties:
       dependencies: >-
         [
@@ -5005,6 +5029,9 @@ targets:
   - name: Mac_x64 tool_tests_commands
     recipe: flutter/flutter_drone
     timeout: 60
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -5454,6 +5481,9 @@ targets:
   - name: Mac_x64 hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
     timeout: 60
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     properties:
       dependencies: >-
         [
@@ -5489,6 +5519,9 @@ targets:
   - name: Mac_x64_ios integration_test_test_ios
     recipe: devicelab/devicelab_drone
     presubmit: false
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       tags: >
@@ -5543,6 +5576,9 @@ targets:
   - name: Mac_x64 ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
     presubmit: false
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       dependencies: >-
@@ -5605,6 +5641,9 @@ targets:
   - name: Mac_x64 macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
     presubmit: false
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       dependencies: >-
@@ -5812,6 +5851,9 @@ targets:
   - name: Mac_x64_ios hot_mode_dev_cycle_ios__benchmark
     recipe: devicelab/devicelab_drone
     presubmit: false
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       tags: >
@@ -5922,6 +5964,9 @@ targets:
   - name: Mac_x64 native_ui_tests_macos
     recipe: devicelab/devicelab_drone
     timeout: 60
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     properties:
       dependencies: >-
         [

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5172,6 +5172,9 @@ targets:
   - name: Mac_mokey hello_world_android__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       tags: >
@@ -5202,6 +5205,9 @@ targets:
   - name: Mac_mokey integration_test_test
     recipe: devicelab/devicelab_drone
     presubmit: false
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     timeout: 60
     properties:
       tags: >
@@ -5252,6 +5258,9 @@ targets:
   - name: Mac_mokey run_debug_test_android
     recipe: devicelab/devicelab_drone
     presubmit: false
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     runIf:
       - .ci.yaml
       - dev/**
@@ -5282,6 +5291,9 @@ targets:
   - name: Mac_mokey run_release_test
     recipe: devicelab/devicelab_drone
     presubmit: false
+    enabled_branches:
+      - beta # TODO(flutter/flutter#189295): Remove after 3.48.0-0.1.pre is released.
+      - stable # TODO(flutter/flutter#189295): Delete this builder after 3.50 is released.
     runIf:
       - .ci.yaml
       - engine/**


### PR DESCRIPTION
Per https://flutter.dev/go/macos-intel-deprecation we are turning down Intel-based Mac support. Stop running x64 tests in CI that already have ARM variants. The x64 Mac tests are very slow and therefore flaky so this will improve CI health as well.

Note: If we just deleted these builders, the beta and stable releases would fail since the builder config would be missing. Instead, stop running them on master. Once master is promoted to beta, we can remove `enabled_branches: beta`. And once that beta is promoted to stable, we won't want to run x64 anywhere, so we can delete the builders completely on all branches.

I left the `Mac_x64 verify_binaries_codesigned` and `Mac_x64 verify_binaries_pre_codesigned` since we likely want to keep those until we stop publishing those binaries.

First part of https://github.com/flutter/flutter/issues/189295
Fixes https://github.com/flutter/flutter/issues/188491 ("fixes")

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
