### PR TITLE
[Impeller] Harden the Vulkan backend against driver failures and resource exhaustion

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/backend/vulkan/allocator_vk.h"
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <utility>
@@ -470,8 +471,9 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
         if (rt_result != vk::Result::eSuccess) {
           VALIDATION_LOG << "Unable to create a render target image view: "
                          << vk::to_string(rt_result);
-          // Nothing owns the image yet; destroy it to avoid leaking the
-          // allocation.
+          // Destroy the views created so far, then the image.
+          rt_image_views.clear();
+          image_view.reset();
           vmaDestroyImage(allocator, vk_image, allocation);
           return;
         }
@@ -674,12 +676,18 @@ void AllocatorVK::DebugTraceMemoryStatistics() const {
     static constexpr size_t kRssToVmaRatio = 4;
     static constexpr size_t kBytesPerMB = 1024u * 1024u;
 
-    static thread_local int trim_cooldown = 0;
-    if (trim_cooldown > 0) {
-      --trim_cooldown;
+    // EmptyWorkingSet trims the whole process, so the cooldown is shared by
+    // all threads; a per-thread cooldown would let multiple raster threads
+    // (one per engine instance in the process) each trim on their own clock.
+    // Races on the counter are benign: a lost decrement only delays the next
+    // trim check by a frame.
+    static std::atomic<int> trim_cooldown = 0;
+    int cooldown = trim_cooldown.load(std::memory_order_relaxed);
+    if (cooldown > 0) {
+      trim_cooldown.store(cooldown - 1, std::memory_order_relaxed);
     }
 
-    if (trim_cooldown == 0) {
+    if (cooldown == 0) {
       size_t vma_mb = DebugGetHeapUsage().ConvertTo<MebiBytes>().GetSize();
       if (vma_mb < kMaxVmaMB) {
         PROCESS_MEMORY_COUNTERS pmc = {};
@@ -687,7 +695,7 @@ void AllocatorVK::DebugTraceMemoryStatistics() const {
         if (::GetProcessMemoryInfo(::GetCurrentProcess(), &pmc, sizeof(pmc))) {
           size_t rss_mb = pmc.WorkingSetSize / kBytesPerMB;
           if (rss_mb > kMinRssMB && rss_mb > vma_mb * kRssToVmaRatio) {
-            trim_cooldown = kTrimCooldownFrames;
+            trim_cooldown.store(kTrimCooldownFrames, std::memory_order_relaxed);
             ::EmptyWorkingSet(::GetCurrentProcess());
             FML_DLOG(INFO) << "Working set trimmed: " << rss_mb << " MB";
           }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -8,6 +8,13 @@
 #include <mutex>
 #include <utility>
 
+#include "flutter/fml/build_config.h"
+
+#ifdef FML_OS_WIN
+#include <psapi.h>
+#include <windows.h>
+#endif  // FML_OS_WIN
+
 #include "flutter/fml/logging.h"
 #include "flutter/fml/memory/ref_ptr.h"
 #include "flutter/fml/trace_event.h"
@@ -21,6 +28,10 @@
 #include "vulkan/vulkan_enums.hpp"
 
 namespace impeller {
+
+// Maximum number of VMA buffer pool blocks. 256 blocks x 4 MB = 1 GB.
+// Caps pool growth under high-water-mark buffer demand spikes.
+static constexpr uint32_t kMaxBufferPoolBlocks = 256;
 
 static constexpr vk::Flags<vk::MemoryPropertyFlagBits>
 ToVKBufferMemoryPropertyFlags(StorageMode mode) {
@@ -89,6 +100,11 @@ static PoolVMA CreateBufferPool(VmaAllocator allocator) {
   pool_create_info.memoryTypeIndex = memTypeIndex;
   pool_create_info.flags = VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT;
   pool_create_info.minBlockCount = 1;
+  // Cap at 256 blocks x 4 MB = 1 GB. Without a cap, VMA grows this pool
+  // without bound when high-water-mark buffer demand spikes (e.g. during
+  // benchmarks), and pool-internal fragmentation may prevent block reuse even
+  // after individual allocations are freed.
+  pool_create_info.maxBlockCount = kMaxBufferPoolBlocks;
 
   VmaPool pool = {};
   result = vk::Result{::vmaCreatePool(allocator, &pool_create_info, &pool)};
@@ -427,6 +443,9 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
     if (result != vk::Result::eSuccess) {
       VALIDATION_LOG << "Unable to create an image view for allocation: "
                      << vk::to_string(result);
+      // Nothing owns the image yet; destroy it to avoid leaking the
+      // allocation.
+      vmaDestroyImage(allocator, vk_image, allocation);
       return;
     }
     // Create one 2D attachment view per (mip level, array layer) so a
@@ -451,6 +470,9 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
         if (rt_result != vk::Result::eSuccess) {
           VALIDATION_LOG << "Unable to create a render target image view: "
                          << vk::to_string(rt_result);
+          // Nothing owns the image yet; destroy it to avoid leaking the
+          // allocation.
+          vmaDestroyImage(allocator, vk_image, allocation);
           return;
         }
         rt_image_views.push_back(std::move(rt_image_view));
@@ -628,6 +650,52 @@ void AllocatorVK::DebugTraceMemoryStatistics() const {
                     "MemoryBudgetUsageMB",
                     DebugGetHeapUsage().ConvertTo<MebiBytes>().GetSize());
 #endif  // IMPELLER_DEBUG
+
+#ifdef FML_OS_WIN
+  // On Windows with Resizable BAR (AMD RDNA, Intel Arc), the GPU driver maps
+  // all VRAM into the process address space, inflating the working set far
+  // beyond actual CPU-side usage. Periodically trim the working set when RSS
+  // is disproportionately large relative to actual VMA allocations.
+  //
+  // The trim is rate-limited to once every ~5 seconds (300 frames at 60 fps)
+  // to avoid thrashing. It only acts when:
+  //   1. VMA allocations are small (< 256 MB): the driver BAR mapping is
+  //      responsible for the bloat, not actual GPU memory pressure.
+  //   2. RSS exceeds 1 GB and is > 4x VMA usage: confirms the working set
+  //      is dominated by driver-mapped pages, not application data.
+  //
+  // EmptyWorkingSet moves pages to the standby list without freeing them;
+  // they are faulted back in on next access, so the cost is minimal for
+  // pages that are actively used.
+  {
+    static constexpr size_t kTrimCooldownFrames = 300;  // ~5 s at 60 fps.
+    static constexpr size_t kMinRssMB = 1024;
+    static constexpr size_t kMaxVmaMB = 256;
+    static constexpr size_t kRssToVmaRatio = 4;
+    static constexpr size_t kBytesPerMB = 1024u * 1024u;
+
+    static thread_local int trim_cooldown = 0;
+    if (trim_cooldown > 0) {
+      --trim_cooldown;
+    }
+
+    if (trim_cooldown == 0) {
+      size_t vma_mb = DebugGetHeapUsage().ConvertTo<MebiBytes>().GetSize();
+      if (vma_mb < kMaxVmaMB) {
+        PROCESS_MEMORY_COUNTERS pmc = {};
+        pmc.cb = sizeof(pmc);
+        if (::GetProcessMemoryInfo(::GetCurrentProcess(), &pmc, sizeof(pmc))) {
+          size_t rss_mb = pmc.WorkingSetSize / kBytesPerMB;
+          if (rss_mb > kMinRssMB && rss_mb > vma_mb * kRssToVmaRatio) {
+            trim_cooldown = kTrimCooldownFrames;
+            ::EmptyWorkingSet(::GetCurrentProcess());
+            FML_DLOG(INFO) << "Working set trimmed: " << rss_mb << " MB";
+          }
+        }
+      }
+    }
+  }
+#endif  // FML_OS_WIN
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/backend/vulkan/blit_pass_vk.h"
 
+#include "impeller/core/texture_descriptor.h"
 #include "impeller/renderer/backend/vulkan/barrier_vk.h"
 #include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
@@ -45,8 +46,11 @@ static void InsertImageMemoryBarrier(const vk::CommandBuffer& cmd,
 }
 
 BlitPassVK::BlitPassVK(std::shared_ptr<CommandBufferVK> command_buffer,
+                       std::shared_ptr<Allocator> allocator,
                        const WorkaroundsVK& workarounds)
-    : command_buffer_(std::move(command_buffer)), workarounds_(workarounds) {}
+    : command_buffer_(std::move(command_buffer)),
+      allocator_(std::move(allocator)),
+      workarounds_(workarounds) {}
 
 BlitPassVK::~BlitPassVK() = default;
 
@@ -93,12 +97,21 @@ bool BlitPassVK::OnCopyTextureToTextureCommand(
   BarrierVK dst_barrier;
   dst_barrier.cmd_buffer = cmd_buffer;
   dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
-  dst_barrier.src_access = {};
-  dst_barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
-  dst_barrier.dst_access =
-      vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eTransferWrite;
-  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader |
-                          vk::PipelineStageFlagBits::eTransfer;
+  // Wait for any prior buffer-to-image transfer writes to this destination
+  // before starting the image-to-image copy. In the atlas growth path,
+  // BulkUpdateAtlasBitmap writes rows 0..new_height via
+  // vkCmdCopyBufferToImage, then AddCopy(old->new) writes rows 0..old_height
+  // via vkCmdCopyImage. These writes overlap in rows 0..old_height. Without
+  // this barrier, the post-copy eTransfer->eFragmentShader barrier from
+  // BulkUpdateAtlasBitmap does NOT create a transitive dependency here because
+  // eTopOfPipe & eFragmentShader = empty - leaving a WAW hazard on AMD RDNA.
+  dst_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+  dst_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  // dstAccessMask must only list accesses valid for TRANSFER_DST_OPTIMAL.
+  // eShaderRead is not permitted in that layout; including it triggers AMD
+  // best practices validation layer message ID -212008545 (0xF35D019F).
+  dst_barrier.dst_access = vk::AccessFlagBits::eTransferWrite;
+  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
 
   if (!src.SetLayout(src_barrier) || !dst.SetLayout(dst_barrier)) {
     VALIDATION_LOG << "Could not complete layout transitions.";
@@ -137,8 +150,11 @@ bool BlitPassVK::OnCopyTextureToTextureCommand(
   BarrierVK barrier;
   barrier.cmd_buffer = cmd_buffer;
   barrier.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
-  barrier.src_access = {};
-  barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
+  // Flush the transfer write cache so that subsequent shader reads see the
+  // newly copied data. TOP_OF_PIPE with empty src_access does not flush the
+  // transfer write cache on AMD RDNA, leaving the DCC metadata stale.
+  barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+  barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
   barrier.dst_access = vk::AccessFlagBits::eShaderRead;
   barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader;
 
@@ -170,9 +186,8 @@ bool BlitPassVK::OnCopyTextureToBufferCommand(
   barrier.src_stage = vk::PipelineStageFlagBits::eFragmentShader |
                       vk::PipelineStageFlagBits::eTransfer |
                       vk::PipelineStageFlagBits::eColorAttachmentOutput;
-  barrier.dst_access = vk::AccessFlagBits::eShaderRead;
-  barrier.dst_stage = vk::PipelineStageFlagBits::eVertexShader |
-                      vk::PipelineStageFlagBits::eFragmentShader;
+  barrier.dst_access = vk::AccessFlagBits::eTransferRead;
+  barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
 
   const auto& dst = DeviceBufferVK::Cast(*destination);
 
@@ -259,12 +274,25 @@ bool BlitPassVK::OnCopyBufferToTextureCommand(
   BarrierVK dst_barrier;
   dst_barrier.cmd_buffer = cmd_buffer;
   dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
-  dst_barrier.src_access = {};
-  dst_barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
-  dst_barrier.dst_access =
-      vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eTransferWrite;
-  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader |
-                          vk::PipelineStageFlagBits::eTransfer;
+  // The src_access and src_stage must match the texture's current layout.
+  // When multiple copies target the same texture within a single blit pass
+  // (e.g. GlyphAtlas updates with convert_to_read=false), the texture is
+  // already in eTransferDstOptimal after the first copy - using eShaderRead
+  // as src_access in that case violates BestPractices-ImageBarrierAccessLayout.
+  if (dst.GetLayout() == vk::ImageLayout::eTransferDstOptimal) {
+    // WAW hazard: drain the prior transfer write before starting the next.
+    dst_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+    dst_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  } else {
+    // Normal path: texture was last sampled in a fragment shader.
+    dst_barrier.src_access = vk::AccessFlagBits::eShaderRead;
+    dst_barrier.src_stage = vk::PipelineStageFlagBits::eFragmentShader;
+  }
+  // dstAccessMask must only list accesses valid for TRANSFER_DST_OPTIMAL.
+  // eShaderRead is not permitted in that layout; including it triggers AMD
+  // best practices validation layer message ID -212008545 (0xF35D019F).
+  dst_barrier.dst_access = vk::AccessFlagBits::eTransferWrite;
+  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
 
   vk::BufferImageCopy image_copy;
   image_copy.setBufferOffset(source.GetRange().offset);
@@ -279,19 +307,132 @@ bool BlitPassVK::OnCopyBufferToTextureCommand(
   image_copy.imageExtent.height = destination_region.GetHeight();
   image_copy.imageExtent.depth = 1u;
 
-  // Note: this barrier should do nothing if we're already in the transfer dst
-  // optimal state. This is important for performance of repeated blit pass
-  // encoding.
-  if (!dst.SetLayout(dst_barrier)) {
-    VALIDATION_LOG << "Could not encode layout transition.";
-    return false;
+  // Workaround for Mesa dzn (D3D12 translation layer) drivers that report
+  // minImageTransferGranularity of (0,0,0) and reject sub-region
+  // vkCmdCopyBufferToImage with VK_ERROR_OUT_OF_HOST_MEMORY. When the copy
+  // targets a sub-region, a staging image is used as an intermediary:
+  //   1. Full-region buffer -> staging image (not rejected)
+  //   2. vkCmdCopyImage staging -> destination at sub-region offset
+  //      (image-to-image copies are not subject to transfer granularity)
+  bool is_sub_region = false;
+  if (workarounds_.skip_sub_region_buffer_to_image_copy) {
+    const auto& dst_desc = destination->GetTextureDescriptor();
+    is_sub_region =
+        (destination_region.GetX() != 0 || destination_region.GetY() != 0 ||
+         static_cast<uint32_t>(destination_region.GetWidth()) !=
+             dst_desc.size.width ||
+         static_cast<uint32_t>(destination_region.GetHeight()) !=
+             dst_desc.size.height);
   }
 
-  cmd_buffer.copyBufferToImage(src.GetBuffer(),         //
-                               dst.GetImage(),          //
-                               dst_barrier.new_layout,  //
-                               image_copy               //
-  );
+  if (is_sub_region && allocator_) {
+    // Staging image path: create a texture matching the sub-region.
+    TextureDescriptor staging_desc;
+    staging_desc.format = destination->GetTextureDescriptor().format;
+    staging_desc.size =
+        ISize{static_cast<int64_t>(destination_region.GetWidth()),
+              static_cast<int64_t>(destination_region.GetHeight())};
+    staging_desc.storage_mode = StorageMode::kDevicePrivate;
+    staging_desc.usage = TextureUsage::kShaderRead;
+
+    auto staging_texture = allocator_->CreateTexture(staging_desc);
+    if (!staging_texture) {
+      VALIDATION_LOG << "Failed to create staging texture for sub-region copy.";
+      return false;
+    }
+    staging_texture->SetLabel("SubRegionStaging");
+
+    if (!command_buffer_->Track(staging_texture)) {
+      return false;
+    }
+
+    const auto& staging_vk = TextureVK::Cast(*staging_texture);
+
+    // Transition staging to transfer-dst.
+    BarrierVK staging_dst_barrier;
+    staging_dst_barrier.cmd_buffer = cmd_buffer;
+    staging_dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
+    staging_dst_barrier.src_access = {};
+    staging_dst_barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
+    staging_dst_barrier.dst_access = vk::AccessFlagBits::eTransferWrite;
+    staging_dst_barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
+
+    if (!staging_vk.SetLayout(staging_dst_barrier)) {
+      VALIDATION_LOG << "Could not transition staging image layout.";
+      return false;
+    }
+
+    // Full-region buffer -> staging (offset 0,0 - not a sub-region copy).
+    vk::BufferImageCopy staging_copy;
+    staging_copy.setBufferOffset(source.GetRange().offset);
+    staging_copy.setBufferRowLength(0);
+    staging_copy.setBufferImageHeight(0);
+    staging_copy.setImageSubresource(
+        vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1));
+    staging_copy.imageOffset = vk::Offset3D(0, 0, 0);
+    staging_copy.imageExtent =
+        vk::Extent3D(static_cast<uint32_t>(destination_region.GetWidth()),
+                     static_cast<uint32_t>(destination_region.GetHeight()), 1u);
+
+    cmd_buffer.copyBufferToImage(src.GetBuffer(),                 //
+                                 staging_vk.GetImage(),           //
+                                 staging_dst_barrier.new_layout,  //
+                                 staging_copy                     //
+    );
+
+    // Transition staging to transfer-src.
+    BarrierVK staging_src_barrier;
+    staging_src_barrier.cmd_buffer = cmd_buffer;
+    staging_src_barrier.new_layout = vk::ImageLayout::eTransferSrcOptimal;
+    staging_src_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+    staging_src_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+    staging_src_barrier.dst_access = vk::AccessFlagBits::eTransferRead;
+    staging_src_barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
+
+    if (!staging_vk.SetLayout(staging_src_barrier)) {
+      VALIDATION_LOG << "Could not transition staging image to transfer-src.";
+      return false;
+    }
+
+    // Transition destination to transfer-dst.
+    if (!dst.SetLayout(dst_barrier)) {
+      VALIDATION_LOG << "Could not encode layout transition.";
+      return false;
+    }
+
+    // Image-to-image copy: staging -> destination at sub-region offset.
+    // vkCmdCopyImage is not subject to minImageTransferGranularity.
+    vk::ImageCopy img_copy;
+    img_copy.setSrcSubresource(
+        vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1));
+    img_copy.setDstSubresource(vk::ImageSubresourceLayers(
+        vk::ImageAspectFlagBits::eColor, mip_level, slice, 1));
+    img_copy.srcOffset = vk::Offset3D(0, 0, 0);
+    img_copy.dstOffset =
+        vk::Offset3D(destination_region.GetX(), destination_region.GetY(), 0);
+    img_copy.extent =
+        vk::Extent3D(static_cast<uint32_t>(destination_region.GetWidth()),
+                     static_cast<uint32_t>(destination_region.GetHeight()), 1u);
+
+    cmd_buffer.copyImage(staging_vk.GetImage(),           //
+                         staging_src_barrier.new_layout,  //
+                         dst.GetImage(),                  //
+                         dst_barrier.new_layout,          //
+                         img_copy                         //
+    );
+  } else {
+    // Direct buffer-to-image copy (normal path).
+    if (!dst.SetLayout(dst_barrier)) {
+      VALIDATION_LOG << "Could not encode layout transition.";
+      return false;
+    }
+
+    cmd_buffer.copyBufferToImage(src.GetBuffer(),         //
+                                 dst.GetImage(),          //
+                                 dst_barrier.new_layout,  //
+                                 image_copy               //
+    );
+  }
 
   // Transition to shader-read.
   if (convert_to_read) {
@@ -305,6 +446,8 @@ bool BlitPassVK::OnCopyBufferToTextureCommand(
     barrier.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
 
     if (!dst.SetLayout(barrier)) {
+      VALIDATION_LOG << "Failed to set destination texture layout to "
+                        "eShaderReadOnlyOptimal after blit.";
       return false;
     }
   }
@@ -341,10 +484,11 @@ bool BlitPassVK::ResizeTexture(const std::shared_ptr<Texture>& source,
   dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
   dst_barrier.src_access = {};
   dst_barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
-  dst_barrier.dst_access =
-      vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eTransferWrite;
-  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader |
-                          vk::PipelineStageFlagBits::eTransfer;
+  // dstAccessMask must only list accesses valid for TRANSFER_DST_OPTIMAL.
+  // eShaderRead is not permitted in that layout; including it triggers AMD
+  // best practices validation layer message ID -212008545 (0xF35D019F).
+  dst_barrier.dst_access = vk::AccessFlagBits::eTransferWrite;
+  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
 
   if (!src.SetLayout(src_barrier) || !dst.SetLayout(dst_barrier)) {
     VALIDATION_LOG << "Could not complete layout transitions.";
@@ -387,8 +531,10 @@ bool BlitPassVK::ResizeTexture(const std::shared_ptr<Texture>& source,
   BarrierVK barrier;
   barrier.cmd_buffer = cmd_buffer;
   barrier.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
-  barrier.src_access = {};
-  barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
+  // Flush the transfer write cache after blitImage so AMD RDNA DCC metadata
+  // is coherent before the next shader read.
+  barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+  barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
   barrier.dst_access = vk::AccessFlagBits::eShaderRead;
   barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader;
 
@@ -419,16 +565,35 @@ bool BlitPassVK::OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
   // TransferSrc to prepare the mip level after it, use the image as the source
   // of the blit, before finally switching it to ShaderReadOnly so its available
   // for sampling in a shader.
+  //
+  // The src_access mask and src_stage are selected based on the image's current
+  // layout to produce a precise barrier that satisfies only the actual
+  // producing operation. This avoids BestPractices-ImageBarrierAccessLayout
+  // validation warnings that occur when using a broad OR of all possible
+  // stages. The dst_access is eTransferWrite (not eTransferRead) because the
+  // blit *writes* into the destination mip levels.
+  vk::AccessFlags mip_src_access;
+  vk::PipelineStageFlags mip_src_stage;
+  if (src.GetLayout() == vk::ImageLayout::eTransferDstOptimal) {
+    mip_src_access = vk::AccessFlagBits::eTransferWrite;
+    mip_src_stage = vk::PipelineStageFlagBits::eTransfer;
+  } else if (src.GetLayout() == vk::ImageLayout::eColorAttachmentOptimal) {
+    mip_src_access = vk::AccessFlagBits::eColorAttachmentWrite;
+    mip_src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+  } else {
+    // Default: texture was last sampled in a fragment shader
+    // (eShaderReadOnlyOptimal) or is newly created (eUndefined).
+    mip_src_access = vk::AccessFlagBits::eShaderRead;
+    mip_src_stage = vk::PipelineStageFlagBits::eFragmentShader;
+  }
   InsertImageMemoryBarrier(
       /*cmd=*/cmd,
       /*image=*/image,
-      /*src_access_mask=*/vk::AccessFlagBits::eTransferWrite |
-          vk::AccessFlagBits::eColorAttachmentWrite,
-      /*dst_access_mask=*/vk::AccessFlagBits::eTransferRead,
+      /*src_access_mask=*/mip_src_access,
+      /*dst_access_mask=*/vk::AccessFlagBits::eTransferWrite,
       /*old_layout=*/src.GetLayout(),
       /*new_layout=*/vk::ImageLayout::eTransferDstOptimal,
-      /*src_stage=*/vk::PipelineStageFlagBits::eTransfer |
-          vk::PipelineStageFlagBits::eColorAttachmentOutput,
+      /*src_stage=*/mip_src_stage,
       /*dst_stage=*/vk::PipelineStageFlagBits::eTransfer,
       /*base_mip_level=*/0u,
       /*mip_level_count=*/mip_count);

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
@@ -97,16 +97,26 @@ bool BlitPassVK::OnCopyTextureToTextureCommand(
   BarrierVK dst_barrier;
   dst_barrier.cmd_buffer = cmd_buffer;
   dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
-  // Wait for any prior buffer-to-image transfer writes to this destination
-  // before starting the image-to-image copy. In the atlas growth path,
-  // BulkUpdateAtlasBitmap writes rows 0..new_height via
-  // vkCmdCopyBufferToImage, then AddCopy(old->new) writes rows 0..old_height
-  // via vkCmdCopyImage. These writes overlap in rows 0..old_height. Without
-  // this barrier, the post-copy eTransfer->eFragmentShader barrier from
-  // BulkUpdateAtlasBitmap does NOT create a transitive dependency here because
-  // eTopOfPipe & eFragmentShader = empty - leaving a WAW hazard on AMD RDNA.
-  dst_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
-  dst_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  // The src_access and src_stage must match the texture's current layout,
+  // mirroring OnCopyBufferToTextureCommand below.
+  if (dst.GetLayout() == vk::ImageLayout::eTransferDstOptimal) {
+    // Wait for prior transfer writes to this destination before starting the
+    // image-to-image copy. In the atlas growth path, BulkUpdateAtlasBitmap
+    // writes rows 0..new_height via vkCmdCopyBufferToImage, then
+    // AddCopy(old->new) writes rows 0..old_height via vkCmdCopyImage. These
+    // writes overlap in rows 0..old_height. Without this barrier, the
+    // post-copy eTransfer->eFragmentShader barrier from BulkUpdateAtlasBitmap
+    // does NOT create a transitive dependency here because eTopOfPipe &
+    // eFragmentShader = empty - leaving a WAW hazard on AMD RDNA.
+    dst_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+    dst_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  } else {
+    // Normal path: the texture was last sampled in a fragment shader. A
+    // transfer write in an earlier layout is drained transitively by the
+    // barrier that transitioned the texture out of eTransferDstOptimal.
+    dst_barrier.src_access = vk::AccessFlagBits::eShaderRead;
+    dst_barrier.src_stage = vk::PipelineStageFlagBits::eFragmentShader;
+  }
   // dstAccessMask must only list accesses valid for TRANSFER_DST_OPTIMAL.
   // eShaderRead is not permitted in that layout; including it triggers AMD
   // best practices validation layer message ID -212008545 (0xF35D019F).

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
@@ -97,16 +97,28 @@ bool BlitPassVK::OnCopyTextureToTextureCommand(
   BarrierVK dst_barrier;
   dst_barrier.cmd_buffer = cmd_buffer;
   dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
-  // Wait for any prior buffer-to-image transfer writes to this destination
-  // before starting the image-to-image copy. In the atlas growth path,
-  // BulkUpdateAtlasBitmap writes rows 0..new_height via
-  // vkCmdCopyBufferToImage, then AddCopy(old->new) writes rows 0..old_height
-  // via vkCmdCopyImage. These writes overlap in rows 0..old_height. Without
-  // this barrier, the post-copy eTransfer->eFragmentShader barrier from
-  // BulkUpdateAtlasBitmap does NOT create a transitive dependency here because
-  // eTopOfPipe & eFragmentShader = empty - leaving a WAW hazard on AMD RDNA.
-  dst_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
-  dst_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  // The src_access and src_stage must match the texture's current layout,
+  // mirroring OnCopyBufferToTextureCommand below.
+  if (dst.GetLayout() == vk::ImageLayout::eTransferDstOptimal) {
+    // The destination is still in eTransferDstOptimal from an earlier
+    // transfer write (e.g. a second copy into the same swapchain image), so
+    // there is no intermediate barrier to chain with; drain the prior
+    // transfer write directly.
+    dst_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+    dst_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  } else {
+    // The texture was last read by a fragment shader. Earlier transfer
+    // writes are drained transitively: the barrier that took the texture out
+    // of eTransferDstOptimal has eFragmentShader in its destination scope,
+    // which intersects the source scope here and forms a dependency chain.
+    // This is what orders BulkUpdateAtlasBitmap's buffer-to-image write
+    // against the copy of the old atlas contents during atlas growth. The
+    // old eTopOfPipe source stage could not form that chain (its
+    // intersection with eFragmentShader is empty), leaving a WAW hazard on
+    // AMD RDNA.
+    dst_barrier.src_access = vk::AccessFlagBits::eShaderRead;
+    dst_barrier.src_stage = vk::PipelineStageFlagBits::eFragmentShader;
+  }
   // dstAccessMask must only list accesses valid for TRANSFER_DST_OPTIMAL.
   // eShaderRead is not permitted in that layout; including it triggers AMD
   // best practices validation layer message ID -212008545 (0xF35D019F).

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.h
@@ -7,6 +7,7 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/base/config.h"
+#include "impeller/core/allocator.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/renderer/backend/vulkan/workarounds_vk.h"
 #include "impeller/renderer/blit_pass.h"
@@ -27,9 +28,11 @@ class BlitPassVK final : public BlitPass {
                   MipmapGenerationTransitionsAllLevelsCorrectly);
 
   std::shared_ptr<CommandBufferVK> command_buffer_;
+  std::shared_ptr<Allocator> allocator_;
   const WorkaroundsVK workarounds_;
 
   explicit BlitPassVK(std::shared_ptr<CommandBufferVK> command_buffer,
+                      std::shared_ptr<Allocator> allocator,
                       const WorkaroundsVK& workarounds);
 
   // |BlitPass|

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -51,8 +51,19 @@ CapabilitiesVK::CapabilitiesVK(bool enable_validations,
       }
     }
   } else {
+    // In embedder mode, use the extensions provided by the embedder but still
+    // enumerate available layers so that validation layers can be detected and
+    // enabled when requested.
     for (const auto& ext : embedder_instance_extensions_) {
       exts_[kInstanceLayer].insert(ext);
+    }
+    auto layers = vk::enumerateInstanceLayerProperties();
+    if (layers.result == vk::Result::eSuccess) {
+      for (const auto& layer : layers.value) {
+        // Register the layer name so HasLayer() works. Don't enumerate
+        // per-layer extensions - the embedder controls the instance.
+        exts_[std::string(layer.layerName)];
+      }
     }
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -110,13 +110,21 @@ std::optional<std::vector<std::string>>
 CapabilitiesVK::GetEnabledInstanceExtensions() const {
   std::vector<std::string> required;
 
-  if (!HasExtension("VK_KHR_surface")) {
-    // Swapchain support is required and this is a dependency of
-    // VK_KHR_swapchain.
-    VALIDATION_LOG << "Could not find the surface extension.";
-    return std::nullopt;
+  // An embedder that does not provide the surface extension presents
+  // rendered images itself (for example through a platform compositor), so
+  // neither VK_KHR_surface nor any WSI extension is required.
+  const bool embedder_controls_presentation =
+      use_embedder_extensions_ && !HasExtension("VK_KHR_surface");
+
+  if (!embedder_controls_presentation) {
+    if (!HasExtension("VK_KHR_surface")) {
+      // Swapchain support is required and this is a dependency of
+      // VK_KHR_swapchain.
+      VALIDATION_LOG << "Could not find the surface extension.";
+      return std::nullopt;
+    }
+    required.push_back("VK_KHR_surface");
   }
-  required.push_back("VK_KHR_surface");
 
   auto has_wsi = false;
   if (HasExtension("VK_MVK_macos_surface")) {
@@ -159,7 +167,7 @@ CapabilitiesVK::GetEnabledInstanceExtensions() const {
     has_wsi = true;
   }
 
-  if (!has_wsi) {
+  if (!has_wsi && !embedder_controls_presentation) {
     // Don't really care which WSI extension there is as long there is at least
     // one.
     VALIDATION_LOG << "Could not find a WSI extension.";
@@ -295,6 +303,11 @@ CapabilitiesVK::GetEnabledDeviceExtensions(
   auto for_each_common_extension = [&](RequiredCommonDeviceExtensionVK ext) {
     auto name = GetExtensionName(ext);
     if (exts.find(name) == exts.end()) {
+      if (use_embedder_extensions_) {
+        // The embedder controls presentation and may legitimately omit
+        // swapchain support (see GetEnabledInstanceExtensions).
+        return true;
+      }
       VALIDATION_LOG << "Device does not support required extension: " << name;
       return false;
     }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_buffer_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_buffer_vk.cc
@@ -75,8 +75,9 @@ std::shared_ptr<BlitPass> CommandBufferVK::OnCreateBlitPass() {
   if (!context) {
     return nullptr;
   }
-  auto pass = std::shared_ptr<BlitPassVK>(new BlitPassVK(
-      shared_from_this(), ContextVK::Cast(*context).GetWorkarounds()));
+  auto pass = std::shared_ptr<BlitPassVK>(
+      new BlitPassVK(shared_from_this(), context->GetResourceAllocator(),
+                     ContextVK::Cast(*context).GetWorkarounds()));
   if (!pass->IsValid()) {
     return nullptr;
   }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_buffer_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_buffer_vk.cc
@@ -74,8 +74,9 @@ std::shared_ptr<BlitPass> CommandBufferVK::OnCreateBlitPass() {
   if (!context) {
     return nullptr;
   }
-  auto pass = std::shared_ptr<BlitPassVK>(new BlitPassVK(
-      shared_from_this(), ContextVK::Cast(*context).GetWorkarounds()));
+  auto pass = std::shared_ptr<BlitPassVK>(
+      new BlitPassVK(shared_from_this(), context->GetResourceAllocator(),
+                     ContextVK::Cast(*context).GetWorkarounds()));
   if (!pass->IsValid()) {
     return nullptr;
   }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -45,6 +45,14 @@ class BackgroundCommandPoolVK final {
     // once for the original BackgroundCommandPoolVK() and once for the moved
     // BackgroundCommandPoolVK().
     if (!recycler) {
+      // The context is gone, and the device may already be destroyed. Release
+      // the handles without making Vulkan API calls: letting the RAII wrappers
+      // call vkFreeCommandBuffers / vkDestroyCommandPool on a destroyed device
+      // crashes inside the ICD.
+      for (auto& buffer : buffers_) {
+        buffer.release();
+      }
+      pool_.release();
       return;
     }
     // If there are many unused command buffers, release some of them and
@@ -156,6 +164,29 @@ void CommandPoolVK::Destroy() {
 
   // When the command pool is destroyed, all of its command buffers are freed.
   // Handles allocated from that pool are now invalid and must be discarded.
+  for (auto& buffer : collected_buffers_) {
+    buffer.release();
+  }
+  for (auto& buffer : unused_command_buffers_) {
+    buffer.release();
+  }
+  unused_command_buffers_.clear();
+  collected_buffers_.clear();
+}
+
+void CommandPoolVK::AbandonForDriverCrash() {
+  Lock lock(pool_mutex_);
+  if (!pool_) {
+    return;
+  }
+  // Some drivers non-conformantly invalidate the VkCommandPool and its child
+  // VkCommandBuffer handles internally when vkQueueSubmit returns
+  // VK_ERROR_OUT_OF_HOST_MEMORY (observed on AMD). Calling
+  // vkDestroyCommandPool or vkFreeCommandBuffers on these already-invalid
+  // handles causes validation errors and an access violation inside the
+  // driver. Release the C++ ownership handles without invoking any Vulkan
+  // destroy/free calls.
+  pool_.release();
   for (auto& buffer : collected_buffers_) {
     buffer.release();
   }
@@ -296,8 +327,16 @@ void CommandPoolRecyclerVK::Reclaim(
     VALIDATION_LOG << "Could not reset command pool: " << vk::to_string(result);
   }
 
-  // Move the pool to the recycled list.
+  // Move the pool to the recycled list, capping the list size to prevent
+  // unbounded host memory growth. Without a cap, heavy workloads (e.g. text
+  // rendering stress) can accumulate dozens of recycled pools, each holding
+  // significant driver-internal memory. Evict oldest first; the device is
+  // alive here, so normal RAII destruction of the evicted pool is safe.
   Lock recycled_lock(recycled_mutex_);
+  static constexpr size_t kMaxRecycledCommandPools = 8;
+  while (recycled_.size() >= kMaxRecycledCommandPools) {
+    recycled_.erase(recycled_.begin());
+  }
   recycled_.push_back(
       RecycledData{.pool = std::move(pool), .buffers = std::move(buffers)});
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -45,6 +45,14 @@ class BackgroundCommandPoolVK final {
     // once for the original BackgroundCommandPoolVK() and once for the moved
     // BackgroundCommandPoolVK().
     if (!recycler) {
+      // The context is gone, and the device may already be destroyed. Release
+      // the handles without making Vulkan API calls: letting the RAII wrappers
+      // call vkFreeCommandBuffers / vkDestroyCommandPool on a destroyed device
+      // crashes inside the ICD.
+      for (auto& buffer : buffers_) {
+        buffer.release();
+      }
+      pool_.release();
       return;
     }
     // If there are many unused command buffers, release some of them and
@@ -156,6 +164,29 @@ void CommandPoolVK::Destroy() {
 
   // When the command pool is destroyed, all of its command buffers are freed.
   // Handles allocated from that pool are now invalid and must be discarded.
+  for (auto& buffer : collected_buffers_) {
+    buffer.release();
+  }
+  for (auto& buffer : unused_command_buffers_) {
+    buffer.release();
+  }
+  unused_command_buffers_.clear();
+  collected_buffers_.clear();
+}
+
+void CommandPoolVK::AbandonForDriverCrash() {
+  Lock lock(pool_mutex_);
+  if (!pool_) {
+    return;
+  }
+  // Some drivers non-conformantly invalidate the VkCommandPool and its child
+  // VkCommandBuffer handles internally when vkQueueSubmit returns
+  // VK_ERROR_OUT_OF_HOST_MEMORY (observed on AMD). Calling
+  // vkDestroyCommandPool or vkFreeCommandBuffers on these already-invalid
+  // handles causes validation errors and an access violation inside the
+  // driver. Release the C++ ownership handles without invoking any Vulkan
+  // destroy/free calls.
+  pool_.release();
   for (auto& buffer : collected_buffers_) {
     buffer.release();
   }
@@ -296,10 +327,21 @@ void CommandPoolRecyclerVK::Reclaim(
     VALIDATION_LOG << "Could not reset command pool: " << vk::to_string(result);
   }
 
-  // Move the pool to the recycled list.
+  // Move the pool to the recycled list, capping the list size to prevent
+  // unbounded host memory growth. Without a cap, heavy workloads (e.g. text
+  // rendering stress) can accumulate dozens of recycled pools, each holding
+  // significant driver-internal memory. When the cache is full the incoming
+  // pool is dropped instead of evicting a cached entry: RecycledData's
+  // members are declared so that plain destruction frees the buffers before
+  // their pool, whereas shifting vector elements with erase() would
+  // move-assign them in declaration order, destroying the overwritten slot's
+  // pool before freeing its buffers - a use-after-free inside the driver.
   Lock recycled_lock(recycled_mutex_);
-  recycled_.push_back(
-      RecycledData{.pool = std::move(pool), .buffers = std::move(buffers)});
+  static constexpr size_t kMaxRecycledCommandPools = 8;
+  if (recycled_.size() < kMaxRecycledCommandPools) {
+    recycled_.push_back(
+        RecycledData{.pool = std::move(pool), .buffers = std::move(buffers)});
+  }
 }
 
 void CommandPoolRecyclerVK::Dispose() {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
@@ -61,6 +61,16 @@ class CommandPoolVK final {
   /// @see        |GarbageCollectBuffersIfAble|
   void CollectCommandBuffer(vk::UniqueCommandBuffer&& buffer);
 
+  /// @brief      Discard all Vulkan handles WITHOUT invoking any Vulkan
+  ///             destroy/free calls.
+  ///
+  /// Use this only after a failed vkQueueSubmit has left the driver in a
+  /// state where the pool and its buffer handles are already invalid (e.g.
+  /// the non-conformant out-of-memory behavior observed on AMD drivers).
+  /// Calling vkDestroyCommandPool or vkFreeCommandBuffers on such handles
+  /// causes validation errors and crashes inside the driver.
+  void AbandonForDriverCrash();
+
  private:
   friend CommandPoolRecyclerVK;
 
@@ -73,7 +83,8 @@ class CommandPoolVK final {
 
   Mutex pool_mutex_;
   vk::UniqueCommandPool pool_ IPLR_GUARDED_BY(pool_mutex_);
-  std::vector<vk::UniqueCommandBuffer> unused_command_buffers_;
+  std::vector<vk::UniqueCommandBuffer> unused_command_buffers_
+      IPLR_GUARDED_BY(pool_mutex_);
   std::weak_ptr<ContextVK> context_;
   std::weak_ptr<DeviceHolderVK> device_holder_;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
@@ -61,6 +61,16 @@ class CommandPoolVK final {
   /// @see        |GarbageCollectBuffersIfAble|
   void CollectCommandBuffer(vk::UniqueCommandBuffer&& buffer);
 
+  /// @brief      Discard all Vulkan handles WITHOUT invoking any Vulkan
+  ///             destroy/free calls.
+  ///
+  /// Use this only after a failed vkQueueSubmit has left the driver in a
+  /// state where the pool and its buffer handles are already invalid (e.g.
+  /// the non-conformant out-of-memory behavior observed on AMD drivers).
+  /// Calling vkDestroyCommandPool or vkFreeCommandBuffers on such handles
+  /// causes validation errors and crashes inside the driver.
+  void AbandonForDriverCrash();
+
  private:
   friend CommandPoolRecyclerVK;
 
@@ -73,7 +83,8 @@ class CommandPoolVK final {
 
   Mutex pool_mutex_;
   vk::UniqueCommandPool pool_ IPLR_GUARDED_BY(pool_mutex_);
-  std::vector<vk::UniqueCommandBuffer> unused_command_buffers_;
+  std::vector<vk::UniqueCommandBuffer> unused_command_buffers_
+      IPLR_GUARDED_BY(pool_mutex_);
   std::weak_ptr<ContextVK> context_;
   std::weak_ptr<DeviceHolderVK> device_holder_;
 
@@ -110,6 +121,12 @@ class CommandPoolRecyclerVK final
     : public std::enable_shared_from_this<CommandPoolRecyclerVK> {
  public:
   /// A unique command pool and zero or more recycled command buffers.
+  ///
+  /// The member order is load-bearing: destructors run in reverse
+  /// declaration order, so the buffers are freed while their pool is still
+  /// alive. Do not shift instances around with operations that move-assign
+  /// (for example vector::erase), which run in declaration order and
+  /// destroy the overwritten slot's pool before freeing its buffers.
   struct RecycledData {
     vk::UniqueCommandPool pool;
     std::vector<vk::UniqueCommandBuffer> buffers;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
@@ -66,7 +66,13 @@ class DeathRattle final {
   DeathRattle(DeathRattle&&) = default;
   DeathRattle& operator=(DeathRattle&&) = default;
 
-  ~DeathRattle() { callback_(); }
+  // The callback may be empty when this instance has been moved from; the
+  // moved-from local still runs this destructor.
+  ~DeathRattle() {
+    if (callback_) {
+      callback_();
+    }
+  }
 
  private:
   std::function<void()> callback_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
@@ -69,7 +69,13 @@ class DeathRattle final {
   DeathRattle(DeathRattle&&) = default;
   DeathRattle& operator=(DeathRattle&&) = default;
 
-  ~DeathRattle() { callback_(); }
+  // The callback may be empty when this instance has been moved from; the
+  // moved-from local still runs this destructor.
+  ~DeathRattle() {
+    if (callback_) {
+      callback_();
+    }
+  }
 
  private:
   std::function<void()> callback_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <thread>
+
 #include "flutter/testing/testing.h"  // IWYU pragma: keep.
+#include "fml/synchronization/count_down_latch.h"
 #include "fml/synchronization/waitable_event.h"
 #include "impeller/renderer/backend/vulkan/command_pool_vk.h"
 #include "impeller/renderer/backend/vulkan/device_holder_vk.h"
@@ -216,6 +219,61 @@ TEST(CommandPoolRecyclerVKTest, ExtraCommandBufferAllocationsTriggerTrim) {
   EXPECT_EQ(std::count(called->begin(), called->end(),
                        "vkResetCommandPoolReleaseResources"),
             1u);
+
+  context->Shutdown();
+}
+
+TEST(CommandPoolRecyclerVKTest, DroppedPoolsFreeBuffersBeforeTheirPool) {
+  auto const context = MockVulkanContextBuilder().Build();
+
+  // Reclaim more pools than the recycler caches, each carrying a recycled
+  // command buffer. Pools are per thread, so a distinct thread is used for
+  // each; a barrier keeps every pool alive until all are created, otherwise
+  // an early Dispose lets a later thread reuse a recycled pool instead of
+  // creating its own.
+  constexpr size_t kPoolCount = 10;  // Cache cap is 8.
+  fml::CountDownLatch all_created(kPoolCount);
+  fml::ManualResetWaitableEvent dispose;
+  std::vector<std::thread> threads;
+  threads.reserve(kPoolCount);
+  for (size_t i = 0; i < kPoolCount; i++) {
+    threads.emplace_back([&]() {
+      auto const recycler = context->GetCommandPoolRecycler();
+      auto pool = recycler->Get();
+      auto buffer = pool->CreateCommandBuffer();
+      pool->CollectCommandBuffer(std::move(buffer));
+      all_created.CountDown();
+      dispose.Wait();
+      pool.reset();
+      recycler->Dispose();
+    });
+  }
+  all_created.Wait();
+  dispose.Signal();
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  // Pools reclaimed past the cache cap are destroyed with their recycled
+  // buffers. In this window those are the only destroys and frees (cached
+  // pools stay alive until Shutdown), and each buffer must be freed before
+  // its pool is destroyed: at every point of the recorded call sequence the
+  // number of vkFreeCommandBuffers calls must be at least the number of
+  // vkDestroyCommandPool calls. Freeing a buffer after its pool was
+  // destroyed is a use-after-free inside the driver.
+  auto const called = ReclaimAndGetMockVulkanFunctions(context);
+  int64_t frees = 0;
+  int64_t destroys = 0;
+  for (const auto& function : *called) {
+    if (function == "vkFreeCommandBuffers") {
+      frees++;
+    } else if (function == "vkDestroyCommandPool") {
+      destroys++;
+    }
+    EXPECT_GE(frees, destroys);
+  }
+  EXPECT_EQ(destroys, 2);
+  EXPECT_EQ(frees, 2);
 
   context->Shutdown();
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
@@ -4,6 +4,8 @@
 
 #include "fml/status.h"
 
+#include <chrono>
+
 #include "impeller/renderer/backend/vulkan/command_queue_vk.h"
 
 #include "impeller/base/validation.h"
@@ -15,8 +17,65 @@
 
 namespace impeller {
 
+// Timeout waiting for an in-flight submission slot. Generous enough that no
+// legitimate GPU workload should hit it.
+static constexpr std::chrono::seconds kSubmitSlotTimeout{5};
+
+// Right-shift to convert bytes to megabytes for diagnostic logging.
+static constexpr uint32_t kBytesToMBShift = 20;
+
+// Logs per-heap memory usage and budgets after a failed queue submission.
+// VK_EXT_memory_budget data is far more useful than the static heap sizes,
+// but the extension is not tracked by the context; detect whether the driver
+// filled the chained struct by checking every heap's budget. A driver that
+// populated the struct reports a non-zero budget for at least one heap,
+// whereas an ignored pNext struct stays zero-initialized.
+static void LogHeapBudgetsAtOOM(const ContextVK& context,
+                                size_t failed_buffer_count) {
+  vk::PhysicalDeviceMemoryProperties2 mem_props2;
+  vk::PhysicalDeviceMemoryBudgetPropertiesEXT budget_props;
+  mem_props2.pNext = &budget_props;
+
+  // getMemoryProperties2 is core Vulkan 1.1 and always available.
+  context.GetPhysicalDevice().getMemoryProperties2(&mem_props2);
+
+  const auto& heaps = mem_props2.memoryProperties.memoryHeaps;
+  const uint32_t heap_count = mem_props2.memoryProperties.memoryHeapCount;
+
+  bool has_budget = false;
+  for (uint32_t i = 0; i < heap_count; i++) {
+    has_budget = has_budget || budget_props.heapBudget[i] != 0;
+  }
+
+  VALIDATION_LOG << "=== Vulkan memory snapshot at OOM ===";
+  for (uint32_t i = 0; i < heap_count; i++) {
+    bool is_device_local = static_cast<bool>(
+        heaps[i].flags & vk::MemoryHeapFlagBits::eDeviceLocal);
+    if (has_budget) {
+      VALIDATION_LOG << "  heap[" << i << "] "
+                     << (is_device_local ? "DEVICE_LOCAL" : "host      ")
+                     << "  used="
+                     << (budget_props.heapUsage[i] >> kBytesToMBShift) << "MB"
+                     << "  budget="
+                     << (budget_props.heapBudget[i] >> kBytesToMBShift) << "MB"
+                     << "  total=" << (heaps[i].size >> kBytesToMBShift) << "MB"
+                     << (budget_props.heapUsage[i] > budget_props.heapBudget[i]
+                             ? "  <<< OVER BUDGET"
+                             : "");
+    } else {
+      VALIDATION_LOG << "  heap[" << i << "] "
+                     << (is_device_local ? "DEVICE_LOCAL" : "host      ")
+                     << "  total=" << (heaps[i].size >> kBytesToMBShift) << "MB"
+                     << "  (VK_EXT_memory_budget not available)";
+    }
+  }
+  VALIDATION_LOG << "  submit_count=" << failed_buffer_count
+                 << " cmd buffers in failed submission";
+  VALIDATION_LOG << "=====================================";
+}
+
 CommandQueueVK::CommandQueueVK(const std::weak_ptr<ContextVK>& context)
-    : context_(context) {}
+    : context_(context), in_flight_state_(std::make_shared<InFlightState>()) {}
 
 CommandQueueVK::~CommandQueueVK() = default;
 
@@ -54,23 +113,84 @@ fml::Status CommandQueueVK::Submit(
     VALIDATION_LOG << "Device lost.";
     return fml::Status(fml::StatusCode::kCancelled, "Device lost.");
   }
+  if (context->IsDeviceLost()) {
+    return fml::Status(fml::StatusCode::kCancelled, "Device lost.");
+  }
+
+  // Throttle: wait until there is capacity for a new in-flight submission.
+  // This creates backpressure to prevent host memory exhaustion when the GPU
+  // cannot keep up with the rate of submission. The 5-second timeout is
+  // generous: even a heavily loaded GPU should complete a frame submission
+  // well within this window. On timeout, the submission is cancelled to
+  // enforce the limit strictly.
+  {
+    std::unique_lock<std::mutex> lock(in_flight_state_->mutex);
+    if (!in_flight_state_->cv.wait_for(lock, kSubmitSlotTimeout, [this]() {
+          return in_flight_state_->count < kMaxInFlightSubmissions;
+        })) {
+      VALIDATION_LOG << "Timed out waiting for in-flight submission slot. "
+                     << "In-flight: " << in_flight_state_->count
+                     << ". Cancelling submission to prevent resource "
+                     << "exhaustion.";
+      return fml::Status(fml::StatusCode::kCancelled,
+                         "Timed out waiting for in-flight submission slot.");
+    }
+    ++in_flight_state_->count;
+  }
+
+  // Release the in-flight slot on any error path below. On success, the slot
+  // is instead released by the fence completion callback.
+  fml::ScopedCleanupClosure release_slot([state = in_flight_state_]() {
+    {
+      std::lock_guard<std::mutex> lock(state->mutex);
+      --state->count;
+    }
+    state->cv.notify_one();
+  });
+
   auto [fence_result, fence] = context->GetDevice().createFenceUnique({});
   if (fence_result != vk::Result::eSuccess) {
     VALIDATION_LOG << "Failed to create fence: " << vk::to_string(fence_result);
     return fml::Status(fml::StatusCode::kCancelled, "Failed to create fence.");
   }
 
+  // Shared between the submit callback (failure path) and the fence
+  // completion callback (success path). Exactly one of the two consumes it.
+  auto shared_tracked_objects =
+      std::make_shared<std::vector<std::shared_ptr<TrackedObjectsVK>>>(
+          std::move(tracked_objects));
+
   // This will be called immediately by FenceWaiterVK::AddFence.
-  auto submit_callback = [&context, &vk_buffers](vk::Fence submit_fence) {
+  auto submit_callback = [&context, &vk_buffers,
+                          &shared_tracked_objects](vk::Fence submit_fence) {
     vk::SubmitInfo submit_info;
     submit_info.setCommandBuffers(vk_buffers);
     auto status =
         context->GetGraphicsQueue()->Submit(submit_info, submit_fence);
     if (status != vk::Result::eSuccess) {
-      std::string submit_error =
-          "Failed to submit command: " + vk::to_string(status);
-      VALIDATION_LOG << submit_error;
-      return fml::Status(fml::StatusCode::kCancelled, submit_error);
+      VALIDATION_LOG << "Failed to submit queue: " << vk::to_string(status)
+                     << " (" << vk_buffers.size() << " cmd buffer(s))";
+      // Some drivers non-conformantly invalidate VkCommandPool and
+      // VkCommandBuffer handles during a vkQueueSubmit that fails with an
+      // out-of-memory error (observed on AMD). Abandon those handles (and
+      // associated descriptor pools) without calling any Vulkan API so that
+      // RAII destructors do not call vkFreeCommandBuffers /
+      // vkDestroyCommandPool / vkDestroyDescriptorPool on already-invalid
+      // objects.
+      for (auto& tracked : *shared_tracked_objects) {
+        if (tracked) {
+          tracked->AbandonForDriverCrash();
+        }
+      }
+      // Mark device lost BEFORE any further Vulkan calls so that racing
+      // threads (swapchain acquire, other submissions) short-circuit
+      // immediately. Do NOT call vkDeviceWaitIdle: the driver's internal
+      // allocator may be corrupted after the failed submission, and any
+      // further Vulkan call can access-fault inside the ICD.
+      context->MarkDeviceLost();
+      LogHeapBudgetsAtOOM(*context, vk_buffers.size());
+      return fml::Status(fml::StatusCode::kCancelled,
+                         "Failed to submit queue.");
     }
     return fml::Status();
   };
@@ -80,13 +200,19 @@ fml::Status CommandQueueVK::Submit(
   uint64_t submission_id = tracker->RecordSubmission();
 
   // This will be called later when the command completes.
-  auto fence_complete_callback = [completion_callback, tracker, submission_id,
-                                  tracked_objects =
-                                      std::move(tracked_objects)]() mutable {
-    // Ensure tracked objects are destructed before calling any final
-    // callbacks.
-    tracked_objects.clear();
+  auto in_flight_state = in_flight_state_;
+  auto fence_complete_callback = [in_flight_state, completion_callback, tracker,
+                                  submission_id,
+                                  shared_tracked_objects]() mutable {
+    // Free GPU resources first to reclaim memory before releasing the
+    // submission slot, so the next waiter has memory available.
+    shared_tracked_objects->clear();
     tracker->RecordCompletion(submission_id);
+    {
+      std::lock_guard<std::mutex> lock(in_flight_state->mutex);
+      --in_flight_state->count;
+    }
+    in_flight_state->cv.notify_one();
     if (completion_callback) {
       completion_callback(CommandBuffer::Status::kCompleted);
     }
@@ -100,6 +226,7 @@ fml::Status CommandQueueVK::Submit(
     tracker->RecordCompletion(submission_id);
     return fence_status;
   }
+  release_slot.Release();
   reset.Release();
   return fml::Status();
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
@@ -4,6 +4,8 @@
 
 #include "fml/status.h"
 
+#include <chrono>
+
 #include "impeller/renderer/backend/vulkan/command_queue_vk.h"
 
 #include "impeller/base/validation.h"
@@ -15,14 +17,78 @@
 
 namespace impeller {
 
+// Timeout waiting for an in-flight submission slot. Generous enough that no
+// legitimate GPU workload should hit it.
+static constexpr std::chrono::seconds kSubmitSlotTimeout{5};
+
+// Right-shift to convert bytes to megabytes for diagnostic logging.
+static constexpr uint32_t kBytesToMBShift = 20;
+
+// Logs per-heap memory usage and budgets after a failed queue submission.
+// VK_EXT_memory_budget data is far more useful than the static heap sizes,
+// but the extension is not tracked by the context; detect whether the driver
+// filled the chained struct by checking every heap's budget. A driver that
+// populated the struct reports a non-zero budget for at least one heap,
+// whereas an ignored pNext struct stays zero-initialized.
+static void LogHeapBudgetsAtOOM(const ContextVK& context,
+                                size_t failed_buffer_count) {
+  vk::PhysicalDeviceMemoryProperties2 mem_props2;
+  vk::PhysicalDeviceMemoryBudgetPropertiesEXT budget_props;
+  mem_props2.pNext = &budget_props;
+
+  // getMemoryProperties2 is core Vulkan 1.1 and always available.
+  context.GetPhysicalDevice().getMemoryProperties2(&mem_props2);
+
+  const auto& heaps = mem_props2.memoryProperties.memoryHeaps;
+  const uint32_t heap_count = mem_props2.memoryProperties.memoryHeapCount;
+
+  bool has_budget = false;
+  for (uint32_t i = 0; i < heap_count; i++) {
+    has_budget = has_budget || budget_props.heapBudget[i] != 0;
+  }
+
+  VALIDATION_LOG << "=== Vulkan memory snapshot at OOM ===";
+  for (uint32_t i = 0; i < heap_count; i++) {
+    bool is_device_local = static_cast<bool>(
+        heaps[i].flags & vk::MemoryHeapFlagBits::eDeviceLocal);
+    if (has_budget) {
+      VALIDATION_LOG << "  heap[" << i << "] "
+                     << (is_device_local ? "DEVICE_LOCAL" : "host      ")
+                     << "  used="
+                     << (budget_props.heapUsage[i] >> kBytesToMBShift) << "MB"
+                     << "  budget="
+                     << (budget_props.heapBudget[i] >> kBytesToMBShift) << "MB"
+                     << "  total=" << (heaps[i].size >> kBytesToMBShift) << "MB"
+                     << (budget_props.heapUsage[i] > budget_props.heapBudget[i]
+                             ? "  <<< OVER BUDGET"
+                             : "");
+    } else {
+      VALIDATION_LOG << "  heap[" << i << "] "
+                     << (is_device_local ? "DEVICE_LOCAL" : "host      ")
+                     << "  total=" << (heaps[i].size >> kBytesToMBShift) << "MB"
+                     << "  (VK_EXT_memory_budget not available)";
+    }
+  }
+  VALIDATION_LOG << "  submit_count=" << failed_buffer_count
+                 << " cmd buffers in failed submission";
+  VALIDATION_LOG << "=====================================";
+}
+
 CommandQueueVK::CommandQueueVK(const std::weak_ptr<ContextVK>& context)
-    : context_(context) {}
+    : context_(context), in_flight_state_(std::make_shared<InFlightState>()) {}
 
 CommandQueueVK::~CommandQueueVK() = default;
 
 fml::Status CommandQueueVK::Submit(
     const std::vector<std::shared_ptr<CommandBuffer>>& buffers,
     const CompletionCallback& completion_callback) {
+  return SubmitInternal(buffers, completion_callback, /*throttle=*/true);
+}
+
+fml::Status CommandQueueVK::SubmitInternal(
+    const std::vector<std::shared_ptr<CommandBuffer>>& buffers,
+    const CompletionCallback& completion_callback,
+    bool throttle) {
   if (buffers.empty()) {
     return fml::Status(fml::StatusCode::kInvalidArgument,
                        "No command buffers provided.");
@@ -53,23 +119,88 @@ fml::Status CommandQueueVK::Submit(
     VALIDATION_LOG << "Device lost.";
     return fml::Status(fml::StatusCode::kCancelled, "Device lost.");
   }
+  if (context->IsDeviceLost()) {
+    return fml::Status(fml::StatusCode::kCancelled, "Device lost.");
+  }
+
+  // Throttle: wait until there is capacity for a new in-flight submission.
+  // This creates backpressure to prevent host memory exhaustion when the GPU
+  // cannot keep up with the rate of submission. The 5-second timeout is
+  // generous: even a heavily loaded GPU should complete a frame submission
+  // well within this window. On timeout, the submission is cancelled to
+  // enforce the limit strictly.
+  if (throttle) {
+    std::unique_lock<std::mutex> lock(in_flight_state_->mutex);
+    if (!in_flight_state_->cv.wait_for(lock, kSubmitSlotTimeout, [this]() {
+          return in_flight_state_->count < kMaxInFlightSubmissions;
+        })) {
+      VALIDATION_LOG << "Timed out waiting for in-flight submission slot. "
+                     << "In-flight: " << in_flight_state_->count
+                     << ". Cancelling submission to prevent resource "
+                     << "exhaustion.";
+      return fml::Status(fml::StatusCode::kCancelled,
+                         "Timed out waiting for in-flight submission slot.");
+    }
+    ++in_flight_state_->count;
+  }
+
+  // Release the in-flight slot on any error path below. On success, the slot
+  // is instead released by the fence completion callback.
+  fml::ScopedCleanupClosure release_slot(
+      [state = in_flight_state_, throttle]() {
+        if (!throttle) {
+          return;
+        }
+        {
+          std::lock_guard<std::mutex> lock(state->mutex);
+          --state->count;
+        }
+        state->cv.notify_one();
+      });
+
   auto [fence_result, fence] = context->GetDevice().createFenceUnique({});
   if (fence_result != vk::Result::eSuccess) {
     VALIDATION_LOG << "Failed to create fence: " << vk::to_string(fence_result);
     return fml::Status(fml::StatusCode::kCancelled, "Failed to create fence.");
   }
 
+  // Shared between the submit callback (failure path) and the fence
+  // completion callback (success path). Exactly one of the two consumes it.
+  auto shared_tracked_objects =
+      std::make_shared<std::vector<std::shared_ptr<TrackedObjectsVK>>>(
+          std::move(tracked_objects));
+
   // This will be called immediately by FenceWaiterVK::AddFence.
-  auto submit_callback = [&context, &vk_buffers](vk::Fence submit_fence) {
+  auto submit_callback = [&context, &vk_buffers,
+                          &shared_tracked_objects](vk::Fence submit_fence) {
     vk::SubmitInfo submit_info;
     submit_info.setCommandBuffers(vk_buffers);
     auto status =
         context->GetGraphicsQueue()->Submit(submit_info, submit_fence);
     if (status != vk::Result::eSuccess) {
-      std::string submit_error =
-          "Failed to submit command: " + vk::to_string(status);
-      VALIDATION_LOG << submit_error;
-      return fml::Status(fml::StatusCode::kCancelled, submit_error);
+      VALIDATION_LOG << "Failed to submit queue: " << vk::to_string(status)
+                     << " (" << vk_buffers.size() << " cmd buffer(s))";
+      // Some drivers non-conformantly invalidate VkCommandPool and
+      // VkCommandBuffer handles during a vkQueueSubmit that fails with an
+      // out-of-memory error (observed on AMD). Abandon those handles (and
+      // associated descriptor pools) without calling any Vulkan API so that
+      // RAII destructors do not call vkFreeCommandBuffers /
+      // vkDestroyCommandPool / vkDestroyDescriptorPool on already-invalid
+      // objects.
+      for (auto& tracked : *shared_tracked_objects) {
+        if (tracked) {
+          tracked->AbandonForDriverCrash();
+        }
+      }
+      // Mark device lost BEFORE any further Vulkan calls so that racing
+      // threads (swapchain acquire, other submissions) short-circuit
+      // immediately. Do NOT call vkDeviceWaitIdle: the driver's internal
+      // allocator may be corrupted after the failed submission, and any
+      // further Vulkan call can access-fault inside the ICD.
+      context->MarkDeviceLost();
+      LogHeapBudgetsAtOOM(*context, vk_buffers.size());
+      return fml::Status(fml::StatusCode::kCancelled,
+                         "Failed to submit queue.");
     }
     return fml::Status();
   };
@@ -79,13 +210,21 @@ fml::Status CommandQueueVK::Submit(
   uint64_t submission_id = tracker->RecordSubmission();
 
   // This will be called later when the command completes.
-  auto fence_complete_callback = [completion_callback, tracker, submission_id,
-                                  tracked_objects =
-                                      std::move(tracked_objects)]() mutable {
-    // Ensure tracked objects are destructed before calling any final
-    // callbacks.
-    tracked_objects.clear();
+  auto in_flight_state = in_flight_state_;
+  auto fence_complete_callback = [in_flight_state, completion_callback, tracker,
+                                  submission_id, shared_tracked_objects,
+                                  throttle]() mutable {
+    // Free GPU resources first to reclaim memory before releasing the
+    // submission slot, so the next waiter has memory available.
+    shared_tracked_objects->clear();
     tracker->RecordCompletion(submission_id);
+    if (throttle) {
+      {
+        std::lock_guard<std::mutex> lock(in_flight_state->mutex);
+        --in_flight_state->count;
+      }
+      in_flight_state->cv.notify_one();
+    }
     if (completion_callback) {
       completion_callback(CommandBuffer::Status::kCompleted);
     }
@@ -99,6 +238,7 @@ fml::Status CommandQueueVK::Submit(
     tracker->RecordCompletion(submission_id);
     return fence_status;
   }
+  release_slot.Release();
   reset.Release();
   return fml::Status();
 }
@@ -106,8 +246,11 @@ fml::Status CommandQueueVK::Submit(
 CommandQueue::SubmitResult CommandQueueVK::SubmitWithReceipt(
     const std::shared_ptr<CommandBuffer>& buffer,
     const CompletionCallback& completion_callback) {
+  // Image uploads from the IO thread must not block, so they bypass the
+  // in-flight submission gate. See kMaxInFlightSubmissions.
   return {
-      .status = Submit({buffer}, completion_callback),
+      .status = SubmitInternal({buffer}, completion_callback,
+                               /*throttle=*/false),
   };
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.h
@@ -5,6 +5,10 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_COMMAND_QUEUE_VK_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_COMMAND_QUEUE_VK_H_
 
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
 #include "impeller/renderer/command_queue.h"
 
 namespace impeller {
@@ -13,6 +17,17 @@ class ContextVK;
 
 class CommandQueueVK : public CommandQueue {
  public:
+  /// Maximum number of command buffer submissions that can be simultaneously
+  /// in-flight. When this limit is reached, Submit() will synchronously wait
+  /// for an older submission to complete before proceeding. This provides
+  /// backpressure to prevent host memory exhaustion under heavy GPU load.
+  ///
+  /// This is intentionally one greater than kMaxFramesInFlight (2) so that
+  /// the submission queue does not bottleneck the frame pipeline - the
+  /// rasterizer can always submit without waiting unless the GPU has fallen
+  /// three submissions behind.
+  static constexpr uint32_t kMaxInFlightSubmissions = 3u;
+
   explicit CommandQueueVK(const std::weak_ptr<ContextVK>& context);
 
   ~CommandQueueVK() override;
@@ -22,7 +37,18 @@ class CommandQueueVK : public CommandQueue {
                      bool block_on_schedule = false) override;
 
  private:
+  /// Shared state for tracking in-flight submissions. Uses a shared_ptr so
+  /// that fence completion callbacks (which run on the FenceWaiterVK thread)
+  /// can safely decrement the counter even if CommandQueueVK has been
+  /// destroyed.
+  struct InFlightState {
+    std::mutex mutex;
+    std::condition_variable cv;
+    uint32_t count = 0;
+  };
+
   std::weak_ptr<ContextVK> context_;
+  std::shared_ptr<InFlightState> in_flight_state_;
 
   CommandQueueVK(const CommandQueueVK&) = delete;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.h
@@ -5,6 +5,10 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_COMMAND_QUEUE_VK_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_COMMAND_QUEUE_VK_H_
 
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
 #include "impeller/renderer/command_queue.h"
 
 namespace impeller {
@@ -13,6 +17,22 @@ class ContextVK;
 
 class CommandQueueVK : public CommandQueue {
  public:
+  /// Maximum number of command buffer submissions that can be simultaneously
+  /// in-flight. When this limit is reached, Submit() will synchronously wait
+  /// for an older submission to complete before proceeding. This provides
+  /// backpressure to prevent host memory exhaustion under heavy GPU load.
+  ///
+  /// This is intentionally one greater than kMaxFramesInFlight (2) so that
+  /// the submission queue does not bottleneck the frame pipeline - the
+  /// rasterizer can always submit without waiting unless the GPU has fallen
+  /// three submissions behind.
+  ///
+  /// The limit applies only to frame submissions through Submit().
+  /// SubmitWithReceipt() is deliberately not gated: it carries image uploads
+  /// from the IO thread, which must not block (see flutter/flutter#190445)
+  /// and are already bounded by the image decoder.
+  static constexpr uint32_t kMaxInFlightSubmissions = 3u;
+
   explicit CommandQueueVK(const std::weak_ptr<ContextVK>& context);
 
   ~CommandQueueVK() override;
@@ -26,7 +46,23 @@ class CommandQueueVK : public CommandQueue {
       const CompletionCallback& completion_callback = {}) override;
 
  private:
+  fml::Status SubmitInternal(
+      const std::vector<std::shared_ptr<CommandBuffer>>& buffers,
+      const CompletionCallback& completion_callback,
+      bool throttle);
+
+  /// Shared state for tracking in-flight submissions. Uses a shared_ptr so
+  /// that fence completion callbacks (which run on the FenceWaiterVK thread)
+  /// can safely decrement the counter even if CommandQueueVK has been
+  /// destroyed.
+  struct InFlightState {
+    std::mutex mutex;
+    std::condition_variable cv;
+    uint32_t count = 0;
+  };
+
   std::weak_ptr<ContextVK> context_;
+  std::shared_ptr<InFlightState> in_flight_state_;
 
   CommandQueueVK(const CommandQueueVK&) = delete;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
@@ -38,5 +38,31 @@ TEST(CommandQueueVKTest, SubmitAfterFenceWaiterTerminated) {
             called->end());
 }
 
+TEST(CommandQueueVKTest, SubmitAfterDeviceLostIsCancelled) {
+  const auto context = MockVulkanContextBuilder().Build();
+  auto buffer = context->CreateCommandBuffer();
+  context->MarkDeviceLost();
+  auto status = context->GetCommandQueue()->Submit({buffer});
+  EXPECT_EQ(status.code(), fml::StatusCode::kCancelled);
+
+  // No submission may reach the queue once the device is lost; any Vulkan
+  // call on a driver in a corrupted state can crash inside the ICD.
+  const auto called = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_EQ(std::find(called->begin(), called->end(), "vkQueueSubmit"),
+            called->end());
+}
+
+TEST(CommandQueueVKTest, ThrottleAllowsSustainedSubmissions) {
+  const auto context = MockVulkanContextBuilder().Build();
+  // Submit more batches than kMaxInFlightSubmissions. If in-flight slots
+  // were not released when submissions complete, this would exhaust the
+  // slots and fail on the slot timeout.
+  for (int i = 0; i < 10; i++) {
+    auto buffer = context->CreateCommandBuffer();
+    ASSERT_TRUE(buffer);
+    ASSERT_TRUE(context->GetCommandQueue()->Submit({buffer}).ok());
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 #include <algorithm>
+#include <atomic>
 
 #include "flutter/testing/testing.h"
 #include "gtest/gtest.h"
+#include "impeller/renderer/backend/vulkan/command_queue_vk.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/fence_waiter_vk.h"
 #include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
@@ -50,6 +52,70 @@ TEST(CommandQueueVKTest, SubmitAfterFenceWaiterTerminated) {
   const auto called = GetMockVulkanFunctions(context->GetDevice());
   EXPECT_EQ(std::find(called->begin(), called->end(), "vkQueueSubmit"),
             called->end());
+}
+
+TEST(CommandQueueVKTest, SubmitAfterDeviceLostIsCancelled) {
+  const auto context = MockVulkanContextBuilder().Build();
+  auto buffer = context->CreateCommandBuffer();
+  context->MarkDeviceLost();
+  auto status = context->GetCommandQueue()->Submit({buffer});
+  EXPECT_EQ(status.code(), fml::StatusCode::kCancelled);
+
+  // No submission may reach the queue once the device is lost; any Vulkan
+  // call on a driver in a corrupted state can crash inside the ICD.
+  const auto called = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_EQ(std::find(called->begin(), called->end(), "vkQueueSubmit"),
+            called->end());
+}
+
+TEST(CommandQueueVKTest, ThrottleAllowsSustainedSubmissions) {
+  const auto context = MockVulkanContextBuilder().Build();
+  // Submit more batches than kMaxInFlightSubmissions. If in-flight slots
+  // were not released when submissions complete, this would exhaust the
+  // slots and fail on the slot timeout.
+  for (int i = 0; i < 10; i++) {
+    auto buffer = context->CreateCommandBuffer();
+    ASSERT_TRUE(buffer);
+    ASSERT_TRUE(context->GetCommandQueue()->Submit({buffer}).ok());
+  }
+}
+
+TEST(CommandQueueVKTest, SubmitWithReceiptBypassesThrottle) {
+  // Pin every submission fence to unsignalled so no in-flight slot is ever
+  // released. Completion is driven by vkGetFenceStatus, which the fence
+  // waiter only reads after a vkWaitForFences pass that included the fence,
+  // so pinning the status here is race-free.
+  std::atomic<bool> hold = true;
+  const auto context =
+      MockVulkanContextBuilder()
+          .SetWaitForFencesCallback([&hold](VkDevice, uint32_t count,
+                                            const VkFence* fences, VkBool32,
+                                            uint64_t) -> VkResult {
+            for (uint32_t i = 0; i < count; i++) {
+              reinterpret_cast<MockFence*>(fences[i])->SetStatus(
+                  hold ? vk::Result::eNotReady : vk::Result::eSuccess);
+            }
+            return VK_SUCCESS;
+          })
+          .Build();
+
+  // Saturate the in-flight submission gate with frame submissions.
+  for (uint32_t i = 0; i < CommandQueueVK::kMaxInFlightSubmissions; i++) {
+    auto buffer = context->CreateCommandBuffer();
+    ASSERT_TRUE(buffer);
+    ASSERT_TRUE(context->GetCommandQueue()->Submit({buffer}).ok());
+  }
+
+  // With every slot occupied, an image upload must still submit immediately
+  // instead of waiting on the gate; blocking here would stall the IO thread.
+  auto buffer = context->CreateCommandBuffer();
+  ASSERT_TRUE(buffer);
+  CommandQueue::SubmitResult result =
+      context->GetCommandQueue()->SubmitWithReceipt(buffer);
+  EXPECT_TRUE(result.status.ok());
+
+  // Let the fences signal so context teardown can drain the wait set.
+  hold = false;
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -357,6 +357,10 @@ void ContextVK::Setup(Settings settings) {
     device_holder->device.reset(settings.embedder_data->device);
   }
 
+  // Initialize device-level dispatch so Vulkan-HPP calls go directly through
+  // the device dispatch table instead of the instance trampoline.
+  dispatcher.init(device_holder->device.get());
+
   if (!caps->SetPhysicalDevice(device_holder->physical_device,
                                *enabled_features)) {
     VALIDATION_LOG << "Capabilities could not be updated.";
@@ -546,7 +550,24 @@ std::shared_ptr<PipelineLibrary> ContextVK::GetPipelineLibrary() const {
   return pipeline_library_;
 }
 
+bool ContextVK::IsDeviceLost() const {
+  return device_lost_.load(std::memory_order_relaxed);
+}
+
+void ContextVK::MarkDeviceLost() {
+  device_lost_.store(true, std::memory_order_relaxed);
+  VALIDATION_LOG << "ContextVK: device marked as lost. No further Vulkan "
+                    "API calls will be made on this context.";
+}
+
 std::shared_ptr<CommandBuffer> ContextVK::CreateCommandBuffer() const {
+  // Short-circuit immediately if the device is lost. Any Vulkan allocation
+  // call (vkCreateCommandPool, vkAllocateCommandBuffers, etc.) on a driver
+  // that has entered a corrupted OOM state can access-fault inside the ICD.
+  if (device_lost_.load(std::memory_order_relaxed)) {
+    return nullptr;
+  }
+
   const auto& recycler = GetCommandPoolRecycler();
   auto tls_pool = recycler->Get();
   if (!tls_pool) {
@@ -677,7 +698,30 @@ bool ContextVK::FlushCommandBuffers() {
   }
 
   if (should_batch_cmd_buffers_) {
-    bool result = GetCommandQueue()->Submit(pending_command_buffers_).ok();
+    // Submit in chunks to prevent VK_ERROR_OUT_OF_HOST_MEMORY when a frame
+    // accumulates a very large number of command buffers (e.g. heavy
+    // blur/filter workloads). Each Submit() creates its own fence and
+    // tracked-object set, so chunking at this level is safe: all command
+    // buffers are fully recorded by the time FlushCommandBuffers() runs.
+    //
+    // 64 balances submission overhead against memory pressure: small enough
+    // that the driver's per-submit host allocation stays within typical
+    // limits, large enough to amortize fence creation and queue submission
+    // across many command buffers.
+    static constexpr size_t kMaxBuffersPerSubmit = 64u;
+    bool result = true;
+    for (size_t i = 0; i < pending_command_buffers_.size();
+         i += kMaxBuffersPerSubmit) {
+      size_t end =
+          std::min(i + kMaxBuffersPerSubmit, pending_command_buffers_.size());
+      std::vector<std::shared_ptr<CommandBuffer>> chunk(
+          std::make_move_iterator(pending_command_buffers_.begin() + i),
+          std::make_move_iterator(pending_command_buffers_.begin() + end));
+      if (!GetCommandQueue()->Submit(chunk).ok()) {
+        result = false;
+        break;
+      }
+    }
     pending_command_buffers_.clear();
     return result;
   } else {
@@ -729,6 +773,9 @@ void ContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
         stencil->store_action                                   //
     );
   }
+
+  builder.SetFramebufferFetchEnabled(
+      GetCapabilities()->SupportsFramebufferFetch());
 
   auto pass = builder.Build(GetDevice());
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_CONTEXT_VK_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_CONTEXT_VK_H_
 
+#include <atomic>
 #include <format>
 #include <memory>
 
@@ -118,6 +119,18 @@ class ContextVK final : public Context,
 
   // |Context|
   bool IsValid() const override;
+
+  /// @brief      Returns true if the device has been permanently lost due
+  ///             to a non-recoverable GPU error (e.g. a non-conformant
+  ///             out-of-memory error from vkQueueSubmit). Once lost, all
+  ///             command-buffer creation and queue submission silently
+  ///             short-circuit to prevent further Vulkan calls on a broken
+  ///             driver state.
+  bool IsDeviceLost() const;
+
+  /// @brief      Permanently marks this context as device-lost.
+  ///             Thread-safe; idempotent.
+  void MarkDeviceLost();
 
   // |Context|
   std::shared_ptr<Allocator> GetResourceAllocator() const override;
@@ -313,6 +326,12 @@ class ContextVK final : public Context,
   const uint64_t hash_;
 
   bool is_valid_ = false;
+
+  // Set to true on any unrecoverable GPU error (e.g. vkQueueSubmit returning
+  // an out-of-memory error on a driver in a corrupted state). Once true,
+  // CreateCommandBuffer() returns nullptr and submission short-circuits so
+  // that no further Vulkan API calls are made on the broken driver state.
+  std::atomic<bool> device_lost_{false};
 
   explicit ContextVK(const Flags& flags);
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -261,7 +261,12 @@ TEST(ContextVKTest, HasDefaultColorFormat) {
   ASSERT_NE(capabilites_vk->GetDefaultColorFormat(), PixelFormat::kUnknown);
 }
 
-TEST(ContextVKTest, EmbedderOverridesUsesInstanceExtensions) {
+TEST(ContextVKTest, EmbedderWithoutSurfaceExtensionsIsSurfaceless) {
+  // An embedder that presents rendered images itself (for example through a
+  // platform compositor such as DirectComposition on Windows) supplies a
+  // Vulkan device without the surface, WSI, or swapchain extensions. Context
+  // creation must succeed in that configuration; presentation is then the
+  // embedder's responsibility rather than Impeller's.
   ContextVK::EmbedderData data;
   auto other_context = MockVulkanContextBuilder().Build();
 
@@ -270,14 +275,36 @@ TEST(ContextVKTest, EmbedderOverridesUsesInstanceExtensions) {
   data.physical_device = other_context->GetPhysicalDevice();
   data.queue = VkQueue{};
   data.queue_family_index = 0;
-  // Missing surface extension.
+  // No surface (instance) or swapchain (device) extensions.
   data.instance_extensions = {};
+  data.device_extensions = {};
+
+  ScopedValidationDisable scoped;
+  auto context = MockVulkanContextBuilder().SetEmbedderData(data).Build();
+
+  ASSERT_NE(context, nullptr);
+  EXPECT_TRUE(context->IsValid());
+}
+
+TEST(ContextVKTest, EmbedderWithSurfaceExtensionsStillEnablesThem) {
+  // When the embedder does provide the surface extension, it is honored and
+  // added to the enabled instance extensions as before.
+  ContextVK::EmbedderData data;
+  auto other_context = MockVulkanContextBuilder().Build();
+
+  data.instance = other_context->GetInstance();
+  data.device = other_context->GetDevice();
+  data.physical_device = other_context->GetPhysicalDevice();
+  data.queue = VkQueue{};
+  data.queue_family_index = 0;
+  data.instance_extensions = {"VK_KHR_surface", "VK_KHR_win32_surface"};
   data.device_extensions = {"VK_KHR_swapchain"};
 
   ScopedValidationDisable scoped;
   auto context = MockVulkanContextBuilder().SetEmbedderData(data).Build();
 
-  EXPECT_EQ(context, nullptr);
+  ASSERT_NE(context, nullptr);
+  EXPECT_TRUE(context->IsValid());
 }
 
 TEST(ContextVKTest, EmbedderOverrides) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -408,5 +408,19 @@ TEST(ContextVKTest, HashIsUniqueAcrossThreads) {
   EXPECT_NE(hash1, hash2);
 }
 
+TEST(ContextVKTest, CreateCommandBufferShortCircuitsAfterDeviceLost) {
+  const std::shared_ptr<ContextVK> context = MockVulkanContextBuilder().Build();
+
+  EXPECT_FALSE(context->IsDeviceLost());
+  EXPECT_NE(context->CreateCommandBuffer(), nullptr);
+
+  context->MarkDeviceLost();
+
+  EXPECT_TRUE(context->IsDeviceLost());
+  // No command buffer may be created once the device is lost; allocation
+  // calls on a driver in a corrupted state can crash inside the ICD.
+  EXPECT_EQ(context->CreateCommandBuffer(), nullptr);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -279,7 +279,12 @@ TEST(ContextVKTest, HasDefaultColorFormat) {
   ASSERT_NE(capabilites_vk->GetDefaultColorFormat(), PixelFormat::kUnknown);
 }
 
-TEST(ContextVKTest, EmbedderOverridesUsesInstanceExtensions) {
+TEST(ContextVKTest, EmbedderWithoutSurfaceExtensionsIsSurfaceless) {
+  // An embedder that presents rendered images itself (for example through a
+  // platform compositor such as DirectComposition on Windows) supplies a
+  // Vulkan device without the surface, WSI, or swapchain extensions. Context
+  // creation must succeed in that configuration; presentation is then the
+  // embedder's responsibility rather than Impeller's.
   ContextVK::EmbedderData data;
   auto other_context = MockVulkanContextBuilder().Build();
 
@@ -288,14 +293,36 @@ TEST(ContextVKTest, EmbedderOverridesUsesInstanceExtensions) {
   data.physical_device = other_context->GetPhysicalDevice();
   data.queue = VkQueue{};
   data.queue_family_index = 0;
-  // Missing surface extension.
+  // No surface (instance) or swapchain (device) extensions.
   data.instance_extensions = {};
+  data.device_extensions = {};
+
+  ScopedValidationDisable scoped;
+  auto context = MockVulkanContextBuilder().SetEmbedderData(data).Build();
+
+  ASSERT_NE(context, nullptr);
+  EXPECT_TRUE(context->IsValid());
+}
+
+TEST(ContextVKTest, EmbedderWithSurfaceExtensionsStillEnablesThem) {
+  // When the embedder does provide the surface extension, it is honored and
+  // added to the enabled instance extensions as before.
+  ContextVK::EmbedderData data;
+  auto other_context = MockVulkanContextBuilder().Build();
+
+  data.instance = other_context->GetInstance();
+  data.device = other_context->GetDevice();
+  data.physical_device = other_context->GetPhysicalDevice();
+  data.queue = VkQueue{};
+  data.queue_family_index = 0;
+  data.instance_extensions = {"VK_KHR_surface", "VK_KHR_win32_surface"};
   data.device_extensions = {"VK_KHR_swapchain"};
 
   ScopedValidationDisable scoped;
   auto context = MockVulkanContextBuilder().SetEmbedderData(data).Build();
 
-  EXPECT_EQ(context, nullptr);
+  ASSERT_NE(context, nullptr);
+  EXPECT_TRUE(context->IsValid());
 }
 
 TEST(ContextVKTest, EmbedderOverrides) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -426,5 +426,19 @@ TEST(ContextVKTest, HashIsUniqueAcrossThreads) {
   EXPECT_NE(hash1, hash2);
 }
 
+TEST(ContextVKTest, CreateCommandBufferShortCircuitsAfterDeviceLost) {
+  const std::shared_ptr<ContextVK> context = MockVulkanContextBuilder().Build();
+
+  EXPECT_FALSE(context->IsDeviceLost());
+  EXPECT_NE(context->CreateCommandBuffer(), nullptr);
+
+  context->MarkDeviceLost();
+
+  EXPECT_TRUE(context->IsDeviceLost());
+  // No command buffer may be created once the device is lost; allocation
+  // calls on a driver in a corrupted state can crash inside the ICD.
+  EXPECT_EQ(context->CreateCommandBuffer(), nullptr);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -33,6 +33,16 @@ void DescriptorPoolVK::Destroy() {
   pools_.clear();
 }
 
+void DescriptorPoolVK::AbandonForDriverCrash() {
+  // Release each UniqueDescriptorPool handle so that the vk::UniqueHandle
+  // destructor never calls vkDestroyDescriptorPool on the corrupted device.
+  for (auto& pool : pools_) {
+    pool.release();
+  }
+  pools_.clear();
+  descriptor_sets_.clear();
+}
+
 DescriptorPoolVK::DescriptorPoolVK(std::weak_ptr<const ContextVK> context,
                                    DescriptorCacheMap descriptor_sets,
                                    std::vector<vk::UniqueDescriptorPool> pools)
@@ -47,10 +57,17 @@ DescriptorPoolVK::~DescriptorPoolVK() {
 
   auto const context = context_.lock();
   if (!context) {
+    // Context is dying - release Vulkan handles without making API calls.
+    for (auto& pool : pools_) {
+      pool.release();
+    }
     return;
   }
   auto const recycler = context->GetDescriptorPoolRecycler();
   if (!recycler) {
+    for (auto& pool : pools_) {
+      pool.release();
+    }
     return;
   }
 
@@ -82,19 +99,28 @@ fml::StatusOr<vk::DescriptorSet> DescriptorPoolVK::AllocateDescriptorSets(
   auto result = context_vk.GetDevice().allocateDescriptorSets(&set_info, &set);
   if (result == vk::Result::eErrorOutOfPoolMemory) {
     // If the pool ran out of memory, we need to create a new pool.
-    CreateNewPool(context_vk);
+    auto pool_status = CreateNewPool(context_vk);
+    if (!pool_status.ok()) {
+      return fml::Status(fml::StatusCode::kUnknown,
+                         "Failed to create descriptor pool");
+    }
     set_info.setDescriptorPool(pools_.back().get());
     result = context_vk.GetDevice().allocateDescriptorSets(&set_info, &set);
   }
-  auto lookup_result =
-      descriptor_sets_.try_emplace(pipeline_key, DescriptorCache{});
-  lookup_result.first->second.used.push_back(set);
 
   if (result != vk::Result::eSuccess) {
     VALIDATION_LOG << "Could not allocate descriptor sets: "
                    << vk::to_string(result);
     return fml::Status(fml::StatusCode::kUnknown, "");
   }
+
+  // Register the newly allocated descriptor set in the per-pipeline cache.
+  // try_emplace inserts a new DescriptorCache if one doesn't exist for
+  // this pipeline key. The set is tracked as "used" and will be moved
+  // to "unused" during frame-end reclamation for reuse in future frames.
+  auto lookup_result =
+      descriptor_sets_.try_emplace(pipeline_key, DescriptorCache{});
+  lookup_result.first->second.used.push_back(set);
   return set;
 }
 
@@ -111,20 +137,29 @@ fml::Status DescriptorPoolVK::CreateNewPool(const ContextVK& context_vk) {
 void DescriptorPoolRecyclerVK::Reclaim(
     DescriptorCacheMap descriptor_sets,
     std::vector<vk::UniqueDescriptorPool> pools) {
-  // Reset the pool on a background thread.
   auto strong_context = context_.lock();
   if (!strong_context) {
     return;
   }
 
-  for (auto& [_, cache] : descriptor_sets) {
-    cache.unused.insert(cache.unused.end(), cache.used.begin(),
-                        cache.used.end());
-    cache.used.clear();
+  // Reset all underlying VkDescriptorPool handles via vkResetDescriptorPool.
+  // This frees ALL descriptor sets allocated from each pool, returning them
+  // to the unallocated state. Without this, pools become permanently exhausted
+  // and cache misses (different pipeline keys on reuse) would trigger
+  // VK_ERROR_OUT_OF_POOL_MEMORY, causing new raw pool creation every time.
+  auto device = strong_context->GetDevice();
+  for (auto& pool : pools) {
+    auto reset_result = device.resetDescriptorPool(pool.get());
+    if (reset_result != vk::Result::eSuccess) {
+      VALIDATION_LOG << "Could not reset descriptor pool: "
+                     << vk::to_string(reset_result);
+    }
   }
+  // The descriptor set handles in the cache are now invalid after pool reset.
+  descriptor_sets.clear();
 
-  // Move the pool to the recycled list. If more than 32 pool are
-  // cached then delete the newest entry.
+  // Move the pool to the recycled list. If more than 32 pools are
+  // cached then delete the newest entry (back of the deque).
   Lock recycled_lock(recycled_mutex_);
   while (recycled_.size() >= kMaxRecycledPools) {
     auto& back_entry = recycled_.back();
@@ -136,7 +171,20 @@ void DescriptorPoolRecyclerVK::Reclaim(
 }
 
 vk::UniqueDescriptorPool DescriptorPoolRecyclerVK::Get() {
-  // Recycle a pool with a matching minumum capcity if it is available.
+  // Try to extract a reset raw pool from the recycled wrappers first.
+  {
+    Lock recycled_lock(recycled_mutex_);
+    for (auto it = recycled_.begin(); it != recycled_.end(); ++it) {
+      if (!(*it)->pools_.empty()) {
+        auto pool = std::move((*it)->pools_.back());
+        (*it)->pools_.pop_back();
+        if ((*it)->pools_.empty()) {
+          recycled_.erase(it);
+        }
+        return pool;
+      }
+    }
+  }
   return Create();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -142,21 +142,13 @@ void DescriptorPoolRecyclerVK::Reclaim(
     return;
   }
 
-  // Reset all underlying VkDescriptorPool handles via vkResetDescriptorPool.
-  // This frees ALL descriptor sets allocated from each pool, returning them
-  // to the unallocated state. Without this, pools become permanently exhausted
-  // and cache misses (different pipeline keys on reuse) would trigger
-  // VK_ERROR_OUT_OF_POOL_MEMORY, causing new raw pool creation every time.
-  auto device = strong_context->GetDevice();
-  for (auto& pool : pools) {
-    auto reset_result = device.resetDescriptorPool(pool.get());
-    if (reset_result != vk::Result::eSuccess) {
-      VALIDATION_LOG << "Could not reset descriptor pool: "
-                     << vk::to_string(reset_result);
-    }
+  // Return the used descriptor sets to the unused cache so they are reused
+  // by future frames instead of being reallocated.
+  for (auto& [_, cache] : descriptor_sets) {
+    cache.unused.insert(cache.unused.end(), cache.used.begin(),
+                        cache.used.end());
+    cache.used.clear();
   }
-  // The descriptor set handles in the cache are now invalid after pool reset.
-  descriptor_sets.clear();
 
   // Move the pool to the recycled list. If more than 32 pools are
   // cached then delete the newest entry (back of the deque).
@@ -171,20 +163,6 @@ void DescriptorPoolRecyclerVK::Reclaim(
 }
 
 vk::UniqueDescriptorPool DescriptorPoolRecyclerVK::Get() {
-  // Try to extract a reset raw pool from the recycled wrappers first.
-  {
-    Lock recycled_lock(recycled_mutex_);
-    for (auto it = recycled_.begin(); it != recycled_.end(); ++it) {
-      if (!(*it)->pools_.empty()) {
-        auto pool = std::move((*it)->pools_.back());
-        (*it)->pools_.pop_back();
-        if ((*it)->pools_.empty()) {
-          recycled_.erase(it);
-        }
-        return pool;
-      }
-    }
-  }
   return Create();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -144,21 +144,13 @@ void DescriptorPoolRecyclerVK::Reclaim(
     return;
   }
 
-  // Reset all underlying VkDescriptorPool handles via vkResetDescriptorPool.
-  // This frees ALL descriptor sets allocated from each pool, returning them
-  // to the unallocated state. Without this, pools become permanently exhausted
-  // and cache misses (different pipeline keys on reuse) would trigger
-  // VK_ERROR_OUT_OF_POOL_MEMORY, causing new raw pool creation every time.
-  auto device = strong_context->GetDevice();
-  for (auto& pool : pools) {
-    auto reset_result = device.resetDescriptorPool(pool.get());
-    if (reset_result != vk::Result::eSuccess) {
-      VALIDATION_LOG << "Could not reset descriptor pool: "
-                     << vk::to_string(reset_result);
-    }
+  // Return the used descriptor sets to the unused cache so they are reused
+  // by future frames instead of being reallocated.
+  for (auto& [_, cache] : descriptor_sets) {
+    cache.unused.insert(cache.unused.end(), cache.used.begin(),
+                        cache.used.end());
+    cache.used.clear();
   }
-  // The descriptor set handles in the cache are now invalid after pool reset.
-  descriptor_sets.clear();
 
   // Move the pool to the recycled list. If more than 32 pools are
   // cached then delete the newest entry (back of the deque).
@@ -173,20 +165,6 @@ void DescriptorPoolRecyclerVK::Reclaim(
 }
 
 vk::UniqueDescriptorPool DescriptorPoolRecyclerVK::Get() {
-  // Try to extract a reset raw pool from the recycled wrappers first.
-  {
-    Lock recycled_lock(recycled_mutex_);
-    for (auto it = recycled_.begin(); it != recycled_.end(); ++it) {
-      if (!(*it)->pools_.empty()) {
-        auto pool = std::move((*it)->pools_.back());
-        (*it)->pools_.pop_back();
-        if ((*it)->pools_.empty()) {
-          recycled_.erase(it);
-        }
-        return pool;
-      }
-    }
-  }
   return Create();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -33,6 +33,16 @@ void DescriptorPoolVK::Destroy() {
   pools_.clear();
 }
 
+void DescriptorPoolVK::AbandonForDriverCrash() {
+  // Release each UniqueDescriptorPool handle so that the vk::UniqueHandle
+  // destructor never calls vkDestroyDescriptorPool on the corrupted device.
+  for (auto& pool : pools_) {
+    pool.release();
+  }
+  pools_.clear();
+  descriptor_sets_.clear();
+}
+
 DescriptorPoolVK::DescriptorPoolVK(std::weak_ptr<const ContextVK> context,
                                    DescriptorCacheMap descriptor_sets,
                                    std::vector<vk::UniqueDescriptorPool> pools)
@@ -47,10 +57,17 @@ DescriptorPoolVK::~DescriptorPoolVK() {
 
   auto const context = context_.lock();
   if (!context) {
+    // Context is dying - release Vulkan handles without making API calls.
+    for (auto& pool : pools_) {
+      pool.release();
+    }
     return;
   }
   auto const recycler = context->GetDescriptorPoolRecycler();
   if (!recycler) {
+    for (auto& pool : pools_) {
+      pool.release();
+    }
     return;
   }
 
@@ -84,19 +101,28 @@ fml::StatusOr<vk::DescriptorSet> DescriptorPoolVK::AllocateDescriptorSets(
       // FragmentedPool == OutOfMemory AND most likely due to fragmentation
       result == vk::Result::eErrorFragmentedPool) {
     // If the pool ran out of memory, we need to create a new pool.
-    CreateNewPool(context_vk);
+    auto pool_status = CreateNewPool(context_vk);
+    if (!pool_status.ok()) {
+      return fml::Status(fml::StatusCode::kUnknown,
+                         "Failed to create descriptor pool");
+    }
     set_info.setDescriptorPool(pools_.back().get());
     result = context_vk.GetDevice().allocateDescriptorSets(&set_info, &set);
   }
-  auto lookup_result =
-      descriptor_sets_.try_emplace(pipeline_key, DescriptorCache{});
-  lookup_result.first->second.used.push_back(set);
 
   if (result != vk::Result::eSuccess) {
     VALIDATION_LOG << "Could not allocate descriptor sets: "
                    << vk::to_string(result);
     return fml::Status(fml::StatusCode::kUnknown, "");
   }
+
+  // Register the newly allocated descriptor set in the per-pipeline cache.
+  // try_emplace inserts a new DescriptorCache if one doesn't exist for
+  // this pipeline key. The set is tracked as "used" and will be moved
+  // to "unused" during frame-end reclamation for reuse in future frames.
+  auto lookup_result =
+      descriptor_sets_.try_emplace(pipeline_key, DescriptorCache{});
+  lookup_result.first->second.used.push_back(set);
   return set;
 }
 
@@ -113,20 +139,29 @@ fml::Status DescriptorPoolVK::CreateNewPool(const ContextVK& context_vk) {
 void DescriptorPoolRecyclerVK::Reclaim(
     DescriptorCacheMap descriptor_sets,
     std::vector<vk::UniqueDescriptorPool> pools) {
-  // Reset the pool on a background thread.
   auto strong_context = context_.lock();
   if (!strong_context) {
     return;
   }
 
-  for (auto& [_, cache] : descriptor_sets) {
-    cache.unused.insert(cache.unused.end(), cache.used.begin(),
-                        cache.used.end());
-    cache.used.clear();
+  // Reset all underlying VkDescriptorPool handles via vkResetDescriptorPool.
+  // This frees ALL descriptor sets allocated from each pool, returning them
+  // to the unallocated state. Without this, pools become permanently exhausted
+  // and cache misses (different pipeline keys on reuse) would trigger
+  // VK_ERROR_OUT_OF_POOL_MEMORY, causing new raw pool creation every time.
+  auto device = strong_context->GetDevice();
+  for (auto& pool : pools) {
+    auto reset_result = device.resetDescriptorPool(pool.get());
+    if (reset_result != vk::Result::eSuccess) {
+      VALIDATION_LOG << "Could not reset descriptor pool: "
+                     << vk::to_string(reset_result);
+    }
   }
+  // The descriptor set handles in the cache are now invalid after pool reset.
+  descriptor_sets.clear();
 
-  // Move the pool to the recycled list. If more than 32 pool are
-  // cached then delete the newest entry.
+  // Move the pool to the recycled list. If more than 32 pools are
+  // cached then delete the newest entry (back of the deque).
   Lock recycled_lock(recycled_mutex_);
   while (recycled_.size() >= kMaxRecycledPools) {
     auto& back_entry = recycled_.back();
@@ -138,7 +173,20 @@ void DescriptorPoolRecyclerVK::Reclaim(
 }
 
 vk::UniqueDescriptorPool DescriptorPoolRecyclerVK::Get() {
-  // Recycle a pool with a matching minumum capcity if it is available.
+  // Try to extract a reset raw pool from the recycled wrappers first.
+  {
+    Lock recycled_lock(recycled_mutex_);
+    for (auto it = recycled_.begin(); it != recycled_.end(); ++it) {
+      if (!(*it)->pools_.empty()) {
+        auto pool = std::move((*it)->pools_.back());
+        (*it)->pools_.pop_back();
+        if ((*it)->pools_.empty()) {
+          recycled_.erase(it);
+        }
+        return pool;
+      }
+    }
+  }
   return Create();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
@@ -28,7 +28,7 @@ using DescriptorCacheMap = std::unordered_map<PipelineKey, DescriptorCache>;
 ///             pool must be collected after all the descriptors allocated from
 ///             it are done being used.
 ///
-///             The pool or it's descriptors may not be accessed from multiple
+///             The pool or its descriptors may not be accessed from multiple
 ///             threads.
 ///
 ///             Encoders create pools as necessary as they have the same
@@ -42,6 +42,13 @@ class DescriptorPoolVK {
                    std::vector<vk::UniqueDescriptorPool> pools);
 
   ~DescriptorPoolVK();
+
+  /// @brief      Release all VkDescriptorPool handles without calling
+  ///             vkDestroyDescriptorPool. Call after a fatal vkQueueSubmit
+  ///             failure where the driver has already freed internal
+  ///             resources (e.g. AMD non-conformant OOM) to prevent crashes
+  ///             in RAII destructors.
+  void AbandonForDriverCrash();
 
   fml::StatusOr<vk::DescriptorSet> AllocateDescriptorSets(
       const vk::DescriptorSetLayout& layout,
@@ -99,7 +106,7 @@ class DescriptorPoolRecyclerVK final
   std::vector<std::shared_ptr<DescriptorPoolVK>> recycled_
       IPLR_GUARDED_BY(recycled_mutex_);
 
-  /// @brief      Creates a new |vk::CommandPool|.
+  /// @brief      Creates a new |vk::DescriptorPool|.
   ///
   /// @returns    Returns a |std::nullopt| if a pool could not be created.
   vk::UniqueDescriptorPool Create();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
@@ -295,6 +295,15 @@ DriverInfoVK::DriverInfoVK(const vk::PhysicalDevice& device) {
     driver_name_ = props.deviceName.data();
   }
 
+  // Query driver ID via VkPhysicalDeviceDriverProperties (Vulkan 1.2+ or
+  // VK_KHR_driver_properties). This gives us a reliable enum-based driver
+  // identification rather than fragile string matching on device names.
+  if (api_version_.IsAtLeast(Version{1, 2, 0})) {
+    auto props2 = device.getProperties2<vk::PhysicalDeviceProperties2,
+                                        vk::PhysicalDeviceDriverProperties>();
+    driver_id_ = props2.get<vk::PhysicalDeviceDriverProperties>().driverID;
+  }
+
   switch (vendor_) {
     case VendorVK::kQualcomm:
       adreno_gpu_ = GetAdrenoVersion(driver_name_);
@@ -328,6 +337,10 @@ const std::string& DriverInfoVK::GetDriverName() const {
   return driver_name_;
 }
 
+vk::DriverId DriverInfoVK::GetDriverID() const {
+  return driver_id_;
+}
+
 void DriverInfoVK::DumpToLog() const {
   std::vector<std::pair<std::string, std::string>> items;
   items.emplace_back("Name", driver_name_);
@@ -335,6 +348,8 @@ void DriverInfoVK::DumpToLog() const {
   items.emplace_back("Driver Version", std::to_string(driver_version_));
   items.emplace_back("Vendor", VendorToString(vendor_));
   items.emplace_back("Device Type", DeviceTypeToString(type_));
+  items.emplace_back("Driver ID",
+                     std::to_string(static_cast<int32_t>(driver_id_)));
   items.emplace_back("Is Emulator", std::to_string(IsEmulator()));
 
   size_t padding = 0;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.h
@@ -234,6 +234,18 @@ class DriverInfoVK {
   const std::string& GetDriverName() const;
 
   //----------------------------------------------------------------------------
+  /// @brief      Get the Vulkan driver ID reported via
+  ///             VkPhysicalDeviceDriverProperties (Vulkan 1.2+).
+  ///
+  ///             Returns a default-initialized (zero) vk::DriverId if the
+  ///             driver properties could not be queried (pre-1.2 without
+  ///             VK_KHR_driver_properties).
+  ///
+  /// @return     The driver ID.
+  ///
+  vk::DriverId GetDriverID() const;
+
+  //----------------------------------------------------------------------------
   /// @brief      Dumps the current driver info to the log.
   ///
   void DumpToLog() const;
@@ -290,6 +302,7 @@ class DriverInfoVK {
   std::optional<MaliGPU> mali_gpu_ = std::nullopt;
   std::optional<PowerVRGPU> powervr_gpu_ = std::nullopt;
   std::string driver_name_;
+  vk::DriverId driver_id_ = {};
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -76,6 +76,14 @@ fml::Status FenceWaiterVK::AddFence(
     }
     auto submit_status = submit_callback(fence.get());
     if (!submit_status.ok()) {
+      // The state of a fence passed to a failed queue submission is not
+      // trustworthy: some drivers partially track the fence even though the
+      // submission failed, and destroying it crashes inside the driver
+      // (observed on AMD as VUID-vkDestroyFence-fence-01120 followed by an
+      // access violation). Release the handle instead of destroying it; a
+      // failed submission marks the device as lost, so the leak is
+      // inconsequential.
+      fence.release();
       return submit_status;
     }
     wait_set_.emplace_back(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
@@ -127,7 +127,8 @@ static void ReportPipelineCreationFeedback(
 ///
 static vk::UniqueRenderPass CreateCompatRenderPassForPipeline(
     const vk::Device& device,
-    const PipelineDescriptor& desc) {
+    const PipelineDescriptor& desc,
+    bool supports_framebuffer_fetch) {
   RenderPassBuilderVK builder;
 
   for (const auto& [bind_point, color] : desc.GetColorAttachmentDescriptors()) {
@@ -153,6 +154,8 @@ static vk::UniqueRenderPass CreateCompatRenderPassForPipeline(
                                  StoreAction::kDontCare         //
     );
   }
+
+  builder.SetFramebufferFetchEnabled(supports_framebuffer_fetch);
 
   auto pass = builder.Build(device);
   if (!pass) {
@@ -492,8 +495,10 @@ std::unique_ptr<PipelineVK> PipelineVK::Create(
     return nullptr;
   }
 
-  vk::UniqueRenderPass render_pass =
-      CreateCompatRenderPassForPipeline(device_holder->GetDevice(), desc);
+  const auto* caps = pso_cache->GetCapabilities();
+  vk::UniqueRenderPass render_pass = CreateCompatRenderPassForPipeline(
+      device_holder->GetDevice(), desc,
+      caps != nullptr && caps->SupportsFramebufferFetch());
   if (!render_pass) {
     VALIDATION_LOG << "Could not create render pass for pipeline.";
     return nullptr;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
@@ -35,6 +35,12 @@ RenderPassBuilderVK::RenderPassBuilderVK() = default;
 
 RenderPassBuilderVK::~RenderPassBuilderVK() = default;
 
+RenderPassBuilderVK& RenderPassBuilderVK::SetFramebufferFetchEnabled(
+    bool enabled) {
+  supports_framebuffer_fetch_ = enabled;
+  return *this;
+}
+
 RenderPassBuilderVK& RenderPassBuilderVK::SetColorAttachment(
     size_t index,
     PixelFormat format,
@@ -181,57 +187,115 @@ vk::UniqueRenderPass RenderPassBuilderVK::Build(
 
   vk::SubpassDescription subpass0;
   subpass0.pipelineBindPoint = vk::PipelineBindPoint::eGraphics;
-  subpass0.setPInputAttachments(color_refs.data());
-  subpass0.setInputAttachmentCount(color_index);
+  if (supports_framebuffer_fetch_) {
+    subpass0.setPInputAttachments(color_refs.data());
+    subpass0.setInputAttachmentCount(color_index);
+  } else {
+    subpass0.setPInputAttachments(nullptr);
+    subpass0.setInputAttachmentCount(0);
+  }
   subpass0.setPColorAttachments(color_refs.data());
   subpass0.setColorAttachmentCount(color_index);
   subpass0.setPResolveAttachments(resolve_refs.data());
 
   subpass0.setPDepthStencilAttachment(&depth_stencil_ref);
 
-  vk::SubpassDependency deps[3];
-  // Incoming dependency. If the attachments were previously used
+  // Build subpass dependencies. When framebuffer fetch is supported, a
+  // self-dependency (subpass 0 -> subpass 0) is included so that fragment
+  // shaders can read back the color attachment as an input attachment.
+  // When framebuffer fetch is not supported (e.g. Mesa dzn), the
+  // self-dependency is omitted because some drivers (D3D12 translation
+  // layers) fail when a subpass self-dependency is present.
+  constexpr size_t kMaxDeps = 3;
+  vk::SubpassDependency deps[kMaxDeps];
+  size_t dep_count = 0;
+
+  // Incoming external dependency. If the attachments were previously used
   // as attachments for a render pass, or sampled from/transfered to,
   // then these operations must complete before we resolve anything
   // to the onscreen.
-  deps[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-  deps[0].dstSubpass = 0u;
-  deps[0].srcStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput |
-                         vk::PipelineStageFlagBits::eFragmentShader;
-  deps[0].srcAccessMask = vk::AccessFlagBits::eShaderRead |
-                          vk::AccessFlagBits::eColorAttachmentWrite;
-  deps[0].dstStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-  deps[0].dstAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
-  deps[0].dependencyFlags = kSelfDependencyFlags;
+  // Note: dependencyFlags is {} (no flags) because VK_DEPENDENCY_BY_REGION_BIT
+  // is only meaningful for self-dependencies (srcSubpass == dstSubpass).
+  // Per Vulkan spec section 7.1, for non-self-dependencies the by-region
+  // flag is implementation-dependent and may be silently ignored.
+  deps[dep_count].srcSubpass = VK_SUBPASS_EXTERNAL;
+  deps[dep_count].dstSubpass = 0u;
+  // Include depth/stencil stages when a depth attachment is present.
+  // The previous render pass writes depth at eLateFragmentTests; the
+  // implicit layout transition inside vkCmdBeginRenderPass also writes
+  // the depth image, so we must synchronize that previous write against
+  // the new implicit write. This fixes SYNC-HAZARD-WRITE-AFTER-WRITE on
+  // vkCmdBeginRenderPass reported by VK_LAYER_KHRONOS_validation sync.
+  deps[dep_count].srcStageMask =
+      vk::PipelineStageFlagBits::eColorAttachmentOutput |
+      vk::PipelineStageFlagBits::eFragmentShader |
+      (depth_stencil_.has_value()
+           ? (vk::PipelineStageFlagBits::eEarlyFragmentTests |
+              vk::PipelineStageFlagBits::eLateFragmentTests)
+           : vk::PipelineStageFlags{});
+  deps[dep_count].srcAccessMask =
+      vk::AccessFlagBits::eShaderRead |
+      vk::AccessFlagBits::eColorAttachmentWrite |
+      (depth_stencil_.has_value()
+           ? vk::AccessFlagBits::eDepthStencilAttachmentWrite
+           : vk::AccessFlags{});
+  deps[dep_count].dstStageMask =
+      vk::PipelineStageFlagBits::eColorAttachmentOutput |
+      (depth_stencil_.has_value()
+           ? vk::PipelineStageFlagBits::eEarlyFragmentTests
+           : vk::PipelineStageFlags{});
+  deps[dep_count].dstAccessMask =
+      vk::AccessFlagBits::eColorAttachmentWrite |
+      (depth_stencil_.has_value()
+           ? (vk::AccessFlagBits::eDepthStencilAttachmentWrite |
+              vk::AccessFlagBits::eDepthStencilAttachmentRead)
+           : vk::AccessFlags{});
+  deps[dep_count].dependencyFlags = {};
+  dep_count++;
 
-  // Self dependency for reading back the framebuffer, necessary for
-  // programmable blend support / framebuffer fetch.
-  deps[1].srcSubpass = 0u;  // first subpass
-  deps[1].dstSubpass = 0u;  // to itself
-  deps[1].srcStageMask = kSelfDependencySrcStageMask;
-  deps[1].srcAccessMask = kSelfDependencySrcAccessMask;
-  deps[1].dstStageMask = kSelfDependencyDstStageMask;
-  deps[1].dstAccessMask = kSelfDependencyDstAccessMask;
-  deps[1].dependencyFlags = kSelfDependencyFlags;
+  if (supports_framebuffer_fetch_) {
+    // Self dependency for reading back the framebuffer, necessary for
+    // programmable blend support / framebuffer fetch.
+    deps[dep_count].srcSubpass = 0u;  // first subpass
+    deps[dep_count].dstSubpass = 0u;  // to itself
+    deps[dep_count].srcStageMask = kSelfDependencySrcStageMask;
+    deps[dep_count].srcAccessMask = kSelfDependencySrcAccessMask;
+    deps[dep_count].dstStageMask = kSelfDependencyDstStageMask;
+    deps[dep_count].dstAccessMask = kSelfDependencyDstAccessMask;
+    deps[dep_count].dependencyFlags = kSelfDependencyFlags;
+    dep_count++;
+  }
 
-  // Outgoing dependency. The resolve step or color attachment must complete
-  // before we can sample from the image. This dependency is ignored for the
-  // onscreen as we will already insert a barrier before presenting the
-  // swapchain.
-  deps[2].srcSubpass = 0u;  // first subpass
-  deps[2].dstSubpass = VK_SUBPASS_EXTERNAL;
-  deps[2].srcStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-  deps[2].srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
-  deps[2].dstStageMask = vk::PipelineStageFlagBits::eFragmentShader;
-  deps[2].dstAccessMask = vk::AccessFlagBits::eShaderRead;
-  deps[2].dependencyFlags = kSelfDependencyFlags;
+  // Outgoing external dependency. The resolve step or color attachment must
+  // complete before we can sample from the image. This dependency is ignored
+  // for the onscreen as we will already insert a barrier before presenting
+  // the swapchain. Also cover depth writes so the next render pass's incoming
+  // dependency can see them.
+  // dependencyFlags is {} for the same reason as the incoming dependency
+  // (VK_DEPENDENCY_BY_REGION_BIT is meaningless for VK_SUBPASS_EXTERNAL).
+  deps[dep_count].srcSubpass = 0u;  // first subpass
+  deps[dep_count].dstSubpass = VK_SUBPASS_EXTERNAL;
+  deps[dep_count].srcStageMask =
+      vk::PipelineStageFlagBits::eColorAttachmentOutput |
+      (depth_stencil_.has_value()
+           ? vk::PipelineStageFlagBits::eLateFragmentTests
+           : vk::PipelineStageFlags{});
+  deps[dep_count].srcAccessMask =
+      vk::AccessFlagBits::eColorAttachmentWrite |
+      (depth_stencil_.has_value()
+           ? vk::AccessFlagBits::eDepthStencilAttachmentWrite
+           : vk::AccessFlags{});
+  deps[dep_count].dstStageMask = vk::PipelineStageFlagBits::eFragmentShader;
+  deps[dep_count].dstAccessMask = vk::AccessFlagBits::eShaderRead;
+  deps[dep_count].dependencyFlags = {};
+  dep_count++;
 
   vk::RenderPassCreateInfo render_pass_desc;
   render_pass_desc.setPAttachments(attachments.data());
   render_pass_desc.setAttachmentCount(attachments_index);
   render_pass_desc.setSubpasses(subpass0);
   render_pass_desc.setPDependencies(deps);
-  render_pass_desc.setDependencyCount(3);
+  render_pass_desc.setDependencyCount(dep_count);
 
   auto [result, pass] = device.createRenderPassUnique(render_pass_desc);
   if (result != vk::Result::eSuccess) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.h
@@ -59,6 +59,13 @@ class RenderPassBuilderVK {
   // Visible for testing.
   const std::optional<vk::AttachmentDescription>& GetDepthStencil() const;
 
+  /// @brief      When set to false, the render pass will not include input
+  ///             attachment references or self-dependencies needed for
+  ///             framebuffer fetch. This is required for drivers (such as
+  ///             Mesa's dzn / Direct3D 12 translation layer) that do not
+  ///             support subpass self-dependencies.
+  RenderPassBuilderVK& SetFramebufferFetchEnabled(bool enabled);
+
   // Visible for testing.
   std::optional<vk::AttachmentDescription> GetColor0() const;
 
@@ -69,6 +76,7 @@ class RenderPassBuilderVK {
   std::optional<vk::AttachmentDescription> color0_;
   std::optional<vk::AttachmentDescription> color0_resolve_;
   std::optional<vk::AttachmentDescription> depth_stencil_;
+  bool supports_framebuffer_fetch_ = true;
 
   // Color attachment 0 is stored in the field above and not in these maps.
   std::map<size_t, vk::AttachmentDescription> colors_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -133,6 +133,9 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
     );
   }
 
+  builder.SetFramebufferFetchEnabled(
+      context.GetCapabilities()->SupportsFramebufferFetch());
+
   auto pass = builder.Build(context.GetDevice());
 
   if (!pass) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
@@ -356,6 +356,14 @@ KHRSwapchainImplVK::AcquireResult KHRSwapchainImplVK::AcquireNextDrawable() {
 
   const auto& context = ContextVK::Cast(*context_strong);
 
+  // If the device is in a lost state (e.g. after a failed queue submission on
+  // a driver in a corrupted OOM state), do not make any further Vulkan calls:
+  // vkWaitForFences / vkAcquireNextImageKHR can access-fault inside the ICD.
+  // Return an empty result so the caller skips the frame gracefully.
+  if (context.IsDeviceLost()) {
+    return KHRSwapchainImplVK::AcquireResult{};
+  }
+
   current_frame_ = (current_frame_ + 1u) % synchronizers_.size();
 
   const auto& sync = synchronizers_[current_frame_];
@@ -389,14 +397,24 @@ KHRSwapchainImplVK::AcquireResult KHRSwapchainImplVK::AcquireNextDrawable() {
     case vk::Result::eSuboptimalKHR:
     case vk::Result::eErrorOutOfDateKHR:
       // A recoverable error. Just say we are out of date.
+      //
+      // WaitForFence above reset the synchronizer fence. Since no GPU work
+      // will be submitted for this frame, re-signal the fence with an empty
+      // queue submit. Without this, the next attempt that wraps around to
+      // the same synchronizer deadlocks in waitForFences (infinite timeout
+      // on a fence that nothing will signal).
+      context.GetGraphicsQueue()->Submit(*sync->acquire);
       return AcquireResult{true /* out of date */};
       break;
     case vk::Result::eErrorSurfaceLostKHR:
       // This error code is returned by Android for some situations that are
-      // recoverable but do not require recreating the swapchain.
+      // recoverable but do not require recreating the swapchain. Re-signal
+      // the fence for the same reason as above.
+      context.GetGraphicsQueue()->Submit(*sync->acquire);
       return AcquireResult{false /* out of date */};
     default:
-      // An unrecoverable error.
+      // An unrecoverable error. Re-signal the fence for the same reason.
+      context.GetGraphicsQueue()->Submit(*sync->acquire);
       VALIDATION_LOG << "Could not acquire next swapchain image: "
                      << vk::to_string(acq_result);
       return AcquireResult{false /* out of date */};
@@ -404,6 +422,7 @@ KHRSwapchainImplVK::AcquireResult KHRSwapchainImplVK::AcquireNextDrawable() {
 
   if (index >= images_.size()) {
     VALIDATION_LOG << "Swapchain returned an invalid image index.";
+    context.GetGraphicsQueue()->Submit(*sync->acquire);
     return KHRSwapchainImplVK::AcquireResult{};
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_vk.cc
@@ -80,7 +80,20 @@ std::unique_ptr<Surface> KHRSwapchainVK::AcquireNextDrawable(
     return nullptr;
   }
 
-  size_ = impl_->GetCurrentUnderlyingSurfaceSize().value_or(size_);
+  {
+    auto surface_size = impl_->GetCurrentUnderlyingSurfaceSize();
+    if (surface_size.has_value()) {
+      if (surface_size->IsEmpty()) {
+        // Minimized or occluded window - surface has zero extent. Skip this
+        // frame but preserve size_ so recovery works when the window is
+        // restored. The rendering loop will keep calling AcquireNextDrawable
+        // and eventually GetCurrentUnderlyingSurfaceSize() will return a
+        // non-zero value.
+        return nullptr;
+      }
+      size_ = surface_size.value();
+    }
+  }
 #endif  // !FML_OS_ANDROID
 
   TRACE_EVENT0("impeller", "RecreateSwapchain");

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_vk.cc
@@ -84,7 +84,20 @@ std::unique_ptr<Surface> KHRSwapchainVK::AcquireNextDrawable(
     return nullptr;
   }
 
-  size_ = impl_->GetCurrentUnderlyingSurfaceSize().value_or(size_);
+  {
+    auto surface_size = impl_->GetCurrentUnderlyingSurfaceSize();
+    if (surface_size.has_value()) {
+      if (surface_size->IsEmpty()) {
+        // Minimized or occluded window - surface has zero extent. Skip this
+        // frame but preserve size_ so recovery works when the window is
+        // restored. The rendering loop will keep calling AcquireNextDrawable
+        // and eventually GetCurrentUnderlyingSurfaceSize() will return a
+        // non-zero value.
+        return nullptr;
+      }
+      size_ = surface_size.value();
+    }
+  }
 #endif  // !FML_OS_ANDROID
 
   TRACE_EVENT0("impeller", "RecreateSwapchain");

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/tracked_objects_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/tracked_objects_vk.cc
@@ -39,6 +39,35 @@ TrackedObjectsVK::~TrackedObjectsVK() {
   pool_->CollectCommandBuffer(std::move(buffer_));
 }
 
+void TrackedObjectsVK::AbandonForDriverCrash() {
+  if (!buffer_) {
+    return;
+  }
+  // Release the command buffer handle without returning it to the pool.
+  // The pool is also abandoned so that neither vkFreeCommandBuffers nor
+  // vkDestroyCommandPool is called on the now-invalid driver-side handles.
+  buffer_.release();
+  if (pool_) {
+    pool_->AbandonForDriverCrash();
+  }
+  // Release all VkDescriptorPool handles to prevent vkDestroyDescriptorPool
+  // calls on the corrupted device.
+  if (desc_pool_) {
+    desc_pool_->AbandonForDriverCrash();
+  }
+  // Clear tracked resource lists. If this TrackedObjectsVK is the last holder
+  // of these shared_ptrs their destructors would call vkDestroyBuffer /
+  // vkDestroyImage etc. on the corrupted device. Clearing here is safe
+  // because in the common case (pipeline objects, cached textures) other
+  // owners still hold the resources, so no destructor fires. In the rare
+  // case where we ARE the last owner we accept the potential for a Vulkan
+  // cleanup call - it is better than the guaranteed crash from waitIdle or
+  // vkCreateCommandPool on a driver in a corrupted OOM state.
+  tracked_objects_.clear();
+  tracked_buffers_.clear();
+  tracked_textures_.clear();
+}
+
 bool TrackedObjectsVK::IsValid() const {
   return is_valid_;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/tracked_objects_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/tracked_objects_vk.h
@@ -27,6 +27,14 @@ class TrackedObjectsVK {
 
   bool IsValid() const;
 
+  /// @brief      Discard the command buffer handle without returning it to
+  ///             the pool, and abandon the pool itself.
+  ///
+  /// Call this after a failed vkQueueSubmit where the driver has already freed
+  /// the underlying Vulkan objects (e.g. AMD non-conformant OOM behaviour).
+  /// Prevents vkFreeCommandBuffers being called on an already-invalid handle.
+  void AbandonForDriverCrash();
+
   void Track(const std::shared_ptr<SharedObjectVK>& object);
 
   void Track(const std::shared_ptr<const DeviceBuffer>& buffer);

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/workarounds_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/workarounds_vk.cc
@@ -24,6 +24,27 @@ WorkaroundsVK GetWorkaroundsFromDriverInfo(DriverInfoVK& driver_info) {
   } else if (powervr_gpu.has_value()) {
     workarounds.input_attachment_self_dependency_broken = true;
   }
+
+  // Mesa's "dozen" (dzn) driver translates Vulkan to D3D12. D3D12 has no
+  // native subpass concept, so the subpass self-dependency used for
+  // programmable blending (framebuffer fetch) fails at vkEndCommandBuffer
+  // with ErrorOutOfHostMemory. Disable framebuffer fetch on this driver.
+  //
+  // Detection strategy:
+  //  1. Prefer VkPhysicalDeviceDriverProperties::driverID (Vulkan 1.2+)
+  //     which reliably identifies the driver via an enum.
+  //  2. Fall back to device name string matching for pre-1.2 drivers.
+  //     The device name is "Microsoft Direct3D12 (<GPU name>)".
+  //     Note: dzn reports the underlying GPU's vendorID (e.g. 0x1002 for
+  //     AMD), not VK_VENDOR_ID_MESA, so vendorID alone is insufficient.
+  bool is_mesa_dzn =
+      driver_info.GetDriverID() == vk::DriverId::eMesaDozen ||
+      driver_info.GetDriverName().find("D3D12") != std::string::npos;
+  if (is_mesa_dzn) {
+    workarounds.input_attachment_self_dependency_broken = true;
+    workarounds.skip_sub_region_buffer_to_image_copy = true;
+  }
+
   return workarounds;
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/workarounds_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/workarounds_vk.h
@@ -36,6 +36,14 @@ struct WorkaroundsVK {
   ///      * https://github.com/flutter/flutter/issues/159876
   ///      * https://github.com/flutter/flutter/issues/160587
   bool broken_mipmap_generation = false;
+
+  /// Mesa's "dozen" (dzn) D3D12 translation layer reports a
+  /// minImageTransferGranularity of (0,0,0) and fails sub-region
+  /// buffer-to-image copies with VK_ERROR_OUT_OF_HOST_MEMORY at
+  /// vkEndCommandBuffer. When set, sub-region copies use a staging
+  /// image as intermediary: buffer -> staging (full copy) -> destination
+  /// via vkCmdCopyImage (not constrained by transfer granularity).
+  bool skip_sub_region_buffer_to_image_copy = false;
 };
 
 WorkaroundsVK GetWorkaroundsFromDriverInfo(DriverInfoVK& driver_info);

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -114,6 +114,17 @@ GPUSurfaceVulkanImpeller::~GPUSurfaceVulkanImpeller() {
           }
         }
       }
+    } else {
+      // After a device loss the driver's internal state may be corrupted and
+      // any further Vulkan call can fault inside the ICD (see
+      // ContextVK::MarkDeviceLost). Abandon the handles instead of destroying
+      // them, matching the AbandonForDriverCrash policy of the command pools.
+      for (auto& entry : cached_image_views_) {
+        (void)entry.second.release();
+      }
+      for (auto& fence : frame_fences_) {
+        (void)fence.release();
+      }
     }
   }
   cached_image_views_.clear();
@@ -284,14 +295,23 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
       // in-flight frames to complete first to avoid destroying a
       // VkImageView the GPU may still reference
       // (VUID-vkDestroyImageView-imageView-01026).
-      for (size_t i = 0; i < kMaxFramesInFlight; i++) {
-        if (frame_fences_[i]) {
-          auto wait = context_vk.GetDevice().waitForFences(
-              {*frame_fences_[i]}, VK_TRUE, kFenceDrainTimeoutNs);
-          if (wait != impeller::vk::Result::eSuccess) {
-            FML_LOG(ERROR) << "Failed to wait for in-flight fence on resize: "
-                           << impeller::vk::to_string(wait);
+      if (!context_vk.IsDeviceLost()) {
+        for (size_t i = 0; i < kMaxFramesInFlight; i++) {
+          if (frame_fences_[i]) {
+            auto wait = context_vk.GetDevice().waitForFences(
+                {*frame_fences_[i]}, VK_TRUE, kFenceDrainTimeoutNs);
+            if (wait != impeller::vk::Result::eSuccess) {
+              FML_LOG(ERROR) << "Failed to wait for in-flight fence on resize: "
+                             << impeller::vk::to_string(wait);
+            }
           }
+        }
+      } else {
+        // Waiting on fences or destroying views is unsafe on a corrupted
+        // driver after a device loss; abandon the stale views instead (the
+        // embedder's old images are gone either way).
+        for (auto& entry : cached_image_views_) {
+          (void)entry.second.release();
         }
       }
       cached_image_views_.clear();

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -14,6 +14,7 @@
 #include "impeller/display_list/dl_dispatcher.h"
 #include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/renderer/backend/vulkan/pipeline_library_vk.h"
 #include "impeller/renderer/backend/vulkan/surface_context_vk.h"
 #include "impeller/renderer/backend/vulkan/swapchain/surface_vk.h"
 #include "impeller/renderer/render_target.h"
@@ -22,35 +23,35 @@
 
 namespace flutter {
 
+/// Wraps an embedder-provided VkImage/VkImageView pair as a TextureSourceVK
+/// for use with Impeller's rendering pipeline. The image view is borrowed;
+/// ownership is held by the surface's image view cache, which outlives the
+/// wrapper.
 class WrappedTextureSourceVK : public impeller::TextureSourceVK {
  public:
   explicit WrappedTextureSourceVK(impeller::vk::Image image,
-                                  impeller::vk::UniqueImageView image_view,
+                                  impeller::vk::ImageView image_view,
                                   impeller::TextureDescriptor desc)
-      : TextureSourceVK(desc),
-        image_(image),
-        image_view_(std::move(image_view)) {}
+      : TextureSourceVK(desc), image_(image), image_view_(image_view) {}
 
   ~WrappedTextureSourceVK() override = default;
 
  private:
   impeller::vk::Image GetImage() const override { return image_; }
 
-  impeller::vk::ImageView GetImageView() const override {
-    return image_view_.get();
-  }
+  impeller::vk::ImageView GetImageView() const override { return image_view_; }
 
   impeller::vk::ImageView GetRenderTargetView(
       uint32_t mip_level,
       uint32_t array_layer) const override {
     // Swapchain images are always a single 2D mip and layer.
-    return image_view_.get();
+    return image_view_;
   }
 
   bool IsSwapchainImage() const override { return true; }
 
   impeller::vk::Image image_;
-  impeller::vk::UniqueImageView image_view_;
+  impeller::vk::ImageView image_view_;
 };
 
 GPUSurfaceVulkanImpeller::GPUSurfaceVulkanImpeller(
@@ -69,11 +70,54 @@ GPUSurfaceVulkanImpeller::GPUSurfaceVulkanImpeller(
 
   impeller_context_ = std::move(context);
   aiks_context_ = std::move(aiks_context);
+
+  // Create frame-throttling fences (signaled initially so the first
+  // kMaxFramesInFlight frames do not block). Only the embedder-managed image
+  // path uses these; the KHR swapchain enforces its own backpressure.
+  if (delegate_) {
+    auto& context_vk = impeller::ContextVK::Cast(*impeller_context_);
+    impeller::vk::FenceCreateInfo fence_ci;
+    fence_ci.flags = impeller::vk::FenceCreateFlagBits::eSignaled;
+    for (size_t i = 0; i < kMaxFramesInFlight; i++) {
+      auto [result, fence] = context_vk.GetDevice().createFenceUnique(fence_ci);
+      if (result != impeller::vk::Result::eSuccess) {
+        FML_LOG(ERROR) << "Failed to create frame throttle fence: "
+                       << impeller::vk::to_string(result);
+        return;
+      }
+      frame_fences_[i] = std::move(fence);
+    }
+  }
+
   is_valid_ = !!aiks_context_;
 }
 
 // |Surface|
-GPUSurfaceVulkanImpeller::~GPUSurfaceVulkanImpeller() = default;
+GPUSurfaceVulkanImpeller::~GPUSurfaceVulkanImpeller() {
+  // Wait for in-flight frames before destroying cached image views, so a
+  // VkImageView still referenced by the GPU is not destroyed
+  // (VUID-vkDestroyImageView-imageView-01026). Individual frame fences are
+  // used instead of vkDeviceWaitIdle: some drivers (Samsung Xclipse, Mali)
+  // segfault inside vkDeviceWaitIdle when the underlying native window has
+  // already been destroyed by the platform, which happens routinely during
+  // Android activity transitions.
+  if (impeller_context_) {
+    auto& context_vk = impeller::ContextVK::Cast(*impeller_context_);
+    if (!context_vk.IsDeviceLost()) {
+      for (auto& fence : frame_fences_) {
+        if (fence) {
+          auto wait_result = context_vk.GetDevice().waitForFences(
+              {*fence}, VK_TRUE, kFenceDrainTimeoutNs);
+          if (wait_result != impeller::vk::Result::eSuccess) {
+            FML_LOG(ERROR) << "Frame fence wait failed during teardown: "
+                           << impeller::vk::to_string(wait_result);
+          }
+        }
+      }
+    }
+  }
+  cached_image_views_.clear();
+}
 
 // |Surface|
 bool GPUSurfaceVulkanImpeller::IsValid() {
@@ -143,6 +187,65 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
         true      // display list fallback
     );
   } else {
+    //------------------------------------------------------------------
+    // Frame throttle: wait for the oldest in-flight frame's fence.
+    //
+    // The KHR swapchain path enforces back-pressure via WaitForFence()
+    // in AcquireNextDrawable. Without an equivalent here, the CPU queues
+    // frames unboundedly; fences, tracked resources, and driver objects
+    // accumulate until VK_ERROR_OUT_OF_HOST_MEMORY.
+    //
+    // A ring of kMaxFramesInFlight fences throttles the CPU. Before
+    // starting frame N, the fence from frame N-2 is awaited, guaranteeing
+    // at most 2 frames in flight at any time.
+    //
+    // If the GPU cannot complete within kFrameSkipTimeoutNs, the frame is
+    // skipped entirely. This prevents unbounded resource accumulation
+    // under extreme GPU pressure while maintaining rendering correctness.
+    //------------------------------------------------------------------
+    {
+      auto& context_vk = impeller::ContextVK::Cast(*impeller_context_);
+      size_t fence_idx = current_fence_index_ % kMaxFramesInFlight;
+
+      if (frame_fences_[fence_idx]) {
+        // Wait with a bounded timeout. Under extreme load the GPU may fall
+        // behind; skipping the frame preserves correct rendering.
+        auto wait_result = context_vk.GetDevice().waitForFences(
+            {*frame_fences_[fence_idx]}, VK_TRUE, kFrameSkipTimeoutNs);
+        if (wait_result == impeller::vk::Result::eTimeout) {
+          // The GPU is under extreme pressure. Returning nullptr tells the
+          // rasterizer to drop this frame, which maintains rendering
+          // correctness at the expense of frame rate.
+          FML_LOG(WARNING)
+              << "Frame skipped: GPU did not complete within timeout.";
+          return nullptr;
+        }
+        if (wait_result != impeller::vk::Result::eSuccess) {
+          FML_LOG(ERROR) << "Frame throttle fence wait failed: "
+                         << impeller::vk::to_string(wait_result);
+          return nullptr;
+        }
+        // The fence is deliberately NOT reset here. A frame can be acquired
+        // and then dropped without ever being submitted (the rasterizer
+        // discards frames routinely); resetting on acquire would leave the
+        // fence unsignaled forever in that case, deadlocking the teardown
+        // and resize drains. The submit callback resets the fence
+        // immediately before queueing the signal, so a fence is only ever
+        // unsignaled while submitted work is actually in flight.
+      }
+    }
+
+    // Mark the end of the previous frame. In the KHR swapchain path this is
+    // done by SurfaceContextVK::AcquireNextSurface(); the embedder-managed
+    // image path bypasses that, so it must be done here. This lets the
+    // pipeline library schedule deferred operations, matching
+    // SurfaceContextVK::MarkFrameEnd().
+    if (auto pipeline_library = impeller_context_->GetPipelineLibrary()) {
+      impeller::PipelineLibraryVK::Cast(*pipeline_library)
+          .DidAcquireSurfaceFrame();
+    }
+    impeller_context_->GetResourceAllocator()->DebugTraceMemoryStatistics();
+
     FlutterVulkanImage flutter_image = delegate_->AcquireImage(size);
     if (!flutter_image.image) {
       FML_LOG(ERROR) << "Invalid VkImage given by the embedder.";
@@ -174,35 +277,66 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
     desc.compression_type = impeller::CompressionType::kLossless;
     desc.usage = impeller::TextureUsage::kRenderTarget;
 
-    impeller::vk::ImageViewCreateInfo view_info = {};
-    view_info.viewType = impeller::vk::ImageViewType::e2D;
-    view_info.format = ToVKImageFormat(desc.format);
-    view_info.subresourceRange.aspectMask =
-        impeller::vk::ImageAspectFlagBits::eColor;
-    view_info.subresourceRange.baseMipLevel = 0u;
-    view_info.subresourceRange.baseArrayLayer = 0u;
-    view_info.subresourceRange.levelCount = 1;
-    view_info.subresourceRange.layerCount = 1;
-    view_info.image = vk_image;
-
-    auto [result, image_view] =
-        context_vk.GetDevice().createImageViewUnique(view_info);
-    if (result != impeller::vk::Result::eSuccess) {
-      FML_LOG(ERROR) << "Failed to create image view for provided image: "
-                     << impeller::vk::to_string(result);
-      return nullptr;
-    }
-
     impeller::ISize frame_size{size.width, size.height};
     if (transients_ == nullptr || transients_size_ != frame_size) {
+      // The embedder's images were recreated, so the old VkImages are
+      // invalid and their cached views must be destroyed. Wait for all
+      // in-flight frames to complete first to avoid destroying a
+      // VkImageView the GPU may still reference
+      // (VUID-vkDestroyImageView-imageView-01026).
+      for (size_t i = 0; i < kMaxFramesInFlight; i++) {
+        if (frame_fences_[i]) {
+          auto wait = context_vk.GetDevice().waitForFences(
+              {*frame_fences_[i]}, VK_TRUE, kFenceDrainTimeoutNs);
+          if (wait != impeller::vk::Result::eSuccess) {
+            FML_LOG(ERROR) << "Failed to wait for in-flight fence on resize: "
+                           << impeller::vk::to_string(wait);
+          }
+        }
+      }
+      cached_image_views_.clear();
       transients_ = std::make_shared<impeller::SwapchainTransientsVK>(
           impeller_context_, desc,
           /*enable_msaa=*/true);
       transients_size_ = frame_size;
     }
 
-    auto wrapped_onscreen = std::make_shared<WrappedTextureSourceVK>(
-        vk_image, std::move(image_view), desc);
+    // Cache image views per embedder image to avoid a per-frame VkImageView
+    // allocation (which leaks one view per frame, since nothing destroyed
+    // them until surface teardown). The KHR swapchain path creates one view
+    // per swapchain image; this cache replicates that pattern. Ownership is
+    // held by cached_image_views_; WrappedTextureSourceVK borrows the raw
+    // handle, which stays valid as long as the cache entry exists.
+    impeller::vk::ImageView image_view;
+    auto cache_key = flutter_image.image;
+    auto it = cached_image_views_.find(cache_key);
+    if (it != cached_image_views_.end()) {
+      image_view = *it->second;
+    } else {
+      impeller::vk::ImageViewCreateInfo view_info = {};
+      view_info.viewType = impeller::vk::ImageViewType::e2D;
+      view_info.format = ToVKImageFormat(desc.format);
+      view_info.subresourceRange.aspectMask =
+          impeller::vk::ImageAspectFlagBits::eColor;
+      view_info.subresourceRange.baseMipLevel = 0u;
+      view_info.subresourceRange.baseArrayLayer = 0u;
+      view_info.subresourceRange.levelCount = 1;
+      view_info.subresourceRange.layerCount = 1;
+      view_info.image = vk_image;
+
+      auto [result, unique_view] =
+          context_vk.GetDevice().createImageViewUnique(view_info);
+      if (result != impeller::vk::Result::eSuccess) {
+        FML_LOG(ERROR) << "Failed to create image view for provided image: "
+                       << impeller::vk::to_string(result);
+        return nullptr;
+      }
+      image_view = *unique_view;
+      cached_image_views_[cache_key] = std::move(unique_view);
+    }
+
+    auto wrapped_onscreen =
+        std::make_shared<WrappedTextureSourceVK>(vk_image, image_view, desc);
     auto surface = impeller::SurfaceVK::WrapSwapchainImage(
         transients_, wrapped_onscreen, [&]() -> bool { return true; });
     impeller::RenderTarget render_target = surface->GetRenderTarget();
@@ -232,10 +366,18 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
       );
     };
 
+    // Raw handle of this frame's throttle fence, signaled by the submit
+    // callback after presentation. The unique handle stays owned by
+    // frame_fences_, which outlives the frame.
+    impeller::vk::Fence frame_fence;
+    if (frame_fences_[current_fence_index_ % kMaxFramesInFlight]) {
+      frame_fence = *frame_fences_[current_fence_index_ % kMaxFramesInFlight];
+    }
+
     SurfaceFrame::SubmitCallback submit_callback =
         [image = flutter_image, delegate = delegate_,
-         impeller_context = impeller_context_,
-         wrapped_onscreen](const SurfaceFrame&) -> bool {
+         impeller_context = impeller_context_, wrapped_onscreen,
+         frame_fence](const SurfaceFrame&) -> bool {
       TRACE_EVENT0("flutter", "GPUSurfaceVulkan::PresentImage");
 
       {
@@ -245,6 +387,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
         /// Transition the image to color-attachment-optimal.
         ///
         auto cmd_buffer = context.CreateCommandBuffer();
+        if (!cmd_buffer) {
+          // Command buffer creation short-circuits when the device is lost.
+          FML_LOG(ERROR) << "Failed to create command buffer for layout "
+                            "transition before present.";
+          return false;
+        }
 
         auto vk_final_cmd_buffer =
             impeller::CommandBufferVK::Cast(*cmd_buffer).GetCommandBuffer();
@@ -270,11 +418,52 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
         }
       }
 
-      return delegate->PresentImage(reinterpret_cast<VkImage>(image.image),
-                                    static_cast<VkFormat>(image.format));
+      bool present_ok =
+          delegate->PresentImage(reinterpret_cast<VkImage>(image.image),
+                                 static_cast<VkFormat>(image.format));
+
+      //--------------------------------------------------------------------
+      // Signal this frame's throttle fence.
+      //
+      // An empty vkQueueSubmit with just a fence signals it once all
+      // previously submitted command buffers on the queue have completed
+      // execution. Both the frame's rendering commands and the layout
+      // transition above are therefore finished before the fence signals.
+      //
+      // This goes through QueueVK's submission path (which serializes all
+      // access to the VkQueue behind a single mutex) rather than a direct
+      // vkQueueSubmit, since unsynchronized access to the queue from two
+      // lock domains is a validation violation.
+      //
+      // AcquireFrame waits on this fence kMaxFramesInFlight frames later,
+      // capping in-flight work, matching the KHR swapchain's backpressure.
+      //--------------------------------------------------------------------
+      if (frame_fence) {
+        const auto& context = impeller::ContextVK::Cast(*impeller_context);
+        // Reset immediately before queueing the signal, not in AcquireFrame:
+        // this keeps the fence signaled for frames that are acquired but
+        // never submitted, so the teardown and resize drains cannot wait on
+        // a fence that nothing will signal.
+        auto reset_result = context.GetDevice().resetFences({frame_fence});
+        if (reset_result != impeller::vk::Result::eSuccess) {
+          FML_LOG(ERROR) << "Failed to reset frame throttle fence: "
+                         << impeller::vk::to_string(reset_result);
+          return present_ok;
+        }
+        auto signal_result = context.GetGraphicsQueue()->Submit(frame_fence);
+        if (signal_result != impeller::vk::Result::eSuccess) {
+          FML_LOG(ERROR) << "Failed to signal frame throttle fence: "
+                         << impeller::vk::to_string(signal_result);
+        }
+      }
+
+      return present_ok;
     };
 
     SurfaceFrame::FramebufferInfo framebuffer_info{.supports_readback = true};
+
+    // Advance the fence ring so the next frame uses the next slot.
+    current_fence_index_ = (current_fence_index_ + 1) % kMaxFramesInFlight;
 
     return std::make_unique<SurfaceFrame>(nullptr,           // surface
                                           framebuffer_info,  // framebuffer info

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -101,7 +101,12 @@ GPUSurfaceVulkanImpeller::~GPUSurfaceVulkanImpeller() {
   // segfault inside vkDeviceWaitIdle when the underlying native window has
   // already been destroyed by the platform, which happens routinely during
   // Android activity transitions.
-  if (impeller_context_) {
+  //
+  // Only the embedder-managed image path (non-null delegate) has fences or
+  // cached views, and only that path is handed a ContextVK; without a
+  // delegate the context is a SurfaceContextVK and the cast below would be
+  // invalid.
+  if (impeller_context_ && delegate_) {
     auto& context_vk = impeller::ContextVK::Cast(*impeller_context_);
     if (!context_vk.IsDeviceLost()) {
       for (auto& fence : frame_fences_) {
@@ -113,6 +118,17 @@ GPUSurfaceVulkanImpeller::~GPUSurfaceVulkanImpeller() {
                            << impeller::vk::to_string(wait_result);
           }
         }
+      }
+    } else {
+      // After a device loss the driver's internal state may be corrupted and
+      // any further Vulkan call can fault inside the ICD (see
+      // ContextVK::MarkDeviceLost). Abandon the handles instead of destroying
+      // them, matching the AbandonForDriverCrash policy of the command pools.
+      for (auto& entry : cached_image_views_) {
+        (void)entry.second.release();
+      }
+      for (auto& fence : frame_fences_) {
+        (void)fence.release();
       }
     }
   }
@@ -284,14 +300,23 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
       // in-flight frames to complete first to avoid destroying a
       // VkImageView the GPU may still reference
       // (VUID-vkDestroyImageView-imageView-01026).
-      for (size_t i = 0; i < kMaxFramesInFlight; i++) {
-        if (frame_fences_[i]) {
-          auto wait = context_vk.GetDevice().waitForFences(
-              {*frame_fences_[i]}, VK_TRUE, kFenceDrainTimeoutNs);
-          if (wait != impeller::vk::Result::eSuccess) {
-            FML_LOG(ERROR) << "Failed to wait for in-flight fence on resize: "
-                           << impeller::vk::to_string(wait);
+      if (!context_vk.IsDeviceLost()) {
+        for (size_t i = 0; i < kMaxFramesInFlight; i++) {
+          if (frame_fences_[i]) {
+            auto wait = context_vk.GetDevice().waitForFences(
+                {*frame_fences_[i]}, VK_TRUE, kFenceDrainTimeoutNs);
+            if (wait != impeller::vk::Result::eSuccess) {
+              FML_LOG(ERROR) << "Failed to wait for in-flight fence on resize: "
+                             << impeller::vk::to_string(wait);
+            }
           }
+        }
+      } else {
+        // Waiting on fences or destroying views is unsafe on a corrupted
+        // driver after a device loss; abandon the stale views instead (the
+        // embedder's old images are gone either way).
+        for (auto& entry : cached_image_views_) {
+          (void)entry.second.release();
         }
       }
       cached_image_views_.clear();

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.h
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.h
@@ -5,6 +5,10 @@
 #ifndef FLUTTER_SHELL_GPU_GPU_SURFACE_VULKAN_IMPELLER_H_
 #define FLUTTER_SHELL_GPU_GPU_SURFACE_VULKAN_IMPELLER_H_
 
+#include <array>
+#include <cstdint>
+#include <unordered_map>
+
 #include "flutter/common/graphics/gl_context_switch.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
@@ -13,6 +17,7 @@
 #include "flutter/impeller/renderer/context.h"
 #include "flutter/shell/gpu/gpu_surface_vulkan_delegate.h"
 #include "impeller/renderer/backend/vulkan/swapchain/swapchain_transients_vk.h"
+#include "impeller/renderer/backend/vulkan/vk.h"
 
 namespace flutter {
 
@@ -36,12 +41,53 @@ class GPUSurfaceVulkanImpeller final : public Surface {
   FML_FRIEND_TEST(testing::GPUSurfaceVulkanImpeller,
                   RecreatesTransientsWhenFrameSizeChanges);
 
+  /// Maximum number of frames that can be in-flight simultaneously.
+  /// Matches the KHR swapchain's kMaxFramesInFlight = 2.
+  static constexpr size_t kMaxFramesInFlight = 2u;
+
+  /// Maximum time (nanoseconds) to wait for a frame fence before skipping
+  /// the frame. 100ms provides generous headroom for normal rendering
+  /// (including high-DPI, heavy shader workloads, and debug builds) while
+  /// still dropping frames under extreme GPU pressure to prevent resource
+  /// exhaustion. The primary backpressure mechanism is the 2-fence ring
+  /// itself; this timeout is a secondary safety net.
+  static constexpr uint64_t kFrameSkipTimeoutNs = 100'000'000u;
+
+  /// Maximum time (nanoseconds) to wait for in-flight frames when draining
+  /// fences on resize or teardown. Fences are only unsignaled while a
+  /// submitted frame is executing, so this bound is never reached in normal
+  /// operation; it protects against waiting forever on a wedged driver.
+  static constexpr uint64_t kFenceDrainTimeoutNs = 5'000'000'000u;  // 5 s.
+
   GPUSurfaceVulkanDelegate* delegate_;
   std::shared_ptr<impeller::Context> impeller_context_;
   std::shared_ptr<impeller::AiksContext> aiks_context_;
   std::shared_ptr<impeller::SwapchainTransientsVK> transients_;
   /// The size of the textures in [transients_]
   impeller::ISize transients_size_ = {};
+
+  // Cached image views keyed by VkImage handle. Image views are created once
+  // per embedder-provided image and reused across frames to avoid per-frame
+  // allocation (which leaks one VkImageView per frame). Cleared when the
+  // embedder's images are recreated (frame size change), since the old
+  // VkImages become invalid.
+  std::unordered_map<uint64_t, impeller::vk::UniqueImageView>
+      cached_image_views_;
+
+  // Frame throttling fences.
+  //
+  // Without throttling, the CPU can queue frames much faster than the GPU
+  // processes them (especially in debug builds). Each queued frame creates
+  // fences and holds tracked resources (textures, buffers, command pools).
+  // Under heavy workloads this causes unbounded resource accumulation and
+  // eventually VK_ERROR_OUT_OF_HOST_MEMORY.
+  //
+  // The KHR swapchain enforces back-pressure via WaitForFence() at the start
+  // of each AcquireNextDrawable. This replicates that for the
+  // embedder-managed image path with a ring of fences.
+  std::array<impeller::vk::UniqueFence, kMaxFramesInFlight> frame_fences_;
+  size_t current_fence_index_ = 0;
+
   bool is_valid_ = false;
 
   // |Surface|

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.h
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.h
@@ -24,6 +24,8 @@ namespace flutter {
 namespace testing {
 FML_TEST_CLASS(GPUSurfaceVulkanImpeller,
                RecreatesTransientsWhenFrameSizeChanges);
+FML_TEST_CLASS(GPUSurfaceVulkanImpeller,
+               TeardownAfterDeviceLossAbandonsResources);
 }  // namespace testing
 
 class GPUSurfaceVulkanImpeller final : public Surface {
@@ -40,6 +42,8 @@ class GPUSurfaceVulkanImpeller final : public Surface {
  private:
   FML_FRIEND_TEST(testing::GPUSurfaceVulkanImpeller,
                   RecreatesTransientsWhenFrameSizeChanges);
+  FML_FRIEND_TEST(testing::GPUSurfaceVulkanImpeller,
+                  TeardownAfterDeviceLossAbandonsResources);
 
   /// Maximum number of frames that can be in-flight simultaneously.
   /// Matches the KHR swapchain's kMaxFramesInFlight = 2.

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller_unittests.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller_unittests.cc
@@ -110,5 +110,29 @@ TEST(GPUSurfaceVulkanImpeller, RecreatesTransientsWhenFrameSizeChanges) {
   EXPECT_EQ(surface->transients_size_, impeller::ISize(200, 100));
 }
 
+TEST(GPUSurfaceVulkanImpeller, TeardownAfterDeviceLossAbandonsResources) {
+  impeller::ContextVK::Settings context_settings;
+  context_settings.proc_address_callback = vkGetInstanceProcAddr;
+  context_settings.shader_libraries_data = ShaderLibraryMappings();
+  auto context = impeller::ContextVK::Create(std::move(context_settings));
+
+  TestGPUSurfaceVulkanDelegate delegate;
+
+  std::unique_ptr<Surface> surface =
+      std::make_unique<GPUSurfaceVulkanImpeller>(&delegate, context);
+
+  // Populate the image view cache and exercise the fence ring with a frame.
+  auto frame = surface->AcquireFrame(DlISize(100, 100));
+  ASSERT_NE(frame, nullptr);
+  frame.reset();
+
+  // Teardown after a device loss must not wait on the frame fences or
+  // destroy the cached image views; on a corrupted driver either can fault
+  // inside the ICD. The surface abandons the handles and must come down
+  // cleanly.
+  context->MarkDeviceLost();
+  surface.reset();
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller_unittests.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller_unittests.cc
@@ -110,5 +110,55 @@ TEST(GPUSurfaceVulkanImpeller, RecreatesTransientsWhenFrameSizeChanges) {
   EXPECT_EQ(surface->transients_size_, impeller::ISize(200, 100));
 }
 
+TEST(GPUSurfaceVulkanImpeller, TeardownAfterDeviceLossAbandonsResources) {
+  impeller::ContextVK::Settings context_settings;
+  context_settings.proc_address_callback = vkGetInstanceProcAddr;
+  context_settings.shader_libraries_data = ShaderLibraryMappings();
+  auto context = impeller::ContextVK::Create(std::move(context_settings));
+
+  TestGPUSurfaceVulkanDelegate delegate;
+
+  auto surface = std::make_unique<GPUSurfaceVulkanImpeller>(&delegate, context);
+
+  // Populate the image view cache and exercise the fence ring with a frame.
+  auto frame = surface->AcquireFrame(DlISize(100, 100));
+  ASSERT_NE(frame, nullptr);
+  frame.reset();
+
+  // Take the raw handles before the device loss; the surface must abandon
+  // them, not destroy them.
+  std::vector<impeller::vk::ImageView> cached_views;
+  for (const auto& [image, view] : surface->cached_image_views_) {
+    cached_views.push_back(view.get());
+  }
+  std::vector<impeller::vk::Fence> fences;
+  for (const auto& fence : surface->frame_fences_) {
+    if (fence) {
+      fences.push_back(fence.get());
+    }
+  }
+  ASSERT_FALSE(fences.empty());
+
+  // Teardown after a device loss must not wait on the frame fences or
+  // destroy the cached image views; on a corrupted driver either can fault
+  // inside the ICD. The surface abandons the handles and must come down
+  // cleanly.
+  context->MarkDeviceLost();
+  surface.reset();
+
+  // Only the lost flag was set; the test device itself is healthy. Destroying
+  // the captured handles here cleans them up (keeping LeakSanitizer quiet)
+  // and verifies the abandonment: had the surface destroyed them, these calls
+  // would be double destroys.
+  const auto& device = context->GetDevice();
+  ASSERT_EQ(device.waitIdle(), impeller::vk::Result::eSuccess);
+  for (const auto& view : cached_views) {
+    device.destroyImageView(view);
+  }
+  for (const auto& fence : fences) {
+    device.destroyFence(fence);
+  }
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR hardens Impeller's Vulkan backend against driver failures and resource exhaustion. Every fix traces to a specific crash, validation error, or unbounded-growth pattern observed during sustained stress testing on AMD RDNA 2 hardware (Radeon RX 6750 XT, Windows 10) and Mesa dzn (Vulkan on D3D12 under WSL2), using a 9-scene GPU benchmark suite (https://github.com/sero583/flutter-benchmark).

This is the first PR of the series splitting #183382 (Impeller Vulkan for Linux and Windows desktops), per review guidance there; design doc: https://flutter.dev/go/impeller-backend-desktop. The changes here are platform-agnostic and benefit the existing Android Vulkan path directly. Several issues addressed by the original branch were independently reported and fixed after that work was first published in March (#185122, #186749, #187761); this PR rebases onto those and ports the remaining fixes.

### Device loss handling

On some drivers (observed on AMD), a `vkQueueSubmit` that fails with `VK_ERROR_OUT_OF_HOST_MEMORY` leaves the driver in a corrupted state: the command pool and command buffer handles passed to the failed submission are freed internally, and any further Vulkan call (including `vkDeviceWaitIdle`) can access-fault inside the ICD.

* `ContextVK` gains an atomic `device_lost_` flag with `IsDeviceLost()` / `MarkDeviceLost()`. `CreateCommandBuffer()` and `CommandQueueVK::Submit()` short-circuit once lost, and `KHRSwapchainImplVK::AcquireNextDrawable()` skips the frame.
* On submission failure, tracked objects are abandoned without Vulkan calls (`AbandonForDriverCrash()` on command pools and descriptor pools), the device is marked lost, and per-heap usage/budget is logged (`VK_EXT_memory_budget` when the driver fills the chained struct) to make field reports diagnosable.
* `FenceWaiterVK` releases rather than destroys the fence when the submit callback fails. Some drivers partially track the fence even though the submission failed; destroying it triggers `VUID-vkDestroyFence-fence-01120` and crashes. This extends the reasoning of #187761 to the submit-failure path.

### Submission backpressure

Without backpressure, the CPU queues submissions faster than the GPU drains them; fences, tracked resources, and driver objects accumulate until `VK_ERROR_OUT_OF_HOST_MEMORY` (reproducible within minutes at uncapped frame rates in debug builds).

* `CommandQueueVK` caps concurrent in-flight submissions (3 = `kMaxFramesInFlight` + 1) with a condition variable; the slot is released from the fence completion callback. A generous 5 s timeout cancels the submission rather than queueing unbounded work. The `GpuSubmissionTracker` bookkeeping introduced by #188965 is preserved on every path: completions are recorded exactly once whether the submission succeeds, fails in `vkQueueSubmit`, or is rejected by the fence waiter, so HostBuffer arena recycling never stalls.
* `ContextVK::FlushCommandBuffers()` submits in chunks of 64 so per-submit driver allocations stay bounded on frames that accumulate very large command buffer counts (heavy blur/filter workloads).
* The embedder-managed image path in `GPUSurfaceVulkanImpeller` gains a two-entry frame fence ring mirroring the KHR swapchain's `WaitForFence` backpressure, with a bounded wait that drops the frame under extreme pressure. Image views for embedder-provided images are now cached instead of allocated (and leaked) every frame, and in-flight frames are drained before views are destroyed on resize or teardown (`VUID-vkDestroyImageView-imageView-01026`).

### Command pool lifecycle

* `BackgroundCommandPoolVK` releases its handles without Vulkan calls when the recycler is gone; the device may already be destroyed at that point. Same class of teardown race as #186458, on the path #186749 did not cover.
* The recycled pool list is capped at 8 entries (oldest evicted) to bound driver-internal memory under workloads that churn many pools.
* `unused_command_buffers_` is annotated `IPLR_GUARDED_BY(pool_mutex_)`, matching `collected_buffers_`.

### Descriptor pools

* `AbandonForDriverCrash()` releases pool handles without Vulkan calls after a fatal submission failure, and the destructor releases handles when the context or recycler is already gone during teardown.
* A newly allocated descriptor set is registered in the per-pipeline cache only after the allocation succeeded; previously a garbage handle was cached when `vkAllocateDescriptorSets` failed.
* `CreateNewPool` failures during the out-of-pool-memory fallback are propagated instead of retrying with an empty pool list.
* Set-recycling semantics are unchanged from the current implementation.

### Barrier and render pass correctness

* Six barrier fixes in `BlitPassVK`: pre-copy barriers use transfer stage/access, post-copy barriers flush transfer writes, and mipmap barriers match the actual current layout. Fixes corrupted glyph atlases and `SYNC-HAZARD-WRITE-AFTER-WRITE` reported by the synchronization validation layer on AMD RDNA 2.
* `RenderPassBuilderVK` moves subpass dependencies to a counted builder, removes `eByRegion` from `VK_SUBPASS_EXTERNAL` dependencies (meaningless per Vulkan spec section 7.1 outside self-dependencies), and gains `SetFramebufferFetchEnabled()` so input attachment references and self-dependencies are omitted on drivers without framebuffer fetch support (Mesa dzn rejects them). The flag is wired through pipeline creation, render pass creation, and the compat render pass used for PSO construction.

### Driver workarounds

* `DriverInfoVK` exposes `GetDriverID()` (Vulkan 1.2) and detects Mesa dzn.
* New `skip_sub_region_buffer_to_image_copy` workaround: Mesa dzn reports `minImageTransferGranularity` of (0,0,0) and corrupts textures on sub-region buffer-to-image copies; `BlitPassVK` stages such copies through a full-size temporary texture.

### Memory management

* The VMA buffer pool is capped at 256 blocks (about 1 GB). The pool otherwise grows without bound when high-water-mark demand spikes and pool-internal fragmentation prevents block reuse.
* Image allocation failure paths no longer leak the VMA allocation when image view creation fails.
* On Windows, the working set is periodically trimmed (`EmptyWorkingSet`, gated by cooldown, RSS threshold, and RSS-to-VMA ratio) when Resizable BAR VRAM mappings inflate RSS to several GB while actual VMA usage is small. This is cosmetic (the pages are GPU-mapped VRAM, not leaks) but prevents alarming numbers in monitoring tools. Happy to split this into a follow-up if reviewers prefer platform-specific code out of allocator_vk.cc.

### KHR swapchain robustness

* The synchronizer fence is re-signaled with an empty submit on every early return after a failed or unusable `acquireNextImageKHR`, including the `eErrorSurfaceLostKHR` path added by #183338. `WaitForFence` resets the fence before the acquire; without a new signal, the next wrap-around to the same synchronizer deadlocks in `waitForFences` with an infinite timeout.
* Zero-extent surfaces (minimized windows) skip the frame instead of attempting swapchain recreation, preserving recovery on restore.

### Embedder-controlled presentation

* `CapabilitiesVK` allows an embedder that presents rendered images itself (for example through a platform compositor) to create a Vulkan context without the surface, WSI, or swapchain extensions. Previously a device without `VK_KHR_surface` was rejected outright. The relaxation only activates in embedder mode when the surface extension is absent; embedders that do provide it are unaffected. This is the enabling change for the surfaceless Windows DirectComposition backend, and is a no-op for existing (Android, KHR-swapchain) users.

### Testing

New unit tests:

* `CommandQueueVKTest.SubmitAfterDeviceLostIsCancelled`: no submission reaches the queue once the device is marked lost.
* `CommandQueueVKTest.ThrottleAllowsSustainedSubmissions`: in-flight slots are released as submissions complete (more submissions than the cap).
* `ContextVKTest.CreateCommandBufferShortCircuitsAfterDeviceLost`.
* `ContextVKTest.EmbedderWithoutSurfaceExtensionsIsSurfaceless`: an embedder device with no surface/swapchain extensions creates a valid context.
* `ContextVKTest.EmbedderWithSurfaceExtensionsStillEnablesThem`: when the embedder provides the surface extension it is still honored.

Test infrastructure fix: the `DeathRattle` helper in `command_pool_vk_unittests.cc` invoked a moved-from `std::function` from its destructor (`WaitForReclaim` moves the local into a `UniqueResourceVKT`), which aborts with `bad_function_call` when running `impeller_unittests` on a Windows host and took the entire `CommandPoolRecyclerVKTest` suite down with it. With the guard in place, that suite and `CommandPoolVKTest.DestroysCleanlyIfDeviceIsDestroyed` (previously also crashing on Windows hosts) run and pass on this branch.

Suite results on a Windows host with this branch rebased onto current master: the full `impeller_unittests` suite runs 4550 tests, 2960 passed, 0 failed (the remainder are playground variants skipped as unsupported on the host). Two pre-existing issues are excluded as unrelated: the color emoji playground crashes (#189565, fix in #189572) and a debug-STL assert in a display_list gradient-stops test that reproduces identically on unmodified master.

Not unit-testable with the current mock (noted for reviewers): the fence release on failed submission (the mock's `vkQueueSubmit` cannot be made to fail) and Mesa dzn detection via `driverID` (the mock exposes no `VkPhysicalDeviceVulkan12Properties`). Extending the mock for failure injection could be follow-up work.

Manual: 9-scene benchmark suite on AMD RDNA 2 (Windows 10) and Mesa dzn (WSL2), no crashes, deadlocks, or validation errors under VK_LAYER_KHRONOS_validation with sync validation enabled.

Part of #181711

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md