### PR TITLE
Turn HCPP on by default in master and beta branches

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -276,7 +276,8 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   bool get enableVulkanValidation => boolArg('enable-vulkan-validation');
   bool get uninstallFirst => boolArg('uninstall-first');
   bool get enableEmbedderApi => boolArg('enable-embedder-api');
-  bool get enableHcpp => boolArg('enable-hcpp');
+  bool get enableHcpp =>
+      argResults!.wasParsed('enable-hcpp') ? boolArg('enable-hcpp') : featureFlags.isHcppEnabled;
   bool get testFlag => boolArg('test-flag');
 
   @override

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -12,6 +12,7 @@ import '../build_info.dart';
 import '../bundle_builder.dart';
 import '../devfs.dart';
 import '../device.dart';
+import '../features.dart';
 import '../globals.dart' as globals;
 import '../native_assets.dart';
 import '../project.dart';
@@ -495,7 +496,9 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
           : null,
       printDtd: boolArg(FlutterGlobalOptions.kPrintDtd, global: true),
       webUseWasm: useWasm,
-      enableHcpp: boolArg('enable-hcpp'),
+      enableHcpp: argResults!.wasParsed('enable-hcpp')
+          ? boolArg('enable-hcpp')
+          : featureFlags.isHcppEnabled,
       uninstallApp: boolArg('uninstall'),
     );
 

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -88,6 +88,9 @@ abstract class FeatureFlags {
   /// Whether to only build for arm64 when targeting macOS.
   bool get isMacOSArm64OnlyEnabled;
 
+  /// Whether HCPP gating is enabled.
+  bool get isHcppEnabled;
+
   /// Whether a particular feature is enabled for the current channel.
   ///
   /// Prefer using one of the specific getters above instead of this API.
@@ -115,6 +118,7 @@ abstract class FeatureFlags {
     uiSceneMigration,
     riscv64,
     macOSArm64Only,
+    hcpp,
   ];
 
   /// All current Flutter feature flags that can be configured.
@@ -324,6 +328,16 @@ const macOSArm64Only = Feature(
   environmentOverride: 'FLUTTER_MACOS_ARM64_ONLY',
   master: FeatureChannelSetting(available: true),
   beta: FeatureChannelSetting(available: true),
+  stable: FeatureChannelSetting(available: true),
+);
+
+/// Enable Hybrid Composition++ (HCPP) gating.
+const hcpp = Feature(
+  name: 'support for Hybrid Composition++ (HCPP)',
+  configSetting: 'enable-hcpp',
+  environmentOverride: 'FLUTTER_ENABLE_HCPP',
+  master: FeatureChannelSetting(available: true, enabledByDefault: true),
+  beta: FeatureChannelSetting(available: true, enabledByDefault: true),
   stable: FeatureChannelSetting(available: true),
 );
 

--- a/packages/flutter_tools/lib/src/flutter_features.dart
+++ b/packages/flutter_tools/lib/src/flutter_features.dart
@@ -78,6 +78,9 @@ mixin FlutterFeatureFlagsIsEnabled implements FeatureFlags {
 
   @override
   bool get isMacOSArm64OnlyEnabled => isEnabled(macOSArm64Only);
+
+  @override
+  bool get isHcppEnabled => isEnabled(hcpp);
 }
 
 interface class FlutterFeatureFlags extends FeatureFlags with FlutterFeatureFlagsIsEnabled {

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -428,7 +428,7 @@ void main() {
                 runProjectHostLanguage: 'swift',
                 runIOSInterfaceType: 'usb',
                 runIsTest: false,
-                runEnableHcpp: false,
+                runEnableHcpp: true,
               ),
             ),
           );
@@ -482,7 +482,7 @@ void main() {
                 runProjectHostLanguage: 'swift',
                 runIOSInterfaceType: 'usb',
                 runIsTest: true,
-                runEnableHcpp: false,
+                runEnableHcpp: true,
               ),
             ),
           );
@@ -789,7 +789,7 @@ void main() {
                 runProjectModule: false,
                 runProjectHostLanguage: '',
                 runIsTest: false,
-                runEnableHcpp: false,
+                runEnableHcpp: true,
               ),
             ),
           );
@@ -840,7 +840,7 @@ void main() {
                 runProjectHostLanguage: '',
                 runIOSInterfaceType: 'usb',
                 runIsTest: false,
-                runEnableHcpp: false,
+                runEnableHcpp: true,
               ),
             ),
           );
@@ -896,7 +896,7 @@ void main() {
                 runProjectHostLanguage: '',
                 runIOSInterfaceType: 'wireless',
                 runIsTest: false,
-                runEnableHcpp: false,
+                runEnableHcpp: true,
               ),
             ),
           );
@@ -953,7 +953,7 @@ void main() {
                 runProjectHostLanguage: '',
                 runIOSInterfaceType: 'wireless',
                 runIsTest: false,
-                runEnableHcpp: false,
+                runEnableHcpp: true,
               ),
             ),
           );
