### PR TITLE
[windows] Make keyboard layout tests hermetic

### DIFF
--- a/engine/src/flutter/shell/platform/windows/keyboard_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/keyboard_unittests.cc
@@ -79,8 +79,64 @@ constexpr bool kNotSynthesized = false;
 typedef UINT (*MapVirtualKeyLayout)(UINT uCode, UINT uMapType);
 typedef std::function<UINT(UINT)> MapVirtualKeyToChar;
 
+// A hermetic US English keyboard layout. The tests are authored against the
+// US (and US-International) layout, but MapVirtualKey consults the layout
+// installed on the machine running the tests, so on a non-US host the same
+// virtual key produces a different character and layout-sensitive tests fail
+// (for example, VK_OEM_3 is the grave accent on US but an umlaut on German).
+// This returns the character MapVirtualKey(uCode, MAPVK_VK_TO_CHAR) would
+// return on a US layout for the keys the tests exercise; other map types are
+// layout independent and are forwarded to the platform.
+UINT LayoutUsStandard(UINT uCode, UINT uMapType) {
+  if (uMapType != MAPVK_VK_TO_CHAR) {
+    return MapVirtualKey(uCode, uMapType);
+  }
+  // Digits and letters map to their ASCII characters, which are numerically
+  // equal to their virtual-key codes on the US layout.
+  if ((uCode >= '0' && uCode <= '9') || (uCode >= 'A' && uCode <= 'Z')) {
+    return uCode;
+  }
+  switch (uCode) {
+    // Control keys are layout independent; their values match a US layout.
+    case VK_BACK:  // 0x08
+      return '\b';
+    case VK_TAB:  // 0x09
+      return '\t';
+    case VK_RETURN:  // 0x0D
+      return '\r';
+    case VK_ESCAPE:  // 0x1B
+      return 0x1B;
+    case VK_SPACE:
+      return ' ';
+    case VK_OEM_1:  // 0xBA
+      return ';';
+    case VK_OEM_PLUS:  // 0xBB
+      return '=';
+    case VK_OEM_COMMA:  // 0xBC
+      return ',';
+    case VK_OEM_MINUS:  // 0xBD
+      return '-';
+    case VK_OEM_PERIOD:  // 0xBE
+      return '.';
+    case VK_OEM_2:  // 0xBF
+      return '/';
+    case VK_OEM_3:  // 0xC0
+      return '`';
+    case VK_OEM_4:  // 0xDB
+      return '[';
+    case VK_OEM_5:  // 0xDC
+      return '\\';
+    case VK_OEM_6:  // 0xDD
+      return ']';
+    case VK_OEM_7:  // 0xDE
+      return '\'';
+    default:
+      return 0;
+  }
+}
+
 UINT LayoutDefault(UINT uCode, UINT uMapType) {
-  return MapVirtualKey(uCode, uMapType);
+  return LayoutUsStandard(uCode, uMapType);
 }
 
 UINT LayoutFrench(UINT uCode, UINT uMapType) {
@@ -90,7 +146,7 @@ UINT LayoutFrench(UINT uCode, UINT uMapType) {
         case 0xDD:
           return 0x8000005E;
         default:
-          return MapVirtualKey(uCode, MAPVK_VK_TO_CHAR);
+          return LayoutUsStandard(uCode, MAPVK_VK_TO_CHAR);
       }
     default:
       return MapVirtualKey(uCode, uMapType);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

The Windows keyboard tests in `keyboard_unittests.cc` are authored against the US and US-International layouts, but the test harness resolves a virtual key to a character through `MapVirtualKey(vk, MAPVK_VK_TO_CHAR)`, which consults the keyboard layout installed on the machine running the tests. On a host configured with a non-US layout the same virtual key produces a different character, so layout-sensitive tests fail. For example, `KeyboardTest.DeadKeyTwiceThenLetter` presses `VK_OEM_3`, which is the grave accent on a US layout but an umlaut on a German layout, so the test expects `` ` `` and receives `ö`.

This makes the character mapping hermetic. A new `LayoutUsStandard` returns the value `MapVirtualKey(vk, MAPVK_VK_TO_CHAR)` produces on a US layout for the keys the tests exercise (digits, letters, the OEM punctuation keys, and the control keys the tests use), and the default and French test layouts route their `MAPVK_VK_TO_CHAR` lookups through it. Non-character virtual keys keep returning `0`, matching the platform. The tests no longer depend on the layout installed on the machine running them.

Verified on a machine configured with the German (de-DE) layout: before this change `KeyboardTest.DeadKeyTwiceThenLetter` fails; after it, all 36 `KeyboardTest` cases pass. The suite continues to pass on US layouts.

Fixes #189566

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
