### PR TITLE
fix(ci): quote labels to fix yaml mapping error

### DIFF
--- a/.github/workflows/scheduled-localization-update.yml
+++ b/.github/workflows/scheduled-localization-update.yml
@@ -28,7 +28,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TITLE: '[Automated Task] Quarterly Localizations Update (flutter_localizations)'
           ASSIGNEES: QuncCccccc
-          LABELS: automated task,a: internationalization,team-framework
+          LABELS: 'automated task,a: internationalization,team-framework'
           BODY: |
             ### Quarterly Localization Update
 


### PR DESCRIPTION
`env:` block requires `string: string` types. 