### PR TITLE
[iOS] Inject DisplayLinkManager into FlutterMetalLayer

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -23,6 +23,7 @@ extern CFTimeInterval display_link_target;
 @interface FlutterMetalLayer () {
   id<MTLDevice> _preferredDevice;
   CGSize _drawableSize;
+  FlutterDisplayLinkManager* _displayLinkManager;
 
   NSUInteger _nextDrawableId;
 
@@ -181,11 +182,12 @@ extern CFTimeInterval display_link_target;
     self.device = self.preferredDevice;
     self.pixelFormat = MTLPixelFormatBGRA8Unorm;
     _availableTextures = [[NSMutableSet alloc] init];
+    _displayLinkManager = FlutterDisplayLinkManager.shared;
 
     FlutterMetalLayerDisplayLinkProxy* proxy =
         [[FlutterMetalLayerDisplayLinkProxy alloc] initWithLayer:self];
     _displayLink = [CADisplayLink displayLinkWithTarget:proxy selector:@selector(onDisplayLink:)];
-    [self setMaxRefreshRate:FlutterDisplayLinkManager.shared.displayRefreshRate forceMax:NO];
+    [self setMaxRefreshRate:_displayLinkManager.displayRefreshRate forceMax:NO];
     [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didEnterBackground:)
@@ -205,7 +207,7 @@ extern CFTimeInterval display_link_target;
   // thread which does not trigger actual core animation frame. As a workaround FlutterMetalLayer
   // has it's own displaylink scheduled on main thread, which is used to trigger core animation
   // frame allowing for 120hz updates.
-  if (!FlutterDisplayLinkManager.shared.maxRefreshRateEnabledOnIPhone) {
+  if (!_displayLinkManager.maxRefreshRateEnabledOnIPhone) {
     return;
   }
   double maxFrameRate = fmax(refreshRate, 60);
@@ -220,7 +222,7 @@ extern CFTimeInterval display_link_target;
   if (_displayLinkPauseCountdown == 3) {
     _displayLink.paused = YES;
     if (_displayLinkForcedMaxRate) {
-      [self setMaxRefreshRate:FlutterDisplayLinkManager.shared.displayRefreshRate forceMax:NO];
+      [self setMaxRefreshRate:_displayLinkManager.displayRefreshRate forceMax:NO];
       _displayLinkForcedMaxRate = NO;
     }
   } else {
@@ -418,7 +420,7 @@ extern CFTimeInterval display_link_target;
     _didSetContentsDuringThisDisplayLinkPeriod = YES;
   } else if (!_displayLinkForcedMaxRate) {
     _displayLinkForcedMaxRate = YES;
-    [self setMaxRefreshRate:FlutterDisplayLinkManager.shared.displayRefreshRate forceMax:YES];
+    [self setMaxRefreshRate:_displayLinkManager.displayRefreshRate forceMax:YES];
   }
 }
 


### PR DESCRIPTION
Follow-up to the DisplayLinkManager singleton migration (#189492). FlutterMetalLayer read FlutterDisplayLinkManager.shared directly in four places when seeding and re-seeding its own CADisplayLink's preferred frame rate range.

FlutterMetalLayer can't take a constructor parameter since it's a CALayer subclass, and every instance is created implicitly by UIKit via `+layerClass` returning `[FlutterMetalLayer class]` (see rendering_api_selection.mm and the various +layerClass overrides), which always calls the parameterless `-init`. There's no callsite anywhere in the tree that does `[[FlutterMetalLayer alloc] init]` directly, so unlike VsyncWaiterIOS/FlutterKeyboardInsetManager there's no initializer to extend, and no common-initialization method to fall back on; just -init itself.

This adds a _displayLinkManager ivar, which we wire up from FlutterDisplayLinkManager.shared at the top of -init, and switches the four reads (the initial setMaxRefreshRate:forceMax: call, the maxRefreshRateEnabledOnIPhone guard, and the two re-seeds in onDisplayLink: and presentOnMainThread:) to read from it instead.

I deliberately didn't add this as a property on the class: FlutterMetalLayer.h's header comment states properties and methods "must exactly match those in the CAMetalLayer interface declaration" — it deliberately masquerades as CAMetalLayer (which you can see in -isKindOfClass:), so there's no point in increasing its API surface with this. Added the ivar in a private class extension alongside the existing _preferredDevice and _drawableSize.

No semantic change, just a refactoring, so no change to the tests.

Issue: https://github.com/flutter/flutter/issues/175879
Issue: https://github.com/flutter/flutter/issues/181684

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
