### PR TITLE
[iOS] Fix missing nil checks and improve SemanticsObject bridge API

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSemanticsScrollView.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSemanticsScrollView.mm
@@ -30,11 +30,12 @@ FLUTTER_ASSERT_ARC
 // UIScrollView class, the base class.
 
 - (BOOL)isAccessibilityElement {
-  if (![self.semanticsObject isAccessibilityBridgeAlive]) {
+  flutter::AccessibilityBridgeIos* bridge = self.semanticsObject.bridge;
+  if (!bridge) {
     return NO;
   }
 
-  if ([self.semanticsObject bridge]->isVoiceOverRunning()) {
+  if (bridge->isVoiceOverRunning()) {
     return self.semanticsObject.accessibilityLabel.length > 0;
   }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject+UIFocusSystem.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject+UIFocusSystem.mm
@@ -61,7 +61,7 @@ FLUTTER_ASSERT_ARC
 
 - (id<UIFocusEnvironment>)parentFocusEnvironment {
   // The root SemanticsObject node's parent is the FlutterView.
-  return self.parent.focusItem ?: ([self isAccessibilityBridgeAlive] ? self.bridge->view() : nil);
+  return self.parent.focusItem ?: [self bridgeView];
 }
 
 - (NSArray<id<UIFocusEnvironment>>*)preferredFocusEnvironments {
@@ -89,7 +89,7 @@ FLUTTER_ASSERT_ARC
 // See also the `coordinateSpace` implementation.
 // TODO(LongCatIsLooong): use CoreGraphics types.
 - (CGRect)frame {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return CGRectZero;
   }
   SkPoint quad[4] = {SkPoint::Make(self.node.rect.left(), self.node.rect.top()),
@@ -134,7 +134,8 @@ FLUTTER_ASSERT_ARC
   // UIFocusItem is not inside of a scroll view).
   //
   // Screen can be nil if the FlutterView is covered by another native view.
-  CGFloat scale = (self.bridge->view().window.screen ?: UIScreen.mainScreen).scale;
+  UIView* view = self.bridgeView;
+  CGFloat scale = (view.window.screen ?: UIScreen.mainScreen).scale;
   return CGRectMake(unscaledRect.origin.x / scale, unscaledRect.origin.y / scale,
                     unscaledRect.size.width / scale, unscaledRect.size.height / scale);
 }
@@ -162,8 +163,7 @@ FLUTTER_ASSERT_ARC
 
 - (id<UICoordinateSpace>)coordinateSpace {
   // A regular SemanticsObject uses the same coordinate space as its parent.
-  return self.parent.coordinateSpace
-             ?: ([self isAccessibilityBridgeAlive] ? self.bridge->view() : nil);
+  return self.parent.coordinateSpace ?: [self bridgeView];
 }
 
 @end
@@ -214,7 +214,8 @@ FLUTTER_ASSERT_ARC
   [super setContentOffset:contentOffset];
   // Do no send flutter::SemanticsAction::kScrollToOffset if it's triggered
   // by a framework update.
-  if (![self.semanticsObject isAccessibilityBridgeAlive] || !self.isDoingSystemScrolling) {
+  flutter::AccessibilityBridgeIos* bridge = self.semanticsObject.bridge;
+  if (!bridge || !self.isDoingSystemScrolling) {
     return;
   }
 
@@ -222,9 +223,9 @@ FLUTTER_ASSERT_ARC
   FlutterStandardTypedData* offsetData = [FlutterStandardTypedData
       typedDataWithFloat64:[NSData dataWithBytes:&offset length:sizeof(offset)]];
   NSData* encoded = [[FlutterStandardMessageCodec sharedInstance] encode:offsetData];
-  self.semanticsObject.bridge->DispatchSemanticsAction(
-      self.semanticsObject.uid, flutter::SemanticsAction::kScrollToOffset,
-      fml::MallocMapping::Copy(encoded.bytes, encoded.length));
+  bridge->DispatchSemanticsAction(self.semanticsObject.uid,
+                                  flutter::SemanticsAction::kScrollToOffset,
+                                  fml::MallocMapping::Copy(encoded.bytes, encoded.length));
 }
 
 - (BOOL)canBecomeFocused {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
@@ -13,6 +13,8 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterSemanticsScrollView.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 constexpr int32_t kRootNodeId = 0;
 // This can be arbitrary number as long as it is bigger than 0.
 constexpr float kScrollExtentMaxForInf = 1000;
@@ -39,17 +41,7 @@ constexpr float kScrollExtentMaxForInf = 1000;
  * The parent of this node in the node tree. Will be nil for the root node and
  * during transient state changes.
  */
-@property(nonatomic, weak, readonly) SemanticsObject* parent;
-
-/**
- * The accessibility bridge that this semantics object is attached to. This
- * object may use the bridge to access contextual application information. A weak
- * pointer is used because the platform view owns the accessibility bridge.
- * If you are referencing this property from an iOS callback, be sure to
- * use `isAccessibilityBridgeActive` to protect against the case where this
- * node may be orphaned.
- */
-@property(nonatomic, readonly) fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge;
+@property(nonatomic, weak, readonly, nullable) SemanticsObject* parent;
 
 /**
  * The semantics node used to produce this semantics object.
@@ -71,7 +63,7 @@ constexpr float kScrollExtentMaxForInf = 1000;
  * Direct children of this semantics object in hit test order. Each child's `parent` property
  * must be equal to this object.
  */
-@property(nonatomic, copy) NSArray<SemanticsObject*>* childrenInHitTestOrder;
+@property(nonatomic, copy, nullable) NSArray<SemanticsObject*>* childrenInHitTestOrder;
 
 /**
  * The UIAccessibility that represents this object.
@@ -86,12 +78,20 @@ constexpr float kScrollExtentMaxForInf = 1000;
  * Due to the fact that VoiceOver may hold onto SemanticObjects even after it shuts down,
  * there can be situations where the AccessibilityBridge is shutdown, but the SemanticObject
  * will still be alive. If VoiceOver is turned on again, it may try to access this orphaned
- * SemanticObject. Methods that are called from the accessiblity framework should use
- * this to guard against this case by just returning early if its bridge has been shutdown.
+ * SemanticObject. Methods that are called from the accessibility framework should use
+ * `bridge` (or `bridgeView`) to guard against this case by just returning early if its bridge
+ * has been shutdown.
  *
  * See https://github.com/flutter/flutter/issues/43795 for more information.
+ *
+ * Returns a raw pointer to the AccessibilityBridge if it is still alive, or nullptr if destroyed.
  */
-- (BOOL)isAccessibilityBridgeAlive;
+- (nullable flutter::AccessibilityBridgeIos*)bridge;
+
+/**
+ * Returns the underlying UIView from the bridge if alive, or nil if destroyed.
+ */
+- (nullable UIView*)bridgeView;
 
 /**
  * Updates this semantics object using data from the `node` argument.
@@ -104,11 +104,11 @@ constexpr float kScrollExtentMaxForInf = 1000;
 
 - (BOOL)nodeWillCauseScroll:(const flutter::SemanticsNode*)node;
 
-- (BOOL)nodeShouldTriggerAnnouncement:(const flutter::SemanticsNode*)node;
+- (BOOL)nodeShouldTriggerAnnouncement:(nullable const flutter::SemanticsNode*)node;
 
 - (void)collectRoutes:(NSMutableArray<SemanticsObject*>*)edges;
 
-- (NSString*)routeName;
+- (nullable NSString*)routeName;
 
 - (BOOL)onCustomAccessibilityAction:(FlutterCustomAccessibilityAction*)action;
 
@@ -228,12 +228,12 @@ constexpr float kScrollExtentMaxForInf = 1000;
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)initWithAccessibilityContainer:(id)container NS_UNAVAILABLE;
-- (instancetype)initWithSemanticsObject:(SemanticsObject*)semanticsObject
-                                 bridge:(fml::WeakPtr<flutter::AccessibilityBridgeIos>)bridge
-    NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithSemanticsObject:(SemanticsObject*)semanticsObject NS_DESIGNATED_INITIALIZER;
 
-@property(nonatomic, weak) SemanticsObject* semanticsObject;
+@property(nonatomic, weak, nullable) SemanticsObject* semanticsObject;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_SEMANTICSOBJECT_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -50,20 +50,28 @@ SkPoint ApplyTransform(SkPoint& point, const SkM44& transform) {
 }
 
 CGPoint ConvertPointToGlobal(SemanticsObject* reference, CGPoint local_point) {
+  UIView* containerView = [reference bridgeView];
+  if (!containerView) {
+    return CGPointZero;
+  }
   SkM44 globalTransform = GetGlobalTransform(reference);
   SkPoint point = SkPoint::Make(local_point.x, local_point.y);
   point = ApplyTransform(point, globalTransform);
   // `rect` is in the physical pixel coordinate system. iOS expects the accessibility frame in
   // the logical pixel coordinate system. Therefore, we divide by the `scale` (pixel ratio) to
   // convert.
-  UIScreen* screen = reference.bridge->view().window.screen;
+  UIScreen* screen = containerView.window.screen;
   // Screen can be nil if the FlutterView is covered by another native view.
   CGFloat scale = (screen ?: UIScreen.mainScreen).scale;
   auto result = CGPointMake(point.x() / scale, point.y() / scale);
-  return [reference.bridge->view() convertPoint:result toView:nil];
+  return [containerView convertPoint:result toView:nil];
 }
 
 CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
+  UIView* containerView = [reference bridgeView];
+  if (!containerView) {
+    return CGRectZero;
+  }
   SkM44 globalTransform = GetGlobalTransform(reference);
 
   SkPoint quad[4] = {
@@ -84,12 +92,12 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   // `rect` is in the physical pixel coordinate system. iOS expects the accessibility frame in
   // the logical pixel coordinate system. Therefore, we divide by the `scale` (pixel ratio) to
   // convert.
-  UIScreen* screen = reference.bridge->view().window.screen;
+  UIScreen* screen = containerView.window.screen;
   // Screen can be nil if the FlutterView is covered by another native view.
   CGFloat scale = (screen ?: UIScreen.mainScreen).scale;
   auto result =
       CGRectMake(rect.x() / scale, rect.y() / scale, rect.width() / scale, rect.height() / scale);
-  return UIAccessibilityConvertFrameToScreenCoordinates(result, reference.bridge->view());
+  return UIAccessibilityConvertFrameToScreenCoordinates(result, containerView);
 }
 
 }  // namespace
@@ -126,7 +134,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   self.nativeSwitch.on = self.node.flags.isToggled == flutter::SemanticsTristate::kTrue ||
                          self.node.flags.isChecked == flutter::SemanticsCheckState::kTrue;
 
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return nil;
   } else {
     return self.nativeSwitch.accessibilityValue;
@@ -156,7 +164,10 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
     [_scrollView setShowsVerticalScrollIndicator:NO];
     [_scrollView setContentInset:UIEdgeInsetsZero];
     [_scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
-    [self.bridge->view() addSubview:_scrollView];
+    UIView* containerView = self.bridgeView;
+    if (containerView) {
+      [containerView addSubview:_scrollView];
+    }
   }
   return self;
 }
@@ -189,7 +200,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // private methods
 
 - (float)scrollExtentMax {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return 0.0f;
   }
   float scrollExtentMax = self.node.scrollExtentMax;
@@ -202,7 +213,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (float)scrollPosition {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return 0.0f;
   }
   float scrollPosition = self.node.scrollPosition;
@@ -256,6 +267,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 @end
 
 @implementation SemanticsObject {
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> _weakBridge;
   NSMutableArray<SemanticsObject*>* _children;
   BOOL _inDealloc;
 }
@@ -270,10 +282,10 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   // The UIView will not necessarily be accessibility parent for this object.
   // The bridge informs the OS of the actual structure via
   // `accessibilityContainer` and `accessibilityElementAtIndex`.
-  self = [super initWithAccessibilityContainer:bridge->view()];
+  self = [super initWithAccessibilityContainer:bridge ? bridge->view() : nil];
 
   if (self) {
-    _bridge = bridge;
+    _weakBridge = bridge;
     _uid = uid;
     _children = [[NSMutableArray alloc] init];
     _childrenInHitTestOrder = [[NSArray alloc] init];
@@ -299,6 +311,10 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 #pragma mark - Semantic object property accesser
+
+- (NSArray<SemanticsObject*>*)children {
+  return [_children copy];
+}
 
 - (void)setChildren:(NSArray<SemanticsObject*>*)children {
   for (SemanticsObject* child in _children) {
@@ -326,8 +342,13 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
 #pragma mark - Semantic object method
 
-- (BOOL)isAccessibilityBridgeAlive {
-  return self.bridge.get() != nil;
+- (flutter::AccessibilityBridgeIos*)bridge {
+  return _weakBridge.get();
+}
+
+- (UIView*)bridgeView {
+  flutter::AccessibilityBridgeIos* bridge = [self bridge];
+  return bridge ? bridge->view() : nil;
 }
 
 - (void)setSemanticsNode:(const flutter::SemanticsNode*)node {
@@ -432,13 +453,17 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (void)showOnScreen {
-  self.bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kShowOnScreen);
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
+    return;
+  }
+  bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kShowOnScreen);
 }
 
 #pragma mark - UIAccessibility overrides
 
 - (BOOL)isAccessibilityElement {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return false;
   }
 
@@ -455,14 +480,15 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (NSString*)accessibilityLanguage {
-  if (![self isAccessibilityBridgeAlive]) {
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
     return nil;
   }
 
   if (!self.node.locale.empty()) {
     return @(self.node.locale.data());
   }
-  return self.bridge->GetDefaultLocale();
+  return bridge->GetDefaultLocale();
 }
 
 - (bool)isFocusable {
@@ -492,6 +518,10 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (BOOL)onCustomAccessibilityAction:(FlutterCustomAccessibilityAction*)action {
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
+    return NO;
+  }
   if (!self.node.HasAction(flutter::SemanticsAction::kCustomAction)) {
     return NO;
   }
@@ -502,14 +532,14 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   args.push_back(action_id >> 8);
   args.push_back(action_id >> 16);
   args.push_back(action_id >> 24);
-  self.bridge->DispatchSemanticsAction(
+  bridge->DispatchSemanticsAction(
       self.uid, flutter::SemanticsAction::kCustomAction,
       fml::MallocMapping::Copy(args.data(), args.size() * sizeof(uint8_t)));
   return YES;
 }
 
 - (NSString*)accessibilityIdentifier {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return nil;
   }
 
@@ -520,7 +550,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (NSString*)accessibilityLabel {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return nil;
   }
   NSString* label = nil;
@@ -565,6 +595,9 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // IOS 16. Overrides this method to focus the first eligiable semantics
 // object in hit test order.
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
+  if (!self.bridge) {
+    return nil;
+  }
   return [self search:point];
 }
 
@@ -592,7 +625,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (NSString*)accessibilityHint {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return nil;
   }
 
@@ -611,7 +644,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (NSString*)accessibilityValue {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return nil;
   }
 
@@ -646,8 +679,8 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (CGRect)accessibilityFrame {
-  if (![self isAccessibilityBridgeAlive]) {
-    return CGRectMake(0, 0, 0, 0);
+  if (!self.bridge) {
+    return CGRectZero;
   }
 
   if (self.node.flags.isHidden) {
@@ -678,14 +711,13 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
     return nil;
   }
 
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return nil;
   }
 
   if ([self hasChildren] || self.uid == kRootNodeId) {
     if (self.container == nil) {
-      self.container = [[SemanticsObjectContainer alloc] initWithSemanticsObject:self
-                                                                          bridge:self.bridge];
+      self.container = [[SemanticsObjectContainer alloc] initWithSemanticsObject:self];
     }
     return self.container;
   }
@@ -701,7 +733,8 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 #pragma mark - UIAccessibilityAction overrides
 
 - (BOOL)accessibilityActivate {
-  if (![self isAccessibilityBridgeAlive]) {
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
     return NO;
   }
   if (!self.node.HasAction(flutter::SemanticsAction::kTap)) {
@@ -714,77 +747,81 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
     }
     return NO;
   }
-  self.bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kTap);
+  bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kTap);
   return YES;
 }
 
 - (void)accessibilityIncrement {
-  if (![self isAccessibilityBridgeAlive]) {
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
     return;
   }
   if (self.node.HasAction(flutter::SemanticsAction::kIncrease)) {
     self.node.value = self.node.increasedValue;
-    self.bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kIncrease);
+    bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kIncrease);
   }
 }
 
 - (void)accessibilityDecrement {
-  if (![self isAccessibilityBridgeAlive]) {
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
     return;
   }
   if (self.node.HasAction(flutter::SemanticsAction::kDecrease)) {
     self.node.value = self.node.decreasedValue;
-    self.bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kDecrease);
+    bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kDecrease);
   }
 }
 
 - (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
-  if (![self isAccessibilityBridgeAlive]) {
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
     return NO;
   }
   flutter::SemanticsAction action = GetSemanticsActionForScrollDirection(direction);
   if (!self.node.HasAction(action)) {
     return NO;
   }
-  self.bridge->DispatchSemanticsAction(self.uid, action);
+  bridge->DispatchSemanticsAction(self.uid, action);
   return YES;
 }
 
 - (BOOL)accessibilityPerformEscape {
-  if (![self isAccessibilityBridgeAlive]) {
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
     return NO;
   }
   if (!self.node.HasAction(flutter::SemanticsAction::kDismiss)) {
     return NO;
   }
-  self.bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kDismiss);
+  bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kDismiss);
   return YES;
 }
 
 #pragma mark UIAccessibilityFocus overrides
 
 - (void)accessibilityElementDidBecomeFocused {
-  if (![self isAccessibilityBridgeAlive]) {
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
     return;
   }
-  self.bridge->AccessibilityObjectDidBecomeFocused(self.uid);
+  bridge->AccessibilityObjectDidBecomeFocused(self.uid);
   if (self.node.flags.isHidden || self.node.flags.isHeader) {
     [self showOnScreen];
   }
   if (self.node.HasAction(flutter::SemanticsAction::kDidGainAccessibilityFocus)) {
-    self.bridge->DispatchSemanticsAction(self.uid,
-                                         flutter::SemanticsAction::kDidGainAccessibilityFocus);
+    bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kDidGainAccessibilityFocus);
   }
 }
 
 - (void)accessibilityElementDidLoseFocus {
-  if (![self isAccessibilityBridgeAlive]) {
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
     return;
   }
-  self.bridge->AccessibilityObjectDidLoseFocus(self.uid);
+  bridge->AccessibilityObjectDidLoseFocus(self.uid);
   if (self.node.HasAction(flutter::SemanticsAction::kDidLoseAccessibilityFocus)) {
-    self.bridge->DispatchSemanticsAction(self.uid,
-                                         flutter::SemanticsAction::kDidLoseAccessibilityFocus);
+    bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kDidLoseAccessibilityFocus);
   }
 }
 
@@ -884,23 +921,20 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 @end
 
 @implementation SemanticsObjectContainer {
-  fml::WeakPtr<flutter::AccessibilityBridgeIos> _bridge;
 }
 
 #pragma mark - initializers
 
-- (instancetype)initWithSemanticsObject:(SemanticsObject*)semanticsObject
-                                 bridge:(fml::WeakPtr<flutter::AccessibilityBridgeIos>)bridge {
+- (instancetype)initWithSemanticsObject:(SemanticsObject*)semanticsObject {
   FML_DCHECK(semanticsObject) << "semanticsObject must be set";
   // Initialize with the UIView as the container.
   // The UIView will not necessarily be accessibility parent for this object.
   // The bridge informs the OS of the actual structure via
   // `accessibilityContainer` and `accessibilityElementAtIndex`.
-  self = [super initWithAccessibilityContainer:bridge->view()];
+  self = [super initWithAccessibilityContainer:semanticsObject.bridgeView];
 
   if (self) {
     _semanticsObject = semanticsObject;
-    _bridge = bridge;
   }
 
   return self;
@@ -960,11 +994,8 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (id)accessibilityContainer {
-  if (!_bridge) {
-    return nil;
-  }
   return ([self.semanticsObject uid] == kRootNodeId)
-             ? _bridge->view()
+             ? self.semanticsObject.bridgeView
              : self.semanticsObject.parent.accessibilityContainer;
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
@@ -211,7 +211,11 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
 - (void)setSemanticsNode:(const flutter::SemanticsNode*)node {
   [super setSemanticsNode:node];
   _inactive_text_input.text = @(node->value.data());
-  FlutterTextInputView* textInput = (FlutterTextInputView*)[self bridge]->textInputView();
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (!bridge) {
+    return;
+  }
+  FlutterTextInputView* textInput = (FlutterTextInputView*)bridge->textInputView();
   if ([self node].flags.isFocused == flutter::SemanticsTristate::kTrue) {
     textInput.backingTextInputAccessibilityObject = self;
     // The text input view must have a non-trivial size for the accessibility
@@ -233,8 +237,9 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
  * we use an FlutterInactiveTextInput.
  */
 - (UIView<UITextInput>*)textInputSurrogate {
-  if ([self node].flags.isFocused == flutter::SemanticsTristate::kTrue) {
-    return [self bridge]->textInputView();
+  flutter::AccessibilityBridgeIos* bridge = self.bridge;
+  if (bridge && [self node].flags.isFocused == flutter::SemanticsTristate::kTrue) {
+    return bridge->textInputView();
   } else {
     return _inactive_text_input;
   }
@@ -245,7 +250,7 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
 }
 
 - (void)accessibilityElementDidBecomeFocused {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return;
   }
   [[self textInputSurrogate] accessibilityElementDidBecomeFocused];
@@ -253,7 +258,7 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
 }
 
 - (void)accessibilityElementDidLoseFocus {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return;
   }
   [[self textInputSurrogate] accessibilityElementDidLoseFocus];
@@ -261,21 +266,21 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
 }
 
 - (BOOL)accessibilityElementIsFocused {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return false;
   }
   return [self node].flags.isFocused == flutter::SemanticsTristate::kTrue;
 }
 
 - (BOOL)accessibilityActivate {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return false;
   }
   return [[self textInputSurrogate] accessibilityActivate];
 }
 
 - (NSString*)accessibilityLabel {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return nil;
   }
 
@@ -287,7 +292,7 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
 }
 
 - (NSString*)accessibilityHint {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return nil;
   }
   NSString* hint = [super accessibilityHint];
@@ -298,7 +303,7 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
 }
 
 - (NSString*)accessibilityValue {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return nil;
   }
   NSString* value = [super accessibilityValue];
