### PR TITLE
[windows] Add an Impeller Vulkan backend presented through DirectComposition

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/backend/vulkan/allocator_vk.h"
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <utility>
@@ -470,8 +471,9 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
         if (rt_result != vk::Result::eSuccess) {
           VALIDATION_LOG << "Unable to create a render target image view: "
                          << vk::to_string(rt_result);
-          // Nothing owns the image yet; destroy it to avoid leaking the
-          // allocation.
+          // Destroy the views created so far, then the image.
+          rt_image_views.clear();
+          image_view.reset();
           vmaDestroyImage(allocator, vk_image, allocation);
           return;
         }
@@ -674,12 +676,18 @@ void AllocatorVK::DebugTraceMemoryStatistics() const {
     static constexpr size_t kRssToVmaRatio = 4;
     static constexpr size_t kBytesPerMB = 1024u * 1024u;
 
-    static thread_local int trim_cooldown = 0;
-    if (trim_cooldown > 0) {
-      --trim_cooldown;
+    // EmptyWorkingSet trims the whole process, so the cooldown is shared by
+    // all threads; a per-thread cooldown would let multiple raster threads
+    // (one per engine instance in the process) each trim on their own clock.
+    // Races on the counter are benign: a lost decrement only delays the next
+    // trim check by a frame.
+    static std::atomic<int> trim_cooldown = 0;
+    int cooldown = trim_cooldown.load(std::memory_order_relaxed);
+    if (cooldown > 0) {
+      trim_cooldown.store(cooldown - 1, std::memory_order_relaxed);
     }
 
-    if (trim_cooldown == 0) {
+    if (cooldown == 0) {
       size_t vma_mb = DebugGetHeapUsage().ConvertTo<MebiBytes>().GetSize();
       if (vma_mb < kMaxVmaMB) {
         PROCESS_MEMORY_COUNTERS pmc = {};
@@ -687,7 +695,7 @@ void AllocatorVK::DebugTraceMemoryStatistics() const {
         if (::GetProcessMemoryInfo(::GetCurrentProcess(), &pmc, sizeof(pmc))) {
           size_t rss_mb = pmc.WorkingSetSize / kBytesPerMB;
           if (rss_mb > kMinRssMB && rss_mb > vma_mb * kRssToVmaRatio) {
-            trim_cooldown = kTrimCooldownFrames;
+            trim_cooldown.store(kTrimCooldownFrames, std::memory_order_relaxed);
             ::EmptyWorkingSet(::GetCurrentProcess());
             FML_DLOG(INFO) << "Working set trimmed: " << rss_mb << " MB";
           }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -8,6 +8,13 @@
 #include <mutex>
 #include <utility>
 
+#include "flutter/fml/build_config.h"
+
+#ifdef FML_OS_WIN
+#include <psapi.h>
+#include <windows.h>
+#endif  // FML_OS_WIN
+
 #include "flutter/fml/logging.h"
 #include "flutter/fml/memory/ref_ptr.h"
 #include "flutter/fml/trace_event.h"
@@ -21,6 +28,10 @@
 #include "vulkan/vulkan_enums.hpp"
 
 namespace impeller {
+
+// Maximum number of VMA buffer pool blocks. 256 blocks x 4 MB = 1 GB.
+// Caps pool growth under high-water-mark buffer demand spikes.
+static constexpr uint32_t kMaxBufferPoolBlocks = 256;
 
 static constexpr vk::Flags<vk::MemoryPropertyFlagBits>
 ToVKBufferMemoryPropertyFlags(StorageMode mode) {
@@ -89,6 +100,11 @@ static PoolVMA CreateBufferPool(VmaAllocator allocator) {
   pool_create_info.memoryTypeIndex = memTypeIndex;
   pool_create_info.flags = VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT;
   pool_create_info.minBlockCount = 1;
+  // Cap at 256 blocks x 4 MB = 1 GB. Without a cap, VMA grows this pool
+  // without bound when high-water-mark buffer demand spikes (e.g. during
+  // benchmarks), and pool-internal fragmentation may prevent block reuse even
+  // after individual allocations are freed.
+  pool_create_info.maxBlockCount = kMaxBufferPoolBlocks;
 
   VmaPool pool = {};
   result = vk::Result{::vmaCreatePool(allocator, &pool_create_info, &pool)};
@@ -427,6 +443,9 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
     if (result != vk::Result::eSuccess) {
       VALIDATION_LOG << "Unable to create an image view for allocation: "
                      << vk::to_string(result);
+      // Nothing owns the image yet; destroy it to avoid leaking the
+      // allocation.
+      vmaDestroyImage(allocator, vk_image, allocation);
       return;
     }
     // Create one 2D attachment view per (mip level, array layer) so a
@@ -451,6 +470,9 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
         if (rt_result != vk::Result::eSuccess) {
           VALIDATION_LOG << "Unable to create a render target image view: "
                          << vk::to_string(rt_result);
+          // Nothing owns the image yet; destroy it to avoid leaking the
+          // allocation.
+          vmaDestroyImage(allocator, vk_image, allocation);
           return;
         }
         rt_image_views.push_back(std::move(rt_image_view));
@@ -628,6 +650,52 @@ void AllocatorVK::DebugTraceMemoryStatistics() const {
                     "MemoryBudgetUsageMB",
                     DebugGetHeapUsage().ConvertTo<MebiBytes>().GetSize());
 #endif  // IMPELLER_DEBUG
+
+#ifdef FML_OS_WIN
+  // On Windows with Resizable BAR (AMD RDNA, Intel Arc), the GPU driver maps
+  // all VRAM into the process address space, inflating the working set far
+  // beyond actual CPU-side usage. Periodically trim the working set when RSS
+  // is disproportionately large relative to actual VMA allocations.
+  //
+  // The trim is rate-limited to once every ~5 seconds (300 frames at 60 fps)
+  // to avoid thrashing. It only acts when:
+  //   1. VMA allocations are small (< 256 MB): the driver BAR mapping is
+  //      responsible for the bloat, not actual GPU memory pressure.
+  //   2. RSS exceeds 1 GB and is > 4x VMA usage: confirms the working set
+  //      is dominated by driver-mapped pages, not application data.
+  //
+  // EmptyWorkingSet moves pages to the standby list without freeing them;
+  // they are faulted back in on next access, so the cost is minimal for
+  // pages that are actively used.
+  {
+    static constexpr size_t kTrimCooldownFrames = 300;  // ~5 s at 60 fps.
+    static constexpr size_t kMinRssMB = 1024;
+    static constexpr size_t kMaxVmaMB = 256;
+    static constexpr size_t kRssToVmaRatio = 4;
+    static constexpr size_t kBytesPerMB = 1024u * 1024u;
+
+    static thread_local int trim_cooldown = 0;
+    if (trim_cooldown > 0) {
+      --trim_cooldown;
+    }
+
+    if (trim_cooldown == 0) {
+      size_t vma_mb = DebugGetHeapUsage().ConvertTo<MebiBytes>().GetSize();
+      if (vma_mb < kMaxVmaMB) {
+        PROCESS_MEMORY_COUNTERS pmc = {};
+        pmc.cb = sizeof(pmc);
+        if (::GetProcessMemoryInfo(::GetCurrentProcess(), &pmc, sizeof(pmc))) {
+          size_t rss_mb = pmc.WorkingSetSize / kBytesPerMB;
+          if (rss_mb > kMinRssMB && rss_mb > vma_mb * kRssToVmaRatio) {
+            trim_cooldown = kTrimCooldownFrames;
+            ::EmptyWorkingSet(::GetCurrentProcess());
+            FML_DLOG(INFO) << "Working set trimmed: " << rss_mb << " MB";
+          }
+        }
+      }
+    }
+  }
+#endif  // FML_OS_WIN
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/backend/vulkan/blit_pass_vk.h"
 
+#include "impeller/core/texture_descriptor.h"
 #include "impeller/renderer/backend/vulkan/barrier_vk.h"
 #include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
@@ -45,8 +46,11 @@ static void InsertImageMemoryBarrier(const vk::CommandBuffer& cmd,
 }
 
 BlitPassVK::BlitPassVK(std::shared_ptr<CommandBufferVK> command_buffer,
+                       std::shared_ptr<Allocator> allocator,
                        const WorkaroundsVK& workarounds)
-    : command_buffer_(std::move(command_buffer)), workarounds_(workarounds) {}
+    : command_buffer_(std::move(command_buffer)),
+      allocator_(std::move(allocator)),
+      workarounds_(workarounds) {}
 
 BlitPassVK::~BlitPassVK() = default;
 
@@ -93,12 +97,21 @@ bool BlitPassVK::OnCopyTextureToTextureCommand(
   BarrierVK dst_barrier;
   dst_barrier.cmd_buffer = cmd_buffer;
   dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
-  dst_barrier.src_access = {};
-  dst_barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
-  dst_barrier.dst_access =
-      vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eTransferWrite;
-  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader |
-                          vk::PipelineStageFlagBits::eTransfer;
+  // Wait for any prior buffer-to-image transfer writes to this destination
+  // before starting the image-to-image copy. In the atlas growth path,
+  // BulkUpdateAtlasBitmap writes rows 0..new_height via
+  // vkCmdCopyBufferToImage, then AddCopy(old->new) writes rows 0..old_height
+  // via vkCmdCopyImage. These writes overlap in rows 0..old_height. Without
+  // this barrier, the post-copy eTransfer->eFragmentShader barrier from
+  // BulkUpdateAtlasBitmap does NOT create a transitive dependency here because
+  // eTopOfPipe & eFragmentShader = empty - leaving a WAW hazard on AMD RDNA.
+  dst_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+  dst_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  // dstAccessMask must only list accesses valid for TRANSFER_DST_OPTIMAL.
+  // eShaderRead is not permitted in that layout; including it triggers AMD
+  // best practices validation layer message ID -212008545 (0xF35D019F).
+  dst_barrier.dst_access = vk::AccessFlagBits::eTransferWrite;
+  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
 
   if (!src.SetLayout(src_barrier) || !dst.SetLayout(dst_barrier)) {
     VALIDATION_LOG << "Could not complete layout transitions.";
@@ -137,8 +150,11 @@ bool BlitPassVK::OnCopyTextureToTextureCommand(
   BarrierVK barrier;
   barrier.cmd_buffer = cmd_buffer;
   barrier.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
-  barrier.src_access = {};
-  barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
+  // Flush the transfer write cache so that subsequent shader reads see the
+  // newly copied data. TOP_OF_PIPE with empty src_access does not flush the
+  // transfer write cache on AMD RDNA, leaving the DCC metadata stale.
+  barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+  barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
   barrier.dst_access = vk::AccessFlagBits::eShaderRead;
   barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader;
 
@@ -170,9 +186,8 @@ bool BlitPassVK::OnCopyTextureToBufferCommand(
   barrier.src_stage = vk::PipelineStageFlagBits::eFragmentShader |
                       vk::PipelineStageFlagBits::eTransfer |
                       vk::PipelineStageFlagBits::eColorAttachmentOutput;
-  barrier.dst_access = vk::AccessFlagBits::eShaderRead;
-  barrier.dst_stage = vk::PipelineStageFlagBits::eVertexShader |
-                      vk::PipelineStageFlagBits::eFragmentShader;
+  barrier.dst_access = vk::AccessFlagBits::eTransferRead;
+  barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
 
   const auto& dst = DeviceBufferVK::Cast(*destination);
 
@@ -259,12 +274,25 @@ bool BlitPassVK::OnCopyBufferToTextureCommand(
   BarrierVK dst_barrier;
   dst_barrier.cmd_buffer = cmd_buffer;
   dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
-  dst_barrier.src_access = {};
-  dst_barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
-  dst_barrier.dst_access =
-      vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eTransferWrite;
-  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader |
-                          vk::PipelineStageFlagBits::eTransfer;
+  // The src_access and src_stage must match the texture's current layout.
+  // When multiple copies target the same texture within a single blit pass
+  // (e.g. GlyphAtlas updates with convert_to_read=false), the texture is
+  // already in eTransferDstOptimal after the first copy - using eShaderRead
+  // as src_access in that case violates BestPractices-ImageBarrierAccessLayout.
+  if (dst.GetLayout() == vk::ImageLayout::eTransferDstOptimal) {
+    // WAW hazard: drain the prior transfer write before starting the next.
+    dst_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+    dst_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  } else {
+    // Normal path: texture was last sampled in a fragment shader.
+    dst_barrier.src_access = vk::AccessFlagBits::eShaderRead;
+    dst_barrier.src_stage = vk::PipelineStageFlagBits::eFragmentShader;
+  }
+  // dstAccessMask must only list accesses valid for TRANSFER_DST_OPTIMAL.
+  // eShaderRead is not permitted in that layout; including it triggers AMD
+  // best practices validation layer message ID -212008545 (0xF35D019F).
+  dst_barrier.dst_access = vk::AccessFlagBits::eTransferWrite;
+  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
 
   vk::BufferImageCopy image_copy;
   image_copy.setBufferOffset(source.GetRange().offset);
@@ -279,19 +307,132 @@ bool BlitPassVK::OnCopyBufferToTextureCommand(
   image_copy.imageExtent.height = destination_region.GetHeight();
   image_copy.imageExtent.depth = 1u;
 
-  // Note: this barrier should do nothing if we're already in the transfer dst
-  // optimal state. This is important for performance of repeated blit pass
-  // encoding.
-  if (!dst.SetLayout(dst_barrier)) {
-    VALIDATION_LOG << "Could not encode layout transition.";
-    return false;
+  // Workaround for Mesa dzn (D3D12 translation layer) drivers that report
+  // minImageTransferGranularity of (0,0,0) and reject sub-region
+  // vkCmdCopyBufferToImage with VK_ERROR_OUT_OF_HOST_MEMORY. When the copy
+  // targets a sub-region, a staging image is used as an intermediary:
+  //   1. Full-region buffer -> staging image (not rejected)
+  //   2. vkCmdCopyImage staging -> destination at sub-region offset
+  //      (image-to-image copies are not subject to transfer granularity)
+  bool is_sub_region = false;
+  if (workarounds_.skip_sub_region_buffer_to_image_copy) {
+    const auto& dst_desc = destination->GetTextureDescriptor();
+    is_sub_region =
+        (destination_region.GetX() != 0 || destination_region.GetY() != 0 ||
+         static_cast<uint32_t>(destination_region.GetWidth()) !=
+             dst_desc.size.width ||
+         static_cast<uint32_t>(destination_region.GetHeight()) !=
+             dst_desc.size.height);
   }
 
-  cmd_buffer.copyBufferToImage(src.GetBuffer(),         //
-                               dst.GetImage(),          //
-                               dst_barrier.new_layout,  //
-                               image_copy               //
-  );
+  if (is_sub_region && allocator_) {
+    // Staging image path: create a texture matching the sub-region.
+    TextureDescriptor staging_desc;
+    staging_desc.format = destination->GetTextureDescriptor().format;
+    staging_desc.size =
+        ISize{static_cast<int64_t>(destination_region.GetWidth()),
+              static_cast<int64_t>(destination_region.GetHeight())};
+    staging_desc.storage_mode = StorageMode::kDevicePrivate;
+    staging_desc.usage = TextureUsage::kShaderRead;
+
+    auto staging_texture = allocator_->CreateTexture(staging_desc);
+    if (!staging_texture) {
+      VALIDATION_LOG << "Failed to create staging texture for sub-region copy.";
+      return false;
+    }
+    staging_texture->SetLabel("SubRegionStaging");
+
+    if (!command_buffer_->Track(staging_texture)) {
+      return false;
+    }
+
+    const auto& staging_vk = TextureVK::Cast(*staging_texture);
+
+    // Transition staging to transfer-dst.
+    BarrierVK staging_dst_barrier;
+    staging_dst_barrier.cmd_buffer = cmd_buffer;
+    staging_dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
+    staging_dst_barrier.src_access = {};
+    staging_dst_barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
+    staging_dst_barrier.dst_access = vk::AccessFlagBits::eTransferWrite;
+    staging_dst_barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
+
+    if (!staging_vk.SetLayout(staging_dst_barrier)) {
+      VALIDATION_LOG << "Could not transition staging image layout.";
+      return false;
+    }
+
+    // Full-region buffer -> staging (offset 0,0 - not a sub-region copy).
+    vk::BufferImageCopy staging_copy;
+    staging_copy.setBufferOffset(source.GetRange().offset);
+    staging_copy.setBufferRowLength(0);
+    staging_copy.setBufferImageHeight(0);
+    staging_copy.setImageSubresource(
+        vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1));
+    staging_copy.imageOffset = vk::Offset3D(0, 0, 0);
+    staging_copy.imageExtent =
+        vk::Extent3D(static_cast<uint32_t>(destination_region.GetWidth()),
+                     static_cast<uint32_t>(destination_region.GetHeight()), 1u);
+
+    cmd_buffer.copyBufferToImage(src.GetBuffer(),                 //
+                                 staging_vk.GetImage(),           //
+                                 staging_dst_barrier.new_layout,  //
+                                 staging_copy                     //
+    );
+
+    // Transition staging to transfer-src.
+    BarrierVK staging_src_barrier;
+    staging_src_barrier.cmd_buffer = cmd_buffer;
+    staging_src_barrier.new_layout = vk::ImageLayout::eTransferSrcOptimal;
+    staging_src_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+    staging_src_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+    staging_src_barrier.dst_access = vk::AccessFlagBits::eTransferRead;
+    staging_src_barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
+
+    if (!staging_vk.SetLayout(staging_src_barrier)) {
+      VALIDATION_LOG << "Could not transition staging image to transfer-src.";
+      return false;
+    }
+
+    // Transition destination to transfer-dst.
+    if (!dst.SetLayout(dst_barrier)) {
+      VALIDATION_LOG << "Could not encode layout transition.";
+      return false;
+    }
+
+    // Image-to-image copy: staging -> destination at sub-region offset.
+    // vkCmdCopyImage is not subject to minImageTransferGranularity.
+    vk::ImageCopy img_copy;
+    img_copy.setSrcSubresource(
+        vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1));
+    img_copy.setDstSubresource(vk::ImageSubresourceLayers(
+        vk::ImageAspectFlagBits::eColor, mip_level, slice, 1));
+    img_copy.srcOffset = vk::Offset3D(0, 0, 0);
+    img_copy.dstOffset =
+        vk::Offset3D(destination_region.GetX(), destination_region.GetY(), 0);
+    img_copy.extent =
+        vk::Extent3D(static_cast<uint32_t>(destination_region.GetWidth()),
+                     static_cast<uint32_t>(destination_region.GetHeight()), 1u);
+
+    cmd_buffer.copyImage(staging_vk.GetImage(),           //
+                         staging_src_barrier.new_layout,  //
+                         dst.GetImage(),                  //
+                         dst_barrier.new_layout,          //
+                         img_copy                         //
+    );
+  } else {
+    // Direct buffer-to-image copy (normal path).
+    if (!dst.SetLayout(dst_barrier)) {
+      VALIDATION_LOG << "Could not encode layout transition.";
+      return false;
+    }
+
+    cmd_buffer.copyBufferToImage(src.GetBuffer(),         //
+                                 dst.GetImage(),          //
+                                 dst_barrier.new_layout,  //
+                                 image_copy               //
+    );
+  }
 
   // Transition to shader-read.
   if (convert_to_read) {
@@ -305,6 +446,8 @@ bool BlitPassVK::OnCopyBufferToTextureCommand(
     barrier.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
 
     if (!dst.SetLayout(barrier)) {
+      VALIDATION_LOG << "Failed to set destination texture layout to "
+                        "eShaderReadOnlyOptimal after blit.";
       return false;
     }
   }
@@ -341,10 +484,11 @@ bool BlitPassVK::ResizeTexture(const std::shared_ptr<Texture>& source,
   dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
   dst_barrier.src_access = {};
   dst_barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
-  dst_barrier.dst_access =
-      vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eTransferWrite;
-  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader |
-                          vk::PipelineStageFlagBits::eTransfer;
+  // dstAccessMask must only list accesses valid for TRANSFER_DST_OPTIMAL.
+  // eShaderRead is not permitted in that layout; including it triggers AMD
+  // best practices validation layer message ID -212008545 (0xF35D019F).
+  dst_barrier.dst_access = vk::AccessFlagBits::eTransferWrite;
+  dst_barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
 
   if (!src.SetLayout(src_barrier) || !dst.SetLayout(dst_barrier)) {
     VALIDATION_LOG << "Could not complete layout transitions.";
@@ -387,8 +531,10 @@ bool BlitPassVK::ResizeTexture(const std::shared_ptr<Texture>& source,
   BarrierVK barrier;
   barrier.cmd_buffer = cmd_buffer;
   barrier.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
-  barrier.src_access = {};
-  barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
+  // Flush the transfer write cache after blitImage so AMD RDNA DCC metadata
+  // is coherent before the next shader read.
+  barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+  barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
   barrier.dst_access = vk::AccessFlagBits::eShaderRead;
   barrier.dst_stage = vk::PipelineStageFlagBits::eFragmentShader;
 
@@ -419,16 +565,35 @@ bool BlitPassVK::OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
   // TransferSrc to prepare the mip level after it, use the image as the source
   // of the blit, before finally switching it to ShaderReadOnly so its available
   // for sampling in a shader.
+  //
+  // The src_access mask and src_stage are selected based on the image's current
+  // layout to produce a precise barrier that satisfies only the actual
+  // producing operation. This avoids BestPractices-ImageBarrierAccessLayout
+  // validation warnings that occur when using a broad OR of all possible
+  // stages. The dst_access is eTransferWrite (not eTransferRead) because the
+  // blit *writes* into the destination mip levels.
+  vk::AccessFlags mip_src_access;
+  vk::PipelineStageFlags mip_src_stage;
+  if (src.GetLayout() == vk::ImageLayout::eTransferDstOptimal) {
+    mip_src_access = vk::AccessFlagBits::eTransferWrite;
+    mip_src_stage = vk::PipelineStageFlagBits::eTransfer;
+  } else if (src.GetLayout() == vk::ImageLayout::eColorAttachmentOptimal) {
+    mip_src_access = vk::AccessFlagBits::eColorAttachmentWrite;
+    mip_src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+  } else {
+    // Default: texture was last sampled in a fragment shader
+    // (eShaderReadOnlyOptimal) or is newly created (eUndefined).
+    mip_src_access = vk::AccessFlagBits::eShaderRead;
+    mip_src_stage = vk::PipelineStageFlagBits::eFragmentShader;
+  }
   InsertImageMemoryBarrier(
       /*cmd=*/cmd,
       /*image=*/image,
-      /*src_access_mask=*/vk::AccessFlagBits::eTransferWrite |
-          vk::AccessFlagBits::eColorAttachmentWrite,
-      /*dst_access_mask=*/vk::AccessFlagBits::eTransferRead,
+      /*src_access_mask=*/mip_src_access,
+      /*dst_access_mask=*/vk::AccessFlagBits::eTransferWrite,
       /*old_layout=*/src.GetLayout(),
       /*new_layout=*/vk::ImageLayout::eTransferDstOptimal,
-      /*src_stage=*/vk::PipelineStageFlagBits::eTransfer |
-          vk::PipelineStageFlagBits::eColorAttachmentOutput,
+      /*src_stage=*/mip_src_stage,
       /*dst_stage=*/vk::PipelineStageFlagBits::eTransfer,
       /*base_mip_level=*/0u,
       /*mip_level_count=*/mip_count);

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
@@ -97,16 +97,26 @@ bool BlitPassVK::OnCopyTextureToTextureCommand(
   BarrierVK dst_barrier;
   dst_barrier.cmd_buffer = cmd_buffer;
   dst_barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
-  // Wait for any prior buffer-to-image transfer writes to this destination
-  // before starting the image-to-image copy. In the atlas growth path,
-  // BulkUpdateAtlasBitmap writes rows 0..new_height via
-  // vkCmdCopyBufferToImage, then AddCopy(old->new) writes rows 0..old_height
-  // via vkCmdCopyImage. These writes overlap in rows 0..old_height. Without
-  // this barrier, the post-copy eTransfer->eFragmentShader barrier from
-  // BulkUpdateAtlasBitmap does NOT create a transitive dependency here because
-  // eTopOfPipe & eFragmentShader = empty - leaving a WAW hazard on AMD RDNA.
-  dst_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
-  dst_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  // The src_access and src_stage must match the texture's current layout,
+  // mirroring OnCopyBufferToTextureCommand below.
+  if (dst.GetLayout() == vk::ImageLayout::eTransferDstOptimal) {
+    // Wait for prior transfer writes to this destination before starting the
+    // image-to-image copy. In the atlas growth path, BulkUpdateAtlasBitmap
+    // writes rows 0..new_height via vkCmdCopyBufferToImage, then
+    // AddCopy(old->new) writes rows 0..old_height via vkCmdCopyImage. These
+    // writes overlap in rows 0..old_height. Without this barrier, the
+    // post-copy eTransfer->eFragmentShader barrier from BulkUpdateAtlasBitmap
+    // does NOT create a transitive dependency here because eTopOfPipe &
+    // eFragmentShader = empty - leaving a WAW hazard on AMD RDNA.
+    dst_barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+    dst_barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  } else {
+    // Normal path: the texture was last sampled in a fragment shader. A
+    // transfer write in an earlier layout is drained transitively by the
+    // barrier that transitioned the texture out of eTransferDstOptimal.
+    dst_barrier.src_access = vk::AccessFlagBits::eShaderRead;
+    dst_barrier.src_stage = vk::PipelineStageFlagBits::eFragmentShader;
+  }
   // dstAccessMask must only list accesses valid for TRANSFER_DST_OPTIMAL.
   // eShaderRead is not permitted in that layout; including it triggers AMD
   // best practices validation layer message ID -212008545 (0xF35D019F).

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.h
@@ -7,6 +7,7 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/base/config.h"
+#include "impeller/core/allocator.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/renderer/backend/vulkan/workarounds_vk.h"
 #include "impeller/renderer/blit_pass.h"
@@ -27,9 +28,11 @@ class BlitPassVK final : public BlitPass {
                   MipmapGenerationTransitionsAllLevelsCorrectly);
 
   std::shared_ptr<CommandBufferVK> command_buffer_;
+  std::shared_ptr<Allocator> allocator_;
   const WorkaroundsVK workarounds_;
 
   explicit BlitPassVK(std::shared_ptr<CommandBufferVK> command_buffer,
+                      std::shared_ptr<Allocator> allocator,
                       const WorkaroundsVK& workarounds);
 
   // |BlitPass|

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -51,8 +51,19 @@ CapabilitiesVK::CapabilitiesVK(bool enable_validations,
       }
     }
   } else {
+    // In embedder mode, use the extensions provided by the embedder but still
+    // enumerate available layers so that validation layers can be detected and
+    // enabled when requested.
     for (const auto& ext : embedder_instance_extensions_) {
       exts_[kInstanceLayer].insert(ext);
+    }
+    auto layers = vk::enumerateInstanceLayerProperties();
+    if (layers.result == vk::Result::eSuccess) {
+      for (const auto& layer : layers.value) {
+        // Register the layer name so HasLayer() works. Don't enumerate
+        // per-layer extensions - the embedder controls the instance.
+        exts_[std::string(layer.layerName)];
+      }
     }
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -110,13 +110,21 @@ std::optional<std::vector<std::string>>
 CapabilitiesVK::GetEnabledInstanceExtensions() const {
   std::vector<std::string> required;
 
-  if (!HasExtension("VK_KHR_surface")) {
-    // Swapchain support is required and this is a dependency of
-    // VK_KHR_swapchain.
-    VALIDATION_LOG << "Could not find the surface extension.";
-    return std::nullopt;
+  // An embedder that does not provide the surface extension presents
+  // rendered images itself (for example through a platform compositor), so
+  // neither VK_KHR_surface nor any WSI extension is required.
+  const bool embedder_controls_presentation =
+      use_embedder_extensions_ && !HasExtension("VK_KHR_surface");
+
+  if (!embedder_controls_presentation) {
+    if (!HasExtension("VK_KHR_surface")) {
+      // Swapchain support is required and this is a dependency of
+      // VK_KHR_swapchain.
+      VALIDATION_LOG << "Could not find the surface extension.";
+      return std::nullopt;
+    }
+    required.push_back("VK_KHR_surface");
   }
-  required.push_back("VK_KHR_surface");
 
   auto has_wsi = false;
   if (HasExtension("VK_MVK_macos_surface")) {
@@ -159,7 +167,7 @@ CapabilitiesVK::GetEnabledInstanceExtensions() const {
     has_wsi = true;
   }
 
-  if (!has_wsi) {
+  if (!has_wsi && !embedder_controls_presentation) {
     // Don't really care which WSI extension there is as long there is at least
     // one.
     VALIDATION_LOG << "Could not find a WSI extension.";
@@ -295,6 +303,11 @@ CapabilitiesVK::GetEnabledDeviceExtensions(
   auto for_each_common_extension = [&](RequiredCommonDeviceExtensionVK ext) {
     auto name = GetExtensionName(ext);
     if (exts.find(name) == exts.end()) {
+      if (use_embedder_extensions_) {
+        // The embedder controls presentation and may legitimately omit
+        // swapchain support (see GetEnabledInstanceExtensions).
+        return true;
+      }
       VALIDATION_LOG << "Device does not support required extension: " << name;
       return false;
     }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_buffer_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_buffer_vk.cc
@@ -75,8 +75,9 @@ std::shared_ptr<BlitPass> CommandBufferVK::OnCreateBlitPass() {
   if (!context) {
     return nullptr;
   }
-  auto pass = std::shared_ptr<BlitPassVK>(new BlitPassVK(
-      shared_from_this(), ContextVK::Cast(*context).GetWorkarounds()));
+  auto pass = std::shared_ptr<BlitPassVK>(
+      new BlitPassVK(shared_from_this(), context->GetResourceAllocator(),
+                     ContextVK::Cast(*context).GetWorkarounds()));
   if (!pass->IsValid()) {
     return nullptr;
   }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -45,6 +45,14 @@ class BackgroundCommandPoolVK final {
     // once for the original BackgroundCommandPoolVK() and once for the moved
     // BackgroundCommandPoolVK().
     if (!recycler) {
+      // The context is gone, and the device may already be destroyed. Release
+      // the handles without making Vulkan API calls: letting the RAII wrappers
+      // call vkFreeCommandBuffers / vkDestroyCommandPool on a destroyed device
+      // crashes inside the ICD.
+      for (auto& buffer : buffers_) {
+        buffer.release();
+      }
+      pool_.release();
       return;
     }
     // If there are many unused command buffers, release some of them and
@@ -156,6 +164,29 @@ void CommandPoolVK::Destroy() {
 
   // When the command pool is destroyed, all of its command buffers are freed.
   // Handles allocated from that pool are now invalid and must be discarded.
+  for (auto& buffer : collected_buffers_) {
+    buffer.release();
+  }
+  for (auto& buffer : unused_command_buffers_) {
+    buffer.release();
+  }
+  unused_command_buffers_.clear();
+  collected_buffers_.clear();
+}
+
+void CommandPoolVK::AbandonForDriverCrash() {
+  Lock lock(pool_mutex_);
+  if (!pool_) {
+    return;
+  }
+  // Some drivers non-conformantly invalidate the VkCommandPool and its child
+  // VkCommandBuffer handles internally when vkQueueSubmit returns
+  // VK_ERROR_OUT_OF_HOST_MEMORY (observed on AMD). Calling
+  // vkDestroyCommandPool or vkFreeCommandBuffers on these already-invalid
+  // handles causes validation errors and an access violation inside the
+  // driver. Release the C++ ownership handles without invoking any Vulkan
+  // destroy/free calls.
+  pool_.release();
   for (auto& buffer : collected_buffers_) {
     buffer.release();
   }
@@ -296,8 +327,16 @@ void CommandPoolRecyclerVK::Reclaim(
     VALIDATION_LOG << "Could not reset command pool: " << vk::to_string(result);
   }
 
-  // Move the pool to the recycled list.
+  // Move the pool to the recycled list, capping the list size to prevent
+  // unbounded host memory growth. Without a cap, heavy workloads (e.g. text
+  // rendering stress) can accumulate dozens of recycled pools, each holding
+  // significant driver-internal memory. Evict oldest first; the device is
+  // alive here, so normal RAII destruction of the evicted pool is safe.
   Lock recycled_lock(recycled_mutex_);
+  static constexpr size_t kMaxRecycledCommandPools = 8;
+  while (recycled_.size() >= kMaxRecycledCommandPools) {
+    recycled_.erase(recycled_.begin());
+  }
   recycled_.push_back(
       RecycledData{.pool = std::move(pool), .buffers = std::move(buffers)});
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
@@ -61,6 +61,16 @@ class CommandPoolVK final {
   /// @see        |GarbageCollectBuffersIfAble|
   void CollectCommandBuffer(vk::UniqueCommandBuffer&& buffer);
 
+  /// @brief      Discard all Vulkan handles WITHOUT invoking any Vulkan
+  ///             destroy/free calls.
+  ///
+  /// Use this only after a failed vkQueueSubmit has left the driver in a
+  /// state where the pool and its buffer handles are already invalid (e.g.
+  /// the non-conformant out-of-memory behavior observed on AMD drivers).
+  /// Calling vkDestroyCommandPool or vkFreeCommandBuffers on such handles
+  /// causes validation errors and crashes inside the driver.
+  void AbandonForDriverCrash();
+
  private:
   friend CommandPoolRecyclerVK;
 
@@ -73,7 +83,8 @@ class CommandPoolVK final {
 
   Mutex pool_mutex_;
   vk::UniqueCommandPool pool_ IPLR_GUARDED_BY(pool_mutex_);
-  std::vector<vk::UniqueCommandBuffer> unused_command_buffers_;
+  std::vector<vk::UniqueCommandBuffer> unused_command_buffers_
+      IPLR_GUARDED_BY(pool_mutex_);
   std::weak_ptr<ContextVK> context_;
   std::weak_ptr<DeviceHolderVK> device_holder_;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
@@ -66,7 +66,13 @@ class DeathRattle final {
   DeathRattle(DeathRattle&&) = default;
   DeathRattle& operator=(DeathRattle&&) = default;
 
-  ~DeathRattle() { callback_(); }
+  // The callback may be empty when this instance has been moved from; the
+  // moved-from local still runs this destructor.
+  ~DeathRattle() {
+    if (callback_) {
+      callback_();
+    }
+  }
 
  private:
   std::function<void()> callback_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.cc
@@ -4,6 +4,8 @@
 
 #include "fml/status.h"
 
+#include <chrono>
+
 #include "impeller/renderer/backend/vulkan/command_queue_vk.h"
 
 #include "impeller/base/validation.h"
@@ -15,8 +17,65 @@
 
 namespace impeller {
 
+// Timeout waiting for an in-flight submission slot. Generous enough that no
+// legitimate GPU workload should hit it.
+static constexpr std::chrono::seconds kSubmitSlotTimeout{5};
+
+// Right-shift to convert bytes to megabytes for diagnostic logging.
+static constexpr uint32_t kBytesToMBShift = 20;
+
+// Logs per-heap memory usage and budgets after a failed queue submission.
+// VK_EXT_memory_budget data is far more useful than the static heap sizes,
+// but the extension is not tracked by the context; detect whether the driver
+// filled the chained struct by checking every heap's budget. A driver that
+// populated the struct reports a non-zero budget for at least one heap,
+// whereas an ignored pNext struct stays zero-initialized.
+static void LogHeapBudgetsAtOOM(const ContextVK& context,
+                                size_t failed_buffer_count) {
+  vk::PhysicalDeviceMemoryProperties2 mem_props2;
+  vk::PhysicalDeviceMemoryBudgetPropertiesEXT budget_props;
+  mem_props2.pNext = &budget_props;
+
+  // getMemoryProperties2 is core Vulkan 1.1 and always available.
+  context.GetPhysicalDevice().getMemoryProperties2(&mem_props2);
+
+  const auto& heaps = mem_props2.memoryProperties.memoryHeaps;
+  const uint32_t heap_count = mem_props2.memoryProperties.memoryHeapCount;
+
+  bool has_budget = false;
+  for (uint32_t i = 0; i < heap_count; i++) {
+    has_budget = has_budget || budget_props.heapBudget[i] != 0;
+  }
+
+  VALIDATION_LOG << "=== Vulkan memory snapshot at OOM ===";
+  for (uint32_t i = 0; i < heap_count; i++) {
+    bool is_device_local = static_cast<bool>(
+        heaps[i].flags & vk::MemoryHeapFlagBits::eDeviceLocal);
+    if (has_budget) {
+      VALIDATION_LOG << "  heap[" << i << "] "
+                     << (is_device_local ? "DEVICE_LOCAL" : "host      ")
+                     << "  used="
+                     << (budget_props.heapUsage[i] >> kBytesToMBShift) << "MB"
+                     << "  budget="
+                     << (budget_props.heapBudget[i] >> kBytesToMBShift) << "MB"
+                     << "  total=" << (heaps[i].size >> kBytesToMBShift) << "MB"
+                     << (budget_props.heapUsage[i] > budget_props.heapBudget[i]
+                             ? "  <<< OVER BUDGET"
+                             : "");
+    } else {
+      VALIDATION_LOG << "  heap[" << i << "] "
+                     << (is_device_local ? "DEVICE_LOCAL" : "host      ")
+                     << "  total=" << (heaps[i].size >> kBytesToMBShift) << "MB"
+                     << "  (VK_EXT_memory_budget not available)";
+    }
+  }
+  VALIDATION_LOG << "  submit_count=" << failed_buffer_count
+                 << " cmd buffers in failed submission";
+  VALIDATION_LOG << "=====================================";
+}
+
 CommandQueueVK::CommandQueueVK(const std::weak_ptr<ContextVK>& context)
-    : context_(context) {}
+    : context_(context), in_flight_state_(std::make_shared<InFlightState>()) {}
 
 CommandQueueVK::~CommandQueueVK() = default;
 
@@ -54,23 +113,84 @@ fml::Status CommandQueueVK::Submit(
     VALIDATION_LOG << "Device lost.";
     return fml::Status(fml::StatusCode::kCancelled, "Device lost.");
   }
+  if (context->IsDeviceLost()) {
+    return fml::Status(fml::StatusCode::kCancelled, "Device lost.");
+  }
+
+  // Throttle: wait until there is capacity for a new in-flight submission.
+  // This creates backpressure to prevent host memory exhaustion when the GPU
+  // cannot keep up with the rate of submission. The 5-second timeout is
+  // generous: even a heavily loaded GPU should complete a frame submission
+  // well within this window. On timeout, the submission is cancelled to
+  // enforce the limit strictly.
+  {
+    std::unique_lock<std::mutex> lock(in_flight_state_->mutex);
+    if (!in_flight_state_->cv.wait_for(lock, kSubmitSlotTimeout, [this]() {
+          return in_flight_state_->count < kMaxInFlightSubmissions;
+        })) {
+      VALIDATION_LOG << "Timed out waiting for in-flight submission slot. "
+                     << "In-flight: " << in_flight_state_->count
+                     << ". Cancelling submission to prevent resource "
+                     << "exhaustion.";
+      return fml::Status(fml::StatusCode::kCancelled,
+                         "Timed out waiting for in-flight submission slot.");
+    }
+    ++in_flight_state_->count;
+  }
+
+  // Release the in-flight slot on any error path below. On success, the slot
+  // is instead released by the fence completion callback.
+  fml::ScopedCleanupClosure release_slot([state = in_flight_state_]() {
+    {
+      std::lock_guard<std::mutex> lock(state->mutex);
+      --state->count;
+    }
+    state->cv.notify_one();
+  });
+
   auto [fence_result, fence] = context->GetDevice().createFenceUnique({});
   if (fence_result != vk::Result::eSuccess) {
     VALIDATION_LOG << "Failed to create fence: " << vk::to_string(fence_result);
     return fml::Status(fml::StatusCode::kCancelled, "Failed to create fence.");
   }
 
+  // Shared between the submit callback (failure path) and the fence
+  // completion callback (success path). Exactly one of the two consumes it.
+  auto shared_tracked_objects =
+      std::make_shared<std::vector<std::shared_ptr<TrackedObjectsVK>>>(
+          std::move(tracked_objects));
+
   // This will be called immediately by FenceWaiterVK::AddFence.
-  auto submit_callback = [&context, &vk_buffers](vk::Fence submit_fence) {
+  auto submit_callback = [&context, &vk_buffers,
+                          &shared_tracked_objects](vk::Fence submit_fence) {
     vk::SubmitInfo submit_info;
     submit_info.setCommandBuffers(vk_buffers);
     auto status =
         context->GetGraphicsQueue()->Submit(submit_info, submit_fence);
     if (status != vk::Result::eSuccess) {
-      std::string submit_error =
-          "Failed to submit command: " + vk::to_string(status);
-      VALIDATION_LOG << submit_error;
-      return fml::Status(fml::StatusCode::kCancelled, submit_error);
+      VALIDATION_LOG << "Failed to submit queue: " << vk::to_string(status)
+                     << " (" << vk_buffers.size() << " cmd buffer(s))";
+      // Some drivers non-conformantly invalidate VkCommandPool and
+      // VkCommandBuffer handles during a vkQueueSubmit that fails with an
+      // out-of-memory error (observed on AMD). Abandon those handles (and
+      // associated descriptor pools) without calling any Vulkan API so that
+      // RAII destructors do not call vkFreeCommandBuffers /
+      // vkDestroyCommandPool / vkDestroyDescriptorPool on already-invalid
+      // objects.
+      for (auto& tracked : *shared_tracked_objects) {
+        if (tracked) {
+          tracked->AbandonForDriverCrash();
+        }
+      }
+      // Mark device lost BEFORE any further Vulkan calls so that racing
+      // threads (swapchain acquire, other submissions) short-circuit
+      // immediately. Do NOT call vkDeviceWaitIdle: the driver's internal
+      // allocator may be corrupted after the failed submission, and any
+      // further Vulkan call can access-fault inside the ICD.
+      context->MarkDeviceLost();
+      LogHeapBudgetsAtOOM(*context, vk_buffers.size());
+      return fml::Status(fml::StatusCode::kCancelled,
+                         "Failed to submit queue.");
     }
     return fml::Status();
   };
@@ -80,13 +200,19 @@ fml::Status CommandQueueVK::Submit(
   uint64_t submission_id = tracker->RecordSubmission();
 
   // This will be called later when the command completes.
-  auto fence_complete_callback = [completion_callback, tracker, submission_id,
-                                  tracked_objects =
-                                      std::move(tracked_objects)]() mutable {
-    // Ensure tracked objects are destructed before calling any final
-    // callbacks.
-    tracked_objects.clear();
+  auto in_flight_state = in_flight_state_;
+  auto fence_complete_callback = [in_flight_state, completion_callback, tracker,
+                                  submission_id,
+                                  shared_tracked_objects]() mutable {
+    // Free GPU resources first to reclaim memory before releasing the
+    // submission slot, so the next waiter has memory available.
+    shared_tracked_objects->clear();
     tracker->RecordCompletion(submission_id);
+    {
+      std::lock_guard<std::mutex> lock(in_flight_state->mutex);
+      --in_flight_state->count;
+    }
+    in_flight_state->cv.notify_one();
     if (completion_callback) {
       completion_callback(CommandBuffer::Status::kCompleted);
     }
@@ -100,6 +226,7 @@ fml::Status CommandQueueVK::Submit(
     tracker->RecordCompletion(submission_id);
     return fence_status;
   }
+  release_slot.Release();
   reset.Release();
   return fml::Status();
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk.h
@@ -5,6 +5,10 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_COMMAND_QUEUE_VK_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_COMMAND_QUEUE_VK_H_
 
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
 #include "impeller/renderer/command_queue.h"
 
 namespace impeller {
@@ -13,6 +17,17 @@ class ContextVK;
 
 class CommandQueueVK : public CommandQueue {
  public:
+  /// Maximum number of command buffer submissions that can be simultaneously
+  /// in-flight. When this limit is reached, Submit() will synchronously wait
+  /// for an older submission to complete before proceeding. This provides
+  /// backpressure to prevent host memory exhaustion under heavy GPU load.
+  ///
+  /// This is intentionally one greater than kMaxFramesInFlight (2) so that
+  /// the submission queue does not bottleneck the frame pipeline - the
+  /// rasterizer can always submit without waiting unless the GPU has fallen
+  /// three submissions behind.
+  static constexpr uint32_t kMaxInFlightSubmissions = 3u;
+
   explicit CommandQueueVK(const std::weak_ptr<ContextVK>& context);
 
   ~CommandQueueVK() override;
@@ -22,7 +37,18 @@ class CommandQueueVK : public CommandQueue {
                      bool block_on_schedule = false) override;
 
  private:
+  /// Shared state for tracking in-flight submissions. Uses a shared_ptr so
+  /// that fence completion callbacks (which run on the FenceWaiterVK thread)
+  /// can safely decrement the counter even if CommandQueueVK has been
+  /// destroyed.
+  struct InFlightState {
+    std::mutex mutex;
+    std::condition_variable cv;
+    uint32_t count = 0;
+  };
+
   std::weak_ptr<ContextVK> context_;
+  std::shared_ptr<InFlightState> in_flight_state_;
 
   CommandQueueVK(const CommandQueueVK&) = delete;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_queue_vk_unittests.cc
@@ -38,5 +38,31 @@ TEST(CommandQueueVKTest, SubmitAfterFenceWaiterTerminated) {
             called->end());
 }
 
+TEST(CommandQueueVKTest, SubmitAfterDeviceLostIsCancelled) {
+  const auto context = MockVulkanContextBuilder().Build();
+  auto buffer = context->CreateCommandBuffer();
+  context->MarkDeviceLost();
+  auto status = context->GetCommandQueue()->Submit({buffer});
+  EXPECT_EQ(status.code(), fml::StatusCode::kCancelled);
+
+  // No submission may reach the queue once the device is lost; any Vulkan
+  // call on a driver in a corrupted state can crash inside the ICD.
+  const auto called = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_EQ(std::find(called->begin(), called->end(), "vkQueueSubmit"),
+            called->end());
+}
+
+TEST(CommandQueueVKTest, ThrottleAllowsSustainedSubmissions) {
+  const auto context = MockVulkanContextBuilder().Build();
+  // Submit more batches than kMaxInFlightSubmissions. If in-flight slots
+  // were not released when submissions complete, this would exhaust the
+  // slots and fail on the slot timeout.
+  for (int i = 0; i < 10; i++) {
+    auto buffer = context->CreateCommandBuffer();
+    ASSERT_TRUE(buffer);
+    ASSERT_TRUE(context->GetCommandQueue()->Submit({buffer}).ok());
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -357,6 +357,10 @@ void ContextVK::Setup(Settings settings) {
     device_holder->device.reset(settings.embedder_data->device);
   }
 
+  // Initialize device-level dispatch so Vulkan-HPP calls go directly through
+  // the device dispatch table instead of the instance trampoline.
+  dispatcher.init(device_holder->device.get());
+
   if (!caps->SetPhysicalDevice(device_holder->physical_device,
                                *enabled_features)) {
     VALIDATION_LOG << "Capabilities could not be updated.";
@@ -546,7 +550,24 @@ std::shared_ptr<PipelineLibrary> ContextVK::GetPipelineLibrary() const {
   return pipeline_library_;
 }
 
+bool ContextVK::IsDeviceLost() const {
+  return device_lost_.load(std::memory_order_relaxed);
+}
+
+void ContextVK::MarkDeviceLost() {
+  device_lost_.store(true, std::memory_order_relaxed);
+  VALIDATION_LOG << "ContextVK: device marked as lost. No further Vulkan "
+                    "API calls will be made on this context.";
+}
+
 std::shared_ptr<CommandBuffer> ContextVK::CreateCommandBuffer() const {
+  // Short-circuit immediately if the device is lost. Any Vulkan allocation
+  // call (vkCreateCommandPool, vkAllocateCommandBuffers, etc.) on a driver
+  // that has entered a corrupted OOM state can access-fault inside the ICD.
+  if (device_lost_.load(std::memory_order_relaxed)) {
+    return nullptr;
+  }
+
   const auto& recycler = GetCommandPoolRecycler();
   auto tls_pool = recycler->Get();
   if (!tls_pool) {
@@ -677,7 +698,30 @@ bool ContextVK::FlushCommandBuffers() {
   }
 
   if (should_batch_cmd_buffers_) {
-    bool result = GetCommandQueue()->Submit(pending_command_buffers_).ok();
+    // Submit in chunks to prevent VK_ERROR_OUT_OF_HOST_MEMORY when a frame
+    // accumulates a very large number of command buffers (e.g. heavy
+    // blur/filter workloads). Each Submit() creates its own fence and
+    // tracked-object set, so chunking at this level is safe: all command
+    // buffers are fully recorded by the time FlushCommandBuffers() runs.
+    //
+    // 64 balances submission overhead against memory pressure: small enough
+    // that the driver's per-submit host allocation stays within typical
+    // limits, large enough to amortize fence creation and queue submission
+    // across many command buffers.
+    static constexpr size_t kMaxBuffersPerSubmit = 64u;
+    bool result = true;
+    for (size_t i = 0; i < pending_command_buffers_.size();
+         i += kMaxBuffersPerSubmit) {
+      size_t end =
+          std::min(i + kMaxBuffersPerSubmit, pending_command_buffers_.size());
+      std::vector<std::shared_ptr<CommandBuffer>> chunk(
+          std::make_move_iterator(pending_command_buffers_.begin() + i),
+          std::make_move_iterator(pending_command_buffers_.begin() + end));
+      if (!GetCommandQueue()->Submit(chunk).ok()) {
+        result = false;
+        break;
+      }
+    }
     pending_command_buffers_.clear();
     return result;
   } else {
@@ -729,6 +773,9 @@ void ContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
         stencil->store_action                                   //
     );
   }
+
+  builder.SetFramebufferFetchEnabled(
+      GetCapabilities()->SupportsFramebufferFetch());
 
   auto pass = builder.Build(GetDevice());
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_CONTEXT_VK_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_CONTEXT_VK_H_
 
+#include <atomic>
 #include <format>
 #include <memory>
 
@@ -118,6 +119,18 @@ class ContextVK final : public Context,
 
   // |Context|
   bool IsValid() const override;
+
+  /// @brief      Returns true if the device has been permanently lost due
+  ///             to a non-recoverable GPU error (e.g. a non-conformant
+  ///             out-of-memory error from vkQueueSubmit). Once lost, all
+  ///             command-buffer creation and queue submission silently
+  ///             short-circuit to prevent further Vulkan calls on a broken
+  ///             driver state.
+  bool IsDeviceLost() const;
+
+  /// @brief      Permanently marks this context as device-lost.
+  ///             Thread-safe; idempotent.
+  void MarkDeviceLost();
 
   // |Context|
   std::shared_ptr<Allocator> GetResourceAllocator() const override;
@@ -313,6 +326,12 @@ class ContextVK final : public Context,
   const uint64_t hash_;
 
   bool is_valid_ = false;
+
+  // Set to true on any unrecoverable GPU error (e.g. vkQueueSubmit returning
+  // an out-of-memory error on a driver in a corrupted state). Once true,
+  // CreateCommandBuffer() returns nullptr and submission short-circuits so
+  // that no further Vulkan API calls are made on the broken driver state.
+  std::atomic<bool> device_lost_{false};
 
   explicit ContextVK(const Flags& flags);
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -261,7 +261,12 @@ TEST(ContextVKTest, HasDefaultColorFormat) {
   ASSERT_NE(capabilites_vk->GetDefaultColorFormat(), PixelFormat::kUnknown);
 }
 
-TEST(ContextVKTest, EmbedderOverridesUsesInstanceExtensions) {
+TEST(ContextVKTest, EmbedderWithoutSurfaceExtensionsIsSurfaceless) {
+  // An embedder that presents rendered images itself (for example through a
+  // platform compositor such as DirectComposition on Windows) supplies a
+  // Vulkan device without the surface, WSI, or swapchain extensions. Context
+  // creation must succeed in that configuration; presentation is then the
+  // embedder's responsibility rather than Impeller's.
   ContextVK::EmbedderData data;
   auto other_context = MockVulkanContextBuilder().Build();
 
@@ -270,14 +275,36 @@ TEST(ContextVKTest, EmbedderOverridesUsesInstanceExtensions) {
   data.physical_device = other_context->GetPhysicalDevice();
   data.queue = VkQueue{};
   data.queue_family_index = 0;
-  // Missing surface extension.
+  // No surface (instance) or swapchain (device) extensions.
   data.instance_extensions = {};
+  data.device_extensions = {};
+
+  ScopedValidationDisable scoped;
+  auto context = MockVulkanContextBuilder().SetEmbedderData(data).Build();
+
+  ASSERT_NE(context, nullptr);
+  EXPECT_TRUE(context->IsValid());
+}
+
+TEST(ContextVKTest, EmbedderWithSurfaceExtensionsStillEnablesThem) {
+  // When the embedder does provide the surface extension, it is honored and
+  // added to the enabled instance extensions as before.
+  ContextVK::EmbedderData data;
+  auto other_context = MockVulkanContextBuilder().Build();
+
+  data.instance = other_context->GetInstance();
+  data.device = other_context->GetDevice();
+  data.physical_device = other_context->GetPhysicalDevice();
+  data.queue = VkQueue{};
+  data.queue_family_index = 0;
+  data.instance_extensions = {"VK_KHR_surface", "VK_KHR_win32_surface"};
   data.device_extensions = {"VK_KHR_swapchain"};
 
   ScopedValidationDisable scoped;
   auto context = MockVulkanContextBuilder().SetEmbedderData(data).Build();
 
-  EXPECT_EQ(context, nullptr);
+  ASSERT_NE(context, nullptr);
+  EXPECT_TRUE(context->IsValid());
 }
 
 TEST(ContextVKTest, EmbedderOverrides) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -408,5 +408,19 @@ TEST(ContextVKTest, HashIsUniqueAcrossThreads) {
   EXPECT_NE(hash1, hash2);
 }
 
+TEST(ContextVKTest, CreateCommandBufferShortCircuitsAfterDeviceLost) {
+  const std::shared_ptr<ContextVK> context = MockVulkanContextBuilder().Build();
+
+  EXPECT_FALSE(context->IsDeviceLost());
+  EXPECT_NE(context->CreateCommandBuffer(), nullptr);
+
+  context->MarkDeviceLost();
+
+  EXPECT_TRUE(context->IsDeviceLost());
+  // No command buffer may be created once the device is lost; allocation
+  // calls on a driver in a corrupted state can crash inside the ICD.
+  EXPECT_EQ(context->CreateCommandBuffer(), nullptr);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -33,6 +33,16 @@ void DescriptorPoolVK::Destroy() {
   pools_.clear();
 }
 
+void DescriptorPoolVK::AbandonForDriverCrash() {
+  // Release each UniqueDescriptorPool handle so that the vk::UniqueHandle
+  // destructor never calls vkDestroyDescriptorPool on the corrupted device.
+  for (auto& pool : pools_) {
+    pool.release();
+  }
+  pools_.clear();
+  descriptor_sets_.clear();
+}
+
 DescriptorPoolVK::DescriptorPoolVK(std::weak_ptr<const ContextVK> context,
                                    DescriptorCacheMap descriptor_sets,
                                    std::vector<vk::UniqueDescriptorPool> pools)
@@ -47,10 +57,17 @@ DescriptorPoolVK::~DescriptorPoolVK() {
 
   auto const context = context_.lock();
   if (!context) {
+    // Context is dying - release Vulkan handles without making API calls.
+    for (auto& pool : pools_) {
+      pool.release();
+    }
     return;
   }
   auto const recycler = context->GetDescriptorPoolRecycler();
   if (!recycler) {
+    for (auto& pool : pools_) {
+      pool.release();
+    }
     return;
   }
 
@@ -82,19 +99,28 @@ fml::StatusOr<vk::DescriptorSet> DescriptorPoolVK::AllocateDescriptorSets(
   auto result = context_vk.GetDevice().allocateDescriptorSets(&set_info, &set);
   if (result == vk::Result::eErrorOutOfPoolMemory) {
     // If the pool ran out of memory, we need to create a new pool.
-    CreateNewPool(context_vk);
+    auto pool_status = CreateNewPool(context_vk);
+    if (!pool_status.ok()) {
+      return fml::Status(fml::StatusCode::kUnknown,
+                         "Failed to create descriptor pool");
+    }
     set_info.setDescriptorPool(pools_.back().get());
     result = context_vk.GetDevice().allocateDescriptorSets(&set_info, &set);
   }
-  auto lookup_result =
-      descriptor_sets_.try_emplace(pipeline_key, DescriptorCache{});
-  lookup_result.first->second.used.push_back(set);
 
   if (result != vk::Result::eSuccess) {
     VALIDATION_LOG << "Could not allocate descriptor sets: "
                    << vk::to_string(result);
     return fml::Status(fml::StatusCode::kUnknown, "");
   }
+
+  // Register the newly allocated descriptor set in the per-pipeline cache.
+  // try_emplace inserts a new DescriptorCache if one doesn't exist for
+  // this pipeline key. The set is tracked as "used" and will be moved
+  // to "unused" during frame-end reclamation for reuse in future frames.
+  auto lookup_result =
+      descriptor_sets_.try_emplace(pipeline_key, DescriptorCache{});
+  lookup_result.first->second.used.push_back(set);
   return set;
 }
 
@@ -111,20 +137,29 @@ fml::Status DescriptorPoolVK::CreateNewPool(const ContextVK& context_vk) {
 void DescriptorPoolRecyclerVK::Reclaim(
     DescriptorCacheMap descriptor_sets,
     std::vector<vk::UniqueDescriptorPool> pools) {
-  // Reset the pool on a background thread.
   auto strong_context = context_.lock();
   if (!strong_context) {
     return;
   }
 
-  for (auto& [_, cache] : descriptor_sets) {
-    cache.unused.insert(cache.unused.end(), cache.used.begin(),
-                        cache.used.end());
-    cache.used.clear();
+  // Reset all underlying VkDescriptorPool handles via vkResetDescriptorPool.
+  // This frees ALL descriptor sets allocated from each pool, returning them
+  // to the unallocated state. Without this, pools become permanently exhausted
+  // and cache misses (different pipeline keys on reuse) would trigger
+  // VK_ERROR_OUT_OF_POOL_MEMORY, causing new raw pool creation every time.
+  auto device = strong_context->GetDevice();
+  for (auto& pool : pools) {
+    auto reset_result = device.resetDescriptorPool(pool.get());
+    if (reset_result != vk::Result::eSuccess) {
+      VALIDATION_LOG << "Could not reset descriptor pool: "
+                     << vk::to_string(reset_result);
+    }
   }
+  // The descriptor set handles in the cache are now invalid after pool reset.
+  descriptor_sets.clear();
 
-  // Move the pool to the recycled list. If more than 32 pool are
-  // cached then delete the newest entry.
+  // Move the pool to the recycled list. If more than 32 pools are
+  // cached then delete the newest entry (back of the deque).
   Lock recycled_lock(recycled_mutex_);
   while (recycled_.size() >= kMaxRecycledPools) {
     auto& back_entry = recycled_.back();
@@ -136,7 +171,20 @@ void DescriptorPoolRecyclerVK::Reclaim(
 }
 
 vk::UniqueDescriptorPool DescriptorPoolRecyclerVK::Get() {
-  // Recycle a pool with a matching minumum capcity if it is available.
+  // Try to extract a reset raw pool from the recycled wrappers first.
+  {
+    Lock recycled_lock(recycled_mutex_);
+    for (auto it = recycled_.begin(); it != recycled_.end(); ++it) {
+      if (!(*it)->pools_.empty()) {
+        auto pool = std::move((*it)->pools_.back());
+        (*it)->pools_.pop_back();
+        if ((*it)->pools_.empty()) {
+          recycled_.erase(it);
+        }
+        return pool;
+      }
+    }
+  }
   return Create();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -142,21 +142,13 @@ void DescriptorPoolRecyclerVK::Reclaim(
     return;
   }
 
-  // Reset all underlying VkDescriptorPool handles via vkResetDescriptorPool.
-  // This frees ALL descriptor sets allocated from each pool, returning them
-  // to the unallocated state. Without this, pools become permanently exhausted
-  // and cache misses (different pipeline keys on reuse) would trigger
-  // VK_ERROR_OUT_OF_POOL_MEMORY, causing new raw pool creation every time.
-  auto device = strong_context->GetDevice();
-  for (auto& pool : pools) {
-    auto reset_result = device.resetDescriptorPool(pool.get());
-    if (reset_result != vk::Result::eSuccess) {
-      VALIDATION_LOG << "Could not reset descriptor pool: "
-                     << vk::to_string(reset_result);
-    }
+  // Return the used descriptor sets to the unused cache so they are reused
+  // by future frames instead of being reallocated.
+  for (auto& [_, cache] : descriptor_sets) {
+    cache.unused.insert(cache.unused.end(), cache.used.begin(),
+                        cache.used.end());
+    cache.used.clear();
   }
-  // The descriptor set handles in the cache are now invalid after pool reset.
-  descriptor_sets.clear();
 
   // Move the pool to the recycled list. If more than 32 pools are
   // cached then delete the newest entry (back of the deque).
@@ -171,20 +163,6 @@ void DescriptorPoolRecyclerVK::Reclaim(
 }
 
 vk::UniqueDescriptorPool DescriptorPoolRecyclerVK::Get() {
-  // Try to extract a reset raw pool from the recycled wrappers first.
-  {
-    Lock recycled_lock(recycled_mutex_);
-    for (auto it = recycled_.begin(); it != recycled_.end(); ++it) {
-      if (!(*it)->pools_.empty()) {
-        auto pool = std::move((*it)->pools_.back());
-        (*it)->pools_.pop_back();
-        if ((*it)->pools_.empty()) {
-          recycled_.erase(it);
-        }
-        return pool;
-      }
-    }
-  }
   return Create();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
@@ -28,7 +28,7 @@ using DescriptorCacheMap = std::unordered_map<PipelineKey, DescriptorCache>;
 ///             pool must be collected after all the descriptors allocated from
 ///             it are done being used.
 ///
-///             The pool or it's descriptors may not be accessed from multiple
+///             The pool or its descriptors may not be accessed from multiple
 ///             threads.
 ///
 ///             Encoders create pools as necessary as they have the same
@@ -42,6 +42,13 @@ class DescriptorPoolVK {
                    std::vector<vk::UniqueDescriptorPool> pools);
 
   ~DescriptorPoolVK();
+
+  /// @brief      Release all VkDescriptorPool handles without calling
+  ///             vkDestroyDescriptorPool. Call after a fatal vkQueueSubmit
+  ///             failure where the driver has already freed internal
+  ///             resources (e.g. AMD non-conformant OOM) to prevent crashes
+  ///             in RAII destructors.
+  void AbandonForDriverCrash();
 
   fml::StatusOr<vk::DescriptorSet> AllocateDescriptorSets(
       const vk::DescriptorSetLayout& layout,
@@ -99,7 +106,7 @@ class DescriptorPoolRecyclerVK final
   std::vector<std::shared_ptr<DescriptorPoolVK>> recycled_
       IPLR_GUARDED_BY(recycled_mutex_);
 
-  /// @brief      Creates a new |vk::CommandPool|.
+  /// @brief      Creates a new |vk::DescriptorPool|.
   ///
   /// @returns    Returns a |std::nullopt| if a pool could not be created.
   vk::UniqueDescriptorPool Create();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
@@ -295,6 +295,15 @@ DriverInfoVK::DriverInfoVK(const vk::PhysicalDevice& device) {
     driver_name_ = props.deviceName.data();
   }
 
+  // Query driver ID via VkPhysicalDeviceDriverProperties (Vulkan 1.2+ or
+  // VK_KHR_driver_properties). This gives us a reliable enum-based driver
+  // identification rather than fragile string matching on device names.
+  if (api_version_.IsAtLeast(Version{1, 2, 0})) {
+    auto props2 = device.getProperties2<vk::PhysicalDeviceProperties2,
+                                        vk::PhysicalDeviceDriverProperties>();
+    driver_id_ = props2.get<vk::PhysicalDeviceDriverProperties>().driverID;
+  }
+
   switch (vendor_) {
     case VendorVK::kQualcomm:
       adreno_gpu_ = GetAdrenoVersion(driver_name_);
@@ -328,6 +337,10 @@ const std::string& DriverInfoVK::GetDriverName() const {
   return driver_name_;
 }
 
+vk::DriverId DriverInfoVK::GetDriverID() const {
+  return driver_id_;
+}
+
 void DriverInfoVK::DumpToLog() const {
   std::vector<std::pair<std::string, std::string>> items;
   items.emplace_back("Name", driver_name_);
@@ -335,6 +348,8 @@ void DriverInfoVK::DumpToLog() const {
   items.emplace_back("Driver Version", std::to_string(driver_version_));
   items.emplace_back("Vendor", VendorToString(vendor_));
   items.emplace_back("Device Type", DeviceTypeToString(type_));
+  items.emplace_back("Driver ID",
+                     std::to_string(static_cast<int32_t>(driver_id_)));
   items.emplace_back("Is Emulator", std::to_string(IsEmulator()));
 
   size_t padding = 0;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.h
@@ -234,6 +234,18 @@ class DriverInfoVK {
   const std::string& GetDriverName() const;
 
   //----------------------------------------------------------------------------
+  /// @brief      Get the Vulkan driver ID reported via
+  ///             VkPhysicalDeviceDriverProperties (Vulkan 1.2+).
+  ///
+  ///             Returns a default-initialized (zero) vk::DriverId if the
+  ///             driver properties could not be queried (pre-1.2 without
+  ///             VK_KHR_driver_properties).
+  ///
+  /// @return     The driver ID.
+  ///
+  vk::DriverId GetDriverID() const;
+
+  //----------------------------------------------------------------------------
   /// @brief      Dumps the current driver info to the log.
   ///
   void DumpToLog() const;
@@ -290,6 +302,7 @@ class DriverInfoVK {
   std::optional<MaliGPU> mali_gpu_ = std::nullopt;
   std::optional<PowerVRGPU> powervr_gpu_ = std::nullopt;
   std::string driver_name_;
+  vk::DriverId driver_id_ = {};
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -76,6 +76,14 @@ fml::Status FenceWaiterVK::AddFence(
     }
     auto submit_status = submit_callback(fence.get());
     if (!submit_status.ok()) {
+      // The state of a fence passed to a failed queue submission is not
+      // trustworthy: some drivers partially track the fence even though the
+      // submission failed, and destroying it crashes inside the driver
+      // (observed on AMD as VUID-vkDestroyFence-fence-01120 followed by an
+      // access violation). Release the handle instead of destroying it; a
+      // failed submission marks the device as lost, so the leak is
+      // inconsequential.
+      fence.release();
       return submit_status;
     }
     wait_set_.emplace_back(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
@@ -127,7 +127,8 @@ static void ReportPipelineCreationFeedback(
 ///
 static vk::UniqueRenderPass CreateCompatRenderPassForPipeline(
     const vk::Device& device,
-    const PipelineDescriptor& desc) {
+    const PipelineDescriptor& desc,
+    bool supports_framebuffer_fetch) {
   RenderPassBuilderVK builder;
 
   for (const auto& [bind_point, color] : desc.GetColorAttachmentDescriptors()) {
@@ -153,6 +154,8 @@ static vk::UniqueRenderPass CreateCompatRenderPassForPipeline(
                                  StoreAction::kDontCare         //
     );
   }
+
+  builder.SetFramebufferFetchEnabled(supports_framebuffer_fetch);
 
   auto pass = builder.Build(device);
   if (!pass) {
@@ -492,8 +495,10 @@ std::unique_ptr<PipelineVK> PipelineVK::Create(
     return nullptr;
   }
 
-  vk::UniqueRenderPass render_pass =
-      CreateCompatRenderPassForPipeline(device_holder->GetDevice(), desc);
+  const auto* caps = pso_cache->GetCapabilities();
+  vk::UniqueRenderPass render_pass = CreateCompatRenderPassForPipeline(
+      device_holder->GetDevice(), desc,
+      caps != nullptr && caps->SupportsFramebufferFetch());
   if (!render_pass) {
     VALIDATION_LOG << "Could not create render pass for pipeline.";
     return nullptr;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
@@ -35,6 +35,12 @@ RenderPassBuilderVK::RenderPassBuilderVK() = default;
 
 RenderPassBuilderVK::~RenderPassBuilderVK() = default;
 
+RenderPassBuilderVK& RenderPassBuilderVK::SetFramebufferFetchEnabled(
+    bool enabled) {
+  supports_framebuffer_fetch_ = enabled;
+  return *this;
+}
+
 RenderPassBuilderVK& RenderPassBuilderVK::SetColorAttachment(
     size_t index,
     PixelFormat format,
@@ -181,57 +187,115 @@ vk::UniqueRenderPass RenderPassBuilderVK::Build(
 
   vk::SubpassDescription subpass0;
   subpass0.pipelineBindPoint = vk::PipelineBindPoint::eGraphics;
-  subpass0.setPInputAttachments(color_refs.data());
-  subpass0.setInputAttachmentCount(color_index);
+  if (supports_framebuffer_fetch_) {
+    subpass0.setPInputAttachments(color_refs.data());
+    subpass0.setInputAttachmentCount(color_index);
+  } else {
+    subpass0.setPInputAttachments(nullptr);
+    subpass0.setInputAttachmentCount(0);
+  }
   subpass0.setPColorAttachments(color_refs.data());
   subpass0.setColorAttachmentCount(color_index);
   subpass0.setPResolveAttachments(resolve_refs.data());
 
   subpass0.setPDepthStencilAttachment(&depth_stencil_ref);
 
-  vk::SubpassDependency deps[3];
-  // Incoming dependency. If the attachments were previously used
+  // Build subpass dependencies. When framebuffer fetch is supported, a
+  // self-dependency (subpass 0 -> subpass 0) is included so that fragment
+  // shaders can read back the color attachment as an input attachment.
+  // When framebuffer fetch is not supported (e.g. Mesa dzn), the
+  // self-dependency is omitted because some drivers (D3D12 translation
+  // layers) fail when a subpass self-dependency is present.
+  constexpr size_t kMaxDeps = 3;
+  vk::SubpassDependency deps[kMaxDeps];
+  size_t dep_count = 0;
+
+  // Incoming external dependency. If the attachments were previously used
   // as attachments for a render pass, or sampled from/transfered to,
   // then these operations must complete before we resolve anything
   // to the onscreen.
-  deps[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-  deps[0].dstSubpass = 0u;
-  deps[0].srcStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput |
-                         vk::PipelineStageFlagBits::eFragmentShader;
-  deps[0].srcAccessMask = vk::AccessFlagBits::eShaderRead |
-                          vk::AccessFlagBits::eColorAttachmentWrite;
-  deps[0].dstStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-  deps[0].dstAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
-  deps[0].dependencyFlags = kSelfDependencyFlags;
+  // Note: dependencyFlags is {} (no flags) because VK_DEPENDENCY_BY_REGION_BIT
+  // is only meaningful for self-dependencies (srcSubpass == dstSubpass).
+  // Per Vulkan spec section 7.1, for non-self-dependencies the by-region
+  // flag is implementation-dependent and may be silently ignored.
+  deps[dep_count].srcSubpass = VK_SUBPASS_EXTERNAL;
+  deps[dep_count].dstSubpass = 0u;
+  // Include depth/stencil stages when a depth attachment is present.
+  // The previous render pass writes depth at eLateFragmentTests; the
+  // implicit layout transition inside vkCmdBeginRenderPass also writes
+  // the depth image, so we must synchronize that previous write against
+  // the new implicit write. This fixes SYNC-HAZARD-WRITE-AFTER-WRITE on
+  // vkCmdBeginRenderPass reported by VK_LAYER_KHRONOS_validation sync.
+  deps[dep_count].srcStageMask =
+      vk::PipelineStageFlagBits::eColorAttachmentOutput |
+      vk::PipelineStageFlagBits::eFragmentShader |
+      (depth_stencil_.has_value()
+           ? (vk::PipelineStageFlagBits::eEarlyFragmentTests |
+              vk::PipelineStageFlagBits::eLateFragmentTests)
+           : vk::PipelineStageFlags{});
+  deps[dep_count].srcAccessMask =
+      vk::AccessFlagBits::eShaderRead |
+      vk::AccessFlagBits::eColorAttachmentWrite |
+      (depth_stencil_.has_value()
+           ? vk::AccessFlagBits::eDepthStencilAttachmentWrite
+           : vk::AccessFlags{});
+  deps[dep_count].dstStageMask =
+      vk::PipelineStageFlagBits::eColorAttachmentOutput |
+      (depth_stencil_.has_value()
+           ? vk::PipelineStageFlagBits::eEarlyFragmentTests
+           : vk::PipelineStageFlags{});
+  deps[dep_count].dstAccessMask =
+      vk::AccessFlagBits::eColorAttachmentWrite |
+      (depth_stencil_.has_value()
+           ? (vk::AccessFlagBits::eDepthStencilAttachmentWrite |
+              vk::AccessFlagBits::eDepthStencilAttachmentRead)
+           : vk::AccessFlags{});
+  deps[dep_count].dependencyFlags = {};
+  dep_count++;
 
-  // Self dependency for reading back the framebuffer, necessary for
-  // programmable blend support / framebuffer fetch.
-  deps[1].srcSubpass = 0u;  // first subpass
-  deps[1].dstSubpass = 0u;  // to itself
-  deps[1].srcStageMask = kSelfDependencySrcStageMask;
-  deps[1].srcAccessMask = kSelfDependencySrcAccessMask;
-  deps[1].dstStageMask = kSelfDependencyDstStageMask;
-  deps[1].dstAccessMask = kSelfDependencyDstAccessMask;
-  deps[1].dependencyFlags = kSelfDependencyFlags;
+  if (supports_framebuffer_fetch_) {
+    // Self dependency for reading back the framebuffer, necessary for
+    // programmable blend support / framebuffer fetch.
+    deps[dep_count].srcSubpass = 0u;  // first subpass
+    deps[dep_count].dstSubpass = 0u;  // to itself
+    deps[dep_count].srcStageMask = kSelfDependencySrcStageMask;
+    deps[dep_count].srcAccessMask = kSelfDependencySrcAccessMask;
+    deps[dep_count].dstStageMask = kSelfDependencyDstStageMask;
+    deps[dep_count].dstAccessMask = kSelfDependencyDstAccessMask;
+    deps[dep_count].dependencyFlags = kSelfDependencyFlags;
+    dep_count++;
+  }
 
-  // Outgoing dependency. The resolve step or color attachment must complete
-  // before we can sample from the image. This dependency is ignored for the
-  // onscreen as we will already insert a barrier before presenting the
-  // swapchain.
-  deps[2].srcSubpass = 0u;  // first subpass
-  deps[2].dstSubpass = VK_SUBPASS_EXTERNAL;
-  deps[2].srcStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-  deps[2].srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite;
-  deps[2].dstStageMask = vk::PipelineStageFlagBits::eFragmentShader;
-  deps[2].dstAccessMask = vk::AccessFlagBits::eShaderRead;
-  deps[2].dependencyFlags = kSelfDependencyFlags;
+  // Outgoing external dependency. The resolve step or color attachment must
+  // complete before we can sample from the image. This dependency is ignored
+  // for the onscreen as we will already insert a barrier before presenting
+  // the swapchain. Also cover depth writes so the next render pass's incoming
+  // dependency can see them.
+  // dependencyFlags is {} for the same reason as the incoming dependency
+  // (VK_DEPENDENCY_BY_REGION_BIT is meaningless for VK_SUBPASS_EXTERNAL).
+  deps[dep_count].srcSubpass = 0u;  // first subpass
+  deps[dep_count].dstSubpass = VK_SUBPASS_EXTERNAL;
+  deps[dep_count].srcStageMask =
+      vk::PipelineStageFlagBits::eColorAttachmentOutput |
+      (depth_stencil_.has_value()
+           ? vk::PipelineStageFlagBits::eLateFragmentTests
+           : vk::PipelineStageFlags{});
+  deps[dep_count].srcAccessMask =
+      vk::AccessFlagBits::eColorAttachmentWrite |
+      (depth_stencil_.has_value()
+           ? vk::AccessFlagBits::eDepthStencilAttachmentWrite
+           : vk::AccessFlags{});
+  deps[dep_count].dstStageMask = vk::PipelineStageFlagBits::eFragmentShader;
+  deps[dep_count].dstAccessMask = vk::AccessFlagBits::eShaderRead;
+  deps[dep_count].dependencyFlags = {};
+  dep_count++;
 
   vk::RenderPassCreateInfo render_pass_desc;
   render_pass_desc.setPAttachments(attachments.data());
   render_pass_desc.setAttachmentCount(attachments_index);
   render_pass_desc.setSubpasses(subpass0);
   render_pass_desc.setPDependencies(deps);
-  render_pass_desc.setDependencyCount(3);
+  render_pass_desc.setDependencyCount(dep_count);
 
   auto [result, pass] = device.createRenderPassUnique(render_pass_desc);
   if (result != vk::Result::eSuccess) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk.h
@@ -59,6 +59,13 @@ class RenderPassBuilderVK {
   // Visible for testing.
   const std::optional<vk::AttachmentDescription>& GetDepthStencil() const;
 
+  /// @brief      When set to false, the render pass will not include input
+  ///             attachment references or self-dependencies needed for
+  ///             framebuffer fetch. This is required for drivers (such as
+  ///             Mesa's dzn / Direct3D 12 translation layer) that do not
+  ///             support subpass self-dependencies.
+  RenderPassBuilderVK& SetFramebufferFetchEnabled(bool enabled);
+
   // Visible for testing.
   std::optional<vk::AttachmentDescription> GetColor0() const;
 
@@ -69,6 +76,7 @@ class RenderPassBuilderVK {
   std::optional<vk::AttachmentDescription> color0_;
   std::optional<vk::AttachmentDescription> color0_resolve_;
   std::optional<vk::AttachmentDescription> depth_stencil_;
+  bool supports_framebuffer_fetch_ = true;
 
   // Color attachment 0 is stored in the field above and not in these maps.
   std::map<size_t, vk::AttachmentDescription> colors_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -133,6 +133,9 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
     );
   }
 
+  builder.SetFramebufferFetchEnabled(
+      context.GetCapabilities()->SupportsFramebufferFetch());
+
   auto pass = builder.Build(context.GetDevice());
 
   if (!pass) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
@@ -356,6 +356,14 @@ KHRSwapchainImplVK::AcquireResult KHRSwapchainImplVK::AcquireNextDrawable() {
 
   const auto& context = ContextVK::Cast(*context_strong);
 
+  // If the device is in a lost state (e.g. after a failed queue submission on
+  // a driver in a corrupted OOM state), do not make any further Vulkan calls:
+  // vkWaitForFences / vkAcquireNextImageKHR can access-fault inside the ICD.
+  // Return an empty result so the caller skips the frame gracefully.
+  if (context.IsDeviceLost()) {
+    return KHRSwapchainImplVK::AcquireResult{};
+  }
+
   current_frame_ = (current_frame_ + 1u) % synchronizers_.size();
 
   const auto& sync = synchronizers_[current_frame_];
@@ -389,14 +397,24 @@ KHRSwapchainImplVK::AcquireResult KHRSwapchainImplVK::AcquireNextDrawable() {
     case vk::Result::eSuboptimalKHR:
     case vk::Result::eErrorOutOfDateKHR:
       // A recoverable error. Just say we are out of date.
+      //
+      // WaitForFence above reset the synchronizer fence. Since no GPU work
+      // will be submitted for this frame, re-signal the fence with an empty
+      // queue submit. Without this, the next attempt that wraps around to
+      // the same synchronizer deadlocks in waitForFences (infinite timeout
+      // on a fence that nothing will signal).
+      context.GetGraphicsQueue()->Submit(*sync->acquire);
       return AcquireResult{true /* out of date */};
       break;
     case vk::Result::eErrorSurfaceLostKHR:
       // This error code is returned by Android for some situations that are
-      // recoverable but do not require recreating the swapchain.
+      // recoverable but do not require recreating the swapchain. Re-signal
+      // the fence for the same reason as above.
+      context.GetGraphicsQueue()->Submit(*sync->acquire);
       return AcquireResult{false /* out of date */};
     default:
-      // An unrecoverable error.
+      // An unrecoverable error. Re-signal the fence for the same reason.
+      context.GetGraphicsQueue()->Submit(*sync->acquire);
       VALIDATION_LOG << "Could not acquire next swapchain image: "
                      << vk::to_string(acq_result);
       return AcquireResult{false /* out of date */};
@@ -404,6 +422,7 @@ KHRSwapchainImplVK::AcquireResult KHRSwapchainImplVK::AcquireNextDrawable() {
 
   if (index >= images_.size()) {
     VALIDATION_LOG << "Swapchain returned an invalid image index.";
+    context.GetGraphicsQueue()->Submit(*sync->acquire);
     return KHRSwapchainImplVK::AcquireResult{};
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_vk.cc
@@ -80,7 +80,20 @@ std::unique_ptr<Surface> KHRSwapchainVK::AcquireNextDrawable(
     return nullptr;
   }
 
-  size_ = impl_->GetCurrentUnderlyingSurfaceSize().value_or(size_);
+  {
+    auto surface_size = impl_->GetCurrentUnderlyingSurfaceSize();
+    if (surface_size.has_value()) {
+      if (surface_size->IsEmpty()) {
+        // Minimized or occluded window - surface has zero extent. Skip this
+        // frame but preserve size_ so recovery works when the window is
+        // restored. The rendering loop will keep calling AcquireNextDrawable
+        // and eventually GetCurrentUnderlyingSurfaceSize() will return a
+        // non-zero value.
+        return nullptr;
+      }
+      size_ = surface_size.value();
+    }
+  }
 #endif  // !FML_OS_ANDROID
 
   TRACE_EVENT0("impeller", "RecreateSwapchain");

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/tracked_objects_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/tracked_objects_vk.cc
@@ -39,6 +39,35 @@ TrackedObjectsVK::~TrackedObjectsVK() {
   pool_->CollectCommandBuffer(std::move(buffer_));
 }
 
+void TrackedObjectsVK::AbandonForDriverCrash() {
+  if (!buffer_) {
+    return;
+  }
+  // Release the command buffer handle without returning it to the pool.
+  // The pool is also abandoned so that neither vkFreeCommandBuffers nor
+  // vkDestroyCommandPool is called on the now-invalid driver-side handles.
+  buffer_.release();
+  if (pool_) {
+    pool_->AbandonForDriverCrash();
+  }
+  // Release all VkDescriptorPool handles to prevent vkDestroyDescriptorPool
+  // calls on the corrupted device.
+  if (desc_pool_) {
+    desc_pool_->AbandonForDriverCrash();
+  }
+  // Clear tracked resource lists. If this TrackedObjectsVK is the last holder
+  // of these shared_ptrs their destructors would call vkDestroyBuffer /
+  // vkDestroyImage etc. on the corrupted device. Clearing here is safe
+  // because in the common case (pipeline objects, cached textures) other
+  // owners still hold the resources, so no destructor fires. In the rare
+  // case where we ARE the last owner we accept the potential for a Vulkan
+  // cleanup call - it is better than the guaranteed crash from waitIdle or
+  // vkCreateCommandPool on a driver in a corrupted OOM state.
+  tracked_objects_.clear();
+  tracked_buffers_.clear();
+  tracked_textures_.clear();
+}
+
 bool TrackedObjectsVK::IsValid() const {
   return is_valid_;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/tracked_objects_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/tracked_objects_vk.h
@@ -27,6 +27,14 @@ class TrackedObjectsVK {
 
   bool IsValid() const;
 
+  /// @brief      Discard the command buffer handle without returning it to
+  ///             the pool, and abandon the pool itself.
+  ///
+  /// Call this after a failed vkQueueSubmit where the driver has already freed
+  /// the underlying Vulkan objects (e.g. AMD non-conformant OOM behaviour).
+  /// Prevents vkFreeCommandBuffers being called on an already-invalid handle.
+  void AbandonForDriverCrash();
+
   void Track(const std::shared_ptr<SharedObjectVK>& object);
 
   void Track(const std::shared_ptr<const DeviceBuffer>& buffer);

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/workarounds_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/workarounds_vk.cc
@@ -24,6 +24,27 @@ WorkaroundsVK GetWorkaroundsFromDriverInfo(DriverInfoVK& driver_info) {
   } else if (powervr_gpu.has_value()) {
     workarounds.input_attachment_self_dependency_broken = true;
   }
+
+  // Mesa's "dozen" (dzn) driver translates Vulkan to D3D12. D3D12 has no
+  // native subpass concept, so the subpass self-dependency used for
+  // programmable blending (framebuffer fetch) fails at vkEndCommandBuffer
+  // with ErrorOutOfHostMemory. Disable framebuffer fetch on this driver.
+  //
+  // Detection strategy:
+  //  1. Prefer VkPhysicalDeviceDriverProperties::driverID (Vulkan 1.2+)
+  //     which reliably identifies the driver via an enum.
+  //  2. Fall back to device name string matching for pre-1.2 drivers.
+  //     The device name is "Microsoft Direct3D12 (<GPU name>)".
+  //     Note: dzn reports the underlying GPU's vendorID (e.g. 0x1002 for
+  //     AMD), not VK_VENDOR_ID_MESA, so vendorID alone is insufficient.
+  bool is_mesa_dzn =
+      driver_info.GetDriverID() == vk::DriverId::eMesaDozen ||
+      driver_info.GetDriverName().find("D3D12") != std::string::npos;
+  if (is_mesa_dzn) {
+    workarounds.input_attachment_self_dependency_broken = true;
+    workarounds.skip_sub_region_buffer_to_image_copy = true;
+  }
+
   return workarounds;
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/workarounds_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/workarounds_vk.h
@@ -36,6 +36,14 @@ struct WorkaroundsVK {
   ///      * https://github.com/flutter/flutter/issues/159876
   ///      * https://github.com/flutter/flutter/issues/160587
   bool broken_mipmap_generation = false;
+
+  /// Mesa's "dozen" (dzn) D3D12 translation layer reports a
+  /// minImageTransferGranularity of (0,0,0) and fails sub-region
+  /// buffer-to-image copies with VK_ERROR_OUT_OF_HOST_MEMORY at
+  /// vkEndCommandBuffer. When set, sub-region copies use a staging
+  /// image as intermediary: buffer -> staging (full copy) -> destination
+  /// via vkCmdCopyImage (not constrained by transfer granularity).
+  bool skip_sub_region_buffer_to_image_copy = false;
 };
 
 WorkaroundsVK GetWorkaroundsFromDriverInfo(DriverInfoVK& driver_info);

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -56,8 +56,9 @@ class WrappedTextureSourceVK : public impeller::TextureSourceVK {
 
 GPUSurfaceVulkanImpeller::GPUSurfaceVulkanImpeller(
     GPUSurfaceVulkanDelegate* delegate,
-    std::shared_ptr<impeller::Context> context)
-    : delegate_(delegate) {
+    std::shared_ptr<impeller::Context> context,
+    bool render_to_surface)
+    : delegate_(delegate), render_to_surface_(render_to_surface) {
   if (!context || !context->IsValid()) {
     return;
   }
@@ -74,7 +75,7 @@ GPUSurfaceVulkanImpeller::GPUSurfaceVulkanImpeller(
   // Create frame-throttling fences (signaled initially so the first
   // kMaxFramesInFlight frames do not block). Only the embedder-managed image
   // path uses these; the KHR swapchain enforces its own backpressure.
-  if (delegate_) {
+  if (delegate_ && render_to_surface_) {
     auto& context_vk = impeller::ContextVK::Cast(*impeller_context_);
     impeller::vk::FenceCreateInfo fence_ci;
     fence_ci.flags = impeller::vk::FenceCreateFlagBits::eSignaled;
@@ -146,6 +147,23 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
   if (size.IsEmpty()) {
     FML_LOG(ERROR) << "Vulkan surface was asked for an empty frame.";
     return nullptr;
+  }
+
+  if (!render_to_surface_) {
+    // An external view embedder renders the content through embedder
+    // backing stores; the root surface contributes nothing. Still mark the
+    // frame boundary so the pipeline library can run deferred work, which
+    // AcquireNextSurface would otherwise do.
+    if (auto pipeline_library = impeller_context_->GetPipelineLibrary()) {
+      impeller::PipelineLibraryVK::Cast(*pipeline_library)
+          .DidAcquireSurfaceFrame();
+    }
+    return std::make_unique<SurfaceFrame>(
+        nullptr, SurfaceFrame::FramebufferInfo{.supports_readback = true},
+        [](const SurfaceFrame& surface_frame, DlCanvas* canvas) {
+          return true;
+        },
+        [](const SurfaceFrame& surface_frame) { return true; }, size);
   }
 
   if (delegate_ == nullptr) {

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -114,6 +114,17 @@ GPUSurfaceVulkanImpeller::~GPUSurfaceVulkanImpeller() {
           }
         }
       }
+    } else {
+      // After a device loss the driver's internal state may be corrupted and
+      // any further Vulkan call can fault inside the ICD (see
+      // ContextVK::MarkDeviceLost). Abandon the handles instead of destroying
+      // them, matching the AbandonForDriverCrash policy of the command pools.
+      for (auto& entry : cached_image_views_) {
+        (void)entry.second.release();
+      }
+      for (auto& fence : frame_fences_) {
+        (void)fence.release();
+      }
     }
   }
   cached_image_views_.clear();
@@ -284,14 +295,23 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
       // in-flight frames to complete first to avoid destroying a
       // VkImageView the GPU may still reference
       // (VUID-vkDestroyImageView-imageView-01026).
-      for (size_t i = 0; i < kMaxFramesInFlight; i++) {
-        if (frame_fences_[i]) {
-          auto wait = context_vk.GetDevice().waitForFences(
-              {*frame_fences_[i]}, VK_TRUE, kFenceDrainTimeoutNs);
-          if (wait != impeller::vk::Result::eSuccess) {
-            FML_LOG(ERROR) << "Failed to wait for in-flight fence on resize: "
-                           << impeller::vk::to_string(wait);
+      if (!context_vk.IsDeviceLost()) {
+        for (size_t i = 0; i < kMaxFramesInFlight; i++) {
+          if (frame_fences_[i]) {
+            auto wait = context_vk.GetDevice().waitForFences(
+                {*frame_fences_[i]}, VK_TRUE, kFenceDrainTimeoutNs);
+            if (wait != impeller::vk::Result::eSuccess) {
+              FML_LOG(ERROR) << "Failed to wait for in-flight fence on resize: "
+                             << impeller::vk::to_string(wait);
+            }
           }
+        }
+      } else {
+        // Waiting on fences or destroying views is unsafe on a corrupted
+        // driver after a device loss; abandon the stale views instead (the
+        // embedder's old images are gone either way).
+        for (auto& entry : cached_image_views_) {
+          (void)entry.second.release();
         }
       }
       cached_image_views_.clear();

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -14,6 +14,7 @@
 #include "impeller/display_list/dl_dispatcher.h"
 #include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/renderer/backend/vulkan/pipeline_library_vk.h"
 #include "impeller/renderer/backend/vulkan/surface_context_vk.h"
 #include "impeller/renderer/backend/vulkan/swapchain/surface_vk.h"
 #include "impeller/renderer/render_target.h"
@@ -22,35 +23,35 @@
 
 namespace flutter {
 
+/// Wraps an embedder-provided VkImage/VkImageView pair as a TextureSourceVK
+/// for use with Impeller's rendering pipeline. The image view is borrowed;
+/// ownership is held by the surface's image view cache, which outlives the
+/// wrapper.
 class WrappedTextureSourceVK : public impeller::TextureSourceVK {
  public:
   explicit WrappedTextureSourceVK(impeller::vk::Image image,
-                                  impeller::vk::UniqueImageView image_view,
+                                  impeller::vk::ImageView image_view,
                                   impeller::TextureDescriptor desc)
-      : TextureSourceVK(desc),
-        image_(image),
-        image_view_(std::move(image_view)) {}
+      : TextureSourceVK(desc), image_(image), image_view_(image_view) {}
 
   ~WrappedTextureSourceVK() override = default;
 
  private:
   impeller::vk::Image GetImage() const override { return image_; }
 
-  impeller::vk::ImageView GetImageView() const override {
-    return image_view_.get();
-  }
+  impeller::vk::ImageView GetImageView() const override { return image_view_; }
 
   impeller::vk::ImageView GetRenderTargetView(
       uint32_t mip_level,
       uint32_t array_layer) const override {
     // Swapchain images are always a single 2D mip and layer.
-    return image_view_.get();
+    return image_view_;
   }
 
   bool IsSwapchainImage() const override { return true; }
 
   impeller::vk::Image image_;
-  impeller::vk::UniqueImageView image_view_;
+  impeller::vk::ImageView image_view_;
 };
 
 GPUSurfaceVulkanImpeller::GPUSurfaceVulkanImpeller(
@@ -69,11 +70,54 @@ GPUSurfaceVulkanImpeller::GPUSurfaceVulkanImpeller(
 
   impeller_context_ = std::move(context);
   aiks_context_ = std::move(aiks_context);
+
+  // Create frame-throttling fences (signaled initially so the first
+  // kMaxFramesInFlight frames do not block). Only the embedder-managed image
+  // path uses these; the KHR swapchain enforces its own backpressure.
+  if (delegate_) {
+    auto& context_vk = impeller::ContextVK::Cast(*impeller_context_);
+    impeller::vk::FenceCreateInfo fence_ci;
+    fence_ci.flags = impeller::vk::FenceCreateFlagBits::eSignaled;
+    for (size_t i = 0; i < kMaxFramesInFlight; i++) {
+      auto [result, fence] = context_vk.GetDevice().createFenceUnique(fence_ci);
+      if (result != impeller::vk::Result::eSuccess) {
+        FML_LOG(ERROR) << "Failed to create frame throttle fence: "
+                       << impeller::vk::to_string(result);
+        return;
+      }
+      frame_fences_[i] = std::move(fence);
+    }
+  }
+
   is_valid_ = !!aiks_context_;
 }
 
 // |Surface|
-GPUSurfaceVulkanImpeller::~GPUSurfaceVulkanImpeller() = default;
+GPUSurfaceVulkanImpeller::~GPUSurfaceVulkanImpeller() {
+  // Wait for in-flight frames before destroying cached image views, so a
+  // VkImageView still referenced by the GPU is not destroyed
+  // (VUID-vkDestroyImageView-imageView-01026). Individual frame fences are
+  // used instead of vkDeviceWaitIdle: some drivers (Samsung Xclipse, Mali)
+  // segfault inside vkDeviceWaitIdle when the underlying native window has
+  // already been destroyed by the platform, which happens routinely during
+  // Android activity transitions.
+  if (impeller_context_) {
+    auto& context_vk = impeller::ContextVK::Cast(*impeller_context_);
+    if (!context_vk.IsDeviceLost()) {
+      for (auto& fence : frame_fences_) {
+        if (fence) {
+          auto wait_result = context_vk.GetDevice().waitForFences(
+              {*fence}, VK_TRUE, kFenceDrainTimeoutNs);
+          if (wait_result != impeller::vk::Result::eSuccess) {
+            FML_LOG(ERROR) << "Frame fence wait failed during teardown: "
+                           << impeller::vk::to_string(wait_result);
+          }
+        }
+      }
+    }
+  }
+  cached_image_views_.clear();
+}
 
 // |Surface|
 bool GPUSurfaceVulkanImpeller::IsValid() {
@@ -143,6 +187,65 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
         true      // display list fallback
     );
   } else {
+    //------------------------------------------------------------------
+    // Frame throttle: wait for the oldest in-flight frame's fence.
+    //
+    // The KHR swapchain path enforces back-pressure via WaitForFence()
+    // in AcquireNextDrawable. Without an equivalent here, the CPU queues
+    // frames unboundedly; fences, tracked resources, and driver objects
+    // accumulate until VK_ERROR_OUT_OF_HOST_MEMORY.
+    //
+    // A ring of kMaxFramesInFlight fences throttles the CPU. Before
+    // starting frame N, the fence from frame N-2 is awaited, guaranteeing
+    // at most 2 frames in flight at any time.
+    //
+    // If the GPU cannot complete within kFrameSkipTimeoutNs, the frame is
+    // skipped entirely. This prevents unbounded resource accumulation
+    // under extreme GPU pressure while maintaining rendering correctness.
+    //------------------------------------------------------------------
+    {
+      auto& context_vk = impeller::ContextVK::Cast(*impeller_context_);
+      size_t fence_idx = current_fence_index_ % kMaxFramesInFlight;
+
+      if (frame_fences_[fence_idx]) {
+        // Wait with a bounded timeout. Under extreme load the GPU may fall
+        // behind; skipping the frame preserves correct rendering.
+        auto wait_result = context_vk.GetDevice().waitForFences(
+            {*frame_fences_[fence_idx]}, VK_TRUE, kFrameSkipTimeoutNs);
+        if (wait_result == impeller::vk::Result::eTimeout) {
+          // The GPU is under extreme pressure. Returning nullptr tells the
+          // rasterizer to drop this frame, which maintains rendering
+          // correctness at the expense of frame rate.
+          FML_LOG(WARNING)
+              << "Frame skipped: GPU did not complete within timeout.";
+          return nullptr;
+        }
+        if (wait_result != impeller::vk::Result::eSuccess) {
+          FML_LOG(ERROR) << "Frame throttle fence wait failed: "
+                         << impeller::vk::to_string(wait_result);
+          return nullptr;
+        }
+        // The fence is deliberately NOT reset here. A frame can be acquired
+        // and then dropped without ever being submitted (the rasterizer
+        // discards frames routinely); resetting on acquire would leave the
+        // fence unsignaled forever in that case, deadlocking the teardown
+        // and resize drains. The submit callback resets the fence
+        // immediately before queueing the signal, so a fence is only ever
+        // unsignaled while submitted work is actually in flight.
+      }
+    }
+
+    // Mark the end of the previous frame. In the KHR swapchain path this is
+    // done by SurfaceContextVK::AcquireNextSurface(); the embedder-managed
+    // image path bypasses that, so it must be done here. This lets the
+    // pipeline library schedule deferred operations, matching
+    // SurfaceContextVK::MarkFrameEnd().
+    if (auto pipeline_library = impeller_context_->GetPipelineLibrary()) {
+      impeller::PipelineLibraryVK::Cast(*pipeline_library)
+          .DidAcquireSurfaceFrame();
+    }
+    impeller_context_->GetResourceAllocator()->DebugTraceMemoryStatistics();
+
     FlutterVulkanImage flutter_image = delegate_->AcquireImage(size);
     if (!flutter_image.image) {
       FML_LOG(ERROR) << "Invalid VkImage given by the embedder.";
@@ -174,35 +277,66 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
     desc.compression_type = impeller::CompressionType::kLossless;
     desc.usage = impeller::TextureUsage::kRenderTarget;
 
-    impeller::vk::ImageViewCreateInfo view_info = {};
-    view_info.viewType = impeller::vk::ImageViewType::e2D;
-    view_info.format = ToVKImageFormat(desc.format);
-    view_info.subresourceRange.aspectMask =
-        impeller::vk::ImageAspectFlagBits::eColor;
-    view_info.subresourceRange.baseMipLevel = 0u;
-    view_info.subresourceRange.baseArrayLayer = 0u;
-    view_info.subresourceRange.levelCount = 1;
-    view_info.subresourceRange.layerCount = 1;
-    view_info.image = vk_image;
-
-    auto [result, image_view] =
-        context_vk.GetDevice().createImageViewUnique(view_info);
-    if (result != impeller::vk::Result::eSuccess) {
-      FML_LOG(ERROR) << "Failed to create image view for provided image: "
-                     << impeller::vk::to_string(result);
-      return nullptr;
-    }
-
     impeller::ISize frame_size{size.width, size.height};
     if (transients_ == nullptr || transients_size_ != frame_size) {
+      // The embedder's images were recreated, so the old VkImages are
+      // invalid and their cached views must be destroyed. Wait for all
+      // in-flight frames to complete first to avoid destroying a
+      // VkImageView the GPU may still reference
+      // (VUID-vkDestroyImageView-imageView-01026).
+      for (size_t i = 0; i < kMaxFramesInFlight; i++) {
+        if (frame_fences_[i]) {
+          auto wait = context_vk.GetDevice().waitForFences(
+              {*frame_fences_[i]}, VK_TRUE, kFenceDrainTimeoutNs);
+          if (wait != impeller::vk::Result::eSuccess) {
+            FML_LOG(ERROR) << "Failed to wait for in-flight fence on resize: "
+                           << impeller::vk::to_string(wait);
+          }
+        }
+      }
+      cached_image_views_.clear();
       transients_ = std::make_shared<impeller::SwapchainTransientsVK>(
           impeller_context_, desc,
           /*enable_msaa=*/true);
       transients_size_ = frame_size;
     }
 
-    auto wrapped_onscreen = std::make_shared<WrappedTextureSourceVK>(
-        vk_image, std::move(image_view), desc);
+    // Cache image views per embedder image to avoid a per-frame VkImageView
+    // allocation (which leaks one view per frame, since nothing destroyed
+    // them until surface teardown). The KHR swapchain path creates one view
+    // per swapchain image; this cache replicates that pattern. Ownership is
+    // held by cached_image_views_; WrappedTextureSourceVK borrows the raw
+    // handle, which stays valid as long as the cache entry exists.
+    impeller::vk::ImageView image_view;
+    auto cache_key = flutter_image.image;
+    auto it = cached_image_views_.find(cache_key);
+    if (it != cached_image_views_.end()) {
+      image_view = *it->second;
+    } else {
+      impeller::vk::ImageViewCreateInfo view_info = {};
+      view_info.viewType = impeller::vk::ImageViewType::e2D;
+      view_info.format = ToVKImageFormat(desc.format);
+      view_info.subresourceRange.aspectMask =
+          impeller::vk::ImageAspectFlagBits::eColor;
+      view_info.subresourceRange.baseMipLevel = 0u;
+      view_info.subresourceRange.baseArrayLayer = 0u;
+      view_info.subresourceRange.levelCount = 1;
+      view_info.subresourceRange.layerCount = 1;
+      view_info.image = vk_image;
+
+      auto [result, unique_view] =
+          context_vk.GetDevice().createImageViewUnique(view_info);
+      if (result != impeller::vk::Result::eSuccess) {
+        FML_LOG(ERROR) << "Failed to create image view for provided image: "
+                       << impeller::vk::to_string(result);
+        return nullptr;
+      }
+      image_view = *unique_view;
+      cached_image_views_[cache_key] = std::move(unique_view);
+    }
+
+    auto wrapped_onscreen =
+        std::make_shared<WrappedTextureSourceVK>(vk_image, image_view, desc);
     auto surface = impeller::SurfaceVK::WrapSwapchainImage(
         transients_, wrapped_onscreen, [&]() -> bool { return true; });
     impeller::RenderTarget render_target = surface->GetRenderTarget();
@@ -232,10 +366,18 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
       );
     };
 
+    // Raw handle of this frame's throttle fence, signaled by the submit
+    // callback after presentation. The unique handle stays owned by
+    // frame_fences_, which outlives the frame.
+    impeller::vk::Fence frame_fence;
+    if (frame_fences_[current_fence_index_ % kMaxFramesInFlight]) {
+      frame_fence = *frame_fences_[current_fence_index_ % kMaxFramesInFlight];
+    }
+
     SurfaceFrame::SubmitCallback submit_callback =
         [image = flutter_image, delegate = delegate_,
-         impeller_context = impeller_context_,
-         wrapped_onscreen](const SurfaceFrame&) -> bool {
+         impeller_context = impeller_context_, wrapped_onscreen,
+         frame_fence](const SurfaceFrame&) -> bool {
       TRACE_EVENT0("flutter", "GPUSurfaceVulkan::PresentImage");
 
       {
@@ -245,6 +387,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
         /// Transition the image to color-attachment-optimal.
         ///
         auto cmd_buffer = context.CreateCommandBuffer();
+        if (!cmd_buffer) {
+          // Command buffer creation short-circuits when the device is lost.
+          FML_LOG(ERROR) << "Failed to create command buffer for layout "
+                            "transition before present.";
+          return false;
+        }
 
         auto vk_final_cmd_buffer =
             impeller::CommandBufferVK::Cast(*cmd_buffer).GetCommandBuffer();
@@ -270,11 +418,52 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
         }
       }
 
-      return delegate->PresentImage(reinterpret_cast<VkImage>(image.image),
-                                    static_cast<VkFormat>(image.format));
+      bool present_ok =
+          delegate->PresentImage(reinterpret_cast<VkImage>(image.image),
+                                 static_cast<VkFormat>(image.format));
+
+      //--------------------------------------------------------------------
+      // Signal this frame's throttle fence.
+      //
+      // An empty vkQueueSubmit with just a fence signals it once all
+      // previously submitted command buffers on the queue have completed
+      // execution. Both the frame's rendering commands and the layout
+      // transition above are therefore finished before the fence signals.
+      //
+      // This goes through QueueVK's submission path (which serializes all
+      // access to the VkQueue behind a single mutex) rather than a direct
+      // vkQueueSubmit, since unsynchronized access to the queue from two
+      // lock domains is a validation violation.
+      //
+      // AcquireFrame waits on this fence kMaxFramesInFlight frames later,
+      // capping in-flight work, matching the KHR swapchain's backpressure.
+      //--------------------------------------------------------------------
+      if (frame_fence) {
+        const auto& context = impeller::ContextVK::Cast(*impeller_context);
+        // Reset immediately before queueing the signal, not in AcquireFrame:
+        // this keeps the fence signaled for frames that are acquired but
+        // never submitted, so the teardown and resize drains cannot wait on
+        // a fence that nothing will signal.
+        auto reset_result = context.GetDevice().resetFences({frame_fence});
+        if (reset_result != impeller::vk::Result::eSuccess) {
+          FML_LOG(ERROR) << "Failed to reset frame throttle fence: "
+                         << impeller::vk::to_string(reset_result);
+          return present_ok;
+        }
+        auto signal_result = context.GetGraphicsQueue()->Submit(frame_fence);
+        if (signal_result != impeller::vk::Result::eSuccess) {
+          FML_LOG(ERROR) << "Failed to signal frame throttle fence: "
+                         << impeller::vk::to_string(signal_result);
+        }
+      }
+
+      return present_ok;
     };
 
     SurfaceFrame::FramebufferInfo framebuffer_info{.supports_readback = true};
+
+    // Advance the fence ring so the next frame uses the next slot.
+    current_fence_index_ = (current_fence_index_ + 1) % kMaxFramesInFlight;
 
     return std::make_unique<SurfaceFrame>(nullptr,           // surface
                                           framebuffer_info,  // framebuffer info

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.h
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.h
@@ -28,8 +28,9 @@ FML_TEST_CLASS(GPUSurfaceVulkanImpeller,
 
 class GPUSurfaceVulkanImpeller final : public Surface {
  public:
-  explicit GPUSurfaceVulkanImpeller(GPUSurfaceVulkanDelegate* delegate,
-                                    std::shared_ptr<impeller::Context> context);
+  GPUSurfaceVulkanImpeller(GPUSurfaceVulkanDelegate* delegate,
+                           std::shared_ptr<impeller::Context> context,
+                           bool render_to_surface);
 
   // |Surface|
   ~GPUSurfaceVulkanImpeller() override;
@@ -87,6 +88,11 @@ class GPUSurfaceVulkanImpeller final : public Surface {
   // embedder-managed image path with a ring of fences.
   std::array<impeller::vk::UniqueFence, kMaxFramesInFlight> frame_fences_;
   size_t current_fence_index_ = 0;
+
+  // False when an external view embedder handles rendering: the frame is
+  // then a no-op and content reaches the screen through embedder-provided
+  // backing stores, matching GPUSurfaceGLImpeller.
+  bool render_to_surface_ = true;
 
   bool is_valid_ = false;
 

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.h
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller.h
@@ -5,6 +5,10 @@
 #ifndef FLUTTER_SHELL_GPU_GPU_SURFACE_VULKAN_IMPELLER_H_
 #define FLUTTER_SHELL_GPU_GPU_SURFACE_VULKAN_IMPELLER_H_
 
+#include <array>
+#include <cstdint>
+#include <unordered_map>
+
 #include "flutter/common/graphics/gl_context_switch.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
@@ -13,6 +17,7 @@
 #include "flutter/impeller/renderer/context.h"
 #include "flutter/shell/gpu/gpu_surface_vulkan_delegate.h"
 #include "impeller/renderer/backend/vulkan/swapchain/swapchain_transients_vk.h"
+#include "impeller/renderer/backend/vulkan/vk.h"
 
 namespace flutter {
 
@@ -36,12 +41,53 @@ class GPUSurfaceVulkanImpeller final : public Surface {
   FML_FRIEND_TEST(testing::GPUSurfaceVulkanImpeller,
                   RecreatesTransientsWhenFrameSizeChanges);
 
+  /// Maximum number of frames that can be in-flight simultaneously.
+  /// Matches the KHR swapchain's kMaxFramesInFlight = 2.
+  static constexpr size_t kMaxFramesInFlight = 2u;
+
+  /// Maximum time (nanoseconds) to wait for a frame fence before skipping
+  /// the frame. 100ms provides generous headroom for normal rendering
+  /// (including high-DPI, heavy shader workloads, and debug builds) while
+  /// still dropping frames under extreme GPU pressure to prevent resource
+  /// exhaustion. The primary backpressure mechanism is the 2-fence ring
+  /// itself; this timeout is a secondary safety net.
+  static constexpr uint64_t kFrameSkipTimeoutNs = 100'000'000u;
+
+  /// Maximum time (nanoseconds) to wait for in-flight frames when draining
+  /// fences on resize or teardown. Fences are only unsignaled while a
+  /// submitted frame is executing, so this bound is never reached in normal
+  /// operation; it protects against waiting forever on a wedged driver.
+  static constexpr uint64_t kFenceDrainTimeoutNs = 5'000'000'000u;  // 5 s.
+
   GPUSurfaceVulkanDelegate* delegate_;
   std::shared_ptr<impeller::Context> impeller_context_;
   std::shared_ptr<impeller::AiksContext> aiks_context_;
   std::shared_ptr<impeller::SwapchainTransientsVK> transients_;
   /// The size of the textures in [transients_]
   impeller::ISize transients_size_ = {};
+
+  // Cached image views keyed by VkImage handle. Image views are created once
+  // per embedder-provided image and reused across frames to avoid per-frame
+  // allocation (which leaks one VkImageView per frame). Cleared when the
+  // embedder's images are recreated (frame size change), since the old
+  // VkImages become invalid.
+  std::unordered_map<uint64_t, impeller::vk::UniqueImageView>
+      cached_image_views_;
+
+  // Frame throttling fences.
+  //
+  // Without throttling, the CPU can queue frames much faster than the GPU
+  // processes them (especially in debug builds). Each queued frame creates
+  // fences and holds tracked resources (textures, buffers, command pools).
+  // Under heavy workloads this causes unbounded resource accumulation and
+  // eventually VK_ERROR_OUT_OF_HOST_MEMORY.
+  //
+  // The KHR swapchain enforces back-pressure via WaitForFence() at the start
+  // of each AcquireNextDrawable. This replicates that for the
+  // embedder-managed image path with a ring of fences.
+  std::array<impeller::vk::UniqueFence, kMaxFramesInFlight> frame_fences_;
+  size_t current_fence_index_ = 0;
+
   bool is_valid_ = false;
 
   // |Surface|

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller_unittests.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller_unittests.cc
@@ -110,5 +110,29 @@ TEST(GPUSurfaceVulkanImpeller, RecreatesTransientsWhenFrameSizeChanges) {
   EXPECT_EQ(surface->transients_size_, impeller::ISize(200, 100));
 }
 
+TEST(GPUSurfaceVulkanImpeller, TeardownAfterDeviceLossAbandonsResources) {
+  impeller::ContextVK::Settings context_settings;
+  context_settings.proc_address_callback = vkGetInstanceProcAddr;
+  context_settings.shader_libraries_data = ShaderLibraryMappings();
+  auto context = impeller::ContextVK::Create(std::move(context_settings));
+
+  TestGPUSurfaceVulkanDelegate delegate;
+
+  std::unique_ptr<Surface> surface =
+      std::make_unique<GPUSurfaceVulkanImpeller>(&delegate, context);
+
+  // Populate the image view cache and exercise the fence ring with a frame.
+  auto frame = surface->AcquireFrame(DlISize(100, 100));
+  ASSERT_NE(frame, nullptr);
+  frame.reset();
+
+  // Teardown after a device loss must not wait on the frame fences or
+  // destroy the cached image views; on a corrupted driver either can fault
+  // inside the ICD. The surface abandons the handles and must come down
+  // cleanly.
+  context->MarkDeviceLost();
+  surface.reset();
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller_unittests.cc
+++ b/engine/src/flutter/shell/gpu/gpu_surface_vulkan_impeller_unittests.cc
@@ -39,6 +39,7 @@ class TestGPUSurfaceVulkanDelegate : public GPUSurfaceVulkanDelegate {
   const vulkan::VulkanProcTable& vk() override { return *vk_; }
 
   FlutterVulkanImage AcquireImage(const DlISize& size) override {
+    acquire_image_count_++;
     if (!test_surface_ || surface_size_ != size) {
       test_surface_ = TestVulkanSurface::Create(*test_context_, size);
       surface_size_ = size;
@@ -55,11 +56,14 @@ class TestGPUSurfaceVulkanDelegate : public GPUSurfaceVulkanDelegate {
 
   bool PresentImage(VkImage image, VkFormat format) override { return true; }
 
+  int acquire_image_count() const { return acquire_image_count_; }
+
  private:
   fml::RefPtr<vulkan::VulkanProcTable> vk_;
   fml::RefPtr<TestVulkanContext> test_context_;
   std::unique_ptr<TestVulkanSurface> test_surface_;
   DlISize surface_size_ = {};
+  int acquire_image_count_ = 0;
 };
 
 TEST(GPUSurfaceVulkanImpeller, DisposesThreadLocalResources) {
@@ -70,8 +74,8 @@ TEST(GPUSurfaceVulkanImpeller, DisposesThreadLocalResources) {
 
   TestGPUSurfaceVulkanDelegate delegate;
 
-  std::unique_ptr<Surface> surface =
-      std::make_unique<GPUSurfaceVulkanImpeller>(&delegate, context);
+  std::unique_ptr<Surface> surface = std::make_unique<GPUSurfaceVulkanImpeller>(
+      &delegate, context, /*render_to_surface=*/true);
 
   // Add a command pool to the global map.
   auto pool = context->GetCommandPoolRecycler()->Get();
@@ -83,6 +87,30 @@ TEST(GPUSurfaceVulkanImpeller, DisposesThreadLocalResources) {
   EXPECT_EQ(impeller::CommandPoolRecyclerVK::GetGlobalPoolCount(*context), 0);
 }
 
+TEST(GPUSurfaceVulkanImpeller, RenderToSurfaceDisabledYieldsNoOpFrame) {
+  impeller::ContextVK::Settings context_settings;
+  context_settings.proc_address_callback = vkGetInstanceProcAddr;
+  context_settings.shader_libraries_data = ShaderLibraryMappings();
+  auto context = impeller::ContextVK::Create(std::move(context_settings));
+
+  TestGPUSurfaceVulkanDelegate delegate;
+
+  // When an external view embedder handles presentation (as the Windows
+  // DirectComposition compositor does), the root surface renders nothing and
+  // must not pull an image from the delegate.
+  std::unique_ptr<Surface> surface = std::make_unique<GPUSurfaceVulkanImpeller>(
+      &delegate, context, /*render_to_surface=*/false);
+  ASSERT_TRUE(surface->IsValid());
+
+  auto frame = surface->AcquireFrame(DlISize(100, 100));
+  ASSERT_NE(frame, nullptr);
+  EXPECT_EQ(delegate.acquire_image_count(), 0);
+
+  // Submitting the no-op frame succeeds without touching the delegate.
+  EXPECT_TRUE(frame->Submit());
+  EXPECT_EQ(delegate.acquire_image_count(), 0);
+}
+
 TEST(GPUSurfaceVulkanImpeller, RecreatesTransientsWhenFrameSizeChanges) {
   impeller::ContextVK::Settings context_settings;
   context_settings.proc_address_callback = vkGetInstanceProcAddr;
@@ -91,7 +119,8 @@ TEST(GPUSurfaceVulkanImpeller, RecreatesTransientsWhenFrameSizeChanges) {
 
   TestGPUSurfaceVulkanDelegate delegate;
 
-  auto surface = std::make_unique<GPUSurfaceVulkanImpeller>(&delegate, context);
+  auto surface = std::make_unique<GPUSurfaceVulkanImpeller>(
+      &delegate, context, /*render_to_surface=*/true);
 
   auto frame = surface->AcquireFrame(DlISize(100, 100));
   ASSERT_NE(frame, nullptr);
@@ -118,8 +147,8 @@ TEST(GPUSurfaceVulkanImpeller, TeardownAfterDeviceLossAbandonsResources) {
 
   TestGPUSurfaceVulkanDelegate delegate;
 
-  std::unique_ptr<Surface> surface =
-      std::make_unique<GPUSurfaceVulkanImpeller>(&delegate, context);
+  std::unique_ptr<Surface> surface = std::make_unique<GPUSurfaceVulkanImpeller>(
+      &delegate, context, /*render_to_surface=*/true);
 
   // Populate the image view cache and exercise the fence ring with a frame.
   auto frame = surface->AcquireFrame(DlISize(100, 100));

--- a/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_surface_vk_impeller.cc
@@ -49,7 +49,8 @@ std::unique_ptr<Surface> AndroidSurfaceVKImpeller::CreateGPUSurface(
   }
 
   std::unique_ptr<GPUSurfaceVulkanImpeller> gpu_surface =
-      std::make_unique<GPUSurfaceVulkanImpeller>(nullptr, surface_context_vk_);
+      std::make_unique<GPUSurfaceVulkanImpeller>(nullptr, surface_context_vk_,
+                                                 /*render_to_surface=*/true);
 
   if (!gpu_surface->IsValid()) {
     return nullptr;

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -104,6 +104,15 @@ extern const intptr_t kPlatformStrongDillSize;
 #ifdef SHELL_ENABLE_VULKAN
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkTypes.h"
+#ifdef IMPELLER_SUPPORTS_RENDERING
+#include "flutter/shell/platform/embedder/embedder_render_target_impeller.h"  // nogncheck
+#include "impeller/core/texture.h"                               // nogncheck
+#include "impeller/renderer/backend/vulkan/context_vk.h"         // nogncheck
+#include "impeller/renderer/backend/vulkan/formats_vk.h"         // nogncheck
+#include "impeller/renderer/backend/vulkan/texture_source_vk.h"  // nogncheck
+#include "impeller/renderer/backend/vulkan/texture_vk.h"         // nogncheck
+#include "impeller/renderer/render_target.h"                     // nogncheck
+#endif  // IMPELLER_SUPPORTS_RENDERING
 #endif  // SHELL_ENABLE_VULKAN
 
 const int32_t kFlutterSemanticsNodeIdBatchEnd = -1;
@@ -668,6 +677,10 @@ InferVulkanPlatformViewCreationCallback(
 
 #if IMPELLER_SUPPORTS_RENDERING
   if (enable_impeller) {
+    // When the embedder supplies a compositor, rendering happens through
+    // backing stores and the root surface is a no-op, matching OpenGL.
+    const bool render_to_surface = !view_embedder;
+
     flutter::EmbedderSurfaceVulkanImpeller::VulkanDispatchTable
         vulkan_dispatch_table = {
             .get_instance_proc_address =
@@ -687,7 +700,7 @@ InferVulkanPlatformViewCreationCallback(
             static_cast<VkDevice>(config->vulkan.device),
             config->vulkan.queue_family_index,
             static_cast<VkQueue>(config->vulkan.queue), vulkan_dispatch_table,
-            view_embedder, impeller_flags);
+            view_embedder, render_to_surface, impeller_flags);
 
     return fml::MakeCopyable(
         [embedder_surface = std::move(embedder_surface),
@@ -1310,6 +1323,167 @@ MakeRenderTargetFromBackingStoreImpeller(
 #endif
 }
 
+#if defined(SHELL_ENABLE_VULKAN) && defined(IMPELLER_SUPPORTS_RENDERING)
+namespace {
+// Wraps an embedder-provided VkImage as an Impeller texture source. The
+// image is borrowed and stays owned by the embedder; the image view is owned
+// by this source and destroyed with it. In-flight command buffers keep the
+// source alive through Impeller's tracked objects until GPU work completes.
+class EmbedderTextureSourceVK final : public impeller::TextureSourceVK {
+ public:
+  EmbedderTextureSourceVK(impeller::TextureDescriptor desc,
+                          impeller::vk::Image image,
+                          impeller::vk::UniqueImageView image_view)
+      : TextureSourceVK(desc),
+        image_(image),
+        image_view_(std::move(image_view)) {}
+
+  ~EmbedderTextureSourceVK() override = default;
+
+ private:
+  impeller::vk::Image GetImage() const override { return image_; }
+
+  impeller::vk::ImageView GetImageView() const override {
+    return image_view_.get();
+  }
+
+  impeller::vk::ImageView GetRenderTargetView(
+      uint32_t mip_level,
+      uint32_t array_layer) const override {
+    // Embedder backing store images are always a single 2D mip and layer.
+    return image_view_.get();
+  }
+
+  // The embedder's backing store is the final presentation target, not a
+  // sampled texture. Reporting it as a swapchain image makes the render
+  // pass leave it in VK_IMAGE_LAYOUT_GENERAL (instead of
+  // SHADER_READ_ONLY_OPTIMAL, which would require VK_IMAGE_USAGE_SAMPLED_BIT
+  // that the imported image does not have).
+  bool IsSwapchainImage() const override { return true; }
+
+  impeller::vk::Image image_;
+  impeller::vk::UniqueImageView image_view_;
+};
+}  // namespace
+#endif  // defined(SHELL_ENABLE_VULKAN) &&
+        // defined(IMPELLER_SUPPORTS_RENDERING)
+
+static std::unique_ptr<flutter::EmbedderRenderTarget>
+MakeRenderTargetFromBackingStoreImpeller(
+    FlutterBackingStore backing_store,
+    const fml::closure& on_release,
+    const std::shared_ptr<impeller::AiksContext>& aiks_context,
+    const FlutterBackingStoreConfig& config,
+    const FlutterVulkanBackingStore* vulkan) {
+#if defined(SHELL_ENABLE_VULKAN) && defined(IMPELLER_SUPPORTS_RENDERING)
+  if (!vulkan->image || !vulkan->image->image) {
+    FML_LOG(ERROR) << "Embedder supplied null Vulkan image.";
+    return nullptr;
+  }
+
+  auto vk_format = static_cast<impeller::vk::Format>(vulkan->image->format);
+  std::optional<impeller::PixelFormat> format =
+      impeller::VkFormatToImpellerFormat(vk_format);
+  if (!format.has_value()) {
+    FML_LOG(ERROR) << "Unsupported pixel format: "
+                   << impeller::vk::to_string(vk_format);
+    return nullptr;
+  }
+
+  const auto size = impeller::ISize(config.size.width, config.size.height);
+
+  impeller::TextureDescriptor resolve_tex_desc;
+  resolve_tex_desc.size = size;
+  resolve_tex_desc.format = format.value();
+  resolve_tex_desc.sample_count = impeller::SampleCount::kCount1;
+  resolve_tex_desc.storage_mode = impeller::StorageMode::kDevicePrivate;
+  resolve_tex_desc.usage = impeller::TextureUsage::kRenderTarget;
+
+  auto& context_vk = impeller::ContextVK::Cast(*aiks_context->GetContext());
+
+  impeller::vk::Image vk_image =
+      impeller::vk::Image(reinterpret_cast<VkImage>(vulkan->image->image));
+
+  impeller::vk::ImageViewCreateInfo view_info;
+  view_info.viewType = impeller::vk::ImageViewType::e2D;
+  view_info.format = vk_format;
+  view_info.image = vk_image;
+  view_info.subresourceRange.aspectMask =
+      impeller::vk::ImageAspectFlagBits::eColor;
+  view_info.subresourceRange.baseMipLevel = 0u;
+  view_info.subresourceRange.levelCount = 1u;
+  view_info.subresourceRange.baseArrayLayer = 0u;
+  view_info.subresourceRange.layerCount = 1u;
+
+  auto [view_result, image_view] =
+      context_vk.GetDevice().createImageViewUnique(view_info);
+  if (view_result != impeller::vk::Result::eSuccess) {
+    FML_LOG(ERROR) << "Could not create an image view for the embedder "
+                      "supplied Vulkan image: "
+                   << impeller::vk::to_string(view_result);
+    return nullptr;
+  }
+
+  const std::shared_ptr<impeller::Context>& context =
+      aiks_context->GetContext();
+
+  // Wrap the imported presentation image as the resolve target, mirroring
+  // SurfaceVK::WrapSwapchainImage. The MSAA color texture and depth-stencil
+  // are Impeller-allocated transients owned by the render target.
+  std::shared_ptr<impeller::Texture> resolve_tex =
+      std::make_shared<impeller::TextureVK>(
+          context, std::make_shared<EmbedderTextureSourceVK>(
+                       resolve_tex_desc, vk_image, std::move(image_view)));
+  resolve_tex->SetLabel("ImpellerBackingStoreResolve");
+
+  context->UpdateOffscreenLayerPixelFormat(format.value());
+
+  impeller::TextureDescriptor msaa_tex_desc;
+  msaa_tex_desc.storage_mode = impeller::StorageMode::kDeviceTransient;
+  msaa_tex_desc.type = impeller::TextureType::kTexture2DMultisample;
+  msaa_tex_desc.sample_count = impeller::SampleCount::kCount4;
+  msaa_tex_desc.format = format.value();
+  msaa_tex_desc.size = size;
+  msaa_tex_desc.usage = impeller::TextureUsage::kRenderTarget;
+
+  auto msaa_tex = context->GetResourceAllocator()->CreateTexture(msaa_tex_desc);
+  if (!msaa_tex) {
+    FML_LOG(ERROR) << "Could not allocate MSAA color texture.";
+    return nullptr;
+  }
+  msaa_tex->SetLabel("ImpellerBackingStoreColorMSAA");
+
+  impeller::ColorAttachment color0;
+  color0.texture = msaa_tex;
+  color0.clear_color = impeller::Color::DarkSlateGray();
+  color0.load_action = impeller::LoadAction::kClear;
+  color0.store_action = impeller::StoreAction::kMultisampleResolve;
+  color0.resolve_texture = resolve_tex;
+
+  impeller::RenderTarget render_target_desc;
+  render_target_desc.SetColorAttachment(color0, 0u);
+  render_target_desc.SetupDepthStencilAttachments(
+      *context,                           //
+      *context->GetResourceAllocator(),   //
+      size,                               //
+      /*msaa=*/true,                      //
+      /*label=*/"ImpellerBackingStore");  //
+
+  fml::closure image_destruct;
+  if (vulkan->destruction_callback) {
+    image_destruct = [callback = vulkan->destruction_callback,
+                      user_data = vulkan->user_data]() { callback(user_data); };
+  }
+
+  return std::make_unique<flutter::EmbedderRenderTargetImpeller>(
+      backing_store, aiks_context,
+      std::make_unique<impeller::RenderTarget>(std::move(render_target_desc)),
+      on_release, image_destruct);
+#else
+  return nullptr;
+#endif
+}
+
 static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
     GrDirectContext* context,
     const FlutterBackingStoreConfig& config,
@@ -1522,7 +1696,9 @@ CreateEmbedderRenderTarget(
     }
     case kFlutterBackingStoreTypeVulkan: {
       if (enable_impeller) {
-        FML_LOG(ERROR) << "Unimplemented";
+        render_target = MakeRenderTargetFromBackingStoreImpeller(
+            backing_store, collect_callback.Release(), aiks_context, config,
+            &backing_store.vulkan);
         break;
       } else {
         auto skia_surface = MakeSkSurfaceFromBackingStore(

--- a/engine/src/flutter/shell/platform/embedder/embedder_surface_vulkan_impeller.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_surface_vulkan_impeller.cc
@@ -30,11 +30,13 @@ EmbedderSurfaceVulkanImpeller::EmbedderSurfaceVulkanImpeller(
     VkQueue queue,
     const VulkanDispatchTable& vulkan_dispatch_table,
     std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder,
+    bool render_to_surface,
     impeller::Flags impeller_flags)
     : vk_(fml::MakeRefCounted<vulkan::VulkanProcTable>(
           vulkan_dispatch_table.get_instance_proc_address)),
       vulkan_dispatch_table_(vulkan_dispatch_table),
-      external_view_embedder_(std::move(external_view_embedder)) {
+      external_view_embedder_(std::move(external_view_embedder)),
+      render_to_surface_(render_to_surface) {
   // Make sure all required members of the dispatch table are checked.
   if (!vulkan_dispatch_table_.get_instance_proc_address ||
       !vulkan_dispatch_table_.get_next_image ||
@@ -118,7 +120,8 @@ bool EmbedderSurfaceVulkanImpeller::IsValid() const {
 
 // |EmbedderSurface|
 std::unique_ptr<Surface> EmbedderSurfaceVulkanImpeller::CreateGPUSurface() {
-  return std::make_unique<GPUSurfaceVulkanImpeller>(this, context_);
+  return std::make_unique<GPUSurfaceVulkanImpeller>(this, context_,
+                                                    render_to_surface_);
 }
 
 // |EmbedderSurface|

--- a/engine/src/flutter/shell/platform/embedder/embedder_surface_vulkan_impeller.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder_surface_vulkan_impeller.h
@@ -42,6 +42,7 @@ class EmbedderSurfaceVulkanImpeller final : public EmbedderSurface,
       VkQueue queue,
       const VulkanDispatchTable& vulkan_dispatch_table,
       std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder,
+      bool render_to_surface,
       impeller::Flags impeller_flags = {});
 
   ~EmbedderSurfaceVulkanImpeller() override;
@@ -63,6 +64,7 @@ class EmbedderSurfaceVulkanImpeller final : public EmbedderSurface,
   fml::RefPtr<vulkan::VulkanProcTable> vk_;
   VulkanDispatchTable vulkan_dispatch_table_;
   std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder_;
+  bool render_to_surface_ = true;
   std::shared_ptr<impeller::ContextVK> context_;
 
   // |EmbedderSurface|

--- a/engine/src/flutter/shell/platform/windows/BUILD.gn
+++ b/engine/src/flutter/shell/platform/windows/BUILD.gn
@@ -48,8 +48,12 @@ source_set("flutter_windows_source") {
     "compositor_opengl.h",
     "compositor_software.cc",
     "compositor_software.h",
+    "compositor_vulkan.cc",
+    "compositor_vulkan.h",
     "cursor_handler.cc",
     "cursor_handler.h",
+    "dcomp_presenter.cc",
+    "dcomp_presenter.h",
     "direct_manipulation.cc",
     "direct_manipulation.h",
     "display_manager.cc",
@@ -135,6 +139,10 @@ source_set("flutter_windows_source") {
     "text_input_manager.h",
     "text_input_plugin.cc",
     "text_input_plugin.h",
+    "vulkan_imported_image.cc",
+    "vulkan_imported_image.h",
+    "vulkan_manager.cc",
+    "vulkan_manager.h",
     "wchar_util.cc",
     "wchar_util.h",
     "window_binding_handler.h",
@@ -152,7 +160,10 @@ source_set("flutter_windows_source") {
   ]
 
   libs = [
+    "d3d11.lib",
+    "dcomp.lib",
     "dwmapi.lib",
+    "dxgi.lib",
     "imm32.lib",
   ]
 
@@ -186,6 +197,7 @@ source_set("flutter_windows_source") {
     "//flutter/shell/platform/common/client_wrapper",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/platform/windows/client_wrapper:client_wrapper_windows",
+    "//flutter/vulkan/procs",
 
     # libEGL_static MUST be ordered before libGLESv2_static in this list. If
     # reversed, a linker error will occur, reporting DllMain already defined in
@@ -225,6 +237,7 @@ executable("flutter_windows_unittests") {
     "compositor_opengl_unittests.cc",
     "compositor_software_unittests.cc",
     "cursor_handler_unittests.cc",
+    "dcomp_presenter_unittests.cc",
     "direct_manipulation_unittests.cc",
     "display_manager_unittests.cc",
     "dpi_utils_unittests.cc",
@@ -273,6 +286,8 @@ executable("flutter_windows_unittests") {
     "testing/wm_builders.cc",
     "testing/wm_builders.h",
     "text_input_plugin_unittest.cc",
+    "vulkan_imported_image_unittests.cc",
+    "vulkan_manager_unittests.cc",
     "window_manager_unittests.cc",
     "window_proc_delegate_manager_unittests.cc",
     "window_unittests.cc",

--- a/engine/src/flutter/shell/platform/windows/compositor_vulkan.cc
+++ b/engine/src/flutter/shell/platform/windows/compositor_vulkan.cc
@@ -1,0 +1,139 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/compositor_vulkan.h"
+
+#include "flutter/fml/logging.h"
+#include "flutter/shell/platform/windows/flutter_windows_engine.h"
+#include "flutter/shell/platform/windows/flutter_windows_view.h"
+#include "flutter/shell/platform/windows/vulkan_manager.h"
+
+namespace flutter {
+
+CompositorVulkan::CompositorVulkan(FlutterWindowsEngine* engine)
+    : engine_(engine) {}
+
+CompositorVulkan::~CompositorVulkan() = default;
+
+bool CompositorVulkan::EnsurePresenter() {
+  if (presenter_) {
+    return true;
+  }
+  VulkanManager* manager = engine_->vulkan_manager();
+  if (!manager) {
+    return false;
+  }
+  presenter_ = DCompPresenter::Create(manager->GetDeviceLUID());
+  return presenter_ != nullptr;
+}
+
+bool CompositorVulkan::CreateBackingStore(
+    const FlutterBackingStoreConfig& config,
+    FlutterBackingStore* result) {
+  if (!EnsurePresenter()) {
+    return false;
+  }
+
+  VulkanManager* manager = engine_->vulkan_manager();
+  uint32_t width = static_cast<uint32_t>(config.size.width);
+  uint32_t height = static_cast<uint32_t>(config.size.height);
+
+  HANDLE nt_handle = presenter_->CreateSharedTexture(width, height);
+  if (!nt_handle) {
+    return false;
+  }
+
+  std::unique_ptr<VulkanImportedImage> image =
+      VulkanImportedImage::Import(manager, nt_handle, width, height);
+  if (!image) {
+    presenter_->EvictTexture(nt_handle);
+    return false;
+  }
+
+  auto data = std::make_unique<BackingStoreData>();
+  data->nt_handle = nt_handle;
+  data->width = width;
+  data->height = height;
+  data->flutter_image.struct_size = sizeof(FlutterVulkanImage);
+  data->flutter_image.image = reinterpret_cast<FlutterVulkanImageHandle>(
+      reinterpret_cast<uint64_t>(image->image()));
+  data->flutter_image.format = VK_FORMAT_B8G8R8A8_UNORM;
+  data->image = std::move(image);
+
+  result->type = kFlutterBackingStoreTypeVulkan;
+  result->vulkan.struct_size = sizeof(FlutterVulkanBackingStore);
+  result->vulkan.image = &data->flutter_image;
+  result->vulkan.user_data = data.release();
+  // Resources are released in CollectBackingStore; the engine-side
+  // destruction callback has nothing left to do.
+  result->vulkan.destruction_callback = [](void* user_data) {};
+
+  return true;
+}
+
+bool CompositorVulkan::CollectBackingStore(const FlutterBackingStore* store) {
+  FML_DCHECK(store->type == kFlutterBackingStoreTypeVulkan);
+
+  auto* data = static_cast<BackingStoreData*>(store->vulkan.user_data);
+  if (!data) {
+    return false;
+  }
+
+  // Release the Vulkan import before destroying the Direct3D texture it is
+  // bound to.
+  data->image.reset();
+  if (presenter_) {
+    presenter_->EvictTexture(data->nt_handle);
+  }
+  delete data;
+  return true;
+}
+
+bool CompositorVulkan::Present(FlutterWindowsView* view,
+                               const FlutterLayer** layers,
+                               size_t layers_count) {
+  FML_DCHECK(view != nullptr);
+  if (!presenter_) {
+    return false;
+  }
+
+  // Nothing to draw; keep the previous frame. DirectComposition retains the
+  // last committed content.
+  if (layers_count == 0) {
+    return true;
+  }
+
+  // Platform views are not yet supported, matching the other compositors.
+  if (layers_count != 1 ||
+      layers[0]->type != kFlutterLayerContentTypeBackingStore ||
+      layers[0]->offset.x != 0 || layers[0]->offset.y != 0) {
+    FML_LOG(ERROR) << "CompositorVulkan cannot present platform views or "
+                      "offset layers yet.";
+    return false;
+  }
+
+  const FlutterBackingStore* store = layers[0]->backing_store;
+  FML_DCHECK(store->type == kFlutterBackingStoreTypeVulkan);
+  auto* data = static_cast<BackingStoreData*>(store->vulkan.user_data);
+  if (!data) {
+    return false;
+  }
+
+  if (!presenter_->BindToWindow(view->GetWindowHandle())) {
+    return false;
+  }
+
+  if (!presenter_->PresentTexture(data->nt_handle, data->width, data->height)) {
+    return false;
+  }
+
+  // Fires the first-frame callback (the runner shows the window only after
+  // the first presented frame) and completes any pending resize bookkeeping.
+  // Without an EGL manager the view never enters resize synchronization, so
+  // no OnFrameGenerated gate is required before presenting.
+  view->OnFramePresented();
+  return true;
+}
+
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/compositor_vulkan.h
+++ b/engine/src/flutter/shell/platform/windows/compositor_vulkan.h
@@ -1,0 +1,73 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_COMPOSITOR_VULKAN_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_COMPOSITOR_VULKAN_H_
+
+#include <memory>
+
+#include "flutter/fml/macros.h"
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/windows/compositor.h"
+#include "flutter/shell/platform/windows/dcomp_presenter.h"
+#include "flutter/shell/platform/windows/vulkan_imported_image.h"
+
+namespace flutter {
+
+class FlutterWindowsEngine;
+
+// Enables the Flutter engine to render content on Windows using Impeller's
+// Vulkan backend, presented through DirectComposition.
+//
+// Backing stores are shared Direct3D 11 textures (allocated by the
+// presenter, since Windows drivers only support importing Direct3D textures
+// into Vulkan, not exporting from it) imported as VkImages that Impeller
+// renders into. Present copies the texture into a composition swapchain and
+// commits, so the window chrome and content update atomically.
+//
+// Platform views are not yet supported, matching the other compositors.
+class CompositorVulkan : public Compositor {
+ public:
+  explicit CompositorVulkan(FlutterWindowsEngine* engine);
+
+  ~CompositorVulkan() override;
+
+  // |Compositor|
+  bool CreateBackingStore(const FlutterBackingStoreConfig& config,
+                          FlutterBackingStore* result) override;
+
+  // |Compositor|
+  bool CollectBackingStore(const FlutterBackingStore* store) override;
+
+  // |Compositor|
+  bool Present(FlutterWindowsView* view,
+               const FlutterLayer** layers,
+               size_t layers_count) override;
+
+ private:
+  // One backing store: the shared texture handle plus its Vulkan import.
+  // Owned through FlutterBackingStore::vulkan.user_data.
+  struct BackingStoreData {
+    HANDLE nt_handle = nullptr;
+    std::unique_ptr<VulkanImportedImage> image;
+    FlutterVulkanImage flutter_image = {};
+    uint32_t width = 0;
+    uint32_t height = 0;
+  };
+
+  // Lazily creates the presenter on the adapter of the engine's Vulkan
+  // device. Returns false if the presenter cannot be created.
+  bool EnsurePresenter();
+
+  // The Flutter engine that manages the views to render.
+  FlutterWindowsEngine* engine_;
+
+  std::unique_ptr<DCompPresenter> presenter_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(CompositorVulkan);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_COMPOSITOR_VULKAN_H_

--- a/engine/src/flutter/shell/platform/windows/dcomp_presenter.cc
+++ b/engine/src/flutter/shell/platform/windows/dcomp_presenter.cc
@@ -1,0 +1,313 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/dcomp_presenter.h"
+
+#include <cstring>
+
+#include "flutter/fml/logging.h"
+
+namespace flutter {
+
+namespace {
+
+// Both sides of the shared texture access it under key 0; each acquires and
+// releases with the same key so the next acquire succeeds. See the class
+// comment in the header for the synchronization contract.
+constexpr uint64_t kKeyedMutexKey = 0;
+
+// How long to wait for the keyed mutex before dropping the frame. The
+// Vulkan work is host-synced before present, so contention can only come
+// from a previous copy still in flight; 100ms is far beyond any sane frame.
+constexpr DWORD kAcquireTimeoutMs = 100;
+
+}  // namespace
+
+// static
+std::unique_ptr<DCompPresenter> DCompPresenter::Create(
+    const std::array<uint8_t, 8>& adapter_luid) {
+  auto presenter = std::unique_ptr<DCompPresenter>(new DCompPresenter());
+  if (!presenter->Initialize(adapter_luid)) {
+    return nullptr;
+  }
+  return presenter;
+}
+
+DCompPresenter::~DCompPresenter() = default;
+
+bool DCompPresenter::Initialize(const std::array<uint8_t, 8>& adapter_luid) {
+  Microsoft::WRL::ComPtr<IDXGIFactory2> factory;
+  HRESULT hr = ::CreateDXGIFactory2(0, IID_PPV_ARGS(&factory));
+  if (FAILED(hr)) {
+    FML_LOG(ERROR) << "DCompPresenter: CreateDXGIFactory2 failed (hr=" << hr
+                   << ").";
+    return false;
+  }
+
+  // Open the adapter the Vulkan device renders on. Creating the Direct3D
+  // device on any other adapter would make the shared textures unopenable.
+  Microsoft::WRL::ComPtr<IDXGIAdapter1> adapter;
+  Microsoft::WRL::ComPtr<IDXGIAdapter1> candidate;
+  for (UINT i = 0;
+       factory->EnumAdapters1(i, candidate.ReleaseAndGetAddressOf()) !=
+       DXGI_ERROR_NOT_FOUND;
+       i++) {
+    DXGI_ADAPTER_DESC1 desc;
+    if (FAILED(candidate->GetDesc1(&desc))) {
+      continue;
+    }
+    static_assert(sizeof(desc.AdapterLuid) == 8,
+                  "LUID size mismatch with VK_LUID_SIZE");
+    if (std::memcmp(&desc.AdapterLuid, adapter_luid.data(), 8) == 0) {
+      adapter = candidate;
+      break;
+    }
+  }
+  if (!adapter) {
+    FML_LOG(ERROR) << "DCompPresenter: No DXGI adapter matches the Vulkan "
+                      "device LUID.";
+    return false;
+  }
+
+  UINT flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+  Microsoft::WRL::ComPtr<ID3D11Device> device;
+  Microsoft::WRL::ComPtr<ID3D11DeviceContext> context;
+  hr = ::D3D11CreateDevice(adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr,
+                           flags, nullptr, 0, D3D11_SDK_VERSION, &device,
+                           nullptr, &context);
+  if (FAILED(hr)) {
+    FML_LOG(ERROR) << "DCompPresenter: D3D11CreateDevice failed (hr=" << hr
+                   << ").";
+    return false;
+  }
+  if (FAILED(device.As(&d3d_device_))) {
+    FML_LOG(ERROR) << "DCompPresenter: ID3D11Device1 is unavailable.";
+    return false;
+  }
+  d3d_context_ = std::move(context);
+  dxgi_factory_ = std::move(factory);
+
+  Microsoft::WRL::ComPtr<IDXGIDevice> dxgi_device;
+  if (FAILED(d3d_device_.As(&dxgi_device))) {
+    FML_LOG(ERROR) << "DCompPresenter: IDXGIDevice is unavailable.";
+    return false;
+  }
+
+  hr = ::DCompositionCreateDevice(dxgi_device.Get(),
+                                  IID_PPV_ARGS(&dcomp_device_));
+  if (FAILED(hr)) {
+    FML_LOG(ERROR) << "DCompPresenter: DCompositionCreateDevice failed (hr="
+                   << hr << ").";
+    return false;
+  }
+
+  hr = dcomp_device_->CreateVisual(&dcomp_visual_);
+  if (FAILED(hr)) {
+    FML_LOG(ERROR) << "DCompPresenter: CreateVisual failed (hr=" << hr << ").";
+    return false;
+  }
+
+  return true;
+}
+
+bool DCompPresenter::BindToWindow(HWND hwnd) {
+  if (!hwnd) {
+    return false;
+  }
+  if (hwnd == bound_hwnd_) {
+    return true;
+  }
+
+  Microsoft::WRL::ComPtr<IDCompositionTarget> target;
+  HRESULT hr =
+      dcomp_device_->CreateTargetForHwnd(hwnd, /*topmost=*/TRUE, &target);
+  if (FAILED(hr)) {
+    FML_LOG(ERROR) << "DCompPresenter: CreateTargetForHwnd failed (hr=" << hr
+                   << ").";
+    return false;
+  }
+
+  hr = target->SetRoot(dcomp_visual_.Get());
+  if (FAILED(hr)) {
+    FML_LOG(ERROR) << "DCompPresenter: SetRoot failed (hr=" << hr << ").";
+    return false;
+  }
+
+  dcomp_target_ = std::move(target);
+  bound_hwnd_ = hwnd;
+  // The new target needs a commit before its content becomes visible.
+  committed_ = false;
+  return true;
+}
+
+bool DCompPresenter::EnsureSwapChain(uint32_t width, uint32_t height) {
+  if (swapchain_ && swapchain_width_ == width && swapchain_height_ == height) {
+    return true;
+  }
+
+  if (swapchain_) {
+    // Flip-model resizing requires all backbuffer references to be dropped.
+    d3d_context_->ClearState();
+    d3d_context_->Flush();
+    HRESULT hr =
+        swapchain_->ResizeBuffers(0, width, height, DXGI_FORMAT_UNKNOWN, 0);
+    if (FAILED(hr)) {
+      FML_LOG(ERROR) << "DCompPresenter: ResizeBuffers failed (hr=" << hr
+                     << ").";
+      return false;
+    }
+    swapchain_width_ = width;
+    swapchain_height_ = height;
+    return true;
+  }
+
+  DXGI_SWAP_CHAIN_DESC1 desc = {};
+  desc.Width = width;
+  desc.Height = height;
+  desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+  desc.SampleDesc.Count = 1;
+  desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+  desc.BufferCount = 2;
+  desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+  desc.AlphaMode = DXGI_ALPHA_MODE_PREMULTIPLIED;
+
+  HRESULT hr = dxgi_factory_->CreateSwapChainForComposition(
+      d3d_device_.Get(), &desc, nullptr, &swapchain_);
+  if (FAILED(hr)) {
+    FML_LOG(ERROR)
+        << "DCompPresenter: CreateSwapChainForComposition failed (hr=" << hr
+        << ").";
+    return false;
+  }
+
+  swapchain_width_ = width;
+  swapchain_height_ = height;
+
+  hr = dcomp_visual_->SetContent(swapchain_.Get());
+  if (FAILED(hr)) {
+    FML_LOG(ERROR) << "DCompPresenter: SetContent failed (hr=" << hr << ").";
+    return false;
+  }
+  committed_ = false;
+  return true;
+}
+
+HANDLE DCompPresenter::CreateSharedTexture(uint32_t width, uint32_t height) {
+  if (width == 0 || height == 0) {
+    return nullptr;
+  }
+
+  D3D11_TEXTURE2D_DESC desc = {};
+  desc.Width = width;
+  desc.Height = height;
+  desc.MipLevels = 1;
+  desc.ArraySize = 1;
+  desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+  desc.SampleDesc.Count = 1;
+  desc.Usage = D3D11_USAGE_DEFAULT;
+  desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+  desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX |
+                   D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
+
+  SharedTexture entry;
+  HRESULT hr = d3d_device_->CreateTexture2D(&desc, nullptr, &entry.texture);
+  if (FAILED(hr)) {
+    FML_LOG(ERROR) << "DCompPresenter: CreateTexture2D failed (hr=" << hr
+                   << ").";
+    return nullptr;
+  }
+  if (FAILED(entry.texture.As(&entry.keyed_mutex))) {
+    FML_LOG(ERROR) << "DCompPresenter: Shared texture has no keyed mutex.";
+    return nullptr;
+  }
+
+  Microsoft::WRL::ComPtr<IDXGIResource1> resource;
+  if (FAILED(entry.texture.As(&resource))) {
+    FML_LOG(ERROR) << "DCompPresenter: IDXGIResource1 is unavailable.";
+    return nullptr;
+  }
+
+  HANDLE nt_handle = nullptr;
+  hr = resource->CreateSharedHandle(
+      nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE, nullptr,
+      &nt_handle);
+  if (FAILED(hr) || nt_handle == nullptr) {
+    FML_LOG(ERROR) << "DCompPresenter: CreateSharedHandle failed (hr=" << hr
+                   << ").";
+    return nullptr;
+  }
+
+  texture_cache_.emplace(nt_handle, std::move(entry));
+  return nt_handle;
+}
+
+bool DCompPresenter::PresentTexture(HANDLE nt_handle,
+                                    uint32_t width,
+                                    uint32_t height) {
+  if (!nt_handle || width == 0 || height == 0) {
+    return false;
+  }
+  if (!bound_hwnd_) {
+    FML_LOG(ERROR) << "DCompPresenter: PresentTexture requires BindToWindow.";
+    return false;
+  }
+  if (!EnsureSwapChain(width, height)) {
+    return false;
+  }
+
+  auto it = texture_cache_.find(nt_handle);
+  if (it == texture_cache_.end()) {
+    FML_LOG(ERROR) << "DCompPresenter: Unknown shared texture handle.";
+    return false;
+  }
+  SharedTexture* shared = &it->second;
+
+  Microsoft::WRL::ComPtr<ID3D11Texture2D> backbuffer;
+  HRESULT hr = swapchain_->GetBuffer(0, IID_PPV_ARGS(&backbuffer));
+  if (FAILED(hr)) {
+    FML_LOG(ERROR) << "DCompPresenter: GetBuffer failed (hr=" << hr << ").";
+    return false;
+  }
+
+  hr = shared->keyed_mutex->AcquireSync(kKeyedMutexKey, kAcquireTimeoutMs);
+  if (hr != S_OK) {
+    // WAIT_TIMEOUT and abandoned-mutex results both mean the frame cannot
+    // be copied safely; drop it rather than stall the raster thread.
+    FML_LOG(ERROR) << "DCompPresenter: AcquireSync failed (hr=" << hr << ").";
+    return false;
+  }
+
+  d3d_context_->CopyResource(backbuffer.Get(), shared->texture.Get());
+  shared->keyed_mutex->ReleaseSync(kKeyedMutexKey);
+
+  hr = swapchain_->Present(0, 0);
+  if (FAILED(hr)) {
+    FML_LOG(ERROR) << "DCompPresenter: Present failed (hr=" << hr << ").";
+    return false;
+  }
+
+  // The visual tree only changes on the first present and on resize; DWM
+  // picks up swapchain presents without a new commit.
+  if (!committed_) {
+    hr = dcomp_device_->Commit();
+    if (FAILED(hr)) {
+      FML_LOG(ERROR) << "DCompPresenter: Commit failed (hr=" << hr << ").";
+      return false;
+    }
+    committed_ = true;
+  }
+
+  return true;
+}
+
+void DCompPresenter::EvictTexture(HANDLE nt_handle) {
+  auto it = texture_cache_.find(nt_handle);
+  if (it == texture_cache_.end()) {
+    return;
+  }
+  texture_cache_.erase(it);
+  ::CloseHandle(nt_handle);
+}
+
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/dcomp_presenter.h
+++ b/engine/src/flutter/shell/platform/windows/dcomp_presenter.h
@@ -1,0 +1,109 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_DCOMP_PRESENTER_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_DCOMP_PRESENTER_H_
+
+#include <d3d11_1.h>
+#include <dcomp.h>
+#include <dxgi1_3.h>
+#include <windows.h>
+#include <wrl/client.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+
+#include "flutter/fml/macros.h"
+
+namespace flutter {
+
+/// Presents Vulkan-rendered content to a window through DirectComposition.
+///
+/// The presenter owns a Direct3D 11 device on the same adapter as the Vulkan
+/// device (matched by LUID), a flip-model composition swapchain, and a
+/// DirectComposition visual tree rooted on the window. It also allocates the
+/// shared textures that Vulkan renders into: Windows drivers expose
+/// Direct3D 11 texture memory to Vulkan as import-only, so the allocation
+/// must originate here (see |CreateSharedTexture| and
+/// |VulkanImportedImage|). Each frame, the shared texture is copied into the
+/// swapchain backbuffer and presented; DWM then composes the window content
+/// and chrome in one transaction, which is what makes resizing atomic.
+///
+/// Synchronization: the engine performs a host sync for all layers before
+/// invoking the compositor present callback, so the Vulkan writes are
+/// complete before the copy. The Direct3D side still brackets its access
+/// with the shared texture's keyed mutex (acquire and release with key 0),
+/// which issues the cross-device flushes on the adapter. If a driver ever
+/// requires Vulkan-side participation in the keyed mutex, the acquire and
+/// release must additionally be chained onto the final Vulkan submission
+/// through VkWin32KeyedMutexAcquireReleaseInfoKHR; that requires an engine
+/// hook and is deliberately not part of this presenter.
+class DCompPresenter {
+ public:
+  /// Creates a presenter on the adapter identified by |adapter_luid| (from
+  /// VulkanManager::GetDeviceLUID). Returns nullptr on failure. The
+  /// presenter can allocate shared textures immediately; presentation
+  /// additionally requires |BindToWindow|.
+  static std::unique_ptr<DCompPresenter> Create(
+      const std::array<uint8_t, 8>& adapter_luid);
+
+  ~DCompPresenter();
+
+  /// Roots the composition target on |hwnd|. Idempotent for the same
+  /// window; rebinding to a different window replaces the target. Returns
+  /// false on failure.
+  bool BindToWindow(HWND hwnd);
+
+  /// Allocates a shared BGRA8 render target texture of the given size with
+  /// a keyed mutex, and returns the NT handle identifying it. Vulkan
+  /// imports the handle via |VulkanImportedImage|. Returns nullptr on
+  /// failure. The presenter owns the texture and the handle until
+  /// |EvictTexture| is called with the returned handle.
+  HANDLE CreateSharedTexture(uint32_t width, uint32_t height);
+
+  /// Copies the shared texture identified by |nt_handle| into the swapchain
+  /// and presents it. |width| and |height| are the texture dimensions; the
+  /// swapchain is resized when they change. Returns false on failure.
+  bool PresentTexture(HANDLE nt_handle, uint32_t width, uint32_t height);
+
+  /// Destroys the shared texture for |nt_handle| and closes the handle.
+  /// Call when the backing store owning the texture is collected.
+  void EvictTexture(HANDLE nt_handle);
+
+  /// The Direct3D device, exposed for tests.
+  ID3D11Device1* GetD3DDeviceForTesting() const { return d3d_device_.Get(); }
+
+ private:
+  struct SharedTexture {
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
+    Microsoft::WRL::ComPtr<IDXGIKeyedMutex> keyed_mutex;
+  };
+
+  DCompPresenter() = default;
+
+  bool Initialize(const std::array<uint8_t, 8>& adapter_luid);
+  bool EnsureSwapChain(uint32_t width, uint32_t height);
+
+  Microsoft::WRL::ComPtr<ID3D11Device1> d3d_device_;
+  Microsoft::WRL::ComPtr<ID3D11DeviceContext> d3d_context_;
+  Microsoft::WRL::ComPtr<IDXGIFactory2> dxgi_factory_;
+  Microsoft::WRL::ComPtr<IDXGISwapChain1> swapchain_;
+  Microsoft::WRL::ComPtr<IDCompositionDevice> dcomp_device_;
+  Microsoft::WRL::ComPtr<IDCompositionTarget> dcomp_target_;
+  Microsoft::WRL::ComPtr<IDCompositionVisual> dcomp_visual_;
+
+  std::unordered_map<HANDLE, SharedTexture> texture_cache_;
+  HWND bound_hwnd_ = nullptr;
+  uint32_t swapchain_width_ = 0;
+  uint32_t swapchain_height_ = 0;
+  bool committed_ = false;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DCompPresenter);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_DCOMP_PRESENTER_H_

--- a/engine/src/flutter/shell/platform/windows/dcomp_presenter_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/dcomp_presenter_unittests.cc
@@ -1,0 +1,168 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/dcomp_presenter.h"
+
+#include "flutter/shell/platform/windows/vulkan_imported_image.h"
+#include "flutter/shell/platform/windows/vulkan_manager.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+namespace {
+
+// A hidden top-level window to attach DirectComposition targets to.
+class TestWindow {
+ public:
+  TestWindow() {
+    WNDCLASS window_class = {};
+    window_class.lpszClassName = L"FlutterDCompPresenterTestWindow";
+    window_class.lpfnWndProc = ::DefWindowProc;
+    window_class.hInstance = ::GetModuleHandle(nullptr);
+    ::RegisterClass(&window_class);
+    hwnd_ = ::CreateWindowEx(0, window_class.lpszClassName, L"", WS_POPUP, 0, 0,
+                             320, 240, nullptr, nullptr, window_class.hInstance,
+                             nullptr);
+  }
+
+  ~TestWindow() {
+    if (hwnd_) {
+      ::DestroyWindow(hwnd_);
+    }
+    ::UnregisterClass(L"FlutterDCompPresenterTestWindow",
+                      ::GetModuleHandle(nullptr));
+  }
+
+  HWND hwnd() const { return hwnd_; }
+
+ private:
+  HWND hwnd_ = nullptr;
+};
+
+}  // namespace
+
+// A LUID that matches no adapter must fail creation instead of silently
+// using a different GPU, where the shared textures could not be imported
+// by the Vulkan device.
+TEST(DCompPresenterTest, CreateWithUnknownLuidFails) {
+  std::array<uint8_t, 8> bogus_luid;
+  bogus_luid.fill(0xFF);
+  EXPECT_EQ(DCompPresenter::Create(bogus_luid), nullptr);
+}
+
+// Presentation requires a window binding; texture allocation does not.
+TEST(DCompPresenterTest, PresentWithoutWindowBindingFails) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  auto presenter = DCompPresenter::Create(manager->GetDeviceLUID());
+  ASSERT_NE(presenter, nullptr);
+
+  EXPECT_FALSE(presenter->BindToWindow(nullptr));
+
+  HANDLE handle = presenter->CreateSharedTexture(64, 64);
+  ASSERT_NE(handle, nullptr);
+  EXPECT_FALSE(presenter->PresentTexture(handle, 64, 64));
+
+  presenter->EvictTexture(handle);
+}
+
+// The full interop pipeline: shared texture allocated on the Direct3D
+// side, imported into Vulkan, then copied and presented through
+// DirectComposition. This is the regression test for the Vulkan to DXGI
+// handoff itself.
+TEST(DCompPresenterTest, PresentsSharedTextureImportedByVulkan) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  TestWindow window;
+  ASSERT_NE(window.hwnd(), nullptr);
+
+  auto presenter = DCompPresenter::Create(manager->GetDeviceLUID());
+  ASSERT_NE(presenter, nullptr);
+  ASSERT_TRUE(presenter->BindToWindow(window.hwnd()));
+
+  EXPECT_EQ(presenter->CreateSharedTexture(0, 256), nullptr);
+
+  HANDLE handle = presenter->CreateSharedTexture(256, 256);
+  ASSERT_NE(handle, nullptr);
+
+  auto image = VulkanImportedImage::Import(manager.get(), handle, 256, 256);
+  ASSERT_NE(image, nullptr);
+  EXPECT_NE(image->image(), VK_NULL_HANDLE);
+
+  // First present commits the visual tree; repeats exercise the steady
+  // state and the keyed mutex round trips.
+  EXPECT_TRUE(presenter->PresentTexture(handle, 256, 256));
+  EXPECT_TRUE(presenter->PresentTexture(handle, 256, 256));
+  EXPECT_TRUE(presenter->PresentTexture(handle, 256, 256));
+
+  // The imported image must be released before the texture is evicted:
+  // this mirrors the backing store collect order in the compositor.
+  image.reset();
+  presenter->EvictTexture(handle);
+  EXPECT_FALSE(presenter->PresentTexture(handle, 256, 256));
+}
+
+// A size change resizes the swapchain in place and keeps presenting.
+TEST(DCompPresenterTest, ResizeRecreatesSwapchainBuffers) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  TestWindow window;
+  ASSERT_NE(window.hwnd(), nullptr);
+
+  auto presenter = DCompPresenter::Create(manager->GetDeviceLUID());
+  ASSERT_NE(presenter, nullptr);
+  ASSERT_TRUE(presenter->BindToWindow(window.hwnd()));
+
+  // Note: |small| is a macro in the Windows headers; avoid it as a name.
+  HANDLE small_texture = presenter->CreateSharedTexture(256, 256);
+  HANDLE large_texture = presenter->CreateSharedTexture(512, 384);
+  ASSERT_NE(small_texture, nullptr);
+  ASSERT_NE(large_texture, nullptr);
+
+  EXPECT_TRUE(presenter->PresentTexture(small_texture, 256, 256));
+  EXPECT_TRUE(presenter->PresentTexture(large_texture, 512, 384));
+  EXPECT_TRUE(presenter->PresentTexture(small_texture, 256, 256));
+
+  presenter->EvictTexture(small_texture);
+  presenter->EvictTexture(large_texture);
+}
+
+// Repeated allocate, import, and evict cycles model the engine collecting
+// and recreating backing stores across resizes; nothing may leak or crash.
+TEST(DCompPresenterTest, RepeatedSharedTextureLifecycle) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  TestWindow window;
+  ASSERT_NE(window.hwnd(), nullptr);
+
+  auto presenter = DCompPresenter::Create(manager->GetDeviceLUID());
+  ASSERT_NE(presenter, nullptr);
+  ASSERT_TRUE(presenter->BindToWindow(window.hwnd()));
+
+  for (int i = 0; i < 8; i++) {
+    HANDLE handle = presenter->CreateSharedTexture(128 + i, 128 + i);
+    ASSERT_NE(handle, nullptr);
+    auto image =
+        VulkanImportedImage::Import(manager.get(), handle, 128 + i, 128 + i);
+    ASSERT_NE(image, nullptr);
+    image.reset();
+    presenter->EvictTexture(handle);
+  }
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
@@ -21,11 +21,13 @@
 #include "flutter/shell/platform/windows/accessibility_bridge_windows.h"
 #include "flutter/shell/platform/windows/compositor_opengl.h"
 #include "flutter/shell/platform/windows/compositor_software.h"
+#include "flutter/shell/platform/windows/compositor_vulkan.h"
 #include "flutter/shell/platform/windows/display_manager.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/keyboard_key_channel_handler.h"
 #include "flutter/shell/platform/windows/system_utils.h"
 #include "flutter/shell/platform/windows/task_runner.h"
+#include "flutter/shell/platform/windows/vulkan_manager.h"
 #include "flutter/shell/platform/windows/window_manager.h"
 #include "flutter/third_party/accessibility/ax/ax_node.h"
 #include "shell/platform/windows/flutter_project_bundle.h"
@@ -98,6 +100,52 @@ FlutterRendererConfig GetOpenGLRendererConfig() {
     }
     return host->texture_registrar()->PopulateTexture(texture_id, width, height,
                                                       texture);
+  };
+  return config;
+}
+
+// Creates and returns a FlutterRendererConfig for Impeller's Vulkan backend.
+// The user_data received by the render callbacks refers to the
+// FlutterWindowsEngine. Rendering targets and presentation are handled by
+// the compositor (CompositorVulkan), so the image callbacks are never
+// invoked; they exist to satisfy the renderer config validation.
+FlutterRendererConfig GetVulkanRendererConfig(VulkanManager* vulkan_manager) {
+  FlutterRendererConfig config = {};
+  config.type = kVulkan;
+  config.vulkan.struct_size = sizeof(config.vulkan);
+  config.vulkan.version = vulkan_manager->GetVulkanVersion();
+  config.vulkan.instance = vulkan_manager->GetInstance();
+  config.vulkan.physical_device = vulkan_manager->GetPhysicalDevice();
+  config.vulkan.device = vulkan_manager->GetDevice();
+  config.vulkan.queue_family_index = vulkan_manager->GetQueueFamilyIndex();
+  config.vulkan.queue = vulkan_manager->GetQueue();
+  config.vulkan.enabled_instance_extensions =
+      vulkan_manager->GetEnabledInstanceExtensions(
+          &config.vulkan.enabled_instance_extension_count);
+  config.vulkan.enabled_device_extensions =
+      vulkan_manager->GetEnabledDeviceExtensions(
+          &config.vulkan.enabled_device_extension_count);
+  config.vulkan.get_instance_proc_address_callback =
+      [](void* user_data, FlutterVulkanInstanceHandle instance,
+         const char* name) -> void* {
+    auto host = static_cast<FlutterWindowsEngine*>(user_data);
+    return host->vulkan_manager()->GetInstanceProcAddress(
+        reinterpret_cast<VkInstance>(instance), name);
+  };
+  // The image callbacks are only used when the engine renders to the root
+  // surface. The Windows embedder always supplies a compositor, which makes
+  // the root surface a no-op; content is rendered into backing stores
+  // instead. This matches GetOpenGLRendererConfig.
+  config.vulkan.get_next_image_callback =
+      [](void* user_data,
+         const FlutterFrameInfo* frame_info) -> FlutterVulkanImage {
+    FML_UNREACHABLE();
+    return {};
+  };
+  config.vulkan.present_image_callback =
+      [](void* user_data, const FlutterVulkanImage* image) -> bool {
+    FML_UNREACHABLE();
+    return false;
   };
   return config;
 }
@@ -210,8 +258,26 @@ FlutterWindowsEngine::FlutterWindowsEngine(
   }
   enable_impeller_ = enable_impeller;
 
-  egl_manager_ = egl::Manager::Create(
-      static_cast<egl::GpuPreference>(project_->gpu_preference()));
+  // Check for an explicit Impeller backend request. The Vulkan backend is
+  // used when it is requested, Impeller is enabled, and a device capable of
+  // Direct3D 11 interop exists; VulkanManager::Create() otherwise returns
+  // null and the existing ANGLE and software paths are used.
+  bool vulkan_requested = false;
+  for (const auto& env_switch : switches) {
+    if (env_switch == "--impeller-backend=vulkan") {
+      vulkan_requested = true;
+    }
+  }
+  if (enable_impeller_ && vulkan_requested) {
+    vulkan_manager_ = VulkanManager::Create();
+  }
+
+  // The Vulkan backend renders and presents without ANGLE; do not
+  // initialize EGL when it is active.
+  if (!vulkan_manager_) {
+    egl_manager_ = egl::Manager::Create(
+        static_cast<egl::GpuPreference>(project_->gpu_preference()));
+  }
   window_proc_delegate_manager_ = std::make_unique<WindowProcDelegateManager>();
 
   display_manager_ = std::make_shared<DisplayManagerWin32>(this);
@@ -304,7 +370,11 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
   std::vector<const char*> argv = {executable_name.c_str()};
   std::vector<std::string> switches = project_->GetSwitches();
   if (enable_impeller_) {
-    if (std::find(switches.begin(), switches.end(),
+    // SDF rendering is enabled by default for the ANGLE/OpenGL Impeller
+    // backend. The Vulkan backend does not use it, so only apply the default
+    // when Vulkan is not active. Respect an explicit request either way.
+    if (!vulkan_manager_ &&
+        std::find(switches.begin(), switches.end(),
                   "--impeller-use-sdfs=true") == switches.end() &&
         std::find(switches.begin(), switches.end(),
                   "--impeller-use-sdfs=false") == switches.end()) {
@@ -463,7 +533,9 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
     platform_view_plugin_ = std::make_unique<PlatformViewPlugin>(
         messenger_wrapper_.get(), task_runner_.get());
   }
-  if (egl_manager_) {
+  if (vulkan_manager_) {
+    compositor_ = std::make_unique<CompositorVulkan>(this);
+  } else if (egl_manager_) {
     auto resolver = [](const char* name) -> void* {
       return reinterpret_cast<void*>(::eglGetProcAddress(name));
     };
@@ -512,7 +584,9 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
 
   FlutterRendererConfig renderer_config;
 
-  if (enable_impeller_) {
+  if (vulkan_manager_) {
+    renderer_config = GetVulkanRendererConfig(vulkan_manager_.get());
+  } else if (enable_impeller_) {
     // Impeller does not support a Software backend. Avoid falling back and
     // confusing the engine on which renderer is selected.
     if (!egl_manager_) {

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
@@ -57,6 +57,7 @@ constexpr FlutterViewId kImplicitViewId = 0;
 
 class FlutterWindowsView;
 class DisplayManagerWin32;
+class VulkanManager;
 
 // Update the thread priority for the Windows engine.
 static void WindowsPlatformThreadPrioritySetter(
@@ -181,6 +182,12 @@ class FlutterWindowsEngine {
   // The EGL manager object. If this is nullptr, then we are
   // rendering using software instead of OpenGL.
   egl::Manager* egl_manager() const { return egl_manager_.get(); }
+
+  // The Vulkan manager object. Non-null only when the Vulkan Impeller
+  // backend was requested through --impeller-backend=vulkan and a capable
+  // device exists; rendering then uses Impeller's Vulkan backend presented
+  // through DirectComposition instead of ANGLE.
+  VulkanManager* vulkan_manager() const { return vulkan_manager_.get(); }
 
   WindowProcDelegateManager* window_proc_delegate_manager() {
     return window_proc_delegate_manager_.get();
@@ -526,6 +533,10 @@ class FlutterWindowsEngine {
   std::shared_ptr<WindowsProcTable> windows_proc_table_;
 
   std::shared_ptr<egl::ProcTable> gl_;
+
+  // Non-null only when the Vulkan Impeller backend is active. See
+  // |vulkan_manager()|.
+  std::unique_ptr<VulkanManager> vulkan_manager_;
 
   std::unique_ptr<PlatformViewPlugin> platform_view_plugin_;
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -534,6 +534,68 @@ TEST_F(FlutterWindowsEngineTest, RunWithProjectFlagEnableImpeller) {
   modifier.ReleaseEGLManager();
 }
 
+TEST_F(FlutterWindowsEngineTest, VulkanBackendDoesNotEnableSdfs) {
+  FlutterWindowsEngineBuilder builder{GetContext()};
+  // Request the Vulkan Impeller backend. It is only activated when a device
+  // capable of Direct3D 11 interop is present.
+  builder.SetSwitches({"--enable-impeller=true", "--impeller-backend=vulkan"});
+  std::unique_ptr<FlutterWindowsEngine> engine = builder.Build();
+  if (!engine->vulkan_manager()) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+  EngineModifier modifier(engine.get());
+
+  modifier.embedder_api().NotifyDisplayUpdate =
+      MOCK_ENGINE_PROC(NotifyDisplayUpdate,
+                       ([](FLUTTER_API_SYMBOL(FlutterEngine) raw_engine,
+                           const FlutterEngineDisplaysUpdateType update_type,
+                           const FlutterEngineDisplay* embedder_displays,
+                           size_t display_count) { return kSuccess; }));
+
+  modifier.embedder_api().UpdateAccessibilityFeatures = MOCK_ENGINE_PROC(
+      UpdateAccessibilityFeatures,
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+         FlutterAccessibilityFeature flags) { return kSuccess; });
+
+  modifier.embedder_api().UpdateLocales = MOCK_ENGINE_PROC(
+      UpdateLocales, ([](auto engine, const FlutterLocale** locales,
+                         size_t locales_count) { return kSuccess; }));
+
+  modifier.embedder_api().SendPlatformMessage =
+      MOCK_ENGINE_PROC(SendPlatformMessage,
+                       ([](auto engine, auto message) { return kSuccess; }));
+
+  bool run_called = false;
+  modifier.embedder_api().Run = MOCK_ENGINE_PROC(
+      Run, ([&run_called](size_t version, const FlutterRendererConfig* config,
+                          const FlutterProjectArgs* args, void* user_data,
+                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+        run_called = true;
+        *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
+
+        // SDF rendering is an ANGLE/OpenGL Impeller default. The Vulkan
+        // backend must not enable it (it is unsupported there), so the
+        // switch must be absent even though Impeller is enabled.
+        bool has_sdf_switch = false;
+        for (int i = 0; i < args->command_line_argc; ++i) {
+          if (strcmp(args->command_line_argv[i], "--impeller-use-sdfs=true") ==
+              0) {
+            has_sdf_switch = true;
+          }
+        }
+        EXPECT_FALSE(has_sdf_switch);
+        EXPECT_EQ(config->type, kVulkan);
+        return kSuccess;
+      }));
+
+  // The Vulkan backend renders without ANGLE, so no EGL manager is set.
+  engine->Run();
+
+  EXPECT_TRUE(run_called);
+
+  modifier.embedder_api().Shutdown = [](auto engine) { return kSuccess; };
+}
+
 TEST_F(FlutterWindowsEngineTest, RunWithProjectFlagDisableImpeller) {
   FlutterWindowsEngineBuilder builder{GetContext()};
   builder.SetImpellerSwitch(DisabledImpeller);
@@ -932,6 +994,37 @@ TEST_F(FlutterWindowsEngineTest, GetExecutableName) {
   FlutterWindowsEngineBuilder builder{GetContext()};
   std::unique_ptr<FlutterWindowsEngine> engine = builder.Build();
   EXPECT_EQ(engine->GetExecutableName(), "flutter_windows_unittests.exe");
+}
+
+// The Vulkan backend must never initialize without an explicit
+// --impeller-backend=vulkan request; ANGLE remains the Impeller default.
+TEST_F(FlutterWindowsEngineTest, VulkanRequiresExplicitBackendSwitch) {
+  FlutterWindowsEngineBuilder builder{GetContext()};
+  builder.SetSwitches({"--enable-impeller=true"});
+  std::unique_ptr<FlutterWindowsEngine> engine = builder.Build();
+  EXPECT_EQ(engine->vulkan_manager(), nullptr);
+}
+
+// The Vulkan backend request only takes effect when Impeller is enabled.
+TEST_F(FlutterWindowsEngineTest, VulkanBackendIgnoredWithoutImpeller) {
+  FlutterWindowsEngineBuilder builder{GetContext()};
+  builder.SetSwitches({"--enable-impeller=false", "--impeller-backend=vulkan"});
+  std::unique_ptr<FlutterWindowsEngine> engine = builder.Build();
+  EXPECT_EQ(engine->vulkan_manager(), nullptr);
+}
+
+// When the Vulkan backend is requested, either the Vulkan manager comes up
+// (and ANGLE is skipped entirely) or the engine falls back to the existing
+// paths without failing engine construction.
+TEST_F(FlutterWindowsEngineTest, VulkanBackendSelectsVulkanOrFallsBack) {
+  FlutterWindowsEngineBuilder builder{GetContext()};
+  builder.SetSwitches({"--enable-impeller=true", "--impeller-backend=vulkan"});
+  std::unique_ptr<FlutterWindowsEngine> engine = builder.Build();
+  ASSERT_NE(engine, nullptr);
+  if (engine->vulkan_manager() != nullptr) {
+    // Vulkan is active: the ANGLE path must not be initialized.
+    EXPECT_EQ(engine->egl_manager(), nullptr);
+  }
 }
 
 // Ensure that after setting or resetting the high contrast feature,

--- a/engine/src/flutter/shell/platform/windows/vulkan_imported_image.cc
+++ b/engine/src/flutter/shell/platform/windows/vulkan_imported_image.cc
@@ -1,0 +1,165 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/vulkan_imported_image.h"
+
+#include "flutter/fml/logging.h"
+
+namespace flutter {
+
+namespace {
+
+// Finds a device-local memory type from |type_bits|. Returns UINT32_MAX if
+// none exists.
+uint32_t FindDeviceLocalMemoryType(
+    const VkPhysicalDeviceMemoryProperties& props,
+    uint32_t type_bits) {
+  for (uint32_t i = 0; i < props.memoryTypeCount; i++) {
+    if (!(type_bits & (1u << i))) {
+      continue;
+    }
+    if (props.memoryTypes[i].propertyFlags &
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
+      return i;
+    }
+  }
+  return UINT32_MAX;
+}
+
+}  // namespace
+
+// static
+std::unique_ptr<VulkanImportedImage> VulkanImportedImage::Import(
+    VulkanManager* manager,
+    HANDLE nt_handle,
+    uint32_t width,
+    uint32_t height) {
+  FML_DCHECK(manager != nullptr);
+  if (nt_handle == nullptr || width == 0 || height == 0) {
+    return nullptr;
+  }
+
+  VkInstance instance = manager->GetInstance();
+  VkDevice device = manager->GetDevice();
+  auto* vk = manager->GetProcTable();
+
+  auto get_image_memory_requirements =
+      reinterpret_cast<PFN_vkGetImageMemoryRequirements>(
+          manager->GetInstanceProcAddress(instance,
+                                          "vkGetImageMemoryRequirements"));
+  auto get_memory_properties =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceMemoryProperties>(
+          manager->GetInstanceProcAddress(
+              instance, "vkGetPhysicalDeviceMemoryProperties"));
+  if (!get_image_memory_requirements || !get_memory_properties) {
+    FML_LOG(ERROR) << "Failed to resolve memory entry points.";
+    return nullptr;
+  }
+
+  // The image mirrors the Direct3D texture: BGRA8, one mip, one layer,
+  // usable as a color attachment (Impeller's onscreen resolve target) and
+  // as a transfer source.
+  VkExternalMemoryImageCreateInfo external_info = {};
+  external_info.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+  external_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
+
+  VkImageCreateInfo image_info = {};
+  image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+  image_info.pNext = &external_info;
+  image_info.imageType = VK_IMAGE_TYPE_2D;
+  image_info.format = VK_FORMAT_B8G8R8A8_UNORM;
+  image_info.extent = {width, height, 1};
+  image_info.mipLevels = 1;
+  image_info.arrayLayers = 1;
+  image_info.samples = VK_SAMPLE_COUNT_1_BIT;
+  image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+  image_info.usage =
+      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+  image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+  VkImage image = VK_NULL_HANDLE;
+  VkResult result = vk->CreateImage(device, &image_info, nullptr, &image);
+  if (result != VK_SUCCESS) {
+    FML_LOG(ERROR) << "Failed to create importable VkImage (result=" << result
+                   << ").";
+    return nullptr;
+  }
+
+  VkMemoryRequirements requirements = {};
+  get_image_memory_requirements(device, image, &requirements);
+
+  VkPhysicalDeviceMemoryProperties memory_props = {};
+  get_memory_properties(manager->GetPhysicalDevice(), &memory_props);
+
+  uint32_t memory_type =
+      FindDeviceLocalMemoryType(memory_props, requirements.memoryTypeBits);
+  if (memory_type == UINT32_MAX) {
+    FML_LOG(ERROR) << "No device-local memory type for imported image.";
+    vk->DestroyImage(device, image, nullptr);
+    return nullptr;
+  }
+
+  // Direct3D 11 texture imports require a dedicated allocation.
+  VkMemoryDedicatedAllocateInfo dedicated_info = {};
+  dedicated_info.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+  dedicated_info.image = image;
+
+  VkImportMemoryWin32HandleInfoKHR import_info = {};
+  import_info.sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
+  import_info.pNext = &dedicated_info;
+  import_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
+  import_info.handle = nt_handle;
+
+  VkMemoryAllocateInfo alloc_info = {};
+  alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  alloc_info.pNext = &import_info;
+  alloc_info.allocationSize = requirements.size;
+  alloc_info.memoryTypeIndex = memory_type;
+
+  VkDeviceMemory memory = VK_NULL_HANDLE;
+  result = vk->AllocateMemory(device, &alloc_info, nullptr, &memory);
+  if (result != VK_SUCCESS) {
+    FML_LOG(ERROR) << "Failed to import Direct3D texture memory (result="
+                   << result << ").";
+    vk->DestroyImage(device, image, nullptr);
+    return nullptr;
+  }
+
+  result = vk->BindImageMemory(device, image, memory, 0);
+  if (result != VK_SUCCESS) {
+    FML_LOG(ERROR) << "Failed to bind imported image memory (result=" << result
+                   << ").";
+    vk->FreeMemory(device, memory, nullptr);
+    vk->DestroyImage(device, image, nullptr);
+    return nullptr;
+  }
+
+  return std::unique_ptr<VulkanImportedImage>(
+      new VulkanImportedImage(manager, image, memory, width, height));
+}
+
+VulkanImportedImage::VulkanImportedImage(VulkanManager* manager,
+                                         VkImage image,
+                                         VkDeviceMemory memory,
+                                         uint32_t width,
+                                         uint32_t height)
+    : manager_(manager),
+      image_(image),
+      memory_(memory),
+      width_(width),
+      height_(height) {}
+
+VulkanImportedImage::~VulkanImportedImage() {
+  auto* vk = manager_->GetProcTable();
+  VkDevice device = manager_->GetDevice();
+  if (image_ != VK_NULL_HANDLE) {
+    vk->DestroyImage(device, image_, nullptr);
+  }
+  if (memory_ != VK_NULL_HANDLE) {
+    vk->FreeMemory(device, memory_, nullptr);
+  }
+}
+
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/vulkan_imported_image.h
+++ b/engine/src/flutter/shell/platform/windows/vulkan_imported_image.h
@@ -1,0 +1,67 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_VULKAN_IMPORTED_IMAGE_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_VULKAN_IMPORTED_IMAGE_H_
+
+#include <windows.h>
+
+#include <cstdint>
+#include <memory>
+
+#include "flutter/fml/macros.h"
+#include "flutter/shell/platform/windows/vulkan_manager.h"
+
+namespace flutter {
+
+/// A VkImage bound to the memory of a shared Direct3D 11 texture.
+///
+/// The texture is allocated on the Direct3D side (see
+/// |DCompPresenter::CreateSharedTexture|) with a keyed mutex and an NT
+/// handle; this class imports that handle into Vulkan so Impeller can render
+/// into the same GPU allocation that DirectComposition later presents.
+/// Windows drivers expose Direct3D 11 texture memory to Vulkan as
+/// import-only, which is why the allocation cannot originate on the Vulkan
+/// side.
+///
+/// The NT handle stays owned by the caller; the import duplicates the
+/// underlying reference, so the imported image remains valid independently
+/// of when the caller closes the handle.
+///
+/// One imported image backs one engine backing store.
+class VulkanImportedImage {
+ public:
+  /// Imports the Direct3D texture behind |nt_handle| as a VkImage of the
+  /// given size. Returns nullptr on failure. |manager| must outlive the
+  /// returned image.
+  static std::unique_ptr<VulkanImportedImage> Import(VulkanManager* manager,
+                                                     HANDLE nt_handle,
+                                                     uint32_t width,
+                                                     uint32_t height);
+
+  ~VulkanImportedImage();
+
+  VkImage image() const { return image_; }
+  uint32_t width() const { return width_; }
+  uint32_t height() const { return height_; }
+
+ private:
+  VulkanImportedImage(VulkanManager* manager,
+                      VkImage image,
+                      VkDeviceMemory memory,
+                      uint32_t width,
+                      uint32_t height);
+
+  VulkanManager* manager_;
+  VkImage image_ = VK_NULL_HANDLE;
+  VkDeviceMemory memory_ = VK_NULL_HANDLE;
+  uint32_t width_ = 0;
+  uint32_t height_ = 0;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(VulkanImportedImage);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_VULKAN_IMPORTED_IMAGE_H_

--- a/engine/src/flutter/shell/platform/windows/vulkan_imported_image_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/vulkan_imported_image_unittests.cc
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/vulkan_imported_image.h"
+
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+// Invalid arguments must be rejected before any Vulkan call. The
+// import pipeline itself is covered by DCompPresenterTest, which owns the
+// Direct3D side of the shared texture.
+TEST(VulkanImportedImageTest, RejectsInvalidArguments) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  HANDLE fake_handle = reinterpret_cast<HANDLE>(0x1);
+  EXPECT_EQ(VulkanImportedImage::Import(manager.get(), nullptr, 100, 100),
+            nullptr);
+  EXPECT_EQ(VulkanImportedImage::Import(manager.get(), fake_handle, 0, 100),
+            nullptr);
+  EXPECT_EQ(VulkanImportedImage::Import(manager.get(), fake_handle, 100, 0),
+            nullptr);
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/vulkan_manager.cc
+++ b/engine/src/flutter/shell/platform/windows/vulkan_manager.cc
@@ -1,0 +1,534 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/vulkan_manager.h"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "flutter/fml/logging.h"
+
+namespace flutter {
+
+namespace {
+
+// The Windows Vulkan loader. VulkanProcTable's default constructor loads
+// the Linux library name, so the name must be spelled out here.
+constexpr char kVulkanLoaderLibraryName[] = "vulkan-1.dll";
+
+}  // namespace
+
+// static
+std::unique_ptr<VulkanManager> VulkanManager::Create() {
+  auto manager = std::unique_ptr<VulkanManager>(new VulkanManager());
+  if (!manager->Initialize()) {
+    FML_LOG(WARNING) << "Failed to initialize Vulkan for Direct3D 11 interop. "
+                        "Falling back to ANGLE or software rendering.";
+    return nullptr;
+  }
+  return manager;
+}
+
+// static
+bool VulkanManager::IsAvailable() {
+  auto vk =
+      fml::MakeRefCounted<vulkan::VulkanProcTable>(kVulkanLoaderLibraryName);
+  return vk->HasAcquiredMandatoryProcAddresses();
+}
+
+VulkanManager::VulkanManager() = default;
+
+VulkanManager::~VulkanManager() {
+  // Wait for all GPU work to complete before destroying resources.
+  // Per Vulkan spec VUID-vkDestroyDevice-device-00378, the device must
+  // be idle before destruction.
+  if (device_ != VK_NULL_HANDLE && vk_ &&
+      static_cast<bool>(vk_->DeviceWaitIdle)) {
+    vk_->DeviceWaitIdle(device_);
+  }
+
+  if (device_ != VK_NULL_HANDLE && vk_ &&
+      static_cast<bool>(vk_->DestroyDevice)) {
+    vk_->DestroyDevice(device_, nullptr);
+    device_ = VK_NULL_HANDLE;
+  }
+
+  if (instance_ != VK_NULL_HANDLE && vk_ &&
+      static_cast<bool>(vk_->DestroyInstance)) {
+    vk_->DestroyInstance(instance_, nullptr);
+    instance_ = VK_NULL_HANDLE;
+  }
+}
+
+// static
+std::unordered_set<std::string> VulkanManager::BuildExtensionSet(
+    const std::vector<VkExtensionProperties>& extensions) {
+  std::unordered_set<std::string> set;
+  for (const auto& ext : extensions) {
+    set.insert(ext.extensionName);
+  }
+  return set;
+}
+
+bool VulkanManager::Initialize() {
+  vk_ = fml::MakeRefCounted<vulkan::VulkanProcTable>(kVulkanLoaderLibraryName);
+  if (!vk_->HasAcquiredMandatoryProcAddresses()) {
+    FML_LOG(ERROR) << "Failed to load vulkan-1.dll or resolve required "
+                      "Vulkan entry points.";
+    return false;
+  }
+
+  // Query the highest available Vulkan version. vkEnumerateInstanceVersion
+  // is resolved through the loader directly (with a null instance, as the
+  // spec requires for global commands); it only exists on Vulkan 1.1+
+  // loaders, and its absence means a 1.0 loader.
+  auto global_get_proc = vk_->NativeGetInstanceProcAddr();
+  auto enumerate_instance_version =
+      reinterpret_cast<PFN_vkEnumerateInstanceVersion>(
+          global_get_proc(nullptr, "vkEnumerateInstanceVersion"));
+  if (enumerate_instance_version) {
+    uint32_t api_version = 0;
+    if (enumerate_instance_version(&api_version) == VK_SUCCESS) {
+      vulkan_version_ = api_version;
+    }
+  }
+
+  // Impeller requires Vulkan 1.1 at minimum; so does querying the device
+  // LUID and external memory capabilities used below.
+  if (vulkan_version_ < VK_API_VERSION_1_1) {
+    FML_LOG(ERROR) << "VulkanManager: Vulkan 1.1 or later is required (found "
+                   << VK_VERSION_MAJOR(vulkan_version_) << "."
+                   << VK_VERSION_MINOR(vulkan_version_) << ").";
+    return false;
+  }
+
+  // No instance extensions are required: presentation happens on the DXGI
+  // side, so no VK_KHR_surface / VK_KHR_win32_surface, and the external
+  // memory capability queries are core in Vulkan 1.1.
+  enabled_instance_extensions_ = {};
+
+  uint32_t available_ext_count = 0;
+  if (vk_->EnumerateInstanceExtensionProperties(nullptr, &available_ext_count,
+                                                nullptr) != VK_SUCCESS) {
+    FML_LOG(ERROR) << "VulkanManager: Failed to enumerate instance extensions.";
+    return false;
+  }
+
+  std::vector<VkExtensionProperties> available_extensions(available_ext_count);
+  if (vk_->EnumerateInstanceExtensionProperties(nullptr, &available_ext_count,
+                                                available_extensions.data()) !=
+      VK_SUCCESS) {
+    FML_LOG(ERROR) << "VulkanManager: Failed to enumerate instance extensions.";
+    return false;
+  }
+
+  available_instance_extensions_ = BuildExtensionSet(available_extensions);
+
+  // Enable validation layers in debug builds if requested.
+#if !defined(NDEBUG)
+  {
+    const char* env = std::getenv("FLUTTER_VULKAN_VALIDATION");
+    if (env && strcmp(env, "1") == 0) {
+      uint32_t layer_count = 0;
+      if (vk_->EnumerateInstanceLayerProperties(&layer_count, nullptr) ==
+              VK_SUCCESS &&
+          layer_count > 0) {
+        std::vector<VkLayerProperties> available_layers(layer_count);
+        if (vk_->EnumerateInstanceLayerProperties(
+                &layer_count, available_layers.data()) == VK_SUCCESS) {
+          const char* validation_layer = "VK_LAYER_KHRONOS_validation";
+          for (const auto& layer : available_layers) {
+            if (strcmp(validation_layer, layer.layerName) == 0) {
+              enabled_layers_.push_back(validation_layer);
+              FML_LOG(INFO)
+                  << "VulkanManager: Enabling Vulkan validation layers.";
+              // Also enable the debug utils and validation features
+              // extensions required by Impeller's DebugReportVK.
+              if (available_instance_extensions_.count(
+                      VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+                enabled_instance_extensions_.push_back(
+                    VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+              }
+              if (available_instance_extensions_.count(
+                      VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME)) {
+                enabled_instance_extensions_.push_back(
+                    VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+              }
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+#endif
+
+  // Create the VkInstance.
+  VkApplicationInfo app_info = {};
+  app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+  app_info.pApplicationName = "Flutter";
+  app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+  app_info.pEngineName = "Flutter Engine";
+  app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+  app_info.apiVersion = vulkan_version_;
+
+  VkInstanceCreateInfo instance_info = {};
+  instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+  instance_info.pApplicationInfo = &app_info;
+  instance_info.enabledExtensionCount =
+      static_cast<uint32_t>(enabled_instance_extensions_.size());
+  instance_info.ppEnabledExtensionNames =
+      enabled_instance_extensions_.empty()
+          ? nullptr
+          : enabled_instance_extensions_.data();
+  instance_info.enabledLayerCount =
+      static_cast<uint32_t>(enabled_layers_.size());
+  instance_info.ppEnabledLayerNames =
+      enabled_layers_.empty() ? nullptr : enabled_layers_.data();
+
+  VkResult result = vk_->CreateInstance(&instance_info, nullptr, &instance_);
+  if (result != VK_SUCCESS) {
+    FML_LOG(ERROR) << "VulkanManager: Failed to create VkInstance (result="
+                   << result << ").";
+    return false;
+  }
+
+  if (!vk_->SetupInstanceProcAddresses(
+          vulkan::VulkanHandle<VkInstance>(instance_))) {
+    FML_LOG(ERROR) << "VulkanManager: Failed to setup instance proc addresses.";
+    return false;
+  }
+
+  if (!SelectPhysicalDevice()) {
+    FML_LOG(ERROR) << "VulkanManager: No Vulkan device supports Direct3D 11 "
+                      "image export.";
+    return false;
+  }
+
+  if (!CreateLogicalDevice()) {
+    FML_LOG(ERROR) << "VulkanManager: Failed to create Vulkan logical device.";
+    return false;
+  }
+
+  // Log the selected device.
+  if (static_cast<bool>(vk_->GetPhysicalDeviceProperties)) {
+    VkPhysicalDeviceProperties props;
+    vk_->GetPhysicalDeviceProperties(physical_device_, &props);
+    FML_DLOG(INFO) << "VulkanManager: Using Vulkan device: "
+                   << props.deviceName;
+  }
+
+  return true;
+}
+
+bool VulkanManager::SupportsD3D11Interop(
+    VkPhysicalDevice device,
+    std::array<uint8_t, VK_LUID_SIZE>* out_luid) const {
+  auto get_proc = vk_->NativeGetInstanceProcAddr();
+
+  // The adapter LUID identifies the same GPU on the DXGI side. Without a
+  // valid LUID the exported images could land on a different adapter.
+  auto vkGetPhysicalDeviceProperties2 =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2>(
+          get_proc(instance_, "vkGetPhysicalDeviceProperties2"));
+  if (!vkGetPhysicalDeviceProperties2) {
+    return false;
+  }
+
+  VkPhysicalDeviceIDProperties id_props = {};
+  id_props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+
+  VkPhysicalDeviceProperties2 props2 = {};
+  props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+  props2.pNext = &id_props;
+  vkGetPhysicalDeviceProperties2(device, &props2);
+
+  if (!id_props.deviceLUIDValid) {
+    FML_DLOG(INFO) << "VulkanManager: '" << props2.properties.deviceName
+                   << "' reports no valid adapter LUID.";
+    return false;
+  }
+  if (out_luid) {
+    std::memcpy(out_luid->data(), id_props.deviceLUID, VK_LUID_SIZE);
+  }
+
+  // The render targets must be exportable as Direct3D 11 textures.
+  auto vkGetPhysicalDeviceImageFormatProperties2 =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceImageFormatProperties2>(
+          get_proc(instance_, "vkGetPhysicalDeviceImageFormatProperties2"));
+  if (!vkGetPhysicalDeviceImageFormatProperties2) {
+    return false;
+  }
+
+  VkPhysicalDeviceExternalImageFormatInfo external_info = {};
+  external_info.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
+  external_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
+
+  VkPhysicalDeviceImageFormatInfo2 format_info = {};
+  format_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
+  format_info.pNext = &external_info;
+  format_info.format = VK_FORMAT_B8G8R8A8_UNORM;
+  format_info.type = VK_IMAGE_TYPE_2D;
+  format_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+  // Color attachment and transfer source only: the exported image is the
+  // resolve target of the onscreen pass and the source of the Direct3D
+  // copy. Input attachment usage is deliberately absent; drivers commonly
+  // reject it for externally exportable images, and framebuffer fetch is
+  // not used on the exported image.
+  format_info.usage =
+      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+
+  VkExternalImageFormatProperties external_props = {};
+  external_props.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
+
+  VkImageFormatProperties2 format_props = {};
+  format_props.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
+  format_props.pNext = &external_props;
+
+  VkResult format_result = vkGetPhysicalDeviceImageFormatProperties2(
+      device, &format_info, &format_props);
+  if (format_result != VK_SUCCESS) {
+    FML_DLOG(INFO) << "VulkanManager: '" << props2.properties.deviceName
+                   << "' rejects exportable image creation (result="
+                   << format_result << ").";
+    return false;
+  }
+
+  // Windows drivers report Direct3D 11 texture memory as importable into
+  // Vulkan, not exportable from it (observed on AMD as DEDICATED_ONLY |
+  // IMPORTABLE). The interop therefore allocates the shared texture on the
+  // Direct3D side and imports it here, which is also the canonical
+  // direction used by other Vulkan-on-Windows compositor integrations.
+  constexpr VkExternalMemoryFeatureFlags kRequiredFeatures =
+      VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT;
+  VkExternalMemoryFeatureFlags features =
+      external_props.externalMemoryProperties.externalMemoryFeatures;
+  if ((features & kRequiredFeatures) != kRequiredFeatures) {
+    FML_DLOG(INFO) << "VulkanManager: '" << props2.properties.deviceName
+                   << "' cannot import Direct3D 11 textures (features="
+                   << features << ").";
+    return false;
+  }
+  return true;
+}
+
+bool VulkanManager::SelectPhysicalDevice() {
+  uint32_t device_count = 0;
+  if (vk_->EnumeratePhysicalDevices(instance_, &device_count, nullptr) !=
+          VK_SUCCESS ||
+      device_count == 0) {
+    FML_LOG(ERROR) << "VulkanManager: No Vulkan physical devices found.";
+    return false;
+  }
+
+  std::vector<VkPhysicalDevice> devices(device_count);
+  if (vk_->EnumeratePhysicalDevices(instance_, &device_count, devices.data()) !=
+      VK_SUCCESS) {
+    FML_LOG(ERROR) << "VulkanManager: Failed to enumerate physical devices.";
+    return false;
+  }
+
+  struct DeviceCandidate {
+    VkPhysicalDevice device;
+    uint32_t queue_family;
+    VkPhysicalDeviceType type;
+    std::array<uint8_t, VK_LUID_SIZE> luid;
+  };
+
+  std::vector<DeviceCandidate> candidates;
+
+  for (const auto& device : devices) {
+    // The device must be able to export render targets to Direct3D 11.
+    std::array<uint8_t, VK_LUID_SIZE> luid = {};
+    if (!SupportsD3D11Interop(device, &luid)) {
+      continue;
+    }
+
+    uint32_t queue_family_count = 0;
+    vk_->GetPhysicalDeviceQueueFamilyProperties(device, &queue_family_count,
+                                                nullptr);
+    std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);
+    vk_->GetPhysicalDeviceQueueFamilyProperties(device, &queue_family_count,
+                                                queue_families.data());
+
+    for (uint32_t i = 0; i < queue_family_count; i++) {
+      if (!(queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)) {
+        continue;
+      }
+
+      VkPhysicalDeviceProperties props;
+      vk_->GetPhysicalDeviceProperties(device, &props);
+
+      candidates.push_back({device, i, props.deviceType, luid});
+      break;  // Use the first graphics queue family for this device.
+    }
+  }
+
+  if (candidates.empty()) {
+    FML_LOG(ERROR) << "VulkanManager: No device with a graphics queue and "
+                      "Direct3D 11 export support found.";
+    return false;
+  }
+
+  // Prefer discrete > integrated > other.
+  const DeviceCandidate* best = &candidates[0];
+  for (const auto& c : candidates) {
+    if (c.type == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+      best = &c;
+      break;
+    }
+    if (c.type == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU &&
+        best->type != VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+      best = &c;
+    }
+  }
+
+  physical_device_ = best->device;
+  queue_family_index_ = best->queue_family;
+  device_luid_ = best->luid;
+
+  return true;
+}
+
+bool VulkanManager::CreateLogicalDevice() {
+  float queue_priority = 1.0f;
+
+  VkDeviceQueueCreateInfo queue_create_info = {};
+  queue_create_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+  queue_create_info.queueFamilyIndex = queue_family_index_;
+  queue_create_info.queueCount = 1;
+  queue_create_info.pQueuePriorities = &queue_priority;
+
+  // Extensions required to export images to Direct3D 11 and coordinate
+  // access with the DXGI side through the shared texture's keyed mutex.
+  // VK_KHR_external_memory and VK_KHR_dedicated_allocation are core in
+  // Vulkan 1.1 and need no explicit enablement.
+  enabled_device_extensions_ = {
+      VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,
+      VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME,
+  };
+
+  auto instance_get_proc = vk_->NativeGetInstanceProcAddr();
+  auto enumerate_device_extensions =
+      reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(
+          instance_get_proc(instance_, "vkEnumerateDeviceExtensionProperties"));
+  if (!enumerate_device_extensions) {
+    FML_LOG(ERROR) << "Failed to resolve device extension enumeration.";
+    return false;
+  }
+
+  uint32_t ext_count = 0;
+  if (enumerate_device_extensions(physical_device_, nullptr, &ext_count,
+                                  nullptr) != VK_SUCCESS) {
+    FML_LOG(ERROR) << "Failed to enumerate device extension count.";
+    return false;
+  }
+
+  std::vector<VkExtensionProperties> available_exts(ext_count);
+  if (enumerate_device_extensions(physical_device_, nullptr, &ext_count,
+                                  available_exts.data()) != VK_SUCCESS) {
+    FML_LOG(ERROR) << "Failed to enumerate device extensions.";
+    return false;
+  }
+
+  available_device_extensions_ = BuildExtensionSet(available_exts);
+
+  for (const char* required : enabled_device_extensions_) {
+    if (available_device_extensions_.find(required) ==
+        available_device_extensions_.end()) {
+      FML_LOG(ERROR) << "VulkanManager: Required device extension '" << required
+                     << "' not available.";
+      return false;
+    }
+  }
+
+  // Enable optional extensions that Impeller checks for.
+  // VK_EXT_pipeline_creation_feedback provides shader compilation
+  // diagnostics.
+  if (available_device_extensions_.count(
+          VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME)) {
+    enabled_device_extensions_.push_back(
+        VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
+  }
+
+  // Query device features using the Vulkan 1.1 pNext chain approach.
+  auto get_proc = vk_->NativeGetInstanceProcAddr();
+
+  VkPhysicalDevice16BitStorageFeatures storage_16bit = {};
+  storage_16bit.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES;
+
+  VkPhysicalDeviceFeatures2 device_features2 = {};
+  device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+  device_features2.pNext = &storage_16bit;
+
+  auto vkGetPhysicalDeviceFeatures2 =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(
+          get_proc(instance_, "vkGetPhysicalDeviceFeatures2"));
+  if (vkGetPhysicalDeviceFeatures2) {
+    vkGetPhysicalDeviceFeatures2(physical_device_, &device_features2);
+  } else {
+    vk_->GetPhysicalDeviceFeatures(physical_device_,
+                                   &device_features2.features);
+  }
+
+  VkDeviceCreateInfo device_info = {};
+  device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+  device_info.pNext = &device_features2;
+  device_info.queueCreateInfoCount = 1;
+  device_info.pQueueCreateInfos = &queue_create_info;
+  device_info.enabledExtensionCount =
+      static_cast<uint32_t>(enabled_device_extensions_.size());
+  device_info.ppEnabledExtensionNames = enabled_device_extensions_.data();
+  device_info.pEnabledFeatures = nullptr;
+
+  VkResult result =
+      vk_->CreateDevice(physical_device_, &device_info, nullptr, &device_);
+  if (result != VK_SUCCESS) {
+    FML_LOG(ERROR) << "VulkanManager: Failed to create VkDevice (result="
+                   << result << ").";
+    return false;
+  }
+
+  if (!vk_->SetupDeviceProcAddresses(vulkan::VulkanHandle<VkDevice>(device_))) {
+    FML_LOG(ERROR) << "VulkanManager: Failed to setup device proc addresses.";
+    return false;
+  }
+
+  vk_->GetDeviceQueue(device_, queue_family_index_, 0, &queue_);
+  if (queue_ == VK_NULL_HANDLE) {
+    FML_LOG(ERROR) << "VulkanManager: Failed to get device queue.";
+    return false;
+  }
+
+  return true;
+}
+
+const char** VulkanManager::GetEnabledInstanceExtensions(size_t* count) {
+  FML_DCHECK(count != nullptr);
+  *count = enabled_instance_extensions_.size();
+  return enabled_instance_extensions_.data();
+}
+
+const char** VulkanManager::GetEnabledDeviceExtensions(size_t* count) {
+  FML_DCHECK(count != nullptr);
+  *count = enabled_device_extensions_.size();
+  return enabled_device_extensions_.data();
+}
+
+void* VulkanManager::GetInstanceProcAddress(VkInstance instance,
+                                            const char* name) const {
+  if (!vk_) {
+    return nullptr;
+  }
+  auto get_proc = vk_->NativeGetInstanceProcAddr();
+  if (!get_proc) {
+    return nullptr;
+  }
+  return reinterpret_cast<void*>(get_proc(instance, name));
+}
+
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/vulkan_manager.h
+++ b/engine/src/flutter/shell/platform/windows/vulkan_manager.h
@@ -1,0 +1,126 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_VULKAN_MANAGER_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_VULKAN_MANAGER_H_
+
+#include <windows.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "flutter/fml/macros.h"
+#include "flutter/vulkan/procs/vulkan_proc_table.h"
+
+namespace flutter {
+
+/// Manages the Vulkan instance, device, and queue for Impeller rendering on
+/// Windows.
+///
+/// This class only initializes Vulkan resources (instance, physical device,
+/// logical device, queue) with the extensions required to import shared
+/// Direct3D 11 textures as render targets. It creates no VkSurfaceKHR and
+/// no swapchain: the shared textures are allocated and presented on the
+/// DXGI/DirectComposition side (see |DCompPresenter| and
+/// |VulkanImportedImage|).
+///
+/// Creating a VulkanManager fails and returns nullptr when Vulkan is not
+/// usable for this path: no loader, no Vulkan 1.1 device, or no device that
+/// can import Direct3D 11 textures. The engine falls back to ANGLE or
+/// software rendering in that case.
+class VulkanManager {
+ public:
+  /// Creates a VulkanManager. Returns nullptr if Vulkan is not available or
+  /// no device supports Direct3D 11 texture import.
+  static std::unique_ptr<VulkanManager> Create();
+
+  ~VulkanManager();
+
+  /// Returns true if a Vulkan runtime is present (vulkan-1.dll loadable).
+  static bool IsAvailable();
+
+  /// Returns the Vulkan API version supported by the instance.
+  uint32_t GetVulkanVersion() const { return vulkan_version_; }
+
+  /// Returns the Vulkan instance handle.
+  VkInstance GetInstance() const { return instance_; }
+
+  /// Returns the selected physical device.
+  VkPhysicalDevice GetPhysicalDevice() const { return physical_device_; }
+
+  /// Returns the logical device handle.
+  VkDevice GetDevice() const { return device_; }
+
+  /// Returns the graphics queue handle.
+  ///
+  /// Thread safety: all queue submissions in the Impeller rendering path are
+  /// serialized through Impeller's QueueVK internal mutex. Do not submit
+  /// directly to this queue outside that path.
+  VkQueue GetQueue() const { return queue_; }
+
+  /// Returns the queue family index used for graphics operations.
+  uint32_t GetQueueFamilyIndex() const { return queue_family_index_; }
+
+  /// Gets the Vulkan proc table used for function resolution.
+  vulkan::VulkanProcTable* GetProcTable() const { return vk_.get(); }
+
+  /// Gets enabled instance extension names. The pointer type matches
+  /// FlutterVulkanRendererConfig::enabled_instance_extensions.
+  const char** GetEnabledInstanceExtensions(size_t* count);
+
+  /// Gets enabled device extension names. The pointer type matches
+  /// FlutterVulkanRendererConfig::enabled_device_extensions.
+  const char** GetEnabledDeviceExtensions(size_t* count);
+
+  /// Resolves a Vulkan instance function pointer by name.
+  void* GetInstanceProcAddress(VkInstance instance, const char* name) const;
+
+  /// The locally unique identifier of the selected physical device's
+  /// adapter. Used to open the same adapter on the DXGI side so that
+  /// exported images stay on one GPU. Only valid when Create() succeeded.
+  const std::array<uint8_t, VK_LUID_SIZE>& GetDeviceLUID() const {
+    return device_luid_;
+  }
+
+ private:
+  VulkanManager();
+
+  bool Initialize();
+  bool SelectPhysicalDevice();
+  bool CreateLogicalDevice();
+
+  /// Returns true if |device| can import shared Direct3D 11 textures
+  /// (VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT) as B8G8R8A8 color
+  /// attachments and reports a valid adapter LUID.
+  bool SupportsD3D11Interop(VkPhysicalDevice device,
+                            std::array<uint8_t, VK_LUID_SIZE>* out_luid) const;
+
+  static std::unordered_set<std::string> BuildExtensionSet(
+      const std::vector<VkExtensionProperties>& extensions);
+
+  fml::RefPtr<vulkan::VulkanProcTable> vk_;
+  uint32_t vulkan_version_ = VK_API_VERSION_1_0;
+  VkInstance instance_ = VK_NULL_HANDLE;
+  VkPhysicalDevice physical_device_ = VK_NULL_HANDLE;
+  VkDevice device_ = VK_NULL_HANDLE;
+  VkQueue queue_ = VK_NULL_HANDLE;
+  uint32_t queue_family_index_ = 0;
+  std::array<uint8_t, VK_LUID_SIZE> device_luid_ = {};
+
+  std::vector<const char*> enabled_instance_extensions_;
+  std::vector<const char*> enabled_device_extensions_;
+  std::vector<const char*> enabled_layers_;
+  std::unordered_set<std::string> available_instance_extensions_;
+  std::unordered_set<std::string> available_device_extensions_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(VulkanManager);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_VULKAN_MANAGER_H_

--- a/engine/src/flutter/shell/platform/windows/vulkan_manager_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/vulkan_manager_unittests.cc
@@ -1,0 +1,134 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/vulkan_manager.h"
+
+#include <algorithm>
+#include <cstring>
+
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+// IsAvailable must not crash regardless of whether a Vulkan runtime is
+// installed.
+TEST(VulkanManagerTest, IsAvailable) {
+  bool available = VulkanManager::IsAvailable();
+  (void)available;
+}
+
+// Create() returns a fully initialized manager when Vulkan with Direct3D 11
+// interop is available, or nullptr otherwise. It must never crash.
+TEST(VulkanManagerTest, CreateReturnsManagerOrNull) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  EXPECT_NE(manager->GetInstance(), VK_NULL_HANDLE);
+  EXPECT_NE(manager->GetPhysicalDevice(), VK_NULL_HANDLE);
+  EXPECT_NE(manager->GetDevice(), VK_NULL_HANDLE);
+  EXPECT_NE(manager->GetQueue(), VK_NULL_HANDLE);
+  EXPECT_NE(manager->GetProcTable(), nullptr);
+  EXPECT_GE(manager->GetVulkanVersion(), VK_API_VERSION_1_1);
+}
+
+// A successfully created manager must report a valid adapter LUID: it is
+// what ties the Vulkan device to the same DXGI adapter on the Direct3D
+// side. An all-zero LUID never identifies a hardware adapter.
+TEST(VulkanManagerTest, DeviceLUIDIsValid) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  const auto& luid = manager->GetDeviceLUID();
+  bool all_zero =
+      std::all_of(luid.begin(), luid.end(), [](uint8_t b) { return b == 0; });
+  EXPECT_FALSE(all_zero);
+}
+
+// The device must be created with the extensions the DXGI interop relies
+// on; anything less and image export or the keyed mutex handoff would fail
+// at runtime instead of falling back cleanly at startup.
+TEST(VulkanManagerTest, EnabledExtensionsIncludeExternalMemory) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  size_t device_ext_count = 0;
+  const char* const* device_exts =
+      manager->GetEnabledDeviceExtensions(&device_ext_count);
+  ASSERT_NE(device_exts, nullptr);
+
+  auto has_extension = [&](const char* name) {
+    for (size_t i = 0; i < device_ext_count; i++) {
+      if (std::strcmp(device_exts[i], name) == 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  EXPECT_TRUE(has_extension(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME));
+  EXPECT_TRUE(has_extension(VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME));
+}
+
+// No windowing system extensions may be enabled: presentation happens on
+// the DXGI side and a VK_KHR_win32_surface dependency would be a
+// regression toward the swapchain design.
+TEST(VulkanManagerTest, NoSurfaceExtensionsEnabled) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  size_t instance_ext_count = 0;
+  const char* const* instance_exts =
+      manager->GetEnabledInstanceExtensions(&instance_ext_count);
+  for (size_t i = 0; i < instance_ext_count; i++) {
+    EXPECT_STRNE(instance_exts[i], "VK_KHR_surface");
+    EXPECT_STRNE(instance_exts[i], "VK_KHR_win32_surface");
+  }
+
+  size_t device_ext_count = 0;
+  const char* const* device_exts =
+      manager->GetEnabledDeviceExtensions(&device_ext_count);
+  for (size_t i = 0; i < device_ext_count; i++) {
+    EXPECT_STRNE(device_exts[i], "VK_KHR_swapchain");
+  }
+}
+
+// Instance proc address resolution works for real functions and returns
+// null for unknown names.
+TEST(VulkanManagerTest, GetInstanceProcAddress) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  void* proc = manager->GetInstanceProcAddress(manager->GetInstance(),
+                                               "vkEnumeratePhysicalDevices");
+  EXPECT_NE(proc, nullptr);
+
+  void* bad_proc = manager->GetInstanceProcAddress(manager->GetInstance(),
+                                                   "vkNonExistentFunction");
+  EXPECT_EQ(bad_proc, nullptr);
+}
+
+// Destroying the manager must clean up the device and instance without
+// crashing.
+TEST(VulkanManagerTest, DestructionOrder) {
+  auto manager = VulkanManager::Create();
+  if (!manager) {
+    GTEST_SKIP() << "Vulkan with D3D11 interop is not available.";
+  }
+
+  manager.reset();
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/testing/tester_context_vk_factory.cc
+++ b/engine/src/flutter/shell/testing/tester_context_vk_factory.cc
@@ -92,8 +92,8 @@ class TesterContextVK : public TesterContext {
   // |TesterContext|
   std::unique_ptr<Surface> CreateRenderingSurface() override {
     FML_DCHECK(context_);
-    auto surface =
-        std::make_unique<GPUSurfaceVulkanImpeller>(nullptr, surface_context_);
+    auto surface = std::make_unique<GPUSurfaceVulkanImpeller>(
+        nullptr, surface_context_, /*render_to_surface=*/true);
     FML_DCHECK(surface->IsValid());
     return surface;
   }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Adds an opt-in Vulkan rendering path to the Windows embedder: Impeller renders with its existing Vulkan backend, and the content is presented through DXGI and DirectComposition, so the OS compositor owns presentation. There is no VkSurfaceKHR and no Vulkan swapchain anywhere in this path, addressing the review feedback on #183382 that a KHR swapchain would block compositor integration, resize synchronization, and future platform views.

Activation uses the engine switch mechanism, in line with the review guidance to gate the backend behind flags rather than public API. The engine accepts `--impeller-backend=vulkan` next to the existing `--enable-impeller` handling; until the flutter_tools plumbing lands in a follow-up, the switch reaches the engine through the standard FLUTTER_ENGINE_SWITCHES environment protocol (debug and profile only):

```
set FLUTTER_ENGINE_SWITCHES=2
set FLUTTER_ENGINE_SWITCH_1=enable-impeller=true
set FLUTTER_ENGINE_SWITCH_2=impeller-backend=vulkan
```

Without the explicit backend switch, or when no capable device exists, nothing changes: ANGLE remains the default and the fallback. When Vulkan is active, ANGLE is not initialized at all.

### How it works

```
CompositorVulkan (FlutterCompositor)
  backing store = shared D3D11 texture (keyed mutex, NT handle)
                  imported into Vulkan, wrapped as the resolve target of an
                  MSAA color attachment with a depth-stencil (matching
                  SurfaceVK::WrapSwapchainImage) that Impeller renders into
  present       = keyed-mutex bracketed CopyResource into a flip-model
                  composition swapchain, Present(0), DComp commit
```

* `VulkanManager` initializes the instance and device with dynamic loading (`vulkan-1.dll`; missing runtimes fall back before engine start) and no windowing extensions. Device selection requires a graphics queue, a valid adapter LUID, and Direct3D 11 texture import support, verified per device through `vkGetPhysicalDeviceImageFormatProperties2` before selection, so a successful `Create()` guarantees the interop works. Every rejection path logs its reason for field diagnosis.
* `DCompPresenter` owns a Direct3D 11 device on the LUID-matched adapter, allocates the shared textures, and presents them through a composition swapchain rooted in a DirectComposition visual on the window. Because content reaches the screen only through the DComp commit, the window chrome and the Flutter content resize atomically.
* `VulkanImportedImage` binds a VkImage to the shared texture's memory (dedicated allocation, `VkImportMemoryWin32HandleInfoKHR`).
* The interop direction is dictated by the drivers: Direct3D 11 texture memory is reported to Vulkan as import-only (measured on AMD Adrenalin: `DEDICATED_ONLY | IMPORTABLE`), so the allocation originates on the Direct3D side. This matches the direction used by Chromium and Dawn.
* `CompositorVulkan` renders each backing store with Impeller. The imported image is reported as a swapchain image so the render pass leaves it in `VK_IMAGE_LAYOUT_GENERAL` rather than a sampled layout the imported image does not support. `GPUSurfaceVulkanImpeller` gains a `render_to_surface` flag: with an external view embedder present the root surface is a no-op and all content arrives through backing stores, matching the OpenGL Impeller path.
* The SDF rendering option is an ANGLE/OpenGL Impeller default and is not applied when the Vulkan backend is active.

### Synchronization

The engine performs a host sync for all layers before invoking the compositor present callback (documented in `FlutterVulkanBackingStore`), so Vulkan writes are complete before the copy. The Direct3D side still brackets its access with the shared texture's keyed mutex, which performs the cross-device flushes.

### Depends on

The Impeller hardening PR (#189580), which includes the CapabilitiesVK change that allows an embedder to create a surfaceless Vulkan context (no `VK_KHR_surface` / swapchain), required by this presentation path.

### Not in this PR

* Platform views: the compositor rejects multi-layer scenes with a clear error. The visual-tree architecture is what makes them possible later.
* flutter_tools changes: activation is manual until the backend matures.
* Any embedder API change: the existing `FlutterVulkanRendererConfig`, `FlutterCompositor`, and `FlutterVulkanBackingStore` surfaces are used as-is. The engine-side `kFlutterBackingStoreTypeVulkan` Impeller path is implemented here (it previously logged "Unimplemented").

### Testing

Regression tests run in `flutter_windows_unittests` and `impeller_unittests`; hardware-dependent tests skip cleanly on machines without Vulkan:

* `VulkanManagerTest` (7): dynamic loading, create-or-null, LUID validity, required extensions present, no windowing extensions ever, proc resolution, teardown.
* `VulkanImportedImageTest`: argument validation.
* `DCompPresenterTest` (5): unknown LUID rejection, present-before-bind rejection, the full pipeline (allocate, import, keyed-mutex present through a live DComp tree, evict), swapchain resize in place, and an 8-cycle allocate/import/evict lifecycle.
* `FlutterWindowsEngineTest`: the backend requires the explicit switch, is ignored without Impeller, either activates (ANGLE skipped) or falls back without failing engine construction, and does not enable SDF rendering when Vulkan is active.
* `GPUSurfaceVulkanImpeller.RenderToSurfaceDisabledYieldsNoOpFrame`: with an external view embedder the root surface yields a no-op frame and never pulls an image from the delegate.

### Performance

Release-mode comparison of this Vulkan/DComp path against the default ANGLE/DXGI path (Impeller both sides), AMD Radeon RX 6750 XT, Windows 10, same [benchmark app](https://github.com/sero583/flutter-benchmark) and binary:

| Scene | ANGLE/DXGI | Vulkan/DComp |
|---|---|---|
| Transform & Clip | 13.8 | 96.1 |
| Image Composition | 31.2 | 143.5 |
| Custom Painter Heavy | 90.3 | 108.8 |
| Widget Cascade | 136.7 | 138.3 |
| Opacity Tree | 143.8 | 49.0 |
| Shader Mask Matrix | 96.8 | 22.5 |
| Geomean (avg fps) | 39.7 | 43.9 |

Native Vulkan wins substantially on composition/clip/transform-heavy scenes (no ANGLE GL-to-D3D11 translation), and regresses on offscreen-layer-heavy scenes (save layers, shader masks), where the 1%-low frame rate drops sharply. Net a modest geomean gain with a clear optimization target (the offscreen/save-layer path) called out honestly rather than cherry-picked.

Manual verification on AMD Radeon RX 6750 XT (Windows 10): the backend activates, renders the full 9-scene benchmark suite in both debug and release AOT builds with no Vulkan validation errors under VK_LAYER_KHRONOS_validation, and presents through the DirectComposition tree with correct visuals throughout the runs. Window resizing is exercised by DCompPresenterTest.ResizeRecreatesSwapchainBuffers; because presentation goes through a single DComp commit, chrome and content resize atomically by construction.

Part of #181711. Design doc: https://flutter.dev/go/impeller-backend-desktop

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
