### PR TITLE
[Impeller] Register the PNG codec for playground tests

### DIFF
--- a/engine/src/flutter/impeller/playground/BUILD.gn
+++ b/engine/src/flutter/impeller/playground/BUILD.gn
@@ -89,6 +89,8 @@ impeller_component("playground_test") {
     "playground_test.h",
   ]
 
+  deps = [ "//flutter/skia" ]
+
   public_deps = [
     ":playground",
     "//flutter/impeller/testing:golden_digest_manager",

--- a/engine/src/flutter/impeller/playground/playground_test.cc
+++ b/engine/src/flutter/impeller/playground/playground_test.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/playground/playground_test.h"
 
+#include <mutex>
+
 #ifndef FML_OS_WIN
 #include <wordexp.h>
 #endif
@@ -14,6 +16,8 @@
 #include "impeller/base/validation.h"
 #include "impeller/playground/playground_impl.h"
 #include "impeller/testing/golden_digest_manager.h"
+#include "third_party/skia/include/codec/SkCodec.h"
+#include "third_party/skia/include/codec/SkPngDecoder.h"
 
 namespace impeller {
 
@@ -41,6 +45,15 @@ PlaygroundTest::~PlaygroundTest() {
 }
 
 void PlaygroundTest::SetUp() {
+  // Playground tests rasterize text with the host's font stack. On Windows,
+  // Skia's DirectWrite backend decodes PNG format color emoji glyphs through
+  // the SkCodecs registry and aborts with a fatal assert when no PNG decoder
+  // is registered. The engine runtime registers the codecs in
+  // ImageGeneratorRegistry; test binaries must register them for themselves.
+  static std::once_flag png_codec_registered;
+  std::call_once(png_codec_registered,
+                 []() { SkCodecs::Register(SkPngDecoder::Decoder()); });
+
   if (!Playground::SupportsBackend(GetParam())) {
     GTEST_SKIP() << "Playground doesn't support this backend type.";
     return;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Five playground tests crash with SIGABRT when `impeller_unittests` runs on a Windows host:

* `Play/AiksTest.CanRenderEmojiTextFrame/Vulkan`
* `Play/AiksTest.CanRenderEmojiTextFrameWithBlur/Vulkan`
* `Play/AiksTest.CanRenderEmojiTextFrameWithAlpha/Vulkan`
* `Play/TypographerTest.LazyAtlasTracksColor/Vulkan`
* `Play/TypographerTest.GlyphColorIsPartOfCacheKey/Vulkan`

The crash is a Skia hard assert:

```console
SkScalerContext_win_dw.cpp(1724): fatal error:
"assertf(SkCodecs::HasDecoder("png")): No PNG decoder registered.
A call to SkCodecs::Register is necessary."
```

These tests rasterize color emoji with the host's font stack. On Windows that is Skia's DirectWrite backend, which decodes PNG-format color glyphs (for example from Segoe UI Emoji) through the `SkCodecs` registry. The engine runtime registers the codecs in `ImageGeneratorRegistry`, but test binaries must register them for themselves; `impeller_unittests` never does, so the first color glyph aborts the process. Linux CI takes the FreeType scaler path and never triggers the decode, which is why this only surfaces on Windows hosts.

The fix registers the PNG decoder once in `PlaygroundTest::SetUp()`, matching the local-registration pattern already used by `lib/ui/painting/image_decoder_no_gl_unittests.cc`. All five tests pass on a Windows host with this change; behavior on other hosts is unchanged (the registration is additive and idempotent for the running binary).

Fixes #189565

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
