### PR TITLE
[beta] [flutter_tools] Fix ADB device listing output parsing regression

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -115,13 +115,19 @@ class AndroidDevices extends PollingDeviceDiscovery {
   // The regex is structured as:
   // 1. Group 1 (Serial): Lazily matched to allow spaces in the serial (which
   //    can happen during wireless ADB mDNS name conflicts, e.g., "device (2)").
-  // 2. Group 2 (State): Matches "no permissions" explicitly (as it is the only
-  //    known state containing a space) or any other non-whitespace word (\S+).
-  // 3. Group 3 (Extra Info): Anchors the state match by requiring it to be
-  //    followed by either a space and a key:value pair (e.g., "usb:123") or the
-  //    end of the line. This prevents false positives if the serial contains
-  //    state keywords.
-  static final _kDeviceRegex = RegExp(r'^(.*?)\s+(no permissions|\S+)(?:\s+(\w+:.*)|$)');
+  //    The column separator requires at least two spaces or a tab to prevent
+  //    single spaces within a serial from being mis-matched.
+  // 2. Group 2 (State): Matches known ADB device states explicitly, including
+  //    "no permissions" (which contains a space). Explicitly listing states
+  //    prevents false positive state matching on extra device info/attributes
+  //    or serial name components.
+  // 3. Group 3 (Extra Info): Optional trailing details (e.g. key:value pairs
+  //    like "product:mokey model:mokey device:mokey transport_id:1" or "usb:123").
+  static final _kDeviceRegex = RegExp(
+    r'^(.*?)(?:\s{2,}|\t+)'
+    r'(device|offline|unauthorized|no permissions|bootloader|recovery|sideload|rescue|connecting|authorizing|host|unknown)'
+    r'(?:\s+(.*)|$)',
+  );
 
   /// Parse the given `adb devices` output in [text], and fill out the given list
   /// of devices and possible device issue diagnostics. Either argument can be null,

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -549,6 +549,64 @@ device4       unknown usb:3-7
       expect(diagnostics[1], contains('device2 is offline'));
     },
   );
+
+  // Related to https://github.com/flutter/flutter/issues/189274
+  testWithoutContext(
+    'AndroidDevices can parse output with extra non-key-value attributes without mis-matching device ID',
+    () async {
+      final androidDevices = AndroidDevices(
+        userMessages: UserMessages(),
+        androidWorkflow: androidWorkflow,
+        androidSdk: FakeAndroidSdk(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['adb', 'devices', '-l'],
+            stdout: '''
+List of devices attached
+ABCDEFG           device 20-30 product:mokey model:mokey device:mokey transport_id:1
+''',
+          ),
+        ]),
+        platform: FakePlatform(),
+        fileSystem: MemoryFileSystem.test(),
+      );
+
+      final List<Device> devices = await androidDevices.pollingGetDevices();
+
+      expect(devices, hasLength(1));
+      expect(devices.first.id, 'ABCDEFG');
+      expect(devices.first.name, 'mokey');
+    },
+  );
+
+  testWithoutContext(
+    'AndroidDevices handles serial containing spaces and state keywords correctly',
+    () async {
+      final androidDevices = AndroidDevices(
+        userMessages: UserMessages(),
+        androidWorkflow: androidWorkflow,
+        androidSdk: FakeAndroidSdk(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['adb', 'devices', '-l'],
+            stdout: '''
+List of devices attached
+my device (2)          device product:model
+''',
+          ),
+        ]),
+        platform: FakePlatform(),
+        fileSystem: MemoryFileSystem.test(),
+      );
+
+      final List<Device> devices = await androidDevices.pollingGetDevices();
+
+      expect(devices, hasLength(1));
+      expect(devices.first.id, 'my device (2)');
+    },
+  );
 }
 
 class FakeAndroidSdk extends Fake implements AndroidSdk {


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)

### Issue Link:
https://github.com/flutter/flutter/issues/189274

### Impact Description:
Fixes a regression in `flutter_tools` where `adb devices -l` output containing non-key-value attributes (e.g. `ABCDEFG device 20-30 product:mokey ...`) causes regex backtracking, incorrectly capturing `ABCDEFG device` into the device ID. This breaks device discovery and prevents running apps on affected Android devices/bots in devicelab.

### Changelog Description:
[flutter_tools] When parsing ADB device output containing non-key-value attributes on Android, flutter tool misparses the device ID.

### Workaround:
None.

### Risk:
  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
  - [x] Yes
  - [ ] No

### Validation Steps:
Run `flutter test test/general.shard/android/android_device_discovery_test.dart` to verify device regex output parsing.