### PR TITLE
fix(tool): parse ADB device lists by connection state

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -113,18 +113,17 @@ class AndroidDevices extends PollingDeviceDiscovery {
   // Parses the output of `adb devices -l`.
   //
   // The regex is structured as:
-  // 1. Group 1 (Serial): Lazily matched to allow spaces in the serial (which
-  //    can happen during wireless ADB mDNS name conflicts, e.g., "device (2)").
-  //    The column separator requires at least two spaces or a tab to prevent
-  //    single spaces within a serial from being mis-matched.
+  // 1. Group 1 (Serial): Greedily matched before the state. ADB formats long
+  //    listings as `%-22s %s`, so the width is a minimum: serials longer than
+  //    22 characters are followed by one space. Serials can also contain
+  //    whitespace, such as a wireless mDNS conflict suffix (`device (2)`).
   // 2. Group 2 (State): Matches known ADB device states explicitly, including
   //    "no permissions" (which contains a space). Explicitly listing states
-  //    prevents false positive state matching on extra device info/attributes
-  //    or serial name components.
+  //    lets the greedy serial capture retain state-like serial components.
   // 3. Group 3 (Extra Info): Optional trailing details (e.g. key:value pairs
   //    like "product:mokey model:mokey device:mokey transport_id:1" or "usb:123").
   static final _kDeviceRegex = RegExp(
-    r'^(.*?)(?:\s{2,}|\t+)'
+    r'^(.*)\s+'
     r'(device|offline|unauthorized|no permissions|bootloader|recovery|sideload|rescue|connecting|authorizing|host|unknown)'
     r'(?:\s+(.*)|$)',
   );
@@ -163,7 +162,9 @@ class AndroidDevices extends PollingDeviceDiscovery {
       if (_kDeviceRegex.hasMatch(line)) {
         final Match match = _kDeviceRegex.firstMatch(line)!;
 
-        final String deviceID = match[1]!;
+        // The greedy serial capture includes the optional padding from ADB's
+        // minimum-width serial field.
+        final String deviceID = match[1]!.trimRight();
         final String deviceState = match[2]!;
         String? rest = match[3];
 

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -238,6 +238,84 @@ adb-ZY22MGW35T-Z3uXXq (2)._adb-tls-connect._tcp    device product:vantage_ge mod
         'expectedId': '127.0.0.1:5555',
         'expectedStatus': 'success',
       },
+      // ADB long listings use a minimum-width serial column, so a serial that
+      // is 22 characters or longer can be followed by only one space.
+      <String, String>{
+        'input':
+            'adb-0123456789abcdef._adb-tls-connect._tcp device product:socrates model:22127RK46C device:socrates transport_id:1',
+        'expectedId': 'adb-0123456789abcdef._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
+      // mDNS conflict suffixes introduce whitespace into the serial itself.
+      <String, String>{
+        'input':
+            'adb-0123456789abcdef (2)._adb-tls-connect._tcp device product:socrates model:22127RK46C device:socrates transport_id:1',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp offline',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'offline',
+      },
+      // Serial contents may themselves include known ADB state names.
+      <String, String>{
+        'input': 'my device offline device',
+        'expectedId': 'my device offline',
+        'expectedStatus': 'success',
+      },
+      // Exercise every state currently recognized by Flutter with the ADB
+      // single-space form and a serial containing whitespace.
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp unauthorized',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'unauthorized',
+      },
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp no permissions',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'no permissions',
+      },
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp bootloader',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp recovery',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp sideload',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp rescue',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp connecting',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp authorizing',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp host',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
+      <String, String>{
+        'input': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp unknown',
+        'expectedId': 'adb-0123456789abcdef (2)._adb-tls-connect._tcp',
+        'expectedStatus': 'success',
+      },
       // States that should go to diagnostics
       <String, String>{
         'input': '015d172c98400a03       offline',


### PR DESCRIPTION
Fixes #189972

Related to #189430 and #189369. This supersedes the narrower parser approach from closed PR #189431.

## Summary

ADB formats long device-list rows as [`%-22s %s`](https://android.googlesource.com/platform/packages/modules/adb/+/1cf2f017d312f73b3dc53bda85ef2610e35a80e9/transport.cpp#1410): the serial field has a minimum width, so a long wireless serial can be separated from its connection state by a single space. mDNS conflict suffixes can also introduce whitespace inside the serial.

[PR #189369](https://github.com/flutter/flutter/pull/189369) correctly protects serials containing whitespace by requiring two spaces or a tab before the state. [PR #189431](https://github.com/flutter/flutter/pull/189431) proposed a narrower one-space fallback for serials without whitespace and was closed after #189369 landed. The combined case has both an mDNS conflict suffix and a valid single-space state delimiter, so neither earlier rule accepts it.

This change parses the explicit known ADB connection-state field instead of inferring a boundary from whitespace width. The serial capture is greedy so state-like words and mDNS conflict suffixes remain part of the serial, and right-side padding from ADB's minimum-width field is removed.

## Tests

Added regression coverage for:

- ordinary single-space wireless mDNS serials;
- mDNS conflict serials containing ` (2)` with `device` and `offline` states;
- every state currently recognized by Flutter Tools;
- serials that contain state-like words; and
- existing padded and tab-separated output forms.

Ran:

```text
flutter test packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
flutter analyze packages/flutter_tools
```

The device-discovery test file passed with 16 tests, and analysis reported no issues.

## Real-device validation

After deleting `bin/cache/flutter_tools.snapshot`, unmodified `upstream/master` at `0ed149e63db1f68d2042063baf0a99d969ccd84b` omitted the wireless Android device and reported an unexpected ADB parsing failure. With this patch, `flutter devices -v` listed the device with the complete mDNS conflict serial and successfully used that serial for `adb -s ... shell getprop`.

## Scope

This PR changes only Flutter Tools parsing and its Android device-discovery tests. It does not change ADB, mDNS pairing, wireless transport behavior, or device-state handling after a row has been parsed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.