### PR TITLE
Fix null-deref/double-dispose in StretchingOverscrollIndicator (#189589)

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -998,13 +998,20 @@ class _StretchController extends Listenable {
       ..addListener(() {
         final double newOverscroll = _controller?.value ?? 0.0;
         overscroll = newOverscroll;
-      })
-      ..animateWith(simulation).whenComplete(() {
+      });
+    controller.animateWith(simulation).whenComplete(() {
+      // Only clean up if this controller is still the active one. A later
+      // pull(), animate(), or dispose() may have already replaced and disposed
+      // it, in which case that path owns the cleanup and this stale completion
+      // callback must not touch the shared state (or double dispose the
+      // controller).
+      if (_controller == controller) {
         overscroll = 0.0;
         _interruptedOverscroll = 0.0;
-        _controller!.dispose();
+        controller.dispose();
         _controller = null;
-      });
+      }
+    });
 
     _controller?.dispose();
     _controller = controller;
@@ -1035,6 +1042,7 @@ class _StretchController extends Listenable {
 
   void dispose() {
     _controller?.dispose();
+    _controller = null;
     _overscrollNotifier.dispose();
   }
 

--- a/packages/flutter/test/widgets/overscroll_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_indicator_test.dart
@@ -744,6 +744,42 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets(
+    'StretchingOverscrollIndicator does not crash when disposed mid stretch animation',
+    // Regression test for https://github.com/flutter/flutter/issues/189589
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: StretchingOverscrollIndicator(
+            axisDirection: AxisDirection.down,
+            child: ListView.builder(
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemCount: 20,
+              itemBuilder: (BuildContext context, int index) =>
+                  SizedBox(height: 100.0, child: Text('Item $index')),
+            ),
+          ),
+        ),
+      );
+
+      // Fling at the top edge to overscroll, which starts the stretch
+      // animation via _StretchController.animate().
+      await tester.fling(find.byType(ListView), const Offset(0.0, 300.0), 1000.0);
+      await tester.pump(); // Start the fling.
+      await tester.pump(const Duration(milliseconds: 100)); // Let the animation begin.
+
+      // Tear down the widget before the animation completes. This disposes the
+      // _StretchController (and its AnimationController) while the animation's
+      // whenComplete callback is still pending, which previously dereferenced a
+      // null _controller when the stale callback fired.
+      await tester.pumpWidget(const SizedBox());
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets('GlowingOverscrollIndicator does not crash at zero area', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
## Description

Fixes a null pointer dereference crash in `_StretchController.animate()`. The `whenComplete` callback could execute after the controller was already disposed by a subsequent `pull()`, `animate()`, or `dispose()` call. 

The fix captures the controller instance and guards cleanup to only execute if it's still active, preventing null dereference and double-dispose.

## Fixed Issues

Fixes #189589

## Pre-launch Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene) wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo), including [Features we expect every widget to implement](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement).
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with ///).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/wiki/Tree-hygiene#tests).
- [x] All existing and new tests are passing.