### PR TITLE
[Material] Use switch expressions in app.dart and bottom_navigation_bar.dart

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -147,3 +147,4 @@ Michal Kucharski <michal.kucharski17@gmail.com>
 Alexander Dmitriev <veselblu@yandex.ru>
 Solvejet <karan@solvejet.net>
 Mohamed Risaldar Uppil Thodi <mohamed.ut@travancoreanalytics.com>
+Ender Yücel <marijua@schweis.com.tr>

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -1223,40 +1223,31 @@ class _MaterialInspectorButton extends InspectorButton {
   }
 
   BorderSide? _borderSide({required Color color}) {
-    switch (variant) {
-      case InspectorButtonVariant.filled:
-      case InspectorButtonVariant.iconOnly:
-        return null;
-      case InspectorButtonVariant.toggle:
-        return toggledOn == false ? BorderSide(color: color) : null;
-    }
+    return switch (variant) {
+      InspectorButtonVariant.filled || InspectorButtonVariant.iconOnly => null,
+      InspectorButtonVariant.toggle => toggledOn == false ? BorderSide(color: color) : null,
+    };
   }
 
   @override
   Color foregroundColor(BuildContext context) {
     final Color primaryColor = _primaryColor(context);
     final Color secondaryColor = _secondaryColor(context);
-    switch (variant) {
-      case InspectorButtonVariant.filled:
-        return primaryColor;
-      case InspectorButtonVariant.iconOnly:
-        return secondaryColor;
-      case InspectorButtonVariant.toggle:
-        return !toggledOn! ? secondaryColor : primaryColor;
-    }
+    return switch (variant) {
+      InspectorButtonVariant.filled => primaryColor,
+      InspectorButtonVariant.iconOnly => secondaryColor,
+      InspectorButtonVariant.toggle => !toggledOn! ? secondaryColor : primaryColor,
+    };
   }
 
   @override
   Color backgroundColor(BuildContext context) {
     final Color secondaryColor = _secondaryColor(context);
-    switch (variant) {
-      case InspectorButtonVariant.filled:
-        return secondaryColor;
-      case InspectorButtonVariant.iconOnly:
-        return Colors.transparent;
-      case InspectorButtonVariant.toggle:
-        return !toggledOn! ? Colors.transparent : secondaryColor;
-    }
+    return switch (variant) {
+      InspectorButtonVariant.filled => secondaryColor,
+      InspectorButtonVariant.iconOnly => Colors.transparent,
+      InspectorButtonVariant.toggle => !toggledOn! ? Colors.transparent : secondaryColor,
+    };
   }
 
   Color _primaryColor(BuildContext context) {

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -957,94 +957,85 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
           themeData.unselectedWidgetColor,
     );
 
-    final ColorTween colorTween;
-    switch (_effectiveType) {
-      case BottomNavigationBarType.fixed:
-        colorTween = ColorTween(
-          begin:
-              widget.unselectedItemColor ??
-              bottomTheme.unselectedItemColor ??
-              themeData.unselectedWidgetColor,
-          end:
-              widget.selectedItemColor ??
-              bottomTheme.selectedItemColor ??
-              widget.fixedColor ??
-              themeColor,
-        );
-      case BottomNavigationBarType.shifting:
-        colorTween = ColorTween(
-          begin:
-              widget.unselectedItemColor ??
-              bottomTheme.unselectedItemColor ??
-              themeData.colorScheme.surface,
-          end:
-              widget.selectedItemColor ??
-              bottomTheme.selectedItemColor ??
-              themeData.colorScheme.surface,
-        );
-    }
+    final ColorTween colorTween = switch (_effectiveType) {
+      BottomNavigationBarType.fixed => ColorTween(
+        begin:
+            widget.unselectedItemColor ??
+            bottomTheme.unselectedItemColor ??
+            themeData.unselectedWidgetColor,
+        end:
+            widget.selectedItemColor ??
+            bottomTheme.selectedItemColor ??
+            widget.fixedColor ??
+            themeColor,
+      ),
+      BottomNavigationBarType.shifting => ColorTween(
+        begin:
+            widget.unselectedItemColor ??
+            bottomTheme.unselectedItemColor ??
+            themeData.colorScheme.surface,
+        end:
+            widget.selectedItemColor ??
+            bottomTheme.selectedItemColor ??
+            themeData.colorScheme.surface,
+      ),
+    };
 