@@ -309,7 +314,7 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
 }
 
 - (UIAccessibilityTraits)accessibilityTraits {
-  if (![self isAccessibilityBridgeAlive]) {
+  if (!self.bridge) {
     return 0;
   }
   UIAccessibilityTraits results =

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -13,6 +13,7 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterSemanticsScrollView.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h"
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 
@@ -20,6 +21,10 @@ FLUTTER_ASSERT_ARC
 
 @class MockPlatformView;
 __weak static MockPlatformView* gMockPlatformView = nil;
+
+@interface SemanticsObject (Test)
+- (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event;
+@end
 
 @interface MockPlatformView : UIView
 @end
@@ -231,8 +236,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
                                  SemanticsObjectContainer* container = value[0];
                                  SemanticsObject* object = container.semanticsObject;
                                  return object.uid == kRootNodeId &&
-                                        object.bridge.get() == bridge.get() &&
-                                        object.node.label == label;
+                                        object.bridge == bridge.get() && object.node.label == label;
                                }
                              }]]);
 
@@ -2444,6 +2448,75 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
     XCTAssertNotNil(bridge->view());
   }
   XCTAssertNil(bridge->view());
+}
+
+- (void)testSemanticsObjectAndContainerAccessAfterBridgeDestruction {
+  flutter::MockDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/mock_delegate.settings_.enable_impeller
+          ? flutter::IOSRenderingAPI::kMetal
+          : flutter::IOSRenderingAPI::kSoftware,
+      /*platform_views_controller=*/nil,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_sync_switch=*/std::make_shared<fml::SyncSwitch>());
+  id mockEngine = OCMClassMock([FlutterEngine class]);
+  id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  FlutterView* flutterView = [[FlutterView alloc] initWithDelegate:mockEngine
+                                                            opaque:YES
+                                                   enableWideGamut:NO];
+  OCMStub([mockFlutterViewController view]).andReturn(flutterView);
+  // `~AccessibilityBridge` calls `clearState`, which reads `viewIfLoaded` on the view
+  // controller; stub it so `bridge.reset()` below doesn't hit an unstubbed selector.
+  OCMStub([mockFlutterViewController viewIfLoaded]).andReturn(flutterView);
+
+  auto bridge = std::make_unique<flutter::AccessibilityBridge>(
+      /*view_controller=*/mockFlutterViewController,
+      /*platform_view=*/platform_view.get(),
+      /*platform_views_controller=*/nil);
+
+  flutter::SemanticsNodeUpdates nodes;
+  flutter::SemanticsNode root_node;
+  root_node.id = kRootNodeId;
+  root_node.label = "root";
+  root_node.childrenInTraversalOrder = {1};
+  root_node.childrenInHitTestOrder = {1};
+
+  flutter::SemanticsNode child_node;
+  child_node.id = 1;
+  child_node.label = "child";
+  nodes[root_node.id] = root_node;
+  nodes[child_node.id] = child_node;
+
+  flutter::CustomAccessibilityActionUpdates actions;
+  bridge->UpdateSemantics(/*nodes=*/nodes, /*actions=*/actions);
+
+  NSArray* accessibilityElements = flutterView.accessibilityElements;
+  XCTAssertEqual([accessibilityElements count], 1u);
+  SemanticsObjectContainer* rootContainer = accessibilityElements[0];
+  XCTAssertNotNil(rootContainer);
+  SemanticsObject* rootObject = rootContainer.semanticsObject;
+  XCTAssertNotNil(rootObject);
+
+  // Destroy the AccessibilityBridge instance. VoiceOver runtime may still hold references
+  // to SemanticsObject and SemanticsObjectContainer.
+  bridge.reset();
+
+  XCTAssertNil([rootContainer accessibilityContainer]);
+
+  // Verify calling actions, geometry, and hit-testing methods post-destruction does not crash
+  // or access freed memory.
+  XCTAssertFalse([rootObject accessibilityActivate]);
+  XCTAssertTrue(CGPointEqualToPoint([rootObject accessibilityActivationPoint], CGPointZero));
+  XCTAssertTrue(CGRectEqualToRect([rootObject accessibilityFrame], CGRectZero));
+  XCTAssertNil([rootObject _accessibilityHitTest:CGPointZero withEvent:nil]);
 }
 
 @end


