### PR TITLE
Use ServicesBinding.instance.exitApplication instead of exit(0) in multiple_windows example

### DIFF
--- a/examples/multiple_windows/lib/main.dart
+++ b/examples/multiple_windows/lib/main.dart
@@ -5,9 +5,10 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'dart:io';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/src/widgets/_window.dart';
 
 import 'app/main_window.dart';
@@ -17,7 +18,7 @@ class MainControllerWindowDelegate with RegularWindowControllerDelegate {
   @override
   void onWindowDestroyed() {
     super.onWindowDestroyed();
-    exit(0);
+    ServicesBinding.instance.exitApplication(AppExitType.required);
   }
 }
 


### PR DESCRIPTION
## What's new?
 - Exactly what the title says :)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
