### PR TITLE
Offload blocking work in ProcessTextPlugin to the background

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/ProcessTextChannel.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/ProcessTextChannel.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.StandardMethodCodec;
@@ -87,7 +88,14 @@ public class ProcessTextChannel {
   public ProcessTextChannel(
       @NonNull DartExecutor dartExecutor, @NonNull PackageManager packageManager) {
     this.packageManager = packageManager;
-    channel = new MethodChannel(dartExecutor, CHANNEL_NAME, StandardMethodCodec.INSTANCE);
+    BinaryMessenger.TaskQueue taskQueue =
+        dartExecutor.getBinaryMessenger().makeBackgroundTaskQueue();
+    channel =
+        new MethodChannel(
+            dartExecutor.getBinaryMessenger(),
+            CHANNEL_NAME,
+            StandardMethodCodec.INSTANCE,
+            taskQueue);
     channel.setMethodCallHandler(parsingMethodHandler);
   }
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/text/ProcessTextPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/text/ProcessTextPlugin.java
@@ -11,6 +11,8 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -32,9 +34,14 @@ public class ProcessTextPlugin
 
   @NonNull private final ProcessTextChannel processTextChannel;
   @NonNull private final PackageManager packageManager;
-  @Nullable private ActivityPluginBinding activityBinding;
+  @NonNull private final Handler mainThreadHandler;
+  @Nullable private volatile ActivityPluginBinding activityBinding;
+  // The use of a Map for this variable assumes that it is only accessed
+  // serially on the background task queue.
   private Map<String, ResolveInfo> resolveInfosById;
 
+  // The use of a Map for this variable assumes that it is only accessed
+  // serially on the main thread.
   @NonNull
   private Map<Integer, MethodChannel.Result> requestsByCode =
       new HashMap<Integer, MethodChannel.Result>();
@@ -42,6 +49,7 @@ public class ProcessTextPlugin
   public ProcessTextPlugin(@NonNull ProcessTextChannel processTextChannel) {
     this.processTextChannel = processTextChannel;
     this.packageManager = processTextChannel.packageManager;
+    this.mainThreadHandler = new Handler(Looper.getMainLooper());
 
     processTextChannel.setMethodHandler(this);
   }
@@ -81,20 +89,27 @@ public class ProcessTextPlugin
       return;
     }
 
-    Integer requestCode = result.hashCode();
-    requestsByCode.put(requestCode, result);
+    mainThreadHandler.post(
+        () -> {
+          if (activityBinding == null) {
+            result.error("error", "Plugin not bound to an Activity", null);
+            return;
+          }
 
-    Intent intent = new Intent();
-    intent.setClassName(info.activityInfo.packageName, info.activityInfo.name);
-    intent.setAction(Intent.ACTION_PROCESS_TEXT);
-    intent.setType("text/plain");
-    intent.putExtra(Intent.EXTRA_PROCESS_TEXT, text);
-    intent.putExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, readOnly);
+          final Integer requestCode = result.hashCode();
+          requestsByCode.put(requestCode, result);
 
-    // Start the text processing activity. When the activity completes, the onActivityResult
-    // callback
-    // is called.
-    activityBinding.getActivity().startActivityForResult(intent, requestCode);
+          Intent intent = new Intent();
+          intent.setClassName(info.activityInfo.packageName, info.activityInfo.name);
+          intent.setAction(Intent.ACTION_PROCESS_TEXT);
+          intent.setType("text/plain");
+          intent.putExtra(Intent.EXTRA_PROCESS_TEXT, text);
+          intent.putExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, readOnly);
+
+          // Start the text processing activity. When the activity completes, the
+          // onActivityResult callback is called.
+          activityBinding.getActivity().startActivityForResult(intent, requestCode);
+        });
   }
 
   private void cacheResolveInfos() {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/text/ProcessTextPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/text/ProcessTextPluginTest.java
@@ -4,6 +4,7 @@ import static io.flutter.Build.API_LEVELS;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.robolectric.shadows.ShadowLooper;
 
 @RunWith(AndroidJUnit4.class)
 @TargetApi(API_LEVELS.API_24)
@@ -48,18 +50,19 @@ public class ProcessTextPluginTest {
         (ByteBuffer) encodedMethodCall.flip(), mock(BinaryMessenger.BinaryReply.class));
   }
 