### PR DESCRIPTION
UIKit and VoiceOver can retain `SemanticsObject`/`SemanticsObjectContainer` instances after the engine's `AccessibilityBridge` that created them has been destroyed, e.g. during engine shutdown, view controller teardown, or a `FlutterViewController` being swapped out while VoiceOver still holds a reference to its accessibility tree (e.g. flutter/flutter#43795). Existing code already guarded *most* `UIAccessibilityElement`/`UIAccessibilityContainer` overrides for this with an `isAccessibilityBridgeAlive` check followed by a separate `self.bridge` re-read, but a few call sites had no guard at all.

In debug builds, `fml::WeakPtr`'s debug-mode assertion will trigger an `abort()` in such cases, but this is undefined behaviour in release builds.

This patch replaces the `fml::WeakPtr<AccessibilityBridgeIos> bridge` property on `SemanticsObject` with `- (AccessibilityBridgeIos*)bridge` and `- (UIView*)bridgeView` accessor methods.

`bridge` resolves the weak pointer and hands back a raw `AccessibilityBridgeIos*` or nullptr. Callers fetch it once into a local, check it against nullptr, and use it synchronously within that same scope. This simplifies the previous two-step pattern (an `isAccessibilityBridgeAlive` check followed by a separate `self.bridge` re-read, which could in theory observe different liveness between the two) into one step, and keeps the C++ smart pointer type out of the Objective-C API. Similar to the previous code (when we did the two-step process to get the raw pointer at each call site), these pointers should never escape the scope in which they're created. 

