### PR TITLE
[web] Remove per-launch browser console listener from test harness

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -17,7 +17,6 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test_core/src/platform.dart'; // ignore: implementation_imports
 import 'package:web_socket_channel/web_socket_channel.dart';
-import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart' hide StackTrace;
 
 import '../artifacts.dart';
 import '../base/common.dart';
@@ -879,28 +878,6 @@ class BrowserManager {
       url.toString(),
       headless: headless,
       webBrowserFlags: webBrowserFlags,
-    );
-    unawaited(
-      Future<void>(() async {
-        try {
-          final ChromeTab? tab = await chrome.chromeConnection.getTab(
-            (ChromeTab tab) => tab.url.contains('index.html'),
-            retryFor: const Duration(seconds: 5),
-          );
-          if (tab != null) {
-            final WipConnection connection = await tab.connect();
-            await connection.runtime.enable();
-            connection.runtime.onConsoleAPICalled.listen((ConsoleAPIEvent event) {
-              logger.printStatus(
-                '[BROWSER CONSOLE] [${event.type}]: ${event.args.map((RemoteObject a) => a.value ?? a.description).join(" ")}',
-              );
-            });
-            connection.runtime.onExceptionThrown.listen((ExceptionThrownEvent event) {
-              logger.printStatus('[BROWSER EXCEPTION]: ${event.exceptionDetails}');
-            });
-          }
-        } on Object catch (_) {}
-      }),
     );
     final completer = Completer<BrowserManager>();
 


### PR DESCRIPTION
 Draft, do not merge. Measurement only for #189275. Removes the per-launch browser console listener added in #182861 to see whether it recovers meaningful time on the web test shards. If it does, the landable version would gate the listener behind verbose mode rather than delete it.