### PR TITLE
Add dart_runtime_service_vm_aot.dart.snapshot to the snapshot list in the macOS code signing configuration

### DIFF
--- a/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
+++ b/dev/bots/suite_runners/run_verify_binaries_codesigned_tests.dart
@@ -121,6 +121,7 @@ List<String> binariesWithoutEntitlements(String flutterRoot) {
     'dart-sdk/bin/snapshots/dart2bytecode.dart.snapshot',
     'dart-sdk/bin/snapshots/dart2js_aot.dart.snapshot',
     'dart-sdk/bin/snapshots/dart2wasm_product.snapshot',
+    'dart-sdk/bin/snapshots/dart_runtime_service_vm_aot.dart.snapshot',
     'dart-sdk/bin/snapshots/dart_tooling_daemon_aot.dart.snapshot',
     'dart-sdk/bin/snapshots/dartdev_aot.dart.snapshot',
     'dart-sdk/bin/snapshots/dartdevc_aot.dart.snapshot',

--- a/engine/src/flutter/build/archives/BUILD.gn
+++ b/engine/src/flutter/build/archives/BUILD.gn
@@ -219,6 +219,7 @@ _dart_sdk_without_entitlement_contents = [
   "dart-sdk/bin/snapshots/dart2bytecode.dart.snapshot",
   "dart-sdk/bin/snapshots/dart2js_aot.dart.snapshot",
   "dart-sdk/bin/snapshots/dart2wasm_product.snapshot",
+  "dart-sdk/bin/snapshots/dart_runtime_service_vm_aot.dart.snapshot",
   "dart-sdk/bin/snapshots/dart_tooling_daemon_aot.dart.snapshot",
   "dart-sdk/bin/snapshots/dartdev_aot.dart.snapshot",
   "dart-sdk/bin/snapshots/dartdevc_aot.dart.snapshot",


### PR DESCRIPTION
This file was added by a recent Dart SDK roll
(see https://github.com/flutter/flutter/pull/189949)