### PR TITLE
[flutter_test][Test cross imports] Move TestWidgetsApp to flutter_test

### DIFF
--- a/packages/flutter/test/animation/live_binding_test.dart
+++ b/packages/flutter/test/animation/live_binding_test.dart
@@ -10,8 +10,6 @@ library;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/widgets_app_tester.dart';
-
 void main() {
   /*
    * Here lies golden tests for packages/flutter_test/lib/src/binding.dart

--- a/packages/flutter/test/gestures/gesture_config_regression_test.dart
+++ b/packages/flutter/test/gestures/gesture_config_regression_test.dart
@@ -7,8 +7,6 @@ import 'dart:ui' as ui;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/widgets_app_tester.dart';
-
 class TestResult {
   bool dragStarted = false;
   bool dragUpdate = false;

--- a/packages/flutter/test/gestures/monodrag_test.dart
+++ b/packages/flutter/test/gestures/monodrag_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/widgets_app_tester.dart';
 import 'gesture_tester.dart';
 
 void main() {

--- a/packages/flutter/test/semantics/traversal_order_test.dart
+++ b/packages/flutter/test/semantics/traversal_order_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/semantics_tester.dart';
-import '../widgets/widgets_app_tester.dart';
 
 void main() {
   testWidgets('Traversal order handles touching elements', (WidgetTester tester) async {

--- a/packages/flutter/test/services/system_context_menu_controller_test.dart
+++ b/packages/flutter/test/services/system_context_menu_controller_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../system_context_menu_utils.dart';
 import '../widgets/clipboard_utils.dart';
-import '../widgets/widgets_app_tester.dart';
 import 'text_input_utils.dart';
 
 void main() {

--- a/packages/flutter/test/widgets/absorb_pointer_test.dart
+++ b/packages/flutter/test/widgets/absorb_pointer_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'button_tester.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('AbsorbPointers do not block siblings', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/accessibility_evaluations_service_extension_test.dart
+++ b/packages/flutter/test/widgets/accessibility_evaluations_service_extension_test.dart
@@ -8,8 +8,6 @@ import 'package:flutter/src/foundation/_features.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 class AccessibilityEvaluationTestBinding extends AutomatedTestWidgetsFlutterBinding {
   static AccessibilityEvaluationTestBinding? _instance;
 

--- a/packages/flutter/test/widgets/accessibility_evaluations_test.dart
+++ b/packages/flutter/test/widgets/accessibility_evaluations_test.dart
@@ -8,8 +8,6 @@ import 'package:flutter/src/widgets/_accessibility_evaluations.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   group('MinimumTapTargetEvaluation', () {
     late final Set<String> originalFeatureFlags;

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'button_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   group(ActionDispatcher, () {

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'editable_text_tester.dart';
 import 'list_tile_tester.dart';
 import 'multi_view_testing.dart';
-import 'widgets_app_tester.dart';
 
 // Matches the Material kMinInteractiveDimension (48.0).
 const double _kMinInteractiveDimension = 48.0;

--- a/packages/flutter/test/widgets/autofill_group_test.dart
+++ b/packages/flutter/test/widgets/autofill_group_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'editable_text_tester.dart';
-import 'widgets_app_tester.dart';
 
 final Matcher _matchesCommit = isMethodCall('TextInput.finishAutofillContext', arguments: true);
 final Matcher _matchesCancel = isMethodCall('TextInput.finishAutofillContext', arguments: false);

--- a/packages/flutter/test/widgets/banner_test.dart
+++ b/packages/flutter/test/widgets/banner_test.dart
@@ -8,8 +8,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
-import 'widgets_app_tester.dart';
-
 class TestCanvas implements Canvas {
   final List<Invocation> invocations = <Invocation>[];
 

--- a/packages/flutter/test/widgets/baseline_test.dart
+++ b/packages/flutter/test/widgets/baseline_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'list_tile_tester.dart';
-import 'widgets_app_tester.dart';
 
 const Color _debugChipColor = Color(0xFFCCCCCC);
 

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -19,7 +19,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'button_tester.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   group('RawImage', () {

--- a/packages/flutter/test/widgets/color_filter_test.dart
+++ b/packages/flutter/test/widgets/color_filter_test.dart
@@ -12,8 +12,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   const debugRed = Color(0xFFFF0000);
   const debugGreen = Color(0xFF00FF00);

--- a/packages/flutter/test/widgets/context_menu_controller_test.dart
+++ b/packages/flutter/test/widgets/context_menu_controller_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'clipboard_utils.dart';
 import 'editable_text_tester.dart';
 import 'editable_text_utils.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   const kGreyColor = Color(0xFFAAAAAA);

--- a/packages/flutter/test/widgets/debug_test.dart
+++ b/packages/flutter/test/widgets/debug_test.dart
@@ -8,8 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   test('debugChildrenHaveDuplicateKeys control test', () {
     const key = Key('key');

--- a/packages/flutter/test/widgets/decorated_sliver_test.dart
+++ b/packages/flutter/test/widgets/decorated_sliver_test.dart
@@ -11,8 +11,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('DecoratedSliver creates, paints, and disposes BoxPainter', (
     WidgetTester tester,

--- a/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/default_text_editing_shortcuts_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'editable_text_tester.dart';
 import 'keyboard_utils.dart';
-import 'widgets_app_tester.dart';
 
 const Color _blue = Color(0xFF0000FF);
 const Color _grey = Color(0xFF9E9E9E);

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -9,7 +9,6 @@ import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'button_tester.dart';
 import 'utils.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   Widget boilerplateWidget(

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'route_tester.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('Drag and drop - control test', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -18,7 +18,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'editable_text_tester.dart';
 import 'editable_text_utils.dart';
-import 'widgets_app_tester.dart';
 
 const TextStyle textStyle = TextStyle();
 const Color cursorColor = Color.fromARGB(0xFF, 0xFF, 0x00, 0x00);

--- a/packages/flutter/test/widgets/editable_text_scribble_test.dart
+++ b/packages/flutter/test/widgets/editable_text_scribble_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'editable_text_tester.dart';
 import 'editable_text_utils.dart';
-import 'widgets_app_tester.dart';
 
 const Color _blue = Color(0xFF0000FF);
 const Color _grey = Color(0xFF888888);

--- a/packages/flutter/test/widgets/editable_text_scribe_test.dart
+++ b/packages/flutter/test/widgets/editable_text_scribe_test.dart
@@ -9,8 +9,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 const Color _grey = Color(0xFF888888);
 
 void main() {

--- a/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'clipboard_utils.dart';
 import 'keyboard_utils.dart';
-import 'widgets_app_tester.dart';
 
 Iterable<SingleActivator> allModifierVariants(LogicalKeyboardKey trigger) {
   const Iterable<bool> trueFalse = <bool>[false, true];

--- a/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
+++ b/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'editable_text_tester.dart';
-import 'widgets_app_tester.dart';
 
 class _TestSliverPersistentHeaderDelegate extends SliverPersistentHeaderDelegate {
   _TestSliverPersistentHeaderDelegate({

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -26,7 +26,6 @@ import 'editable_text_tester.dart';
 import 'editable_text_utils.dart';
 import 'live_text_utils.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 Matcher matchesMethodCall(String method, {dynamic args}) =>
     _MatchesMethodCall(method, arguments: args == null ? null : wrapMatcher(args));

--- a/packages/flutter/test/widgets/expansible_test.dart
+++ b/packages/flutter/test/widgets/expansible_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('Controller expands and collapses the widget', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'button_tester.dart';
 import 'semantics_tester.dart';
 import 'utils.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   group(WidgetOrderTraversalPolicy, () {

--- a/packages/flutter/test/widgets/gesture_detector_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_test.dart
@@ -7,8 +7,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   const forcePressOffset = Offset(400.0, 50.0);
 

--- a/packages/flutter/test/widgets/image_filter_test.dart
+++ b/packages/flutter/test/widgets/image_filter_test.dart
@@ -15,8 +15,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   const debugBlue = Color(0xFF0000FF);
   testWidgets('Image filter - blur', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/inherited_model_test.dart
+++ b/packages/flutter/test/widgets/inherited_model_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'button_tester.dart';
-import 'widgets_app_tester.dart';
 
 // A simple "flat" InheritedModel: the data model is just 3 integer
 // valued fields: a, b, c.

--- a/packages/flutter/test/widgets/list_view_viewporting_test.dart
+++ b/packages/flutter/test/widgets/list_view_viewporting_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_widgets.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   const debugBlue = Color(0xFF0000FF);

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/rendering_tester.dart' show TestCallbackPainter, TestClipPaintingContext;
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('ListWheelScrollView respects clipBehavior', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/magnifier_test.dart
+++ b/packages/flutter/test/widgets/magnifier_test.dart
@@ -10,8 +10,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 class _MockAnimationController extends AnimationController {
   _MockAnimationController()
     : super(duration: const Duration(minutes: 1), vsync: const TestVSync());

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'button_tester.dart';
-import 'widgets_app_tester.dart';
 
 class _MediaQueryAspectCase {
   const _MediaQueryAspectCase(this.method, this.data);

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 const Color _kTestRed = Color(0xFFFF0000);
 

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -9,8 +9,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 class HoverClient extends StatefulWidget {
   const HoverClient({super.key, this.onHover, this.child, this.onEnter, this.onExit});
 

--- a/packages/flutter/test/widgets/navigator_and_layers_test.dart
+++ b/packages/flutter/test/widgets/navigator_and_layers_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_widgets.dart';
-import 'widgets_app_tester.dart';
 
 class TestCustomPainter extends CustomPainter {
   TestCustomPainter({required this.log, required this.name});

--- a/packages/flutter/test/widgets/navigator_replacement_test.dart
+++ b/packages/flutter/test/widgets/navigator_replacement_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'observer_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('Back during pushReplacement', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -18,7 +18,6 @@ import 'navigator_utils.dart';
 import 'observer_tester.dart';
 import 'route_tester.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 @pragma('vm:entry-point')
 Route<void> _routeBuilder(BuildContext context, Object? arguments) {

--- a/packages/flutter/test/widgets/obscured_animated_image_test.dart
+++ b/packages/flutter/test/widgets/obscured_animated_image_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter_test/flutter_test.dart';
 import '../image_data.dart';
 import '../painting/fake_codec.dart';
 import '../painting/fake_image_provider.dart';
-import 'widgets_app_tester.dart';
 
 Future<void> main() async {
   final FakeCodec fakeCodec = await FakeCodec.fromData(Uint8List.fromList(kAnimatedGif));

--- a/packages/flutter/test/widgets/opacity_test.dart
+++ b/packages/flutter/test/widgets/opacity_test.dart
@@ -14,7 +14,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('Opacity', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_forward_transitions_test.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 class TestTransition extends AnimatedWidget {
   const TestTransition({
     super.key,

--- a/packages/flutter/test/widgets/page_route_builder_test.dart
+++ b/packages/flutter/test/widgets/page_route_builder_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'button_tester.dart';
-import 'widgets_app_tester.dart';
 
 const Color _debugBlack54 = Color(0x8A000000);
 const Color _debugTeal = Color(0xFF009688);

--- a/packages/flutter/test/widgets/page_storage_test.dart
+++ b/packages/flutter/test/widgets/page_storage_test.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('PageStorage read and write', (WidgetTester tester) async {
     const Key builderKey = PageStorageKey<String>('builderKey');

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -17,7 +17,6 @@ import '../rendering/rendering_tester.dart' show TestClipPaintingContext;
 import 'semantics_tester.dart';
 import 'states.dart';
 import 'test_page_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   const kBlue = Color(0xFF0000FF);

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -11,8 +11,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 const Color _debugBlack = Color(0xFF000000);
 const Color _debugCanvas = Color(0xFFFAFAFA);
 const Color _debugText = Color(0xDD000000);

--- a/packages/flutter/test/widgets/pinned_header_sliver_test.dart
+++ b/packages/flutter/test/widgets/pinned_header_sliver_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('PinnedHeaderSliver basics', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -8,8 +8,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 

--- a/packages/flutter/test/widgets/pop_scope_test.dart
+++ b/packages/flutter/test/widgets/pop_scope_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'navigator_utils.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   bool? lastFrameworkHandlesBack;

--- a/packages/flutter/test/widgets/radio_group_test.dart
+++ b/packages/flutter/test/widgets/radio_group_test.dart
@@ -11,7 +11,6 @@ import 'checkbox_tester.dart';
 import 'editable_text_tester.dart';
 import 'radio_group_tester.dart';
 import 'radio_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('Radio group control test', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/radio_tester_test.dart
+++ b/packages/flutter/test/widgets/radio_tester_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'radio_group_tester.dart';
 import 'radio_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('TestRadio renders and can be selected', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'button_tester.dart';
-import 'widgets_app_tester.dart';
 
 const Color _green = Color(0xFF00FF00);
 const Color _red = Color(0xFFFF0000);

--- a/packages/flutter/test/widgets/raw_radio_test.dart
+++ b/packages/flutter/test/widgets/raw_radio_test.dart
@@ -12,8 +12,6 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('RawRadio control test', (WidgetTester tester) async {
     final node = FocusNode();

--- a/packages/flutter/test/widgets/raw_tooltip_test.dart
+++ b/packages/flutter/test/widgets/raw_tooltip_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../widgets/feedback_tester.dart';
 import '../widgets/semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 const String tooltipText = 'TIP';
 

--- a/packages/flutter/test/widgets/reassemble_test.dart
+++ b/packages/flutter/test/widgets/reassemble_test.dart
@@ -7,8 +7,6 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('reassemble does not crash', (WidgetTester tester) async {
     await tester.pumpWidget(const TestWidgetsApp(home: Text('Hello World')));

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'list_tile_tester.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 const _kRedColor = Color(0xFFFF0000);
 const _kGreenColor = Color(0xFF00FF00);

--- a/packages/flutter/test/widgets/route_notification_messages_test.dart
+++ b/packages/flutter/test/widgets/route_notification_messages_test.dart
@@ -10,8 +10,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 class OnTapPage extends StatelessWidget {
   const OnTapPage({super.key, required this.id, required this.onTap});
 

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -12,7 +12,6 @@ import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'button_tester.dart';
 import 'test_page_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   const kWhite = Color(0xFFFFFFFF);

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'button_tester.dart';
 import 'editable_text_tester.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 const Color _transparent = Color(0x00000000);
 const Color _green = Color(0xFF00FF00);

--- a/packages/flutter/test/widgets/scroll_activity_test.dart
+++ b/packages/flutter/test/widgets/scroll_activity_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'button_tester.dart';
-import 'widgets_app_tester.dart';
 
 List<Widget> children(int n) {
   return List<Widget>.generate(n, (int i) {

--- a/packages/flutter/test/widgets/scroll_notification_test.dart
+++ b/packages/flutter/test/widgets/scroll_notification_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('ScrollMetricsNotification test', (WidgetTester tester) async {
     final events = <Notification>[];

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'editable_text_tester.dart';
 import 'states.dart';
-import 'widgets_app_tester.dart';
 
 class ItemWidget extends StatefulWidget {
   const ItemWidget({super.key, required this.value});

--- a/packages/flutter/test/widgets/scrollable_fling_test.dart
+++ b/packages/flutter/test/widgets/scrollable_fling_test.dart
@@ -7,8 +7,6 @@ import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 const TextStyle testFont = TextStyle(color: Color(0xFF00FF00));
 
 Future<void> pumpTest(WidgetTester tester, TargetPlatform platform) async {

--- a/packages/flutter/test/widgets/scrollable_helpers_test.dart
+++ b/packages/flutter/test/widgets/scrollable_helpers_test.dart
@@ -8,8 +8,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 final LogicalKeyboardKey modifierKey = defaultTargetPlatform == TargetPlatform.macOS
     ? LogicalKeyboardKey.metaLeft
     : LogicalKeyboardKey.controlLeft;

--- a/packages/flutter/test/widgets/scrollable_selection_test.dart
+++ b/packages/flutter/test/widgets/scrollable_selection_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'clipboard_utils.dart';
 import 'editable_text_tester.dart' show testTextSelectionHandleControls;
 import 'keyboard_utils.dart';
-import 'widgets_app_tester.dart';
 
 Offset textOffsetToPosition(RenderParagraph paragraph, int offset) {
   const caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -14,7 +14,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'button_tester.dart';
 import 'editable_text_tester.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 Future<void> pumpTest(
   WidgetTester tester,

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:web/web.dart' as web;
 
 import 'web_platform_view_registry_utils.dart';
-import 'widgets_app_tester.dart';
 
 extension on web.HTMLCollection {
   Iterable<web.Element?> get iterable =>

--- a/packages/flutter/test/widgets/selectable_region_scroll_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_scroll_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   // Regression test for https://github.com/flutter/flutter/issues/122680.
   testWidgets(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -18,7 +18,6 @@ import 'keyboard_utils.dart';
 import 'process_text_utils.dart';
 import 'semantics_tester.dart';
 import 'test_page_tester.dart';
-import 'widgets_app_tester.dart';
 
 Offset textOffsetToPosition(RenderParagraph paragraph, int offset) {
   const caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);

--- a/packages/flutter/test/widgets/selection_container_test.dart
+++ b/packages/flutter/test/widgets/selection_container_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   Future<void> pumpContainer(WidgetTester tester, Widget child) async {
     await tester.pumpWidget(TestWidgetsApp(home: child));

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -10,7 +10,6 @@ import 'button_tester.dart';
 import 'checkbox_tester.dart';
 import 'editable_text_tester.dart';
 import 'slider_tester.dart';
-import 'widgets_app_tester.dart';
 
 const Color _green = Color(0xFF4CAF50);
 const Color _amber = Color(0xFFFFC107);

--- a/packages/flutter/test/widgets/semantics_keep_alive_offstage_test.dart
+++ b/packages/flutter/test/widgets/semantics_keep_alive_offstage_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets(

--- a/packages/flutter/test/widgets/semantics_tester_generate_test_semantics_expression_for_current_semantics_tree_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_generate_test_semantics_expression_for_current_semantics_tree_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   group('generateTestSemanticsExpressionForCurrentSemanticsTree', () {

--- a/packages/flutter/test/widgets/sensitive_content_test.dart
+++ b/packages/flutter/test/widgets/sensitive_content_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'sensitive_content_utils.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   const ContentSensitivity defaultContentSensitivitySetting = ContentSensitivity.autoSensitive;

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -10,7 +10,6 @@ import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'editable_text_tester.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   const kOrangeColor = Color(0xFFFF8800);

--- a/packages/flutter/test/widgets/shrink_wrapping_viewport_test.dart
+++ b/packages/flutter/test/widgets/shrink_wrapping_viewport_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/rendering_tester.dart' show TestClipPaintingContext;
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('ShrinkWrappingViewport respects clipBehavior', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/simple_semantics_test.dart
+++ b/packages/flutter/test/widgets/simple_semantics_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('Simple tree is simple', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/rendering_tester.dart' show TestClipPaintingContext;
 import 'editable_text_tester.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 class TestScrollPosition extends ScrollPositionWithSingleContext {
   TestScrollPosition({

--- a/packages/flutter/test/widgets/size_changed_layout_notification_test.dart
+++ b/packages/flutter/test/widgets/size_changed_layout_notification_test.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('SizeChangedLayoutNotification test', (WidgetTester tester) async {
     var notified = false;

--- a/packages/flutter/test/widgets/sliver_cross_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_cross_axis_group_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'sliver_utils.dart';
-import 'widgets_app_tester.dart';
 
 const double VIEWPORT_HEIGHT = 600;
 const double VIEWPORT_WIDTH = 300;

--- a/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'button_tester.dart';
-import 'widgets_app_tester.dart';
 
 const Color _debugRed = Color(0xFFFF0000);
 

--- a/packages/flutter/test/widgets/sliver_floating_header_test.dart
+++ b/packages/flutter/test/widgets/sliver_floating_header_test.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('SliverFloatingHeader basics', (WidgetTester tester) async {
     Widget buildFrame({required Axis axis, required bool reverse}) {

--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'list_tile_tester.dart';
 import 'semantics_tester.dart';
 import 'sliver_utils.dart';
-import 'widgets_app_tester.dart';
 
 const double VIEWPORT_HEIGHT = 600;
 const double VIEWPORT_WIDTH = 300;

--- a/packages/flutter/test/widgets/sliver_persistent_header_test.dart
+++ b/packages/flutter/test/widgets/sliver_persistent_header_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'sliver_test_utils.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   void verifyPaintPosition(GlobalKey key, Offset ideal, [bool? visible]) {

--- a/packages/flutter/test/widgets/sliver_prototype_item_extent_test.dart
+++ b/packages/flutter/test/widgets/sliver_prototype_item_extent_test.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 class TestItem extends StatelessWidget {
   const TestItem({super.key, required this.item, this.width, this.height});
   final int item;

--- a/packages/flutter/test/widgets/sliver_resizing_header_test.dart
+++ b/packages/flutter/test/widgets/sliver_resizing_header_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('SliverResizingHeader basics', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/slivers_evil_test.dart
+++ b/packages/flutter/test/widgets/slivers_evil_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 class TestSliverPersistentHeaderDelegate extends SliverPersistentHeaderDelegate {
   TestSliverPersistentHeaderDelegate(this._maxExtent);
 

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 const Color _debugEvenColor = Color(0xFF00FF00);
 const Color _debugOddColor = Color(0xFFFF0000);

--- a/packages/flutter/test/widgets/snapshot_widget_test.dart
+++ b/packages/flutter/test/widgets/snapshot_widget_test.dart
@@ -16,7 +16,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../impeller_test_helpers.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   const kYellowColor = Color(0xFFAABB11);

--- a/packages/flutter/test/widgets/system_context_menu_test.dart
+++ b/packages/flutter/test/widgets/system_context_menu_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../system_context_menu_utils.dart';
 import 'editable_text_tester.dart';
-import 'widgets_app_tester.dart';
 
 Widget _buildSystemContextMenuTestApp({
   required Widget child,

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'editable_text_tester.dart';
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 const Color _debugRowDecorationColor = Color(0xFF00FF00);
 

--- a/packages/flutter/test/widgets/tap_region_test.dart
+++ b/packages/flutter/test/widgets/tap_region_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_page_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('TapRegionSurface detects outside tap down events', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'checkbox_tester.dart';
 import 'editable_text_tester.dart';
-import 'widgets_app_tester.dart';
 
 const Color _debugRed = Color(0xFFFF0000);
 const Color _debugBlue = Color(0xFF0000FF);

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -13,7 +13,6 @@ import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 import 'clipboard_utils.dart';
 import 'editable_text_tester.dart';
 import 'editable_text_utils.dart';
-import 'widgets_app_tester.dart';
 
 const int kSingleTapUpTimeout = 500;
 const Color _white = Color(0xFFFFFFFF);

--- a/packages/flutter/test/widgets/text_semantics_test.dart
+++ b/packages/flutter/test/widgets/text_semantics_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('SemanticsNode ids are stable', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 void main() {
   const kBlack = Color(0xFF000000);

--- a/packages/flutter/test/widgets/ticker_mode_test.dart
+++ b/packages/flutter/test/widgets/ticker_mode_test.dart
@@ -7,8 +7,6 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('Nested TickerMode cannot turn tickers back on', (WidgetTester tester) async {
     var outerTickCount = 0;

--- a/packages/flutter/test/widgets/ticker_provider_test.dart
+++ b/packages/flutter/test/widgets/ticker_provider_test.dart
@@ -8,8 +8,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('TickerMode', (WidgetTester tester) async {
     const Widget widget = TickerMode(enabled: false, child: _TickerWidget());

--- a/packages/flutter/test/widgets/toggleable_test.dart
+++ b/packages/flutter/test/widgets/toggleable_test.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('Toggleable exists in widget layer', (WidgetTester tester) async {
     final testPainter = TestPainter();

--- a/packages/flutter/test/widgets/transformed_scrollable_test.dart
+++ b/packages/flutter/test/widgets/transformed_scrollable_test.dart
@@ -7,8 +7,6 @@ import 'dart:math' as math;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 const Color _kBlue = Color(0xFF0000FF);
 const Color _kRed = Color(0xFFFF0000);
 

--- a/packages/flutter/test/widgets/tween_animation_builder_test.dart
+++ b/packages/flutter/test/widgets/tween_animation_builder_test.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   testWidgets('Animates forward when built', (WidgetTester tester) async {
     final values = <int>[];

--- a/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'editable_text_tester.dart';
 import 'two_dimensional_utils.dart';
-import 'widgets_app_tester.dart';
 
 Widget? _testChildBuilder(BuildContext context, ChildVicinity vicinity) {
   return SizedBox.square(

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -8,8 +8,7 @@ import 'package:flutter/foundation.dart' show clampDouble;
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/rendering.dart' show CacheExtentStyle, ViewportOffset;
 import 'package:flutter/widgets.dart';
-
-import 'widgets_app_tester.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 const Color _kAmber100 = Color(0xFFFFF8E1);
 const Color _kBlueAccent100 = Color(0xFF82B1FF);

--- a/packages/flutter/test/widgets/undo_history_test.dart
+++ b/packages/flutter/test/widgets/undo_history_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'editable_text_utils.dart';
-import 'widgets_app_tester.dart';
 
 final FocusNode _focusNode = FocusNode(debugLabel: 'UndoHistory Node');
 

--- a/packages/flutter/test/widgets/value_listenable_builder_test.dart
+++ b/packages/flutter/test/widgets/value_listenable_builder_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   late SpyStringValueNotifier valueListenable;
   late Widget textBuilderUnderTest;

--- a/packages/flutter/test/widgets/visibility_test.dart
+++ b/packages/flutter/test/widgets/visibility_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
-import 'widgets_app_tester.dart';
 
 class TestState extends StatefulWidget {
   const TestState({super.key, required this.child, required this.log});

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -23,7 +23,6 @@ import 'package:leak_tracker/leak_tracker.dart';
 import '../impeller_test_helpers.dart';
 import 'button_tester.dart';
 import 'widget_inspector_test_utils.dart';
-import 'widgets_app_tester.dart';
 
 // Start of block of code where widget creation location line numbers and
 // columns will impact whether tests pass.

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -3228,18 +3228,12 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         expect(count, equals(5));
       });
 
-      testWidgets('clearCandidates preserves current selection', (
-        WidgetTester tester,
-      ) async {
+      testWidgets('clearCandidates preserves current selection', (WidgetTester tester) async {
         await pumpWidgetTreeWithABC(tester);
         final selection = InspectorSelection();
         addTearDown(selection.dispose);
-        final RenderParagraph renderObjectA = tester.renderObject<RenderParagraph>(
-          find.text('a'),
-        );
-        final RenderParagraph renderObjectB = tester.renderObject<RenderParagraph>(
-          find.text('b'),
-        );
+        final RenderParagraph renderObjectA = tester.renderObject<RenderParagraph>(find.text('a'));
+        final RenderParagraph renderObjectB = tester.renderObject<RenderParagraph>(find.text('b'));
 
         selection.candidates = <RenderObject>[renderObjectA, renderObjectB];
         expect(selection.current, renderObjectA);
@@ -3317,9 +3311,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       final List<RenderObject> candidates = WidgetInspectorService.instance.selection.candidates;
       expect(candidates, isNot(contains(behindRender)));
 
-      final RenderObject sheetRender = tester.renderObject<RenderObject>(
-        find.byKey(sheetTextKey),
-      );
+      final RenderObject sheetRender = tester.renderObject<RenderObject>(find.byKey(sheetTextKey));
       expect(candidates, contains(sheetRender));
     });
 
@@ -3402,11 +3394,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       await tester.tap(find.byKey(innerTextKey), warnIfMissed: false);
       await tester.pump();
 
-      final RenderObject innerRender = tester.renderObject<RenderObject>(
-        find.byKey(innerTextKey),
-      );
-      final List<RenderObject> candidates =
-          WidgetInspectorService.instance.selection.candidates;
+      final RenderObject innerRender = tester.renderObject<RenderObject>(find.byKey(innerTextKey));
+      final List<RenderObject> candidates = WidgetInspectorService.instance.selection.candidates;
       expect(candidates, contains(innerRender));
     });
 
@@ -4619,7 +4608,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         _CreationLocation location = knownLocations[id]!;
         expect(location.file, equals(file));
         // ClockText widget.
-        expect(location.line, equals(58));
+        expect(location.line, equals(57));
         expect(location.column, equals(9));
         expect(location.name, equals('ClockText'));
         expect(count, equals(1));
@@ -4629,7 +4618,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         location = knownLocations[id]!;
         expect(location.file, equals(file));
         // Text widget in _ClockTextState build method.
-        expect(location.line, equals(93));
+        expect(location.line, equals(92));
         expect(location.column, equals(12));
         expect(location.name, equals('Text'));
         expect(count, equals(1));
@@ -4656,7 +4645,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         location = knownLocations[id]!;
         expect(location.file, equals(file));
         // ClockText widget.
-        expect(location.line, equals(58));
+        expect(location.line, equals(57));
         expect(location.column, equals(9));
         expect(location.name, equals('ClockText'));
         expect(count, equals(3)); // 3 clock widget instances rebuilt.
@@ -4666,7 +4655,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         location = knownLocations[id]!;
         expect(location.file, equals(file));
         // Text widget in _ClockTextState build method.
-        expect(location.line, equals(93));
+        expect(location.line, equals(92));
         expect(location.column, equals(12));
         expect(location.name, equals('Text'));
         expect(count, equals(3)); // 3 clock widget instances rebuilt.

--- a/packages/flutter_test/lib/flutter_test.dart
+++ b/packages/flutter_test/lib/flutter_test.dart
@@ -90,6 +90,7 @@ export 'src/test_exception_reporter.dart';
 export 'src/test_pointer.dart';
 export 'src/test_text_input.dart';
 export 'src/test_vsync.dart';
+export 'src/test_widgets_app.dart';
 export 'src/tree_traversal.dart';
 export 'src/widget_tester.dart';
 export 'src/window.dart';

--- a/packages/flutter_test/lib/src/test_widgets_app.dart
+++ b/packages/flutter_test/lib/src/test_widgets_app.dart
@@ -53,7 +53,7 @@ import 'package:flutter/widgets.dart';
 ///       onGenerateRoute: (RouteSettings settings) {
 ///         return PageRouteBuilder<void>(
 ///           settings: settings,
-///           pageBuilder: (_, __, ___) => const Text('Generated'),
+///           pageBuilder: (_, _, _) => const Text('Generated'),
 ///         );
 ///       },
 ///     ),
@@ -85,12 +85,21 @@ class TestWidgetsApp extends StatelessWidget {
   /// programmatic navigation without needing to find the [Navigator] widget:
   ///
   /// ```dart
-  /// final navigatorKey = GlobalKey<NavigatorState>();
-  /// await tester.pumpWidget(TestWidgetsApp(
-  ///   navigatorKey: navigatorKey,
-  ///   home: const Text('Home'),
-  /// ));
-  /// navigatorKey.currentState!.pushNamed('/details');
+  /// import 'package:flutter/widgets.dart';
+  /// import 'package:flutter_test/flutter_test.dart';
+  ///
+  /// void main() {
+  ///   testWidgets('widgets app can use navigator test', (WidgetTester tester) async {
+  ///     final navigatorKey = GlobalKey<NavigatorState>();
+  ///
+  ///     await tester.pumpWidget(TestWidgetsApp(
+  ///       navigatorKey: navigatorKey,
+  ///       home: const Text('Home'),
+  ///     ));
+  ///
+  ///     navigatorKey.currentState!.pushNamed('/details');
+  ///   });
+  /// }
   /// ```
   ///
   /// See also:
@@ -188,8 +197,8 @@ class TestWidgetsApp extends StatelessWidget {
   ///     return PageRouteBuilder<T>(
   ///       settings: settings,
   ///       transitionDuration: const Duration(milliseconds: 300),
-  ///       pageBuilder: (context, _, __) => builder(context),
-  ///       transitionsBuilder: (_, animation, __, child) {
+  ///       pageBuilder: (context, _, _) => builder(context),
+  ///       transitionsBuilder: (_, animation, _, child) {
   ///         return FadeTransition(opacity: animation, child: child);
   ///       },
   ///     );

--- a/packages/flutter_test/lib/src/test_widgets_app.dart
+++ b/packages/flutter_test/lib/src/test_widgets_app.dart
@@ -2,21 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter/cupertino.dart';
-/// @docImport 'package:flutter/material.dart';
-/// @docImport 'package:flutter_test/flutter_test.dart';
-library;
-
 import 'package:flutter/widgets.dart';
 
 /// A minimal [WidgetsApp] wrapper for use in widget tests.
 ///
 /// This provides a convenient way to wrap test widgets with the necessary
 /// app-level widgets (like [Directionality], [MediaQuery], etc.) that
-/// [WidgetsApp] provides, without the overhead of [MaterialApp] or [CupertinoApp].
+/// [WidgetsApp] provides, without the overhead of `MaterialApp` or `CupertinoApp`.
 ///
 /// The [pageRouteBuilder] creates a [Navigator] which provides an [Overlay],
-/// so widgets that need overlay support (like [Draggable], [Tooltip], etc.)
+/// so widgets that need overlay support (like [Draggable], [RawTooltip], etc.)
 /// will work correctly when placed in [home].
 ///
 /// Example usage:
@@ -65,8 +60,6 @@ import 'package:flutter/widgets.dart';
 ///   );
 /// });
 /// ```
-// TODO(rkishan516): Move this to flutter_test package.
-// Tracking issue: https://github.com/flutter/flutter/issues/181283
 class TestWidgetsApp extends StatelessWidget {
   /// Creates a minimal [WidgetsApp] for testing.
   const TestWidgetsApp({

--- a/packages/flutter_test/test/test_widgets_app_test.dart
+++ b/packages/flutter_test/test/test_widgets_app_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widgets_app_tester.dart';
-
 void main() {
   group('TestWidgetsApp', () {
     testWidgets('home widget is displayed', (WidgetTester tester) async {


### PR DESCRIPTION
This PR moves the `TestWidgetsApp` class from `flutter/test/widgets_app_tester.dart` to `flutter_test`, under `test_widgets_app.dart`.

Part of https://github.com/flutter/flutter/issues/181283

This came up in https://github.com/flutter/flutter/pull/189265 as both Flutter and flutter_test require it for their tests (as well as future downstream consumers that could benefit from it)

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
