### PR TITLE
[iOS] Populate display corner radii on iOS 26

### DIFF
--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -2790,7 +2790,7 @@ enum DisplayFeatureState {
 ///
 /// If a corner is square (not rounded), the radius is 0.0.
 ///
-/// This is currently populated only on Android API 31+.
+/// This is populated on Android API 31+ and iOS 26+.
 class DisplayCornerRadii {
   /// Creates a [DisplayCornerRadii].
   const DisplayCornerRadii({

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -2086,8 +2086,8 @@ class _ViewConfiguration {
 
   /// The radii of the display corners in physical pixels.
   ///
-  /// This is currently populated only on Android API 31+. On earlier Android
-  /// versions, iOS, and other platforms, this value is `null`.
+  /// This is populated on Android API 31+ and iOS 26+. On earlier Android and
+  /// iOS versions, and on other platforms, this value is `null`.
   final DisplayCornerRadii? displayCornerRadii;
 
   @override

--- a/engine/src/flutter/lib/ui/window.dart
+++ b/engine/src/flutter/lib/ui/window.dart
@@ -338,8 +338,8 @@ class FlutterView {
 
   /// The radii of the display corners in physical pixels.
   ///
-  /// This is currently populated only on Android API 31+. On earlier Android
-  /// versions, iOS, and other platforms, this value is `null`.
+  /// This is populated on Android API 31+ and iOS 26+. On earlier Android and
+  /// iOS versions, and on other platforms, this value is `null`.
   DisplayCornerRadii? get displayCornerRadii => _viewConfiguration.displayCornerRadii;
 
   /// Updates the view's rendering on the GPU with the newly provided [Scene].

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -76,6 +76,7 @@ typedef struct MouseState {
 // set up a shell along with its platform view before the view has to appear.
 @property(nonatomic, strong) FlutterView* flutterView;
 @property(nonatomic, strong) void (^flutterViewRenderedCallback)(void);
+@property(nonatomic, strong) UIView* displayCornerRadiusProbe API_AVAILABLE(ios(26.0));
 
 @property(nonatomic, strong) FlutterSplashScreenManager* splashScreenManager;
 
@@ -951,6 +952,9 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
 
   [self.keyboardInsetManager invalidate];
   [self invalidateTouchRateCorrectionVSyncClient];
+  if (@available(iOS 26.0, *)) {
+    [_displayCornerRadiusProbe removeFromSuperview];
+  }
 
   // TODO(cbracken): https://github.com/flutter/flutter/issues/156222
   // Ensure all delegates are weak and remove this.
@@ -1390,6 +1394,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [self setViewportMetricsSize];
   [self checkAndUpdateAutoResizeConstraints];
   [self setViewportMetricsPaddings];
+  [self setViewportMetricsDisplayCornerRadii];
   [self updateViewportMetricsIfNeeded];
 
   // There is no guarantee that UIKit will layout subviews when the application/scene is active.
@@ -1415,6 +1420,13 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
                        }
                      }];
   }
+}
+
+- (void)updateProperties API_AVAILABLE(ios(26.0)) {
+  [super updateProperties];
+  // UIKit invalidates controller properties when an effective radius queried here changes.
+  [self setViewportMetricsDisplayCornerRadii];
+  [self updateViewportMetricsIfNeeded];
 }
 
 - (BOOL)isAutoResizable {
@@ -1537,6 +1549,50 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   _viewportMetrics.physical_padding_left = self.view.safeAreaInsets.left * scale;
   _viewportMetrics.physical_padding_right = self.view.safeAreaInsets.right * scale;
   _viewportMetrics.physical_padding_bottom = self.view.safeAreaInsets.bottom * scale;
+}
+
+// Set _viewportMetrics physical display corner radii.
+- (void)setViewportMetricsDisplayCornerRadii {
+  _viewportMetrics.physical_display_corner_radius_top_left = -1.0;
+  _viewportMetrics.physical_display_corner_radius_top_right = -1.0;
+  _viewportMetrics.physical_display_corner_radius_bottom_right = -1.0;
+  _viewportMetrics.physical_display_corner_radius_bottom_left = -1.0;
+
+  if (@available(iOS 26.0, *)) {
+    UIWindow* window = self.viewIfLoaded.window;
+    UIScreen* screen = self.flutterScreenIfViewLoaded;
+    if (!window || !screen) {
+      [self.displayCornerRadiusProbe removeFromSuperview];
+      self.displayCornerRadiusProbe = nil;
+      return;
+    }
+
+    if (self.displayCornerRadiusProbe.superview != window) {
+      [self.displayCornerRadiusProbe removeFromSuperview];
+      self.displayCornerRadiusProbe = [[UIView alloc] initWithFrame:window.bounds];
+      self.displayCornerRadiusProbe.userInteractionEnabled = NO;
+      self.displayCornerRadiusProbe.isAccessibilityElement = NO;
+      self.displayCornerRadiusProbe.accessibilityElementsHidden = YES;
+      self.displayCornerRadiusProbe.cornerConfiguration = [UICornerConfiguration
+          configurationWithRadius:[UICornerRadius containerConcentricRadius]];
+      // Keep the transparent probe behind application content so UIKit can resolve its corners
+      // against the window without changing the Flutter view's rendering.
+      [window insertSubview:self.displayCornerRadiusProbe atIndex:0];
+    }
+
+    self.displayCornerRadiusProbe.frame = window.bounds;
+    [self.displayCornerRadiusProbe layoutIfNeeded];
+
+    CGFloat scale = screen.scale;
+    _viewportMetrics.physical_display_corner_radius_top_left =
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerTopLeft] * scale;
+    _viewportMetrics.physical_display_corner_radius_top_right =
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerTopRight] * scale;
+    _viewportMetrics.physical_display_corner_radius_bottom_right =
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerBottomRight] * scale;
+    _viewportMetrics.physical_display_corner_radius_bottom_left =
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerBottomLeft] * scale;
+  }
 }
 
 #pragma mark - Keyboard events

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -40,6 +40,60 @@
 
 FLUTTER_ASSERT_ARC
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 260000
+// Flutter's engine is built with an older pinned iOS SDK. Declare this iOS 26 override point so
+// the superclass call can compile without requiring the iOS 26 SDK at build time.
+@interface UIViewController (FlutterUpdatePropertiesCompatibility)
+- (void)updateProperties;
+@end
+#endif
+
+typedef id (*FlutterNoArgumentObjectMessage)(id, SEL);
+typedef id (*FlutterOneArgumentObjectMessage)(id, SEL, id);
+typedef void (*FlutterSetObjectMessage)(id, SEL, id);
+typedef CGFloat (*FlutterEffectiveRadiusMessage)(id, SEL, UIRectCorner);
+
+static id CreateDisplayCornerConfiguration() API_AVAILABLE(ios(26.0)) {
+  Class cornerRadiusClass = NSClassFromString(@"UICornerRadius");
+  Class cornerConfigurationClass = NSClassFromString(@"UICornerConfiguration");
+  SEL containerConcentricRadiusSelector = NSSelectorFromString(@"containerConcentricRadius");
+  SEL configurationWithRadiusSelector = NSSelectorFromString(@"configurationWithRadius:");
+  if (![cornerRadiusClass respondsToSelector:containerConcentricRadiusSelector] ||
+      ![cornerConfigurationClass respondsToSelector:configurationWithRadiusSelector]) {
+    return nil;
+  }
+
+  FlutterNoArgumentObjectMessage createRadius = reinterpret_cast<FlutterNoArgumentObjectMessage>(
+      [cornerRadiusClass methodForSelector:containerConcentricRadiusSelector]);
+  id radius = createRadius(cornerRadiusClass, containerConcentricRadiusSelector);
+  FlutterOneArgumentObjectMessage createConfiguration =
+      reinterpret_cast<FlutterOneArgumentObjectMessage>(
+          [cornerConfigurationClass methodForSelector:configurationWithRadiusSelector]);
+  return createConfiguration(cornerConfigurationClass, configurationWithRadiusSelector, radius);
+}
+
+static BOOL SetDisplayCornerConfiguration(UIView* view, id configuration) API_AVAILABLE(ios(26.0)) {
+  SEL selector = NSSelectorFromString(@"setCornerConfiguration:");
+  if (![view respondsToSelector:selector]) {
+    return NO;
+  }
+  FlutterSetObjectMessage setConfiguration =
+      reinterpret_cast<FlutterSetObjectMessage>([view methodForSelector:selector]);
+  setConfiguration(view, selector, configuration);
+  return YES;
+}
+
+static CGFloat GetEffectiveDisplayCornerRadius(UIView* view, UIRectCorner corner)
+    API_AVAILABLE(ios(26.0)) {
+  SEL selector = NSSelectorFromString(@"effectiveRadiusForCorner:");
+  if (![view respondsToSelector:selector]) {
+    return 0.0;
+  }
+  FlutterEffectiveRadiusMessage getEffectiveRadius =
+      reinterpret_cast<FlutterEffectiveRadiusMessage>([view methodForSelector:selector]);
+  return getEffectiveRadius(view, selector, corner);
+}
+
 static constexpr int kMicrosecondsPerSecond = 1000 * 1000;
 static constexpr CGFloat kScrollViewContentSize = 2.0;
 
