### PR TITLE
Derive the SkImage size used by ImageEncodingImpeller::ConvertDlImageToSkImage from the size of the underlying texture, not the size of the DlImage

### DIFF
--- a/engine/src/flutter/lib/ui/painting/image_encoding_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_impeller.cc
@@ -160,7 +160,8 @@ void ImageEncodingImpeller::ConvertDlImageToSkImage(
     return;
   }
 
-  auto dimensions = dl_image->GetSize();
+  auto dimensions =
+      DlISize(texture->GetSize().width, texture->GetSize().height);
   auto color_type = ToSkColorType(texture->GetTextureDescriptor().format);
 
   if (dimensions.IsEmpty()) {

--- a/engine/src/flutter/lib/ui/painting/image_encoding_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_impeller.cc
@@ -160,8 +160,9 @@ void ImageEncodingImpeller::ConvertDlImageToSkImage(
     return;
   }
 
-  auto dimensions =
-      DlISize(texture->GetSize().width, texture->GetSize().height);
+  // Use the size of the texture allocated by the Impeller back end (which may
+  // differ from the original image size).
+  auto dimensions = DlISize(texture->GetSize());
   auto color_type = ToSkColorType(texture->GetTextureDescriptor().format);
 
   if (dimensions.IsEmpty()) {

--- a/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
@@ -494,6 +494,8 @@ TEST(ImageEncodingImpellerTest, ConvertDlImageToSkImage16Float) {
   impeller::TextureDescriptor desc;
   desc.format = impeller::PixelFormat::kR16G16B16A16Float;
   auto texture = std::make_shared<MockTexture>(desc);
+  EXPECT_CALL(*texture, GetSize)
+      .WillRepeatedly(Return(impeller::ISize(100, 100)));
   EXPECT_CALL(*image, GetImpellerTexture(::testing::_))
       .WillOnce(Return(texture));
   std::vector<uint8_t> buffer;
@@ -526,6 +528,8 @@ TEST(ImageEncodingImpellerTest, ConvertDlImageToSkImage10XR) {
   impeller::TextureDescriptor desc;
   desc.format = impeller::PixelFormat::kB10G10R10XR;
   auto texture = std::make_shared<MockTexture>(desc);
+  EXPECT_CALL(*texture, GetSize)
+      .WillRepeatedly(Return(impeller::ISize(100, 100)));
   EXPECT_CALL(*image, GetImpellerTexture(::testing::_))
       .WillOnce(Return(texture));
   std::vector<uint8_t> buffer;
@@ -545,6 +549,44 @@ TEST(ImageEncodingImpellerTest, ConvertDlImageToSkImage10XR) {
         EXPECT_EQ(100, image.value()->height());
         EXPECT_EQ(kBGR_101010x_XR_SkColorType, image.value()->colorType());
         EXPECT_EQ(nullptr, image.value()->colorSpace());
+      },
+      snapshot_delegate.GetWeakPtr(), context);
+  EXPECT_TRUE(did_call);
+}
+
+TEST(ImageEncodingImpellerTest, ConvertDlImageToSkImageTextureSizeMismatch) {
+  DlISize dl_image_size(100, 100);
+  sk_sp<MockDlImage> image(new MockDlImage());
+  EXPECT_CALL(*image, GetSize)  //
+      .WillRepeatedly(Return(dl_image_size));
+
+  // Create a texture that is smaller than the DlImage.
+  impeller::TextureDescriptor desc;
+  desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
+  desc.size = impeller::ISize(50, 50);
+  auto texture = std::make_shared<MockTexture>(desc);
+  EXPECT_CALL(*texture, GetSize).WillRepeatedly(Return(desc.size));
+  EXPECT_CALL(*image, GetImpellerTexture(::testing::_))
+      .WillOnce(Return(texture));
+  std::vector<uint8_t> buffer;
+  buffer.reserve(desc.size.width * desc.size.height *
+                 impeller::BytesPerPixelForPixelFormat(desc.format));
+  auto context = MakeConvertDlImageToSkImageContext(buffer);
+
+  bool did_call = false;
+  MockSnapshotDelegate snapshot_delegate;
+  EXPECT_CALL(snapshot_delegate, MakeRenderContextCurrent)
+      .WillRepeatedly(Return(true));
+  ImageEncodingImpeller::ConvertDlImageToSkImage(
+      image,
+      [&](const fml::StatusOr<sk_sp<SkImage>>& image) {
+        did_call = true;
+        ASSERT_TRUE(image.ok());
+        ASSERT_TRUE(image.value());
+        // The SkImage size should match the size of the actual texture, not
+        // the size of the DlImage.
+        EXPECT_EQ(desc.size.width, image.value()->width());
+        EXPECT_EQ(desc.size.height, image.value()->height());
       },
       snapshot_delegate.GetWeakPtr(), context);
   EXPECT_TRUE(did_call);

--- a/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
@@ -579,14 +579,14 @@ TEST(ImageEncodingImpellerTest, ConvertDlImageToSkImageTextureSizeMismatch) {
       .WillRepeatedly(Return(true));
   ImageEncodingImpeller::ConvertDlImageToSkImage(
       image,
-      [&](const fml::StatusOr<sk_sp<SkImage>>& image) {
+      [&](const fml::StatusOr<sk_sp<SkImage>>& result) {
         did_call = true;
-        ASSERT_TRUE(image.ok());
-        ASSERT_TRUE(image.value());
+        ASSERT_TRUE(result.ok());
+        ASSERT_TRUE(result.value());
         // The SkImage size should match the size of the actual texture, not
         // the size of the DlImage.
-        EXPECT_EQ(desc.size.width, image.value()->width());
-        EXPECT_EQ(desc.size.height, image.value()->height());
+        EXPECT_EQ(desc.size.width, result.value()->width());
+        EXPECT_EQ(desc.size.height, result.value()->height());
       },
       snapshot_delegate.GetWeakPtr(), context);
   EXPECT_TRUE(did_call);


### PR DESCRIPTION
Impeller may allocate a texture that is smaller than the requested DlImage size if the DlImage size exceeds the limits of the back end.

If that happens, then the SkImage that receives the texture data must match the size of the texture.

See b/525536935