### PR TITLE
[flutter_tools] Initialize Cache.flutterRoot at the start of the upgrade_test suite

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -2,11 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(team-tools): Remove when the execution order dependency is resolved.
-// See https://github.com/flutter/flutter/issues/189919
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -29,6 +24,10 @@ import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {
+  setUpAll(() {
+    Cache.flutterRoot = getFlutterRoot();
+  });
+
   group('UpgradeCommandRunner', () {
     final jan12026 = DateTime.utc(2026);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/189919