@@ -963,6 +963,116 @@ void main() {
           Cache: () => Cache.test(processManager: FakeProcessManager.any()),
           FileSystem: () => MemoryFileSystem.test(),
           ProcessManager: () => FakeProcessManager.any(),
+        },
+      );
+    });
+
+    group('HCPP Gating', () {
+      testUsingContext(
+        'enableHcpp is true when --enable-hcpp is explicitly passed',
+        () async {
+          final devices = <Device>[
+            FakeDevice(
+              targetPlatform: TargetPlatform.android_arm,
+              platformType: PlatformType.android,
+            ),
+          ];
+          final command = TestRunCommandForUsageValues(devices: devices);
+          final CommandRunner<void> runner = createTestCommandRunner(command);
+          try {
+            await runner.run(<String>['run', '--enable-hcpp']);
+          } on ToolExit {
+            // Ignore
+          }
+          expect(command.enableHcpp, isTrue);
+        },
+        overrides: <Type, Generator>{
+          DeviceManager: () => testDeviceManager,
+          Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+          FileSystem: () => MemoryFileSystem.test(),
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => TestFeatureFlags(),
+        },
+      );
+
+      testUsingContext(
+        'enableHcpp is false when --no-enable-hcpp is explicitly passed',
+        () async {
+          final devices = <Device>[
+            FakeDevice(
+              targetPlatform: TargetPlatform.android_arm,
+              platformType: PlatformType.android,
+            ),
+          ];
+          final command = TestRunCommandForUsageValues(devices: devices);
+          final CommandRunner<void> runner = createTestCommandRunner(command);
+          try {
+            await runner.run(<String>['run', '--no-enable-hcpp']);
+          } on ToolExit {
+            // Ignore
+          }
+          expect(command.enableHcpp, isFalse);
+        },
+        overrides: <Type, Generator>{
+          DeviceManager: () => testDeviceManager,
+          Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+          FileSystem: () => MemoryFileSystem.test(),
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => TestFeatureFlags(isHcppEnabled: true),
+        },
+      );
+
+      testUsingContext(
+        'enableHcpp falls back to isHcppEnabled = true when flag not explicitly passed',
+        () async {
+          final devices = <Device>[
+            FakeDevice(
+              targetPlatform: TargetPlatform.android_arm,
+              platformType: PlatformType.android,
+            ),
+          ];
+          final command = TestRunCommandForUsageValues(devices: devices);
+          final CommandRunner<void> runner = createTestCommandRunner(command);
+          try {
+            await runner.run(<String>['run']);
+          } on ToolExit {
+            // Ignore
+          }
+          expect(command.enableHcpp, isTrue);
+        },
+        overrides: <Type, Generator>{
+          DeviceManager: () => testDeviceManager,
+          Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+          FileSystem: () => MemoryFileSystem.test(),
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => TestFeatureFlags(isHcppEnabled: true),
+        },
+      );
+
+      testUsingContext(
+        'enableHcpp falls back to isHcppEnabled = false when flag not explicitly passed',
+        () async {
+          final devices = <Device>[
+            FakeDevice(
+              targetPlatform: TargetPlatform.android_arm,
+              platformType: PlatformType.android,
+            ),
+          ];
+          final command = TestRunCommandForUsageValues(devices: devices);
+          final CommandRunner<void> runner = createTestCommandRunner(command);
+          try {
+            await runner.run(<String>['run']);
+          } on ToolExit {
+            // Ignore
+          }
+          expect(command.enableHcpp, isFalse);
+        },
+        overrides: <Type, Generator>{
+          DeviceManager: () => testDeviceManager,
+          Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+          FileSystem: () => MemoryFileSystem.test(),
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => TestFeatureFlags(),
         },
       );
     });
@@ -2236,6 +2346,9 @@ class FakeAnsiTerminal extends Fake implements AnsiTerminal {
 class FakeFeatureFlags extends Fake implements FeatureFlags {
   @override
   bool get isWebEnabled => true;
+
+  @override
+  bool get isHcppEnabled => isEnabled(hcpp);
 
   @override
   bool isEnabled(Feature feature) => feature.master.enabledByDefault;

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/test.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/native_assets.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -35,6 +36,7 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_devices.dart';
 import '../../src/fake_vm_services.dart';
+import '../../src/fakes.dart';
 import '../../src/logging_logger.dart';
 import '../../src/package_config.dart';
 import '../../src/test_flutter_command_runner.dart';
@@ -1555,6 +1557,76 @@ dev_dependencies:
         ProcessManager: () => FakeProcessManager.any(),
       },
     );