@@ -1554,12 +1608,16 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
     if (self.displayCornerRadiusProbe.superview != window) {
       [self.displayCornerRadiusProbe removeFromSuperview];
-      self.displayCornerRadiusProbe = [[UIView alloc] initWithFrame:window.bounds];
-      self.displayCornerRadiusProbe.userInteractionEnabled = NO;
-      self.displayCornerRadiusProbe.isAccessibilityElement = NO;
-      self.displayCornerRadiusProbe.accessibilityElementsHidden = YES;
-      self.displayCornerRadiusProbe.cornerConfiguration = [UICornerConfiguration
-          configurationWithRadius:[UICornerRadius containerConcentricRadius]];
+      UIView* probe = [[UIView alloc] initWithFrame:window.bounds];
+      probe.userInteractionEnabled = NO;
+      probe.isAccessibilityElement = NO;
+      probe.accessibilityElementsHidden = YES;
+      id configuration = CreateDisplayCornerConfiguration();
+      if (!configuration || !SetDisplayCornerConfiguration(probe, configuration)) {
+        self.displayCornerRadiusProbe = nil;
+        return;
+      }
+      self.displayCornerRadiusProbe = probe;
       // Keep the transparent probe behind application content so UIKit can resolve its corners
       // against the window without changing the Flutter view's rendering.
       [window insertSubview:self.displayCornerRadiusProbe atIndex:0];
@@ -1570,13 +1628,16 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
     CGFloat scale = screen.scale;
     _viewportMetrics.physical_display_corner_radius_top_left =
-        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerTopLeft] * scale;
+        GetEffectiveDisplayCornerRadius(self.displayCornerRadiusProbe, UIRectCornerTopLeft) * scale;
     _viewportMetrics.physical_display_corner_radius_top_right =
-        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerTopRight] * scale;
+        GetEffectiveDisplayCornerRadius(self.displayCornerRadiusProbe, UIRectCornerTopRight) *
+        scale;
     _viewportMetrics.physical_display_corner_radius_bottom_right =
-        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerBottomRight] * scale;
+        GetEffectiveDisplayCornerRadius(self.displayCornerRadiusProbe, UIRectCornerBottomRight) *
+        scale;
     _viewportMetrics.physical_display_corner_radius_bottom_left =
-        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerBottomLeft] * scale;
+        GetEffectiveDisplayCornerRadius(self.displayCornerRadiusProbe, UIRectCornerBottomLeft) *
+        scale;
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -77,6 +77,9 @@ typedef struct MouseState {
 @property(nonatomic, strong) FlutterView* flutterView;
 @property(nonatomic, strong) void (^flutterViewRenderedCallback)(void);
 @property(nonatomic, strong) UIView* displayCornerRadiusProbe API_AVAILABLE(ios(26.0));
+@property(nonatomic, assign) BOOL displayCornerRadiusProbeActive;
+- (void)configureDisplayCornerRadiusProbe API_AVAILABLE(ios(26.0));
+- (void)removeDisplayCornerRadiusProbe API_AVAILABLE(ios(26.0));
 
 @property(nonatomic, strong) FlutterSplashScreenManager* splashScreenManager;
 
@@ -837,6 +840,48 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
   [super viewWillAppear:animated];
 }
 
