### PR TITLE
[flutter_tools] Parse single-space wireless ADB device output

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -123,9 +123,20 @@ class AndroidDevices extends PollingDeviceDiscovery {
   //    or serial name components.
   // 3. Group 3 (Extra Info): Optional trailing details (e.g. key:value pairs
   //    like "product:mokey model:mokey device:mokey transport_id:1" or "usb:123").
+  static const String _kDeviceStates =
+      'device|offline|unauthorized|no permissions|bootloader|recovery|sideload|rescue|connecting|authorizing|host|unknown';
+
   static final _kDeviceRegex = RegExp(
     r'^(.*?)(?:\s{2,}|\t+)'
-    r'(device|offline|unauthorized|no permissions|bootloader|recovery|sideload|rescue|connecting|authorizing|host|unknown)'
+    '($_kDeviceStates)'
+    r'(?:\s+(.*)|$)',
+  );
+
+  // ADB may use a single space after a long mDNS serial. Restrict this fallback
+  // to serials without spaces so mDNS conflict names retain the column parser.
+  static final _kUnspacedSerialDeviceRegex = RegExp(
+    r'^(\S+)\s+'
+    '($_kDeviceStates)'
     r'(?:\s+(.*)|$)',
   );
 
@@ -160,9 +171,9 @@ class AndroidDevices extends PollingDeviceDiscovery {
         continue;
       }
 
-      if (_kDeviceRegex.hasMatch(line)) {
-        final Match match = _kDeviceRegex.firstMatch(line)!;
-
+      final Match? match =
+          _kDeviceRegex.firstMatch(line) ?? _kUnspacedSerialDeviceRegex.firstMatch(line);
+      if (match != null) {
         final String deviceID = match[1]!;
         final String deviceState = match[2]!;
         String? rest = match[3];

--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -132,8 +132,8 @@ class AndroidDevices extends PollingDeviceDiscovery {
     r'(?:\s+(.*)|$)',
   );
 
-  // ADB may use a single space after a long mDNS serial. Restrict this fallback
-  // to serials without spaces so mDNS conflict names retain the column parser.
+  /// ADB may use a single space after a long mDNS serial. Restrict this fallback
+  /// to serials without spaces so mDNS conflict names retain the column parser.
   static final _kUnspacedSerialDeviceRegex = RegExp(
     r'^(\S+)\s+'
     '($_kDeviceStates)'

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -238,6 +238,12 @@ adb-ZY22MGW35T-Z3uXXq (2)._adb-tls-connect._tcp    device product:vantage_ge mod
         'expectedId': '127.0.0.1:5555',
         'expectedStatus': 'success',
       },
+      <String, String>{
+        'input':
+            'adb-0123456789abcdef._adb-tls-connect._tcp device product:socrates model:22127RK46C device:socrates transport_id:1',
+        'expectedId': 'adb-0123456789abcdef._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
       // States that should go to diagnostics
       <String, String>{
         'input': '015d172c98400a03       offline',


### PR DESCRIPTION
## Description

Fixes Android device discovery when `adb devices -l` separates a long wireless
mDNS serial and its device state with a single space.

The existing parser accepts two spaces or a tab as the delimiter. Some ADB
output uses a single space instead, causing Flutter to report an unexpected
parsing failure and omit the wireless device.

This change adds a fallback parser for single-space delimiters when the serial
contains no spaces. The existing parser remains the preferred path so mDNS
conflict names containing spaces continue to be handled correctly.

Fixes #189430 

## Testing

- Added a parser test for a single-space wireless mDNS serial.
- Ran:
  `flutter test packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart`
- Ran:
  `flutter analyze packages/flutter_tools`

## Manual verification

Using the same wireless ADB device output:

```text
adb-0123456789abcdef._adb-tls-connect._tcp device product:socrates model:22127RK46C device:socrates transport_id:1
```

- Flutter 3.44.5 detects the device.
- Unmodified Flutter `master` (`3.47.0-1.0.pre-58`, framework
  `11faf0ac6ec69abcc7267e372a703f6d63d5b86f`) reports an ADB parsing
  failure and omits the device.
- This change detects the device as `22127RK46C (wireless)`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.