### PR TITLE
Disable execution order shuffling for the flutter_tools upgrade_test suite

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(https://github.com/flutter/flutter/issues/189919): Remove when the
+// execution order dependency is resolved.
+@Tags(<String>['no-shuffle'])
+library;
+
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(https://github.com/flutter/flutter/issues/189919): Remove when the
-// execution order dependency is resolved.
+// TODO(team-tools): Remove when the execution order dependency is resolved.
+// See https://github.com/flutter/flutter/issues/189919
 @Tags(<String>['no-shuffle'])
 library;
 


### PR DESCRIPTION
This test is failing when run with today's randomized order seed.

See https://github.com/flutter/flutter/issues/189919