### PR TITLE
[CP-beta] Disable execution order shuffling for the flutter_tools upgrade_test suite

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(team-tools): Remove when the execution order dependency is resolved.
+// See https://github.com/flutter/flutter/issues/189919
+@Tags(<String>['no-shuffle'])
+library;
+
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';


### PR DESCRIPTION
Cherry pick of https://github.com/flutter/flutter/pull/189920.

This test is failing when run with today's randomized order seed.

See https://github.com/flutter/flutter/issues/189919