### PR TITLE
Fix `Rect::ExpandToMinTransformedSize` to return the input rectangle when no expansion is needed, and remove 1-pixel roundrect to rect simplification

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1111,36 +1111,27 @@ void Canvas::DrawRoundRect(const RoundRect& round_rect, const Paint& paint) {
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
       IsCompatibleWithSDFRendering(paint) && radii.AreAllCornersCircular()) {
+    Color effective_color = paint.color;
+    Rect bounds = round_rect.GetBounds();
+
     // Expand rrect bounds to 1 pixel minimum dimensions if applicable.
     if (paint.style == Paint::Style::kFill &&
         !GetCurrentTransform().HasPerspective2D()) {
-      Rect rrect_bounds = round_rect.GetBounds();
-      auto [expanded, alpha_scaled_color] =
-          ExpandRectToPixelMinimum(rrect_bounds, paint.color,
-                                   GetCurrentTransform(), /*scale_alpha=*/true);
+      auto [expanded, alpha_scaled_color] = ExpandRectToPixelMinimum(
+          bounds, paint.color, GetCurrentTransform(), /*scale_alpha=*/true);
 
       if (expanded.IsEmpty()) {
         // RRect is invisible due to transform scaling or alpha scaling.
         return;
       }
 
-      // Pixel-minimum expansion is applicable if the expanded bounds is
-      // different from the original bounds.
-      if (expanded != rrect_bounds) {
-        // At a 1-pixel size, the rounded corners can be ignored. Draw a regular
-        // rect matching the expanded bounds.
-        auto params = UberSDFParameters::MakeRect(
-            /*color=*/alpha_scaled_color,
-            /*rect=*/expanded,
-            /*stroke=*/std::nullopt);
-        AddRenderSDFEntityToCurrentPass(paint, params);
-        return;
-      }
+      bounds = expanded;
+      effective_color = alpha_scaled_color;
     }
 
     auto params = UberSDFParameters::MakeRoundedRect(
-        /*color=*/paint.color,
-        /*rect=*/round_rect.GetBounds(),
+        /*color=*/effective_color,
+        /*rect=*/bounds,
         /*radii=*/radii,
         /*stroke=*/paint.style == Paint::Style::kStroke
             ? std::make_optional(paint.stroke)

--- a/engine/src/flutter/impeller/geometry/rect.h
+++ b/engine/src/flutter/impeller/geometry/rect.h
@@ -719,6 +719,13 @@ struct TRect {
       return std::nullopt;
     }
     Size current_size = GetSize();
+
+    if (current_size.width >= min_local_size.width &&
+        current_size.height >= min_local_size.height) {
+      // No expansion needed.
+      return *this;
+    }
+
     Size expanded_size = current_size.Max(min_local_size);
     return MakeEllipseBounds(GetCenter(), Point(expanded_size.width * 0.5f,
                                                 expanded_size.height * 0.5f));

--- a/engine/src/flutter/impeller/geometry/rect_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/rect_unittests.cc
@@ -1444,10 +1444,18 @@ TEST(RectTest, RectExpandToMinTransformedSizeNullForScaledToZero) {
             std::nullopt);
 }
 
-TEST(RectTest,
-     RectExpandToMinTransformedSizeRectReturnsUnmodifiedWhenLargeEnough) {
+TEST(RectTest, RectExpandToMinTransformedSizeReturnsUnmodifiedWhenLargeEnough) {
   Rect rect = Rect::MakeXYWH(0, 0, 10, 20);
   auto transform = Matrix::MakeScale(Vector3(0.5f, 0.5f));
+  EXPECT_EQ(rect.ExpandToMinTransformedSize({1.0f, 1.0f}, transform), rect);
+}
+
+TEST(
+    RectTest,
+    RectExpandToMinTransformedSizeReturnsUnmodifiedWhenLargeEnoughWithFractionalSize) {
+  // Regression test for https://github.com/flutter/flutter/issues/189807.
+  Rect rect = Rect::MakeXYWH(100.0f, 50.0f, 64.2f, 40.0f);
+  auto transform = Matrix();
   EXPECT_EQ(rect.ExpandToMinTransformedSize({1.0f, 1.0f}, transform), rect);
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/189807

See the issue for more context.

Adds a unit test that fails without this change, and passes with this change.

Verified the demo app in the issue renders properly with this change.

From the issue:

## Root cause and fix

[Rect::ExpandToMinTransformedSize](https://github.com/flutter/flutter/blob/1c8b3088238220102df66761685f3a4718b5aa15/engine/src/flutter/impeller/geometry/rect.h#L705) always constructs a new expanded rectangle from the input Rect from its center point and half-extents.

If the input rectangle is already large enough and does not need expansion, this should return an identical rectangle. The returned rectangle is equality-checked against the input in [Canvas::DrawRoundRect](https://github.com/flutter/flutter/blob/1c8b3088238220102df66761685f3a4718b5aa15/engine/src/flutter/impeller/display_list/canvas.cc#L1129) to determine whether expansion happened. That code assumes that if the output does not equal the input, pixel-expansion happened, which means that the rounded rect had sub-pixel dimensions and can be safely drawn as a non-rounded rectangle.

The issue is that for certain cases, particularly with non-integer sizes, ExpandToMinTransformedSize returns a different rectangle even if no expansion happened. This is due to small floating point imprecisions when constructing the new rectangle using the input rectangle's center and half-extents.

To fix this, ExpandToMinTransformedSize should not construct a new rectangle unless expansion is actually needed.

## Removal of 1-pixel roundrect to rect simplification

This PR also removes the 1-pixel roundrect to rect simplification in `Canvas::DrawRoundRect`. As described in https://github.com/flutter/flutter/issues/189807#issuecomment-5042858850, this optimization resulted in slightly different colors at the tips of thin roundrects.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