+- (void)viewIsAppearing:(BOOL)animated {
+  TRACE_EVENT0("flutter", "viewIsAppearing");
+  [super viewIsAppearing:animated];
+
+  if (@available(iOS 26.0, *)) {
+    self.displayCornerRadiusProbeActive = YES;
+    [self configureDisplayCornerRadiusProbe];
+    [self setNeedsUpdateProperties];
+  }
+}
+
+- (void)configureDisplayCornerRadiusProbe API_AVAILABLE(ios(26.0)) {
+  UIWindow* window = self.viewIfLoaded.window;
+  if (!self.displayCornerRadiusProbeActive || !window) {
+    [self removeDisplayCornerRadiusProbe];
+    return;
+  }
+  if (self.displayCornerRadiusProbe.superview == window) {
+    return;
+  }
+
+  [self removeDisplayCornerRadiusProbe];
+  self.displayCornerRadiusProbe = [[UIView alloc] initWithFrame:window.bounds];
+  self.displayCornerRadiusProbe.autoresizingMask =
+      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  self.displayCornerRadiusProbe.backgroundColor = UIColor.clearColor;
+  self.displayCornerRadiusProbe.opaque = NO;
+  self.displayCornerRadiusProbe.userInteractionEnabled = NO;
+  self.displayCornerRadiusProbe.isAccessibilityElement = NO;
+  self.displayCornerRadiusProbe.accessibilityElementsHidden = YES;
+  self.displayCornerRadiusProbe.cornerConfiguration =
+      [UICornerConfiguration configurationWithRadius:[UICornerRadius containerConcentricRadius]];
+  // Keep the transparent probe behind application content so UIKit can resolve its corners
+  // without changing the Flutter view's rendering.
+  [window insertSubview:self.displayCornerRadiusProbe atIndex:0];
+}
+
+- (void)removeDisplayCornerRadiusProbe API_AVAILABLE(ios(26.0)) {
+  [self.displayCornerRadiusProbe removeFromSuperview];
+  self.displayCornerRadiusProbe = nil;
+}
+
 - (void)viewDidAppear:(BOOL)animated {
   TRACE_EVENT0("flutter", "viewDidAppear");
   if (self.engine.viewController == self) {
@@ -866,6 +911,13 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
     [self.engine.lifecycleChannel sendMessage:@"AppLifecycleState.paused"];
     [self flushOngoingTouches];
     [self.engine notifyLowMemory];
+  }
+
+  if (@available(iOS 26.0, *)) {
+    self.displayCornerRadiusProbeActive = NO;
+    [self removeDisplayCornerRadiusProbe];
+    [self setViewportMetricsDisplayCornerRadii];
+    [self updateViewportMetricsIfNeeded];
   }
 
   [super viewDidDisappear:animated];
@@ -1394,6 +1446,15 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [self setViewportMetricsSize];
   [self checkAndUpdateAutoResizeConstraints];
   [self setViewportMetricsPaddings];
+  if (@available(iOS 26.0, *)) {
+    // A view can move directly between windows without another appearance transition. Schedule
+    // probe reconfiguration in the pre-layout property-update phase rather than mutating the view
+    // hierarchy while layout is in progress.
+    if (self.displayCornerRadiusProbeActive &&
+        self.displayCornerRadiusProbe.superview != self.viewIfLoaded.window) {
+      [self setNeedsUpdateProperties];
+    }
+  }
   [self setViewportMetricsDisplayCornerRadii];
   [self updateViewportMetricsIfNeeded];
 
@@ -1409,6 +1470,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
 - (void)updateProperties API_AVAILABLE(ios(26.0)) {
   [super updateProperties];
+  [self configureDisplayCornerRadiusProbe];
   // UIKit invalidates controller properties when an effective radius queried here changes.
   [self setViewportMetricsDisplayCornerRadii];
   [self updateViewportMetricsIfNeeded];
@@ -1546,27 +1608,9 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   if (@available(iOS 26.0, *)) {
     UIWindow* window = self.viewIfLoaded.window;
     UIScreen* screen = self.flutterScreenIfViewLoaded;
-    if (!window || !screen) {
-      [self.displayCornerRadiusProbe removeFromSuperview];
-      self.displayCornerRadiusProbe = nil;
+    if (!window || !screen || self.displayCornerRadiusProbe.superview != window) {
       return;
     }
-
-    if (self.displayCornerRadiusProbe.superview != window) {
-      [self.displayCornerRadiusProbe removeFromSuperview];
-      self.displayCornerRadiusProbe = [[UIView alloc] initWithFrame:window.bounds];
-      self.displayCornerRadiusProbe.userInteractionEnabled = NO;
-      self.displayCornerRadiusProbe.isAccessibilityElement = NO;
-      self.displayCornerRadiusProbe.accessibilityElementsHidden = YES;
-      self.displayCornerRadiusProbe.cornerConfiguration = [UICornerConfiguration
-          configurationWithRadius:[UICornerRadius containerConcentricRadius]];
-      // Keep the transparent probe behind application content so UIKit can resolve its corners
-      // against the window without changing the Flutter view's rendering.
-      [window insertSubview:self.displayCornerRadiusProbe atIndex:0];
-    }
-
-    self.displayCornerRadiusProbe.frame = window.bounds;
-    [self.displayCornerRadiusProbe layoutIfNeeded];
 
     CGFloat scale = screen.scale;
     _viewportMetrics.physical_display_corner_radius_top_left =

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -40,60 +40,6 @@
 
 FLUTTER_ASSERT_ARC
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 260000
-// Flutter's engine is built with an older pinned iOS SDK. Declare this iOS 26 override point so
-// the superclass call can compile without requiring the iOS 26 SDK at build time.
-@interface UIViewController (FlutterUpdatePropertiesCompatibility)
-- (void)updateProperties;
-@end
-#endif
-
-typedef id (*FlutterNoArgumentObjectMessage)(id, SEL);
-typedef id (*FlutterOneArgumentObjectMessage)(id, SEL, id);
-typedef void (*FlutterSetObjectMessage)(id, SEL, id);
-typedef CGFloat (*FlutterEffectiveRadiusMessage)(id, SEL, UIRectCorner);
-
-static id CreateDisplayCornerConfiguration() API_AVAILABLE(ios(26.0)) {
-  Class cornerRadiusClass = NSClassFromString(@"UICornerRadius");
-  Class cornerConfigurationClass = NSClassFromString(@"UICornerConfiguration");
-  SEL containerConcentricRadiusSelector = NSSelectorFromString(@"containerConcentricRadius");
-  SEL configurationWithRadiusSelector = NSSelectorFromString(@"configurationWithRadius:");
-  if (![cornerRadiusClass respondsToSelector:containerConcentricRadiusSelector] ||
-      ![cornerConfigurationClass respondsToSelector:configurationWithRadiusSelector]) {
-    return nil;
-  }
-
-  FlutterNoArgumentObjectMessage createRadius = reinterpret_cast<FlutterNoArgumentObjectMessage>(
-      [cornerRadiusClass methodForSelector:containerConcentricRadiusSelector]);
-  id radius = createRadius(cornerRadiusClass, containerConcentricRadiusSelector);
-  FlutterOneArgumentObjectMessage createConfiguration =
-      reinterpret_cast<FlutterOneArgumentObjectMessage>(
-          [cornerConfigurationClass methodForSelector:configurationWithRadiusSelector]);
-  return createConfiguration(cornerConfigurationClass, configurationWithRadiusSelector, radius);
-}
-
-static BOOL SetDisplayCornerConfiguration(UIView* view, id configuration) API_AVAILABLE(ios(26.0)) {
-  SEL selector = NSSelectorFromString(@"setCornerConfiguration:");
-  if (![view respondsToSelector:selector]) {
-    return NO;
-  }
-  FlutterSetObjectMessage setConfiguration =
-      reinterpret_cast<FlutterSetObjectMessage>([view methodForSelector:selector]);
-  setConfiguration(view, selector, configuration);
-  return YES;
-}
-
-static CGFloat GetEffectiveDisplayCornerRadius(UIView* view, UIRectCorner corner)
-    API_AVAILABLE(ios(26.0)) {
-  SEL selector = NSSelectorFromString(@"effectiveRadiusForCorner:");
-  if (![view respondsToSelector:selector]) {
-    return 0.0;
-  }
-  FlutterEffectiveRadiusMessage getEffectiveRadius =
-      reinterpret_cast<FlutterEffectiveRadiusMessage>([view methodForSelector:selector]);
-  return getEffectiveRadius(view, selector, corner);
-}
-
 static constexpr int kMicrosecondsPerSecond = 1000 * 1000;
 static constexpr CGFloat kScrollViewContentSize = 2.0;
 
@@ -1608,16 +1554,12 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
     if (self.displayCornerRadiusProbe.superview != window) {
       [self.displayCornerRadiusProbe removeFromSuperview];
-      UIView* probe = [[UIView alloc] initWithFrame:window.bounds];
-      probe.userInteractionEnabled = NO;
-      probe.isAccessibilityElement = NO;
-      probe.accessibilityElementsHidden = YES;
-      id configuration = CreateDisplayCornerConfiguration();
-      if (!configuration || !SetDisplayCornerConfiguration(probe, configuration)) {
-        self.displayCornerRadiusProbe = nil;
-        return;
-      }
-      self.displayCornerRadiusProbe = probe;
+      self.displayCornerRadiusProbe = [[UIView alloc] initWithFrame:window.bounds];
+      self.displayCornerRadiusProbe.userInteractionEnabled = NO;
+      self.displayCornerRadiusProbe.isAccessibilityElement = NO;
+      self.displayCornerRadiusProbe.accessibilityElementsHidden = YES;
+      self.displayCornerRadiusProbe.cornerConfiguration = [UICornerConfiguration
+          configurationWithRadius:[UICornerRadius containerConcentricRadius]];
       // Keep the transparent probe behind application content so UIKit can resolve its corners
       // against the window without changing the Flutter view's rendering.
       [window insertSubview:self.displayCornerRadiusProbe atIndex:0];
@@ -1628,16 +1570,13 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
     CGFloat scale = screen.scale;
     _viewportMetrics.physical_display_corner_radius_top_left =
-        GetEffectiveDisplayCornerRadius(self.displayCornerRadiusProbe, UIRectCornerTopLeft) * scale;
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerTopLeft] * scale;
     _viewportMetrics.physical_display_corner_radius_top_right =
-        GetEffectiveDisplayCornerRadius(self.displayCornerRadiusProbe, UIRectCornerTopRight) *
-        scale;
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerTopRight] * scale;
     _viewportMetrics.physical_display_corner_radius_bottom_right =
-        GetEffectiveDisplayCornerRadius(self.displayCornerRadiusProbe, UIRectCornerBottomRight) *
-        scale;
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerBottomRight] * scale;
     _viewportMetrics.physical_display_corner_radius_bottom_left =
-        GetEffectiveDisplayCornerRadius(self.displayCornerRadiusProbe, UIRectCornerBottomLeft) *
-        scale;
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerBottomLeft] * scale;
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -76,6 +76,7 @@ typedef struct MouseState {
 // set up a shell along with its platform view before the view has to appear.
 @property(nonatomic, strong) FlutterView* flutterView;
 @property(nonatomic, strong) void (^flutterViewRenderedCallback)(void);
+@property(nonatomic, strong) UIView* displayCornerRadiusProbe API_AVAILABLE(ios(26.0));
 
 @property(nonatomic, strong) FlutterSplashScreenManager* splashScreenManager;
 
@@ -951,6 +952,9 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
 
   [self.keyboardInsetManager invalidate];
   [self invalidateTouchRateCorrectionVSyncClient];
+  if (@available(iOS 26.0, *)) {
+    [_displayCornerRadiusProbe removeFromSuperview];
+  }
 
   // TODO(cbracken): https://github.com/flutter/flutter/issues/156222
   // Ensure all delegates are weak and remove this.
@@ -1390,6 +1394,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [self setViewportMetricsSize];
   [self checkAndUpdateAutoResizeConstraints];
   [self setViewportMetricsPaddings];
+  [self setViewportMetricsDisplayCornerRadii];
   [self updateViewportMetricsIfNeeded];
 
   // There is no guarantee that UIKit will layout subviews when the application/scene is active.
@@ -1400,6 +1405,13 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   if (firstViewBoundsUpdate && self.stateIsActive && self.engine) {
     [self surfaceUpdated:YES];
   }
+}
+
+- (void)updateProperties API_AVAILABLE(ios(26.0)) {
+  [super updateProperties];
+  // UIKit invalidates controller properties when an effective radius queried here changes.
+  [self setViewportMetricsDisplayCornerRadii];
+  [self updateViewportMetricsIfNeeded];
 }
 
 - (BOOL)isAutoResizable {
@@ -1522,6 +1534,50 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   _viewportMetrics.physical_padding_left = self.view.safeAreaInsets.left * scale;
   _viewportMetrics.physical_padding_right = self.view.safeAreaInsets.right * scale;
   _viewportMetrics.physical_padding_bottom = self.view.safeAreaInsets.bottom * scale;
+}
+
+// Set _viewportMetrics physical display corner radii.
+- (void)setViewportMetricsDisplayCornerRadii {
+  _viewportMetrics.physical_display_corner_radius_top_left = -1.0;
+  _viewportMetrics.physical_display_corner_radius_top_right = -1.0;
+  _viewportMetrics.physical_display_corner_radius_bottom_right = -1.0;
+  _viewportMetrics.physical_display_corner_radius_bottom_left = -1.0;
+
+  if (@available(iOS 26.0, *)) {
+    UIWindow* window = self.viewIfLoaded.window;
+    UIScreen* screen = self.flutterScreenIfViewLoaded;
+    if (!window || !screen) {
+      [self.displayCornerRadiusProbe removeFromSuperview];
+      self.displayCornerRadiusProbe = nil;
+      return;
+    }
+
+    if (self.displayCornerRadiusProbe.superview != window) {
+      [self.displayCornerRadiusProbe removeFromSuperview];
+      self.displayCornerRadiusProbe = [[UIView alloc] initWithFrame:window.bounds];
+      self.displayCornerRadiusProbe.userInteractionEnabled = NO;
+      self.displayCornerRadiusProbe.isAccessibilityElement = NO;
+      self.displayCornerRadiusProbe.accessibilityElementsHidden = YES;
+      self.displayCornerRadiusProbe.cornerConfiguration = [UICornerConfiguration
+          configurationWithRadius:[UICornerRadius containerConcentricRadius]];
+      // Keep the transparent probe behind application content so UIKit can resolve its corners
+      // against the window without changing the Flutter view's rendering.
+      [window insertSubview:self.displayCornerRadiusProbe atIndex:0];
+    }
+
+    self.displayCornerRadiusProbe.frame = window.bounds;
+    [self.displayCornerRadiusProbe layoutIfNeeded];
+
+    CGFloat scale = screen.scale;
+    _viewportMetrics.physical_display_corner_radius_top_left =
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerTopLeft] * scale;
+    _viewportMetrics.physical_display_corner_radius_top_right =
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerTopRight] * scale;
+    _viewportMetrics.physical_display_corner_radius_bottom_right =
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerBottomRight] * scale;
+    _viewportMetrics.physical_display_corner_radius_bottom_left =
+        [self.displayCornerRadiusProbe effectiveRadiusForCorner:UIRectCornerBottomLeft] * scale;
+  }
 }
 
 #pragma mark - Keyboard events

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -203,7 +203,9 @@ typedef void (^FlutterKeyboardAnimationCallback)(NSTimeInterval targetTime);
 
 /// Sometimes we have to use a custom mock to avoid retain cycles in OCMock.
 /// Used for testing low memory notification.
