### PR TITLE
[flutter_tools] Do not always wait for the full timeout when running Spotlight to locate Android Studio on macOS

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -26,7 +26,7 @@ const String kSpotlightMdfindCommand =
     r'  done; '
     r'  kill -9 $$; '
     r') 2>/dev/null & '
-    r'exec mdfind kMDItemCFBundleIdentifier="com.google.android.studio*"';
+    'exec mdfind \'kMDItemCFBundleIdentifier="com.google.android.studio*"\'';
 
 const _androidStudioTitle = 'Android Studio';
 const _androidStudioId = 'AndroidStudio';

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -19,7 +19,14 @@ import '../ios/plist_parser.dart';
 
 @visibleForTesting
 const String kSpotlightMdfindCommand =
-    'mdfind \'kMDItemCFBundleIdentifier="com.google.android.studio*"\' & pid=\$!; (sleep 3; kill -9 \$pid 2>/dev/null) & killer=\$!; wait \$pid 2>/dev/null; status=\$?; kill \$killer 2>/dev/null; exit \$status';
+    r'( '
+    r'  for ((i = 0; i < 30; i++)); do '
+    r'    sleep .1; '
+    r'    kill -0 $$ || exit 0; '
+    r'  done; '
+    r'  kill -9 $$; '
+    r') 2>/dev/null & '
+    r'exec mdfind kMDItemCFBundleIdentifier="com.google.android.studio*"';
 
 const _androidStudioTitle = 'Android Studio';
 const _androidStudioId = 'AndroidStudio';


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/189461 introduced a script in the flutter_tools AndroidStudio class that wraps the Spotlight mdfind command with a timeout.

This script had been waiting for the full 3 second timeout even if the mdfind process exited before then.  The extra wait showed up in performance benchmarks of tasks that invoke AndroidStudio such as app compilation.

See https://github.com/flutter/flutter/issues/189177