### PR TITLE
ci: add mac verify binaries workflow

### DIFF
--- a/.github/actions/composite-flutter-setup/action.yml
+++ b/.github/actions/composite-flutter-setup/action.yml
@@ -10,9 +10,6 @@ inputs:
   ANDROID_BUILDTOOLS:
     description: 'android buildtools version'
     default: '36.1.0'
-  setup_android:
-    description: 'whether to setup android sdk'
-    default: 'true'
 
 runs:
   using: 'composite'
@@ -57,7 +54,7 @@ runs:
 
       # If running locally; install the JDK - Github runners have everything on them
       - name: Set up our JDK environment
-        if: env.ACT || inputs.setup_android == 'true'
+        if: env.ACT
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
         with:
           java-version: '21'
@@ -66,14 +63,14 @@ runs:
       # If running locally; install Android SDK tools - Github runners have everything on them
       - name: Set Android SDK environment variable
         shell: bash
-        if: env.ACT || inputs.setup_android == 'true'
+        if: env.ACT
         run: |
           echo "ANDROID_SDK_ROOT=/opt/android/sdk" >> $GITHUB_ENV
           echo "ANDROID_HOME=/opt/android/sdk" >> $GITHUB_ENV
       - name: Get Android SDK version
         shell: bash
         id: android-sdk-version
-        if: env.ACT || inputs.setup_android == 'true'
+        if: env.ACT
         run: |
           echo "revision=${INPUTS_ANDROID_TOOLS_VERSION};${INPUTS_ANDROID_PLATFORM};build-tools;${INPUTS_ANDROID_BUILDTOOLS}" >> "$GITHUB_OUTPUT"
         env:
@@ -83,12 +80,12 @@ runs:
       - name: Android SDK Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         id: android-sdk-setup
-        if: env.ACT || inputs.setup_android == 'true'
+        if: env.ACT
         with:
           path: /opt/android/sdk
           key: ${{ runner.os }}-${{ steps.android-sdk-version.outputs.revision }}
       - name: Setup Android SDK (cold cache)
-        if: (env.ACT || inputs.setup_android == 'true') && steps.android-sdk-setup.outputs.cache-hit != 'true'
+        if: env.ACT && steps.android-sdk-setup.outputs.cache-hit != 'true'
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
         with:
           packages: 'tools platform-tools platforms;${{inputs.ANDROID_PLATFORM}} build-tools;${{inputs.ANDROID_BUILDTOOLS}}'
@@ -96,14 +93,14 @@ runs:
           cmdline-tools-version: ${{ inputs.ANDROID_TOOLS_VERSION }}
       - name: Setup Android SDK (warm cache) - Tools
         shell: bash
-        if: (env.ACT || inputs.setup_android == 'true') && steps.android-sdk-setup.outputs.cache-hit == 'true'
+        if: env.ACT && steps.android-sdk-setup.outputs.cache-hit == 'true'
         run: echo "/opt/android/sdk/cmdline-tools/${INPUTS_ANDROID_TOOLS_VERSION}/bin" >> "$GITHUB_PATH" # zizmor: ignore[github-env]
         env:
           INPUTS_ANDROID_TOOLS_VERSION: ${{ inputs.ANDROID_TOOLS_VERSION }}
 
       - name: Setup Android SDK (warm cache) - Platform Tools
         shell: bash
-        if: (env.ACT || inputs.setup_android == 'true') && steps.android-sdk-setup.outputs.cache-hit == 'true'
+        if: env.ACT && steps.android-sdk-setup.outputs.cache-hit == 'true'
         run: echo "/opt/android/sdk/platform-tools" >> "$GITHUB_PATH" # zizmor: ignore[github-env]
 
       # ktlint is needed by tree analyze

--- a/.github/actions/composite-flutter-setup/action.yml
+++ b/.github/actions/composite-flutter-setup/action.yml
@@ -10,6 +10,9 @@ inputs:
   ANDROID_BUILDTOOLS:
     description: 'android buildtools version'
     default: '36.1.0'
+  setup_android:
+    description: 'whether to setup android sdk'
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -54,7 +57,7 @@ runs:
 
       # If running locally; install the JDK - Github runners have everything on them
       - name: Set up our JDK environment
-        if: env.ACT
+        if: env.ACT || inputs.setup_android == 'true'
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
         with:
           java-version: '21'
@@ -63,14 +66,14 @@ runs:
       # If running locally; install Android SDK tools - Github runners have everything on them
       - name: Set Android SDK environment variable
         shell: bash
