### PR TITLE
Fix Impeller Vulkan sampling of explicitly supplied manual mip chains

### DIFF
--- a/engine/src/flutter/impeller/core/sampler_descriptor.h
+++ b/engine/src/flutter/impeller/core/sampler_descriptor.h
@@ -26,6 +26,10 @@ struct SamplerDescriptor final {
   /// filtering only applies when all filters are linear.
   uint8_t max_anisotropy = 1;
 
+  /// Allows sampling a complete mip chain supplied explicitly by the caller.
+  /// This must remain false for textures that rely on backend mip generation.
+  bool allow_manual_mip_sampling = false;
+
   std::string_view label = "NN Clamp Sampler";
 
   SamplerDescriptor();
@@ -46,7 +50,8 @@ struct SamplerDescriptor final {
            static_cast<uint64_t>(d.width_address_mode) << 24 |
            static_cast<uint64_t>(d.height_address_mode) << 32 |
            static_cast<uint64_t>(d.depth_address_mode) << 40 |
-           static_cast<uint64_t>(d.max_anisotropy) << 48;
+           static_cast<uint64_t>(d.max_anisotropy) << 48 |
+           static_cast<uint64_t>(d.allow_manual_mip_sampling) << 56;
   }
 };
 

--- a/engine/src/flutter/impeller/core/sampler_descriptor_unittests.cc
+++ b/engine/src/flutter/impeller/core/sampler_descriptor_unittests.cc
@@ -41,6 +41,9 @@ TEST(SamplerDescriptorTest, ToKeyIncludesAllFields) {
   EXPECT_NE(SamplerDescriptor::ToKey(a), SamplerDescriptor::ToKey(b));
   b.max_anisotropy = 1;
   EXPECT_EQ(SamplerDescriptor::ToKey(a), SamplerDescriptor::ToKey(b));
+
+  b.allow_manual_mip_sampling = true;
+  EXPECT_NE(SamplerDescriptor::ToKey(a), SamplerDescriptor::ToKey(b));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/sampler_library_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/sampler_library_vk.cc
@@ -26,7 +26,7 @@ void SamplerLibraryVK::ApplyWorkarounds(const WorkaroundsVK& workarounds) {
 raw_ptr<const Sampler> SamplerLibraryVK::GetSampler(
     const SamplerDescriptor& desc) {
   SamplerDescriptor desc_copy = desc;
-  if (mips_disabled_workaround_) {
+  if (mips_disabled_workaround_ && !desc_copy.allow_manual_mip_sampling) {
     desc_copy.mip_filter = MipFilter::kBase;
   }
   // Clamp to the device limit before keying the cache so that all values

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/sampler_library_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/sampler_library_vk_unittests.cc
@@ -52,6 +52,23 @@ TEST(SamplerLibraryVK, WorkaroundsPreserveExplicitManualMipSampling) {
   EXPECT_EQ(sampler->GetDescriptor().mip_filter, MipFilter::kLinear);
 }
 
+TEST(SamplerLibraryVK, WorkaroundsPreserveExplicitManualNearestMipSampling) {
+  auto const context = MockVulkanContextBuilder().Build();
+
+  auto library_vk = std::make_shared<SamplerLibraryVK>(
+      context->GetDeviceHolder(), /*max_sampler_anisotropy=*/1u);
+  std::shared_ptr<SamplerLibrary> library = library_vk;
+
+  SamplerDescriptor desc;
+  desc.mip_filter = MipFilter::kNearest;
+  desc.allow_manual_mip_sampling = true;
+
+  library_vk->ApplyWorkarounds(WorkaroundsVK{.broken_mipmap_generation = true});
+
+  auto sampler = library->GetSampler(desc);
+  EXPECT_EQ(sampler->GetDescriptor().mip_filter, MipFilter::kNearest);
+}
+
 TEST(SamplerLibraryVK, MaxAnisotropyIsClampedToTheDeviceLimit) {
   auto const context = MockVulkanContextBuilder().Build();
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/sampler_library_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/sampler_library_vk_unittests.cc
@@ -35,6 +35,23 @@ TEST(SamplerLibraryVK, WorkaroundsCanDisableReadingFromMipLevels) {
   EXPECT_EQ(sampler->GetDescriptor().mip_filter, MipFilter::kBase);
 }
 
+TEST(SamplerLibraryVK, WorkaroundsPreserveExplicitManualMipSampling) {
+  auto const context = MockVulkanContextBuilder().Build();
+
+  auto library_vk = std::make_shared<SamplerLibraryVK>(
+      context->GetDeviceHolder(), /*max_sampler_anisotropy=*/1u);
+  std::shared_ptr<SamplerLibrary> library = library_vk;
+
+  SamplerDescriptor desc;
+  desc.mip_filter = MipFilter::kLinear;
+  desc.allow_manual_mip_sampling = true;
+
+  library_vk->ApplyWorkarounds(WorkaroundsVK{.broken_mipmap_generation = true});
+
+  auto sampler = library->GetSampler(desc);
+  EXPECT_EQ(sampler->GetDescriptor().mip_filter, MipFilter::kLinear);
+}
+
 TEST(SamplerLibraryVK, MaxAnisotropyIsClampedToTheDeviceLimit) {
   auto const context = MockVulkanContextBuilder().Build();
 

--- a/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
@@ -171,6 +171,7 @@ base class SamplerOptions {
     this.widthAddressMode = SamplerAddressMode.clampToEdge,
     this.heightAddressMode = SamplerAddressMode.clampToEdge,
     this.maxAnisotropy = 1,
+    this.allowManualMipSampling = false,
   });
 
   MinMagFilter minFilter;
@@ -191,6 +192,10 @@ base class SamplerOptions {
   /// levels (via [Texture.overwrite] or by rendering into them) to get the
   /// full quality benefit.
   int maxAnisotropy;
+
+  /// Allows sampling a complete mip chain supplied explicitly by the caller.
+  /// This does not enable backend mip generation.
+  bool allowManualMipSampling;
 }
 
 base class Scissor {
@@ -520,6 +525,7 @@ base class RenderPass extends NativeFieldWrapperClass1 {
       sampler.widthAddressMode.index,
       sampler.heightAddressMode.index,
       sampler.maxAnisotropy,
+      sampler.allowManualMipSampling,
     );
     if (!success) {
       throw Exception("Failed to bind texture");
@@ -835,6 +841,7 @@ base class RenderPass extends NativeFieldWrapperClass1 {
       Int,
       Int,
       Int,
+      Bool,
     )
   >(symbol: 'InternalFlutterGpu_RenderPass_BindTexture')
   external bool _bindTexture(
@@ -847,6 +854,7 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     int widthAddressMode,
     int heightAddressMode,
     int maxAnisotropy,
+    bool allowManualMipSampling,
   );
 
   @Native<Void Function(Pointer<Void>)>(

--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -473,7 +473,8 @@ bool InternalFlutterGpu_RenderPass_BindTexture(
     int mip_filter,
     int width_address_mode,
     int height_address_mode,
-    int max_anisotropy) {
+    int max_anisotropy,
+    bool allow_manual_mip_sampling) {
   auto uniform_name = tonic::StdStringFromDart(uniform_name_handle);
   const flutter::gpu::Shader::TextureBinding* texture_binding =
       shader->GetUniformTexture(uniform_name);
@@ -487,6 +488,7 @@ bool InternalFlutterGpu_RenderPass_BindTexture(
   sampler_desc.min_filter = flutter::gpu::ToImpellerMinMagFilter(min_filter);
   sampler_desc.mag_filter = flutter::gpu::ToImpellerMinMagFilter(mag_filter);
   sampler_desc.mip_filter = flutter::gpu::ToImpellerMipFilter(mip_filter);
+  sampler_desc.allow_manual_mip_sampling = allow_manual_mip_sampling;
   sampler_desc.width_address_mode =
       flutter::gpu::ToImpellerSamplerAddressMode(width_address_mode);
   sampler_desc.height_address_mode =

--- a/engine/src/flutter/lib/gpu/render_pass.h
+++ b/engine/src/flutter/lib/gpu/render_pass.h
@@ -205,7 +205,8 @@ extern bool InternalFlutterGpu_RenderPass_BindTexture(
     int mip_filter,
     int width_address_mode,
     int height_address_mode,
-    int max_anisotropy);
+    int max_anisotropy,
+    bool allow_manual_mip_sampling);
 
 FLUTTER_GPU_EXPORT
 extern void InternalFlutterGpu_RenderPass_ClearBindings(


### PR DESCRIPTION
Related to #189965 and #189897

## Summary

On affected Adreno Vulkan devices, the `broken_mipmap_generation` workaround forces ordinary mip samplers to base mip. This is appropriate for generated mipmaps, but it also affects complete mip chains supplied explicitly by Flutter GPU callers.

This change proposes an explicit `allowManualMipSampling` opt-in. The default remains `false`, so ordinary samplers continue to use the existing base-mip workaround. Callers that supply every mip level explicitly can preserve their requested nearest or linear mip filtering.

#189897 is the safe capability correction: it reports manually mipped textures as unsupported while the workaround is active, allowing capability-aware clients to fall back. This PR is not a replacement for that behavior. It is a follow-up proposal for maintainers to evaluate whether complete manually supplied mip chains should have an explicit opt-in path.

## Evidence

The standalone reproduction from #189965 isolates the behavior without `flutter_scene`, scene lighting, shadow maps, or a material system.

| Redmi K60 Pro / Adreno 740, Android Impeller Vulkan | Official-engine baseline | Patched local engine |
| --- | --- | --- |
| Roughness 1.00 visual | <img width="300" alt="Baseline reflection remains sharp at roughness 1.00" src="https://raw.githubusercontent.com/Ram-Dawson/flutter_gpu_manual_mip_repro/main/docs/evidence/redmi-k60pro-adreno740-baseline-cubemap-r1.00-visual.png"> | <img width="300" alt="Patched reflection becomes diffuse at roughness 1.00" src="https://raw.githubusercontent.com/Ram-Dawson/flutter_gpu_manual_mip_repro/main/docs/evidence/redmi-k60pro-adreno740-patched-cubemap-r1.00-visual.png"> |
| Roughness 1.00 LOD probe | <img width="300" alt="Baseline requested band 7 but observed red band 0" src="https://raw.githubusercontent.com/Ram-Dawson/flutter_gpu_manual_mip_repro/main/docs/evidence/redmi-k60pro-adreno740-baseline-cubemap-r1.00-lod-band7-observed-band0-red.png"> | <img width="300" alt="Patched local engine observed gray band 7" src="https://raw.githubusercontent.com/Ram-Dawson/flutter_gpu_manual_mip_repro/main/docs/evidence/redmi-k60pro-adreno740-patched-cubemap-r1.00-lod-band7-gray.png"> |

The matching roughness 0.45 probes are available in the [public reproduction repository](https://github.com/Ram-Dawson/flutter_gpu_manual_mip_repro).

## Tests

```sh
out/host_debug_unopt/impeller_unittests \
  --gtest_filter='SamplerDescriptorTest.ToKeyIncludesAllFields:SamplerLibraryVK.WorkaroundsCanDisableReadingFromMipLevels:SamplerLibraryVK.WorkaroundsPreserveExplicitManualMipSampling:SamplerLibraryVK.WorkaroundsPreserveExplicitManualNearestMipSampling'
```

The four focused tests pass. Device validation and local-engine builds were completed against framework revision `ea1bc5dc4f6fedce69957417b6907e45615146e2`, the master revision used for the investigation. `master` has advanced since that validation; this PR's CI provides corresponding coverage against the current target branch.

## Scope

This changes Vulkan sampler selection only. It does not change the Android shadow path or address other rendering artifacts. If the added Flutter GPU API is not considered worthwhile or safe to expose, this PR should be closed in favor of the capability correction in #189897.

## Pre-launch Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I read the AI contribution guidelines and understand my responsibilities.
- [x] I read the Tree Hygiene wiki page, which explains my responsibilities.
- [x] I read and followed the Flutter Style Guide.
- [x] I signed the CLA.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] I followed the breaking change policy and added Data Driven Fixes where supported.
- [x] All existing and new tests are passing.