### PR TITLE
Fix web context-menu client lifecycle in SelectableRegion

### DIFF
--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_io.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_io.dart
@@ -40,6 +40,12 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   /// Detaches the `client` from the platform-appropriate selection context menus.
   static void detach(SelectionContainerDelegate client) => throw UnimplementedError();
 
+  /// The client currently attached to the [PlatformSelectableRegionContextMenu].
+  ///
+  /// This should only be used for testing.
+  @visibleForTesting
+  static SelectionContainerDelegate? get debugActiveClient => throw UnimplementedError();
+
   /// Override this to provide a custom implementation of `ui_web.platformViewRegistry.registerViewFactory`.
   ///
   /// This should only be used for testing.

--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
@@ -56,12 +56,18 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
 
   /// See `_platform_selectable_region_context_menu_io.dart`.
   static void detach(SelectionContainerDelegate client) {
-    if (_activeClient != client) {
+    if (_activeClient == client) {
       _activeClient = null;
     }
   }
 
   static SelectionContainerDelegate? _activeClient;
+
+  /// The client currently attached to the [PlatformSelectableRegionContextMenu].
+  ///
+  /// This should only be used for testing.
+  @visibleForTesting
+  static SelectionContainerDelegate? get debugActiveClient => _activeClient;
 
   // Keeps track if this widget has already registered its view factories or not.
   static String? _registeredViewType;

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -540,8 +540,7 @@ class SelectableRegionState extends State<SelectableRegion>
         _selectionStatusNotifier.value = SelectableRegionSelectionStatus.changing;
         _finalizeSelectableRegionStatus();
       }
-    }
-    if (_webContextMenuEnabled) {
+    } else if (_webContextMenuEnabled) {
       PlatformSelectableRegionContextMenu.attach(_selectionDelegate);
     }
   }
