### PR TITLE
[hooks] Roll record_use to 1.0 and unpin

### DIFF
--- a/dev/integration_tests/data_asset_app/pubspec.yaml
+++ b/dev/integration_tests/data_asset_app/pubspec.yaml
@@ -12,7 +12,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  hooks: ^2.0.0
+  hooks: ^2.1.0
   data_assets: ^0.20.0
   data_asset_package:
     path: ../data_asset_package
@@ -24,4 +24,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: 9jmf6j
+# PUBSPEC CHECKSUM: qa7aie

--- a/dev/integration_tests/data_asset_package/pubspec.yaml
+++ b/dev/integration_tests/data_asset_package/pubspec.yaml
@@ -12,7 +12,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  hooks: ^2.0.0
+  hooks: ^2.1.0
   data_assets: ^0.20.0
 
 dev_dependencies:
@@ -22,4 +22,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: 6cfeb0
+# PUBSPEC CHECKSUM: fqqee1

--- a/dev/integration_tests/hook_user_defines/pubspec.yaml
+++ b/dev/integration_tests/hook_user_defines/pubspec.yaml
@@ -15,11 +15,11 @@ hooks:
       magic_value: 1000
 
 dependencies:
-  hooks: 2.0.2
+  hooks: 2.1.0
   logging: 1.3.0
-  native_toolchain_c: 0.19.2
+  native_toolchain_c: 0.19.3
 
 dev_dependencies:
   test: 1.29.0
 
-# PUBSPEC CHECKSUM: rdht57
+# PUBSPEC CHECKSUM: b3eo7f

--- a/dev/integration_tests/record_use_test_package/lib/record_use_test_package.dart
+++ b/dev/integration_tests/record_use_test_package/lib/record_use_test_package.dart
@@ -19,7 +19,6 @@ Future<Map<String, String>> _getTranslations() async {
   return _cachedTranslations!;
 }
 
