### PR TITLE
[SwiftPM] Read deployment target from pbxproj during package generation

### DIFF
--- a/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
@@ -99,6 +99,22 @@ class SwiftPackageManager {
       targetDependencies.add(flutterFrameworkTargetDependency);
     }
 
+    // Determine the platform version for the generated package.
+    // Use the project's deployment target if it's higher than Flutter's default,
+    // so that plugins requiring a higher version can resolve without errors.
+    // See https://github.com/flutter/flutter/issues/162196.
+    SwiftPackageSupportedPlatform supportedPlatform = platform.supportedPackagePlatform;
+    final String? projectDeploymentTarget = project.deploymentTargetFromPbxproj(platform);
+    if (projectDeploymentTarget != null) {
+      final Version? projectVersion = Version.parse(projectDeploymentTarget);
+      if (projectVersion != null && projectVersion > supportedPlatform.version) {
+        supportedPlatform = SwiftPackageSupportedPlatform(
+          platform: platform.swiftPackagePlatform,
+          version: projectVersion,
+        );
+      }
+    }
+
     // FlutterGeneratedPluginSwiftPackage must be statically linked to ensure
     // any dynamic dependencies are linked to Runner and prevent undefined symbols.
     final generatedProduct = SwiftPackageProduct.library(
@@ -115,7 +131,7 @@ class SwiftPackageManager {
     final pluginsPackage = SwiftPackage(
       manifest: project.flutterPluginSwiftPackageManifest,
       name: kFlutterGeneratedPluginSwiftPackageName,
-      platforms: <SwiftPackageSupportedPlatform>[platform.supportedPackagePlatform],
+      platforms: <SwiftPackageSupportedPlatform>[supportedPlatform],
       products: <SwiftPackageProduct>[generatedProduct],
       dependencies: packageDependencies,
       targets: <SwiftPackageTarget>[generatedTarget],

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -191,6 +191,30 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform {
   File get flutterPluginSwiftPackageManifest =>
       flutterPluginSwiftPackageDirectory.childFile('Package.swift');
 
+  /// Parses the deployment target for the given [platform] from the pbxproj.
+  ///
+  /// Returns the highest `IPHONEOS_DEPLOYMENT_TARGET` or
+  /// `MACOSX_DEPLOYMENT_TARGET` value found across all build configurations,
+  /// or `null` if the file doesn't exist or no value is found.
+  String? deploymentTargetFromPbxproj(FlutterDarwinPlatform platform) {
+    if (!xcodeProjectInfoFile.existsSync()) {
+      return null;
+    }
+    final String key = platform == FlutterDarwinPlatform.ios
+        ? 'IPHONEOS_DEPLOYMENT_TARGET'
+        : 'MACOSX_DEPLOYMENT_TARGET';
+    final RegExp pattern = RegExp('$key\\s*=\\s*([0-9.]+)');
+    final String contents = xcodeProjectInfoFile.readAsStringSync();
+    Version? highest;
+    for (final RegExpMatch match in pattern.allMatches(contents)) {
+      final Version? version = Version.parse(match.group(1));
+      if (version != null && (highest == null || version > highest)) {
+        highest = version;
+      }
+    }
+    return highest?.toString();
+  }
+
   /// Checks if FlutterGeneratedPluginSwiftPackage has been added to the
   /// project's build settings by checking the contents of the pbxproj.
   bool get flutterPluginSwiftPackageInProjectSettings {

--- a/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
@@ -138,6 +138,75 @@ $_doubleIndent
             );
           });
 
+          testWithoutContext('uses project deployment target when higher than default', () async {
+            final fs = MemoryFileSystem();
+            final processManager = FakeProcessManager.any();
+            final logger = BufferLogger.test();
+            final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+            project.xcodeProjectInfoFile.createSync(recursive: true);
+            // Set deployment target higher than Flutter's default (iOS 15.0 / macOS 12.0)
+            final deploymentKey = platform == FlutterDarwinPlatform.ios
+                ? 'IPHONEOS_DEPLOYMENT_TARGET'
+                : 'MACOSX_DEPLOYMENT_TARGET';
+            project.xcodeProjectInfoFile.writeAsStringSync('''
+78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; };
+$deploymentKey = 17.0;
+''');
+
+            final spm = SwiftPackageManager(
+              fileSystem: fs,
+              templateRenderer: const MustacheTemplateRenderer(),
+              processUtils: ProcessUtils(processManager: processManager, logger: logger),
+              config: FakeConfig(),
+            );
+            await spm.generatePluginsSwiftPackage(<Plugin>[], platform, project);
+
+            final expectedPlatform = platform == FlutterDarwinPlatform.ios
+                ? '.iOS("17.0")'
+                : '.macOS("17.0")';
+            expect(project.flutterPluginSwiftPackageManifest.existsSync(), isTrue);
+            expect(
+              project.flutterPluginSwiftPackageManifest.readAsStringSync(),
+              contains(expectedPlatform),
+            );
+          });
+
+          testWithoutContext(
+            'uses default deployment target when project target is lower',
+            () async {
+              final fs = MemoryFileSystem();
+              final processManager = FakeProcessManager.any();
+              final logger = BufferLogger.test();
+              final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+              project.xcodeProjectInfoFile.createSync(recursive: true);
+              final deploymentKey = platform == FlutterDarwinPlatform.ios
+                  ? 'IPHONEOS_DEPLOYMENT_TARGET'
+                  : 'MACOSX_DEPLOYMENT_TARGET';
+              // Set deployment target lower than Flutter's default (iOS 15.0 / macOS 12.0)
+              project.xcodeProjectInfoFile.writeAsStringSync('''
+78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; };
+$deploymentKey = 10.0;
+''');
+
+              final spm = SwiftPackageManager(
+                fileSystem: fs,
+                templateRenderer: const MustacheTemplateRenderer(),
+                processUtils: ProcessUtils(processManager: processManager, logger: logger),
+                config: FakeConfig(),
+              );
+              await spm.generatePluginsSwiftPackage(<Plugin>[], platform, project);
+
+              final expectedPlatform = platform == FlutterDarwinPlatform.ios
+                  ? '.iOS("15.0")'
+                  : '.macOS("12.0")';
+              expect(project.flutterPluginSwiftPackageManifest.existsSync(), isTrue);
+              expect(
+                project.flutterPluginSwiftPackageManifest.readAsStringSync(),
+                contains(expectedPlatform),
+              );
+            },
+          );
+
           testWithoutContext(
             'generate if no dependencies, no Flutter dependency, and already migrated',
             () async {
@@ -783,6 +852,19 @@ class FakeXcodeProject extends Fake implements IosProject {
   bool get flutterPluginSwiftPackageInProjectSettings {
     return xcodeProjectInfoFile.existsSync() &&
         xcodeProjectInfoFile.readAsStringSync().contains('FlutterGeneratedPluginSwiftPackage');
+  }
+
+  @override
+  String? deploymentTargetFromPbxproj(FlutterDarwinPlatform platform) {
+    if (!xcodeProjectInfoFile.existsSync()) {
+      return null;
+    }
+    final String key = platform == FlutterDarwinPlatform.ios
+        ? 'IPHONEOS_DEPLOYMENT_TARGET'
+        : 'MACOSX_DEPLOYMENT_TARGET';
+    final RegExp pattern = RegExp('$key\\s*=\\s*([0-9.]+)');
+    final match = pattern.firstMatch(xcodeProjectInfoFile.readAsStringSync());
+    return match?.group(1);
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/xcode_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/xcode_project_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/darwin/darwin.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
@@ -91,6 +92,37 @@ void main() {
         project.flutterPluginSwiftPackageDirectory.path,
         'app_name/.ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage',
       );
+    });
+
+    testWithoutContext('deploymentTargetFromPbxproj returns iOS target', () {
+      final fs = MemoryFileSystem.test();
+      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
+      project.xcodeProjectInfoFile.createSync(recursive: true);
+      project.xcodeProjectInfoFile.writeAsStringSync('''
+IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+''');
+      expect(project.deploymentTargetFromPbxproj(FlutterDarwinPlatform.ios), '17.0');
+    });
+
+    testWithoutContext(
+      'deploymentTargetFromPbxproj returns highest target across configurations',
+      () {
+        final fs = MemoryFileSystem.test();
+        final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
+        project.xcodeProjectInfoFile.createSync(recursive: true);
+        project.xcodeProjectInfoFile.writeAsStringSync('''
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+''');
+        expect(project.deploymentTargetFromPbxproj(FlutterDarwinPlatform.ios), '17.0');
+      },
+    );
+
+    testWithoutContext('deploymentTargetFromPbxproj returns null when file missing', () {
+      final fs = MemoryFileSystem.test();
+      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
+      expect(project.deploymentTargetFromPbxproj(FlutterDarwinPlatform.ios), isNull);
     });
 
     testWithoutContext('xcodeConfigFor', () {


### PR DESCRIPTION

## Description

During `flutter pub get`, the generated `FlutterGeneratedPluginSwiftPackage/Package.swift` uses Flutter's hardcoded minimum deployment target (iOS 15.0 / macOS 12.0 on master or iOS 13.0 on Flutter 3.44) regardless of what the Xcode project specifies. This causes build failures when plugins require a higher platform version (e.g. Firebase requires iOS 15+, custom plugins require iOS 17+).

Previously, the platform version was only corrected during `flutter build` (via `updateMinimumDeployment`), which meant:
- Building from Xcode directly would fail
- Running `flutter pub get` followed by `pod install` would produce an invalid state
- Users had to remember to run `flutter build ios --config-only` as a workaround

This change reads `IPHONEOS_DEPLOYMENT_TARGET` / `MACOSX_DEPLOYMENT_TARGET` from the pbxproj during package generation and uses the higher of the project's target vs Flutter's default. The generated `Package.swift` is now correct immediately after `flutter pub get`.

### Changes

| File | What |
|------|------|
| `xcode_project.dart` | Add `deploymentTargetFromPbxproj()` method that parses the highest deployment target from the pbxproj across all build configurations. |
| `swift_package_manager.dart` | In `generatePluginsSwiftPackage`, read the project's deployment target and use it if higher than Flutter's default. |

## Related Issue

Fixes https://github.com/flutter/flutter/issues/162196

## Tests

Added unit tests in `xcode_project_test.dart`:
- `deploymentTargetFromPbxproj returns iOS target`
- `deploymentTargetFromPbxproj returns highest target across configurations`
- `deploymentTargetFromPbxproj returns null when file missing`

Added unit tests in `swift_package_manager_test.dart`:
- `uses project deployment target when higher than default`
- `uses default deployment target when project target is lower`

### Manual test scenario

```bash
# Create app and set deployment target higher than Flutter's default
flutter create version_app && cd version_app
flutter pub add url_launcher

# Set iOS deployment target to 17.0
sed -i '' 's/IPHONEOS_DEPLOYMENT_TARGET = [0-9.]*/IPHONEOS_DEPLOYMENT_TARGET = 17.0/g' \
  ios/Runner.xcodeproj/project.pbxproj

# Run pub get
flutter pub get

# Verify Package.swift uses project's target
grep '\.iOS' ios/Flutter/ephemeral/Packages/*/Package.swift
# Expected: .iOS("17.0")
# Before fix: .iOS("15.0")
```

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

> **Breaking change policy note:** This change is backward compatible. It only increases the platform version in the generated package when the project's pbxproj already specifies a higher target. Projects with the default target see no change. No Dart API is affected, so Data Driven Fixes are not applicable.