### PR TITLE
[Impeller] Call glfwTerminate during global test environment teardown if a playground test called glfwInit

### DIFF
--- a/engine/src/flutter/impeller/playground/playground.cc
+++ b/engine/src/flutter/impeller/playground/playground.cc
@@ -83,7 +83,7 @@ std::string PlaygroundBackendToString(PlaygroundBackend backend) {
   FML_UNREACHABLE();
 }
 
-std::atomic_bool Playground::glfw_initialized_ = false;
+std::atomic<bool> Playground::glfw_initialized_ = false;
 
 void Playground::InitializeGLFWOnce() {
   // This guard is a hack to work around a problem where glfwCreateWindow

--- a/engine/src/flutter/impeller/playground/playground.cc
+++ b/engine/src/flutter/impeller/playground/playground.cc
@@ -83,7 +83,9 @@ std::string PlaygroundBackendToString(PlaygroundBackend backend) {
   FML_UNREACHABLE();
 }
 
-static void InitializeGLFWOnce() {
+std::atomic_bool Playground::glfw_initialized_ = false;
+
+void Playground::InitializeGLFWOnce() {
   // This guard is a hack to work around a problem where glfwCreateWindow
   // hangs when opening a second window after GLFW has been reinitialized (for
   // example, when flipping through multiple playground tests).
@@ -106,7 +108,14 @@ static void InitializeGLFWOnce() {
       FML_LOG(ERROR) << "GLFW Error '" << description << "'  (" << code << ").";
     });
     FML_CHECK(::glfwInit() == GLFW_TRUE);
+    glfw_initialized_ = true;
   });
+}
+
+void Playground::OnTearDownTestEnvironment() {
+  if (glfw_initialized_) {
+    ::glfwTerminate();
+  }
 }
 
 testing::GoldenDigestManager* Playground::GetGoldenDigestManager() const {

--- a/engine/src/flutter/impeller/playground/playground.h
+++ b/engine/src/flutter/impeller/playground/playground.h
@@ -201,7 +201,7 @@ class Playground {
 
  private:
   static void InitializeGLFWOnce();
-  static std::atomic_bool glfw_initialized_;
+  static std::atomic<bool> glfw_initialized_;
 
   const PlaygroundBackend backend_;
   PlaygroundSwitches switches_;

--- a/engine/src/flutter/impeller/playground/playground.h
+++ b/engine/src/flutter/impeller/playground/playground.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_IMPELLER_PLAYGROUND_PLAYGROUND_H_
 #define FLUTTER_IMPELLER_PLAYGROUND_PLAYGROUND_H_
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 
@@ -46,6 +47,8 @@ class Playground {
                       const PlaygroundSwitches& switches);
 
   virtual ~Playground();
+
+  static void OnTearDownTestEnvironment();
 
   static bool ShouldOpenNewPlaygrounds();
 
@@ -197,6 +200,9 @@ class Playground {
   virtual testing::GoldenDigestManager* GetGoldenDigestManager() const;
 
  private:
+  static void InitializeGLFWOnce();
+  static std::atomic_bool glfw_initialized_;
+
   const PlaygroundBackend backend_;
   PlaygroundSwitches switches_;
 

--- a/engine/src/flutter/impeller/playground/playground_test.cc
+++ b/engine/src/flutter/impeller/playground/playground_test.cc
@@ -115,6 +115,7 @@ class PlaygroundTestEnvironment : public ::testing::Environment {
       golden_manager_.reset();
     }
     PlaygroundImpl::OnTearDownTestEnvironment();
+    Playground::OnTearDownTestEnvironment();
   }
 
   static testing::GoldenDigestManager* GetGoldenDigestManager() {


### PR DESCRIPTION
glfwTerminate will call eglTerminate, which will execute an orderly shutdown of ANGLE before the test process exits.