All overrides that dereferenced the bridge have been updated to the new API, including the ones that previously had no check at all: 

  * `showOnScreen`
  * `onCustomAccessibilityAction:`
  * `ConvertPointToGlobal`
  * `ConvertRectToGlobal`
  * `_accessibilityHitTest:withEvent:` (which VoiceOver calls directly during touch exploration),
  * the `TextInputSemanticsObject` overrides

`bridgeView` hands back the ARC-managed `UIView*` itself. Once a caller holds a strong reference to it, the view is memory-safe independent of the bridge's C++ lifetime. That view can still outlive the bridge, (it's owned separately by the view hierarchy), so it's longer driven by the engine once the bridge is gone. Both accessors return nil once the bridge is dead.

This allows us to delete the redundant `_bridge` ivar from `SemanticsObjectContainer` in favor of deriving `bridgeView` as needed from its `semanticsObject`, so there's a single source of truth for bridge liveness.

I've also wrapped `SemanticsObject.h` in `NS_ASSUME_NONNULL_BEGIN`/`END` now that `bridge`/`bridgeView` are nullable, and made `parent` and `SemanticsObjectContainer.semanticsObject` `weak` accordingly.

Added a test that destroys an `AccessibilityBridge` then confirms that `SemanticsObject`/ `SemanticsObjectContainer` accessors, actions, geometry conversion, and hit-testing no longer touch freed memory afterward.

Issue: b/525528671

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
