### PR TITLE
Remove Rosetta requirement from engine builds

### DIFF
--- a/engine/src/build/toolchain/android/BUILD.gn
+++ b/engine/src/build/toolchain/android/BUILD.gn
@@ -74,7 +74,7 @@ template("android_toolchain") {
     if (host_os == "linux") {
       host_dir = "linux-x64"
     } else if (host_os == "mac") {
-      host_dir = "mac-x64"
+      host_dir = "mac-${host_cpu}"
     } else {
       assert(false, "Unknown host")
     }

--- a/engine/src/flutter/build/copy_info_plist.py
+++ b/engine/src/flutter/build/copy_info_plist.py
@@ -15,6 +15,7 @@ usage: copy_info_plist.py --source <src_path> --destination <dest_path>
 
 import argparse
 import os
+import platform
 import subprocess
 
 import git_revision
@@ -24,10 +25,11 @@ _src_root_dir = os.path.join(_script_dir, '..', '..')
 
 
 def get_clang_version():
-  clang_executable = str(
-      os.path.join(_src_root_dir, 'flutter', 'buildtools', 'mac-x64', 'clang', 'bin', 'clang++')
+  arch = 'arm64' if platform.machine() in ('arm64', 'aarch64') else 'x64'
+  clang_executable = os.path.join(
+      _src_root_dir, 'flutter', 'buildtools', f'mac-{arch}', 'clang', 'bin', 'clang++'
   )
-  version = subprocess.check_output([clang_executable, '--version'])
+  version = subprocess.check_output([clang_executable, '--version'], text=True)
   return version.splitlines()[0]
 
 

--- a/engine/src/flutter/build/generate_coverage.py
+++ b/engine/src/flutter/build/generate_coverage.py
@@ -9,6 +9,7 @@ import subprocess
 import os
 import argparse
 import errno
+import platform
 import shutil
 
 
@@ -18,7 +19,8 @@ def get_llvm_bin_directory():
   if sys.platform.startswith('linux'):
     platform_dir = 'linux-x64'
   elif sys.platform == 'darwin':
-    platform_dir = 'mac-x64'
+    arch = 'arm64' if platform.machine() in ('arm64', 'aarch64') else 'x64'
+    platform_dir = f'mac-{arch}'
   else:
     raise Exception('Unknown/Unsupported platform.')
   llvm_bin_dir = os.path.abspath(os.path.join(buildtool_dir, platform_dir, 'clang/bin'))

--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -338,8 +338,10 @@ copy("copy_dylib") {
 copy("copy_asan_runtime_dylib") {
   visibility = [ ":*" ]
 
+  # TODO(cbracken): https://github.com/flutter/flutter/issues/186668
+  # Eliminate clang toolchain hardcoding.
   _libclang_base_path =
-      "$buildtools_path/mac-x64/clang/lib/clang/13.0.0/lib/darwin/"
+      "$buildtools_path/mac-${host_cpu}/clang/lib/clang/23/lib/darwin/"
 
   if (defined(use_ios_simulator) && use_ios_simulator) {
     _dylib_name = "libclang_rt.asan_iossim_dynamic.dylib"

--- a/engine/src/flutter/testing/sanitizer_suppressions.sh
+++ b/engine/src/flutter/testing/sanitizer_suppressions.sh
@@ -4,12 +4,21 @@
 TESTING_DIRECTORY=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd -P)
 ENGINE_BUILDROOT=$(cd $TESTING_DIRECTORY/../..; pwd -P)
 
+case "$(uname -m)" in
+  arm64|aarch64)
+    ARCH="arm64"
+    ;;
+  *)
+    ARCH="x64"
+    ;;
+esac
+
 case "$(uname -s)" in
   Linux)
     BUILDTOOLS_DIRECTORY="${ENGINE_BUILDROOT}/flutter/buildtools/linux-x64"
     ;;
   Darwin)
-    BUILDTOOLS_DIRECTORY="${ENGINE_BUILDROOT}/flutter/buildtools/mac-x64"
+    BUILDTOOLS_DIRECTORY="${ENGINE_BUILDROOT}/flutter/buildtools/mac-${ARCH}"
     ;;
 esac
 

--- a/engine/src/flutter/testing/symbols/verify_exported.dart
+++ b/engine/src/flutter/testing/symbols/verify_exported.dart
@@ -47,7 +47,13 @@ void main(List<String> arguments) {
   if (Platform.isLinux) {
     platform = 'linux-x64';
   } else if (Platform.isMacOS) {
-    platform = 'mac-x64';
+    final ProcessResult unameResult = Process.runSync('uname', <String>['-m']);
+    if (unameResult.exitCode != 0) {
+      print('ERROR: failed to execute "uname -m":\n${unameResult.stderr}');
+      exit(1);
+    }
+    final arch = unameResult.stdout.toString().trim() == 'x86_64' ? 'x64' : 'arm64';
+    platform = 'mac-$arch';
   } else {
     throw UnimplementedError('Script only support running on Linux or MacOS.');
   }


### PR DESCRIPTION
Impacted Users (Approximately who will hit this issue, ex. all Flutter devs, Windows developers, all end-customers, apps using X framework feature).

Flutter Contributors and Release Engineers

Impact Description (What is the impact? ex. visual jank on Samsung phones, app crash, cannot ship an iOS app. Does it impact development? ex. flutter doctor crashes when Android Studio is installed. Or shipping a production app? ex. the app crashes on launch).

Building the iOS/macOS engine no longer requires Rosetta to be installed.

Workaround (Is there a workaround for this issue?)

NA

Risk (What is the risk level of this cherry-pick?)

Low

Test Coverage (Are you confident that your fix is well-tested by automated tests?)

Yes

Validation Steps (What are the steps to validate that this fix works?)

Rosetta has already been removed from presubmit bots, so if presubmit tests pass.