### PR TITLE
[iOS] Remove dead RasterThreadMerger plumbing from platform views

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.h
@@ -69,19 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// from the platform thread.
 - (FlutterTouchInterceptingView*)flutterTouchInterceptingViewForId:(int64_t)viewId;
 
-/// @brief Determine if thread merging is required after prerolling platform views.
-///
-/// Called from the raster thread.
-- (flutter::PostPrerollResult)postPrerollActionWithThreadMerger:
-    (const fml::RefPtr<fml::RasterThreadMerger>&)rasterThreadMerger;
-
-/// @brief Mark the end of a compositor frame.
-///
-/// May determine changes are required to the thread merging state.
-/// Called from the raster thread.
-- (void)endFrameWithResubmit:(BOOL)shouldResubmitFrame
-                threadMerger:(const fml::RefPtr<fml::RasterThreadMerger>&)rasterThreadMerger;
-
 /// @brief Returns the Canvas for the overlay slice for the given platform view.
 ///
 /// Called from the raster thread.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -506,15 +506,6 @@ static void ApplyNonRectClipToOverlayCanvas(flutter::DlCanvas* overlay_canvas,
   [self resetFrameState];
 }
 
-- (flutter::PostPrerollResult)postPrerollActionWithThreadMerger:
-    (const fml::RefPtr<fml::RasterThreadMerger>&)rasterThreadMerger {
-  return flutter::PostPrerollResult::kSuccess;
-}
-
-- (void)endFrameWithResubmit:(BOOL)shouldResubmitFrame
-                threadMerger:(const fml::RefPtr<fml::RasterThreadMerger>&)rasterThreadMerger {
-}
-
 - (void)pushFilterToVisitedPlatformViews:(const std::shared_ptr<flutter::DlImageFilter>&)filter
                                 withRect:(const flutter::DlRect&)filterRect {
   for (int64_t id : self.visitedPlatformViews) {

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_external_view_embedder.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_external_view_embedder.h
@@ -44,11 +44,6 @@ class IOSExternalViewEmbedder : public ExternalViewEmbedder {
       std::unique_ptr<flutter::EmbeddedViewParams> params) override;
 
   // |ExternalViewEmbedder|
-  PostPrerollResult PostPrerollAction(
-      const fml::RefPtr<fml::RasterThreadMerger>& raster_thread_merger)
-      override;
-
-  // |ExternalViewEmbedder|
   DlCanvas* CompositeEmbeddedView(int64_t view_id) override;
 
   // |ExternalViewEmbedder|
@@ -57,11 +52,6 @@ class IOSExternalViewEmbedder : public ExternalViewEmbedder {
       GrDirectContext* context,
       const std::shared_ptr<impeller::AiksContext>& aiks_context,
       std::unique_ptr<SurfaceFrame> frame) override;
-
-  // |ExternalViewEmbedder|
-  void EndFrame(bool should_resubmit_frame,
-                const fml::RefPtr<fml::RasterThreadMerger>&
-                    raster_thread_merger) override;
 
   // |ExternalViewEmbedder|
   bool SupportsDynamicThreadMerging() override;

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_external_view_embedder.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_external_view_embedder.mm
@@ -55,16 +55,6 @@ void IOSExternalViewEmbedder::PrerollCompositeEmbeddedView(
 }
 
 // |ExternalViewEmbedder|
-PostPrerollResult IOSExternalViewEmbedder::PostPrerollAction(
-    const fml::RefPtr<fml::RasterThreadMerger>& raster_thread_merger) {
-  TRACE_EVENT0("flutter", "IOSExternalViewEmbedder::PostPrerollAction");
-  FML_CHECK(platform_views_controller_);
-  PostPrerollResult result =
-      [platform_views_controller_ postPrerollActionWithThreadMerger:raster_thread_merger];
-  return result;
-}
-
-// |ExternalViewEmbedder|
 DlCanvas* IOSExternalViewEmbedder::CompositeEmbeddedView(int64_t view_id) {
   TRACE_EVENT0("flutter", "IOSExternalViewEmbedder::CompositeEmbeddedView");
   FML_CHECK(platform_views_controller_);
@@ -85,15 +75,6 @@ void IOSExternalViewEmbedder::SubmitFlutterView(
   FML_CHECK(platform_views_controller_);
   [platform_views_controller_ submitFrame:std::move(frame) withIosContext:ios_context_];
   TRACE_EVENT0("flutter", "IOSExternalViewEmbedder::DidSubmitFrame");
-}
-
-// |ExternalViewEmbedder|
-void IOSExternalViewEmbedder::EndFrame(
-    bool should_resubmit_frame,
-    const fml::RefPtr<fml::RasterThreadMerger>& raster_thread_merger) {
-  TRACE_EVENT0("flutter", "IOSExternalViewEmbedder::EndFrame");
-  [platform_views_controller_ endFrameWithResubmit:should_resubmit_frame
-                                      threadMerger:raster_thread_merger];
 }
 
 // |ExternalViewEmbedder|


### PR DESCRIPTION
IOSExternalViewEmbedder::SupportsDynamicThreadMerging() returns false, so the raster thread merger is never engaged on iOS. 

This deletes two no-op overrides in FlutterPlatformViewsController:

* `postPrerollActionWithThreadMerger:` ignores its merger argument and unconditionally returns PostPrerollResult::kSuccess, which is exactly the base-class default of ExternalViewEmbedder::PostPrerollAction.
* `endFrameWithResubmit:threadMerger: has an empty body, matching the base-class default of ExternalViewEmbedder::EndFrame.

Also deletes the IOSExternalViewEmbedder overrides that existed only to forward to them. We now fall back to the base-class defaults which were identical. BeginFrame is pure virtual, so we still need its empty override. This removes fml::RefPtr<fml::RasterThreadMerger> and flutter::PostPrerollResult from the ObjC embedding surface.

This is pure no-op cleanup stemming from the fact that we now run only in thread-merged mode on iOS, and cleanup that makes an eventual migration to the embedder API easier.

No test changes since there are no semantic changes; covered by existing tests.

Issue: https://github.com/flutter/flutter/issues/112232

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
