### PR TITLE
Fix selection registration for hidden overlay entries

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -27,6 +27,7 @@ import 'framework.dart';
 import 'layout_builder.dart';
 import 'lookup_boundary.dart';
 import 'media_query.dart';
+import 'selection_container.dart';
 import 'ticker_provider.dart';
 
 /// The signature of the widget builder callback used in
@@ -419,12 +420,15 @@ class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
   Widget build(BuildContext context) {
     return TickerMode(
       enabled: widget.tickerEnabled,
-      child: _RenderTheaterMarker(
-        theater: _theater,
-        overlayEntryWidgetState: this,
-        // Use a Builder so that the `widget.entry.builder` can have access to
-        // _RenderTheaterMarker.of
-        child: Builder(builder: widget.entry.builder),
+      child: SelectionRegistrarScope(
+        registrar: widget.tickerEnabled ? SelectionContainer.maybeOf(context) : null,
+        child: _RenderTheaterMarker(
+          theater: _theater,
+          overlayEntryWidgetState: this,
+          // Use a Builder so that the `widget.entry.builder` can have access to
+          // _RenderTheaterMarker.of
+          child: Builder(builder: widget.entry.builder),
+        ),
       ),
     );
   }

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -418,19 +418,17 @@ class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return TickerMode(
-      enabled: widget.tickerEnabled,
-      child: SelectionRegistrarScope(
-        registrar: widget.tickerEnabled ? SelectionContainer.maybeOf(context) : null,
-        child: _RenderTheaterMarker(
-          theater: _theater,
-          overlayEntryWidgetState: this,
-          // Use a Builder so that the `widget.entry.builder` can have access to
-          // _RenderTheaterMarker.of
-          child: Builder(builder: widget.entry.builder),
-        ),
-      ),
+    final Widget overlayChild = _RenderTheaterMarker(
+      theater: _theater,
+      overlayEntryWidgetState: this,
+      // Use a Builder so that the `widget.entry.builder` can have access to
+      // _RenderTheaterMarker.of
+      child: Builder(builder: widget.entry.builder),
     );
+    final Widget child = !widget.tickerEnabled && SelectionContainer.maybeOf(context) != null
+        ? SelectionContainer.disabled(child: overlayChild)
+        : overlayChild;
+    return TickerMode(enabled: widget.tickerEnabled, child: child);
   }
 
   void _markNeedsBuild() {

--- a/packages/flutter/lib/src/widgets/selection_container.dart
+++ b/packages/flutter/lib/src/widgets/selection_container.dart
@@ -231,7 +231,7 @@ class _SelectionContainerState extends State<SelectionContainer>
     if (widget._disabled) {
       return SelectionRegistrarScope._disabled(child: widget.child);
     }
-    return SelectionRegistrarScope(registrar: widget.delegate!, child: widget.child);
+    return SelectionRegistrarScope(registrar: widget.delegate, child: widget.child);
   }
 }
 
@@ -245,12 +245,10 @@ class _SelectionContainerState extends State<SelectionContainer>
 /// of subtree. In that case, one can wrap the subtree with
 /// [SelectionContainer.disabled].
 class SelectionRegistrarScope extends InheritedWidget {
-  /// Creates a selection registrar scope that host the [registrar].
-  const SelectionRegistrarScope({
-    super.key,
-    required SelectionRegistrar this.registrar,
-    required super.child,
-  });
+  /// Creates a selection registrar scope that hosts the [registrar].
+  ///
+  /// If [registrar] is null, selection is disabled for the subtree.
+  const SelectionRegistrarScope({super.key, required this.registrar, required super.child});
 
   /// Creates a selection registrar scope that disables selection for the
   /// subtree.

--- a/packages/flutter/lib/src/widgets/selection_container.dart
+++ b/packages/flutter/lib/src/widgets/selection_container.dart
@@ -231,7 +231,7 @@ class _SelectionContainerState extends State<SelectionContainer>
     if (widget._disabled) {
       return SelectionRegistrarScope._disabled(child: widget.child);
     }
-    return SelectionRegistrarScope(registrar: widget.delegate, child: widget.child);
+    return SelectionRegistrarScope(registrar: widget.delegate!, child: widget.child);
   }
 }
 
