### PR TITLE
[ios] Fix //flutter:unittests build for physical devices

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
@@ -39,13 +39,14 @@ config("test_config") {
       "$darwin_target_arch-apple-ios$ios_testing_deployment_target$darwin_target_sim",
     ]
     if (use_ios_simulator) {
-      cflags += [ "-mios-simulator-version-min=$ios_testing_deployment_target" ]
-      ldflags +=
-          [ "-mios-simulator-version-min=$ios_testing_deployment_target" ]
+      _version_min_flag =
+          "-mios-simulator-version-min=$ios_testing_deployment_target"
     } else {
-      cflags += [ "-miphoneos-version-min=$ios_testing_deployment_target" ]
-      ldflags += [ "-miphoneos-version-min=$ios_testing_deployment_target" ]
+      _version_min_flag =
+          "-miphoneos-version-min=$ios_testing_deployment_target"
     }
+    cflags += [ _version_min_flag ]
+    ldflags += [ _version_min_flag ]
   } else if (is_mac) {
     _platform_path = mac_platform_path
     cflags += [ "-mmacosx-version-min=$mac_testing_deployment_target" ]

--- a/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
@@ -38,8 +38,14 @@ config("test_config") {
       "-target",
       "$darwin_target_arch-apple-ios$ios_testing_deployment_target$darwin_target_sim",
     ]
-    cflags += [ "-mios-simulator-version-min=$ios_testing_deployment_target" ]
-    ldflags += [ "-mios-simulator-version-min=$ios_testing_deployment_target" ]
+    if (use_ios_simulator) {
+      cflags += [ "-mios-simulator-version-min=$ios_testing_deployment_target" ]
+      ldflags +=
+          [ "-mios-simulator-version-min=$ios_testing_deployment_target" ]
+    } else {
+      cflags += [ "-miphoneos-version-min=$ios_testing_deployment_target" ]
+      ldflags += [ "-miphoneos-version-min=$ios_testing_deployment_target" ]
+    }
   } else if (is_mac) {
     _platform_path = mac_platform_path
     cflags += [ "-mmacosx-version-min=$mac_testing_deployment_target" ]

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneLifeCycleTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSceneLifeCycleTest.mm
@@ -1045,7 +1045,7 @@ FLUTTER_ASSERT_ARC
   OCMStub([mockRestorationPlugin restorationData]).andReturn(mockData);
 
   id mockScene = mocks[@"mockScene"];
-  id mockSession = OCMClassMock([UISceneSession class]);
+  UISceneSession* mockSession = OCMClassMock([UISceneSession class]);
   id mockConfiguration = OCMClassMock([UISceneConfiguration class]);
   OCMStub([mockScene session]).andReturn(mockSession);
   OCMStub([mockSession configuration]).andReturn(mockConfiguration);


### PR DESCRIPTION
When building tests under `ios_debug_unopt` targeting physical device SDKs, we get an ambiguous method call error for `[mockSession configuration]` because `mockSession` in `FlutterLifecycleTest` was declared as untyped (`id`), and the iOS device SDK includes `Metal.framework/Headers/MTL4PipelineDataSetSerializer.h`, which defines a `configuration` property returning a primitive enum type `MTL4PipelineDataSetSerializerConfiguration`.

Because the device SDK contains `configuration` methods returning both object pointers (such as `UISceneConfiguration*`) and primitive values, the compiler can't figure out the correct return type and calling convention for the invocation. This issue doesn't surface on simulator builds because `MTL4PipelineDataSetSerializer.h` header is stubbed out in the simulator SDK.

We now explicitly type `mockSession` as a `UISceneSession*`, which fixes the issue.

This also fixes a gn configuration error that triggers a link-time error.

When building tests under `ios_debug_unopt` targeting device SDKs, the build fails at the linking stage with architecture compatibility errors. The `test_config` configuration in `//flutter/shell/platform/darwin/common/BUILD.gn` previously unconditionally appended `-mios-simulator-version-min`, regardless whether we were building for simulator or device.

We now set the compiler/linker flags conditionally to `-miphoneos-version-min` for device targets (when `use_ios_simulator` is false) and `-mios-simulator-version-min` for simulator targets

No changes to tests since this is a compilation fix for existing tests.

Fixes https://github.com/flutter/flutter/issues/189542


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