-@interface FlutterEnginePartialMock : FlutterEngine
+@interface FlutterEnginePartialMock : FlutterEngine {
+  flutter::ViewportMetrics _lastViewportMetrics;
+}
 
 @property(nonatomic, strong) FlutterBasicMessageChannel* lifecycleChannel;
 @property(nonatomic, strong) FlutterBasicMessageChannel* keyEventChannel;
@@ -221,6 +223,7 @@ typedef void (^FlutterKeyboardAnimationCallback)(NSTimeInterval targetTime);
 - (nullable FlutterFMLTaskRunner*)uiTaskRunner;
 - (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint;
 - (void)attachView;
+- (const flutter::ViewportMetrics&)lastViewportMetrics;
 @end
 
 @implementation FlutterEnginePartialMock
@@ -254,6 +257,14 @@ typedef void (^FlutterKeyboardAnimationCallback)(NSTimeInterval targetTime);
 
 - (void)attachView {
   // Do nothing to avoid crash when platformView is nil on bots.
+}
+
+- (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics {
+  _lastViewportMetrics = viewportMetrics;
+}
+
+- (const flutter::ViewportMetrics&)lastViewportMetrics {
+  return _lastViewportMetrics;
 }
 
 - (void)sendKeyEvent:(const FlutterKeyEvent&)event
@@ -328,6 +339,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 @property(nonatomic, strong) FlutterVSyncClient* keyboardAnimationVSyncClient;
 @property(nonatomic, strong) FlutterVSyncClient* touchRateCorrectionVSyncClient;
 @property(nonatomic, assign) BOOL awokenFromNib;
+@property(nonatomic, strong) UIView* displayCornerRadiusProbe API_AVAILABLE(ios(26.0));
 
 - (void)createTouchRateCorrectionVSyncClientIfNeeded;
 - (void)surfaceUpdated:(BOOL)appeared;
@@ -336,6 +348,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
               nextAction:(void (^)())next API_AVAILABLE(ios(13.4));
 - (void)discreteScrollEvent:(UIPanGestureRecognizer*)recognizer;
 - (void)updateViewportMetricsIfNeeded;
+- (void)setViewportMetricsDisplayCornerRadii;
 - (void)updateAutoResizeConstraints;
 - (void)checkAndUpdateAutoResizeConstraints;
 - (void)onUserSettingsChanged:(NSNotification*)notification;
@@ -358,6 +371,33 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (void)sceneWillEnterForeground:(NSNotification*)notification API_AVAILABLE(ios(13.0));
 - (void)triggerTouchRateCorrectionIfNeeded:(NSSet*)touches;
 - (void)onAccessibilityStatusChanged:(NSNotification*)notification;
+@end
+
+API_AVAILABLE(ios(26.0))
+@interface TestDisplayCornerRadiusProbe : UIView
+@property(nonatomic, assign) CGFloat topLeftRadius;
+@property(nonatomic, assign) CGFloat topRightRadius;
+@property(nonatomic, assign) CGFloat bottomRightRadius;
+@property(nonatomic, assign) CGFloat bottomLeftRadius;
+@end
+
+@implementation TestDisplayCornerRadiusProbe
+
+- (CGFloat)effectiveRadiusForCorner:(UIRectCorner)corner {
+  switch (corner) {
+    case UIRectCornerTopLeft:
+      return self.topLeftRadius;
+    case UIRectCornerTopRight:
+      return self.topRightRadius;
+    case UIRectCornerBottomRight:
+      return self.bottomRightRadius;
+    case UIRectCornerBottomLeft:
+      return self.bottomLeftRadius;
+    default:
+      return 0.0;
+  }
+}
+
 @end
 
 @interface FlutterViewControllerTest : XCTestCase
@@ -1320,6 +1360,109 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   OCMExpect([mockEngine updateViewportMetrics:viewportMetrics]).ignoringNonObjectArgs();
   [viewController updateViewportMetricsIfNeeded];
   OCMVerifyAll(mockEngine);
+}
+
+- (void)testUpdatePropertiesSetsDisplayCornerRadiiInPhysicalPixelsOnIOS26 {
+  if (@available(iOS 26.0, *)) {
+    FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+    FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                  nibName:nil
+                                                                                   bundle:nil];
+    engine.viewController = viewController;
+
+    CGRect frame = CGRectMake(0, 0, 390, 844);
+    UIWindow* window = [[UIWindow alloc] initWithFrame:frame];
+    UIView* view = [[UIView alloc] initWithFrame:frame];
+    viewController.view = view;
+    [window addSubview:view];
+
+    UIScreen* screen = OCMClassMock([UIScreen class]);
+    OCMStub([screen scale]).andReturn(3.0);
+    FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
+    OCMStub([viewControllerMock flutterScreenIfViewLoaded]).andReturn(screen);
+
+    TestDisplayCornerRadiusProbe* probe =
+        [[TestDisplayCornerRadiusProbe alloc] initWithFrame:frame];
+    probe.topLeftRadius = 1.0;
+    probe.topRightRadius = 2.0;
+    probe.bottomRightRadius = 3.0;
+    probe.bottomLeftRadius = 4.0;
+    [window insertSubview:probe atIndex:0];
+    viewController.displayCornerRadiusProbe = probe;
+
+    [viewController updateProperties];
+
+    const flutter::ViewportMetrics& viewportMetrics = engine.lastViewportMetrics;
+    XCTAssertEqual(viewportMetrics.physical_display_corner_radius_top_left, 3.0);
+    XCTAssertEqual(viewportMetrics.physical_display_corner_radius_top_right, 6.0);
+    XCTAssertEqual(viewportMetrics.physical_display_corner_radius_bottom_right, 9.0);
+    XCTAssertEqual(viewportMetrics.physical_display_corner_radius_bottom_left, 12.0);
+  }
+}
+
+- (void)testCreatesNonRenderingDisplayCornerRadiusProbeOnIOS26 {
+  if (@available(iOS 26.0, *)) {
+    FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+    FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                  nibName:nil
+                                                                                   bundle:nil];
+    engine.viewController = viewController;
+
+    CGRect frame = UIScreen.mainScreen.bounds;
+    UIWindow* window = [[UIWindow alloc] initWithFrame:frame];
+    viewController.view = [[UIView alloc] initWithFrame:frame];
+    [window addSubview:viewController.view];
+
+    UIScreen* screen = OCMClassMock([UIScreen class]);
+    OCMStub([screen scale]).andReturn(3.0);
+    FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
+    OCMStub([viewControllerMock flutterScreenIfViewLoaded]).andReturn(screen);
+
+    [viewController setViewportMetricsDisplayCornerRadii];
+    [viewController updateViewportMetricsIfNeeded];
+
+    UIView* probe = viewController.displayCornerRadiusProbe;
+    XCTAssertEqual(probe.superview, window);
+    XCTAssertEqual(window.subviews.firstObject, probe);
+    XCTAssertTrue(CGRectEqualToRect(probe.frame, window.bounds));
+    XCTAssertFalse(probe.userInteractionEnabled);
+    XCTAssertFalse(probe.isAccessibilityElement);
+    XCTAssertTrue(probe.accessibilityElementsHidden);
+    XCTAssertNotNil(probe.cornerConfiguration);
+
+    const flutter::ViewportMetrics& viewportMetrics = engine.lastViewportMetrics;
+    XCTAssertGreaterThan(viewportMetrics.physical_display_corner_radius_top_left, 0.0);
+    XCTAssertGreaterThan(viewportMetrics.physical_display_corner_radius_top_right, 0.0);
+    XCTAssertGreaterThan(viewportMetrics.physical_display_corner_radius_bottom_right, 0.0);
+    XCTAssertGreaterThan(viewportMetrics.physical_display_corner_radius_bottom_left, 0.0);
+  }
+}
+
+- (void)testUnsetsDisplayCornerRadiiWhenViewIsDetachedFromWindow {
+  if (@available(iOS 26.0, *)) {
+    FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+    FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                  nibName:nil
+                                                                                   bundle:nil];
+    engine.viewController = viewController;
+    viewController.view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 390, 844)];
+
+    TestDisplayCornerRadiusProbe* probe = [[TestDisplayCornerRadiusProbe alloc] init];
+    UIWindow* probeWindow = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 390, 844)];
+    [probeWindow addSubview:probe];
+    viewController.displayCornerRadiusProbe = probe;
+
+    [viewController setViewportMetricsDisplayCornerRadii];
+    [viewController updateViewportMetricsIfNeeded];
+
+    const flutter::ViewportMetrics& viewportMetrics = engine.lastViewportMetrics;
+    XCTAssertEqual(viewportMetrics.physical_display_corner_radius_top_left, -1.0);
+    XCTAssertEqual(viewportMetrics.physical_display_corner_radius_top_right, -1.0);
+    XCTAssertEqual(viewportMetrics.physical_display_corner_radius_bottom_right, -1.0);
+    XCTAssertEqual(viewportMetrics.physical_display_corner_radius_bottom_left, -1.0);
+    XCTAssertNil(viewController.displayCornerRadiusProbe);
+    XCTAssertNil(probe.superview);
+  }
 }
 
 - (void)testUpdatedViewportMetricsDoesResizeFlutterViewWhenAutoResizable {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -203,9 +203,7 @@ typedef void (^FlutterKeyboardAnimationCallback)(NSTimeInterval targetTime);
 
 /// Sometimes we have to use a custom mock to avoid retain cycles in OCMock.
 /// Used for testing low memory notification.
-@interface FlutterEnginePartialMock : FlutterEngine {
-  flutter::ViewportMetrics _lastViewportMetrics;
-}
+@interface FlutterEnginePartialMock : FlutterEngine
 
 @property(nonatomic, strong) FlutterBasicMessageChannel* lifecycleChannel;
 @property(nonatomic, strong) FlutterBasicMessageChannel* keyEventChannel;
@@ -223,7 +221,6 @@ typedef void (^FlutterKeyboardAnimationCallback)(NSTimeInterval targetTime);
 - (nullable FlutterFMLTaskRunner*)uiTaskRunner;
 - (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint;
 - (void)attachView;
-- (const flutter::ViewportMetrics&)lastViewportMetrics;
 @end
 
 @implementation FlutterEnginePartialMock
@@ -257,14 +254,6 @@ typedef void (^FlutterKeyboardAnimationCallback)(NSTimeInterval targetTime);
 
 - (void)attachView {
   // Do nothing to avoid crash when platformView is nil on bots.
-}
-
-- (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics {
-  _lastViewportMetrics = viewportMetrics;
-}
-
-- (const flutter::ViewportMetrics&)lastViewportMetrics {
-  return _lastViewportMetrics;
 }
 
 - (void)sendKeyEvent:(const FlutterKeyEvent&)event
@@ -324,6 +313,36 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
     NSMutableArray<id<FlutterKeyPrimaryResponder>>* primaryResponders;
 @end
 
+@interface ViewportMetricsCaptureEngine : FlutterEnginePartialMock {
+  flutter::ViewportMetrics _lastViewportMetrics;
+}
+@property(nonatomic, readonly) const flutter::ViewportMetrics& lastViewportMetrics;
+@property(nonatomic, assign) NSUInteger updateViewportMetricsCallCount;
+@end
+
+@implementation ViewportMetricsCaptureEngine
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    // These tests attach the controller's view to a UIWindow, which exercises engine methods that
+    // require a shell.
+    [self createShell:@"" libraryURI:@"" initialRoute:nil];
+  }
+  return self;
+}
+
+- (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics {
+  _lastViewportMetrics = viewportMetrics;
+  self.updateViewportMetricsCallCount += 1;
+}
+
+- (const flutter::ViewportMetrics&)lastViewportMetrics {
+  return _lastViewportMetrics;
+}
+
+@end
+
 @interface FlutterEmbedderKeyResponder (Tests)
 @property(nonatomic, copy, readonly) FlutterSendKeyEvent sendEvent;
 @end
@@ -348,7 +367,6 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
               nextAction:(void (^)())next API_AVAILABLE(ios(13.4));
 - (void)discreteScrollEvent:(UIPanGestureRecognizer*)recognizer;
 - (void)updateViewportMetricsIfNeeded;
-- (void)setViewportMetricsDisplayCornerRadii;
 - (void)updateAutoResizeConstraints;
 - (void)checkAndUpdateAutoResizeConstraints;
 - (void)onUserSettingsChanged:(NSNotification*)notification;
@@ -399,6 +417,47 @@ API_AVAILABLE(ios(26.0))
 }
 
 @end
+
+API_AVAILABLE(ios(26.0))
+@interface TestLayoutTrackingDisplayCornerRadiusProbe : TestDisplayCornerRadiusProbe
+@property(nonatomic, assign) NSUInteger layoutIfNeededCallCount;
+@property(nonatomic, assign) NSUInteger setFrameCallCount;
+@end
+
+@implementation TestLayoutTrackingDisplayCornerRadiusProbe
+
+- (void)layoutIfNeeded {
+  self.layoutIfNeededCallCount += 1;
+  [super layoutIfNeeded];
+}
+
+- (void)setFrame:(CGRect)frame {
+  self.setFrameCallCount += 1;
+  [super setFrame:frame];
+}
+
+@end
+
+static UIWindowScene* WindowSceneForTest() {
+  UIWindowScene* windowScene = nil;
+  for (UIScene* scene in UIApplication.sharedApplication.connectedScenes) {
+    if ([scene isKindOfClass:UIWindowScene.class]) {
+      windowScene = (UIWindowScene*)scene;
+      if (scene.activationState == UISceneActivationStateForegroundActive) {
+        break;
+      }
+    }
+  }
+  return windowScene;
+}
+
+static UIWindow* CreateWindowForTest(CGRect frame) {
+  UIWindowScene* windowScene = WindowSceneForTest();
+  UIWindow* window = windowScene ? [[UIWindow alloc] initWithWindowScene:windowScene]
+                                 : [[UIWindow alloc] initWithFrame:frame];
+  window.frame = frame;
+  return window;
+}
 
 @interface FlutterViewControllerTest : XCTestCase
 @property(nonatomic, strong) id mockEngine;
@@ -1364,104 +1423,208 @@ API_AVAILABLE(ios(26.0))
 
 - (void)testUpdatePropertiesSetsDisplayCornerRadiiInPhysicalPixelsOnIOS26 {
   if (@available(iOS 26.0, *)) {
-    FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+    ViewportMetricsCaptureEngine* engine = [[ViewportMetricsCaptureEngine alloc] init];
     FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                   nibName:nil
                                                                                    bundle:nil];
-    engine.viewController = viewController;
+    engine.viewController = nil;
 
-    CGRect frame = CGRectMake(0, 0, 390, 844);
-    UIWindow* window = [[UIWindow alloc] initWithFrame:frame];
+    UIWindowScene* windowScene = WindowSceneForTest();
+    CGRect frame = windowScene ? windowScene.screen.bounds : UIScreen.mainScreen.bounds;
+    UIWindow* window = CreateWindowForTest(frame);
     UIView* view = [[UIView alloc] initWithFrame:frame];
     viewController.view = view;
     [window addSubview:view];
+    [viewController viewIsAppearing:NO];
+    engine.viewController = viewController;
 
     UIScreen* screen = OCMClassMock([UIScreen class]);
     OCMStub([screen scale]).andReturn(3.0);
     FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
     OCMStub([viewControllerMock flutterScreenIfViewLoaded]).andReturn(screen);
 
-    TestDisplayCornerRadiusProbe* probe =
-        [[TestDisplayCornerRadiusProbe alloc] initWithFrame:frame];
+    TestLayoutTrackingDisplayCornerRadiusProbe* probe =
+        [[TestLayoutTrackingDisplayCornerRadiusProbe alloc] initWithFrame:frame];
     probe.topLeftRadius = 1.0;
     probe.topRightRadius = 2.0;
     probe.bottomRightRadius = 3.0;
     probe.bottomLeftRadius = 4.0;
+    [viewController.displayCornerRadiusProbe removeFromSuperview];
     [window insertSubview:probe atIndex:0];
     viewController.displayCornerRadiusProbe = probe;
+    probe.layoutIfNeededCallCount = 0;
+    probe.setFrameCallCount = 0;
 
-    [viewController updateProperties];
+    [viewController setNeedsUpdateProperties];
+    [viewController updatePropertiesIfNeeded];
 
     const flutter::ViewportMetrics& viewportMetrics = engine.lastViewportMetrics;
     XCTAssertEqual(viewportMetrics.physical_display_corner_radius_top_left, 3.0);
     XCTAssertEqual(viewportMetrics.physical_display_corner_radius_top_right, 6.0);
     XCTAssertEqual(viewportMetrics.physical_display_corner_radius_bottom_right, 9.0);
     XCTAssertEqual(viewportMetrics.physical_display_corner_radius_bottom_left, 12.0);
+    XCTAssertEqual(probe.layoutIfNeededCallCount, 0u);
+    XCTAssertEqual(probe.setFrameCallCount, 0u);
   }
 }
 
 - (void)testCreatesNonRenderingDisplayCornerRadiusProbeOnIOS26 {
   if (@available(iOS 26.0, *)) {
-    FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+    ViewportMetricsCaptureEngine* engine = [[ViewportMetricsCaptureEngine alloc] init];
     FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                   nibName:nil
                                                                                    bundle:nil];
-    engine.viewController = viewController;
+    engine.viewController = nil;
 
-    CGRect frame = UIScreen.mainScreen.bounds;
-    UIWindow* window = [[UIWindow alloc] initWithFrame:frame];
+    UIWindowScene* windowScene = WindowSceneForTest();
+    CGRect frame = windowScene ? windowScene.screen.bounds : UIScreen.mainScreen.bounds;
+    UIWindow* window = CreateWindowForTest(frame);
     viewController.view = [[UIView alloc] initWithFrame:frame];
     [window addSubview:viewController.view];
-
-    UIScreen* screen = OCMClassMock([UIScreen class]);
-    OCMStub([screen scale]).andReturn(3.0);
-    FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
-    OCMStub([viewControllerMock flutterScreenIfViewLoaded]).andReturn(screen);
-
-    [viewController setViewportMetricsDisplayCornerRadii];
-    [viewController updateViewportMetricsIfNeeded];
+    [viewController viewIsAppearing:NO];
 
     UIView* probe = viewController.displayCornerRadiusProbe;
     XCTAssertEqual(probe.superview, window);
     XCTAssertEqual(window.subviews.firstObject, probe);
     XCTAssertTrue(CGRectEqualToRect(probe.frame, window.bounds));
+    XCTAssertEqual(probe.autoresizingMask,
+                   UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+    XCTAssertEqualObjects(probe.backgroundColor, UIColor.clearColor);
+    XCTAssertFalse(probe.opaque);
     XCTAssertFalse(probe.userInteractionEnabled);
     XCTAssertFalse(probe.isAccessibilityElement);
     XCTAssertTrue(probe.accessibilityElementsHidden);
     XCTAssertNotNil(probe.cornerConfiguration);
+    XCTAssertGreaterThan([probe effectiveRadiusForCorner:UIRectCornerTopLeft], 0.0);
+    XCTAssertGreaterThan([probe effectiveRadiusForCorner:UIRectCornerTopRight], 0.0);
+    XCTAssertGreaterThan([probe effectiveRadiusForCorner:UIRectCornerBottomRight], 0.0);
+    XCTAssertGreaterThan([probe effectiveRadiusForCorner:UIRectCornerBottomLeft], 0.0);
 
-    const flutter::ViewportMetrics& viewportMetrics = engine.lastViewportMetrics;
-    XCTAssertGreaterThan(viewportMetrics.physical_display_corner_radius_top_left, 0.0);
-    XCTAssertGreaterThan(viewportMetrics.physical_display_corner_radius_top_right, 0.0);
-    XCTAssertGreaterThan(viewportMetrics.physical_display_corner_radius_bottom_right, 0.0);
-    XCTAssertGreaterThan(viewportMetrics.physical_display_corner_radius_bottom_left, 0.0);
+    CGRect resizedBounds = CGRectMake(0, 0, frame.size.height, frame.size.width);
+    window.bounds = resizedBounds;
+    [window layoutIfNeeded];
+    XCTAssertTrue(CGRectEqualToRect(probe.frame, resizedBounds));
   }
 }
 