-  @SuppressWarnings("deprecation")
-  // setMessageHandler is deprecated.
   @Test
   public void respondsToProcessTextChannelMessage() {
     ArgumentCaptor<BinaryMessenger.BinaryMessageHandler> binaryMessageHandlerCaptor =
         ArgumentCaptor.forClass(BinaryMessenger.BinaryMessageHandler.class);
-    DartExecutor mockBinaryMessenger = mock(DartExecutor.class);
+    DartExecutor mockDartExecutor = mock(DartExecutor.class);
+    BinaryMessenger mockBinaryMessenger = mock(BinaryMessenger.class);
+    when(mockDartExecutor.getBinaryMessenger()).thenReturn(mockBinaryMessenger);
+    doReturn(null).when(mockBinaryMessenger).makeBackgroundTaskQueue();
     ProcessTextChannel.ProcessTextMethodHandler mockHandler =
         mock(ProcessTextChannel.ProcessTextMethodHandler.class);
     PackageManager mockPackageManager = mock(PackageManager.class);
     ProcessTextChannel processTextChannel =
-        new ProcessTextChannel(mockBinaryMessenger, mockPackageManager);
+        new ProcessTextChannel(mockDartExecutor, mockPackageManager);
 
     processTextChannel.setMethodHandler(mockHandler);
 
@@ -74,14 +77,15 @@ public class ProcessTextPluginTest {
     verify(mockHandler).queryTextActions();
   }
 
-  @SuppressWarnings("deprecation")
-  // setMessageHandler is deprecated.
   @Test
   public void performQueryTextActions() {
-    DartExecutor mockBinaryMessenger = mock(DartExecutor.class);
+    DartExecutor mockDartExecutor = mock(DartExecutor.class);
+    BinaryMessenger mockBinaryMessenger = mock(BinaryMessenger.class);
+    when(mockDartExecutor.getBinaryMessenger()).thenReturn(mockBinaryMessenger);
+    doReturn(null).when(mockBinaryMessenger).makeBackgroundTaskQueue();
     PackageManager mockPackageManager = mock(PackageManager.class);
     ProcessTextChannel processTextChannel =
-        new ProcessTextChannel(mockBinaryMessenger, mockPackageManager);
+        new ProcessTextChannel(mockDartExecutor, mockPackageManager);
 
     // Set up mocked result for PackageManager.queryIntentActivities.
     ResolveInfo action1 = createFakeResolveInfo("Action1", mockPackageManager);
@@ -100,63 +104,15 @@ public class ProcessTextPluginTest {
     assertEquals(textActions, Map.of(action1Id, "Action1", action2Id, "Action2"));
   }
 
-  @SuppressWarnings("deprecation")
-  // setMessageHandler is deprecated.
   @Test
   public void performProcessTextActionWithNoReturnedValue() {
-    DartExecutor mockBinaryMessenger = mock(DartExecutor.class);
+    DartExecutor mockDartExecutor = mock(DartExecutor.class);
+    BinaryMessenger mockBinaryMessenger = mock(BinaryMessenger.class);
+    when(mockDartExecutor.getBinaryMessenger()).thenReturn(mockBinaryMessenger);
+    doReturn(null).when(mockBinaryMessenger).makeBackgroundTaskQueue();
     PackageManager mockPackageManager = mock(PackageManager.class);
     ProcessTextChannel processTextChannel =
-        new ProcessTextChannel(mockBinaryMessenger, mockPackageManager);
-
-    // Set up mocked result for PackageManager.queryIntentActivities.
-    ResolveInfo action1 = createFakeResolveInfo("Action1", mockPackageManager);
-    ResolveInfo action2 = createFakeResolveInfo("Action2", mockPackageManager);
-    List<ResolveInfo> infos = new ArrayList<ResolveInfo>(Arrays.asList(action1, action2));
-    when(mockPackageManager.queryIntentActivities(
-            any(Intent.class), any(PackageManager.ResolveInfoFlags.class)))
-        .thenReturn(infos);
-
-    // ProcessTextPlugin should retrieve the mocked text actions.
-    ProcessTextPlugin processTextPlugin = new ProcessTextPlugin(processTextChannel);
-    Map<String, String> textActions = processTextPlugin.queryTextActions();
-    final String action1Id = "mockActivityName.Action1";
-    final String action2Id = "mockActivityName.Action2";
-    assertEquals(textActions, Map.of(action1Id, "Action1", action2Id, "Action2"));
-
-    // Set up the activity binding.
-    ActivityPluginBinding mockActivityPluginBinding = mock(ActivityPluginBinding.class);
-    Activity mockActivity = mock(Activity.class);
-    when(mockActivityPluginBinding.getActivity()).thenReturn(mockActivity);
-    processTextPlugin.onAttachedToActivity(mockActivityPluginBinding);
-
-    // Execute th first action.
-    String textToBeProcessed = "Flutter!";
-    MethodChannel.Result result = mock(MethodChannel.Result.class);
-    processTextPlugin.processTextAction(action1Id, textToBeProcessed, false, result);
-
-    // Activity.startActivityForResult should have been called.
-    ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
-    verify(mockActivity, times(1)).startActivityForResult(intentCaptor.capture(), anyInt());
-    Intent intent = intentCaptor.getValue();
-    assertEquals(textToBeProcessed, intent.getStringExtra(Intent.EXTRA_PROCESS_TEXT));
-
-    // Simulate an Android activity answer which does not return a value.
-    Intent resultIntent = new Intent();
-    processTextPlugin.onActivityResult(result.hashCode(), Activity.RESULT_OK, resultIntent);
-
-    // Success with no returned value is expected.
-    verify(result).success(null);
-  }
-
-  @SuppressWarnings("deprecation")
-  // setMessageHandler is deprecated.
-  @Test
-  public void performProcessTextActionWithReturnedValue() {
-    DartExecutor mockBinaryMessenger = mock(DartExecutor.class);
-    PackageManager mockPackageManager = mock(PackageManager.class);
-    ProcessTextChannel processTextChannel =
-        new ProcessTextChannel(mockBinaryMessenger, mockPackageManager);
+        new ProcessTextChannel(mockDartExecutor, mockPackageManager);
 
     // Set up mocked result for PackageManager.queryIntentActivities.
     ResolveInfo action1 = createFakeResolveInfo("Action1", mockPackageManager);
@@ -183,6 +139,58 @@ public class ProcessTextPluginTest {
     String textToBeProcessed = "Flutter!";
     MethodChannel.Result result = mock(MethodChannel.Result.class);
     processTextPlugin.processTextAction(action1Id, textToBeProcessed, false, result);
+    ShadowLooper.runUiThreadTasks();
+
+    // Activity.startActivityForResult should have been called.
+    ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+    verify(mockActivity, times(1)).startActivityForResult(intentCaptor.capture(), anyInt());
+    Intent intent = intentCaptor.getValue();
+    assertEquals(textToBeProcessed, intent.getStringExtra(Intent.EXTRA_PROCESS_TEXT));
+
+    // Simulate an Android activity answer which does not return a value.
+    Intent resultIntent = new Intent();
+    processTextPlugin.onActivityResult(result.hashCode(), Activity.RESULT_OK, resultIntent);
+
+    // Success with no returned value is expected.
+    verify(result).success(null);
+  }
+
+  @Test
+  public void performProcessTextActionWithReturnedValue() {
+    DartExecutor mockDartExecutor = mock(DartExecutor.class);
+    BinaryMessenger mockBinaryMessenger = mock(BinaryMessenger.class);
+    when(mockDartExecutor.getBinaryMessenger()).thenReturn(mockBinaryMessenger);
+    doReturn(null).when(mockBinaryMessenger).makeBackgroundTaskQueue();
+    PackageManager mockPackageManager = mock(PackageManager.class);
+    ProcessTextChannel processTextChannel =
+        new ProcessTextChannel(mockDartExecutor, mockPackageManager);
+
+    // Set up mocked result for PackageManager.queryIntentActivities.
+    ResolveInfo action1 = createFakeResolveInfo("Action1", mockPackageManager);
+    ResolveInfo action2 = createFakeResolveInfo("Action2", mockPackageManager);
+    List<ResolveInfo> infos = new ArrayList<ResolveInfo>(Arrays.asList(action1, action2));
+    when(mockPackageManager.queryIntentActivities(
+            any(Intent.class), any(PackageManager.ResolveInfoFlags.class)))
+        .thenReturn(infos);
+
+    // ProcessTextPlugin should retrieve the mocked text actions.
+    ProcessTextPlugin processTextPlugin = new ProcessTextPlugin(processTextChannel);
+    Map<String, String> textActions = processTextPlugin.queryTextActions();
+    final String action1Id = "mockActivityName.Action1";
+    final String action2Id = "mockActivityName.Action2";
+    assertEquals(textActions, Map.of(action1Id, "Action1", action2Id, "Action2"));
+
+    // Set up the activity binding.
+    ActivityPluginBinding mockActivityPluginBinding = mock(ActivityPluginBinding.class);
+    Activity mockActivity = mock(Activity.class);
+    when(mockActivityPluginBinding.getActivity()).thenReturn(mockActivity);
+    processTextPlugin.onAttachedToActivity(mockActivityPluginBinding);
+
+    // Execute the first action.
+    String textToBeProcessed = "Flutter!";
+    MethodChannel.Result result = mock(MethodChannel.Result.class);
+    processTextPlugin.processTextAction(action1Id, textToBeProcessed, false, result);
+    ShadowLooper.runUiThreadTasks();
 
     // Activity.startActivityForResult should have been called.
     ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
@@ -200,14 +208,15 @@ public class ProcessTextPluginTest {
     verify(result).success(processedText);
   }
 
-  @SuppressWarnings("deprecation")
-  // setMessageHandler is deprecated.
   @Test
   public void doNotCrashOnNonRelatedActivityResult() {
-    DartExecutor mockBinaryMessenger = mock(DartExecutor.class);
+    DartExecutor mockDartExecutor = mock(DartExecutor.class);
+    BinaryMessenger mockBinaryMessenger = mock(BinaryMessenger.class);
+    when(mockDartExecutor.getBinaryMessenger()).thenReturn(mockBinaryMessenger);
+    doReturn(null).when(mockBinaryMessenger).makeBackgroundTaskQueue();
     PackageManager mockPackageManager = mock(PackageManager.class);
     ProcessTextChannel processTextChannel =
-        new ProcessTextChannel(mockBinaryMessenger, mockPackageManager);
+        new ProcessTextChannel(mockDartExecutor, mockPackageManager);
 
     // Set up mocked result for PackageManager.queryIntentActivities.
     ResolveInfo action1 = createFakeResolveInfo("Action1", mockPackageManager);
@@ -234,6 +243,7 @@ public class ProcessTextPluginTest {
     String textToBeProcessed = "Flutter!";
     MethodChannel.Result result = mock(MethodChannel.Result.class);
     processTextPlugin.processTextAction(action1Id, textToBeProcessed, false, result);
+    ShadowLooper.runUiThreadTasks();
 
     // Activity.startActivityForResult should have been called.
     ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);


### PR DESCRIPTION
This PR offloads the method handlers of the ProcessTextPlugin to a background TaskQueue.

The offloading of the querying of text actions to a background thread moves the following transactions off the main thread:
1. Binder transaction of querying the package manager for activities with process text intent
2. Disk I/O transactions of resolving the text action labels from the APKs of the individual activities

The above transactions occurring on the main thread is an anti-pattern according to https://developer.android.com/topic/performance/anrs/find-unresponsive-thread#common-causes Attached below is a Perfetto trace validating that the querying of text actions now occurs on a background thread.

<img width="2258" height="135" alt="image" src="https://github.com/user-attachments/assets/f5122ded-9a0f-4978-afa9-82ca19324358" />

The processTextAction method handler is also moved to a background thread, with additional handling to ensure that the launching of the text action activity is delegated back to the main UI thread. Attached below is a Perfetto trace validating that the processing of a text action begins on a background thread but is later delegated back to the main thread to launch the activity.

<img width="1982" height="170" alt="image" src="https://github.com/user-attachments/assets/a499377f-9543-4d26-87be-b346132ca472" />

Note that the above Perfetto traces have additional trace logging implemented to better visualize when the method handlers are called.

This PR also refactors ProcessTextChannel to use `DartExecutor.getBinaryMessenger()` instead of using `DartExecutor` as the `BinaryMessenger` object directly, so that the deprecated wrapper methods of `BinaryMessenger` in `DartExecutor` are no longer used.

https://github.com/flutter/flutter/blob/80cabc33032837357c9b233d693266b890860c12/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java#L203-L264

The unit tests for ProcessTextPlugin have also been refactored as such and the obsolete tags to suppress deprecated warnings have also been cleaned up.

Issue: https://github.com/flutter/flutter/issues/189176

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
