### PR TITLE
[flutter_tools] Fix ADB device listing output parsing regression

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -125,7 +125,7 @@ class AndroidDevices extends PollingDeviceDiscovery {
   //    like "product:mokey model:mokey device:mokey transport_id:1" or "usb:123").
   static final _kDeviceRegex = RegExp(
     r'^(.*?)(?:\s{2,}|\t+)'
-    r'(device|offline|unauthorized|no permissions|bootloader|recovery|sideload|connecting|authorizing|host|unknown)'
+    r'(device|offline|unauthorized|no permissions|bootloader|recovery|sideload|rescue|connecting|authorizing|host|unknown)'
     r'(?:\s+(.*)|$)',
   );
 

--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -115,13 +115,19 @@ class AndroidDevices extends PollingDeviceDiscovery {
   // The regex is structured as:
   // 1. Group 1 (Serial): Lazily matched to allow spaces in the serial (which
   //    can happen during wireless ADB mDNS name conflicts, e.g., "device (2)").
-  // 2. Group 2 (State): Matches "no permissions" explicitly (as it is the only
-  //    known state containing a space) or any other non-whitespace word (\S+).
-  // 3. Group 3 (Extra Info): Anchors the state match by requiring it to be
-  //    followed by either a space and a key:value pair (e.g., "usb:123") or the
-  //    end of the line. This prevents false positives if the serial contains
-  //    state keywords.
-  static final _kDeviceRegex = RegExp(r'^(.*?)\s+(no permissions|\S+)(?:\s+(\w+:.*)|$)');
+  //    The column separator requires at least two spaces or a tab to prevent
+  //    single spaces within a serial from being mis-matched.
+  // 2. Group 2 (State): Matches known ADB device states explicitly, including
+  //    "no permissions" (which contains a space). Explicitly listing states
+  //    prevents false positive state matching on extra device info/attributes
+  //    or serial name components.
+  // 3. Group 3 (Extra Info): Optional trailing details (e.g. key:value pairs
+  //    like "product:mokey model:mokey device:mokey transport_id:1" or "usb:123").
+  static final _kDeviceRegex = RegExp(
+    r'^(.*?)(?:\s{2,}|\t+)'
+    r'(device|offline|unauthorized|no permissions|bootloader|recovery|sideload|connecting|authorizing|host|unknown)'
+    r'(?:\s+(.*)|$)',
+  );
 
   /// Parse the given `adb devices` output in [text], and fill out the given list
   /// of devices and possible device issue diagnostics. Either argument can be null,

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -549,6 +549,64 @@ device4       unknown usb:3-7
       expect(diagnostics[1], contains('device2 is offline'));
     },
   );
+
+  // Related to https://github.com/flutter/flutter/issues/189274
+  testWithoutContext(
+    'AndroidDevices can parse output with extra non-key-value attributes without mis-matching device ID',
+    () async {
+      final androidDevices = AndroidDevices(
+        userMessages: UserMessages(),
+        androidWorkflow: androidWorkflow,
+        androidSdk: FakeAndroidSdk(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['adb', 'devices', '-l'],
+            stdout: '''
+List of devices attached
+ABCDEFG           device 20-30 product:mokey model:mokey device:mokey transport_id:1
+''',
+          ),
+        ]),
+        platform: FakePlatform(),
+        fileSystem: MemoryFileSystem.test(),
+      );
+
+      final List<Device> devices = await androidDevices.pollingGetDevices();
+
+      expect(devices, hasLength(1));
+      expect(devices.first.id, 'ABCDEFG');
+      expect(devices.first.name, 'mokey');
+    },
+  );
+
+  testWithoutContext(
+    'AndroidDevices handles serial containing spaces and state keywords correctly',
+    () async {
+      final androidDevices = AndroidDevices(
+        userMessages: UserMessages(),
+        androidWorkflow: androidWorkflow,
+        androidSdk: FakeAndroidSdk(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['adb', 'devices', '-l'],
+            stdout: '''
+List of devices attached
+my device (2)          device product:model
+''',
+          ),
+        ]),
+        platform: FakePlatform(),
+        fileSystem: MemoryFileSystem.test(),
+      );
+
+      final List<Device> devices = await androidDevices.pollingGetDevices();
+
+      expect(devices, hasLength(1));
+      expect(devices.first.id, 'my device (2)');
+    },
+  );
 }
 
 class FakeAndroidSdk extends Fake implements AndroidSdk {


### PR DESCRIPTION
Fixes a regression introduced in 629df07148561e4180238d67de92628b77fbaed0 where `adb devices -l` output containing non-key-value attributes (e.g. `ABCDEFG           device 20-30 product:mokey model:mokey device:mokey transport_id:1`) caused regex lazy-matching to backtrack, incorrectly capturing `ABCDEFG           device` into Group 1 (the device ID).

This change:
* Updates `_kDeviceRegex` in `android_device_discovery.dart` to explicitly match known ADB device states (`device`, `offline`, `unauthorized`, `no permissions`, etc.) and require a column delimiter of at least two spaces or a tab (`(?:\s{2,}|\t+)`).
* Adds regression unit test coverage in `android_device_discovery_test.dart`.

Related to #189274

## Tests

* Added regression unit test in `android_device_discovery_test.dart` for ADB output containing non-key-value attributes.
* Added unit test for wireless serial names containing spaces and state keywords (`my device (2)`).