-- (void)testUnsetsDisplayCornerRadiiWhenViewIsDetachedFromWindow {
+- (void)testViewDidDisappearRemovesProbeAndUnsetsDisplayCornerRadiiOnIOS26 {
   if (@available(iOS 26.0, *)) {
-    FlutterEnginePartialMock* engine = [[FlutterEnginePartialMock alloc] init];
+    ViewportMetricsCaptureEngine* engine = [[ViewportMetricsCaptureEngine alloc] init];
     FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                   nibName:nil
                                                                                    bundle:nil];
+    engine.viewController = nil;
+    CGRect frame = CGRectMake(0, 0, 390, 844);
+    UIWindow* window = CreateWindowForTest(frame);
+    viewController.view = [[UIView alloc] initWithFrame:frame];
+    [window addSubview:viewController.view];
+    [viewController viewIsAppearing:NO];
+    UIView* probe = viewController.displayCornerRadiusProbe;
+
+    TestDisplayCornerRadiusProbe* populatedProbe =
+        [[TestDisplayCornerRadiusProbe alloc] initWithFrame:window.bounds];
+    populatedProbe.topLeftRadius = 1.0;
+    populatedProbe.topRightRadius = 2.0;
+    populatedProbe.bottomRightRadius = 3.0;
+    populatedProbe.bottomLeftRadius = 4.0;
+    [probe removeFromSuperview];
+    [window insertSubview:populatedProbe atIndex:0];
+    viewController.displayCornerRadiusProbe = populatedProbe;
     engine.viewController = viewController;
-    viewController.view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 390, 844)];
+    [viewController setNeedsUpdateProperties];
+    [viewController updatePropertiesIfNeeded];
+    XCTAssertGreaterThan(engine.lastViewportMetrics.physical_display_corner_radius_top_left, 0.0);
+    NSUInteger updateCountBeforeDisappearance = engine.updateViewportMetricsCallCount;
+    viewController.keyboardInsetManager = [[FakeFlutterKeyboardInsetManager alloc]
+        initWithDelegate:(id<FlutterKeyboardInsetManagerDelegate>)viewController];
 