-    final ColorTween labelColorTween;
-    switch (_effectiveType) {
-      case BottomNavigationBarType.fixed:
-        labelColorTween = ColorTween(
-          begin:
-              effectiveUnselectedLabelStyle.color ??
-              widget.unselectedItemColor ??
-              bottomTheme.unselectedItemColor ??
-              themeData.unselectedWidgetColor,
-          end:
-              effectiveSelectedLabelStyle.color ??
-              widget.selectedItemColor ??
-              bottomTheme.selectedItemColor ??
-              widget.fixedColor ??
-              themeColor,
-        );
-      case BottomNavigationBarType.shifting:
-        labelColorTween = ColorTween(
-          begin:
-              effectiveUnselectedLabelStyle.color ??
-              widget.unselectedItemColor ??
-              bottomTheme.unselectedItemColor ??
-              themeData.colorScheme.surface,
-          end:
-              effectiveSelectedLabelStyle.color ??
-              widget.selectedItemColor ??
-              bottomTheme.selectedItemColor ??
-              themeColor,
-        );
-    }
+    final ColorTween labelColorTween = switch (_effectiveType) {
+      BottomNavigationBarType.fixed => ColorTween(
+        begin:
+            effectiveUnselectedLabelStyle.color ??
+            widget.unselectedItemColor ??
+            bottomTheme.unselectedItemColor ??
+            themeData.unselectedWidgetColor,
+        end:
+            effectiveSelectedLabelStyle.color ??
+            widget.selectedItemColor ??
+            bottomTheme.selectedItemColor ??
+            widget.fixedColor ??
+            themeColor,
+      ),
+      BottomNavigationBarType.shifting => ColorTween(
+        begin:
+            effectiveUnselectedLabelStyle.color ??
+            widget.unselectedItemColor ??
+            bottomTheme.unselectedItemColor ??
+            themeData.colorScheme.surface,
+        end:
+            effectiveSelectedLabelStyle.color ??
+            widget.selectedItemColor ??
+            bottomTheme.selectedItemColor ??
+            themeColor,
+      ),
+    };
 
-    final ColorTween iconColorTween;
-    switch (_effectiveType) {
-      case BottomNavigationBarType.fixed:
-        iconColorTween = ColorTween(
-          begin:
-              effectiveSelectedIconTheme.color ??
-              widget.unselectedItemColor ??
-              bottomTheme.unselectedItemColor ??
-              themeData.unselectedWidgetColor,
-          end:
-              effectiveUnselectedIconTheme.color ??
-              widget.selectedItemColor ??
-              bottomTheme.selectedItemColor ??
-              widget.fixedColor ??
-              themeColor,
-        );
-      case BottomNavigationBarType.shifting:
-        iconColorTween = ColorTween(
-          begin:
-              effectiveUnselectedIconTheme.color ??
-              widget.unselectedItemColor ??
-              bottomTheme.unselectedItemColor ??
-              themeData.colorScheme.surface,
-          end:
-              effectiveSelectedIconTheme.color ??
-              widget.selectedItemColor ??
-              bottomTheme.selectedItemColor ??
-              themeColor,
-        );
-    }
+    final ColorTween iconColorTween = switch (_effectiveType) {
+      BottomNavigationBarType.fixed => ColorTween(
+        begin:
+            effectiveSelectedIconTheme.color ??
+            widget.unselectedItemColor ??
+            bottomTheme.unselectedItemColor ??
+            themeData.unselectedWidgetColor,
+        end:
+            effectiveUnselectedIconTheme.color ??
+            widget.selectedItemColor ??
+            bottomTheme.selectedItemColor ??
+            widget.fixedColor ??
+            themeColor,
+      ),
+      BottomNavigationBarType.shifting => ColorTween(
+        begin:
+            effectiveUnselectedIconTheme.color ??
+            widget.unselectedItemColor ??
+            bottomTheme.unselectedItemColor ??
+            themeData.colorScheme.surface,
+        end:
+            effectiveSelectedIconTheme.color ??
+            widget.selectedItemColor ??
+            bottomTheme.selectedItemColor ??
+            themeColor,
+      ),
+    };
 
     final tiles = <Widget>[];
     for (var i = 0; i < widget.items.length; i++) {


### PR DESCRIPTION
This PR converts six exhaustive enum switch statements to switch expressions:

- `_borderSide`, `foregroundColor`, and `backgroundColor` in `_MaterialInspectorButton`.
- `colorTween`, `labelColorTween`, and `iconColorTween` initialization in `_BottomNavigationBarState._createTiles`.

This is a behavior-preserving refactor. The case-to-value mappings, null-coalescing fallback order, and `ColorTween` `begin`/`end` operands are preserved.

This is a smaller follow-up to #182415. It carries forward only the focused, behavior-preserving conversions from that PR. The `MaterialScrollBehavior` and `button.dart` changes are intentionally excluded to keep this patch narrowly scoped.

This PR does not fix a user-facing issue; it is a small behavior-preserving refactor. Related context: #136139.

## Checks

- `./bin/dart format packages/flutter/lib/src/material/app.dart packages/flutter/lib/src/material/bottom_navigation_bar.dart` — no changes
- `./bin/flutter analyze --no-pub packages/flutter/lib/src/material/app.dart packages/flutter/lib/src/material/bottom_navigation_bar.dart` — passed
- `./bin/flutter test packages/flutter/test/material/app_test.dart` — 76 tests passed
- `./bin/flutter test --no-pub packages/flutter/test/material/bottom_navigation_bar_test.dart` — 89 tests passed
- `git diff --check` — passed


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md