+
+    group('HCPP Gating', () {
+      testUsingContext(
+        'enableHcpp is true when --enable-hcpp is explicitly passed',
+        () async {
+          final testRunner = FakeFlutterTestRunner(0);
+          final testCommand = TestCommand(testRunner: testRunner);
+          final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+          await commandRunner.run(const <String>['test', '--no-pub', '--enable-hcpp']);
+          expect(testRunner.lastDebuggingOptionsValue.enableHcpp, isTrue);
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => TestFeatureFlags(),
+        },
+      );
+
+      testUsingContext(
+        'enableHcpp is false when --no-enable-hcpp is explicitly passed',
+        () async {
+          final testRunner = FakeFlutterTestRunner(0);
+          final testCommand = TestCommand(testRunner: testRunner);
+          final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+          await commandRunner.run(const <String>['test', '--no-pub', '--no-enable-hcpp']);
+          expect(testRunner.lastDebuggingOptionsValue.enableHcpp, isFalse);
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => TestFeatureFlags(isHcppEnabled: true),
+        },
+      );
+
+      testUsingContext(
+        'enableHcpp falls back to isHcppEnabled = true when flag not explicitly passed',
+        () async {
+          final testRunner = FakeFlutterTestRunner(0);
+          final testCommand = TestCommand(testRunner: testRunner);
+          final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+          await commandRunner.run(const <String>['test', '--no-pub']);
+          expect(testRunner.lastDebuggingOptionsValue.enableHcpp, isTrue);
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => TestFeatureFlags(isHcppEnabled: true),
+        },
+      );
+
+      testUsingContext(
+        'enableHcpp falls back to isHcppEnabled = false when flag not explicitly passed',
+        () async {
+          final testRunner = FakeFlutterTestRunner(0);
+          final testCommand = TestCommand(testRunner: testRunner);
+          final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+          await commandRunner.run(const <String>['test', '--no-pub']);
+          expect(testRunner.lastDebuggingOptionsValue.enableHcpp, isFalse);
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => TestFeatureFlags(),
+        },
+      );
+    });
 
     testUsingContext(
       'Passes web renderer into debugging options',

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -445,6 +445,29 @@ void main() {
       expect(checkFlags.isMacOSArm64OnlyEnabled, isTrue);
     });
   });
+
+  group('hcpp', () {
+    test('is available on all channels, enabled by default on master and beta', () {
+      expect(
+        hcpp,
+        allOf(<Matcher>[
+          _onChannelIs('master', available: true, enabledByDefault: true),
+          _onChannelIs('beta', available: true, enabledByDefault: true),
+          _onChannelIs('stable', available: true, enabledByDefault: false),
+        ]),
+      );
+    });
+
+    test('can be configured', () {
+      expect(hcpp.configSetting, 'enable-hcpp');
+      expect(hcpp.environmentOverride, 'FLUTTER_ENABLE_HCPP');
+    });
+
+    test('forwards to isEnabled', () {
+      final checkFlags = _TestIsGetterForwarding(shouldInvoke: hcpp);
+      expect(checkFlags.isHcppEnabled, isTrue);
+    });
+  });
 }
 
 final class _FakeFeaturesConfig implements FlutterFeaturesConfig {

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -861,6 +861,9 @@ class FakeFlutterFeatures extends FeatureFlags {
   bool get isMacOSArm64OnlyEnabled => _enabled;
 
   @override
+  bool get isHcppEnabled => _enabled;
+
+  @override
   final List<Feature> allFeatures;
 
   @override

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -554,6 +554,7 @@ class TestFeatureFlags implements FeatureFlags {
     this.isUISceneMigrationEnabled = false,
     this.isRiscv64SupportEnabled = false,
     this.isMacOSArm64OnlyEnabled = false,
+    this.isHcppEnabled = false,
   });
 
   @override
@@ -617,6 +618,9 @@ class TestFeatureFlags implements FeatureFlags {
   final bool isMacOSArm64OnlyEnabled;
 
   @override
+  final bool isHcppEnabled;
+
+  @override
   bool isEnabled(Feature feature) {
     return switch (feature) {
       flutterWebFeature => isWebEnabled,
@@ -638,6 +642,7 @@ class TestFeatureFlags implements FeatureFlags {
       riscv64 => isRiscv64SupportEnabled,
       macOSArm64Only => isMacOSArm64OnlyEnabled,
       recordUse => isRecordUseEnabled,
+      hcpp => isHcppEnabled,
       _ => false,
     };
   }
@@ -664,6 +669,7 @@ class TestFeatureFlags implements FeatureFlags {
     uiSceneMigration,
     riscv64,
     macOSArm64Only,
+    hcpp,
   ];
 
   @override


### PR DESCRIPTION
Add a `Feature` flag for HCPP.

In `flutter run` and `flutter test`, `--enable-hcpp` and `--no-enable-hcpp` flag is always preferred. However, if not specified, it will default to true on the master and dev branches, and false on stable.

It can also be globally set from `flutter config --enable-hcpp`, which defaults to true on master and beta, and false on stable.
```
$ flutter config
...
    --[no-]enable-hcpp                         Enable or disable support for Hybrid Composition++ (HCPP).
                                               (defaults to on)
```


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
