### PR TITLE
ci: Include root pubspec.yaml in pub cache key

### DIFF
--- a/.github/actions/composite-flutter-setup/action.yml
+++ b/.github/actions/composite-flutter-setup/action.yml
@@ -160,10 +160,9 @@ runs:
         shell: bash
         id: pub-deps-hash
         run: |
-          # Generate a stable hash for github caching from the pubspec.yaml
-          # files that drive dependency resolution. Includes the root
-          # pubspec.yaml and all pubspec.yaml files from dev/examples/packages.
-          find pubspec.yaml dev examples packages -name "pubspec.yaml" -print0 | sort -z | xargs -0 cat | sha256sum >> "$RUNNER_TEMP/pub_deps_sha"
+          # Generate a stable hash for github caching from all the pubspec.yaml
+          # files in the tree. Includes the root pubspec.yaml.
+          git ls-tree HEAD  -- $(git ls-files ':(glob)**/pubspec.yaml') | git hash-object --stdin > "$RUNNER_TEMP/pub_deps_sha"
           echo "revision=$(cat "$RUNNER_TEMP/pub_deps_sha")" >> "$GITHUB_OUTPUT"
       - name: pub package cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae

--- a/.github/actions/composite-flutter-setup/action.yml
+++ b/.github/actions/composite-flutter-setup/action.yml
@@ -162,7 +162,7 @@ runs:
         run: |
           # Generate a stable hash for github caching from the pubspec.yaml
           # files that drive dependency resolution. Includes the root
-          # package.yaml and all package.yaml files from dev/examples/packages.
+          # pubspec.yaml and all pubspec.yaml files from dev/examples/packages.
           find pubspec.yaml dev examples packages -name "pubspec.yaml" -print0 | sort -z | xargs -0 cat | sha256sum >> "$RUNNER_TEMP/pub_deps_sha"
           echo "revision=$(cat "$RUNNER_TEMP/pub_deps_sha")" >> "$GITHUB_OUTPUT"
       - name: pub package cache

--- a/.github/actions/composite-flutter-setup/action.yml
+++ b/.github/actions/composite-flutter-setup/action.yml
@@ -160,8 +160,10 @@ runs:
         shell: bash
         id: pub-deps-hash
         run: |
-          # Generate stable hash of pubspec.yaml files
-          find dev examples packages -name "pubspec.yaml" -print0 | sort -z | xargs -0 cat | sha256sum  >> "$RUNNER_TEMP/pub_deps_sha"
+          # Generate a stable hash for github caching from the pubspec.yaml
+          # files that drive dependency resolution. Includes the root
+          # package.yaml and all package.yaml files from dev/examples/packages.
+          find pubspec.yaml dev examples packages -name "pubspec.yaml" -print0 | sort -z | xargs -0 cat | sha256sum >> "$RUNNER_TEMP/pub_deps_sha"
           echo "revision=$(cat "$RUNNER_TEMP/pub_deps_sha")" >> "$GITHUB_OUTPUT"
       - name: pub package cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae


### PR DESCRIPTION
The `pub package cache` step in composite-flutter-setup keys its cache on a hash of the pubspec.yaml files found under dev/, examples/, and packages/, but omits the root workspace pubspec.yaml. The root pubspec pins the versions of all transitive dependencies, so a pub roll that only touches the root, leaves the hash, and therefore the hash key, unchanged. This is exactly what happens on pub package rolls like flutter/flutter#189760.

When that happens the cache still hits and restores a stale pubspec.lock over the freshly checked-out one. At that point, the following `flutter update-packages` then fails when run with `--enforce-lockfile`, since the lock file we just restored from cache no longer matches the pinned versions in the checked-out root pubspec.yaml, which breaks the Tree Analyze step tree-wide until the cache is manually invalidated.

We now include the root pubspec.yaml in the hash so that a packages only roll changes the cache key, forcing a fresh package resolve rather than restoring a stale lock.

Fixes: https://github.com/flutter/flutter/issues/189825

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
