### PR TITLE
[iOS] Inject DisplayLinkManager into FlutterKeyboardInsetManager

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -365,7 +365,9 @@ typedef struct MouseState {
   _statusBarStyle = UIStatusBarStyleDefault;
 
   _accessibilityFeatures = [[FlutterAccessibilityFeatures alloc] init];
-  _keyboardInsetManager = [[FlutterKeyboardInsetManager alloc] initWithDelegate:self];
+  _keyboardInsetManager =
+      [[FlutterKeyboardInsetManager alloc] initWithDelegate:self
+                                         displayLinkManager:FlutterDisplayLinkManager.shared];
 
   // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
   // Eliminate method calls in initializers and dealloc.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -551,7 +551,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   engine.viewController = (FlutterViewController*)delegate;
 
   FlutterKeyboardInsetManager* manager =
-      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate];
+      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate
+                                         displayLinkManager:FlutterDisplayLinkManager.shared];
 
   BOOL isLocal = YES;
 
@@ -639,7 +640,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
   // Exercise the real shouldIgnoreKeyboardNotification: implementation.
   FlutterKeyboardInsetManager* managerMock = [[FlutterKeyboardInsetManager alloc]
-      initWithDelegate:(id<FlutterKeyboardInsetManagerDelegate>)viewControllerMock];
+        initWithDelegate:(id<FlutterKeyboardInsetManagerDelegate>)viewControllerMock
+      displayLinkManager:FlutterDisplayLinkManager.shared];
   viewController.keyboardInsetManager = managerMock;
 
   UIScreen* screen = [self setUpMockScreen];
@@ -973,7 +975,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   delegate.mockConvertedViewRect = convertedViewFrame;
 
   FlutterKeyboardInsetManager* manager =
-      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate];
+      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate
+                                         displayLinkManager:FlutterDisplayLinkManager.shared];
 
   CGFloat adjustment = [manager calculateMultitaskingAdjustment:screenRect
                                                   keyboardFrame:keyboardFrame];
@@ -994,7 +997,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   delegate.mockConvertedViewRect = convertedViewFrame;
 
   FlutterKeyboardInsetManager* manager =
-      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate];
+      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate
+                                         displayLinkManager:FlutterDisplayLinkManager.shared];
 
   CGFloat inset = [manager calculateKeyboardInset:keyboardFrame
                                      keyboardMode:FlutterKeyboardModeDocked];
@@ -1031,7 +1035,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   engine.viewController = (FlutterViewController*)delegate;
 
   FlutterKeyboardInsetManager* manager =
-      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate];
+      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate
+                                         displayLinkManager:FlutterDisplayLinkManager.shared];
   manager.targetViewInsetBottom = 0;
 
   [manager handleKeyboardNotification:notification];
@@ -2834,7 +2839,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   delegate.mockEngine = engine;
 
   FlutterKeyboardInsetManager* manager =
-      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate];
+      [[FlutterKeyboardInsetManager alloc] initWithDelegate:delegate
+                                         displayLinkManager:FlutterDisplayLinkManager.shared];
   manager.targetViewInsetBottom = 100;
   [manager startKeyBoardAnimation:0.25];
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/KeyboardInsetManager.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/KeyboardInsetManager.swift
@@ -99,8 +99,13 @@ public typealias FlutterKeyboardAnimationCallback = (_ targetTime: CFTimeInterva
   @objc public var keyboardSpringAnimation: SpringAnimation?
   @objc public var isKeyboardInOrTransitioningFromBackground: Bool = false
 
-  @objc public init(delegate: FlutterKeyboardInsetManagerDelegate) {
+  private let displayLinkManager: DisplayLinkManager
+
+  @objc public init(
+    delegate: FlutterKeyboardInsetManagerDelegate, displayLinkManager: DisplayLinkManager
+  ) {
     self.delegate = delegate
+    self.displayLinkManager = displayLinkManager
     super.init()
   }
 
@@ -473,8 +478,8 @@ public typealias FlutterKeyboardAnimationCallback = (_ targetTime: CFTimeInterva
 
     keyboardAnimationVSyncClient = VSyncClient(
       taskRunner: taskRunner,
-      isVariableRefreshRateEnabled: DisplayLinkManager.shared.maxRefreshRateEnabledOnIPhone,
-      maxRefreshRate: DisplayLinkManager.shared.displayRefreshRate,
+      isVariableRefreshRateEnabled: displayLinkManager.maxRefreshRateEnabledOnIPhone,
+      maxRefreshRate: displayLinkManager.displayRefreshRate,
       callback: vsyncCallback)
     keyboardAnimationVSyncClient?.allowPauseAfterVsync = false
     keyboardAnimationVSyncClient?.await()


### PR DESCRIPTION
This is a follow-up to the DisplayLinkManager singleton migration (#189492). `FlutterKeyboardInsetManager` was reading `DisplayLinkManager.shared` directly in `setUpKeyboardAnimationVsyncClient` when passing its VSyncClient's isVariableRefreshRateEnabled and maxRefreshRate, which is effectively using a global.

This wires a DisplayLinkManager through the initializer instead and stores it in an instance var, so that read goes through the injected instance. 

I didn't need to touch FakeFlutterKeyboardInsetManager. It's an independent NSObject that conforms to
FlutterKeyboardInsetManagerProtocol and not a subclass, so it never depended on this initializer.

This is a refactoring so introduces no semantic changes. I've updated tests to use the new pattern but there's no new functionality to test.

Issue: https://github.com/flutter/flutter/issues/175879
Issue: https://github.com/flutter/flutter/issues/181684

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
