### PR TITLE
Fix Mockito dynamic agent loading warnings in Robolectric tests

### DIFF
--- a/engine/src/flutter/shell/platform/android/test_runner/build.gradle
+++ b/engine/src/flutter/shell/platform/android/test_runner/build.gradle
@@ -15,6 +15,10 @@ repositories {
 
 apply plugin: "com.android.library"
 
+configurations {
+  mockitoAgent
+}
+
 rootProject.buildDir = project.property("build_dir")
 
 // Shows warnings for usage of deprecated API usages.
@@ -51,6 +55,12 @@ android {
 
     unitTests.all {
       jvmArgs "-Xmx8g" // Max JVM heap size is 8G/30G available in the CI bot.
+      jvmArgumentProviders.add(new CommandLineArgumentProvider() {
+        @Override
+        Iterable<String> asArguments() {
+          return ["-javaagent:${configurations.mockitoAgent.asPath}"]
+        }
+      })
       maxHeapSize "8g"
       maxParallelForks availableProcessors // The CI bot has 8 CPUs.
       testLogging {
@@ -77,6 +87,9 @@ android {
     testImplementation "androidx.test.ext:junit:1.2.1"
 
     testImplementation "org.mockito:mockito-core:5.17.0"
+    mockitoAgent("org.mockito:mockito-core:5.17.0") {
+      transitive = false
+    }
   }
 
   // Configure the embedding dependencies.

--- a/engine/src/flutter/shell/platform/android/test_runner/build.gradle
+++ b/engine/src/flutter/shell/platform/android/test_runner/build.gradle
@@ -56,9 +56,13 @@ android {
     unitTests.all {
       jvmArgs "-Xmx8g" // Max JVM heap size is 8G/30G available in the CI bot.
       jvmArgumentProviders.add(new CommandLineArgumentProvider() {
+        @InputFiles
+        @Classpath
+        def agentFiles = configurations.mockitoAgent
+
         @Override
         Iterable<String> asArguments() {
-          return ["-javaagent:${configurations.mockitoAgent.asPath}"]
+          return ["-javaagent:${agentFiles.asPath}"]
         }
       })
       maxHeapSize "8g"
@@ -86,8 +90,9 @@ android {
     testImplementation "junit:junit:4.13.2"
     testImplementation "androidx.test.ext:junit:1.2.1"
 
-    testImplementation "org.mockito:mockito-core:5.17.0"
-    mockitoAgent("org.mockito:mockito-core:5.17.0") {
+    def mockitoVersion = "5.17.0"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    mockitoAgent("org.mockito:mockito-core:$mockitoVersion") {
       transitive = false
     }
   }


### PR DESCRIPTION
This change configures Mockito-core as a -javaagent in the Gradle build file for unit tests using CommandLineArgumentProvider. This prevents dynamic agent loading warnings during Robolectric tests when running on newer JDKs.

Fixes: #189148

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.