### PR TITLE
Move a few benchmarks from x64 Intel Macs to ARM

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5162,9 +5162,10 @@ targets:
       task_name: hello_world_android__compile
 
   # mac mokey benchmark
-  - name: Mac_mokey hot_mode_dev_cycle__benchmark
+  - name: Mac_arm64_mokey hot_mode_dev_cycle__benchmark
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
@@ -5202,9 +5203,10 @@ targets:
       task_name: integration_ui_frame_number
 
   # mac mokey benchmark
-  - name: Mac_mokey microbenchmarks
+  - name: Mac_arm64_mokey microbenchmarks
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
@@ -5827,9 +5829,10 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: hot_mode_dev_cycle_ios__benchmark
 
-  - name: Mac_x64 hot_mode_dev_cycle_ios_simulator
+  - name: Mac_arm64 hot_mode_dev_cycle_ios_simulator
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
Most of the benchmarks will either run on ARM Macs-only, or run on both ARM and x64 platforms. These 3 benchmarks currently only run on x64 Intel Macs (which we are [deprecating](https://github.com/flutter/flutter/issues/188328)). Move them to ARM bots. 

Generally we want to keep testing Intel Macs on beta and stable until current master is released, but since these 3 benchmarks should have been running on ARM, and they aren't testing anything architecture-specific, I will cherry-pick these changes to stable and beta.

This will unfortunately break the historical data for these benchmarks and it will show up in skiaperf as new benchmarks.

The part of https://github.com/flutter/flutter/issues/189144 that should be cherry-picked to beta and stable.
Fixes https://github.com/flutter/flutter/issues/188851 ("fixes")
Fixes https://github.com/flutter/flutter/issues/189123 ("fixes")

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
