### PR TITLE
[flutter_tools] Supply engine host-tool paths to hooks via flutter_hook_config

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -421,6 +421,10 @@ Future<FlutterNativeAssetsBuildRunner> createFlutterNativeAssetsBuildRunner(
     environment.logger,
     runPackageName,
     includeDevDependencies: includeDevDependencies,
+    flutterExtension: createFlutterExtension(
+      artifacts: environment.artifacts,
+      engineVersion: environment.engineVersion,
+    ),
     pubspecPath,
   );
 }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -6,11 +6,13 @@
 
 import 'package:code_assets/code_assets.dart';
 import 'package:data_assets/data_assets.dart';
+import 'package:flutter_hook_config/flutter_hook_config.dart';
 import 'package:hooks/hooks.dart';
 import 'package:hooks_runner/hooks_runner.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:package_config/package_config_types.dart';
 
+import '../../artifacts.dart';
 import '../../base/common.dart';
 import '../../base/file_system.dart';
 import '../../base/logger.dart';
@@ -536,6 +538,39 @@ abstract interface class FlutterNativeAssetsBuildRunner {
   Future<void> setCCompilerConfig(CodeAssetTarget target);
 }
 
+/// Creates the [FlutterExtension] that supplies engine host-tool paths (such
+/// as `impellerc`) to build and link hooks.
+///
+/// [engineVersion] is the engine revision the invoking SDK targets, or null
+/// for local engine builds (matching `Environment.engineVersion`). Local
+/// engines have no revision, so the version is derived from the host tools
+/// themselves; a rebuilt tool then produces a different version, which
+/// invalidates the hook cache.
+FlutterExtension createFlutterExtension({
+  required Artifacts artifacts,
+  required String? engineVersion,
+}) {
+  final FileSystemEntity impellerc = artifacts.getHostArtifact(HostArtifact.impellerc);
+  final FileSystemEntity libtessellator = artifacts.getHostArtifact(HostArtifact.libtessellator);
+  return FlutterExtension(
+    engineVersion:
+        engineVersion ?? _localEngineToolsVersion(<FileSystemEntity>[impellerc, libtessellator]),
+    impellerc: Uri.file(impellerc.absolute.path),
+    libtessellator: Uri.file(libtessellator.absolute.path),
+  );
+}
+
+/// An opaque engine version for local engine builds, derived from the host
+/// tools' paths, sizes, and timestamps.
+String _localEngineToolsVersion(List<FileSystemEntity> tools) {
+  final buffer = StringBuffer('local-engine');
+  for (final tool in tools) {
+    final FileStat stat = tool.statSync();
+    buffer.write(';${tool.absolute.path};${stat.size};${stat.modified.millisecondsSinceEpoch}');
+  }
+  return buffer.toString();
+}
+
 /// Uses `package:hooks_runner` for its implementation.
 class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunner {
   FlutterNativeAssetsBuildRunnerImpl(
@@ -546,6 +581,7 @@ class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunn
     this.runPackageName,
     this.pubspecPath, {
     required this.includeDevDependencies,
+    required this.flutterExtension,
   });
 
   final String pubspecPath;
@@ -557,6 +593,13 @@ class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunn
 
   /// Include the dev dependencies of [runPackageName].
   final bool includeDevDependencies;
+
+  /// Supplies engine host-tool paths to hooks.
+  ///
+  /// Appended to the extensions of every build and link hook invocation, so
+  /// hooks can locate tools like `impellerc` through the same artifact
+  /// resolution the tool uses itself, including under `--local-engine`.
+  final FlutterExtension flutterExtension;
 
   late final _logger = logging.Logger('')
     ..onRecord.listen((logging.LogRecord record) {
@@ -614,7 +657,7 @@ class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunn
   }) async {
     final Result<BuildResult, HooksRunnerFailure> result = await _buildRunner.build(
       linkingEnabled: linkingEnabled,
-      extensions: extensions,
+      extensions: <ProtocolExtension>[...extensions, flutterExtension],
     );
     if (result.isSuccess) {
       return result.success;
@@ -630,7 +673,7 @@ class FlutterNativeAssetsBuildRunnerImpl implements FlutterNativeAssetsBuildRunn
     required File? recordedUsesFile,
   }) async {
     final Result<LinkResult, HooksRunnerFailure> result = await _buildRunner.link(
-      extensions: extensions,
+      extensions: <ProtocolExtension>[...extensions, flutterExtension],
       buildResult: buildResult,
       resourceIdentifiers: recordedUsesFile?.uri,
     );

--- a/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
@@ -46,6 +46,12 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
     globals.logger,
     runPackageName,
     includeDevDependencies: true,
+    flutterExtension: createFlutterExtension(
+      artifacts: globals.artifacts!,
+      engineVersion: globals.artifacts!.usesLocalArtifacts
+          ? null
+          : globals.flutterVersion.engineRevision,
+    ),
     pubspecPath,
   );
 

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   hooks: 2.1.0
   code_assets: 1.2.1
   data_assets: 0.20.0
+  flutter_hook_config: 0.1.0
 
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so when upgrading
@@ -127,5 +128,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-
-# PUBSPEC CHECKSUM: qi12j
+# PUBSPEC CHECKSUM: cumesd

--- a/packages/flutter_tools/test/general.shard/isolated/flutter_extension_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/flutter_extension_test.dart
@@ -1,0 +1,64 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_hook_config/flutter_hook_config.dart';
+import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  late FileSystem fileSystem;
+  late Artifacts artifacts;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    artifacts = Artifacts.test(fileSystem: fileSystem);
+  });
+
+  testWithoutContext('createFlutterExtension resolves host tools to absolute file URIs', () {
+    final FlutterExtension extension = createFlutterExtension(
+      artifacts: artifacts,
+      engineVersion: 'abc123',
+    );
+
+    expect(extension.engineVersion, 'abc123');
+    expect(extension.impellerc.isScheme('file'), true);
+    expect(extension.impellerc.isAbsolute, true);
+    expect(
+      extension.impellerc,
+      Uri.file(artifacts.getHostArtifact(HostArtifact.impellerc).absolute.path),
+    );
+    expect(extension.libtessellator.isScheme('file'), true);
+    expect(extension.libtessellator.isAbsolute, true);
+    expect(
+      extension.libtessellator,
+      Uri.file(artifacts.getHostArtifact(HostArtifact.libtessellator).absolute.path),
+    );
+  });
+
+  testWithoutContext('local engine version is stable until a host tool changes', () {
+    final File impellerc = fileSystem.file(artifacts.getHostArtifact(HostArtifact.impellerc).path)
+      ..writeAsStringSync('impellerc binary');
+    fileSystem
+        .file(artifacts.getHostArtifact(HostArtifact.libtessellator).path)
+        .writeAsStringSync('libtessellator binary');
+
+    final String before = createFlutterExtension(
+      artifacts: artifacts,
+      engineVersion: null,
+    ).engineVersion;
+    expect(before, isNotEmpty);
+    expect(createFlutterExtension(artifacts: artifacts, engineVersion: null).engineVersion, before);
+
+    impellerc.writeAsStringSync('rebuilt impellerc binary');
+    final String after = createFlutterExtension(
+      artifacts: artifacts,
+      engineVersion: null,
+    ).engineVersion;
+    expect(after, isNot(before));
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -363,6 +363,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  flutter_hook_config:
+    dependency: transitive
+    description:
+      name: flutter_hook_config
+      sha256: af801f91e3e433a939551e601c386ee59683d045ae6148896983c75655ec79e5
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   flutter_lints:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/186299

Passes a `FlutterExtension` (from `package:flutter_hook_config`, added in [flutter/core-packages#19](https://github.com/flutter/core-packages/pull/19)) to every build and link hook invocation. Hooks that consume engine host tools can now read `input.config.flutter.impellerc` and `input.config.flutter.libtessellator` instead of re-implementing artifact discovery, and the paths resolve through the tool's own `Artifacts` lookup, so `--local-engine` propagates to hooks instead of silently using stale cached binaries.

The extension also carries an `engineVersion`. `hooks_runner` keys the hook cache on the hook config, so hooks re-run when the SDK is upgraded even though the tool paths are unchanged. For a stock SDK this is the engine revision. Local engine builds have no revision (`Environment.engineVersion` is null by design), so the version is derived from the host tools' paths, sizes, and mtimes, which invalidates the hook cache when a local engine is rebuilt.

Supersedes [#186300](https://github.com/flutter/flutter/pull/186300), which passed the same paths as environment variables. The typed extension participates in hook caching and needs no env-var plumbing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