-    TestDisplayCornerRadiusProbe* probe = [[TestDisplayCornerRadiusProbe alloc] init];
-    UIWindow* probeWindow = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 390, 844)];
-    [probeWindow addSubview:probe];
-    viewController.displayCornerRadiusProbe = probe;
-
-    [viewController setViewportMetricsDisplayCornerRadii];
-    [viewController updateViewportMetricsIfNeeded];
+    [viewController viewDidDisappear:NO];
+    XCTAssertNil(viewController.displayCornerRadiusProbe);
+    XCTAssertNil(populatedProbe.superview);
 
     const flutter::ViewportMetrics& viewportMetrics = engine.lastViewportMetrics;
     XCTAssertEqual(viewportMetrics.physical_display_corner_radius_top_left, -1.0);
     XCTAssertEqual(viewportMetrics.physical_display_corner_radius_top_right, -1.0);
     XCTAssertEqual(viewportMetrics.physical_display_corner_radius_bottom_right, -1.0);
     XCTAssertEqual(viewportMetrics.physical_display_corner_radius_bottom_left, -1.0);
+    XCTAssertEqual(engine.updateViewportMetricsCallCount, updateCountBeforeDisappearance + 1);
+
+    [viewController setNeedsUpdateProperties];
+    [viewController updatePropertiesIfNeeded];
     XCTAssertNil(viewController.displayCornerRadiusProbe);
