### PR TITLE
Stop querying Spotlight for Android Studio discovery

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -11,7 +11,6 @@ import '../base/io.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
 import '../base/version.dart';
-import '../convert.dart';
 import '../globals.dart' as globals;
 import '../ios/plist_parser.dart';
 
@@ -318,25 +317,6 @@ class AndroidStudio {
         (FileSystemEntity e) => _pathsAreEqual(e.path, configuredStudioDir!.path),
       )) {
         candidatePaths.add(configuredStudioDir);
-      }
-    }
-
-    // Query Spotlight for unexpected installation locations.
-    var spotlightQueryResult = '';
-    try {
-      final ProcessResult spotlightResult = globals.processManager.runSync(<String>[
-        'mdfind',
-        // com.google.android.studio, com.google.android.studio-EAP
-        'kMDItemCFBundleIdentifier="com.google.android.studio*"',
-      ]);
-      spotlightQueryResult = spotlightResult.stdout as String;
-    } on ProcessException {
-      // The Spotlight query is a nice-to-have, continue checking known installation locations.
-    }
-    for (final String studioPath in LineSplitter.split(spotlightQueryResult)) {
-      final Directory appBundle = globals.fs.directory(studioPath);
-      if (!candidatePaths.any((FileSystemEntity e) => e.path == studioPath)) {
-        candidatePaths.add(appBundle);
       }
     }
 

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -421,99 +421,43 @@ void main() {
     );
 
     testUsingContext(
-      'discovers installation from Spotlight query',
+      'discovers installation without querying Spotlight',
       () {
-        // One in expected location.
-        final String studioInApplication = fileSystem.path.join(
+        final String applicationPlistFolder = fileSystem.path.join(
           '/',
-          'Application',
+          'Applications',
           'Android Studio.app',
-        );
-        final String studioInApplicationPlistFolder = fileSystem.path.join(
-          studioInApplication,
           'Contents',
         );
-        fileSystem.directory(studioInApplicationPlistFolder).createSync(recursive: true);
-        final String plistFilePath = fileSystem.path.join(
-          studioInApplicationPlistFolder,
-          'Info.plist',
-        );
-        plistUtils.fileContents[plistFilePath] = macStudioInfoPlist4_1;
+        fileSystem.directory(applicationPlistFolder).createSync(recursive: true);
 
-        // Two in random location only Spotlight knows about.
-        final String randomLocation1 = fileSystem.path.join(
-          '/',
-          'random',
-          'Android Studio Preview.app',
-        );
-        final String randomLocation1PlistFolder = fileSystem.path.join(randomLocation1, 'Contents');
-        fileSystem.directory(randomLocation1PlistFolder).createSync(recursive: true);
-        final String randomLocation1PlistPath = fileSystem.path.join(
-          randomLocation1PlistFolder,
+        final String applicationsPlistFilePath = fileSystem.path.join(
+          applicationPlistFolder,
           'Info.plist',
         );
-        plistUtils.fileContents[randomLocation1PlistPath] = macStudioInfoPlist4_1;
+        plistUtils.fileContents[applicationsPlistFilePath] = macStudioInfoPlist2022_1;
 
-        final String randomLocation2 = fileSystem.path.join(
-          '/',
-          'random',
-          'Android Studio with Blaze.app',
-        );
-        final String randomLocation2PlistFolder = fileSystem.path.join(randomLocation2, 'Contents');
-        fileSystem.directory(randomLocation2PlistFolder).createSync(recursive: true);
-        final String randomLocation2PlistPath = fileSystem.path.join(
-          randomLocation2PlistFolder,
-          'Info.plist',
-        );
-        plistUtils.fileContents[randomLocation2PlistPath] = macStudioInfoPlist4_1;
-        final String javaBin = fileSystem.path.join(
-          'jre',
-          'jdk',
+        final String javaBinary = fileSystem.path.join(
+          applicationPlistFolder,
+          'jbr',
           'Contents',
           'Home',
           'bin',
           'java',
         );
+        processManager.addCommand(
+          FakeCommand(command: <String>[javaBinary, '-version'], stderr: '123'),
+        );
 
-        // Spotlight finds the one known and two random installations.
-        processManager.addCommands(<FakeCommand>[
-          FakeCommand(
-            command: const <String>[
-              'mdfind',
-              'kMDItemCFBundleIdentifier="com.google.android.studio*"',
-            ],
-            stdout: '$randomLocation1\n$randomLocation2\n$studioInApplication',
-          ),
-          FakeCommand(
-            command: <String>[
-              fileSystem.path.join(randomLocation1, 'Contents', javaBin),
-              '-version',
-            ],
-          ),
-          FakeCommand(
-            command: <String>[
-              fileSystem.path.join(randomLocation2, 'Contents', javaBin),
-              '-version',
-            ],
-          ),
-          FakeCommand(
-            command: <String>[
-              fileSystem.path.join(studioInApplicationPlistFolder, javaBin),
-              '-version',
-            ],
-          ),
-        ]);
+        final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
-        // Results are de-duplicated, only 3 installed.
-        expect(AndroidStudio.allInstalled().length, 3);
+        expect(studio.version, equals(Version(2022, 1, null)));
         expect(processManager, hasNoRemainingExpectations);
       },
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         FileSystemUtils: () => fsUtils,
         ProcessManager: () => processManager,
-        // Custom home paths are not supported on macOS nor Windows yet,
-        // so we force the platform to fake Linux here.
         Platform: () => platform,
         PlistParser: () => plistUtils,
       },
@@ -826,16 +770,9 @@ void main() {
           'java',
         );
 
-        processManager.addCommands(<FakeCommand>[
-          FakeCommand(
-            command: const <String>[
-              'mdfind',
-              'kMDItemCFBundleIdentifier="com.google.android.studio*"',
-            ],
-            stdout: extractedDownloadZip,
-          ),
+        processManager.addCommand(
           FakeCommand(command: <String>[studioInApplicationJavaBinary, '-version']),
-        ]);
+        );
 
         final AndroidStudio studio = AndroidStudio.allInstalled().single;
 


### PR DESCRIPTION
Removes the macOS Spotlight `mdfind` lookup from Android Studio discovery. `mdfind` was only used for unexpected installation locations, but it is a synchronous process call and can hang `flutter doctor`/`flutter daemon` when Spotlight is unresponsive.

Android Studio is still discovered from the existing known locations (`/Applications`, `~/Applications`) and from `flutter config --android-studio-dir`.

Fixes https://github.com/flutter/flutter/issues/189177

## Tests

- `dart format --set-exit-if-changed packages/flutter_tools/lib/src/android/android_studio.dart packages/flutter_tools/test/general.shard/android/android_studio_test.dart`
- `./bin/flutter test packages/flutter_tools/test/general.shard/android/android_studio_test.dart`
- `./bin/flutter analyze packages/flutter_tools/lib/src/android/android_studio.dart packages/flutter_tools/test/general.shard/android/android_studio_test.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md