@@ -245,10 +245,12 @@ class _SelectionContainerState extends State<SelectionContainer>
 /// of subtree. In that case, one can wrap the subtree with
 /// [SelectionContainer.disabled].
 class SelectionRegistrarScope extends InheritedWidget {
-  /// Creates a selection registrar scope that hosts the [registrar].
-  ///
-  /// If [registrar] is null, selection is disabled for the subtree.
-  const SelectionRegistrarScope({super.key, required this.registrar, required super.child});
+  /// Creates a selection registrar scope that host the [registrar].
+  const SelectionRegistrarScope({
+    super.key,
+    required SelectionRegistrar this.registrar,
+    required super.child,
+  });
 
   /// Creates a selection registrar scope that disables selection for the
   /// subtree.

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -350,6 +350,64 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('ignores selection content in background Navigator pages', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/119772
+      StateSetter? setState;
+      var showForegroundPage = true;
+      SelectionRegistrar? backgroundRegistrar;
+      SelectionRegistrar? foregroundRegistrar;
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: _selectableRegion(
+            child: StatefulBuilder(
+              builder: (BuildContext context, StateSetter stateSetter) {
+                setState = stateSetter;
+                return Navigator(
+                  pages: <Page<void>>[
+                    TestPage<void>(
+                      key: const ValueKey<String>('background'),
+                      child: Builder(
+                        builder: (BuildContext context) {
+                          backgroundRegistrar = SelectionContainer.maybeOf(context);
+                          return const Text('Background Page');
+                        },
+                      ),
+                    ),
+                    if (showForegroundPage)
+                      TestPage<void>(
+                        key: const ValueKey<String>('foreground'),
+                        child: Builder(
+                          builder: (BuildContext context) {
+                            foregroundRegistrar = SelectionContainer.maybeOf(context);
+                            return const Text('Foreground Page');
+                          },
+                        ),
+                      ),
+                  ],
+                  onPopPage: (_, _) => false,
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(backgroundRegistrar, isNull);
+      expect(foregroundRegistrar, isNotNull);
+
+      setState!(() {
+        showForegroundPage = false;
+      });
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(backgroundRegistrar, isNotNull);
+    });
+
     testWidgets('can draw handles when they are at rect boundaries', (WidgetTester tester) async {
       final spy = UniqueKey();
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -357,7 +357,6 @@ void main() {
       StateSetter? setState;
       var showForegroundPage = true;
       SelectionRegistrar? backgroundRegistrar;
-      SelectionRegistrar? foregroundRegistrar;
 
       await tester.pumpWidget(
         TestWidgetsApp(
@@ -377,14 +376,9 @@ void main() {
                       ),
                     ),
                     if (showForegroundPage)
-                      TestPage<void>(
-                        key: const ValueKey<String>('foreground'),
-                        child: Builder(
-                          builder: (BuildContext context) {
-                            foregroundRegistrar = SelectionContainer.maybeOf(context);
-                            return const Text('Foreground Page');
-                          },
-                        ),
+                      const TestPage<void>(
+                        key: ValueKey<String>('foreground'),
+                        child: Text('Foreground Page'),
                       ),
                   ],
                   onPopPage: (_, _) => false,
@@ -397,7 +391,6 @@ void main() {
 
       expect(tester.takeException(), isNull);
       expect(backgroundRegistrar, isNull);
-      expect(foregroundRegistrar, isNotNull);
 
       setState!(() {
         showForegroundPage = false;
@@ -406,6 +399,20 @@ void main() {
 
       expect(tester.takeException(), isNull);
       expect(backgroundRegistrar, isNotNull);
+
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+        find.descendant(of: find.text('Background Page'), matching: find.byType(RichText)),
+      );
+      final TestGesture gesture = await tester.startGesture(
+        tester.getTopLeft(find.text('Background Page')),
+        kind: PointerDeviceKind.mouse,
+      );
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(tester.getBottomRight(find.text('Background Page')));
+      await gesture.up();
+      await tester.pump();
+
+      expect(paragraph.selections, isNotEmpty);
     });
 
     testWidgets('can draw handles when they are at rect boundaries', (WidgetTester tester) async {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

`OverlayEntry`s that remain mounted behind an opaque entry still build their
subtrees to preserve state, but `_RenderTheater` skips their layout and paint.
Those hidden subtrees were still inheriting the ancestor selection registrar,
so their selectables could be registered and compared before they had been laid
out. That could trigger the `RenderParagraph.debugNeedsLayout` assertion while
selection ordering was flushed.

This wraps only hidden maintained entries in `SelectionContainer.disabled` when
an ancestor selection registrar is present. Onstage entries continue to inherit
the existing registrar, and the route subtree remains mounted throughout so
its state is preserved. The public selection registrar API is unchanged.

Fixes https://github.com/flutter/flutter/issues/119772.

Tests:

- `./bin/flutter test --no-pub packages/flutter/test/widgets/selectable_region_test.dart`
- `../../bin/flutter test --no-pub --platform chrome test/widgets/selectable_region_test.dart --plain-name "ignores selection content in background Navigator pages"` (from `packages/flutter`)
- `./bin/flutter test --no-pub packages/flutter/test/widgets/selection_container_test.dart packages/flutter/test/widgets/overlay_test.dart`
- `./bin/flutter analyze --no-pub packages/flutter/lib/src/widgets/overlay.dart packages/flutter/lib/src/widgets/selection_container.dart packages/flutter/test/widgets/selectable_region_test.dart`
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter/lib/src/widgets/overlay.dart packages/flutter/lib/src/widgets/selection_container.dart packages/flutter/test/widgets/selectable_region_test.dart`
- `git diff --check`

Risk:

- Two focused framework/test files are changed; no generated output is included.
- Existing `SelectionContainer.disabled` behavior is used to exclude hidden overlay entries from selection while preserving their mounted subtree. No public API is changed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting a request.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The Flutter team can override the code freeze workflow. See pinned issues for current guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find comments useful, you may update the code accordingly, but if you are unsure or disagree, wait for a Flutter team member's review.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