-    XCTAssertNil(probe.superview);
+    XCTAssertEqual(engine.lastViewportMetrics.physical_display_corner_radius_top_left, -1.0);
+  }
+}
+
+- (void)testRecreatesDisplayCornerRadiusProbeAfterMovingWindowsOnIOS26 {
+  if (@available(iOS 26.0, *)) {
+    ViewportMetricsCaptureEngine* engine = [[ViewportMetricsCaptureEngine alloc] init];
+    FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                  nibName:nil
+                                                                                   bundle:nil];
+    engine.viewController = nil;
+
+    CGRect frame = CGRectMake(0, 0, 390, 844);
+    UIWindow* firstWindow = CreateWindowForTest(frame);
+    viewController.view = [[UIView alloc] initWithFrame:frame];
+    [firstWindow addSubview:viewController.view];
+    [viewController viewIsAppearing:NO];
+    UIView* firstProbe = viewController.displayCornerRadiusProbe;
+
+    UIWindow* secondWindow = CreateWindowForTest(frame);
+    [secondWindow addSubview:viewController.view];
+    XCTAssertEqual(firstProbe.superview, firstWindow);
+    FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
+    OCMStub([viewControllerMock stateIsActive]).andReturn(NO);
+
+    [viewControllerMock viewDidLayoutSubviews];
+    XCTAssertEqual(viewController.displayCornerRadiusProbe, firstProbe);
+    XCTAssertEqual(firstProbe.superview, firstWindow);
+    XCTAssertEqual(secondWindow.subviews.count, 1u);
+    [viewControllerMock updatePropertiesIfNeeded];
+    UIView* secondProbe = viewController.displayCornerRadiusProbe;
+
+    XCTAssertNil(firstProbe.superview);
+    XCTAssertNotEqual(secondProbe, firstProbe);
+    XCTAssertEqual(secondProbe.superview, secondWindow);
+    XCTAssertEqual(secondWindow.subviews.firstObject, secondProbe);
+  }
+}
+
+- (void)testViewDidLayoutSubviewsDoesNotMutateDisplayCornerRadiusProbeOnIOS26 {
+  if (@available(iOS 26.0, *)) {
+    ViewportMetricsCaptureEngine* engine = [[ViewportMetricsCaptureEngine alloc] init];
+    FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                  nibName:nil
+                                                                                   bundle:nil];
+    engine.viewController = nil;
+
+    CGRect frame = CGRectMake(0, 0, 390, 844);
+    UIWindow* window = CreateWindowForTest(frame);
+    viewController.view = [[UIView alloc] initWithFrame:frame];
+    [window addSubview:viewController.view];
+    [viewController viewIsAppearing:NO];
+    engine.viewController = viewController;
+    FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
+    OCMStub([viewControllerMock stateIsActive]).andReturn(NO);
+
+    TestLayoutTrackingDisplayCornerRadiusProbe* originalProbe =
+        [[TestLayoutTrackingDisplayCornerRadiusProbe alloc] initWithFrame:window.bounds];
+    [viewController.displayCornerRadiusProbe removeFromSuperview];
+    [window insertSubview:originalProbe atIndex:0];
+    viewController.displayCornerRadiusProbe = originalProbe;
+    UIView* originalSuperview = originalProbe.superview;
+    NSUInteger originalSubviewIndex = [originalSuperview.subviews indexOfObject:originalProbe];
+    originalProbe.layoutIfNeededCallCount = 0;
+    originalProbe.setFrameCallCount = 0;
+
+    [viewControllerMock viewDidLayoutSubviews];
+
+    XCTAssertEqual(viewController.displayCornerRadiusProbe, originalProbe);
+    XCTAssertEqual(originalProbe.superview, originalSuperview);
+    XCTAssertEqual([originalSuperview.subviews indexOfObject:originalProbe], originalSubviewIndex);
+    XCTAssertEqual(originalProbe.layoutIfNeededCallCount, 0u);
+    XCTAssertEqual(originalProbe.setFrameCallCount, 0u);
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -347,6 +347,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (void)handlePressEvent:(FlutterUIPressProxy*)press
               nextAction:(void (^)())next API_AVAILABLE(ios(13.4));
 - (void)discreteScrollEvent:(UIPanGestureRecognizer*)recognizer;
+- (void)updateProperties API_AVAILABLE(ios(26.0));
 - (void)updateViewportMetricsIfNeeded;
 - (void)setViewportMetricsDisplayCornerRadii;
 - (void)updateAutoResizeConstraints;
@@ -1428,7 +1429,7 @@ API_AVAILABLE(ios(26.0))
     XCTAssertFalse(probe.userInteractionEnabled);
     XCTAssertFalse(probe.isAccessibilityElement);
     XCTAssertTrue(probe.accessibilityElementsHidden);
-    XCTAssertNotNil(probe.cornerConfiguration);
+    XCTAssertNotNil([probe valueForKey:@"cornerConfiguration"]);
 
     const flutter::ViewportMetrics& viewportMetrics = engine.lastViewportMetrics;
     XCTAssertGreaterThan(viewportMetrics.physical_display_corner_radius_top_left, 0.0);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -347,7 +347,6 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (void)handlePressEvent:(FlutterUIPressProxy*)press
               nextAction:(void (^)())next API_AVAILABLE(ios(13.4));
 - (void)discreteScrollEvent:(UIPanGestureRecognizer*)recognizer;
-- (void)updateProperties API_AVAILABLE(ios(26.0));
 - (void)updateViewportMetricsIfNeeded;
 - (void)setViewportMetricsDisplayCornerRadii;
 - (void)updateAutoResizeConstraints;
@@ -1429,7 +1428,7 @@ API_AVAILABLE(ios(26.0))
     XCTAssertFalse(probe.userInteractionEnabled);
     XCTAssertFalse(probe.isAccessibilityElement);
     XCTAssertTrue(probe.accessibilityElementsHidden);
-    XCTAssertNotNil([probe valueForKey:@"cornerConfiguration"]);
+    XCTAssertNotNil(probe.cornerConfiguration);
 
     const flutter::ViewportMetrics& viewportMetrics = engine.lastViewportMetrics;
     XCTAssertGreaterThan(viewportMetrics.physical_display_corner_radius_top_left, 0.0);

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -813,8 +813,8 @@ class MediaQueryData {
 
   /// The radii of the display corners in logical pixels.
   ///
-  /// This is currently populated only on Android API 31+. On earlier Android
-  /// versions, iOS, and other platforms, this value is `null`.
+  /// This is populated on Android API 31+ and iOS 26+. On earlier Android and
+  /// iOS versions, and on other platforms, this value is `null`.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -842,8 +842,8 @@ class MediaQueryData {
 
   /// The radii of the display corners in logical pixels.
   ///
-  /// This is currently populated only on Android API 31+. On earlier Android
-  /// versions, iOS, and other platforms, this value is `null`.
+  /// This is populated on Android API 31+ and iOS 26+. On earlier Android and
+  /// iOS versions, and on other platforms, this value is `null`.
   ///
   /// See also:
   ///


### PR DESCRIPTION
Populates `FlutterView.displayCornerRadii` and `MediaQueryData.displayCornerRadii` on iOS 26 and later using UIKit's public concentric-corner APIs. A transparent, non-interactive probe is installed behind application content before layout and follows window size through autoresizing. UIKit property updates refresh the effective radii, while `viewDidLayoutSubviews` only reads and publishes them in physical pixels. Moving the Flutter view between windows is repaired in the next pre-layout property-update phase; disappearance removes the probe and resets the metric.

Fixes #189746.

Validation:
- `flutter/bin/et format --dry-run`
- Engine pre-push formatting checks
- Engine lint: C, Dart, and Java passed; Python could not run locally because `pylint-2.7` is unavailable
- `./bin/flutter analyze packages/flutter/lib/src/widgets/media_query.dart`
- `./bin/flutter test packages/flutter/test/widgets/media_query_test.dart` (86 tests)
- `FlutterViewControllerTest` on an iOS 26.5 simulator (101 tests)
- Full iOS Objective-C test suite (729 tests passed, 9 skipped)
- Actual UIKit probe coverage on iPhone 11 and iPad Pro 13-inch iOS 26.5 simulators
- Physical iPhone on iOS 26.5.2 at 390×844 @3x (all four corners reported approximately 47.33 logical pixels / 141.99 physical pixels)

No changes were required in the flutter/tests repository.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member&#39;s review for guidance on which automated comments should be addressed.


[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
