### PR TITLE
[CP-Beta] Fix `Rect::ExpandToMinTransformedSize` to return the input rectangle when no expansion is needed, and remove 1-pixel roundrect to rect simplification

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1113,36 +1113,27 @@ void Canvas::DrawRoundRect(const RoundRect& round_rect, const Paint& paint) {
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
       IsCompatibleWithSDFRendering(paint) && radii.AreAllCornersCircular()) {
+    Color effective_color = paint.color;
+    Rect bounds = round_rect.GetBounds();
+
     // Expand rrect bounds to 1 pixel minimum dimensions if applicable.
     if (paint.style == Paint::Style::kFill &&
         !GetCurrentTransform().HasPerspective2D()) {
-      Rect rrect_bounds = round_rect.GetBounds();
-      auto [expanded, alpha_scaled_color] =
-          ExpandRectToPixelMinimum(rrect_bounds, paint.color,
-                                   GetCurrentTransform(), /*scale_alpha=*/true);
+      auto [expanded, alpha_scaled_color] = ExpandRectToPixelMinimum(
+          bounds, paint.color, GetCurrentTransform(), /*scale_alpha=*/true);
 
       if (expanded.IsEmpty()) {
         // RRect is invisible due to transform scaling or alpha scaling.
         return;
       }
 
-      // Pixel-minimum expansion is applicable if the expanded bounds is
-      // different from the original bounds.
-      if (expanded != rrect_bounds) {
-        // At a 1-pixel size, the rounded corners can be ignored. Draw a regular
-        // rect matching the expanded bounds.
-        auto params = UberSDFParameters::MakeRect(
-            /*color=*/alpha_scaled_color,
-            /*rect=*/expanded,
-            /*stroke=*/std::nullopt);
-        AddRenderSDFEntityToCurrentPass(paint, params);
-        return;
-      }
+      bounds = expanded;
+      effective_color = alpha_scaled_color;
     }
 
     auto params = UberSDFParameters::MakeRoundedRect(
-        /*color=*/paint.color,
-        /*rect=*/round_rect.GetBounds(),
+        /*color=*/effective_color,
+        /*rect=*/bounds,
         /*radii=*/radii,
         /*stroke=*/paint.style == Paint::Style::kStroke
             ? std::make_optional(paint.stroke)

--- a/engine/src/flutter/impeller/geometry/rect.h
+++ b/engine/src/flutter/impeller/geometry/rect.h
@@ -719,6 +719,13 @@ struct TRect {
       return std::nullopt;
     }
     Size current_size = GetSize();
+
+    if (current_size.width >= min_local_size.width &&
+        current_size.height >= min_local_size.height) {
+      // No expansion needed.
+      return *this;
+    }
+
     Size expanded_size = current_size.Max(min_local_size);
     return MakeEllipseBounds(GetCenter(), Point(expanded_size.width * 0.5f,
                                                 expanded_size.height * 0.5f));

--- a/engine/src/flutter/impeller/geometry/rect_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/rect_unittests.cc
@@ -1444,10 +1444,18 @@ TEST(RectTest, RectExpandToMinTransformedSizeNullForScaledToZero) {
             std::nullopt);
 }
 
-TEST(RectTest,
-     RectExpandToMinTransformedSizeRectReturnsUnmodifiedWhenLargeEnough) {
+TEST(RectTest, RectExpandToMinTransformedSizeReturnsUnmodifiedWhenLargeEnough) {
   Rect rect = Rect::MakeXYWH(0, 0, 10, 20);
   auto transform = Matrix::MakeScale(Vector3(0.5f, 0.5f));
+  EXPECT_EQ(rect.ExpandToMinTransformedSize({1.0f, 1.0f}, transform), rect);
+}
+
+TEST(
+    RectTest,
+    RectExpandToMinTransformedSizeReturnsUnmodifiedWhenLargeEnoughWithFractionalSize) {
+  // Regression test for https://github.com/flutter/flutter/issues/189807.
+  Rect rect = Rect::MakeXYWH(100.0f, 50.0f, 64.2f, 40.0f);
+  auto transform = Matrix();
   EXPECT_EQ(rect.ExpandToMinTransformedSize({1.0f, 1.0f}, transform), rect);
 }
 


### PR DESCRIPTION
This was a manual cherry pick of https://github.com/flutter/flutter/pull/189808.

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/189807

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)?
Does it impact development (ex. flutter doctor crashes when Android Studio is installed),
or the shipping of production apps (the app crashes on launch).
This information is for domain experts and release engineers to understand the consequences of saying yes or no to the cherry pick.

Rounded rectangles are sometimes incorrectly rendered as non-rounded rectangles.

This issue is present when impeller is enabled Impeller with SDF rendering. In the beta channel, Impeller with SDF rendering is the default when building apps for desktop platforms: macOS, Linux, and Windows.

### Changelog Description:
Explain this cherry pick:
* In one line that is accessible to most Flutter developers.
* That describes the state prior to the fix.
* That includes which platforms are impacted.
See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples.

< Replace with changelog description here >
[flutter/189807](https://github.com/flutter/flutter/issues/189807): Rounded rectangles are sometimes incorrectly rendered as non-rounded rectangles.

### Workaround:
Is there a workaround for this issue?

Disable Impeller, falling back to Skia rendering.

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

The demo app at https://github.com/flutter/flutter/issues/189807 should render two rounded rectangles, rather than one normal rectangle and one rounded rectangle.