### PR TITLE
[SwiftPM] Derive plugin package name from app name to avoid collisions (#189585)

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -340,6 +340,12 @@ mixin CreateBase on FlutterCommand {
     final String pluginClassCapitalSnakeCase = pluginClassSnakeCase.toUpperCase();
     final String pluginClassLowerCamelCase =
         pluginClass[0].toLowerCase() + pluginClass.substring(1);
+    final String pluginSwiftPackageName =
+        projectName
+            .split('_')
+            .map((s) => s.isEmpty ? '' : '${s[0].toUpperCase()}${s.substring(1)}')
+            .join() +
+        'FlutterPlugins';
     final String appleIdentifier = createUTIIdentifier(organization, projectName);
     final String androidIdentifier = createAndroidIdentifier(organization, projectName);
     final String windowsIdentifier = createWindowsIdentifier(organization, projectName);
@@ -367,6 +373,7 @@ mixin CreateBase on FlutterCommand {
       'pluginClassCapitalSnakeCase': pluginClassCapitalSnakeCase,
       'pluginDartClass': pluginDartClass,
       'pluginProjectUUID': const Uuid().v4().toUpperCase(),
+      'pluginSwiftPackageName': pluginSwiftPackageName,
       'withFfi': withFfiPluginHook || withFfiPackage,
       'withFfiPackage': withFfiPackage,
       'withFfiPluginHook': withFfiPluginHook,

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -1441,7 +1441,9 @@ String? _swiftPackageManagerMinPlatformMismatchMessageFromStdout(String? stdout)
     final Version? requiredMinVersion = Version.parse(match.group(2));
     final Version? targetSupportedVersion = Version.parse(match.group(4));
     final String? targetName = match.group(5);
-    if (targetName != kFlutterGeneratedPluginSwiftPackageName) {
+    if (targetName != null &&
+        !targetName.startsWith(kFlutterGeneratedPluginSwiftPackageName) &&
+        !targetName.endsWith('FlutterPlugins')) {
       continue;
     }
     if (requiredByProduct == null || requiredMinVersion == null || targetSupportedVersion == null) {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -456,6 +456,8 @@ class XcodeProjectInterpreter {
     Directory buildDirectory,
   ) async {
     final ignoredSchemes = <String>{
+      xcodeProject.flutterPluginSwiftPackageName,
+      // Also ignore the legacy name for backward compatibility.
       kFlutterGeneratedPluginSwiftPackageName,
       kFlutterGeneratedFrameworkSwiftPackageTargetName,
       ..._swiftPackageCheckoutSchemes(buildDirectory),

--- a/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
@@ -53,15 +53,18 @@ class SwiftPackageManager {
   final ProcessUtils _processUtils;
   final Config _config;
 
-  /// Creates a Swift Package called 'FlutterGeneratedPluginSwiftPackage' that
-  /// has dependencies on Flutter plugins that are compatible with Swift
-  /// Package Manager.
+  /// Creates a Swift Package that has dependencies on Flutter plugins that are
+  /// compatible with Swift Package Manager.
+  ///
+  /// The package name is derived from the project's app name to ensure
+  /// uniqueness when multiple Flutter apps share a single Xcode project.
   Future<void> generatePluginsSwiftPackage(
     List<Plugin> plugins,
     FlutterDarwinPlatform platform,
     XcodeBasedProject project, {
     bool flutterAsADependency = true,
   }) async {
+    final String packageName = project.flutterPluginSwiftPackageName;
     final Directory symlinkDirectory = project.relativeSwiftPackagesDirectory;
     ErrorHandlingFileSystem.deleteIfExists(symlinkDirectory, recursive: true);
     symlinkDirectory.createSync(recursive: true);
@@ -99,22 +102,22 @@ class SwiftPackageManager {
       targetDependencies.add(flutterFrameworkTargetDependency);
     }
 
-    // FlutterGeneratedPluginSwiftPackage must be statically linked to ensure
+    // The generated plugin package must be statically linked to ensure
     // any dynamic dependencies are linked to Runner and prevent undefined symbols.
     final generatedProduct = SwiftPackageProduct.library(
-      name: kFlutterGeneratedPluginSwiftPackageName,
-      targets: <String>[kFlutterGeneratedPluginSwiftPackageName],
+      name: packageName,
+      targets: <String>[packageName],
       libraryType: SwiftPackageLibraryType.static,
     );
 
     final generatedTarget = SwiftPackageTarget.defaultTarget(
-      name: kFlutterGeneratedPluginSwiftPackageName,
+      name: packageName,
       dependencies: targetDependencies,
     );
 
     final pluginsPackage = SwiftPackage(
       manifest: project.flutterPluginSwiftPackageManifest,
-      name: kFlutterGeneratedPluginSwiftPackageName,
+      name: packageName,
       platforms: <SwiftPackageSupportedPlatform>[platform.supportedPackagePlatform],
       products: <SwiftPackageProduct>[generatedProduct],
       dependencies: packageDependencies,
@@ -122,6 +125,24 @@ class SwiftPackageManager {
       templateRenderer: _templateRenderer,
     );
     pluginsPackage.createSwiftPackage();
+
+    // If the project was previously using the legacy hardcoded package name,
+    // rename all references in the pbxproj to the new project-specific name.
+    // This must happen at pub-get time (not just build time) so that Xcode can
+    // resolve the package immediately.
+    // See https://github.com/flutter/flutter/issues/189585.
+    if (packageName != kFlutterGeneratedPluginSwiftPackageName) {
+      final File pbxproj = project.xcodeProjectInfoFile;
+      if (pbxproj.existsSync()) {
+        final String contents = pbxproj.readAsStringSync();
+        if (contents.contains(kFlutterGeneratedPluginSwiftPackageName) &&
+            !contents.contains(packageName)) {
+          pbxproj.writeAsStringSync(
+            contents.replaceAll(kFlutterGeneratedPluginSwiftPackageName, packageName),
+          );
+        }
+      }
+    }
   }
 
   (List<SwiftPackagePackageDependency>, List<SwiftPackageTargetDependency>)

--- a/packages/flutter_tools/lib/src/migrations/swift_package_manager_integration_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/swift_package_manager_integration_migration.dart
@@ -50,6 +50,12 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
   final PlistParser _plistParser;
   final Config _config;
 
+  /// The project-specific name for the generated plugin Swift package.
+  ///
+  /// This is derived from the app name to ensure uniqueness when multiple
+  /// Flutter apps share a single Xcode project (e.g. main app + App Clip).
+  String get _pluginSwiftPackageName => _xcodeProject.flutterPluginSwiftPackageName;
+
   /// New identifier for FlutterGeneratedPluginSwiftPackage PBXBuildFile.
   static const _flutterPluginsSwiftPackageBuildFileIdentifier = '78A318202AECB46A00862997';
 
@@ -188,6 +194,15 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
       final bool isSchemeMigrated = _isSchemeMigrated(schemeInfo);
       final bool isPbxprojMigrated = _xcodeProject.flutterPluginSwiftPackageInProjectSettings;
       final bool isOptionalFilesMigrated = _areOptionalFilesMigrated(_xcodeProjectInfoFile);
+
+      // If the project was migrated with the legacy hardcoded package name,
+      // rename it to the project-specific name. This ensures uniqueness when
+      // multiple Flutter apps share one Xcode project (e.g. App Clip).
+      // See https://github.com/flutter/flutter/issues/189585.
+      if (isPbxprojMigrated && _pluginSwiftPackageName != kFlutterGeneratedPluginSwiftPackageName) {
+        _renameLegacyPluginSwiftPackage();
+      }
+
       optionalOnly = isPbxprojMigrated && isSchemeMigrated && !isOptionalFilesMigrated;
       if (isSchemeMigrated && isPbxprojMigrated && isOptionalFilesMigrated) {
         return;
@@ -296,6 +311,24 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
       return true;
     }
     return false;
+  }
+
+  /// Renames the legacy hardcoded `FlutterGeneratedPluginSwiftPackage` to the
+  /// project-specific name in the pbxproj and xcscheme files.
+  ///
+  /// This handles upgrading projects that were migrated before the package name
+  /// was made unique per app. See https://github.com/flutter/flutter/issues/189585.
+  void _renameLegacyPluginSwiftPackage() {
+    final String oldName = kFlutterGeneratedPluginSwiftPackageName;
+    final String newName = _pluginSwiftPackageName;
+
+    if (_xcodeProjectInfoFile.existsSync()) {
+      final String contents = _xcodeProjectInfoFile.readAsStringSync();
+      if (contents.contains(oldName) && !contents.contains(newName)) {
+        logger.printTrace('Renaming legacy plugin Swift package from $oldName to $newName...');
+        _xcodeProjectInfoFile.writeAsStringSync(contents.replaceAll(oldName, newName));
+      }
+    }
   }
 
   void _migrateScheme(SchemeInfo schemeInfo) {
@@ -448,7 +481,7 @@ $newContent
   bool _areOptionalFilesMigrated(File xcodeProjectInfoFile) {
     final String fileContents = xcodeProjectInfoFile.readAsStringSync();
     final bool flutterGeneratedPackageAsFileReference = fileContents.contains(
-      '$_flutterPluginsSwiftPackageFileIdentifer /* $kFlutterGeneratedPluginSwiftPackageName */ = {isa = PBXFileReference',
+      '$_flutterPluginsSwiftPackageFileIdentifer /* $_pluginSwiftPackageName */ = {isa = PBXFileReference',
     );
 
     var pluginExampleAppMigrated = true;
@@ -474,7 +507,7 @@ $newContent
       projectInfo,
       logErrorIfNotMigrated: logErrorIfNotMigrated,
       identifer: _flutterPluginsSwiftPackageFileIdentifer,
-      name: kFlutterGeneratedPluginSwiftPackageName,
+      name: _pluginSwiftPackageName,
     );
     final bool packageGroupMigrated = _isGroupMigrated(
       projectInfo,
@@ -609,13 +642,13 @@ $newContent
 
   void _ensureNewIdentifiersNotUsed(String originalProjectContents) {
     if (!originalProjectContents.contains(
-          '$_flutterPluginsSwiftPackageBuildFileIdentifier /* $kFlutterGeneratedPluginSwiftPackageName in Frameworks */',
+          '$_flutterPluginsSwiftPackageBuildFileIdentifier /* $_pluginSwiftPackageName in Frameworks */',
         ) &&
         originalProjectContents.contains(_flutterPluginsSwiftPackageBuildFileIdentifier)) {
       throw Exception('Duplicate id found for PBXBuildFile.');
     }
     if (!originalProjectContents.contains(
-          '$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $kFlutterGeneratedPluginSwiftPackageName */',
+          '$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $_pluginSwiftPackageName */',
         ) &&
         originalProjectContents.contains(_flutterPluginsSwiftPackageProductDependencyIdentifier)) {
       throw Exception('Duplicate id found for XCSwiftPackageProductDependency.');
@@ -630,12 +663,10 @@ $newContent
 
   void _ensureOptionalIdentifiersNotUsed(String originalProjectContents) {
     if (!originalProjectContents.contains(
-          '$_flutterPluginsSwiftPackageFileIdentifer /* $kFlutterGeneratedPluginSwiftPackageName */',
+          '$_flutterPluginsSwiftPackageFileIdentifer /* $_pluginSwiftPackageName */',
         ) &&
         originalProjectContents.contains(_flutterPluginsSwiftPackageFileIdentifer)) {
-      throw Exception(
-        'Duplicate id found for $kFlutterGeneratedPluginSwiftPackageName PBXFileReference.',
-      );
+      throw Exception('Duplicate id found for $_pluginSwiftPackageName PBXFileReference.');
     }
     if (_examplePlugin != null) {
       if (!originalProjectContents.contains(
@@ -671,8 +702,8 @@ $newContent
       return lines;
     }
 
-    const newContent =
-        '		$_flutterPluginsSwiftPackageBuildFileIdentifier /* $kFlutterGeneratedPluginSwiftPackageName in Frameworks */ = {isa = PBXBuildFile; productRef = $_flutterPluginsSwiftPackageProductDependencyIdentifier /* $kFlutterGeneratedPluginSwiftPackageName */; };';
+    final newContent =
+        '		$_flutterPluginsSwiftPackageBuildFileIdentifier /* $_pluginSwiftPackageName in Frameworks */ = {isa = PBXBuildFile; productRef = $_flutterPluginsSwiftPackageProductDependencyIdentifier /* $_pluginSwiftPackageName */; };';
 
     final (int _, int endSectionIndex) = _sectionRange('PBXBuildFile', lines);
 
@@ -775,10 +806,10 @@ $newContent
 
     if (runnerFrameworksPhase.files == null) {
       // If files is null, the files field is missing and must be added.
-      const newContent =
+      final newContent =
           '''
 			files = (
-				$_flutterPluginsSwiftPackageBuildFileIdentifier /* $kFlutterGeneratedPluginSwiftPackageName in Frameworks */,
+				$_flutterPluginsSwiftPackageBuildFileIdentifier /* $_pluginSwiftPackageName in Frameworks */,
 			);''';
       lines.insert(runnerFrameworksPhaseStartIndex + 1, newContent);
     } else {
@@ -792,8 +823,8 @@ $newContent
           'Unable to files for PBXFrameworksBuildPhase ${_xcodeProject.hostAppProjectName} target.',
         );
       }
-      const newContent =
-          '				$_flutterPluginsSwiftPackageBuildFileIdentifier /* $kFlutterGeneratedPluginSwiftPackageName in Frameworks */,';
+      final newContent =
+          '				$_flutterPluginsSwiftPackageBuildFileIdentifier /* $_pluginSwiftPackageName in Frameworks */,';
       lines.insert(startFilesIndex + 1, newContent);
     }
 
@@ -853,9 +884,9 @@ $newContent
 
     if (runnerNativeTarget.packageProductDependencies == null) {
       // If packageProductDependencies is null, the packageProductDependencies field is missing and must be added.
-      const newContent = <String>[
+      final newContent = <String>[
         '			packageProductDependencies = (',
-        '				$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $kFlutterGeneratedPluginSwiftPackageName */,',
+        '				$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $_pluginSwiftPackageName */,',
         '			);',
       ];
       lines.insertAll(runnerNativeTargetStartIndex + 1, newContent);
@@ -871,8 +902,8 @@ $newContent
           'Unable to find packageProductDependencies for ${_xcodeProject.hostAppProjectName} PBXNativeTarget.',
         );
       }
-      const newContent =
-          '				$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $kFlutterGeneratedPluginSwiftPackageName */,';
+      final newContent =
+          '				$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $_pluginSwiftPackageName */,';
       lines.insert(packageProductDependenciesIndex + 1, newContent);
     }
     return lines;
@@ -1000,7 +1031,7 @@ $newContent
       // If packageReferences is null, the packageReferences field is missing and must be added.
       final newContent = <String>[
         '			packageReferences = (',
-        '				$_localFlutterPluginsSwiftPackageReferenceIdentifier /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/$kFlutterGeneratedPluginSwiftPackageName" */,',
+        '				$_localFlutterPluginsSwiftPackageReferenceIdentifier /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/$_pluginSwiftPackageName" */,',
         '			);',
       ];
       lines.insertAll(projectStartIndex + 1, newContent);
@@ -1015,8 +1046,8 @@ $newContent
           'Unable to find packageReferences for ${_xcodeProject.hostAppProjectName} PBXProject.',
         );
       }
-      const newContent =
-          '				$_localFlutterPluginsSwiftPackageReferenceIdentifier /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/$kFlutterGeneratedPluginSwiftPackageName" */,';
+      final newContent =
+          '				$_localFlutterPluginsSwiftPackageReferenceIdentifier /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/$_pluginSwiftPackageName" */,';
       lines.insert(packageReferencesIndex + 1, newContent);
     }
     return lines;
@@ -1056,9 +1087,9 @@ $newContent
       // There isn't a XCLocalSwiftPackageReference section yet, so add it
       final newContent = <String>[
         '/* Begin XCLocalSwiftPackageReference section */',
-        '		$_localFlutterPluginsSwiftPackageReferenceIdentifier /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/$kFlutterGeneratedPluginSwiftPackageName" */ = {',
+        '		$_localFlutterPluginsSwiftPackageReferenceIdentifier /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/$_pluginSwiftPackageName" */ = {',
         '			isa = XCLocalSwiftPackageReference;',
-        '			relativePath = Flutter/ephemeral/Packages/$kFlutterGeneratedPluginSwiftPackageName;',
+        '			relativePath = Flutter/ephemeral/Packages/$_pluginSwiftPackageName;',
         '		};',
         '/* End XCLocalSwiftPackageReference section */',
       ];
@@ -1073,9 +1104,9 @@ $newContent
     }
 
     final newContent = <String>[
-      '		$_localFlutterPluginsSwiftPackageReferenceIdentifier /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/$kFlutterGeneratedPluginSwiftPackageName" */ = {',
+      '		$_localFlutterPluginsSwiftPackageReferenceIdentifier /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/$_pluginSwiftPackageName" */ = {',
       '			isa = XCLocalSwiftPackageReference;',
-      '			relativePath = Flutter/ephemeral/Packages/$kFlutterGeneratedPluginSwiftPackageName;',
+      '			relativePath = Flutter/ephemeral/Packages/$_pluginSwiftPackageName;',
       '		};',
     ];
 
@@ -1118,9 +1149,9 @@ $newContent
       // There isn't a XCSwiftPackageProductDependency section yet, so add it
       final newContent = <String>[
         '/* Begin XCSwiftPackageProductDependency section */',
-        '		$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $kFlutterGeneratedPluginSwiftPackageName */ = {',
+        '		$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $_pluginSwiftPackageName */ = {',
         '			isa = XCSwiftPackageProductDependency;',
-        '			productName = $kFlutterGeneratedPluginSwiftPackageName;',
+        '			productName = $_pluginSwiftPackageName;',
         '		};',
         '/* End XCSwiftPackageProductDependency section */',
       ];
@@ -1135,9 +1166,9 @@ $newContent
     }
 
     final newContent = <String>[
-      '		$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $kFlutterGeneratedPluginSwiftPackageName */ = {',
+      '		$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $_pluginSwiftPackageName */ = {',
       '			isa = XCSwiftPackageProductDependency;',
-      '			productName = $kFlutterGeneratedPluginSwiftPackageName;',
+      '			productName = $_pluginSwiftPackageName;',
       '		};',
     ];
 
@@ -1152,7 +1183,7 @@ $newContent
       lines,
       projectInfo,
       identifier: _flutterPluginsSwiftPackageFileIdentifer,
-      name: kFlutterGeneratedPluginSwiftPackageName,
+      name: _pluginSwiftPackageName,
       path: _xcodeProject.flutterPluginSwiftPackageDirectory.path.replaceAll(
         _xcodeProject.ephemeralDirectory.path,
         _relativeEphemeralPath,
@@ -1162,7 +1193,7 @@ $newContent
       lines,
       projectInfo,
       _flutterPluginsSwiftPackageFileIdentifer,
-      kFlutterGeneratedPluginSwiftPackageName,
+      _pluginSwiftPackageName,
     );
 
     // Add the plugin Swift package and FlutterFramework as a local package overrides (for example

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -177,10 +177,26 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform {
   Directory get relativeSwiftPackagesDirectory =>
       flutterSwiftPackagesDirectory.childDirectory('.packages');
 
+  /// The name of the generated Swift package for this project's plugins.
+  ///
+  /// Derived from the Flutter app name to ensure uniqueness when multiple
+  /// Flutter apps share a single Xcode project (e.g. main app + App Clip).
+  /// See https://github.com/flutter/flutter/issues/189585.
+  ///
+  /// Converts the app name from snake_case to PascalCase and appends a fixed
+  /// suffix, e.g. `my_app` → `MyAppFlutterPlugins`.
+  late final String flutterPluginSwiftPackageName = () {
+    final pascalName = parent.manifest.appName
+        .split('_')
+        .map((s) => s.isEmpty ? '' : '${s[0].toUpperCase()}${s.substring(1)}')
+        .join();
+    return '${pascalName}FlutterPlugins';
+  }();
+
   /// The Flutter generated directory for the Swift package handling plugin
   /// dependencies.
   Directory get flutterPluginSwiftPackageDirectory =>
-      flutterSwiftPackagesDirectory.childDirectory(kFlutterGeneratedPluginSwiftPackageName);
+      flutterSwiftPackagesDirectory.childDirectory(flutterPluginSwiftPackageName);
 
   /// The Flutter generated directory for the Swift package handling the Flutter framework.
   Directory get flutterFrameworkSwiftPackageDirectory => relativeSwiftPackagesDirectory
@@ -191,11 +207,18 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform {
   File get flutterPluginSwiftPackageManifest =>
       flutterPluginSwiftPackageDirectory.childFile('Package.swift');
 
-  /// Checks if FlutterGeneratedPluginSwiftPackage has been added to the
+  /// Checks if the generated plugin Swift package has been added to the
   /// project's build settings by checking the contents of the pbxproj.
+  ///
+  /// Checks for both the project-specific name and the legacy hardcoded name
+  /// for backward compatibility.
   bool get flutterPluginSwiftPackageInProjectSettings {
-    return xcodeProjectInfoFile.existsSync() &&
-        xcodeProjectInfoFile.readAsStringSync().contains(kFlutterGeneratedPluginSwiftPackageName);
+    if (!xcodeProjectInfoFile.existsSync()) {
+      return false;
+    }
+    final String contents = xcodeProjectInfoFile.readAsStringSync();
+    return contents.contains(flutterPluginSwiftPackageName) ||
+        contents.contains(kFlutterGeneratedPluginSwiftPackageName);
   }
 
   /// Checks if FlutterFramework has been added to the project's build settings by checking the

--- a/packages/flutter_tools/templates/app/ios.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
+++ b/packages/flutter_tools/templates/app/ios.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
@@ -13,7 +13,7 @@
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		{{#withSwiftPackageManager}}
-		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		78A318202AECB46A00862997 /* {{pluginSwiftPackageName}} in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* {{pluginSwiftPackageName}} */; };
 		{{/withSwiftPackageManager}}
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -53,7 +53,7 @@
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		{{#withSwiftPackageManager}}
-		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* {{pluginSwiftPackageName}} */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = {{pluginSwiftPackageName}}; path = Flutter/ephemeral/Packages/{{pluginSwiftPackageName}}; sourceTree = "<group>"; };
 		{{#withPlatformChannelPluginHook}}
 		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = Flutter/ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
 		78DABEA22ED26510000E7860 /* {{pluginProjectName}} */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = {{pluginProjectName}}; path = ../../ios/{{pluginProjectName}}; sourceTree = "<group>"; };
@@ -75,7 +75,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				{{#withSwiftPackageManager}}
-				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				78A318202AECB46A00862997 /* {{pluginSwiftPackageName}} in Frameworks */,
 				{{/withSwiftPackageManager}}
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -99,7 +99,7 @@
 				78DABEA22ED26510000E7860 /* {{pluginProjectName}} */,
 				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				{{/withPlatformChannelPluginHook}}
-				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
+				78E0A7A72DC9AD7400C4905E /* {{pluginSwiftPackageName}} */,
 				{{/withSwiftPackageManager}}
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
@@ -182,7 +182,7 @@
 			name = Runner;
 			{{#withSwiftPackageManager}}
 			packageProductDependencies = (
-				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+				78A3181F2AECB46A00862997 /* {{pluginSwiftPackageName}} */,
 			);
 			{{/withSwiftPackageManager}}
 			productName = Runner;
@@ -220,7 +220,7 @@
 			mainGroup = 97C146E51CF9000F007C117D;
 			{{#withSwiftPackageManager}}
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/{{pluginSwiftPackageName}}" */,
 			);
 			{{/withSwiftPackageManager}}
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
@@ -660,16 +660,16 @@
 {{#withSwiftPackageManager}}
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/{{pluginSwiftPackageName}}" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+			relativePath = Flutter/ephemeral/Packages/{{pluginSwiftPackageName}};
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+		78A3181F2AECB46A00862997 /* {{pluginSwiftPackageName}} */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = FlutterGeneratedPluginSwiftPackage;
+			productName = {{pluginSwiftPackageName}};
 		};
 /* End XCSwiftPackageProductDependency section */
 {{/withSwiftPackageManager}}

--- a/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
+++ b/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
@@ -28,7 +28,7 @@
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		{{#withSwiftPackageManager}}
-		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		78A318202AECB46A00862997 /* {{pluginSwiftPackageName}} in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* {{pluginSwiftPackageName}} */; };
 		{{/withSwiftPackageManager}}
 /* End PBXBuildFile section */
 
@@ -80,7 +80,7 @@
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
 		{{#withSwiftPackageManager}}
-		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* {{pluginSwiftPackageName}} */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = {{pluginSwiftPackageName}}; path = ephemeral/Packages/{{pluginSwiftPackageName}}; sourceTree = "<group>"; };
 		{{#withPlatformChannelPluginHook}}
 		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
 		78DABEA22ED26510000E7860 /* {{pluginProjectName}} */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = {{pluginProjectName}}; path = ../../../macos/{{pluginProjectName}}; sourceTree = "<group>"; };
@@ -103,7 +103,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				{{#withSwiftPackageManager}}
-				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				78A318202AECB46A00862997 /* {{pluginSwiftPackageName}} in Frameworks */,
 				{{/withSwiftPackageManager}}
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -169,7 +169,7 @@
 				78DABEA22ED26510000E7860 /* {{pluginProjectName}} */,
 				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				{{/withPlatformChannelPluginHook}}
-				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
+				78E0A7A72DC9AD7400C4905E /* {{pluginSwiftPackageName}} */,
 				{{/withSwiftPackageManager}}
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
@@ -238,7 +238,7 @@
 			name = Runner;
 			{{#withSwiftPackageManager}}
 			packageProductDependencies = (
-				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+				78A3181F2AECB46A00862997 /* {{pluginSwiftPackageName}} */,
 			);
 			{{/withSwiftPackageManager}}
 			productName = Runner;
@@ -287,7 +287,7 @@
 			mainGroup = 33CC10E42044A3C60003C045;
 			{{#withSwiftPackageManager}}
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/{{pluginSwiftPackageName}}" */,
 			);
 			{{/withSwiftPackageManager}}
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
@@ -733,16 +733,16 @@
 {{#withSwiftPackageManager}}
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/{{pluginSwiftPackageName}}" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+			relativePath = Flutter/ephemeral/Packages/{{pluginSwiftPackageName}};
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+		78A3181F2AECB46A00862997 /* {{pluginSwiftPackageName}} */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = FlutterGeneratedPluginSwiftPackage;
+			productName = {{pluginSwiftPackageName}};
 		};
 /* End XCSwiftPackageProductDependency section */
 {{/withSwiftPackageManager}}

--- a/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
@@ -82,19 +82,19 @@ void main() {
 import PackageDescription
 
 let package = Package(
-    name: "FlutterGeneratedPluginSwiftPackage",
+    name: "TestAppFlutterPlugins",
     platforms: [
         $supportedPlatform
     ],
     products: [
-        .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
+        .library(name: "TestAppFlutterPlugins", type: .static, targets: ["TestAppFlutterPlugins"])
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../.packages/FlutterFramework")
     ],
     targets: [
         .target(
-            name: "FlutterGeneratedPluginSwiftPackage",
+            name: "TestAppFlutterPlugins",
             dependencies: [
                 .product(name: "FlutterFramework", package: "FlutterFramework")
             ]
@@ -177,19 +177,19 @@ $_doubleIndent
 import PackageDescription
 
 let package = Package(
-    name: "FlutterGeneratedPluginSwiftPackage",
+    name: "TestAppFlutterPlugins",
     platforms: [
         $supportedPlatform
     ],
     products: [
-        .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
+        .library(name: "TestAppFlutterPlugins", type: .static, targets: ["TestAppFlutterPlugins"])
     ],
     dependencies: [
 $_doubleIndent
     ],
     targets: [
         .target(
-            name: "FlutterGeneratedPluginSwiftPackage"
+            name: "TestAppFlutterPlugins"
         )
     ]
 )
@@ -240,12 +240,12 @@ $_doubleIndent
 import PackageDescription
 
 let package = Package(
-    name: "FlutterGeneratedPluginSwiftPackage",
+    name: "TestAppFlutterPlugins",
     platforms: [
         $supportedPlatform
     ],
     products: [
-        .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
+        .library(name: "TestAppFlutterPlugins", type: .static, targets: ["TestAppFlutterPlugins"])
     ],
     dependencies: [
         .package(name: "valid_plugin_1", path: "../.packages/valid_plugin_1-1.0.0"),
@@ -253,7 +253,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "FlutterGeneratedPluginSwiftPackage",
+            name: "TestAppFlutterPlugins",
             dependencies: [
                 .product(name: "valid-plugin-1", package: "valid_plugin_1"),
                 .product(name: "FlutterFramework", package: "FlutterFramework")
@@ -347,12 +347,12 @@ let package = Package(
 import PackageDescription
 
 let package = Package(
-    name: "FlutterGeneratedPluginSwiftPackage",
+    name: "TestAppFlutterPlugins",
     platforms: [
         $supportedPlatform
     ],
     products: [
-        .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
+        .library(name: "TestAppFlutterPlugins", type: .static, targets: ["TestAppFlutterPlugins"])
     ],
     dependencies: [
         .package(name: "valid_plugin_1", path: "../.packages/valid_plugin_1-1.0.0"),
@@ -361,7 +361,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "FlutterGeneratedPluginSwiftPackage",
+            name: "TestAppFlutterPlugins",
             dependencies: [
                 .product(name: "valid-plugin-1", package: "valid_plugin_1"),
                 .product(name: "valid-plugin-2", package: "valid_plugin_2"),
@@ -533,12 +533,12 @@ let package = Package(
 import PackageDescription
 
 let package = Package(
-    name: "FlutterGeneratedPluginSwiftPackage",
+    name: "TestAppFlutterPlugins",
     platforms: [
         $supportedPlatform
     ],
     products: [
-        .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
+        .library(name: "TestAppFlutterPlugins", type: .static, targets: ["TestAppFlutterPlugins"])
     ],
     dependencies: [
         .package(name: "valid_plugin_1", path: "../.packages/valid_plugin_1-1.0.0"),
@@ -548,7 +548,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "FlutterGeneratedPluginSwiftPackage",
+            name: "TestAppFlutterPlugins",
             dependencies: [
                 .product(name: "valid-plugin-1", package: "valid_plugin_1"),
                 .product(name: "valid-plugin-2", package: "valid_plugin_2"),
@@ -744,8 +744,13 @@ let package = Package(
 }
 
 class FakeXcodeProject extends Fake implements IosProject {
-  FakeXcodeProject({required FileSystem fileSystem, required String platform})
-    : hostAppRoot = fileSystem.directory('app_name').childDirectory(platform);
+  FakeXcodeProject({
+    required FileSystem fileSystem,
+    required String platform,
+    this.appName = 'test_app',
+  }) : hostAppRoot = fileSystem.directory('app_name').childDirectory(platform);
+
+  final String appName;
 
   @override
   Directory hostAppRoot;
@@ -758,6 +763,15 @@ class FakeXcodeProject extends Fake implements IosProject {
 
   @override
   String hostAppProjectName = 'Runner';
+
+  @override
+  String get flutterPluginSwiftPackageName {
+    final pascalName = appName
+        .split('_')
+        .map((s) => s.isEmpty ? '' : '${s[0].toUpperCase()}${s.substring(1)}')
+        .join();
+    return '${pascalName}FlutterPlugins';
+  }
 
   @override
   Directory get flutterSwiftPackagesDirectory =>
@@ -773,7 +787,7 @@ class FakeXcodeProject extends Fake implements IosProject {
 
   @override
   Directory get flutterPluginSwiftPackageDirectory =>
-      flutterSwiftPackagesDirectory.childDirectory('FlutterGeneratedPluginSwiftPackage');
+      flutterSwiftPackagesDirectory.childDirectory(flutterPluginSwiftPackageName);
 
   @override
   File get flutterPluginSwiftPackageManifest =>
@@ -781,8 +795,12 @@ class FakeXcodeProject extends Fake implements IosProject {
 
   @override
   bool get flutterPluginSwiftPackageInProjectSettings {
-    return xcodeProjectInfoFile.existsSync() &&
-        xcodeProjectInfoFile.readAsStringSync().contains('FlutterGeneratedPluginSwiftPackage');
+    if (!xcodeProjectInfoFile.existsSync()) {
+      return false;
+    }
+    final String contents = xcodeProjectInfoFile.readAsStringSync();
+    return contents.contains(flutterPluginSwiftPackageName) ||
+        contents.contains(kFlutterGeneratedPluginSwiftPackageName);
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/xcode_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/xcode_project_test.dart
@@ -75,22 +75,59 @@ void main() {
       );
     });
 
-    testWithoutContext('flutterPluginSwiftPackageDirectory', () {
+    testWithoutContext('flutterPluginSwiftPackageName includes app name', () {
       final fs = MemoryFileSystem.test();
-      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
+      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs, appName: 'my_app'));
+      expect(project.flutterPluginSwiftPackageName, 'MyAppFlutterPlugins');
+    });
+
+    testWithoutContext('flutterPluginSwiftPackageName is unique per app', () {
+      final fs = MemoryFileSystem.test();
+      final mainApp = IosProject.fromFlutter(
+        FakeFlutterProject(fileSystem: fs, appName: 'main_app'),
+      );
+      final clipApp = IosProject.fromFlutter(
+        FakeFlutterProject(fileSystem: fs, appName: 'clip_app'),
+      );
+      expect(mainApp.flutterPluginSwiftPackageName, isNot(clipApp.flutterPluginSwiftPackageName));
+    });
+
+    testWithoutContext('flutterPluginSwiftPackageDirectory uses app-specific name', () {
+      final fs = MemoryFileSystem.test();
+      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs, appName: 'my_app'));
       expect(
         project.flutterPluginSwiftPackageDirectory.path,
-        'app_name/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage',
+        'app_name/ios/Flutter/ephemeral/Packages/MyAppFlutterPlugins',
       );
     });
 
-    testWithoutContext('module flutterPluginSwiftPackageDirectory', () {
+    testWithoutContext('module flutterPluginSwiftPackageDirectory uses app-specific name', () {
       final fs = MemoryFileSystem.test();
-      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs, isModule: true));
+      final project = IosProject.fromFlutter(
+        FakeFlutterProject(fileSystem: fs, isModule: true, appName: 'my_app'),
+      );
       expect(
         project.flutterPluginSwiftPackageDirectory.path,
-        'app_name/.ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage',
+        'app_name/.ios/Flutter/ephemeral/Packages/MyAppFlutterPlugins',
       );
+    });
+
+    testWithoutContext('flutterPluginSwiftPackageInProjectSettings detects legacy name', () {
+      final fs = MemoryFileSystem.test();
+      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs, appName: 'my_app'));
+      project.xcodeProjectInfoFile.createSync(recursive: true);
+      project.xcodeProjectInfoFile.writeAsStringSync(
+        'FlutterGeneratedPluginSwiftPackage in Frameworks',
+      );
+      expect(project.flutterPluginSwiftPackageInProjectSettings, isTrue);
+    });
+
+    testWithoutContext('flutterPluginSwiftPackageInProjectSettings detects new name', () {
+      final fs = MemoryFileSystem.test();
+      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs, appName: 'my_app'));
+      project.xcodeProjectInfoFile.createSync(recursive: true);
+      project.xcodeProjectInfoFile.writeAsStringSync('MyAppFlutterPlugins in Frameworks');
+      expect(project.flutterPluginSwiftPackageInProjectSettings, isTrue);
     });
 
     testWithoutContext('xcodeConfigFor', () {
@@ -470,10 +507,12 @@ void main() {
 
     testWithoutContext('flutterPluginSwiftPackageDirectory', () {
       final fs = MemoryFileSystem.test();
-      final project = MacOSProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
+      final project = MacOSProject.fromFlutter(
+        FakeFlutterProject(fileSystem: fs, appName: 'my_app'),
+      );
       expect(
         project.flutterPluginSwiftPackageDirectory.path,
-        'app_name/macos/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage',
+        'app_name/macos/Flutter/ephemeral/Packages/MyAppFlutterPlugins',
       );
     });
 
@@ -808,9 +847,10 @@ Xcode is fetching Swift Package Manager dependencies. This may take several minu
 }
 
 class FakeFlutterProject extends Fake implements FlutterProject {
-  FakeFlutterProject({required this.fileSystem, this.isModule = false});
+  FakeFlutterProject({required this.fileSystem, this.isModule = false, this.appName = 'test_app'});
 
   MemoryFileSystem fileSystem;
+  String appName;
 
   @override
   late final Directory directory = fileSystem.directory('app_name');
@@ -819,7 +859,7 @@ class FakeFlutterProject extends Fake implements FlutterProject {
   bool isModule = false;
 
   @override
-  FlutterManifest get manifest => FakeFlutterManifest();
+  FlutterManifest get manifest => FakeFlutterManifest(appName: appName);
 }
 
 class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterpreter {
@@ -848,7 +888,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 }
 
 class FakeFlutterManifest extends Fake implements FlutterManifest {
-  FakeFlutterManifest({this.isModule = false});
+  FakeFlutterManifest({this.isModule = false, this.appName = 'test_app'});
 
   @override
   bool isModule;
@@ -863,7 +903,7 @@ class FakeFlutterManifest extends Fake implements FlutterManifest {
   String? get iosBundleIdentifier => null;
 
   @override
-  String get appName => '';
+  final String appName;
 
   @override
   List<String> get workspace => <String>[];


### PR DESCRIPTION
## Description

When multiple Flutter apps share a single Xcode project (e.g. a main app and an App Clip backed by a separate Flutter module), both generate a `FlutterGeneratedPluginSwiftPackage` with the same directory name. Since Xcode identifies local SPM packages by folder name, this causes package resolution to fail.

This change derives the generated plugin Swift package name from the Flutter app name (`pubspec.yaml` `name:` field), converting it to PascalCase and appending `FlutterPlugins`:
- `my_app` → `MyAppFlutterPlugins`
- `my_app_clip` → `MyAppClipFlutterPlugins`

Existing projects that reference the legacy `FlutterGeneratedPluginSwiftPackage` name are automatically renamed in the pbxproj during `flutter pub get`, so no manual migration is needed.

### Changes

| File | What |
|------|------|
| `xcode_project.dart` | Add `flutterPluginSwiftPackageName` property that derives PascalCase name from app name. Backward-compat check for legacy name in pbxproj. |
| `swift_package_manager.dart` | Use project-specific name in generated `Package.swift`. Rename legacy pbxproj references at pub-get time. |
| `swift_package_manager_integration_migration.dart` | Use project-specific name in all pbxproj string manipulation. Add rename step for upgrades. |
| `create_base.dart` | Add `pluginSwiftPackageName` to template context. |
| `ios/macos project templates` | Replace hardcoded `FlutterGeneratedPluginSwiftPackage` with `{{pluginSwiftPackageName}}`. |
| `xcodeproj.dart` | Ignore both legacy and new scheme names. |
| `mac.dart` | Match platform mismatch errors for both name formats. |

## Related Issue

Fixes https://github.com/flutter/flutter/issues/189585

## Tests

Added unit tests in `xcode_project_test.dart`:
- `flutterPluginSwiftPackageName includes app name`
- `flutterPluginSwiftPackageName is unique per app`
- `flutterPluginSwiftPackageDirectory uses app-specific name`
- `module flutterPluginSwiftPackageDirectory uses app-specific name`
- `flutterPluginSwiftPackageInProjectSettings detects legacy name`
- `flutterPluginSwiftPackageInProjectSettings detects new name`

Updated all expectations in `swift_package_manager_test.dart` to use the new naming format.

### Manual test scenario

**New project:**
```bash
export PATH="/path/to/patched/flutter/bin:$PATH"
flutter create test_app
cd test_app
flutter pub add url_launcher
flutter pub get
grep 'name:' ios/Flutter/ephemeral/Packages/*/Package.swift
# Expected: name: "TestAppFlutterPlugins"
```

**Existing project upgrade (backward compatible):**
```bash
# 1. Create a project with stock Flutter
flutter create legacy_app && cd legacy_app
flutter pub add url_launcher && flutter pub get
grep 'FlutterGeneratedPluginSwiftPackage' ios/Runner.xcodeproj/project.pbxproj
# Confirms legacy name is in pbxproj

# 2. Switch to patched Flutter and run pub get
export PATH="/path/to/patched/flutter/bin:$PATH"
flutter pub get
grep 'LegacyAppFlutterPlugins' ios/Runner.xcodeproj/project.pbxproj
# Confirms pbxproj was renamed automatically
grep 'FlutterGeneratedPluginSwiftPackage' ios/Runner.xcodeproj/project.pbxproj
# Confirms no legacy references remain
```

**Multi-app collision (the original issue):**
```bash
flutter create main_app && flutter create clip_app
cd main_app && flutter pub add url_launcher && flutter pub get && cd ..
cd clip_app && flutter pub add url_launcher && flutter pub get && cd ..
grep 'name:' main_app/ios/Flutter/ephemeral/Packages/*/Package.swift
grep 'name:' clip_app/ios/Flutter/ephemeral/Packages/*/Package.swift
# Expected: MainAppFlutterPlugins and ClipAppFlutterPlugins (unique names)
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
-```
## Description

When multiple Flutter apps share a single Xcode project (e.g. a main app and an App Clip backed by a separate Flutter module), both generate a `FlutterGeneratedPluginSwiftPackage` with the same directory name. Since Xcode identifies local SPM packages by folder name, this causes package resolution to fail.

This change derives the generated plugin Swift package name from the Flutter app name (`pubspec.yaml` `name:` field), converting it to PascalCase and appending `FlutterPlugins`:
- `my_app` → `MyAppFlutterPlugins`
- `my_app_clip` → `MyAppClipFlutterPlugins`

Existing projects that reference the legacy `FlutterGeneratedPluginSwiftPackage` name are automatically renamed in the pbxproj during `flutter pub get`, so no manual migration is needed.

### Changes

| File | What |
|------|------|
| `xcode_project.dart` | Add `flutterPluginSwiftPackageName` property that derives PascalCase name from app name. Backward-compat check for legacy name in pbxproj. |
| `swift_package_manager.dart` | Use project-specific name in generated `Package.swift`. Rename legacy pbxproj references at pub-get time. |
| `swift_package_manager_integration_migration.dart` | Use project-specific name in all pbxproj string manipulation. Add rename step for upgrades. |
| `create_base.dart` | Add `pluginSwiftPackageName` to template context. |
| `ios/macos project templates` | Replace hardcoded `FlutterGeneratedPluginSwiftPackage` with `{{pluginSwiftPackageName}}`. |
| `xcodeproj.dart` | Ignore both legacy and new scheme names. |
| `mac.dart` | Match platform mismatch errors for both name formats. |

## Related Issue

Fixes https://github.com/flutter/flutter/issues/189585

## Tests

Added unit tests in `xcode_project_test.dart`:
- `flutterPluginSwiftPackageName includes app name`
- `flutterPluginSwiftPackageName is unique per app`
- `flutterPluginSwiftPackageDirectory uses app-specific name`
- `module flutterPluginSwiftPackageDirectory uses app-specific name`
- `flutterPluginSwiftPackageInProjectSettings detects legacy name`
- `flutterPluginSwiftPackageInProjectSettings detects new name`

Updated all expectations in `swift_package_manager_test.dart` to use the new naming format.

### Manual test scenario

**New project:**

```bash
export PATH="/path/to/patched/flutter/bin:$PATH"
flutter create test_app
cd test_app
flutter pub add url_launcher
flutter pub get
grep 'name:' ios/Flutter/ephemeral/Packages/*/Package.swift
# Expected: name: "TestAppFlutterPlugins"
```

**Existing project upgrade (backward compatible):**

```bash
# 1. Create a project with stock Flutter
flutter create legacy_app && cd legacy_app
flutter pub add url_launcher && flutter pub get
grep 'FlutterGeneratedPluginSwiftPackage' ios/Runner.xcodeproj/project.pbxproj
# Confirms legacy name is in pbxproj

# 2. Switch to patched Flutter and run pub get
export PATH="/path/to/patched/flutter/bin:$PATH"
flutter pub get
grep 'LegacyAppFlutterPlugins' ios/Runner.xcodeproj/project.pbxproj
# Confirms pbxproj was renamed automatically
grep 'FlutterGeneratedPluginSwiftPackage' ios/Runner.xcodeproj/project.pbxproj
# Confirms no legacy references remain
```

**Multi-app collision (the original issue):**

```bash
flutter create main_app && flutter create clip_app
cd main_app && flutter pub add url_launcher && flutter pub get && cd ..
cd clip_app && flutter pub add url_launcher && flutter pub get && cd ..
grep 'name:' main_app/ios/Flutter/ephemeral/Packages/*/Package.swift
grep 'name:' clip_app/ios/Flutter/ephemeral/Packages/*/Package.swift
# Expected: MainAppFlutterPlugins and ClipAppFlutterPlugins (unique names)
```

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
