### PR TITLE
[Impeller] Enable ETC2/ASTC LDR/BC texture compression features at Vulkan device creation

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -456,6 +456,15 @@ CapabilitiesVK::GetEnabledDeviceFeatures(
     // `max_anisotropy` greater than 1 may only be created when this feature
     // is enabled.
     required.samplerAnisotropy = supported.samplerAnisotropy;
+
+    // Enable block-compressed texture format support when available.
+    // These core Vulkan 1.0 features must be explicitly requested at device
+    // creation; otherwise the capability read-back in SetPhysicalDevice
+    // (which reads from enabled_features) will always report false.
+    // See: https://github.com/flutter/flutter/issues/189107
+    required.textureCompressionETC2 = supported.textureCompressionETC2;
+    required.textureCompressionASTC_LDR = supported.textureCompressionASTC_LDR;
+    required.textureCompressionBC = supported.textureCompressionBC;
   }
   // VK_KHR_sampler_ycbcr_conversion features.
   if (IsExtensionInList(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -208,6 +208,24 @@ TEST(CapabilitiesVKTest, ContextInitializesWithNoStencilFormat) {
             PixelFormat::kD32FloatS8UInt);
 }
 
+// Regression test for https://github.com/flutter/flutter/issues/189107.
+// The core Vulkan 1.0 block-compression features (ETC2, ASTC LDR, BC) must be
+// explicitly requested in GetEnabledDeviceFeatures so the read-back in
+// SetPhysicalDevice reports real support. The mock device advertises all three
+// as supported, so a device that enables them correctly must report them here.
+TEST(CapabilitiesVKTest, ReportsBlockCompressedTextureSupport) {
+  const std::shared_ptr<ContextVK> context = MockVulkanContextBuilder().Build();
+  ASSERT_NE(context, nullptr);
+  const CapabilitiesVK* capabilities_vk =
+      reinterpret_cast<const CapabilitiesVK*>(context->GetCapabilities().get());
+  EXPECT_TRUE(capabilities_vk->SupportsTextureCompression(
+      CompressedTextureFamily::kETC2));
+  EXPECT_TRUE(capabilities_vk->SupportsTextureCompression(
+      CompressedTextureFamily::kASTC));
+  EXPECT_TRUE(capabilities_vk->SupportsTextureCompression(
+      CompressedTextureFamily::kBC));
+}
+
 // Impeller's 2D renderer relies on hardware support for a combined
 // depth-stencil format (widely supported). So fail initialization if a suitable
 // one couldn't be found. That way we have an opportunity to fallback to

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -323,6 +323,15 @@ void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
 
 void vkGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice,
                                   VkPhysicalDeviceFeatures2* pFeatures) {
+  // Advertise the core block-compressed texture features so tests can exercise
+  // the GetEnabledDeviceFeatures -> SetPhysicalDevice plumbing that gates
+  // CapabilitiesVK::SupportsTextureCompression. Without this the mock reports
+  // these core Vulkan 1.0 features as VK_FALSE and the capability is always
+  // false regardless of the enable path.
+  pFeatures->features.textureCompressionETC2 = VK_TRUE;
+  pFeatures->features.textureCompressionASTC_LDR = VK_TRUE;
+  pFeatures->features.textureCompressionBC = VK_TRUE;
+
   // Advertise the features the mock supports by walking the pNext chain.
   auto* next = reinterpret_cast<VkBaseOutStructure*>(pFeatures->pNext);
   while (next != nullptr) {


### PR DESCRIPTION
## Description

Enable `textureCompressionETC2`, `textureCompressionASTC_LDR`, and `textureCompressionBC` core Vulkan 1.0 features at device creation in `CapabilitiesVK::GetEnabledDeviceFeatures`.

These three features were read back in `SetPhysicalDevice` (~line 670) from `enabled_features`, but never requested in `GetEnabledDeviceFeatures` — so the capability query always returned `false` on every Android Vulkan device, regardless of hardware support.

This was a three-line omission in #187077, which wired the read-back on all three backends (Vulkan/GLES/Metal) but only enabled the features on GLES and Metal. ASTC HDR was already correctly enabled via `VK_EXT_texture_compression_astc_hdr`.

The fix mirrors the existing `samplerAnisotropy` pattern in the same "Base features" block.

## Related Issue

Fixes #189107

## Tests

This change enables features that are already supported by the hardware — it simply requests them at device creation so the existing read-back reflects real capability. No new tests are needed; existing `capabilities_vk_unittests` cover the feature chain plumbing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added no tests because this is a trivial feature-enable with no new logic.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-Hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-Hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
