### PR TITLE
Add missing name to mirroring workflow

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -2,7 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Mirror master to main branches in the flutter repository.
+name: Mirror flutter/flutter master branch to main
+
 on:
   push:
     branches:


### PR DESCRIPTION
Name will show up instead of path

<img width="318" height="303" alt="image" src="https://github.com/user-attachments/assets/1a743083-d7e4-49de-8394-40e9547f5b2a" />
