### PR TITLE
[stable] Fix AccessibilityBridge startup crash on vendor-modified Android

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -25,6 +25,7 @@ import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityNodeProvider;
+import androidx.annotation.DoNotInline;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -658,11 +659,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     if (rootAccessibilityView == null || rootAccessibilityView.getResources() == null) {
       return;
     }
-    int fontWeightAdjustment =
-        rootAccessibilityView.getResources().getConfiguration().fontWeightAdjustment;
     boolean shouldBold =
-        fontWeightAdjustment != Configuration.FONT_WEIGHT_ADJUSTMENT_UNDEFINED
-            && fontWeightAdjustment >= BOLD_TEXT_WEIGHT_ADJUSTMENT;
+        Api31Impl.isBoldText(rootAccessibilityView.getResources().getConfiguration());
 
     if (shouldBold) {
       accessibilityFeatureFlags |= AccessibilityFeature.BOLD_TEXT.value;
@@ -3255,5 +3253,23 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         break;
     }
     return true;
+  }
+
+  /**
+   * Isolates API-31 field references so that ART's class verifier does not attempt to resolve them
+   * when loading {@link AccessibilityBridge} on older API levels. Without this separation, the
+   * verifier eagerly resolves {@link Configuration#fontWeightAdjustment} at class-load time,
+   * causing a {@link NoSuchFieldError} crash on Android 11 devices (observed on Pixel 4a and
+   * OnePlus 8 Pro). This mirrors the fix AndroidX Compose applied for the same crash (AOSP
+   * b/353988277).
+   */
+  @RequiresApi(API_LEVELS.API_31)
+  private static class Api31Impl {
+    @DoNotInline
+    static boolean isBoldText(Configuration configuration) {
+      int fontWeightAdjustment = configuration.fontWeightAdjustment;
+      return fontWeightAdjustment != Configuration.FONT_WEIGHT_ADJUSTMENT_UNDEFINED
+          && fontWeightAdjustment >= BOLD_TEXT_WEIGHT_ADJUSTMENT;
+    }
   }
 }


### PR DESCRIPTION
Cherry-picks #184630 (fixes #184286) to `flutter-3.44-candidate.0`.

## Impacted Users
Devices on vendor-modified Android 11 ROMs that report `SDK_INT >= 31` but ship a `Configuration` class without the API-31 `fontWeightAdjustment` field. Confirmed in production on OnePlus 8 Pro (Android 11); the OnePlus/Oppo/Realme ROM family is the likely blast radius. #184286 cited 95 fatal events, 100% OnePlus 8 Pro / Android 11.

## Impact Description
Hard crash at startup. `NoSuchFieldError` is thrown from `AccessibilityBridge.setBoldTextFlag` inside the `AccessibilityBridge` constructor during `FlutterActivity.onCreate`, so the process dies before any Dart runs — the app never opens on affected devices.

## Workaround
None from app code. The field read happens inside the engine's `AccessibilityBridge` constructor before the Dart isolate starts, so the embedding app cannot guard or catch it.

## Risk
Low. +20/-4 in a single file (`AccessibilityBridge.java`): moves the `fontWeightAdjustment` read into an `@RequiresApi(31)` `Api31Impl` inner class so ART's class verifier no longer eagerly resolves the field at class-load time on older or vendor-modified runtimes. Mirrors the hardening AndroidX Compose applied for the same crash (AOSP b/353988277). Only touches the already-failing path.

## Test Coverage
No automated test — the trigger is a device/ROM-specific `NoSuchFieldError` that isn't reproducible in CI. The change is defensive and validated against the production crash signature in #184286.

## Validation Steps
Launch the app on an affected device (OnePlus 8 Pro / Android 11). Before: immediate startup crash. After: app launches normally; bold-text accessibility is simply treated as unavailable.