-        if: env.ACT
+        if: env.ACT || inputs.setup_android == 'true'
         run: |
           echo "ANDROID_SDK_ROOT=/opt/android/sdk" >> $GITHUB_ENV
           echo "ANDROID_HOME=/opt/android/sdk" >> $GITHUB_ENV
       - name: Get Android SDK version
         shell: bash
         id: android-sdk-version
-        if: env.ACT
+        if: env.ACT || inputs.setup_android == 'true'
         run: |
           echo "revision=${INPUTS_ANDROID_TOOLS_VERSION};${INPUTS_ANDROID_PLATFORM};build-tools;${INPUTS_ANDROID_BUILDTOOLS}" >> "$GITHUB_OUTPUT"
         env:
@@ -80,12 +83,12 @@ runs:
       - name: Android SDK Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         id: android-sdk-setup
-        if: env.ACT
+        if: env.ACT || inputs.setup_android == 'true'
         with:
           path: /opt/android/sdk
           key: ${{ runner.os }}-${{ steps.android-sdk-version.outputs.revision }}
       - name: Setup Android SDK (cold cache)
-        if: env.ACT && steps.android-sdk-setup.outputs.cache-hit != 'true'
+        if: (env.ACT || inputs.setup_android == 'true') && steps.android-sdk-setup.outputs.cache-hit != 'true'
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
         with:
           packages: 'tools platform-tools platforms;${{inputs.ANDROID_PLATFORM}} build-tools;${{inputs.ANDROID_BUILDTOOLS}}'
@@ -93,14 +96,14 @@ runs:
           cmdline-tools-version: ${{ inputs.ANDROID_TOOLS_VERSION }}
       - name: Setup Android SDK (warm cache) - Tools
         shell: bash
-        if: env.ACT && steps.android-sdk-setup.outputs.cache-hit == 'true'
+        if: (env.ACT || inputs.setup_android == 'true') && steps.android-sdk-setup.outputs.cache-hit == 'true'
         run: echo "/opt/android/sdk/cmdline-tools/${INPUTS_ANDROID_TOOLS_VERSION}/bin" >> "$GITHUB_PATH" # zizmor: ignore[github-env]
         env:
           INPUTS_ANDROID_TOOLS_VERSION: ${{ inputs.ANDROID_TOOLS_VERSION }}
 
       - name: Setup Android SDK (warm cache) - Platform Tools
         shell: bash
-        if: env.ACT && steps.android-sdk-setup.outputs.cache-hit == 'true'
+        if: (env.ACT || inputs.setup_android == 'true') && steps.android-sdk-setup.outputs.cache-hit == 'true'
         run: echo "/opt/android/sdk/platform-tools" >> "$GITHUB_PATH" # zizmor: ignore[github-env]
 
       # ktlint is needed by tree analyze

--- a/.github/actions/has-engine-changes/action.yml
+++ b/.github/actions/has-engine-changes/action.yml
@@ -24,7 +24,11 @@ runs:
         elif [ "$EVENT_NAME" = "push" ] && [ -n "$PUSH_BEFORE_SHA" ] && [ "$PUSH_BEFORE_SHA" != "$EMPTY_SHA" ]; then
           BASE_REF="$PUSH_BEFORE_SHA"
         else
-          BASE_REF="origin/master"
+          if git show-ref --verify --quiet refs/remotes/upstream/master; then
+            BASE_REF="upstream/master"
+          else
+            BASE_REF="origin/master"
+          fi
         fi
 
         echo "Comparing against base SHA: $BASE_REF"

--- a/.github/actions/has-engine-changes/action.yml
+++ b/.github/actions/has-engine-changes/action.yml
@@ -1,0 +1,42 @@
+name: 'Has Engine Changes'
+description: 'Checks if there are any engine changes in the current branch'
+outputs:
+  changed:
+    description: "Returns 'true' if there are engine changes, 'false' otherwise"
+    value: ${{ steps.check.outputs.changed }}
+runs:
+  using: "composite"
+  steps:
+    - name: Check Engine Changes
+      id: check
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        PUSH_BEFORE_SHA: ${{ github.event.before }}
+      run: |
+        EMPTY_SHA="0000000000000000000000000000000000000000"
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          BASE_REF="$PR_BASE_SHA"
+        elif [ "$EVENT_NAME" = "merge_group" ]; then
+          BASE_REF="$MERGE_GROUP_BASE_SHA"
+        elif [ "$EVENT_NAME" = "push" ] && [ -n "$PUSH_BEFORE_SHA" ] && [ "$PUSH_BEFORE_SHA" != "$EMPTY_SHA" ]; then
+          BASE_REF="$PUSH_BEFORE_SHA"
+        else
+          BASE_REF="origin/master"
+        fi
+
+        echo "Comparing against base SHA: $BASE_REF"
+
+        CHANGED_FILES=$(.github/scripts/git_files_changed.sh "$BASE_REF")
+        echo "Changed files in this branch:"
+        echo "$CHANGED_FILES"
+
+        if [ "$(printf '%s\n' "$CHANGED_FILES" | .github/scripts/did_engine_change.sh)" = "true" ]; then
+          echo "Engine files changed."
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "No engine files changed."
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/wait-for-engine-build/action.yml
+++ b/.github/actions/wait-for-engine-build/action.yml
@@ -17,40 +17,16 @@ runs:
   steps:
     - name: Check Engine Changes
       id: check_engine
