### PR TITLE
[Android SDK] Use Android CLI instead of deprecated sdkmanager when available

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -335,6 +335,15 @@ class AndroidSdk {
   String? getAvdManagerPath() =>
       getCmdlineToolsPath(globals.platform.isWindows ? 'avdmanager.bat' : 'avdmanager');
 
+  /// Returns the filesystem path of the Android CLI tool (android/android.bat).
+  ///
+  /// The android CLI is the recommended replacement for the deprecated sdkmanager.
+  /// Returns null if not found.
+  String? getAndroidCommandPath() {
+    final executable = globals.platform.isWindows ? 'android.bat' : 'android';
+    return getCmdlineToolsPath(executable, skipOldTools: true);
+  }
+
   /// From https://developer.android.com/ndk/guides/other_build_systems.
   static const _llvmHostDirectoryName = <String, String>{
     'macos': 'darwin-x86_64',
@@ -529,7 +538,16 @@ class AndroidSdk {
   }
 
   /// Returns the filesystem path of the Android SDK manager tool.
+  ///
+  /// Prefers the Android CLI (android/android.bat) when available, as sdkmanager
+  /// is deprecated. Falls back to sdkmanager if Android CLI is not found.
   String? get sdkManagerPath {
+    // Prefer the new Android CLI tool over the deprecated sdkmanager
+    final androidCommand = getAndroidCommandPath();
+    if (androidCommand != null) {
+      return androidCommand;
+    }
+    
     final executable = globals.platform.isWindows ? 'sdkmanager.bat' : 'sdkmanager';
     return getCmdlineToolsPath(executable, skipOldTools: true);
   }

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -50,13 +50,14 @@ class UserMessages {
       'Run `flutter doctor --android-licenses` to accept the SDK licenses.\n'
       'See ${androidSdkInstallUrl(platform)} for more details.';
   String androidMissingSdkManager(String sdkManagerPath, Platform platform) =>
-      'Android sdkmanager tool not found ($sdkManagerPath).\n'
-      'Try re-installing or updating your Android SDK,\n'
-      'visit ${androidSdkInstallUrl(platform)} for detailed instructions.';
+      'Android SDK manager tool not found ($sdkManagerPath).\n'
+      'Try re-installing or updating your Android SDK.\n'
+      'The Android CLI is the recommended tool; ensure cmdline-tools are installed.\n'
+      'Visit ${androidSdkInstallUrl(platform)} for detailed instructions.';
   String androidCannotRunSdkManager(String sdkManagerPath, String error, Platform platform) =>
-      'Android sdkmanager tool was found, but failed to run ($sdkManagerPath): "$error".\n'
-      'Try re-installing or updating your Android SDK,\n'
-      'visit ${androidSdkInstallUrl(platform)} for detailed instructions.';
+      'Android SDK manager tool was found, but failed to run ($sdkManagerPath): "$error".\n'
+      'Try re-installing or updating your Android SDK.\n'
+      'Visit ${androidSdkInstallUrl(platform)} for detailed instructions.';
   String androidSdkBuildToolsOutdated(
     int sdkMinVersion,
     String buildToolsMinVersion,

--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -258,6 +258,135 @@ void main() {
     );
 
     testUsingContext(
+      'prefers Android CLI over sdkmanager when both are available',
+      () {
+        final Directory sdkDir = createSdkDirectory(fileSystem: fileSystem, withSdkManager: false);
+        config.setValue('android-sdk', sdkDir.path);
+
+        final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+        // Create both android and sdkmanager in the same directory
+        fileSystem
+            .file(
+              fileSystem.path.join(
+                sdk.directory.path,
+                'cmdline-tools',
+                'latest',
+                'bin',
+                'android',
+              ),
+            )
+            .createSync(recursive: true);
+        fileSystem
+            .file(
+              fileSystem.path.join(
+                sdk.directory.path,
+                'cmdline-tools',
+                'latest',
+                'bin',
+                'sdkmanager',
+              ),
+            )
+            .createSync(recursive: true);
+
+        // Should return the android CLI path, not sdkmanager
+        expect(
+          sdk.sdkManagerPath,
+          fileSystem.path.join(
+            sdk.directory.path,
+            'cmdline-tools',
+            'latest',
+            'bin',
+            'android',
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Platform: () => FakePlatform(),
+        Config: () => config,
+      },
+    );
+
+    testUsingContext(
+      'falls back to sdkmanager when Android CLI is not available',
+      () {
+        final Directory sdkDir = createSdkDirectory(fileSystem: fileSystem, withSdkManager: false);
+        config.setValue('android-sdk', sdkDir.path);
+
+        final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+        // Create only sdkmanager
+        fileSystem
+            .file(
+              fileSystem.path.join(
+                sdk.directory.path,
+                'cmdline-tools',
+                'latest',
+                'bin',
+                'sdkmanager',
+              ),
+            )
+            .createSync(recursive: true);
+
+        // Should return the sdkmanager path since android is not available
+        expect(
+          sdk.sdkManagerPath,
+          fileSystem.path.join(
+            sdk.directory.path,
+            'cmdline-tools',
+            'latest',
+            'bin',
+            'sdkmanager',
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Platform: () => FakePlatform(),
+        Config: () => config,
+      },
+    );
+
+    testUsingContext(
+      'getAndroidCommandPath returns Android CLI path when available',
+      () {
+        final Directory sdkDir = createSdkDirectory(fileSystem: fileSystem, withSdkManager: false);
+        config.setValue('android-sdk', sdkDir.path);
+
+        final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+        fileSystem
+            .file(
+              fileSystem.path.join(
+                sdk.directory.path,
+                'cmdline-tools',
+                'latest',
+                'bin',
+                'android',
+              ),
+            )
+            .createSync(recursive: true);
+
+        expect(
+          sdk.getAndroidCommandPath(),
+          fileSystem.path.join(
+            sdk.directory.path,
+            'cmdline-tools',
+            'latest',
+            'bin',
+            'android',
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Platform: () => FakePlatform(),
+        Config: () => config,
+      },
+    );
+
+    testUsingContext(
       'returns sdkmanager version',
       () {
         final Directory sdkDir = createSdkDirectory(fileSystem: fileSystem);


### PR DESCRIPTION
This PR fixes the Android SDK deprecation warning by preferring the Android CLI tool when available, while maintaining backward compatibility with older SDK installations that only have `sdkmanager`.

**Fixes:** #189936

**Changes:**
- Add `getAndroidCommandPath()` method to detect Android CLI executable
- Modify `sdkManagerPath` property to prefer Android CLI with fallback to sdkmanager
- Update error messages to reference Android CLI as the recommended tool
- Add 3 comprehensive unit tests covering preference and fallback logic

**Issue(s) fixed by this PR:**
Fixes Google's deprecation of sdkmanager in favor of Android CLI

## Pre-launch Checklist

- [x] I read the [AI contribution guidelines] and understand my responsibilities
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide]
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.