### PR TITLE
[Impeller] In the AHBTextureSourceVK destructor, do not call Vulkan APIs if the VkDevice has been destroyed

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -196,6 +196,8 @@ if (is_android) {
     sources = [
       "android/ahb_swapchain_vk_unittests.cc",
       "android/ahb_texture_source_vk_unittests.cc",
+      "android/android_test_utils.cc",
+      "android/android_test_utils.h",
     ]
 
     deps = [

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
@@ -42,9 +42,12 @@ TEST(AndroidAHBSwapchainTest,
   auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
       context, std::make_shared<FakeSurfaceControl>(), {}, {100, 100}, false));
 
+  // Acquire a drawable but do not present it.
   auto image = ahb_swapchain->AcquireNextDrawable();
-  EXPECT_FALSE(image);
+  EXPECT_TRUE(image);
 
+  // Call AcquireNextDrawable again.  vkWaitForFences should not be called
+  // because no command was submitted and no fences are pending.
   ahb_swapchain->AcquireNextDrawable();
   EXPECT_FALSE(wait_for_fences_called);
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_swapchain_vk_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "gtest/gtest.h"
 
+#include "impeller/renderer/backend/vulkan/android/android_test_utils.h"
 #include "impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_vk.h"
 #include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
 #include "impeller/toolkit/android/surface_control.h"
@@ -12,15 +13,6 @@ namespace impeller::android::testing {
 
 using impeller::testing::GetMockVulkanFunctions;
 using impeller::testing::MockVulkanContextBuilder;
-
-const std::vector<std::string> kAndroidDeviceExtensions = {
-    "VK_KHR_swapchain",
-    "VK_ANDROID_external_memory_android_hardware_buffer",
-    "VK_KHR_sampler_ycbcr_conversion",
-    "VK_KHR_external_memory",
-    "VK_EXT_queue_family_foreign",
-    "VK_KHR_dedicated_allocation",
-};
 
 class FakeSurfaceControl : public SurfaceControl {
  public:

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
@@ -261,6 +261,7 @@ AHBTextureSourceVK::AHBTextureSourceVK(
     return;
   }
 
+  device_holder_ = context.GetDeviceHolder();
   device_memory_ = std::move(device_memory);
   image_ = std::move(image);
   yuv_conversion_ = std::move(yuv_conversion);
@@ -291,7 +292,17 @@ AHBTextureSourceVK::AHBTextureSourceVK(
 }
 
 // |TextureSourceVK|
-AHBTextureSourceVK::~AHBTextureSourceVK() = default;
+AHBTextureSourceVK::~AHBTextureSourceVK() {
+  // The ASurfaceTransaction completion callback may hold the last reference
+  // to the AHBTextureSourceVK and can be deleted after the ContextVK and
+  // VkDevice have been destroyed.  If the VkDevice is gone, then do not call
+  // APIs to delete Vulkan objects.
+  if (auto device = device_holder_.lock(); !device) {
+    image_view_.release();
+    image_.release();
+    device_memory_.release();
+  }
+}
 
 bool AHBTextureSourceVK::IsValid() const {
   return is_valid_;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_AHB_TEXTURE_SOURCE_VK_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_AHB_TEXTURE_SOURCE_VK_H_
 
+#include "impeller/renderer/backend/vulkan/device_holder_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_source_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 #include "impeller/renderer/backend/vulkan/yuv_conversion_vk.h"
@@ -87,6 +88,7 @@ class AHBTextureSourceVK final : public TextureSourceVK {
       const AHardwareBuffer_Desc& ahb_desc);
 
  private:
+  std::weak_ptr<DeviceHolderVK> device_holder_;
   std::unique_ptr<android::HardwareBuffer> backing_store_;
   vk::UniqueDeviceMemory device_memory_ = {};
   vk::UniqueImage image_ = {};

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk_unittests.cc
@@ -8,12 +8,17 @@
 #include "flutter/testing/testing.h"
 #include "gtest/gtest.h"
 #include "impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h"
+#include "impeller/renderer/backend/vulkan/android/android_test_utils.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/surface_context_vk.h"
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
 #include "impeller/toolkit/android/hardware_buffer.h"
 #include "impeller/toolkit/android/surface_transaction.h"
 
 namespace impeller::android::testing {
+
+using impeller::testing::GetMockVulkanFunctions;
+using impeller::testing::MockVulkanContextBuilder;
 
 struct UniqueAHardwareBufferTraits {
   static AHardwareBuffer* InvalidValue() { return nullptr; }
@@ -150,6 +155,42 @@ TEST(AndroidVulkanTest, CreateImageViewForOpaqueAlpha) {
   EXPECT_EQ(image_info.get().components.a, vk::ComponentSwizzle::eOne);
 
   context_vk->Shutdown();
+}
+
+TEST(AndroidVulkanTest, TextureSourceDeleteAfterContextDelete) {
+  AHardwareBuffer_Desc desc;
+  desc.width = 16;
+  desc.height = 16;
+  desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
+  desc.stride = 0;
+  desc.layers = 1;
+  desc.rfu0 = 0;
+  desc.rfu1 = 0;
+  desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE |
+               AHARDWAREBUFFER_USAGE_CPU_WRITE_MASK |
+               AHARDWAREBUFFER_USAGE_CPU_READ_MASK;
+
+  EXPECT_EQ(AHardwareBuffer_isSupported(&desc), 1);
+
+  UniqueAHardwareBuffer buffer = AllocateAHardwareBuffer(desc);
+  ASSERT_TRUE(buffer.is_valid());
+
+  auto context = MockVulkanContextBuilder()
+                     .SetDeviceExtensions(kAndroidDeviceExtensions)
+                     .Build();
+
+  ASSERT_TRUE(context);
+
+  auto texture =
+      std::make_shared<AHBTextureSourceVK>(context, buffer.get(), desc);
+  ASSERT_TRUE(texture->IsValid());
+
+  // Delete the context and its VkDevice.
+  context.reset();
+
+  // Delete the AHBTextureSourceVK and verify that the destructor does not call
+  // Vulkan APIs on a VkDevice that is no longer valid.
+  texture.reset();
 }
 
 }  // namespace impeller::android::testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/android_test_utils.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/android_test_utils.cc
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/android/android_test_utils.h"
+
+namespace impeller::android::testing {
+
+const std::vector<std::string> kAndroidDeviceExtensions = {
+    "VK_KHR_swapchain",
+    "VK_ANDROID_external_memory_android_hardware_buffer",
+    "VK_KHR_sampler_ycbcr_conversion",
+    "VK_KHR_external_memory",
+    "VK_EXT_queue_family_foreign",
+    "VK_KHR_dedicated_allocation",
+};
+
+}  // namespace impeller::android::testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/android/android_test_utils.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/android/android_test_utils.h
@@ -1,0 +1,21 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_ANDROID_TEST_UTILS_H_
+#define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_ANDROID_TEST_UTILS_H_
+
+#include <string>
+#include <vector>
+
+namespace impeller::android::testing {
+
+/// A list of Vulkan device extensions that are required by Android-specific
+/// services in the Impeller Vulkan back end.
+/// This can be used to configure the mock Vulkan framework to simulate
+/// Android's version of Vulkan.
+extern const std::vector<std::string> kAndroidDeviceExtensions;
+
+}  // namespace impeller::android::testing
+
+#endif  // FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_ANDROID_TEST_UTILS_H_

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -64,10 +64,41 @@ struct MockFramebuffer {};
 
 static ISize currentImageSize = ISize{1, 1};
 
+class MockPhysicalDevice {
+ public:
+  std::weak_ptr<MockDevice> CreateDevice();
+  void DestroyDevice(const std::weak_ptr<MockDevice>& device);
+
+ private:
+  std::vector<std::shared_ptr<MockDevice>> devices_;
+};
+
+class MockInstance {
+ public:
+  MockPhysicalDevice& physical_device() { return physical_device_; }
+
+ private:
+  MockPhysicalDevice physical_device_;
+};
+
 class MockDevice final {
  public:
-  explicit MockDevice()
-      : called_functions_(new std::vector<std::string>()), queue_(*this) {}
+  explicit MockDevice(MockPhysicalDevice& physical_device)
+      : physical_device_(physical_device),
+        called_functions_(new std::vector<std::string>()),
+        queue_(*this) {}
+
+  MockPhysicalDevice& physical_device() { return physical_device_; }
+
+  // Get the MockDevice wrapped by a VkDevice handle and check that the
+  // VkDevice has not been destroyed.
+  static MockDevice* Unwrap(VkDevice vk_device) {
+    std::weak_ptr<MockDevice>* weak_device =
+        reinterpret_cast<std::weak_ptr<MockDevice>*>(vk_device);
+    std::shared_ptr strong_device = weak_device->lock();
+    FML_CHECK(strong_device);
+    return strong_device.get();
+  }
 
   MockCommandBuffer* NewCommandBuffer() {
     auto buffer = std::make_unique<MockCommandBuffer>(called_functions_);
@@ -112,6 +143,8 @@ class MockDevice final {
 
   MockDevice& operator=(const MockDevice&) = delete;
 
+  MockPhysicalDevice& physical_device_;
+
   Mutex called_functions_mutex_;
   std::shared_ptr<std::vector<std::string>> called_functions_
       IPLR_GUARDED_BY(called_functions_mutex_);
@@ -126,6 +159,18 @@ class MockDevice final {
 
   MockQueue queue_;
 };
+
+std::weak_ptr<MockDevice> MockPhysicalDevice::CreateDevice() {
+  devices_.push_back(std::make_shared<MockDevice>(*this));
+  return devices_.back();
+}
+
+void MockPhysicalDevice::DestroyDevice(
+    const std::weak_ptr<MockDevice>& device) {
+  std::shared_ptr<MockDevice> strong_device = device.lock();
+  FML_CHECK(strong_device);
+  std::erase(devices_, strong_device);
+}
 
 struct MockVulkanState {
   std::vector<std::string> instance_extensions;
@@ -237,7 +282,9 @@ VkResult vkEnumeratePhysicalDevices(VkInstance instance,
   if (!pPhysicalDevices) {
     *pPhysicalDeviceCount = 1;
   } else {
-    pPhysicalDevices[0] = reinterpret_cast<VkPhysicalDevice>(0xfeedface);
+    MockInstance* mock_instance = reinterpret_cast<MockInstance*>(instance);
+    pPhysicalDevices[0] =
+        reinterpret_cast<VkPhysicalDevice>(&mock_instance->physical_device());
   }
   return VK_SUCCESS;
 }
@@ -354,14 +401,17 @@ VkResult vkCreateDevice(VkPhysicalDevice physicalDevice,
                         const VkDeviceCreateInfo* pCreateInfo,
                         const VkAllocationCallbacks* pAllocator,
                         VkDevice* pDevice) {
-  *pDevice = reinterpret_cast<VkDevice>(new MockDevice());
+  MockPhysicalDevice* mock_physical_device =
+      reinterpret_cast<MockPhysicalDevice*>(physicalDevice);
+  *pDevice = reinterpret_cast<VkDevice>(
+      new std::weak_ptr<MockDevice>(mock_physical_device->CreateDevice()));
   return VK_SUCCESS;
 }
 
 VkResult vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
                           const VkAllocationCallbacks* pAllocator,
                           VkInstance* pInstance) {
-  *pInstance = reinterpret_cast<VkInstance>(0xbaadf00d);
+  *pInstance = reinterpret_cast<VkInstance>(new MockInstance());
   return VK_SUCCESS;
 }
 
@@ -388,7 +438,7 @@ VkResult vkCreatePipelineCache(VkDevice device,
                                const VkPipelineCacheCreateInfo* pCreateInfo,
                                const VkAllocationCallbacks* pAllocator,
                                VkPipelineCache* pPipelineCache) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkCreatePipelineCache");
   *pPipelineCache = reinterpret_cast<VkPipelineCache>(0xb000dead);
   return VK_SUCCESS;
@@ -398,7 +448,7 @@ VkResult vkCreateCommandPool(VkDevice device,
                              const VkCommandPoolCreateInfo* pCreateInfo,
                              const VkAllocationCallbacks* pAllocator,
                              VkCommandPool* pCommandPool) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkCreateCommandPool");
   *pCommandPool =
       reinterpret_cast<VkCommandPool>(mock_device->NewCommandPool());
@@ -408,7 +458,7 @@ VkResult vkCreateCommandPool(VkDevice device,
 VkResult vkResetCommandPool(VkDevice device,
                             VkCommandPool commandPool,
                             VkCommandPoolResetFlags flags) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   if (flags & VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT) {
     mock_device->AddCalledFunction("vkResetCommandPoolReleaseResources");
   } else {
@@ -421,7 +471,7 @@ VkResult vkAllocateCommandBuffers(
     VkDevice device,
     const VkCommandBufferAllocateInfo* pAllocateInfo,
     VkCommandBuffer* pCommandBuffers) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkAllocateCommandBuffers");
   *pCommandBuffers =
       reinterpret_cast<VkCommandBuffer>(mock_device->NewCommandBuffer());
@@ -437,7 +487,7 @@ VkResult vkCreateImage(VkDevice device,
                        const VkImageCreateInfo* pCreateInfo,
                        const VkAllocationCallbacks* pAllocator,
                        VkImage* pImage) {
-  reinterpret_cast<MockDevice*>(device)->AddCalledFunction("vkCreateImage");
+  MockDevice::Unwrap(device)->AddCalledFunction("vkCreateImage");
   // Simulate VK_ERROR_COMPRESSION_EXHAUSTED_EXT for fixed-rate-compressed image
   // creates (the spec only returns this error for compression requests).
   if (g_mock_vulkan_state &&
@@ -454,6 +504,13 @@ VkResult vkCreateImage(VkDevice device,
   }
   *pImage = reinterpret_cast<VkImage>(0xD0D0CACA);
   return VK_SUCCESS;
+}
+
+void vkDestroyImage(VkDevice device,
+                    VkImage image,
+                    const VkAllocationCallbacks* pAllocator) {
+  MockDevice* mock_device = MockDevice::Unwrap(device);
+  mock_device->AddCalledFunction("vkDestroyImage");
 }
 
 void vkGetImageMemoryRequirements2KHR(
@@ -487,6 +544,13 @@ VkResult vkCreateImageView(VkDevice device,
   return VK_SUCCESS;
 }
 
+void vkDestroyImageView(VkDevice device,
+                        VkImageView imageView,
+                        const VkAllocationCallbacks* pAllocator) {
+  MockDevice* mock_device = MockDevice::Unwrap(device);
+  mock_device->AddCalledFunction("vkDestroyImageView");
+}
+
 VkResult vkCreateBuffer(VkDevice device,
                         const VkBufferCreateInfo* pCreateInfo,
                         const VkAllocationCallbacks* pAllocator,
@@ -515,7 +579,7 @@ VkResult vkCreateRenderPass(VkDevice device,
                             const VkAllocationCallbacks* pAllocator,
                             VkRenderPass* pRenderPass) {
   *pRenderPass = reinterpret_cast<VkRenderPass>(0x12341234);
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkCreateRenderPass");
   return VK_SUCCESS;
 }
@@ -544,22 +608,31 @@ VkResult vkCreateGraphicsPipelines(
     const VkGraphicsPipelineCreateInfo* pCreateInfos,
     const VkAllocationCallbacks* pAllocator,
     VkPipeline* pPipelines) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkCreateGraphicsPipelines");
   *pPipelines = reinterpret_cast<VkPipeline>(0x99999999);
   return VK_SUCCESS;
 }
 
 VkResult vkDeviceWaitIdle(VkDevice device) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkDeviceWaitIdle");
   return VK_SUCCESS;
 }
 
 void vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
-  mock_device->AddCalledFunction("vkDestroyDevice");
-  delete reinterpret_cast<MockDevice*>(device);
+  std::weak_ptr<MockDevice>* weak_device =
+      reinterpret_cast<std::weak_ptr<MockDevice>*>(device);
+
+  {
+    MockDevice* mock_device = MockDevice::Unwrap(device);
+    mock_device->AddCalledFunction("vkDestroyDevice");
+
+    // mock_device is no longer usable after calling DestroyDevice
+    mock_device->physical_device().DestroyDevice(*weak_device);
+  }
+
+  delete weak_device;
 }
 
 void vkDestroyInstance(VkInstance instance,
@@ -567,12 +640,14 @@ void vkDestroyInstance(VkInstance instance,
   if (g_mock_vulkan_state) {
     g_mock_vulkan_state.reset();
   }
+  MockInstance* mock_instance = reinterpret_cast<MockInstance*>(instance);
+  delete mock_instance;
 }
 
 void vkDestroyPipeline(VkDevice device,
                        VkPipeline pipeline,
                        const VkAllocationCallbacks* pAllocator) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkDestroyPipeline");
 }
 
@@ -580,7 +655,7 @@ VkResult vkCreateShaderModule(VkDevice device,
                               const VkShaderModuleCreateInfo* pCreateInfo,
                               const VkAllocationCallbacks* pAllocator,
                               VkShaderModule* pShaderModule) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkCreateShaderModule");
   *pShaderModule = reinterpret_cast<VkShaderModule>(0x11111111);
   return VK_SUCCESS;
@@ -589,14 +664,14 @@ VkResult vkCreateShaderModule(VkDevice device,
 void vkDestroyShaderModule(VkDevice device,
                            VkShaderModule shaderModule,
                            const VkAllocationCallbacks* pAllocator) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkDestroyShaderModule");
 }
 
 void vkDestroyPipelineCache(VkDevice device,
                             VkPipelineCache pipelineCache,
                             const VkAllocationCallbacks* pAllocator) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkDestroyPipelineCache");
 }
 
@@ -668,14 +743,14 @@ void vkFreeCommandBuffers(VkDevice device,
                           VkCommandPool commandPool,
                           uint32_t commandBufferCount,
                           const VkCommandBuffer* pCommandBuffers) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkFreeCommandBuffers");
 }
 
 void vkDestroyCommandPool(VkDevice device,
                           VkCommandPool commandPool,
                           const VkAllocationCallbacks* pAllocator) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->DeleteCommandPool(
       reinterpret_cast<MockCommandPool*>(commandPool));
   mock_device->AddCalledFunction("vkDestroyCommandPool");
@@ -689,7 +764,7 @@ VkResult vkCreateFence(VkDevice device,
                        const VkFenceCreateInfo* pCreateInfo,
                        const VkAllocationCallbacks* pAllocator,
                        VkFence* pFence) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkCreateFence");
   *pFence = reinterpret_cast<VkFence>(new MockFence());
   return VK_SUCCESS;
@@ -706,7 +781,7 @@ void vkGetDeviceQueue(VkDevice device,
                       uint32_t queueFamilyIndex,
                       uint32_t queueIndex,
                       VkQueue* pQueue) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   *pQueue = reinterpret_cast<VkQueue>(&mock_device->GetQueue());
 }
 
@@ -732,7 +807,6 @@ VkResult vkWaitForFences(VkDevice device,
 }
 
 VkResult vkGetFenceStatus(VkDevice device, VkFence fence) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
   MockFence* mock_fence = reinterpret_cast<MockFence*>(fence);
   return mock_fence->GetStatus();
 }
@@ -762,7 +836,7 @@ VkResult vkCreateQueryPool(VkDevice device,
                            const VkAllocationCallbacks* pAllocator,
                            VkQueryPool* pQueryPool) {
   *pQueryPool = reinterpret_cast<VkQueryPool>(new MockQueryPool());
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkCreateQueryPool");
   return VK_SUCCESS;
 }
@@ -770,7 +844,7 @@ VkResult vkCreateQueryPool(VkDevice device,
 void vkDestroyQueryPool(VkDevice device,
                         VkQueryPool queryPool,
                         const VkAllocationCallbacks* pAllocator) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkDestroyQueryPool");
   delete reinterpret_cast<MockQueryPool*>(queryPool);
 }
@@ -783,7 +857,7 @@ VkResult vkGetQueryPoolResults(VkDevice device,
                                void* pData,
                                VkDeviceSize stride,
                                VkQueryResultFlags flags) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   if (dataSize == sizeof(uint32_t)) {
     uint32_t* data = static_cast<uint32_t*>(pData);
     for (auto i = firstQuery; i < queryCount; i++) {
@@ -803,7 +877,7 @@ VkResult vkCreateDescriptorPool(VkDevice device,
                                 const VkDescriptorPoolCreateInfo* pCreateInfo,
                                 const VkAllocationCallbacks* pAllocator,
                                 VkDescriptorPool* pDescriptorPool) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   *pDescriptorPool =
       reinterpret_cast<VkDescriptorPool>(new MockDescriptorPool());
   mock_device->AddCalledFunction("vkCreateDescriptorPool");
@@ -813,7 +887,7 @@ VkResult vkCreateDescriptorPool(VkDevice device,
 void vkDestroyDescriptorPool(VkDevice device,
                              VkDescriptorPool descriptorPool,
                              const VkAllocationCallbacks* pAllocator) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkDestroyDescriptorPool");
   delete reinterpret_cast<MockDescriptorPool*>(descriptorPool);
 }
@@ -821,7 +895,7 @@ void vkDestroyDescriptorPool(VkDevice device,
 VkResult vkResetDescriptorPool(VkDevice device,
                                VkDescriptorPool descriptorPool,
                                VkDescriptorPoolResetFlags flags) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkResetDescriptorPool");
   return VK_SUCCESS;
 }
@@ -830,7 +904,7 @@ VkResult vkAllocateDescriptorSets(
     VkDevice device,
     const VkDescriptorSetAllocateInfo* pAllocateInfo,
     VkDescriptorSet* pDescriptorSets) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkAllocateDescriptorSets");
   return VK_SUCCESS;
 }
@@ -968,7 +1042,7 @@ void vkDestroyFramebuffer(VkDevice device,
 void vkTrimCommandPool(VkDevice device,
                        VkCommandPool commandPool,
                        VkCommandPoolTrimFlags flags) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   mock_device->AddCalledFunction("vkTrimCommandPool");
 }
 
@@ -988,6 +1062,29 @@ VkResult vkGetPipelineCacheData(VkDevice device,
     return VK_SUCCESS;
   }
 }
+
+#if FML_OS_ANDROID
+
+VkResult vkGetAndroidHardwareBufferPropertiesANDROID(
+    VkDevice device,
+    const struct AHardwareBuffer* buffer,
+    VkAndroidHardwareBufferPropertiesANDROID* pProperties) {
+  pProperties->memoryTypeBits = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+
+  auto* out = reinterpret_cast<VkBaseOutStructure*>(pProperties->pNext);
+  while (out != nullptr) {
+    if (out->sType ==
+        VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID) {
+      reinterpret_cast<VkAndroidHardwareBufferFormatPropertiesANDROID*>(out)
+          ->format = VK_FORMAT_R8G8B8A8_UNORM;
+    }
+    out = out->pNext;
+  }
+
+  return VK_SUCCESS;
+}
+
+#endif  // FML_OS_ANDROID
 
 PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
                                             const char* pName) {
@@ -1037,6 +1134,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkBeginCommandBuffer);
   } else if (strcmp("vkCreateImage", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateImage);
+  } else if (strcmp("vkDestroyImage", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyImage);
   } else if (strcmp("vkGetInstanceProcAddr", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(GetMockVulkanProcAddress);
   } else if (strcmp("vkGetDeviceProcAddr", pName) == 0) {
@@ -1051,6 +1150,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkBindImageMemory);
   } else if (strcmp("vkCreateImageView", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateImageView);
+  } else if (strcmp("vkDestroyImageView", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyImageView);
   } else if (strcmp("vkCreateBuffer", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateBuffer);
   } else if (strcmp("vkGetBufferMemoryRequirements2KHR", pName) == 0 ||
@@ -1161,6 +1262,14 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
   } else if (strcmp("vkGetPipelineCacheData", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkGetPipelineCacheData);
   }
+
+#if FML_OS_ANDROID
+  if (strcmp("vkGetAndroidHardwareBufferPropertiesANDROID", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(
+        vkGetAndroidHardwareBufferPropertiesANDROID);
+  }
+#endif  // FML_OS_ANDROID
+
   return noop;
 }
 
@@ -1213,7 +1322,7 @@ std::shared_ptr<ContextVK> MockVulkanContextBuilder::Build() {
 
 std::shared_ptr<std::vector<std::string>> GetMockVulkanFunctions(
     VkDevice device) {
-  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  MockDevice* mock_device = MockDevice::Unwrap(device);
   return mock_device->GetCalledFunctions();
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -66,11 +66,12 @@ static ISize currentImageSize = ISize{1, 1};
 
 class MockPhysicalDevice {
  public:
-  std::weak_ptr<MockDevice> CreateDevice();
+  std::weak_ptr<MockDevice>* CreateDevice();
   void DestroyDevice(const std::weak_ptr<MockDevice>& device);
 
  private:
   std::vector<std::shared_ptr<MockDevice>> devices_;
+  std::vector<std::unique_ptr<std::weak_ptr<MockDevice>>> weak_devices_;
 };
 
 class MockInstance {
@@ -160,15 +161,23 @@ class MockDevice final {
   MockQueue queue_;
 };
 
-std::weak_ptr<MockDevice> MockPhysicalDevice::CreateDevice() {
-  devices_.push_back(std::make_shared<MockDevice>(*this));
-  return devices_.back();
+std::weak_ptr<MockDevice>* MockPhysicalDevice::CreateDevice() {
+  auto strong_device = std::make_shared<MockDevice>(*this);
+  devices_.push_back(strong_device);
+  weak_devices_.push_back(
+      std::make_unique<std::weak_ptr<MockDevice>>(strong_device));
+  return weak_devices_.back().get();
 }
 
 void MockPhysicalDevice::DestroyDevice(
     const std::weak_ptr<MockDevice>& device) {
   std::shared_ptr<MockDevice> strong_device = device.lock();
   FML_CHECK(strong_device);
+
+  // Remove the strong reference to the device from the devices_ list but keep
+  // the weak pointer in weak_devices_ that is wrapped by the VkDevice handle.
+  // This allows MockDevice::Unwrap to safely detect that the VkDevice
+  // references a device that has been destroyed.
   std::erase(devices_, strong_device);
 }
 
@@ -403,8 +412,7 @@ VkResult vkCreateDevice(VkPhysicalDevice physicalDevice,
                         VkDevice* pDevice) {
   MockPhysicalDevice* mock_physical_device =
       reinterpret_cast<MockPhysicalDevice*>(physicalDevice);
-  *pDevice = reinterpret_cast<VkDevice>(
-      new std::weak_ptr<MockDevice>(mock_physical_device->CreateDevice()));
+  *pDevice = reinterpret_cast<VkDevice>(mock_physical_device->CreateDevice());
   return VK_SUCCESS;
 }
 
@@ -631,8 +639,6 @@ void vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
     // mock_device is no longer usable after calling DestroyDevice
     mock_device->physical_device().DestroyDevice(*weak_device);
   }
-
-  delete weak_device;
 }
 
 void vkDestroyInstance(VkInstance instance,

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/yuv_conversion_library_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/yuv_conversion_library_vk.cc
@@ -28,7 +28,7 @@ std::shared_ptr<YUVConversionVK> YUVConversionLibraryVK::GetConversion(
     return nullptr;
   }
   return (conversions_[desc] = std::shared_ptr<YUVConversionVK>(
-              new YUVConversionVK(device_holder->GetDevice(), desc)));
+              new YUVConversionVK(device_holder, desc)));
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/yuv_conversion_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/yuv_conversion_vk.cc
@@ -12,10 +12,13 @@
 
 namespace impeller {
 
-YUVConversionVK::YUVConversionVK(const vk::Device& device,
-                                 const YUVConversionDescriptorVK& chain)
-    : chain_(chain) {
-  auto conversion = device.createSamplerYcbcrConversionUnique(chain_.get());
+YUVConversionVK::YUVConversionVK(
+    const std::shared_ptr<DeviceHolderVK>& device_holder,
+    const YUVConversionDescriptorVK& chain)
+    : device_holder_(device_holder), chain_(chain) {
+  auto conversion =
+      device_holder->GetDevice().createSamplerYcbcrConversionUnique(
+          chain_.get());
   if (conversion.result != vk::Result::eSuccess) {
     VALIDATION_LOG << "Could not create YUV conversion: "
                    << vk::to_string(conversion.result);
@@ -24,7 +27,11 @@ YUVConversionVK::YUVConversionVK(const vk::Device& device,
   conversion_ = std::move(conversion.value);
 }
 
-YUVConversionVK::~YUVConversionVK() = default;
+YUVConversionVK::~YUVConversionVK() {
+  if (auto device = device_holder_.lock(); !device) {
+    conversion_.release();
+  }
+}
 
 bool YUVConversionVK::IsValid() const {
   return conversion_ && !!conversion_.get();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/yuv_conversion_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/yuv_conversion_vk.h
@@ -11,6 +11,7 @@
 #include "impeller/base/comparable.h"
 #include "impeller/base/thread.h"
 #include "impeller/core/sampler.h"
+#include "impeller/renderer/backend/vulkan/device_holder_vk.h"
 #include "impeller/renderer/backend/vulkan/sampler_vk.h"
 #include "impeller/renderer/backend/vulkan/shared_object_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
@@ -75,10 +76,11 @@ class YUVConversionVK final {
  private:
   friend class YUVConversionLibraryVK;
 
+  std::weak_ptr<DeviceHolderVK> device_holder_;
   YUVConversionDescriptorVK chain_;
   vk::UniqueSamplerYcbcrConversion conversion_;
 
-  YUVConversionVK(const vk::Device& device,
+  YUVConversionVK(const std::shared_ptr<DeviceHolderVK>& device_holder,
                   const YUVConversionDescriptorVK& chain);
 };
 


### PR DESCRIPTION
The ASurfaceTransaction completion callback holds a reference to the AHBTextureSourceVK.  Android manages the lifetime of the callback, and the callback can be deleted after the VkDevice has been destroyed.  If that happens, the AHBTextureSourceVK destructor must release its Vulkan objects to avoid calling Vulkan APIs using the invalid VkDevice.

Also extends the mock Vulkan test framework to detect if a deleted VkDevice is passed to a Vulkan API.

See b/525524577