+      uses: ./.github/actions/has-engine-changes
+
+    - name: Log wait requirement
+      if: steps.check_engine.outputs.changed == 'true'
       shell: bash
       env:
-        EVENT_NAME: ${{ github.event_name }}
-        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
-        PUSH_BEFORE_SHA: ${{ github.event.before }}
         INPUTS_CHECK_NAME: ${{ inputs.check-name }}
         INPUTS_CHECK_REGEXP: ${{ inputs.check-regexp }}
       run: |
-        # 1. Determine local base tracking SHA
-        if [ "$EVENT_NAME" = "pull_request" ]; then
-          BASE_REF="$PR_BASE_SHA"
-        elif [ "$EVENT_NAME" = "merge_group" ]; then
-          BASE_REF="$MERGE_GROUP_BASE_SHA"
-        elif [ "$EVENT_NAME" = "push" ] && [ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
-          BASE_REF="$PUSH_BEFORE_SHA"
-        else
-          BASE_REF="origin/master"
-        fi
-
-        echo "Comparing against base SHA: $BASE_REF"
-
-        # 2. Get the changed files using the helper script
-        CHANGED_FILES=$(.github/scripts/git_files_changed.sh "$BASE_REF")
-        echo "Changed files in this branch:"
-        echo "$CHANGED_FILES"
-
-        # 3. Check if any file matches engine pattern using the helper script:
-        if [ "$(printf '%s\n' "$CHANGED_FILES" | .github/scripts/did_engine_change.sh)" = "true" ]; then
-          echo "Engine file changed - forced to wait for check-name: '${INPUTS_CHECK_NAME}', check-regexp: '${INPUTS_CHECK_REGEXP}'"
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "changed=false" >> "$GITHUB_OUTPUT"
-        fi
+        echo "Engine file changed - forced to wait for check-name: '${INPUTS_CHECK_NAME}', check-regexp: '${INPUTS_CHECK_REGEXP}'"
 
     # Note: Use the Cocoon wait-for-tests action to poll the Cocoon API.
     - name: Wait for test check-in

--- a/.github/workflows/mac-verify-binaries.yml
+++ b/.github/workflows/mac-verify-binaries.yml
@@ -48,8 +48,6 @@ jobs:
           check-name: 'Mac mac_host_engine'
 
       - uses: ./.github/actions/composite-flutter-setup
-        with:
-          setup_android: 'false'
 
       - name: Run verify_binaries_pre_codesigned
         run: |

--- a/.github/workflows/mac-verify-binaries.yml
+++ b/.github/workflows/mac-verify-binaries.yml
@@ -1,0 +1,56 @@
+name: Mac Verify Binaries
+
+on:
+  pull_request:
+    branches: [master]
+  merge_group:
+    branches: [master]
+
+jobs:
+  check-engine-changes:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Check Engine Changes
+        id: check
+        uses: ./.github/actions/has-engine-changes
+
+  Mac_arm64_verify_binaries:
+    needs: check-engine-changes
+    if: needs.check-engine-changes.outputs.changed == 'true'
+    permissions:
+      contents: read
+    runs-on: macos-latest
+    timeout-minutes: 130
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Wait for Engine Build
+        uses: ./.github/actions/wait-for-engine-build
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          check-name: 'Mac mac_host_engine'
+
+      - uses: ./.github/actions/composite-flutter-setup
+        with:
+          setup_android: 'false'
+
+      - name: Run verify_binaries_pre_codesigned
+        run: |
+          SHARD=verify_binaries_pre_codesigned LUCI_CI=true dart --enable-asserts dev/bots/test.dart


### PR DESCRIPTION
- Extracts engine change detection logic from `wait-for-engine-build` into a reusable `has-engine-changes` composite action.
- Introduces a new `mac-verify-binaries` GitHub Actions workflow.
- Fixes an empty string check for `PUSH_BEFORE_SHA` in the `wait-for-engine-build` action.

fixes: https://github.com/flutter/flutter/issues/189995