### PR TITLE
[windows] Restore framework cursor when mouse re-enters client area

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window.cc
@@ -712,6 +712,13 @@ FlutterWindow::HandleMessage(UINT const message,
     case WM_SETCURSOR: {
       UINT hit_test_result = LOWORD(lparam);
       if (hit_test_result == HTCLIENT) {
+        // Restore the cursor requested by the Flutter framework. The cursor
+        // may have been changed while the mouse was over the non-client area
+        // (e.g. a resize arrow over the window border), and since processing
+        // is halted below, DefWindowProc never resets it.
+        if (binding_handler_delegate_ != nullptr) {
+          ::SetCursor(binding_handler_delegate_->GetFlutterCursor());
+        }
         // Halt further processing to prevent DefWindowProc from setting the
         // cursor back to the registered class cursor.
         return TRUE;

--- a/engine/src/flutter/shell/platform/windows/flutter_window_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window_unittests.cc
@@ -978,6 +978,40 @@ TEST_F(FlutterWindowTest, OnThemeChange) {
   win32window.InjectWindowMessage(WM_THEMECHANGED, 0, 0);
 }
 
+// WM_SETCURSOR over the client area should restore the cursor requested by
+// the Flutter framework, as the cursor may have been changed while the mouse
+// was over the non-client area (e.g. a resize arrow over the window border).
+// Regression test for stale cursors when re-entering the client area.
+TEST_F(FlutterWindowTest, OnSetCursorRestoresFlutterCursor) {
+  MockFlutterWindow win32window;
+  MockWindowBindingHandlerDelegate delegate;
+  EXPECT_CALL(win32window, OnWindowStateEvent).Times(AnyNumber());
+  win32window.SetView(&delegate);
+
+  HCURSOR hand_cursor = ::LoadCursor(nullptr, IDC_HAND);
+  EXPECT_CALL(delegate, GetFlutterCursor).WillOnce(Return(hand_cursor));
+
+  LRESULT result = win32window.InjectWindowMessage(
+      WM_SETCURSOR, 0, MAKELPARAM(HTCLIENT, WM_MOUSEMOVE));
+
+  EXPECT_EQ(result, TRUE);
+  EXPECT_EQ(::GetCursor(), hand_cursor);
+}
+
+// WM_SETCURSOR over the non-client area should not touch the cursor;
+// DefWindowProc handles it (e.g. resize arrows over the window border).
+TEST_F(FlutterWindowTest, OnSetCursorNonClientAreaLeavesCursorAlone) {
+  MockFlutterWindow win32window;
+  MockWindowBindingHandlerDelegate delegate;
+  EXPECT_CALL(win32window, OnWindowStateEvent).Times(AnyNumber());
+  win32window.SetView(&delegate);
+
+  EXPECT_CALL(delegate, GetFlutterCursor).Times(0);
+
+  win32window.InjectWindowMessage(WM_SETCURSOR, 0,
+                                  MAKELPARAM(HTBOTTOMRIGHT, WM_MOUSEMOVE));
+}
+
 // The window should return no root accessibility node if
 // it isn't attached to a view.
 // Regression test for https://github.com/flutter/flutter/issues/129791

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
@@ -1126,12 +1126,12 @@ std::optional<LRESULT> FlutterWindowsEngine::ProcessExternalWindowMessage(
   return std::nullopt;
 }
 
-void FlutterWindowsEngine::UpdateFlutterCursor(
-    const std::string& cursor_name) const {
+void FlutterWindowsEngine::UpdateFlutterCursor(const std::string& cursor_name) {
   SetFlutterCursor(GetCursorByName(cursor_name));
 }
 
-void FlutterWindowsEngine::SetFlutterCursor(HCURSOR cursor) const {
+void FlutterWindowsEngine::SetFlutterCursor(HCURSOR cursor) {
+  current_cursor_ = cursor;
   windows_proc_table_->SetCursor(cursor);
 }
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
@@ -327,10 +327,14 @@ class FlutterWindowsEngine {
 
   // Sets the cursor that should be used when the mouse is over the Flutter
   // content. See mouse_cursor.dart for the values and meanings of cursor_name.
-  void UpdateFlutterCursor(const std::string& cursor_name) const;
+  void UpdateFlutterCursor(const std::string& cursor_name);
 
   // Sets the cursor directly from a cursor handle.
-  void SetFlutterCursor(HCURSOR cursor) const;
+  void SetFlutterCursor(HCURSOR cursor);
+
+  // Returns the last cursor set through |UpdateFlutterCursor| or
+  // |SetFlutterCursor|. Defaults to the arrow cursor.
+  HCURSOR GetFlutterCursor() const { return current_cursor_; }
 
   WindowManager* window_manager() { return window_manager_.get(); }
 
@@ -526,6 +530,10 @@ class FlutterWindowsEngine {
   std::shared_ptr<WindowsProcTable> windows_proc_table_;
 
   std::shared_ptr<egl::ProcTable> gl_;
+
+  // The last cursor set by the Flutter framework. Used to restore the cursor
+  // in WM_SETCURSOR when the mouse re-enters the window's client area.
+  HCURSOR current_cursor_ = ::LoadCursor(nullptr, IDC_ARROW);
 
   std::unique_ptr<PlatformViewPlugin> platform_view_plugin_;
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -934,6 +934,26 @@ TEST_F(FlutterWindowsEngineTest, GetExecutableName) {
   EXPECT_EQ(engine->GetExecutableName(), "flutter_windows_unittests.exe");
 }
 
+// The engine should remember the cursor set by the framework so that
+// windows can restore it when handling WM_SETCURSOR.
+TEST_F(FlutterWindowsEngineTest, SetFlutterCursorStoresCursor) {
+  auto windows_proc_table = std::make_shared<MockWindowsProcTable>();
+
+  FlutterWindowsEngineBuilder builder{GetContext()};
+  builder.SetWindowsProcTable(windows_proc_table);
+  std::unique_ptr<FlutterWindowsEngine> engine = builder.Build();
+
+  // The default cursor is the arrow cursor.
+  EXPECT_EQ(engine->GetFlutterCursor(), ::LoadCursor(nullptr, IDC_ARROW));
+
+  HCURSOR hand_cursor = ::LoadCursor(nullptr, IDC_HAND);
+  EXPECT_CALL(*windows_proc_table, SetCursor(hand_cursor)).Times(1);
+
+  engine->SetFlutterCursor(hand_cursor);
+
+  EXPECT_EQ(engine->GetFlutterCursor(), hand_cursor);
+}
+
 // Ensure that after setting or resetting the high contrast feature,
 // the corresponding status flag can be retrieved from the engine.
 TEST_F(FlutterWindowsEngineTest, UpdateHighContrastFeature) {

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
@@ -865,7 +865,7 @@ void FlutterWindowsView::OnHighContrastChanged() {
   engine_->UpdateHighContrastMode();
 }
 
-HCURSOR FlutterWindowsView::GetFlutterCursor() {
+HCURSOR FlutterWindowsView::GetFlutterCursor() const {
   return engine_->GetFlutterCursor();
 }
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
@@ -865,6 +865,10 @@ void FlutterWindowsView::OnHighContrastChanged() {
   engine_->UpdateHighContrastMode();
 }
 
+HCURSOR FlutterWindowsView::GetFlutterCursor() {
+  return engine_->GetFlutterCursor();
+}
+
 HWND FlutterWindowsView::GetWindowHandle() const {
   return binding_handler_->GetWindowHandle();
 }

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
@@ -124,7 +124,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   void OnHighContrastChanged() override;
 
   // |WindowBindingHandlerDelegate|
-  HCURSOR GetFlutterCursor() override;
+  HCURSOR GetFlutterCursor() const override;
 
   // Called on the raster thread when |CompositorOpenGL| receives an empty
   // frame. Returns true if the frame can be presented.

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
@@ -123,6 +123,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // |WindowBindingHandlerDelegate|
   void OnHighContrastChanged() override;
 
+  // |WindowBindingHandlerDelegate|
+  HCURSOR GetFlutterCursor() override;
+
   // Called on the raster thread when |CompositorOpenGL| receives an empty
   // frame. Returns true if the frame can be presented.
   //

--- a/engine/src/flutter/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/engine/src/flutter/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -84,7 +84,7 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
               (),
               (override));
 
-  MOCK_METHOD(HCURSOR, GetFlutterCursor, (), (override));
+  MOCK_METHOD(HCURSOR, GetFlutterCursor, (), (const, override));
 
   MOCK_METHOD(void, OnWindowStateEvent, (HWND, WindowStateEvent), (override));
 

--- a/engine/src/flutter/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/engine/src/flutter/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -84,6 +84,8 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
               (),
               (override));
 
+  MOCK_METHOD(HCURSOR, GetFlutterCursor, (), (override));
+
   MOCK_METHOD(void, OnWindowStateEvent, (HWND, WindowStateEvent), (override));
 
  private:

--- a/engine/src/flutter/shell/platform/windows/window_binding_handler_delegate.h
+++ b/engine/src/flutter/shell/platform/windows/window_binding_handler_delegate.h
@@ -169,7 +169,7 @@ class WindowBindingHandlerDelegate {
   // framework's cursor when the mouse re-enters the client area, as the
   // cursor may have been changed while over the non-client area (e.g. a
   // resize arrow over the window border).
-  virtual HCURSOR GetFlutterCursor() = 0;
+  virtual HCURSOR GetFlutterCursor() const = 0;
 
   // Called when a window receives an event that may alter application lifecycle
   // state.

--- a/engine/src/flutter/shell/platform/windows/window_binding_handler_delegate.h
+++ b/engine/src/flutter/shell/platform/windows/window_binding_handler_delegate.h
@@ -162,6 +162,15 @@ class WindowBindingHandlerDelegate {
   // children and parents, so a method such as this is required.
   virtual ui::AXFragmentRootDelegateWin* GetAxFragmentRootDelegate() = 0;
 
+  // Returns the cursor that the Flutter framework has requested for the
+  // window's client area.
+  //
+  // Called by |FlutterWindow| when handling WM_SETCURSOR to restore the
+  // framework's cursor when the mouse re-enters the client area, as the
+  // cursor may have been changed while over the non-client area (e.g. a
+  // resize arrow over the window border).
+  virtual HCURSOR GetFlutterCursor() = 0;
+
   // Called when a window receives an event that may alter application lifecycle
   // state.
   virtual void OnWindowStateEvent(HWND hwnd, WindowStateEvent event) = 0;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

On Windows, a cursor set while the pointer is over the non-client area (for example the resize arrow from a window border) sticks around after the pointer moves back into the Flutter content whenever the UI thread is busy at that moment. The cause is in `FlutterWindow`'s `WM_SETCURSOR` handler: for `HTCLIENT` hits it returns `TRUE` without setting any cursor. That return is intentional (it stops `DefWindowProc` from resetting the cursor to the window class cursor on every mouse move), but it means the visible cursor is only corrected by the framework's next `mouse_cursor` channel update. On a responsive app that round trip completes within milliseconds; under UI-thread latency (app startup, shader-compilation jank, heavy frames, debug builds) the stale cursor stays visible for the whole stall. #189563 documents the analysis, measurements, and a deterministic repro.

This change makes the engine remember the cursor most recently requested by the framework (`FlutterWindowsEngine::SetFlutterCursor` already funnels every cursor update, both system and custom cursors) and makes the `WM_SETCURSOR` handler restore that cursor before halting processing, the way native Win32 apps answer the message. The cursor is then correct as soon as the window processes the message, without waiting for a channel round trip and without depending on the framework's cursor cache. The window pulls the cursor through a new `WindowBindingHandlerDelegate::GetFlutterCursor()`, so the engine remains the single source of truth and windows created at any time behave consistently.

Changes:

* `FlutterWindowsEngine`: remember the last cursor set by the framework, expose it via `GetFlutterCursor()`. `UpdateFlutterCursor`/`SetFlutterCursor` lose their `const` since they now record state.
* `WindowBindingHandlerDelegate`: new `GetFlutterCursor()` pure virtual, implemented by `FlutterWindowsView` (forwards to the engine) and mocked for tests.
* `FlutterWindow`: `WM_SETCURSOR`/`HTCLIENT` now restores the framework cursor before returning `TRUE`.

Tests:

* `FlutterWindowTest.OnSetCursorRestoresFlutterCursor`: `WM_SETCURSOR` over the client area queries the delegate and activates the returned cursor.
* `FlutterWindowTest.OnSetCursorNonClientAreaLeavesCursorAlone`: non-client hits do not touch the cursor.
* `FlutterWindowsEngineTest.SetFlutterCursorStoresCursor`: the engine records the cursor and still forwards it to `::SetCursor` via `WindowsProcTable`.

Part of #189563

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
