### PR TITLE
[iOS] Inject DisplayLinkManager into VsyncWaiterIOS

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VsyncWaiterIOSTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VsyncWaiterIOSTest.mm
@@ -2,9 +2,26 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#include <memory>
+
+#include "flutter/common/task_runners.h"
+#include "flutter/fml/message_loop.h"
+#import "flutter/shell/platform/darwin/ios/InternalFlutterSwift/InternalFlutterSwift.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
+
+namespace {
+
+flutter::TaskRunners CreateTestTaskRunners() {
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  fml::RefPtr<fml::TaskRunner> task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+  return flutter::TaskRunners("VsyncWaiterIOSTest", task_runner, task_runner, task_runner,
+                              task_runner);
+}
+
+}  // namespace
 
 @interface VsyncWaiterIOSTest : XCTestCase
 @end
@@ -40,6 +57,45 @@
 
   snapped = flutter::VsyncWaiterIOS::SnapDuration(-1.0, -10.0);
   XCTAssertEqualWithAccuracy(snapped, 1.0 / 60.0, 0.0001);
+}
+
+- (void)testConstructorUsesInjectedDisplayLinkManagerRefreshRate {
+  id mockDisplayLinkManager = OCMPartialMock([FlutterDisplayLinkManager shared]);
+  [self addTeardownBlock:^{
+    [mockDisplayLinkManager stopMocking];
+  }];
+  double maxFrameRate = 120;
+  (void)[[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
+
+  flutter::TaskRunners taskRunners = CreateTestTaskRunners();
+  auto waiter = std::make_unique<flutter::VsyncWaiterIOS>(taskRunners, mockDisplayLinkManager);
+
+  XCTAssertEqual(waiter->GetMaxRefreshRateForTesting(), maxFrameRate);
+}
+
+- (void)testAwaitVSyncPicksUpRefreshRateChangesFromInjectedDisplayLinkManager {
+  id mockDisplayLinkManager = OCMPartialMock([FlutterDisplayLinkManager shared]);
+  [self addTeardownBlock:^{
+    [mockDisplayLinkManager stopMocking];
+  }];
+  // A single stub whose return value is re-read on every invocation via the __block variable.
+  // OCMock stubs aren't replaced by re-stubbing the same selector — the first-registered stub
+  // keeps answering — so a fixed andReturnValue: can't model a value that changes over time.
+  double initialFrameRate = 60;
+  __block double refreshRate = initialFrameRate;
+  OCMStub([mockDisplayLinkManager displayRefreshRate]).andDo(^(NSInvocation* invocation) {
+    [invocation setReturnValue:&refreshRate];
+  });
+
+  flutter::TaskRunners taskRunners = CreateTestTaskRunners();
+  auto waiter = std::make_unique<flutter::VsyncWaiterIOS>(taskRunners, mockDisplayLinkManager);
+  XCTAssertEqual(waiter->GetMaxRefreshRateForTesting(), initialFrameRate);
+
+  double updatedFrameRate = 120;
+  refreshRate = updatedFrameRate;
+  waiter->AwaitVSync();
+
+  XCTAssertEqual(waiter->GetMaxRefreshRateForTesting(), updatedFrameRate);
 }
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -12,12 +12,14 @@
 #include "flutter/shell/common/vsync_waiter.h"
 
 @class FlutterVSyncClient;
+@class FlutterDisplayLinkManager;
 
 namespace flutter {
 
 class VsyncWaiterIOS final : public VsyncWaiter, public VariableRefreshRateReporter {
  public:
-  explicit VsyncWaiterIOS(const flutter::TaskRunners& task_runners);
+  VsyncWaiterIOS(const flutter::TaskRunners& task_runners,
+                 FlutterDisplayLinkManager* display_link_manager);
 
   ~VsyncWaiterIOS() override;
 
@@ -35,13 +37,16 @@ class VsyncWaiterIOS final : public VsyncWaiter, public VariableRefreshRateRepor
   // Visible for testing.
   static CFTimeInterval SnapDuration(CFTimeInterval duration, double max_refresh_rate);
 
- private:
   // |VsyncWaiter|
   // Made public for testing.
   void AwaitVSync() override;
 
+  // Visible for testing.
+  double GetMaxRefreshRateForTesting() const { return max_refresh_rate_; }
+
  private:
   FlutterVSyncClient* client_;
+  FlutterDisplayLinkManager* display_link_manager_;
   double max_refresh_rate_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiterIOS);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -15,8 +15,10 @@ const static double kRefreshRateDiffToIgnore = 0.1;
 
 namespace flutter {
 
-VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners)
-    : VsyncWaiter(task_runners) {
+VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners,
+                               FlutterDisplayLinkManager* display_link_manager)
+    : VsyncWaiter(task_runners), display_link_manager_(display_link_manager) {
+  FML_DCHECK(display_link_manager);
   auto vsyncCallback = ^(CFTimeInterval startTime, CFTimeInterval targetTime) {
     // Compute delay using the same CACurrentMediaTime() clock.
     CFTimeInterval delay = CACurrentMediaTime() - startTime;
@@ -39,10 +41,10 @@ VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners)
       [[FlutterFMLTaskRunner alloc] initWithTaskRunner:task_runners_.GetUITaskRunner()];
   client_ = [[FlutterVSyncClient alloc]
                 initWithTaskRunner:uiTaskRunner
-      isVariableRefreshRateEnabled:FlutterDisplayLinkManager.shared.maxRefreshRateEnabledOnIPhone
-                    maxRefreshRate:FlutterDisplayLinkManager.shared.displayRefreshRate
+      isVariableRefreshRateEnabled:display_link_manager_.maxRefreshRateEnabledOnIPhone
+                    maxRefreshRate:display_link_manager_.displayRefreshRate
                           callback:vsyncCallback];
-  max_refresh_rate_ = FlutterDisplayLinkManager.shared.displayRefreshRate;
+  max_refresh_rate_ = display_link_manager_.displayRefreshRate;
 }
 
 VsyncWaiterIOS::~VsyncWaiterIOS() {
@@ -52,7 +54,7 @@ VsyncWaiterIOS::~VsyncWaiterIOS() {
 }
 
 void VsyncWaiterIOS::AwaitVSync() {
-  double new_max_refresh_rate = FlutterDisplayLinkManager.shared.displayRefreshRate;
+  double new_max_refresh_rate = display_link_manager_.displayRefreshRate;
   if (fabs(new_max_refresh_rate - max_refresh_rate_) > kRefreshRateDiffToIgnore) {
     max_refresh_rate_ = new_max_refresh_rate;
     [client_ setMaxRefreshRate:max_refresh_rate_];

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios.mm
@@ -12,6 +12,7 @@
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/common/shell_io_manager.h"
 #import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
+#import "flutter/shell/platform/darwin/ios/InternalFlutterSwift/InternalFlutterSwift.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
 
@@ -181,7 +182,7 @@ void PlatformViewIOS::SetSemanticsTreeEnabled(bool enabled) {
 
 // |PlatformView|
 std::unique_ptr<VsyncWaiter> PlatformViewIOS::CreateVSyncWaiter() {
-  return std::make_unique<VsyncWaiterIOS>(task_runners_);
+  return std::make_unique<VsyncWaiterIOS>(task_runners_, FlutterDisplayLinkManager.shared);
 }
 
 // |PlatformView|


### PR DESCRIPTION
This is a follow-up to #189492, which migrated `DisplayLinkManager` to a shared singleton instance. `VsyncWaiterIOS` was using `.shared` directly in three places internally, which is effectively using a hidden global, and it means the only way to exercise `VsyncWaiterIOS` against a non-default refresh rate was to mutate the real shared instance out from under whatever else might be touching it.

This wires a `FlutterDisplayLinkManager*` through the constructor instead and stores a private reference.

I've also added two tests, which required making `AwaitVSync()` accessible again; I accidentally marked it private in #186935 (722be07e285) when adding SnapDuration (despite my comment saying it was made public for testing), so restored it to public.

Issue: https://github.com/flutter/flutter/issues/175879
Issue: https://github.com/flutter/flutter/issues/181684

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
