### PR TITLE
Migrate dev/tools skill validation to new dart_skills_lint API

### DIFF
--- a/dev/tools/pubspec.yaml
+++ b/dev/tools/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
     git:
       url: https://github.com/flutter/skills
       path: tool/dart_skills_lint
-      ref: e4497873950727ee781fa411c1a2f624b1ec50c6
+      ref: 05e5a45fa412ddbdd1d694eee0c71f4bbaea2617
   logging: ^1.3.0
 
 dev_dependencies:

--- a/dev/tools/test/validate_skills_test.dart
+++ b/dev/tools/test/validate_skills_test.dart
@@ -93,14 +93,14 @@ void main() {
     final bool isValid = await validateSkills(
       skillDirPaths: [skillsDirectory, reidbakerSkillsDirectory],
       customRules: [CheckBackticksRelativePathsRule(valid2SegmentPaths, repoRoot.path)],
-      resolvedRules: {
-        'check-absolute-paths': AnalysisSeverity.disabled,
-        'check-relative-paths': AnalysisSeverity.disabled,
-        'check-trailing-whitespace': AnalysisSeverity.disabled,
-        'description-too-long': AnalysisSeverity.disabled,
-        'disallowed-field': AnalysisSeverity.disabled,
-        'invalid-skill-name': AnalysisSeverity.disabled,
-        'valid-yaml-metadata': AnalysisSeverity.disabled,
+      resolvedRuleConfigs: {
+        'check-absolute-paths': const RuleConfigPatch(severity: AnalysisSeverity.disabled),
+        'check-relative-paths': const RuleConfigPatch(severity: AnalysisSeverity.disabled),
+        'check-trailing-whitespace': const RuleConfigPatch(severity: AnalysisSeverity.disabled),
+        'description-too-long': const RuleConfigPatch(severity: AnalysisSeverity.disabled),
+        'disallowed-field': const RuleConfigPatch(severity: AnalysisSeverity.disabled),
+        'invalid-skill-name': const RuleConfigPatch(severity: AnalysisSeverity.disabled),
+        'valid-yaml-metadata': const RuleConfigPatch(severity: AnalysisSeverity.disabled),
       },
     );
     expect(isValid, isTrue, reason: 'Skills validation failed. See above for details.');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -238,11 +238,11 @@ packages:
     dependency: transitive
     description:
       path: "tool/dart_skills_lint"
-      ref: e4497873950727ee781fa411c1a2f624b1ec50c6
-      resolved-ref: e4497873950727ee781fa411c1a2f624b1ec50c6
+      ref: "05e5a45fa412ddbdd1d694eee0c71f4bbaea2617"
+      resolved-ref: "05e5a45fa412ddbdd1d694eee0c71f4bbaea2617"
       url: "https://github.com/flutter/skills"
     source: git
-    version: "0.3.0"
+    version: "0.4.0"
   dart_style:
     dependency: "direct main"
     description:
@@ -1179,26 +1179,26 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "20ef311160e2ced020a62f38e4cc399a1bf289e722fc5fe37c9d7b18e44c9e8d"
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.11.1"
   video_player_android:
     dependency: "direct main"
     description:
       name: video_player_android
-      sha256: "5121de08444d00363efdda630a69ad4d27a208a9f7586482d4909a44a1cdbc63"
+      sha256: "15bfd0598f8d8946bf0e2d50e2ca1a0db9491589a8bb7f6f9a388c0b48aef764"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.10.0"
   video_player_avfoundation:
     dependency: "direct main"
     description:
       name: video_player_avfoundation
-      sha256: c238f5f0a26845cd0bcc2956049b63065a4d3c40ddfc22c3414cd170bef7fff9
+      sha256: "76097729ef0c976937945afa53f1ca3afa9b50c9a95909ba347bcf93270466fd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.10.0"
   video_player_platform_interface:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1179,26 +1179,26 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      sha256: "20ef311160e2ced020a62f38e4cc399a1bf289e722fc5fe37c9d7b18e44c9e8d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.1"
+    version: "2.13.0"
   video_player_android:
     dependency: "direct main"
     description:
       name: video_player_android
-      sha256: "15bfd0598f8d8946bf0e2d50e2ca1a0db9491589a8bb7f6f9a388c0b48aef764"
+      sha256: "5121de08444d00363efdda630a69ad4d27a208a9f7586482d4909a44a1cdbc63"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   video_player_avfoundation:
     dependency: "direct main"
     description:
       name: video_player_avfoundation
-      sha256: "76097729ef0c976937945afa53f1ca3afa9b50c9a95909ba347bcf93270466fd"
+      sha256: c238f5f0a26845cd0bcc2956049b63065a4d3c40ddfc22c3414cd170bef7fff9
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   video_player_platform_interface:
     dependency: "direct main"
     description:


### PR DESCRIPTION
This update lets us use parameters in rules which is helpful for ignoring a class of issues that shows up when doing evals that put artifacts in the skills directories that are ignored by git but otherwise cause false positives. 

Ai authored description below
---
Bumps the pinned `dart_skills_lint` dependency ref to the latest main commit (`05e5a45fa412ddbdd1d694eee0c71f4bbaea2617`) and migrates the validation tests in `dev/tools` to use the new `resolvedRuleConfigs` API.

- **Non-test code changed**: None (only `pubspec.yaml` and `test/` suite).
- **Checks and Tests**: Validated locally that formatting, static analysis, and all test suites pass cleanly.