-// ignore: experimental_member_use
 @RecordUse()
 Future<String> translate(String key) async {
   final Map<String, String> translations = await _getTranslations();

--- a/dev/integration_tests/record_use_test_package/pubspec.yaml
+++ b/dev/integration_tests/record_use_test_package/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  hooks: ^2.0.0
+  hooks: ^2.1.0
   data_assets: ^0.20.0
-  record_use: 0.6.0
+  record_use: ^1.0.0
   meta: any
 
 dev_dependencies:
@@ -23,4 +23,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: ka5c8a
+# PUBSPEC CHECKSUM: 2pvsru

--- a/packages/flutter/lib/src/widgets/icon_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_data.dart
@@ -45,11 +45,8 @@ final class IconData {
   /// need to be explicitly opted out at build time). See [staticIconProvider]
   /// for more context.
   const IconData(
-    // ignore: experimental_member_use
     @mustBeConst this.codePoint, {
-    // ignore: experimental_member_use
     @mustBeConst this.fontFamily,
-    // ignore: experimental_member_use
     @mustBeConst this.fontPackage,
     this.matchTextDirection = false,
     this.fontFamilyFallback,

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   # This is not unpinned currently.
   # See https://github.com/flutter/flutter/issues/185017
   material_color_utilities: 0.13.0
-  meta: ^1.18.3
+  meta: ^1.19.0
   vector_math: ^2.4.0
   sky_engine:
     sdk: flutter
@@ -42,4 +42,4 @@ dev_dependencies:
   path: any
   platform: any
 
-# PUBSPEC CHECKSUM: i71l78
+# PUBSPEC CHECKSUM: ufigpi

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   leak_tracker_flutter_testing: ^3.0.10
 
   collection: ^1.19.1
-  meta: ^1.18.3
+  meta: ^1.19.0
   stream_channel: ^2.1.4
 
 dev_dependencies:
@@ -48,4 +48,4 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
 
-# PUBSPEC CHECKSUM: 226o4f
+# PUBSPEC CHECKSUM: lu8vkm

--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -25,7 +25,6 @@ const kManuallyPinnedDependencies = <String, String>{
   'flutter_template_images': '5.0.0', // Must always exactly match flutter_tools template.
   'material_color_utilities': '0.13.0', // Keep pinned to latest until 1.0.0.
   'data_assets': '0.20.0', //  Keep pinned to latest until 1.0.0. Rolled by @dcharkes.
-  'record_use': '0.6.0', //  Keep pinned to latest until 1.0.0. Rolled by @dcharkes.
 };
 
 /// These are packages that are explicitly excluded from appearing in the list

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   html: 0.15.6
   http: 1.6.0
   intl: 0.20.3
-  meta: 1.18.3
+  meta: 1.19.0
   multicast_dns: 0.3.3+1
   mustache_template: 2.0.5
   package_config: 2.2.0
@@ -57,8 +57,8 @@ dependencies:
   pubspec_parse: 1.5.0
 
   graphs: 2.3.2
-  hooks_runner: 1.5.0
-  hooks: 2.0.2
+  hooks_runner: 1.6.0
+  hooks: 2.1.0
   code_assets: 1.2.1
   data_assets: 0.20.0
 
@@ -127,4 +127,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: ctgrgi
+# PUBSPEC CHECKSUM: 8nrqjq

--- a/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
@@ -6,10 +6,10 @@ environment:
   sdk: {{dartSdkVersionBounds}}
 
 dependencies:
-  code_assets: ^1.1.0
-  hooks: ^2.0.0
+  code_assets: ^1.2.1
+  hooks: ^2.1.0
   logging: ^1.3.0
-  native_toolchain_c: ^0.19.0
+  native_toolchain_c: ^0.19.3
 
 dev_dependencies:
   ffi: ^2.1.4

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -430,10 +430,10 @@ packages:
     dependency: transitive
     description:
       name: google_cloud
-      sha256: fbcde933b2d8600c3cdb2328f8f4c47628ec29a39e9cef85dee535c7868993c4
+      sha256: b385e20726ef5315d302c5933bfb728103116c5be2d3d17094b01a82da538c1f
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.5.0"
   google_fonts:
     dependency: "direct main"
     description:
@@ -486,18 +486,18 @@ packages:
     dependency: "direct main"
     description:
       name: hooks
-      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      sha256: "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   hooks_runner:
     dependency: transitive
     description:
       name: hooks_runner
-      sha256: a67ab8106545fcffcf5c43edf84b4be222fc95a9fbec8baef1bcaf4534540cfc
+      sha256: cb6ab96514ba9935c280fcacdb4b6e9d613bebf253910fecdc78351abd83dbba
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   html:
     dependency: "direct main"
     description:
@@ -662,10 +662,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.3"
+    version: "1.19.0"
   metrics_center:
     dependency: "direct main"
     description:
@@ -710,10 +710,10 @@ packages:
     dependency: "direct main"
     description:
       name: native_toolchain_c
-      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
+      sha256: a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.2"
+    version: "0.19.3"
   nested:
     dependency: "direct main"
     description:
@@ -894,10 +894,10 @@ packages:
     dependency: "direct main"
     description:
       name: record_use
-      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      sha256: af37186ff9ede46fa32f152526c48f46c5b3ad7d3d5a566140cb5df3dc4ed737
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "1.0.0"
   retry:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -120,9 +120,9 @@ dependencies:
   google_mobile_ads: 8.0.0
   googleapis: 14.0.0
   googleapis_auth: 2.3.3
-  hooks: 2.0.2
+  hooks: 2.1.0
   data_assets: 0.20.0
-  record_use: 0.6.0
+  record_use: 1.0.0
   html: 0.15.6
   http: 1.6.0
   http_multi_server: 3.2.2
@@ -138,10 +138,10 @@ dependencies:
   logging: 1.3.0
   matcher: 0.12.20
   material_color_utilities: 0.13.0
-  meta: ^1.18.3
+  meta: ^1.19.0
   metrics_center: 1.0.15
   mime: 2.0.0
-  native_toolchain_c: 0.19.2
+  native_toolchain_c: 0.19.3
   nested: 1.0.0
   node_preamble: 2.0.2
   package_config: 2.2.0
@@ -222,4 +222,4 @@ dependencies:
 dev_dependencies:
   ffigen: 20.1.1
 
-# PUBSPEC CHECKSUM: im9o4p
+# PUBSPEC CHECKSUM: hi4nta


### PR DESCRIPTION
It's a major rev so requires a manual roll.

And roll the other packages from dart-lang/native to versions with constraints on record_use 1.0.

Also roll `package:meta` to make `@RecordUse()` and `@mustBeConst` no longer experimental. (remove experiment lint suppressions)

And update the tmpl files to use new versions.

Tests:

* All existing tests for record use, code assets & hooks, and data assets.