### PR TITLE
[iOS] Migrate DisplayLinkManager to a shared instance

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -256,6 +256,7 @@ if (enable_ios_unittests) {
     sources = [
       "framework/Source/AccessibilityFeaturesTests.swift",
       "framework/Source/ConnectionCollectionTest.swift",
+      "framework/Source/DisplayLinkManagerTest.swift",
       "framework/Source/FakeUIPressProxy.swift",
       "framework/Source/LaunchEngineTest.swift",
       "framework/Source/SplashScreenManagerTests.swift",

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManager.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManager.swift
@@ -4,10 +4,8 @@
 
 import UIKit
 
-/// Provides access to display capabilities and configuration metadata.
-///
-/// - Warning: Do not use this class to drive active frame scheduling or rendering loops. For frame
-///   scheduling, use `VSyncClient` instead.
+/// Provides access to display capabilities and configuration metadata, such as the current
+/// maximum refresh rate and whether ProMotion's full refresh-rate range is enabled.
 ///
 /// This class is responsible for display link configuration management, such as querying the
 /// maximum supported refresh rate from the platform as well as plist-based configuration.
@@ -16,10 +14,18 @@ import UIKit
 /// the `CADisableMinimumFrameDurationOnPhone` key (`disableMinimumFrameDurationOnPhoneKey`) to
 /// `true` in the application's `Info.plist`. iPad Pro devices will use 120Hz by default.
 ///
-/// - Note: This class contains only stateless `static` properties and class methods and should not
-///   be instantiated.
+/// All mutable state is confined to `displayRefreshRate`, which is only ever read or written while
+/// holding a lock. All other stored properties are immutable, so instances are safe to share and
+/// read from any thread once constructed.
 @objc(FlutterDisplayLinkManager)
-public class DisplayLinkManager: NSObject {
+public final class DisplayLinkManager: NSObject, @unchecked Sendable {
+
+  /// The shared DisplayLinkManager.
+  ///
+  /// The first access performs a one-time read of `UIScreen.main`, and must happen on the main
+  /// thread; this is enforced by an assertion in `init()`.
+  @objc
+  public static let shared = DisplayLinkManager()
 
   /// Info.plist key enabling the full range of ProMotion refresh rates for CADisplayLink callbacks
   /// and CAAnimation animations in the app.
@@ -29,55 +35,106 @@ public class DisplayLinkManager: NSObject {
 
   /// Whether the max refresh rate on iPhone ProMotion devices is enabled.
   ///
-  /// This reflects the value of `disableMinimumFrameDurationOnPhoneKey` in the info.plist file.
-  /// On iPads that support ProMotion, the max refresh rate is enabled by default. Maximum frame
+  /// This reflects the value of `disableMinimumFrameDurationOnPhoneKey` in the info.plist file. On
+  /// iPads that support ProMotion, the max refresh rate is enabled by default. The maximum frame
   /// rate can be limited via `VSyncClient.setMaxRefreshRate(_:)`
   ///
   /// - Returns: `true` if the max refresh rate on ProMotion devices is enabled.
   @objc
-  public static var maxRefreshRateEnabledOnIPhone: Bool {
-    return Bundle.main.object(forInfoDictionaryKey: disableMinimumFrameDurationOnPhoneKey)
-      as? Bool ?? false
+  public let maxRefreshRateEnabledOnIPhone: Bool
+
+  /// The maximum display refresh rate, in frames per second.
+  @objc
+  public var displayRefreshRate: Double {
+    // We cache the refresh rate rather than query from UIKit on every read, since this can be read
+    // from background engine threads. The value is kept up-to-date by observing display-mode and
+    // low-power-mode change notifications, so callers always see an up-to-date value without
+    // polling UIKit themselves.
+    //
+    // This always reports the hardware/plist-configured maximum. Implement a means for callers to
+    // request a reduced maximum frame rate.
+    //
+    // TODO(cbracken): https://github.com/flutter/flutter/issues/185759
+    refreshRateLock.lock()
+    defer { refreshRateLock.unlock() }
+    return _displayRefreshRate
   }
 
-  /// The maximum display refresh rate used for reporting purposes.
-  ///
-  /// This is intended to return either the hardware maximum refresh rate or the maximum configured
-  /// by the user (e.g. via an Info.plist setting or custom configuration). The engine does not care
-  /// about this for frame scheduling. It is only used by tools for instrumentation. The engine uses
-  /// the duration field of the link per frame for frame scheduling.
-  ///
-  /// - Attention: Do not use this call in frame scheduling. It is only meant for reporting.
-  /// - Returns: The refresh rate in frames per second.
-  @objc
-  public static var displayRefreshRate: Double {
-    // TODO(cbracken): This code is incorrect. https://github.com/flutter/flutter/issues/185759
-    //
-    // We create a new CADisplayLink, call `preferredFramesPerSecond` on it, then immediately throw
-    // it away. As noted below, the default value for `preferredFramesPerSecond` is zero, in which
-    // case, we just return UIScreen.main.maximumFramesPerSecond in all cases; everything before
-    // that line can be deleted.
-    //
-    // If we intend to support configurable preferred FPS, then we should provide API for it. We
-    // should delete this code either way.
+  private var _displayRefreshRate: Double
+  private let refreshRateLock = NSLock()
 
-    let displayLink = CADisplayLink(target: self, selector: #selector(onDisplayLink(_:)))
-    displayLink.isPaused = true
-    let preferredFPS = displayLink.preferredFramesPerSecond
+  /// The observer tokens returned by `NotificationCenter.addObserver`.
+  ///
+  /// If these aren't retained, they're deallocated immediately and the observers stop firing.
+  private var observers: [Any] = []
 
-    // From Docs:
-    // The default value for preferredFramesPerSecond is 0. When this value is 0, the preferred
-    // frame rate is equal to the maximum refresh rate of the display, as indicated by the
-    // maximumFramesPerSecond property.
-    if preferredFPS != 0 {
-      return Double(preferredFPS)
+  /// Initializes a new DisplayLinkManager.
+  ///
+  /// Queries the system plist and main screen properties on the main thread, then starts observing
+  /// for changes that can affect the cached refresh rate.
+  private override init() {
+    assert(
+      Thread.isMainThread,
+      "DisplayLinkManager.shared must first be accessed on the main thread.")
+    self.maxRefreshRateEnabledOnIPhone =
+      Bundle.main.object(
+        forInfoDictionaryKey: DisplayLinkManager.disableMinimumFrameDurationOnPhoneKey
+      ) as? Bool ?? false
+
+    self._displayRefreshRate = Double(UIScreen.main.maximumFramesPerSecond)
+    super.init()
+
+    startObservingDisplayConfigurationChanges()
+  }
+
+  /// Testing initializer that injects configuration values.
+  ///
+  /// Unlike the standard initializer, this does not start observing system notifications.
+  internal init(maxRefreshRateEnabled: Bool, refreshRate: Double) {
+    self.maxRefreshRateEnabledOnIPhone = maxRefreshRateEnabled
+    self._displayRefreshRate = refreshRate
+    super.init()
+  }
+
+  /// Starts watching for system changes that can affect `UIScreen.main.maximumFramesPerSecond`.
+  ///
+  /// Triggers for frame-rate changes include Low Power Mode or thermal throttling being enabled
+  /// (which caps ProMotion to 60Hz), or the screen's mode changing (e.g. an external display
+  /// connecting).
+  ///
+  /// There's no documented, exhaustive list of everything that can affect the reported refresh
+  /// rate, so on top of the specific triggers above, this also updates whenever the app returns
+  /// to the foreground. That bounds how stale the cached value can get even from a trigger this
+  /// class doesn't explicitly know about.
+  private func startObservingDisplayConfigurationChanges() {
+    let handleChange: (Notification) -> Void = { [weak self] _ in
+      guard let self = self else { return }
+      self.updateCachedDisplayRefreshRate(Double(UIScreen.main.maximumFramesPerSecond))
     }
-
-    return Double(UIScreen.main.maximumFramesPerSecond)
+    observers = [
+      NotificationCenter.default.addObserver(
+        forName: UIScreen.modeDidChangeNotification, object: UIScreen.main, queue: .main,
+        using: handleChange),
+      NotificationCenter.default.addObserver(
+        forName: .NSProcessInfoPowerStateDidChange, object: nil, queue: .main,
+        using: handleChange),
+      NotificationCenter.default.addObserver(
+        forName: ProcessInfo.thermalStateDidChangeNotification, object: nil, queue: .main,
+        using: handleChange),
+      NotificationCenter.default.addObserver(
+        forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main,
+        using: handleChange),
+    ]
   }
 
-  @objc
-  private static func onDisplayLink(_ link: CADisplayLink) {
-    // no-op.
+  /// Updates the cached refresh rate under `refreshRateLock`.
+  ///
+  /// Used by the notification observers started in `startObservingDisplayConfigurationChanges()`.
+  /// Marking as `internal` rather than `private` to allow tests to exercise the locking/storage
+  /// behavior directly, without being able to change what `UIScreen.main` reports in a test host.
+  internal func updateCachedDisplayRefreshRate(_ newValue: Double) {
+    refreshRateLock.lock()
+    _displayRefreshRate = newValue
+    refreshRateLock.unlock()
   }
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManager.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManager.swift
@@ -58,19 +58,24 @@ public final class DisplayLinkManager: NSObject, @unchecked Sendable {
 
   /// The maximum display refresh rate, in frames per second.
   @objc
-  public var displayRefreshRate: Double {
-    // We cache the refresh rate rather than query from UIKit on every read, since this can be read
-    // from background engine threads. The value is kept up-to-date by observing display-mode and
-    // low-power-mode change notifications, so callers always see an up-to-date value without
-    // polling UIKit themselves.
-    //
-    // This always reports the hardware/plist-configured maximum. Implement a means for callers to
-    // request a reduced maximum frame rate.
-    //
-    // TODO(cbracken): https://github.com/flutter/flutter/issues/185759
-    refreshRateLock.lock()
-    defer { refreshRateLock.unlock() }
-    return _displayRefreshRate
+  public internal(set) var displayRefreshRate: Double {
+    get {
+      // We cache the refresh rate rather than query from UIKit on every read, since this can be
+      // read from background engine threads. The value is kept up-to-date by observing
+      // display-mode and low-power-mode change notifications, so callers always see an
+      // up-to-date value without polling UIKit themselves.
+      //
+      // This always reports the hardware/plist-configured maximum. Implement a means for
+      // callers to request a reduced maximum frame rate.
+      //
+      // TODO(cbracken): https://github.com/flutter/flutter/issues/185759
+      refreshRateLock.withLock { _displayRefreshRate }
+    }
+    // The setter is `internal` rather than `private` so tests can exercise the locking/storage
+    // behavior directly, without being able to change what `UIScreen.main` reports in a test host.
+    set {
+      refreshRateLock.withLock { _displayRefreshRate = newValue }
+    }
   }
 
   private var _displayRefreshRate: Double
@@ -122,7 +127,7 @@ public final class DisplayLinkManager: NSObject, @unchecked Sendable {
   private func startObservingDisplayConfigurationChanges() {
     let handleChange: (Notification) -> Void = { [weak self] _ in
       guard let self = self else { return }
-      self.updateCachedDisplayRefreshRate(Double(UIScreen.main.maximumFramesPerSecond))
+      self.displayRefreshRate = Double(UIScreen.main.maximumFramesPerSecond)
     }
     observers = [
       NotificationCenter.default.addObserver(
@@ -138,16 +143,5 @@ public final class DisplayLinkManager: NSObject, @unchecked Sendable {
         forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main,
         using: handleChange),
     ]
-  }
-
-  /// Updates the cached refresh rate under `refreshRateLock`.
-  ///
-  /// Used by the notification observers started in `startObservingDisplayConfigurationChanges()`.
-  /// Marking as `internal` rather than `private` to allow tests to exercise the locking/storage
-  /// behavior directly, without being able to change what `UIScreen.main` reports in a test host.
-  internal func updateCachedDisplayRefreshRate(_ newValue: Double) {
-    refreshRateLock.lock()
-    _displayRefreshRate = newValue
-    refreshRateLock.unlock()
   }
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManager.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManager.swift
@@ -4,19 +4,32 @@
 
 import UIKit
 
-/// Provides access to display capabilities and configuration metadata, such as the current
-/// maximum refresh rate and whether ProMotion's full refresh-rate range is enabled.
+/// Reports the device's display capabilities, including the maximum refresh rate a display can
+/// support and whether the full ProMotion refresh-rate range is unlocked for this app.
 ///
-/// This class is responsible for display link configuration management, such as querying the
-/// maximum supported refresh rate from the platform as well as plist-based configuration.
+/// The maximum refresh rate is the hardware ceiling for the display. On a ProMotion display the
+/// ceiling is commonly 120Hz, while CoreAnimation remains free to drive the panel at any rate at or
+/// below that ceiling depending on on-screen content, thermal state, and power settings. The live
+/// rate is derived separately, once per frame, from the timing of the `CADisplayLink` held by
+/// `VSyncClient`.
 ///
-/// On ProMotion iPhones, 120Hz variable refresh rate support must be explicitly unlocked by setting
-/// the `CADisableMinimumFrameDurationOnPhone` key (`disableMinimumFrameDurationOnPhoneKey`) to
-/// `true` in the application's `Info.plist`. iPad Pro devices will use 120Hz by default.
+/// The full ProMotion refresh-rate range must be explicitly unlocked by setting the
+/// `CADisableMinimumFrameDurationOnPhone` key (`disableMinimumFrameDurationOnPhoneKey`) to `true`
+/// in the application's `Info.plist`; iPad Pro devices default to the full range without this key.
 ///
-/// All mutable state is confined to `displayRefreshRate`, which is only ever read or written while
-/// holding a lock. All other stored properties are immutable, so instances are safe to share and
-/// read from any thread once constructed.
+/// Callers obtain the singleton instance via `shared` and typically use
+/// `maxRefreshRateEnabledOnIPhone` and `displayRefreshRate` to configure a `CADisplayLink`'s
+/// `preferredFrameRateRange`, either indirectly through a `VSyncClient`'s initializer or, in the
+/// case of `FlutterMetalLayer`, by configuring its own `CADisplayLink` similarly. The primary
+/// consumer is `VsyncWaiterIOS`, the C++ engine's vsync entry point, which owns a long-lived
+/// `VSyncClient` and re-reads `displayRefreshRate` on every vsync to detect ceiling changes at
+/// runtime and propagate them to the core engine. `KeyboardInsetManager` and
+/// `FlutterViewController` consult it the same way when configuring their own (short-lived)
+/// `VSyncClient` instances.
+///
+/// All mutable state is confined to the refresh-rate cache, which is only ever read or written
+/// while holding a lock; every other stored property is immutable, so instances are safe to share
+/// and read from any thread once constructed.
 @objc(FlutterDisplayLinkManager)
 public final class DisplayLinkManager: NSObject, @unchecked Sendable {
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManagerTest.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManagerTest.swift
@@ -30,11 +30,11 @@ class DisplayLinkManagerTest: XCTestCase {
     XCTAssertGreaterThan(shared.displayRefreshRate, 0.0)
   }
 
-  func testUpdateCachedDisplayRefreshRateIsReflectedByTheGetter() {
+  func testSettingDisplayRefreshRateIsReflectedByTheGetter() {
     let manager = DisplayLinkManager(maxRefreshRateEnabled: true, refreshRate: 60.0)
     XCTAssertEqual(manager.displayRefreshRate, 60.0)
 
-    manager.updateCachedDisplayRefreshRate(120.0)
+    manager.displayRefreshRate = 120.0
 
     XCTAssertEqual(manager.displayRefreshRate, 120.0)
   }
@@ -54,7 +54,7 @@ class DisplayLinkManagerTest: XCTestCase {
     // UIScreen.main's reported refresh rate can't be swizzled from a test, so this only
     // confirms that the notification handlers run to completion without crashing or
     // deadlocking. The locking/storage behavior they rely on is covered directly by
-    // testUpdateCachedDisplayRefreshRateIsReflectedByTheGetter above.
+    // testSettingDisplayRefreshRateIsReflectedByTheGetter above.
     XCTAssertGreaterThan(shared.displayRefreshRate, 0.0)
   }
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManagerTest.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManagerTest.swift
@@ -1,0 +1,60 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import XCTest
+
+@testable import InternalFlutterSwift
+
+class DisplayLinkManagerTest: XCTestCase {
+
+  func testDisplayLinkManagerCanBeInstantiatedWithMockValues() {
+    let manager = DisplayLinkManager(maxRefreshRateEnabled: true, refreshRate: 120.0)
+
+    XCTAssertTrue(manager.maxRefreshRateEnabledOnIPhone)
+    XCTAssertEqual(manager.displayRefreshRate, 120.0)
+  }
+
+  func testDisplayLinkManagerCanBeInstantiatedWithAlternateMockValues() {
+    let manager = DisplayLinkManager(maxRefreshRateEnabled: false, refreshRate: 60.0)
+
+    XCTAssertFalse(manager.maxRefreshRateEnabledOnIPhone)
+    XCTAssertEqual(manager.displayRefreshRate, 60.0)
+  }
+
+  func testSharedInstanceReturnsAValidValue() {
+    // Verify that the production shared instance does not crash when accessed in test environment.
+    let shared = DisplayLinkManager.shared
+
+    XCTAssertNotNil(shared)
+    XCTAssertGreaterThan(shared.displayRefreshRate, 0.0)
+  }
+
+  func testUpdateCachedDisplayRefreshRateIsReflectedByTheGetter() {
+    let manager = DisplayLinkManager(maxRefreshRateEnabled: true, refreshRate: 60.0)
+    XCTAssertEqual(manager.displayRefreshRate, 60.0)
+
+    manager.updateCachedDisplayRefreshRate(120.0)
+
+    XCTAssertEqual(manager.displayRefreshRate, 120.0)
+  }
+
+  func testDisplayConfigurationNotificationsAreHandledWithoutCrashing() {
+    let shared = DisplayLinkManager.shared
+    let expectation = expectation(description: "Notification handlers ran on the main queue")
+
+    NotificationCenter.default.post(name: UIScreen.modeDidChangeNotification, object: UIScreen.main)
+    NotificationCenter.default.post(name: .NSProcessInfoPowerStateDidChange, object: nil)
+    NotificationCenter.default.post(
+      name: ProcessInfo.thermalStateDidChangeNotification, object: nil)
+    NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+    DispatchQueue.main.async { expectation.fulfill() }
+    wait(for: [expectation], timeout: 1.0)
+
+    // UIScreen.main's reported refresh rate can't be swizzled from a test, so this only
+    // confirms that the notification handlers run to completion without crashing or
+    // deadlocking. The locking/storage behavior they rely on is covered directly by
+    // testUpdateCachedDisplayRefreshRateIsReflectedByTheGetter above.
+    XCTAssertGreaterThan(shared.displayRefreshRate, 0.0)
+  }
+}

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -185,7 +185,7 @@ extern CFTimeInterval display_link_target;
     FlutterMetalLayerDisplayLinkProxy* proxy =
         [[FlutterMetalLayerDisplayLinkProxy alloc] initWithLayer:self];
     _displayLink = [CADisplayLink displayLinkWithTarget:proxy selector:@selector(onDisplayLink:)];
-    [self setMaxRefreshRate:FlutterDisplayLinkManager.displayRefreshRate forceMax:NO];
+    [self setMaxRefreshRate:FlutterDisplayLinkManager.shared.displayRefreshRate forceMax:NO];
     [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didEnterBackground:)
@@ -205,7 +205,7 @@ extern CFTimeInterval display_link_target;
   // thread which does not trigger actual core animation frame. As a workaround FlutterMetalLayer
   // has it's own displaylink scheduled on main thread, which is used to trigger core animation
   // frame allowing for 120hz updates.
-  if (!FlutterDisplayLinkManager.maxRefreshRateEnabledOnIPhone) {
+  if (!FlutterDisplayLinkManager.shared.maxRefreshRateEnabledOnIPhone) {
     return;
   }
   double maxFrameRate = fmax(refreshRate, 60);
@@ -220,7 +220,7 @@ extern CFTimeInterval display_link_target;
   if (_displayLinkPauseCountdown == 3) {
     _displayLink.paused = YES;
     if (_displayLinkForcedMaxRate) {
-      [self setMaxRefreshRate:FlutterDisplayLinkManager.displayRefreshRate forceMax:NO];
+      [self setMaxRefreshRate:FlutterDisplayLinkManager.shared.displayRefreshRate forceMax:NO];
       _displayLinkForcedMaxRate = NO;
     }
   } else {
@@ -418,7 +418,7 @@ extern CFTimeInterval display_link_target;
     _didSetContentsDuringThisDisplayLinkPeriod = YES;
   } else if (!_displayLinkForcedMaxRate) {
     _displayLinkForcedMaxRate = YES;
-    [self setMaxRefreshRate:FlutterDisplayLinkManager.displayRefreshRate forceMax:YES];
+    [self setMaxRefreshRate:FlutterDisplayLinkManager.shared.displayRefreshRate forceMax:YES];
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1311,7 +1311,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     return;
   }
 
-  double displayRefreshRate = FlutterDisplayLinkManager.displayRefreshRate;
+  double displayRefreshRate = FlutterDisplayLinkManager.shared.displayRefreshRate;
   const double epsilon = 0.1;
   if (displayRefreshRate < 60.0 + epsilon) {  // displayRefreshRate <= 60.0
 
@@ -1327,8 +1327,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
       };
   _touchRateCorrectionVSyncClient = [[FlutterVSyncClient alloc]
                 initWithTaskRunner:self.engine.platformTaskRunner
-      isVariableRefreshRateEnabled:FlutterDisplayLinkManager.maxRefreshRateEnabledOnIPhone
-                    maxRefreshRate:FlutterDisplayLinkManager.displayRefreshRate
+      isVariableRefreshRateEnabled:FlutterDisplayLinkManager.shared.maxRefreshRateEnabledOnIPhone
+                    maxRefreshRate:FlutterDisplayLinkManager.shared.displayRefreshRate
                           callback:callback];
   _touchRateCorrectionVSyncClient.allowPauseAfterVsync = NO;
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -2670,7 +2670,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
   OCMStub([bundleMock objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"])
       .andReturn(@YES);
-  id mockDisplayLinkManager = [OCMockObject mockForClass:[FlutterDisplayLinkManager class]];
+  id mockDisplayLinkManager = OCMPartialMock([FlutterDisplayLinkManager shared]);
+  [self addTeardownBlock:^{
+    [mockDisplayLinkManager stopMocking];
+  }];
   double maxFrameRate = 120;
   (void)[[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
   FlutterEngine* engine = [[FlutterEngine alloc] init];
@@ -2702,7 +2705,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
 - (void)
     testCreateTouchRateCorrectionVSyncClientWillCreateVsyncClientWhenRefreshRateIsLargerThan60HZ {
-  id mockDisplayLinkManager = [OCMockObject mockForClass:[FlutterDisplayLinkManager class]];
+  id mockDisplayLinkManager = OCMPartialMock([FlutterDisplayLinkManager shared]);
+  [self addTeardownBlock:^{
+    [mockDisplayLinkManager stopMocking];
+  }];
   double maxFrameRate = 120;
   (void)[[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
   FlutterEngine* engine = [[FlutterEngine alloc] init];
@@ -2715,7 +2721,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 - (void)testCreateTouchRateCorrectionVSyncClientWillNotCreateNewVSyncClientWhenClientAlreadyExists {
-  id mockDisplayLinkManager = [OCMockObject mockForClass:[FlutterDisplayLinkManager class]];
+  id mockDisplayLinkManager = OCMPartialMock([FlutterDisplayLinkManager shared]);
+  [self addTeardownBlock:^{
+    [mockDisplayLinkManager stopMocking];
+  }];
   double maxFrameRate = 120;
   (void)[[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
 
@@ -2736,7 +2745,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 - (void)testCreateTouchRateCorrectionVSyncClientWillNotCreateVsyncClientWhenRefreshRateIs60HZ {
-  id mockDisplayLinkManager = [OCMockObject mockForClass:[FlutterDisplayLinkManager class]];
+  id mockDisplayLinkManager = OCMPartialMock([FlutterDisplayLinkManager shared]);
+  [self addTeardownBlock:^{
+    [mockDisplayLinkManager stopMocking];
+  }];
   double maxFrameRate = 60;
   (void)[[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
   FlutterEngine* engine = [[FlutterEngine alloc] init];
@@ -2749,7 +2761,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 - (void)testTriggerTouchRateCorrectionVSyncClientCorrectly {
-  id mockDisplayLinkManager = [OCMockObject mockForClass:[FlutterDisplayLinkManager class]];
+  id mockDisplayLinkManager = OCMPartialMock([FlutterDisplayLinkManager shared]);
+  [self addTeardownBlock:^{
+    [mockDisplayLinkManager stopMocking];
+  }];
   double maxFrameRate = 120;
   (void)[[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
   FlutterEngine* engine = [[FlutterEngine alloc] init];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/KeyboardInsetManager.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/KeyboardInsetManager.swift
@@ -473,8 +473,8 @@ public typealias FlutterKeyboardAnimationCallback = (_ targetTime: CFTimeInterva
 
     keyboardAnimationVSyncClient = VSyncClient(
       taskRunner: taskRunner,
-      isVariableRefreshRateEnabled: DisplayLinkManager.maxRefreshRateEnabledOnIPhone,
-      maxRefreshRate: DisplayLinkManager.displayRefreshRate,
+      isVariableRefreshRateEnabled: DisplayLinkManager.shared.maxRefreshRateEnabledOnIPhone,
+      maxRefreshRate: DisplayLinkManager.shared.displayRefreshRate,
       callback: vsyncCallback)
     keyboardAnimationVSyncClient?.allowPauseAfterVsync = false
     keyboardAnimationVSyncClient?.await()

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -39,10 +39,10 @@ VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners)
       [[FlutterFMLTaskRunner alloc] initWithTaskRunner:task_runners_.GetUITaskRunner()];
   client_ = [[FlutterVSyncClient alloc]
                 initWithTaskRunner:uiTaskRunner
-      isVariableRefreshRateEnabled:FlutterDisplayLinkManager.maxRefreshRateEnabledOnIPhone
-                    maxRefreshRate:FlutterDisplayLinkManager.displayRefreshRate
+      isVariableRefreshRateEnabled:FlutterDisplayLinkManager.shared.maxRefreshRateEnabledOnIPhone
+                    maxRefreshRate:FlutterDisplayLinkManager.shared.displayRefreshRate
                           callback:vsyncCallback];
-  max_refresh_rate_ = FlutterDisplayLinkManager.displayRefreshRate;
+  max_refresh_rate_ = FlutterDisplayLinkManager.shared.displayRefreshRate;
 }
 
 VsyncWaiterIOS::~VsyncWaiterIOS() {
@@ -52,7 +52,7 @@ VsyncWaiterIOS::~VsyncWaiterIOS() {
 }
 
 void VsyncWaiterIOS::AwaitVSync() {
-  double new_max_refresh_rate = FlutterDisplayLinkManager.displayRefreshRate;
+  double new_max_refresh_rate = FlutterDisplayLinkManager.shared.displayRefreshRate;
   if (fabs(new_max_refresh_rate - max_refresh_rate_) > kRefreshRateDiffToIgnore) {
     max_refresh_rate_ = new_max_refresh_rate;
     [client_ setMaxRefreshRate:max_refresh_rate_];

--- a/engine/src/flutter/testing/symbols/verify_exported.dart
+++ b/engine/src/flutter/testing/symbols/verify_exported.dart
@@ -119,7 +119,8 @@ int _checkIos(String outPath, String nmPath, Iterable<String> builds) {
         '(__TEXT,__constg_swiftt)' ||
         '(__DATA_CONST,__const)' ||
         '(__DATA,__data)' ||
-        '(__DATA,__objc_data)' => entry.name.startsWith(r'_$s'),
+        '(__DATA,__objc_data)' ||
+        '(__DATA,__common)' => entry.name.startsWith(r'_$s'),
         _ => false,
       };
 


### PR DESCRIPTION
Previously, `DisplayLinkManager` was a stateless static utility class that queried `Bundle.main` and `UIScreen.main` directly on every access. Under Swift 6 strict concurrency this produces data-race warnings, and nothing guaranteed these accessors weren't being called from a background engine thread, which would be a UIKit thread-safety violation.

This migrates `DisplayLinkManager` to a `final class` shared singleton conforming to `@unchecked Sendable`. All callers now go through `FlutterDisplayLinkManager.shared`.

### Max refresh rate

`maxRefreshRateEnabledOnIPhone` is plist-derived and doesn't change during a process's lifetime, so we cache it once at initialisation in an immutable field.

### Current refresh rate

`displayRefreshRate` is a bit more complex: `VsyncWaiterIOS::AwaitVSync` polls it on every vsync specifically to detect refresh-rate changes at runtime (e.g. Low Power Mode or thermal throttling limiting refresh rate to 60 Hz even on ProMotion devices), so caching it would break that detection. Instead, `displayRefreshRate` is a computed property backed by a lock-protected cache, following the same pattern already used in `ResizeSynchronizer`/`FlutterRunLoop` on macOS.

There's no documented, exhaustive list of everything that can change the device's effective max refresh rate, so we keep the cached value up to date in two ways:

* by observing the specific triggers we know about (Low Power Mode via `NSProcessInfoPowerStateDidChange`, thermal throttling via `ProcessInfo.thermalStateDidChangeNotification`, and screen mode changes via `UIScreen.modeDidChangeNotification`); and
* by re-checking on `UIApplication.didBecomeActiveNotification` as a sort of forcing function in case there's any other trigger we don't explicitly know about.

Background threads now get a cheap, lock-guarded read instead of touching `UIScreen.main` directly, while the cached value is kept up to date in a couple different ways.

The cache-update code lives in `updateCachedDisplayRefreshRate(_:)`. This is `internal` since it's used both by the real notification handlers as well as in a unit test I've added to verify the locking/storage behaviour directly rather than requiring us to post real notifications and hope `UIScreen.main`'s reported value happens to change in the test host.

### Test updates

`FlutterViewControllerTest` previously stubbed `displayRefreshRate` as a class method via `OCMockObject mockForClass:`. Since it's now a property on the shared instance, those tests now use
`OCMPartialMock([FlutterDisplayLinkManager shared])` instead.

### Preferred frame rate probing cleanup

Finally, this deletes the `CADisplayLink` target-selector probing in the old `displayRefreshRate`.

That code created a throwaway `CADisplayLink(target:selector:)`, set `isPaused = true`, then read back `preferredFramesPerSecond` before discarding it.

`preferredFramesPerSecond` is a property you set to request a rate; its documented default is `0` until something explicitly assigns it, and this link was never added to a run loop, so nothing ever could. The `if preferredFPS != 0` branch was therefore unreachable, and the function always fell through to `UIScreen.main.maximumFramesPerSecond` regardless. As a result, the display link was constructed, queried, and thrown away on every single call for no effect on the result.

It's worth noting that this is a different property from `CADisplayLink.timestamp`/`targetTimestamp`, which do have documented first-frame-is-zero semantics and are already guarded independently in `VSyncClient.onDisplayLink` (see flutter#186457) and again in the C++ code in `VsyncWaiterIOS::SnapDuration`.

`preferredFramesPerSecond`'s zero-ness here had nothing to do with frame timing, only with the fact that nobody had ever set it. Since this was on the read path for a property that's polled up to ~120 times/second by `VsyncWaiterIOS::AwaitVSync`, it meant allocating and discarding a `QuartzCore` object on every vsync for a value that could never differ from a plain `UIScreen.main.maximumFramesPerSecond` read.

The new code does a single read, at construction, and lets the caching/observation machinery described above keep it current.

Configurable preferred-FPS support is tracked separately in flutter#185759.

### Swift exported symbols check

Also adds support for Swift static `let` properties (prefix `_$s`) to the `(__DATA,__common)` section of exported binaries.

Issue: https://github.com/flutter/flutter/issues/175879
Issue: https://github.com/flutter/flutter/issues/181684

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
