### PR TITLE
Clarify CustomScrollView use cases

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -591,7 +591,7 @@ abstract class ScrollView extends StatelessWidget {
 ///
 /// A [CustomScrollView] lets multiple kinds of content scroll together by
 /// supplying [slivers] directly. Slivers can represent lists, grids, expanding
-/// headers, or box widgets wrapped in a [SliverToBoxAdapter]. For example, to
+/// headers, or a box widget wrapped in a [SliverToBoxAdapter]. For example, to
 /// create a scroll view that contains an expanding app bar followed by a list
 /// and a grid, use a list of three slivers: [SliverAppBar], [SliverList], and
 /// [SliverGrid].

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -587,13 +587,14 @@ abstract class ScrollView extends StatelessWidget {
   }
 }
 
-/// A [ScrollView] that creates custom scroll effects using [slivers].
+/// A [ScrollView] that scrolls multiple kinds of content together using [slivers].
 ///
-/// A [CustomScrollView] lets you supply [slivers] directly to create various
-/// scrolling effects, such as lists, grids, and expanding headers. For example,
-/// to create a scroll view that contains an expanding app bar followed by a
-/// list and a grid, use a list of three slivers: [SliverAppBar], [SliverList],
-/// and [SliverGrid].
+/// A [CustomScrollView] lets multiple kinds of content scroll together by
+/// supplying [slivers] directly. Slivers can represent lists, grids, expanding
+/// headers, or box widgets wrapped in a [SliverToBoxAdapter]. For example, to
+/// create a scroll view that contains an expanding app bar followed by a list
+/// and a grid, use a list of three slivers: [SliverAppBar], [SliverList], and
+/// [SliverGrid].
 ///
 /// [Widget]s in these [slivers] must produce [RenderSliver] objects.
 ///
@@ -716,7 +717,7 @@ abstract class ScrollView extends StatelessWidget {
 ///  * [IndexedSemantics], which allows annotating child lists with an index
 ///    for scroll announcements.
 class CustomScrollView extends ScrollView {
-  /// Creates a [ScrollView] that creates custom scroll effects using slivers.
+  /// Creates a [ScrollView] that combines multiple kinds of content using slivers.
   ///
   /// See the [ScrollView] constructor for more details on these arguments.
   const CustomScrollView({

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -587,11 +587,11 @@ abstract class ScrollView extends StatelessWidget {
   }
 }
 
-/// A [ScrollView] that scrolls multiple kinds of content together using [slivers].
+combines multiple [slivers] in one scrollable view.
 ///
-/// A [CustomScrollView] lets multiple kinds of content scroll together by
-/// supplying [slivers] directly. Slivers can represent lists, grids, expanding
-/// headers, or a box widget wrapped in a [SliverToBoxAdapter]. For example, to
+/// A [ScrollView] that combines multiple [slivers] in one scrollable view.
+/// A [CustomScrollView] lets you combine lists, grids, and other widgets in a
+/// single scrollable view by supplying [slivers] directly. Slivers can/// represent lists, grids, and expanding headers. Widgets that use the box
 /// create a scroll view that contains an expanding app bar followed by a list
 /// and a grid, use a list of three slivers: [SliverAppBar], [SliverList], and
 /// [SliverGrid].
@@ -717,7 +717,7 @@ abstract class ScrollView extends StatelessWidget {
 ///  * [IndexedSemantics], which allows annotating child lists with an index
 ///    for scroll announcements.
 class CustomScrollView extends ScrollView {
-  /// Creates a [ScrollView] that combines multiple kinds of content using slivers.
+  /// layout model can be included using a [SliverToBoxAdapter]. For example, to
   ///
   /// See the [ScrollView] constructor for more details on these arguments.
   const CustomScrollView({

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -587,11 +587,12 @@ abstract class ScrollView extends StatelessWidget {
   }
 }
 
-combines multiple [slivers] in one scrollable view.
-///
 /// A [ScrollView] that combines multiple [slivers] in one scrollable view.
+///
 /// A [CustomScrollView] lets you combine lists, grids, and other widgets in a
-/// single scrollable view by supplying [slivers] directly. Slivers can/// represent lists, grids, and expanding headers. Widgets that use the box
+/// single scrollable view by supplying [slivers] directly. Slivers can
+/// represent lists, grids, and expanding headers. Widgets that use the box
+/// layout model can be included using a [SliverToBoxAdapter]. For example, to
 /// create a scroll view that contains an expanding app bar followed by a list
 /// and a grid, use a list of three slivers: [SliverAppBar], [SliverList], and
 /// [SliverGrid].
@@ -717,7 +718,8 @@ combines multiple [slivers] in one scrollable view.
 ///  * [IndexedSemantics], which allows annotating child lists with an index
 ///    for scroll announcements.
 class CustomScrollView extends ScrollView {
-  /// layout model can be included using a [SliverToBoxAdapter]. For example, to
+  /// Creates a [ScrollView] that combines multiple slivers in one scrollable
+  /// view.
   ///
   /// See the [ScrollView] constructor for more details on these arguments.
   const CustomScrollView({


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This updates the `CustomScrollView` API documentation to describe its common use case more directly: combining different kinds of scrollable content. The introduction now also calls out `SliverToBoxAdapter`, so readers can see how regular box widgets fit alongside lists, grids, and expanding headers.

Fixes #142673.

Tests: not run (documentation-only change; comment-only changes are automatically test-exempt).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
