### PR TITLE
Suppress Vulkan rendering backend log when falling back to opengl

### DIFF
--- a/engine/src/flutter/shell/platform/android/android_context_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_vk_impeller.cc
@@ -64,8 +64,8 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
   }
 
   if (!p_settings.quiet) {
-    if (context && impeller::CapabilitiesVK::Cast(*context->GetCapabilities())
-                       .AreValidationsEnabled()) {
+    if (impeller::CapabilitiesVK::Cast(*context->GetCapabilities())
+            .AreValidationsEnabled()) {
       FML_LOG(IMPORTANT) << "Using the Impeller rendering backend (Vulkan with "
                             "Validation Layers).";
     } else {

--- a/engine/src/flutter/shell/platform/android/android_context_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_vk_impeller.cc
@@ -53,7 +53,11 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
 
   auto context = impeller::ContextVK::Create(std::move(settings));
 
-  if (context && context->GetDriverInfo()->IsKnownBadDriver()) {
+  if (!context) {
+    return nullptr;
+  }
+
+  if (context->GetDriverInfo()->IsKnownBadDriver()) {
     FML_LOG(INFO)
         << "Known bad Vulkan driver encountered, falling back to OpenGLES.";
     return nullptr;

--- a/engine/src/flutter/shell/platform/android/android_context_vk_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_vk_impeller.cc
@@ -53,6 +53,12 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
 
   auto context = impeller::ContextVK::Create(std::move(settings));
 
+  if (context && context->GetDriverInfo()->IsKnownBadDriver()) {
+    FML_LOG(INFO)
+        << "Known bad Vulkan driver encountered, falling back to OpenGLES.";
+    return nullptr;
+  }
+
   if (!p_settings.quiet) {
     if (context && impeller::CapabilitiesVK::Cast(*context->GetCapabilities())
                        .AreValidationsEnabled()) {
@@ -61,11 +67,6 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
     } else {
       FML_LOG(IMPORTANT) << "Using the Impeller rendering backend (Vulkan).";
     }
-  }
-  if (context && context->GetDriverInfo()->IsKnownBadDriver()) {
-    FML_LOG(INFO)
-        << "Known bad Vulkan driver encountered, falling back to OpenGLES.";
-    return nullptr;
   }
 
   return context;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/189803.

Before, running an impeller app on a Pixel 4 would emit two logs:

`Using the Impeller rendering backend (Vulkan)`
and
`Using the Impeller rendering backend (OpenGLES)`

Now, only

`Using the Impeller rendering backend (OpenGLES)` is emitted

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.