### PR TITLE
[Linux] Make glBlitFramebuffer optional in the OpenGL compositor

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -21,6 +21,9 @@ struct _FlCompositorOpenGL {
   // TRUE if can share framebuffers between contexts.
   gboolean shareable;
 
+  // TRUE if glBlitFramebuffer can be used to composite the first layer.
+  gboolean can_blit;
+
   // Flutter OpenGL contexts.
   FlOpenGLManager* opengl_manager;
 
@@ -53,18 +56,6 @@ static void fl_compositor_opengl_class_init(FlCompositorOpenGLClass* klass) {
 }
 
 static void fl_compositor_opengl_init(FlCompositorOpenGL* self) {}
-
-FlCompositorOpenGL* fl_compositor_opengl_new(FlOpenGLManager* opengl_manager,
-                                             gboolean shareable) {
-  FlCompositorOpenGL* self = FL_COMPOSITOR_OPENGL(
-      g_object_new(fl_compositor_opengl_get_type(), nullptr));
-
-  self->shareable = shareable;
-  self->opengl_manager = FL_OPENGL_MANAGER(g_object_ref(opengl_manager));
-  self->shader = fl_compositor_opengl_shader_new(opengl_manager);
-
-  return self;
-}
 
 // Checks if the current OpenGL driver is known to have a broken or unsupported
 // glBlitFramebuffer implementation.
@@ -99,6 +90,22 @@ static gboolean can_blit_framebuffer() {
   return driver_supports_blit() &&
          (epoxy_gl_version() >= 30 ||
           epoxy_has_gl_extension("GL_EXT_framebuffer_blit"));
+}
+
+FlCompositorOpenGL* fl_compositor_opengl_new(FlOpenGLManager* opengl_manager,
+                                             gboolean shareable) {
+  FlCompositorOpenGL* self = FL_COMPOSITOR_OPENGL(
+      g_object_new(fl_compositor_opengl_get_type(), nullptr));
+
+  self->shareable = shareable;
+  self->opengl_manager = FL_OPENGL_MANAGER(g_object_ref(opengl_manager));
+  self->shader = fl_compositor_opengl_shader_new(opengl_manager);
+
+  // Determine once whether glBlitFramebuffer is available on this driver.
+  fl_opengl_manager_make_current(opengl_manager);
+  self->can_blit = can_blit_framebuffer();
+
+  return self;
 }
 
 static void composite_layer(FlCompositorOpenGL* self,
@@ -194,7 +201,6 @@ gboolean fl_compositor_opengl_composite_layers(FlCompositorOpenGL* self,
 
   glBindFramebuffer(GL_DRAW_FRAMEBUFFER,
                     fl_framebuffer_get_id(self->framebuffer));
-  gboolean use_blit = can_blit_framebuffer();
   gboolean first_layer = TRUE;
   for (size_t i = 0; i < layers_count; ++i) {
     const FlutterLayer* layer = layers[i];
@@ -206,7 +212,7 @@ gboolean fl_compositor_opengl_composite_layers(FlCompositorOpenGL* self,
         // The first layer can be blitted, and following layers composited with
         // this. If glBlitFramebuffer is unavailable, composite the first layer
         // with the shader instead.
-        if (first_layer && use_blit) {
+        if (first_layer && self->can_blit) {
           glBindFramebuffer(GL_READ_FRAMEBUFFER,
                             fl_framebuffer_get_id(framebuffer));
           glBlitFramebuffer(layer->offset.x, layer->offset.y, layer->size.width,

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -7,6 +7,8 @@
 #include <epoxy/egl.h>
 #include <epoxy/gl.h>
 
+#include <cstring>
+
 #include "flutter/common/constants.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_compositor_opengl_shader.h"
@@ -62,6 +64,41 @@ FlCompositorOpenGL* fl_compositor_opengl_new(FlOpenGLManager* opengl_manager,
   self->shader = fl_compositor_opengl_shader_new(opengl_manager);
 
   return self;
+}
+
+// Checks if the current OpenGL driver is known to have a broken or unsupported
+// glBlitFramebuffer implementation.
+static gboolean driver_supports_blit() {
+  const gchar* vendor = reinterpret_cast<const gchar*>(glGetString(GL_VENDOR));
+  if (vendor == nullptr) {
+    return TRUE;
+  }
+
+  // Note: List of unsupported vendors due to issue
+  // https://github.com/flutter/flutter/issues/152099
+  const char* unsupported_vendors_exact[] = {"Vivante Corporation", "ARM"};
+  const char* unsupported_vendors_fuzzy[] = {"NVIDIA"};
+
+  for (const char* unsupported : unsupported_vendors_fuzzy) {
+    if (strstr(vendor, unsupported) != nullptr) {
+      return FALSE;
+    }
+  }
+  for (const char* unsupported : unsupported_vendors_exact) {
+    if (strcmp(vendor, unsupported) == 0) {
+      return FALSE;
+    }
+  }
+  return TRUE;
+}
+
+// Checks if glBlitFramebuffer can be used. It is a GLES3 / OpenGL 3.0 function
+// and may not be present on older drivers, so treat it as optional and fall
+// back to compositing with the shader when it is unavailable.
+static gboolean can_blit_framebuffer() {
+  return driver_supports_blit() &&
+         (epoxy_gl_version() >= 30 ||
+          epoxy_has_gl_extension("GL_EXT_framebuffer_blit"));
 }
 
 static void composite_layer(FlCompositorOpenGL* self,
@@ -157,6 +194,7 @@ gboolean fl_compositor_opengl_composite_layers(FlCompositorOpenGL* self,
 
   glBindFramebuffer(GL_DRAW_FRAMEBUFFER,
                     fl_framebuffer_get_id(self->framebuffer));
+  gboolean use_blit = can_blit_framebuffer();
   gboolean first_layer = TRUE;
   for (size_t i = 0; i < layers_count; ++i) {
     const FlutterLayer* layer = layers[i];
@@ -165,21 +203,22 @@ gboolean fl_compositor_opengl_composite_layers(FlCompositorOpenGL* self,
         const FlutterBackingStore* backing_store = layer->backing_store;
         FlFramebuffer* framebuffer =
             FL_FRAMEBUFFER(backing_store->open_gl.framebuffer.user_data);
-        glBindFramebuffer(GL_READ_FRAMEBUFFER,
-                          fl_framebuffer_get_id(framebuffer));
         // The first layer can be blitted, and following layers composited with
-        // this.
-        if (first_layer) {
+        // this. If glBlitFramebuffer is unavailable, composite the first layer
+        // with the shader instead.
+        if (first_layer && use_blit) {
+          glBindFramebuffer(GL_READ_FRAMEBUFFER,
+                            fl_framebuffer_get_id(framebuffer));
           glBlitFramebuffer(layer->offset.x, layer->offset.y, layer->size.width,
                             layer->size.height, layer->offset.x,
                             layer->offset.y, layer->size.width,
                             layer->size.height, GL_COLOR_BUFFER_BIT,
                             GL_NEAREST);
-          first_layer = FALSE;
         } else {
           composite_layer(self, framebuffer, layer->offset.x, layer->offset.y,
                           width, height);
         }
+        first_layer = FALSE;
       } break;
       case kFlutterLayerContentTypePlatformView: {
         // TODO(robert-ancell) Not implemented -

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
@@ -267,6 +267,8 @@ TEST_F(FlCompositorOpenGLTest, NoBlitFramebuffer) {
   ON_CALL(epoxy, epoxy_is_desktop_gl).WillByDefault(::testing::Return(true));
   EXPECT_CALL(epoxy, epoxy_gl_version).WillRepeatedly(::testing::Return(20));
 
+  EXPECT_CALL(epoxy, glBlitFramebuffer).Times(0);
+
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, width, height, FALSE);
   FlutterBackingStore backing_store = {
@@ -304,6 +306,8 @@ TEST_F(FlCompositorOpenGLTest, BlitFramebufferNvidia) {
           ::testing::Return(reinterpret_cast<const GLubyte*>("NVIDIA")));
   ON_CALL(epoxy, epoxy_is_desktop_gl).WillByDefault(::testing::Return(true));
   EXPECT_CALL(epoxy, epoxy_gl_version).WillRepeatedly(::testing::Return(30));
+
+  EXPECT_CALL(epoxy, glBlitFramebuffer).Times(0);
 
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, width, height, FALSE);

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
@@ -24,7 +24,6 @@ class FlCompositorOpenGLTest : public flutter::testing::LinuxTest {
   void SetUp() override {
     opengl_manager = fl_opengl_manager_new();
     renderable = fl_mock_renderable_new();
-    compositor = fl_compositor_opengl_new(opengl_manager, FALSE);
     fl_engine_set_implicit_view(engine, FL_RENDERABLE(renderable));
   }
 
@@ -44,6 +43,7 @@ TEST_F(FlCompositorOpenGLTest, Render) {
   // Present layer from a thread.
   constexpr size_t width = 100;
   constexpr size_t height = 100;
+  compositor = fl_compositor_opengl_new(opengl_manager, FALSE);
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, width, height, FALSE);
   FlutterBackingStore backing_store = {
@@ -79,6 +79,7 @@ TEST_F(FlCompositorOpenGLTest, Resize) {
   // Present a layer that is the old size.
   constexpr size_t width1 = 90;
   constexpr size_t height1 = 90;
+  compositor = fl_compositor_opengl_new(opengl_manager, FALSE);
   g_autoptr(FlFramebuffer) framebuffer1 =
       fl_framebuffer_new(GL_RGB, width1, height1, FALSE);
   FlutterBackingStore backing_store1 = {
@@ -135,6 +136,8 @@ TEST_F(FlCompositorOpenGLTest, RestoresGLState) {
   ON_CALL(epoxy, epoxy_is_desktop_gl).WillByDefault(::testing::Return(true));
   ON_CALL(epoxy, epoxy_gl_version).WillByDefault(::testing::Return(30));
 
+  compositor = fl_compositor_opengl_new(opengl_manager, FALSE);
+
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, width, height, FALSE);
   FlutterBackingStore backing_store = {
@@ -186,6 +189,8 @@ TEST_F(FlCompositorOpenGLTest, BlitFramebuffer) {
 
   EXPECT_CALL(epoxy, glBlitFramebuffer);
 
+  compositor = fl_compositor_opengl_new(opengl_manager, FALSE);
+
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, width, height, FALSE);
   FlutterBackingStore backing_store = {
@@ -230,6 +235,8 @@ TEST_F(FlCompositorOpenGLTest, BlitFramebufferExtension) {
 
   EXPECT_CALL(epoxy, glBlitFramebuffer);
 
+  compositor = fl_compositor_opengl_new(opengl_manager, FALSE);
+
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, width, height, FALSE);
   FlutterBackingStore backing_store = {
@@ -268,6 +275,8 @@ TEST_F(FlCompositorOpenGLTest, NoBlitFramebuffer) {
   EXPECT_CALL(epoxy, epoxy_gl_version).WillRepeatedly(::testing::Return(20));
 
   EXPECT_CALL(epoxy, glBlitFramebuffer).Times(0);
+
+  compositor = fl_compositor_opengl_new(opengl_manager, FALSE);
 
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, width, height, FALSE);
@@ -309,6 +318,8 @@ TEST_F(FlCompositorOpenGLTest, BlitFramebufferNvidia) {
 
   EXPECT_CALL(epoxy, glBlitFramebuffer).Times(0);
 
+  compositor = fl_compositor_opengl_new(opengl_manager, FALSE);
+
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, width, height, FALSE);
   FlutterBackingStore backing_store = {
@@ -339,6 +350,7 @@ TEST_F(FlCompositorOpenGLTest, RenderResizeCrash) {
   // Present layer of size 100x100.
   constexpr size_t width = 100;
   constexpr size_t height = 100;
+  compositor = fl_compositor_opengl_new(opengl_manager, FALSE);
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, width, height, FALSE);
   FlutterBackingStore backing_store = {


### PR DESCRIPTION
glBlitFramebuffer is a GLES3 / OpenGL 3.0 function and is not guaranteed to be present, so the Linux embedder should treat it as optional. The compositor was calling it unconditionally to blit the first layer, which breaks on OpenGL 2.0 drivers without the GL_EXT_framebuffer_blit extension and on drivers with a broken implementation (NVIDIA, Vivante, ARM per https://github.com/flutter/flutter/issues/152099).

Restore the blit-availability detection (GL version >= 3.0 or the GL_EXT_framebuffer_blit extension, plus the driver blacklist) and fall back to shader-based compositing for the first layer when blit is unavailable.

This regressed in e983e59620709889ad7aadc7702af3000d4429a0 ("Perform OpenGL compositing in the Flutter thread and write to a framebuffer." #172090), which consolidated compositing and dropped the has_gl_framebuffer_blit check.

Strengthen the NoBlitFramebuffer and BlitFramebufferNvidia tests to assert glBlitFramebuffer is never called.

Fixes https://github.com/flutter/flutter/issues/189322
