### PR TITLE
[macos] Restore framework cursor when the pointer re-enters the view

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -1234,7 +1234,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 
 - (void)sendPointerEvent:(const FlutterPointerEvent&)event {
   _embedderAPI.SendPointerEvent(_engine, &event, 1);
-  _lastViewWithPointerEvent = [self viewControllerForIdentifier:kFlutterImplicitViewId].flutterView;
+  _lastViewWithPointerEvent = [self viewControllerForIdentifier:event.view_id].flutterView;
 }
 
 - (void)setSemanticsEnabled:(BOOL)enabled {
@@ -1525,7 +1525,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 - (void)didUpdateMouseCursor:(NSCursor*)cursor {
   // Mouse cursor plugin does not specify which view is responsible for changing the cursor,
   // so the reasonable assumption here is that cursor change is a result of a mouse movement
-  // and thus the cursor will be paired with last Flutter view that reveived mouse event.
+  // and thus the cursor will be paired with last Flutter view that received a mouse event.
   [_lastViewWithPointerEvent didUpdateMouseCursor:cursor];
 }
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -569,8 +569,15 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
     return;
   }
   if (_mouseTrackingMode != kFlutterMouseTrackingModeNone && self.flutterView) {
+    // NSTrackingCursorUpdate makes AppKit send -cursorUpdate: when the pointer enters the
+    // tracking area, which is forwarded below to let FlutterView restore the cursor last
+    // requested by the framework. Without it the cursor is only restored after the pointer exit
+    // is round tripped through the framework, so anything that changes the cursor outside of
+    // Flutter (a resize arrow over the window border, a closing context menu) stays on screen
+    // for as long as the UI thread is busy.
     NSTrackingAreaOptions options = NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved |
-                                    NSTrackingInVisibleRect | NSTrackingEnabledDuringMouseDrag;
+                                    NSTrackingInVisibleRect | NSTrackingEnabledDuringMouseDrag |
+                                    NSTrackingCursorUpdate;
     switch (_mouseTrackingMode) {
       case kFlutterMouseTrackingModeInKeyWindow:
         options |= NSTrackingActiveInKeyWindow;
@@ -902,6 +909,12 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
     return;
   }
   [self dispatchMouseEvent:event phase:kRemove];
+}
+
+- (void)cursorUpdate:(NSEvent*)event {
+  // The tracking area is owned by the view controller, so AppKit delivers this here rather than
+  // to the FlutterView that knows which cursor the framework last asked for.
+  [self.flutterView cursorUpdate:event];
 }
 
 - (void)mouseDown:(NSEvent*)event {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -248,6 +248,40 @@ TEST_F(FlutterViewControllerTest, ReparentsPluginWhenAccessibilityDisabled) {
   EXPECT_TRUE(viewController.engine.textInputPlugin.superview == viewController.view);
 }
 
+TEST_F(FlutterViewControllerTest, TrackingAreaAsksForCursorUpdates) {
+  FlutterViewController* viewControllerMock = CreateMockViewController();
+  [viewControllerMock loadView];
+
+  // NSTrackingCursorUpdate is what makes AppKit send -cursorUpdate: when the pointer re-enters
+  // the view, which is how the cursor requested by the framework is restored without waiting on
+  // the UI thread.
+  NSArray<NSTrackingArea*>* trackingAreas = viewControllerMock.flutterView.trackingAreas;
+  ASSERT_EQ([trackingAreas count], 1u);
+  EXPECT_TRUE(trackingAreas[0].options & NSTrackingCursorUpdate);
+}
+
+TEST_F(FlutterViewControllerTest, CursorUpdateIsForwardedToFlutterView) {
+  FlutterViewController* viewControllerMock = CreateMockViewController();
+  [viewControllerMock loadView];
+
+  // The tracking area's owner is the view controller, but only FlutterView tracks the cursor the
+  // framework last requested, so the event has to be forwarded to reach it.
+  id flutterViewMock = OCMPartialMock(viewControllerMock.flutterView);
+  NSEvent* event = [NSEvent mouseEventWithType:NSEventTypeCursorUpdate
+                                      location:NSMakePoint(10, 10)
+                                 modifierFlags:0
+                                     timestamp:0
+                                  windowNumber:0
+                                       context:nil
+                                   eventNumber:0
+                                    clickCount:0
+                                      pressure:0];
+
+  [viewControllerMock cursorUpdate:event];
+
+  OCMVerify([flutterViewMock cursorUpdate:event]);
+}
+
 TEST_F(FlutterViewControllerTest, CanSetMouseTrackingModeBeforeViewLoaded) {
   NSString* fixtures = @(testing::GetFixturesPath());
   FlutterDartProject* project = [[FlutterDartProject alloc]


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

On macOS, a cursor set while the pointer is over the window's resize border (the resize arrow drawn by the window frame) sticks around after the pointer moves back onto the Flutter content whenever the UI thread is busy at that moment. This is the macOS counterpart of the same defect on Windows, fixed in #189568, and is reproducible with the same code sample in #189563 by running it with `flutter run -d macos`.

The shared root cause is that restoring the framework's cursor depends on a round trip through the Dart UI thread. On macOS the restore path is: the pointer exit sends `kRemove`, the framework drops its cached cursor session, and the framework re-sends `activateSystemCursor` on re-entry. Every step after `kRemove` runs on the UI thread, so while the UI thread is blocked (app startup, shader-compilation jank, heavy frames) the wrong cursor stays on screen until it frees up. On Windows the corresponding hole was `WM_SETCURSOR` returning without restoring the cursor at all. The diagnosis is the same on both platforms; the fixes are mechanically unrelated because the platform cursor APIs differ.

`FlutterView` already caches the last cursor the framework requested (`_lastCursor`) and already re-applies it in `-cursorUpdate:`, but nothing ever invoked that method: the tracking area did not request `NSTrackingCursorUpdate`, and `FlutterView` registers no cursor rects, so AppKit had no reason to send the event. This change requests `NSTrackingCursorUpdate` so AppKit delivers `-cursorUpdate:` when the pointer re-enters the tracking area, and forwards it from the view controller (which owns the tracking area) to `FlutterView` (which holds the cached cursor). Restoration then happens on the main thread with no engine round trip.

It also sets `_lastViewWithPointerEvent` from the view that actually received the pointer event rather than always the implicit view, so the cursor is cached on the correct view when more than one window is open. This is what the comment on `-didUpdateMouseCursor:` already described.

Changes:

* `FlutterViewController`: add `NSTrackingCursorUpdate` to the tracking area options, and forward `-cursorUpdate:` to the FlutterView.
* `FlutterEngine`: pair the framework cursor with the view named by the pointer event's `view_id` rather than the implicit view.

Tests:

* `FlutterViewControllerTest.TrackingAreaAsksForCursorUpdates`: the tracking area on the FlutterView requests `NSTrackingCursorUpdate`.
* `FlutterViewControllerTest.CursorUpdateIsForwardedToFlutterView`: `-cursorUpdate:` on the controller is forwarded to the FlutterView. (This is the regression guard for the specific mistake of leaving the tracking area's owner unable to reach the cached cursor.)

I do not have access to a Mac, so I have not run these tests or verified the behavior on device. The unit tests here are exercised by macOS CI (`flutter_desktop_darwin_unittests`, via the profile and release host test variants), so the wiring will be verified once CI runs. What still needs a reviewer with a Mac is the on-device behavior: that AppKit actually delivers `-cursorUpdate:` on real pointer re-entry, and that asserting the Flutter cursor near the window's resize band does not weaken the resize affordance. Repro steps are in #189563 (run with `flutter run -d macos`, hover the window border to get the resize arrow, then move onto the text while the indicator is red).

Part of #189563

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing. *(New unit tests added; not run locally because I have no macOS hardware. They will be verified by macOS CI once it runs.)*

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