@@ -1935,6 +1934,9 @@ class SelectableRegionState extends State<SelectableRegion>
   void dispose() {
     _selectable?.removeListener(_updateSelectionStatus);
     _selectable?.pushHandleLayers(null, null);
+    if (_webContextMenuEnabled) {
+      PlatformSelectableRegionContextMenu.detach(_selectionDelegate);
+    }
     _selectionDelegate.dispose();
     _selectionStatusNotifier.dispose();
     // In case dispose was triggered before gesture end, remove the magnifier

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -525,7 +525,11 @@ class SelectableRegionState extends State<SelectableRegion>
 
   void _handleFocusChanged() {
     if (!_focusNode.hasFocus) {
-      if (_webContextMenuEnabled) {
+      if (kIsWeb) {
+        // Detach regardless of the current (dynamic) _webContextMenuEnabled
+        // value: the browser context menu may have been disabled after this
+        // delegate attached, and detach is a no-op for a client that was
+        // never the active one.
         PlatformSelectableRegionContextMenu.detach(_selectionDelegate);
       }
       if (SchedulerBinding.instance.lifecycleState == AppLifecycleState.resumed) {
@@ -1934,7 +1938,7 @@ class SelectableRegionState extends State<SelectableRegion>
   void dispose() {
     _selectable?.removeListener(_updateSelectionStatus);
     _selectable?.pushHandleLayers(null, null);
-    if (_webContextMenuEnabled) {
+    if (kIsWeb) {
       PlatformSelectableRegionContextMenu.detach(_selectionDelegate);
     }
     _selectionDelegate.dispose();

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -210,7 +210,7 @@ void main() {
     // disposed delegate, so this right click reached into its defunct
     // render context and crashed instead of being a no-op.
     web.Event? capturedError;
-    final onWindowError = (web.Event event) {
+    final JSExportedDartFunction onWindowError = (web.Event event) {
       capturedError = event;
     }.toJS;
     web.window.addEventListener('error', onWindowError);

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -142,65 +142,131 @@ void main() {
     expect((selectWordEvent.globalPosition.dy - 300).abs() < precisionErrorTolerance, isTrue);
   }, variant: _browserContextMenuEnabledVariants);
 
-  testWidgets(
-    'detach only clears the active client when detaching the active client',
-    (WidgetTester tester) async {
-      final focusNodeA = FocusNode();
-      final focusNodeB = FocusNode();
-      addTearDown(focusNodeA.dispose);
-      addTearDown(focusNodeB.dispose);
+  testWidgets('detach only clears the active client when detaching the active client', (
+    WidgetTester tester,
+  ) async {
+    final focusNodeA = FocusNode();
+    final focusNodeB = FocusNode();
+    addTearDown(focusNodeA.dispose);
+    addTearDown(focusNodeB.dispose);
 
-      await tester.pumpWidget(
-        TestWidgetsApp(
-          home: Column(
-            children: <Widget>[
-              SizedBox(
-                height: 100,
-                child: SelectableRegion(
-                  focusNode: focusNodeA,
-                  selectionControls: emptyTextSelectionControls,
-                  child: const SelectionSpy(),
-                ),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Column(
+          children: <Widget>[
+            SizedBox(
+              height: 100,
+              child: SelectableRegion(
+                focusNode: focusNodeA,
+                selectionControls: emptyTextSelectionControls,
+                child: const SelectionSpy(),
               ),
-              SizedBox(
-                height: 100,
-                child: SelectableRegion(
-                  focusNode: focusNodeB,
-                  selectionControls: emptyTextSelectionControls,
-                  child: const SelectionSpy(),
-                ),
+            ),
+            SizedBox(
+              height: 100,
+              child: SelectableRegion(
+                focusNode: focusNodeB,
+                selectionControls: emptyTextSelectionControls,
+                child: const SelectionSpy(),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
+      ),
+    );
+
+    focusNodeA.requestFocus();
+    await tester.pump();
+    final SelectionContainerDelegate delegateA =
+        PlatformSelectableRegionContextMenu.debugActiveClient!;
+
+    focusNodeB.requestFocus();
+    await tester.pump();
+    final SelectionContainerDelegate delegateB =
+        PlatformSelectableRegionContextMenu.debugActiveClient!;
+    expect(delegateB, isNot(same(delegateA)));
+
+    // Detaching a client that is not the active client must not clear
+    // the active client.
+    PlatformSelectableRegionContextMenu.detach(delegateA);
+    expect(PlatformSelectableRegionContextMenu.debugActiveClient, same(delegateB));
+
+    // Detaching the active client must clear it.
+    PlatformSelectableRegionContextMenu.detach(delegateB);
+    expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNull);
+  }, variant: _browserContextMenuEnabledVariants);
+
+  testWidgets('losing focus detaches the client and does not reattach it', (
+    WidgetTester tester,
+  ) async {
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          focusNode: focusNode,
+          selectionControls: emptyTextSelectionControls,
+          child: const SelectionSpy(),
+        ),
+      ),
+    );
+
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNotNull);
+
+    focusNode.unfocus();
+    await tester.pump();
+
+    expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNull);
+  }, variant: _browserContextMenuEnabledVariants);
+
+  testWidgets('disposing a SelectableRegion detaches its client from the context menu', (
+    WidgetTester tester,
+  ) async {
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          focusNode: focusNode,
+          selectionControls: emptyTextSelectionControls,
+          child: const SelectionSpy(),
+        ),
+      ),
+    );
+
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNotNull);
+
+    // Removing the SelectableRegion disposes its state without ever
+    // losing focus on the externally-owned focus node, so only the
+    // dispose-time detach can clear the static reference.
+    await tester.pumpWidget(const TestWidgetsApp(home: SizedBox.shrink()));
+
+    expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNull);
+  }, variant: _browserContextMenuEnabledVariants);
+
+  group('when the browser context menu is disabled after attaching', () {
+    setUp(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.contextMenu,
+        (MethodCall call) => Future<void>.value(),
       );
+    });
 
-      focusNodeA.requestFocus();
-      await tester.pump();
-      final SelectionContainerDelegate delegateA =
-          PlatformSelectableRegionContextMenu.debugActiveClient!;
+    tearDown(() async {
+      await BrowserContextMenu.enableContextMenu();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.contextMenu,
+        null,
+      );
+    });
 
-      focusNodeB.requestFocus();
-      await tester.pump();
-      final SelectionContainerDelegate delegateB =
-          PlatformSelectableRegionContextMenu.debugActiveClient!;
-      expect(delegateB, isNot(same(delegateA)));
-
-      // Detaching a client that is not the active client must not clear
-      // the active client.
-      PlatformSelectableRegionContextMenu.detach(delegateA);
-      expect(PlatformSelectableRegionContextMenu.debugActiveClient, same(delegateB));
-
-      // Detaching the active client must clear it.
-      PlatformSelectableRegionContextMenu.detach(delegateB);
-      expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNull);
-    },
-    variant: _browserContextMenuEnabledVariants,
-  );
-
-  testWidgets(
-    'losing focus detaches the client and does not reattach it',
-    (WidgetTester tester) async {
+    testWidgets('losing focus still detaches the client', (WidgetTester tester) async {
       final focusNode = FocusNode();
       addTearDown(focusNode.dispose);
 
@@ -217,18 +283,19 @@ void main() {
       focusNode.requestFocus();
       await tester.pump();
       expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNotNull);
+
+      // Disabling the browser context menu after the delegate attached
+      // must not prevent the eventual detach: _webContextMenuEnabled is
+      // re-evaluated dynamically and would otherwise report false here.
+      await BrowserContextMenu.disableContextMenu();
 
       focusNode.unfocus();
       await tester.pump();
 
       expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNull);
-    },
-    variant: _browserContextMenuEnabledVariants,
-  );
+    }, variant: _browserContextMenuEnabledVariants);
 
-  testWidgets(
-    'disposing a SelectableRegion detaches its client from the context menu',
-    (WidgetTester tester) async {
+    testWidgets('disposing still detaches the client', (WidgetTester tester) async {
       final focusNode = FocusNode();
       addTearDown(focusNode.dispose);
 
@@ -245,6 +312,8 @@ void main() {
       focusNode.requestFocus();
       await tester.pump();
       expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNotNull);
+
+      await BrowserContextMenu.disableContextMenu();
 
       // Removing the SelectableRegion disposes its state without ever
       // losing focus on the externally-owned focus node, so only the
@@ -252,9 +321,8 @@ void main() {
       await tester.pumpWidget(const TestWidgetsApp(home: SizedBox.shrink()));
 
       expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNull);
-    },
-    variant: _browserContextMenuEnabledVariants,
-  );
+    }, variant: _browserContextMenuEnabledVariants);
+  });
 
   // Regression test for https://github.com/flutter/flutter/issues/157579
   testWidgets('prevents default action of mousedown events', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -5,6 +5,8 @@
 @TestOn('browser') // This file contains web-only library.
 library;
 
+import 'dart:js_interop';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -140,6 +142,84 @@ void main() {
     expect(selectWordEvent, isNotNull);
     expect((selectWordEvent!.globalPosition.dx - 200).abs() < precisionErrorTolerance, isTrue);
     expect((selectWordEvent.globalPosition.dy - 300).abs() < precisionErrorTolerance, isTrue);
+  }, variant: _browserContextMenuEnabledVariants);
+
+  // Regression test for https://github.com/flutter/flutter/issues/189575.
+  testWidgets('right click does not dispatch event to previous stale client after losing focus', (
+    WidgetTester tester,
+  ) async {
+    final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    final spy = UniqueKey();
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          focusNode: focusNode,
+          selectionControls: emptyTextSelectionControls,
+          child: SelectionSpy(key: spy),
+        ),
+      ),
+    );
+    final element = fakePlatformViewRegistry.getViewById(currentViewId + 1) as web.HTMLElement;
+    expect(element, isNotNull);
+    focusNode.requestFocus();
+    await tester.pump();
+    focusNode.unfocus();
+    await tester.pump();
+    final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(
+      find.byKey(spy),
+    );
+    renderSelectionSpy.events.clear();
+    // Before the fix, losing focus re-attached the client instead of
+    // detaching it, so the right click below dispatched a
+    // SelectWordSelectionEvent to the stale, no-longer-focused client.
+    element.dispatchEvent(
+      web.MouseEvent('mousedown', web.MouseEventInit(button: 2, clientX: 200, clientY: 300)),
+    );
+    expect(renderSelectionSpy.events, isEmpty);
+  }, variant: _browserContextMenuEnabledVariants);
+
+  testWidgets('right click after the SelectableRegion is disposed does not crash', (
+    WidgetTester tester,
+  ) async {
+    final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SelectableRegion(
+          focusNode: focusNode,
+          selectionControls: emptyTextSelectionControls,
+          child: const SelectionSpy(),
+        ),
+      ),
+    );
+    final element = fakePlatformViewRegistry.getViewById(currentViewId + 1) as web.HTMLElement;
+    expect(element, isNotNull);
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNotNull);
+
+    // Removing the SelectableRegion disposes its state without ever
+    // losing focus on the externally-owned focus node, so only the
+    // dispose-time detach can clear the static reference.
+    await tester.pumpWidget(const TestWidgetsApp(home: SizedBox.shrink()));
+
+    // Before the fix, the static active-client pointer outlived the
+    // disposed delegate, so this right click reached into its defunct
+    // render context and crashed instead of being a no-op.
+    web.Event? capturedError;
+    final onWindowError = (web.Event event) {
+      capturedError = event;
+    }.toJS;
+    web.window.addEventListener('error', onWindowError);
+    addTearDown(() => web.window.removeEventListener('error', onWindowError));
+    element.dispatchEvent(
+      web.MouseEvent('mousedown', web.MouseEventInit(button: 2, clientX: 200, clientY: 300)),
+    );
+    expect(tester.takeException(), isNull);
+    expect(capturedError, isNull, reason: 'window reported an uncaught error: $capturedError');
   }, variant: _browserContextMenuEnabledVariants);
 
   testWidgets('detach only clears the active client when detaching the active client', (

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -142,6 +142,120 @@ void main() {
     expect((selectWordEvent.globalPosition.dy - 300).abs() < precisionErrorTolerance, isTrue);
   }, variant: _browserContextMenuEnabledVariants);
 
+  testWidgets(
+    'detach only clears the active client when detaching the active client',
+    (WidgetTester tester) async {
+      final focusNodeA = FocusNode();
+      final focusNodeB = FocusNode();
+      addTearDown(focusNodeA.dispose);
+      addTearDown(focusNodeB.dispose);
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Column(
+            children: <Widget>[
+              SizedBox(
+                height: 100,
+                child: SelectableRegion(
+                  focusNode: focusNodeA,
+                  selectionControls: emptyTextSelectionControls,
+                  child: const SelectionSpy(),
+                ),
+              ),
+              SizedBox(
+                height: 100,
+                child: SelectableRegion(
+                  focusNode: focusNodeB,
+                  selectionControls: emptyTextSelectionControls,
+                  child: const SelectionSpy(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      focusNodeA.requestFocus();
+      await tester.pump();
+      final SelectionContainerDelegate delegateA =
+          PlatformSelectableRegionContextMenu.debugActiveClient!;
+
+      focusNodeB.requestFocus();
+      await tester.pump();
+      final SelectionContainerDelegate delegateB =
+          PlatformSelectableRegionContextMenu.debugActiveClient!;
+      expect(delegateB, isNot(same(delegateA)));
+
+      // Detaching a client that is not the active client must not clear
+      // the active client.
+      PlatformSelectableRegionContextMenu.detach(delegateA);
+      expect(PlatformSelectableRegionContextMenu.debugActiveClient, same(delegateB));
+
+      // Detaching the active client must clear it.
+      PlatformSelectableRegionContextMenu.detach(delegateB);
+      expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNull);
+    },
+    variant: _browserContextMenuEnabledVariants,
+  );
+
+  testWidgets(
+    'losing focus detaches the client and does not reattach it',
+    (WidgetTester tester) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SelectableRegion(
+            focusNode: focusNode,
+            selectionControls: emptyTextSelectionControls,
+            child: const SelectionSpy(),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+      expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNotNull);
+
+      focusNode.unfocus();
+      await tester.pump();
+
+      expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNull);
+    },
+    variant: _browserContextMenuEnabledVariants,
+  );
+
+  testWidgets(
+    'disposing a SelectableRegion detaches its client from the context menu',
+    (WidgetTester tester) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: SelectableRegion(
+            focusNode: focusNode,
+            selectionControls: emptyTextSelectionControls,
+            child: const SelectionSpy(),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+      expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNotNull);
+
+      // Removing the SelectableRegion disposes its state without ever
+      // losing focus on the externally-owned focus node, so only the
+      // dispose-time detach can clear the static reference.
+      await tester.pumpWidget(const TestWidgetsApp(home: SizedBox.shrink()));
+
+      expect(PlatformSelectableRegionContextMenu.debugActiveClient, isNull);
+    },
+    variant: _browserContextMenuEnabledVariants,
+  );
+
   // Regression test for https://github.com/flutter/flutter/issues/157579
   testWidgets('prevents default action of mousedown events', (WidgetTester tester) async {
     final int currentViewId = platformViewsRegistry.getNextPlatformViewId();


### PR DESCRIPTION
On web, `PlatformSelectableRegionContextMenu._activeClient` — the static `SelectionContainerDelegate` that the right-click `mousedown` listener reads — can end up pointing at a detached or disposed delegate, because of three lifecycle defects:

1. `detach` has an inverted condition — `if (_activeClient != client) { _activeClient = null; }`. Detaching the active client leaves it registered, while detaching an unrelated client wipes another region's registration.
2. `SelectableRegionState._handleFocusChanged` calls `attach` unconditionally at the end of the method, so a region that just lost focus is immediately re-registered.
3. `SelectableRegionState.dispose` never detaches, so the static can keep pointing at a disposed delegate.

Together these produce a crash on web when the user right-clicks during a route transition: the listener calls `getTransformTo(null)` on the stale delegate and hits `"getTransformTo cannot be called before SelectionContainer is laid out"` (`selection_container.dart:303`). We hit this in a production web app.

This PR flips the `detach` condition, moves the re-attach into the focused branch, and detaches in `dispose` before disposing the delegate. It also adds a `@visibleForTesting` `debugActiveClient` getter, mirroring the existing `debugOverrideRegisterViewFactory` pattern, since the delegate is otherwise unobservable from tests. Three new browser tests in `selectable_region_context_menu_test.dart` isolate the defects; each is red before the fix and green after it.

A follow-up commit hardens the detach paths against `BrowserContextMenu.enabled` changing at runtime. Attach stays gated on the full dynamic check, but the focus-loss and dispose detach paths now gate on `kIsWeb` alone, so a delegate attached while the menu was enabled is still detached after the menu is disabled. This is safe because `detach` is identity-selective: calling it for a never-attached delegate is a no-op. Two more browser tests cover unfocus and disposal after `BrowserContextMenu.disableContextMenu()`, bringing it to five lifecycle tests, each red before its fix and green after.

Fixes https://github.com/flutter/flutter/issues/189575

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md