### PR TITLE
[iOS] Inject DisplayLinkManager into FlutterViewController

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -365,9 +365,10 @@ typedef struct MouseState {
   _statusBarStyle = UIStatusBarStyleDefault;
 
   _accessibilityFeatures = [[FlutterAccessibilityFeatures alloc] init];
+  _displayLinkManager = FlutterDisplayLinkManager.shared;
   _keyboardInsetManager =
       [[FlutterKeyboardInsetManager alloc] initWithDelegate:self
-                                         displayLinkManager:FlutterDisplayLinkManager.shared];
+                                         displayLinkManager:_displayLinkManager];
 
   // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
   // Eliminate method calls in initializers and dealloc.
@@ -1313,7 +1314,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     return;
   }
 
-  double displayRefreshRate = FlutterDisplayLinkManager.shared.displayRefreshRate;
+  double displayRefreshRate = self.displayLinkManager.displayRefreshRate;
   const double epsilon = 0.1;
   if (displayRefreshRate < 60.0 + epsilon) {  // displayRefreshRate <= 60.0
 
@@ -1329,8 +1330,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
       };
   _touchRateCorrectionVSyncClient = [[FlutterVSyncClient alloc]
                 initWithTaskRunner:self.engine.platformTaskRunner
-      isVariableRefreshRateEnabled:FlutterDisplayLinkManager.shared.maxRefreshRateEnabledOnIPhone
-                    maxRefreshRate:FlutterDisplayLinkManager.shared.displayRefreshRate
+      isVariableRefreshRateEnabled:self.displayLinkManager.maxRefreshRateEnabledOnIPhone
+                    maxRefreshRate:self.displayLinkManager.displayRefreshRate
                           callback:callback];
   _touchRateCorrectionVSyncClient.allowPauseAfterVsync = NO;
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -52,6 +52,8 @@ extern NSNotificationName const FlutterViewControllerShowHomeIndicator;
 
 @property(nonatomic, strong) FlutterAccessibilityFeatures* accessibilityFeatures;
 
+@property(nonatomic, strong) FlutterDisplayLinkManager* displayLinkManager;
+
 - (FlutterRestorationPlugin*)restorationPlugin;
 - (FlutterTextInputPlugin*)textInputPlugin;
 


### PR DESCRIPTION
Follow-up to DisplayLinkManager singleton migration (#189492). createTouchRateCorrectionVSyncClientIfNeeded read
FlutterDisplayLinkManager.shared directly in three places when deciding whether to create the touch-rate-correction VSyncClient and seeding its isVariableRefreshRateEnabled/maxRefreshRate.

FlutterViewController has too many public initializers to add a constructor parameter without breaking API. However, we can wire this up similarly to how we declare keyboardInsetManager and accessibilityFeatures as internal strong properties in FlutterViewController_Internal.h and assign in
performCommonViewControllerInitialization. We now set FlutterDisplayLinkManager.shared at init, and migrate the existing uses of the static shared singleton to reads of this property.

No changes to tests because there are no semantic changes; this is covered by existing tests.

Issue: https://github.com/flutter/flutter/issues/175879
Issue: https://github.com/flutter/flutter/issues/181684

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
