### PR TITLE
[wimp] fixes ubo padding size issue

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -130,9 +130,13 @@ bool BufferBindingsGLES::ReadUniformsBindingsV3(const ProcTableGLES& gl,
 
     GLuint block_index = gl.GetUniformBlockIndex(program, name.data());
     gl.UniformBlockBinding(program_handle_, block_index, i);
+    GLint block_data_size = 0;
+    gl.GetActiveUniformBlockiv(program, i, GL_UNIFORM_BLOCK_DATA_SIZE,
+                               &block_data_size);
 
     ubo_locations_[std::string{name.data(), static_cast<size_t>(length)}] =
-        std::make_pair(block_index, i);
+        UBOInfo{static_cast<GLint>(block_index), static_cast<GLuint>(i),
+                block_data_size};
   }
   use_ubo_ = true;
   return ReadUniformsBindingsV2(gl, program);
@@ -370,15 +374,14 @@ bool BufferBindingsGLES::BindUniformBufferV3(
     const BufferView& buffer,
     const ShaderMetadata* metadata,
     const DeviceBufferGLES& device_buffer_gles) {
-  absl::flat_hash_map<std::string, std::pair<GLint, GLuint>>::iterator it =
-      ubo_locations_.find(metadata->name);
+  auto it = ubo_locations_.find(metadata->name);
   if (it == ubo_locations_.end()) {
     // This should only happen if we have GLESv3 but are using v2 shaders,
     // as GLESv3 shaders compiled by impeller always have
     // **named** uniform buffer blocks
     return BindUniformBufferV2(gl, buffer, metadata, device_buffer_gles);
   }
-  const auto& [block_index, binding_point] = it->second;
+  const auto& ubo_info = it->second;
   if (!device_buffer_gles.BindAndUploadDataIfNecessary(
           DeviceBufferGLES::BindingType::kUniformBuffer)) {
     return false;
@@ -387,8 +390,10 @@ bool BufferBindingsGLES::BindUniformBufferV3(
   if (!handle.has_value()) {
     return false;
   }
-  gl.BindBufferRange(GL_UNIFORM_BUFFER, binding_point, handle.value(),
-                     buffer.GetRange().offset, buffer.GetRange().length);
+  size_t length = std::max<size_t>(buffer.GetRange().length,
+                                   static_cast<size_t>(ubo_info.data_size));
+  gl.BindBufferRange(GL_UNIFORM_BUFFER, ubo_info.binding_point, handle.value(),
+                     buffer.GetRange().offset, length);
   return true;
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -392,6 +392,11 @@ bool BufferBindingsGLES::BindUniformBufferV3(
   }
   size_t length = std::max<size_t>(buffer.GetRange().length,
                                    static_cast<size_t>(ubo_info.data_size));
+  if (buffer.GetRange().offset + length >
+      device_buffer_gles.GetDeviceBufferDescriptor().size) {
+    VALIDATION_LOG << "Uniform buffer range exceeds device buffer size.";
+    return false;
+  }
   gl.BindBufferRange(GL_UNIFORM_BUFFER, ubo_info.binding_point, handle.value(),
                      buffer.GetRange().offset, length);
   return true;

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -82,7 +82,12 @@ class BufferBindingsGLES {
   std::vector<std::vector<VertexAttribPointer>> vertex_attrib_arrays_;
 
   absl::flat_hash_map<std::string, GLint> uniform_locations_;
-  absl::flat_hash_map<std::string, std::pair<GLint, GLuint>> ubo_locations_;
+  struct UBOInfo {
+    GLint block_index = 0;
+    GLuint binding_point = 0;
+    GLint data_size = 0;
+  };
+  absl::flat_hash_map<std::string, UBOInfo> ubo_locations_;
 
   using BindingMap = absl::flat_hash_map<std::string, std::vector<GLint>>;
   BindingMap binding_map_ = {};

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -8,11 +8,15 @@
 #include "impeller/renderer/backend/gles/buffer_bindings_gles.h"
 #include "impeller/renderer/backend/gles/device_buffer_gles.h"
 #include "impeller/renderer/backend/gles/formats_gles.h"
+#include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/backend/gles/test/mock_gles.h"
 #include "impeller/renderer/command.h"
 
 namespace impeller {
 namespace testing {
+namespace {
+const GLint kBlockDataSize = 16;
+}
 
 using ::testing::_;
 
@@ -263,6 +267,99 @@ TEST(BufferBindingsGLESTest, BindVertexAttributesSetsInstanceRateDivisor) {
   EXPECT_TRUE(bindings.BindVertexAttributes(mock_gl->GetProcTable(),
                                             /*binding=*/1, /*vertex_offset=*/0,
                                             /*instance=*/0));
+}
+
+namespace {
+class TestWorker : public ReactorGLES::Worker {
+ public:
+  bool CanReactorReactOnCurrentThreadNow(
+      const ReactorGLES& reactor) const override {
+    return true;
+  }
+};
+}  // namespace
+
+void TestBindUniformBufferRange(size_t buffer_view_length,
+                                size_t expected_bound_size) {
+  BufferBindingsGLES bindings;
+  auto mock_gles_impl = std::make_unique<::testing::NiceMock<MockGLESImpl>>();
+
+  const GLuint kProgram = 1;
+
+  ON_CALL(*mock_gles_impl,
+          GetProgramiv(/*program=*/kProgram,
+                       /*pname=*/GL_ACTIVE_UNIFORM_BLOCKS, /*params=*/_))
+      .WillByDefault(::testing::SetArgPointee<2>(1));
+  ON_CALL(*mock_gles_impl,
+          GetActiveUniformBlockiv(/*program=*/kProgram,
+                                  /*uniformBlockIndex=*/0,
+                                  /*pname=*/GL_UNIFORM_BLOCK_NAME_LENGTH,
+                                  /*params=*/_))
+      .WillByDefault(::testing::SetArgPointee<3>(9));
+  ON_CALL(*mock_gles_impl,
+          GetActiveUniformBlockName(/*program=*/kProgram,
+                                    /*uniformBlockIndex=*/0,
+                                    /*bufSize=*/9, /*length=*/_,
+                                    /*uniformBlockName=*/_))
+      .WillByDefault(
+          ::testing::Invoke([](GLuint program, GLuint index, GLsizei bufSize,
+                               GLsizei* length, GLchar* name) {
+            *length = 8;
+            std::memcpy(name, "FragInfo", 9);
+          }));
+  ON_CALL(
+      *mock_gles_impl,
+      GetUniformBlockIndex(/*program=*/kProgram,
+                           /*uniformBlockName=*/::testing::StrEq("FragInfo")))
+      .WillByDefault(::testing::Return(0));
+  ON_CALL(*mock_gles_impl,
+          GetActiveUniformBlockiv(/*program=*/kProgram,
+                                  /*uniformBlockIndex=*/0,
+                                  /*pname=*/GL_UNIFORM_BLOCK_DATA_SIZE,
+                                  /*params=*/_))
+      .WillByDefault(::testing::SetArgPointee<3>(kBlockDataSize));
+
+  EXPECT_CALL(*mock_gles_impl,
+              BindBufferRange(/*target=*/GL_UNIFORM_BUFFER, /*index=*/0,
+                              /*buffer=*/_, /*offset=*/0,
+                              /*size=*/expected_bound_size))
+      .Times(1);
+
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+  ASSERT_TRUE(bindings.ReadUniformsBindings(mock_gl->GetProcTable(), kProgram));
+
+  ProcTableGLES::Resolver resolver = kMockResolverGLES;
+  auto proc_table = std::make_unique<ProcTableGLES>(resolver);
+  auto worker = std::make_shared<TestWorker>();
+  auto reactor = std::make_shared<ReactorGLES>(std::move(proc_table));
+  reactor->AddWorker(worker);
+
+  std::vector<BufferResource> bound_buffers;
+  std::vector<TextureAndSampler> bound_textures;
+
+  ShaderMetadata shader_metadata = {.name = "FragInfo"};
+  auto backing_store = std::make_unique<Allocation>();
+  ASSERT_TRUE(backing_store->Truncate(Bytes{1024}));
+  DeviceBufferGLES device_buffer(DeviceBufferDescriptor{.size = 1024}, reactor,
+                                 std::move(backing_store));
+  BufferView buffer_view(&device_buffer, Range(0, buffer_view_length));
+  bound_buffers.push_back(BufferResource(&shader_metadata, buffer_view));
+
+  EXPECT_TRUE(bindings.BindUniformData(mock_gl->GetProcTable(), bound_textures,
+                                       bound_buffers, Range{0, 0},
+                                       Range{0, 1}));
+}
+
+TEST(BufferBindingsGLESTest,
+     BindUniformBufferUsesMaxOfBufferViewAndBlockDataSize) {
+  TestBindUniformBufferRange(/*buffer_view_length=*/4,
+                             /*expected_bound_size=*/kBlockDataSize);
+}
+
+TEST(BufferBindingsGLESTest,
+     BindUniformBufferUsesBufferViewLengthWhenGreaterThanBlockDataSize) {
+  TestBindUniformBufferRange(/*buffer_view_length=*/32,
+                             /*expected_bound_size=*/32);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -301,12 +301,11 @@ void TestBindUniformBufferRange(size_t buffer_view_length,
                                     /*uniformBlockIndex=*/0,
                                     /*bufSize=*/9, /*length=*/_,
                                     /*uniformBlockName=*/_))
-      .WillByDefault(
-          ::testing::Invoke([](GLuint program, GLuint index, GLsizei bufSize,
-                               GLsizei* length, GLchar* name) {
-            *length = 8;
-            std::memcpy(name, "FragInfo", 9);
-          }));
+      .WillByDefault([](GLuint program, GLuint index, GLsizei bufSize,
+                        GLsizei* length, GLchar* name) {
+        *length = 8;
+        std::memcpy(name, "FragInfo", 9);
+      });
   ON_CALL(
       *mock_gles_impl,
       GetUniformBlockIndex(/*program=*/kProgram,

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -303,6 +303,52 @@ void mockBindTexture(GLenum target, GLuint texture) {
 static_assert(CheckSameSignature<decltype(mockBindTexture),  //
                                  decltype(glBindTexture)>::value);
 
+void mockBindBufferRange(GLenum target,
+                         GLuint index,
+                         GLuint buffer,
+                         GLintptr offset,
+                         GLsizeiptr size) {
+  CallMockMethod(&IMockGLESImpl::BindBufferRange, target, index, buffer, offset,
+                 size);
+}
+static_assert(CheckSameSignature<decltype(mockBindBufferRange),  //
+                                 decltype(glBindBufferRange)>::value);
+
+void mockGetProgramiv(GLuint program, GLenum pname, GLint* params) {
+  CallMockMethod(&IMockGLESImpl::GetProgramiv, program, pname, params);
+}
+static_assert(CheckSameSignature<decltype(mockGetProgramiv),  //
+                                 decltype(glGetProgramiv)>::value);
+
+void mockGetActiveUniformBlockiv(GLuint program,
+                                 GLuint uniformBlockIndex,
+                                 GLenum pname,
+                                 GLint* params) {
+  CallMockMethod(&IMockGLESImpl::GetActiveUniformBlockiv, program,
+                 uniformBlockIndex, pname, params);
+}
+static_assert(CheckSameSignature<decltype(mockGetActiveUniformBlockiv),  //
+                                 decltype(glGetActiveUniformBlockiv)>::value);
+
+void mockGetActiveUniformBlockName(GLuint program,
+                                   GLuint uniformBlockIndex,
+                                   GLsizei bufSize,
+                                   GLsizei* length,
+                                   GLchar* uniformBlockName) {
+  CallMockMethod(&IMockGLESImpl::GetActiveUniformBlockName, program,
+                 uniformBlockIndex, bufSize, length, uniformBlockName);
+}
+static_assert(CheckSameSignature<decltype(mockGetActiveUniformBlockName),  //
+                                 decltype(glGetActiveUniformBlockName)>::value);
+
+GLuint mockGetUniformBlockIndex(GLuint program,
+                                const GLchar* uniformBlockName) {
+  return CallMockMethod(&IMockGLESImpl::GetUniformBlockIndex, program,
+                        uniformBlockName);
+}
+static_assert(CheckSameSignature<decltype(mockGetUniformBlockIndex),  //
+                                 decltype(glGetUniformBlockIndex)>::value);
+
 GLboolean mockIsTexture(GLuint texture) {
   return CallMockMethod(&IMockGLESImpl::IsTexture, texture);
 }
@@ -537,6 +583,16 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockDrawElementsInstanced);
   } else if (strcmp(name, "glVertexAttribDivisor") == 0) {
     return reinterpret_cast<void*>(mockVertexAttribDivisor);
+  } else if (strcmp(name, "glBindBufferRange") == 0) {
+    return reinterpret_cast<void*>(mockBindBufferRange);
+  } else if (strcmp(name, "glGetProgramiv") == 0) {
+    return reinterpret_cast<void*>(mockGetProgramiv);
+  } else if (strcmp(name, "glGetActiveUniformBlockiv") == 0) {
+    return reinterpret_cast<void*>(mockGetActiveUniformBlockiv);
+  } else if (strcmp(name, "glGetActiveUniformBlockName") == 0) {
+    return reinterpret_cast<void*>(mockGetActiveUniformBlockName);
+  } else if (strcmp(name, "glGetUniformBlockIndex") == 0) {
+    return reinterpret_cast<void*>(mockGetUniformBlockIndex);
   } else {
     return reinterpret_cast<void*>(&doNothing);
   }

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -125,6 +125,25 @@ class IMockGLESImpl {
                                      const void* indices,
                                      GLsizei instancecount) {}
   virtual void VertexAttribDivisor(GLuint index, GLuint divisor) {}
+  virtual void BindBufferRange(GLenum target,
+                               GLuint index,
+                               GLuint buffer,
+                               GLintptr offset,
+                               GLsizeiptr size) {}
+  virtual void GetProgramiv(GLuint program, GLenum pname, GLint* params) {}
+  virtual void GetActiveUniformBlockiv(GLuint program,
+                                       GLuint uniformBlockIndex,
+                                       GLenum pname,
+                                       GLint* params) {}
+  virtual void GetActiveUniformBlockName(GLuint program,
+                                         GLuint uniformBlockIndex,
+                                         GLsizei bufSize,
+                                         GLsizei* length,
+                                         GLchar* uniformBlockName) {}
+  virtual GLuint GetUniformBlockIndex(GLuint program,
+                                      const GLchar* uniformBlockName) {
+    return 0;
+  }
 };
 
 class MockGLESImpl : public IMockGLESImpl {
@@ -298,6 +317,35 @@ class MockGLESImpl : public IMockGLESImpl {
   MOCK_METHOD(void,
               VertexAttribDivisor,
               (GLuint index, GLuint divisor),
+              (override));
+  MOCK_METHOD(void,
+              BindBufferRange,
+              (GLenum target,
+               GLuint index,
+               GLuint buffer,
+               GLintptr offset,
+               GLsizeiptr size),
+              (override));
+  MOCK_METHOD(void,
+              GetProgramiv,
+              (GLuint program, GLenum pname, GLint* params),
+              (override));
+  MOCK_METHOD(
+      void,
+      GetActiveUniformBlockiv,
+      (GLuint program, GLuint uniformBlockIndex, GLenum pname, GLint* params),
+      (override));
+  MOCK_METHOD(void,
+              GetActiveUniformBlockName,
+              (GLuint program,
+               GLuint uniformBlockIndex,
+               GLsizei bufSize,
+               GLsizei* length,
+               GLchar* uniformBlockName),
+              (override));
+  MOCK_METHOD(GLuint,
+              GetUniformBlockIndex,
+              (GLuint program, const GLchar* uniformBlockName),
               (override));
 };
 


### PR DESCRIPTION
issue https://github.com/flutter/flutter/issues/187212

This clamps the minimum bound size of a UBO to GL_UNIFORM_BLOCK_DATA_SIZE.  This was causing a crash in firefox's webgl2 implementation.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
