### PR TITLE
Fix false positive assertion on GlobalKey reuse for defunct elements

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3192,8 +3192,13 @@ class BuildOwner {
     assert(() {
       if (_globalKeyRegistry.containsKey(key)) {
         final Element oldElement = _globalKeyRegistry[key]!;
-        assert(element.widget.runtimeType != oldElement.widget.runtimeType);
-        _debugIllFatedElements?.add(oldElement);
+        // If the old element is already defunct or failed, allow replacement;
+        // otherwise flag a potential misuse.
+        if (oldElement._lifecycleState != _ElementLifecycle.defunct &&
+            oldElement._lifecycleState != _ElementLifecycle.failed) {
+          assert(element.widget.runtimeType != oldElement.widget.runtimeType);
+          _debugIllFatedElements?.add(oldElement);
+        }
       }
       return true;
     }());

--- a/packages/flutter/test/widgets/global_key_defunct_test.dart
+++ b/packages/flutter/test/widgets/global_key_defunct_test.dart
@@ -1,0 +1,89 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _AlwaysThrowingWidget extends StatelessWidget {
+  const _AlwaysThrowingWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    throw StateError('intentional build failure');
+  }
+}
+
+void main() {
+  testWidgets('GlobalKey reuse after defunct does not assert (different widget type)', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Container(key: key),
+      ),
+    );
+    expect(find.byKey(key), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Text('Reused', key: key),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Reused'), findsOneWidget);
+  });
+
+  testWidgets('GlobalKey reuse after defunct does not assert (same widget type)', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Container(key: key),
+      ),
+    );
+    expect(find.byKey(key), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Container(key: key),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(key), findsOneWidget);
+  });
+
+  testWidgets('GlobalKey reuse after failed does not assert', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: _AlwaysThrowingWidget(key: key),
+      ),
+    );
+    expect(tester.takeException(), isA<StateError>());
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Container(key: key),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(key), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

When a widget tree removes a `GlobalKey`-backed element and then reuses the same key after that element has reached the `defunct` lifecycle state, Flutter can still hit the debug assertion in `BuildOwner._registerGlobalKey` even though the old element is no longer active.

This PR checks `_lifecycleState` to safely permit replacement when the old element is `defunct` or `failed`, while maintaining the strict assertion for active/inactive elements.

Fixes https://github.com/flutter/flutter/issues/186105

## Changes

- `framework.dart`: Guard the duplicate-type assertion in `_registerGlobalKey` to skip when the old element is already `defunct` or `failed`
- New test `global_key_defunct_test.dart` with 3 cases:
  - Different widget type reuse after defunct
  - Same widget type reuse after defunct
  - Reuse after failed build

## Tests

New `global_key_defunct_test.dart` passes. This is a re-opening of #186075 (closed due to head repo deletion).