### PR TITLE
Fix RangeSlider thumb overlay persisting after touch gesture

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1237,6 +1237,18 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     }
   }
 
+  // Tracks the device kind of the most recent pointer-down event so that
+  // _endInteraction can decide whether to drop focus. Touch/stylus interactions
+  // should not retain focus after the finger is lifted; keyboard-acquired focus
+  // should be preserved so the focus indicator keeps showing.
+  PointerDeviceKind? _lastPointerDeviceKind;
+
+  // True once _handleDragUpdate has fired at least once during the current
+  // interaction, meaning the user actually moved their finger. This is used to
+  // distinguish a real drag (should drop focus on touch) from a touch "tap"
+  // that happened to go through the drag-recognizer path (should keep focus).
+  bool _wasDragMoved = false;
+
   void _updateLabelPainters() {
     _updateLabelPainter(Thumb.start);
     _updateLabelPainter(Thumb.end);
@@ -1341,6 +1353,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     if (_active) {
       return;
     }
+    _wasDragMoved = false; // reset for each new interaction
 
     final double tapValue = clampDouble(_getValueFromGlobalPosition(globalPosition), 0.0, 1.0);
     _lastThumbSelection = sliderTheme.thumbSelector!(
@@ -1390,6 +1403,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
+    _wasDragMoved = true; // finger actually moved — this is a real drag
     if (!_state.mounted) {
       return;
     }
@@ -1457,16 +1471,46 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     _state.overlayController.reverse();
   }
 
+  /// Drops focus from the active thumb when the interaction was a touch or
+  /// stylus drag. Taps are intentionally excluded so that tap-acquired focus
+  /// is preserved (e.g., tap a thumb then Tab to navigate to the other thumb).
+  void _unfocusIfTouchDrag() {
+    final bool isTouchInteraction =
+        _lastPointerDeviceKind == PointerDeviceKind.touch ||
+        _lastPointerDeviceKind == PointerDeviceKind.stylus ||
+        _lastPointerDeviceKind == PointerDeviceKind.invertedStylus;
+    if (isTouchInteraction && _lastThumbSelection != null) {
+      switch (_lastThumbSelection!) {
+        case Thumb.start:
+          _state.startFocusNode.unfocus();
+        case Thumb.end:
+          _state.endFocusNode.unfocus();
+      }
+    }
+  }
+
   void _handleDragStart(DragStartDetails details) {
     _startInteraction(details.globalPosition);
   }
 
   void _handleDragEnd(DragEndDetails details) {
     _endInteraction();
+    // When the interaction was driven by touch or stylus AND the user actually
+    // moved their finger, drop focus so the overlay does not linger.
+    // If there was no movement (e.g., the drag recognizer won a tap-like
+    // gesture without any pointer movement), we preserve focus so that
+    // tap-acquired focus works correctly.
+    if (_wasDragMoved) {
+      _unfocusIfTouchDrag();
+    }
   }
 
   void _handleDragCancel() {
     _endInteraction();
+    // Note: do NOT call _unfocusIfTouchDrag here.
+    // _handleDragCancel fires when the drag recognizer loses the gesture
+    // arena to the tap recognizer (i.e. on a touch tap), so clearing focus
+    // here would incorrectly drop focus after a touch tap.
   }
 
   void _handleTapDown(TapDownDetails details) {
@@ -1484,6 +1528,9 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   void handleEvent(PointerEvent event, HitTestEntry entry) {
     assert(debugHandleEvent(event, entry));
     if (event is PointerDownEvent && isEnabled) {
+      // Record the device kind so _endInteraction can decide whether to drop
+      // focus when the gesture ends (touch should not retain focus).
+      _lastPointerDeviceKind = event.kind;
       // We need to add the drag first so that it has priority.
       _drag.addPointer(event);
       _tap.addPointer(event);

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1726,10 +1726,12 @@ void main() {
     expect(values.end, moreOrLessEquals(0.5, epsilon: 0.03));
     await tester.pumpAndSettle();
 
+    // After the drag ends, focus is dropped (touch drag should not retain
+    // focus) so only the two overlapping thumbs and the overlapping stroke
+    // are expected — no focus overlay circle.
     expect(
       sliderBox,
       paints
-        ..circle(color: sliderTheme.overlayColor)
         ..circle(color: sliderTheme.thumbColor)
         ..circle(color: sliderTheme.overlappingShapeStrokeColor)
         ..circle(color: sliderTheme.thumbColor),
@@ -3376,8 +3378,9 @@ void main() {
     );
 
     final RenderObject renderObject = tester.renderObject(find.byType(RangeSlider));
-    // 2 thumbs, 1 overlay for hover, and 1 overlay for focus.
-    expect(renderObject, paintsExactlyCountTimes(#drawCircle, 4));
+    // 2 thumbs and 1 overlay for hover. The touch drag ended above so focus
+    // was dropped — no focus overlay circle is expected.
+    expect(renderObject, paintsExactlyCountTimes(#drawCircle, 3));
 
     // Move away from thumb
     await gesture.moveTo(tester.getTopRight(find.byType(RangeSlider)));
@@ -4073,6 +4076,125 @@ void main() {
     expect(endFocusNode.hasFocus, isTrue, reason: 'End thumb should have focus after tab');
     expect(FocusManager.instance.primaryFocus, equals(endFocusNode));
   });
+
+  testWidgets(
+    'RangeSlider touch drag releases focus after gesture ends',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/XXXXXX
+      // After a touch gesture ends, the dragged thumb should no longer have
+      // focus so the focus overlay does not linger on screen.
+      var values = const RangeValues(0.3, 0.7);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return RangeSlider(
+                    values: values,
+                    onChanged: (RangeValues newValues) {
+                      setState(() {
+                        values = newValues;
+                      });
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider));
+      final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider));
+      final startFocusNode =
+          (tester.state(find.byType(RangeSlider)) as dynamic).startFocusNode as FocusNode;
+      final endFocusNode =
+          (tester.state(find.byType(RangeSlider)) as dynamic).endFocusNode as FocusNode;
+
+      // --- Start thumb: touch drag then release ---
+      final Offset startThumbPos = topLeft + (bottomRight - topLeft) * 0.3;
+      // startGesture uses PointerDeviceKind.touch by default.
+      final TestGesture startGesture = await tester.startGesture(startThumbPos);
+      await tester.pump();
+      expect(startFocusNode.hasFocus, isTrue, reason: 'Start thumb gains focus during touch drag');
+
+      await startGesture.moveBy(const Offset(5, 0));
+      await startGesture.up();
+      await tester.pump();
+
+      // Focus should be cleared automatically after the touch gesture ends.
+      expect(
+        startFocusNode.hasFocus,
+        isFalse,
+        reason: 'Start thumb should lose focus after touch gesture ends',
+      );
+
+      // --- End thumb: touch drag then release ---
+      final Offset endThumbPos = topLeft + (bottomRight - topLeft) * 0.7;
+      final TestGesture endGesture = await tester.startGesture(endThumbPos);
+      await tester.pump();
+      expect(endFocusNode.hasFocus, isTrue, reason: 'End thumb gains focus during touch drag');
+
+      await endGesture.moveBy(const Offset(-5, 0));
+      await endGesture.up();
+      await tester.pump();
+
+      expect(
+        endFocusNode.hasFocus,
+        isFalse,
+        reason: 'End thumb should lose focus after touch gesture ends',
+      );
+    },
+  );
+
+  testWidgets(
+    'RangeSlider keyboard-acquired focus is preserved after key interaction',
+    (WidgetTester tester) async {
+      // Keyboard navigation should keep the focus indicator visible so that
+      // users can see which thumb is active while navigating with arrow keys.
+      var values = const RangeValues(0.3, 0.7);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return RangeSlider(
+                    values: values,
+                    onChanged: (RangeValues newValues) {
+                      setState(() {
+                        values = newValues;
+                      });
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final startFocusNode =
+          (tester.state(find.byType(RangeSlider)) as dynamic).startFocusNode as FocusNode;
+
+      // Programmatically focus the start thumb (simulates keyboard Tab focus).
+      startFocusNode.requestFocus();
+      await tester.pump();
+      expect(startFocusNode.hasFocus, isTrue, reason: 'Start thumb has focus via keyboard');
+
+      // Pressing an arrow key should move the value but keep focus.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        startFocusNode.hasFocus,
+        isTrue,
+        reason: 'Focus should be retained after keyboard interaction',
+      );
+    },
+  );
 }
 
 // A value indicator shape to log labelPainter text.


### PR DESCRIPTION
Previously, dragging a RangeSlider thumb via touch would cause the thumb to request keyboard focus (introduced in PR #182185). This focus was retained after the gesture ended, causing the overlay (circular highlight) to remain visible — a visual regression on touch devices.

This fix detects when focus was obtained via a touch/pointer gesture (as opposed to keyboard navigation) and unfocuses the thumb once the drag ends. Keyboard navigation (Tab + arrow keys) continues to show the focus indicator correctly, maintaining full accessibility compliance.

Fixes #189205

Pre-launch Checklist
 I read the [Contributor Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) and followed the process outlined there for submitting PRs.
 I read the [AI contribution guidelines](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines) and understand my responsibilities, or I am not using AI tools.
 I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) wiki page, which explains my responsibilities.
 I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md), including [Features we expect every widget to implement](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement).
 I signed the [CLA](https://cla.developers.google.com/).
 I listed at least one issue that this PR fixes in the description above.
 I updated/added relevant documentation (doc comments with ///).
 I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests).
 I followed the [breaking change policy](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes) and added [Data Driven Fixes](https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md) where supported.
 All existing and new tests are passing.
If you need help, consider asking for advice on the #hackers-new channel on [Discord](https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md).

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
