### PR TITLE
Prevent mergeAfterLaunch if require_merged_platform_ui_thread set

### DIFF
--- a/engine/src/flutter/shell/common/switches.cc
+++ b/engine/src/flutter/shell/common/switches.cc
@@ -549,6 +549,11 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
       settings.merged_platform_ui_thread =
           Settings::MergedPlatformUIThread::kDisabled;
     } else if (merged_platform_ui == kMergedThreadMergeAfterLaunch) {
+      FML_CHECK(!require_merged_platform_ui_thread)
+          << "This platform does not support the "
+          << FlagForSwitch(Switch::MergedPlatformUIThread) << "="
+          << kMergedThreadMergeAfterLaunch << " flag";
+
       settings.merged_platform_ui_thread =
           Settings::MergedPlatformUIThread::kMergeAfterLaunch;
     }

--- a/engine/src/flutter/shell/common/switches_unittests.cc
+++ b/engine/src/flutter/shell/common/switches_unittests.cc
@@ -161,6 +161,18 @@ TEST(SwitchesTest, RequireMergedPlatformUIThread) {
                             "This platform does not support the "
                             "merged-platform-ui-thread=disabled flag");
 }
+
+TEST(SwitchesTest, RequireMergedPlatformUIThreadRejectsMergeAfterLaunch) {
+  fml::CommandLine command_line = fml::CommandLineFromInitializerList(
+      {"command", "--merged-platform-ui-thread=mergeAfterLaunch"});
+  Settings settings = SettingsFromCommandLine(command_line);
+  EXPECT_EQ(settings.merged_platform_ui_thread,
+            Settings::MergedPlatformUIThread::kMergeAfterLaunch);
+
+  EXPECT_DEATH_IF_SUPPORTED(SettingsFromCommandLine(command_line, true),
+                            "This platform does not support the "
+                            "merged-platform-ui-thread=mergeAfterLaunch flag");
+}
 #endif  // !OS_FUCHSIA
 
 }  // namespace testing


### PR DESCRIPTION
Platforms that pass `require_merged_platform_ui_thread` to `SettingsFromCommandLine` (i.e. iOS) already reject
`--no-enable-merged-platform-ui-thread` and
`--merged-platform-ui-thread=disabled` with an FML_CHECK.

`--merged-platform-ui-thread=mergeAfterLaunch` seems to have accidentally slipped through allowing a command-line flag to select a threading model our embedders no longer support. This adds the missing assertion and logging to prevent an invalid flag combination.

This is cleanup prior to an eventual migration of the iOS embedder to the embedder API.

Issue: https://github.com/flutter/flutter/issues/112232

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
