### PR TITLE
[Windows] Tie IME context to text input client lifecycle

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_window.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window.cc
@@ -341,6 +341,13 @@ void FlutterWindow::OnResetImeComposing() {
   AbortImeComposing();
 }
 
+void FlutterWindow::OnTextInputClientChanged(bool active) {
+  text_input_client_active_ = active;
+  if (focused_) {
+    text_input_manager_->SetImeEnabled(active);
+  }
+}
+
 bool FlutterWindow::OnBitmapSurfaceCleared() {
   HDC dc = ::GetDC(GetWindowHandle());
   bool result = ::PatBlt(dc, 0, 0, current_width_, current_height_, BLACKNESS);
@@ -585,6 +592,7 @@ FlutterWindow::HandleMessage(UINT const message,
                              WPARAM const wparam,
                              LPARAM const lparam) noexcept {
   LPARAM result_lparam = lparam;
+  bool update_ime_after_default = false;
   int x_pos = 0, y_pos = 0;
   UINT width = 0, height = 0;
   UINT button_pressed = 0;
@@ -721,8 +729,10 @@ FlutterWindow::HandleMessage(UINT const message,
     case WM_SETFOCUS:
       OnWindowStateEvent(WindowStateEvent::kFocus);
       ::CreateCaret(window_handle_, nullptr, 1, 1);
+      update_ime_after_default = true;
       break;
     case WM_KILLFOCUS:
+      text_input_manager_->SetImeEnabled(false);
       OnWindowStateEvent(WindowStateEvent::kUnfocus);
       ::DestroyCaret();
       break;
@@ -881,7 +891,12 @@ FlutterWindow::HandleMessage(UINT const message,
       break;
   }
 
-  return Win32DefWindowProc(window_handle_, message, wparam, result_lparam);
+  const LRESULT result =
+      Win32DefWindowProc(window_handle_, message, wparam, result_lparam);
+  if (update_ime_after_default) {
+    text_input_manager_->SetImeEnabled(text_input_client_active_);
+  }
+  return result;
 }
 
 LRESULT FlutterWindow::OnGetObject(UINT const message,

--- a/engine/src/flutter/shell/platform/windows/flutter_window.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_window.h
@@ -142,6 +142,9 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
   // |FlutterWindowBindingHandler|
   virtual void OnResetImeComposing() override;
 
+  // |FlutterWindowBindingHandler|
+  virtual void OnTextInputClientChanged(bool active) override;
+
   // Called when accessibility support is enabled or disabled.
   virtual void OnUpdateSemanticsEnabled(bool enabled);
 
@@ -339,6 +342,9 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
   // proper application lifecycle state can be updated once the view is set.
   bool restored_ = false;
   bool focused_ = false;
+
+  // True while the framework has an active text input client for this view.
+  bool text_input_client_active_ = false;
 
   int current_dpi_ = 0;
   int current_width_ = 0;

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc
@@ -404,6 +404,10 @@ void FlutterWindowsView::OnResetImeComposing() {
   binding_handler_->OnResetImeComposing();
 }
 
+void FlutterWindowsView::OnTextInputClientChanged(bool active) {
+  binding_handler_->OnTextInputClientChanged(active);
+}
+
 // Sends new size information to FlutterEngine.
 void FlutterWindowsView::SendWindowMetrics(size_t width,
                                            size_t height,

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
@@ -266,6 +266,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // Notifies the delegate that the system IME composing state should be reset.
   virtual void OnResetImeComposing();
 
+  // Notifies the delegate that this view gained or lost a text input client.
+  virtual void OnTextInputClientChanged(bool active);
+
   // Called when a WM_ONCOMPOSITIONCHANGED message is received.
   void OnDwmCompositionChanged();
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -418,6 +418,20 @@ TEST(FlutterWindowsViewTest, EnableSemantics) {
   EXPECT_TRUE(semantics_enabled);
 }
 
+TEST(FlutterWindowsViewTest, ForwardsTextInputClientState) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  auto window_binding_handler =
+      std::make_unique<NiceMock<MockWindowBindingHandler>>();
+  MockWindowBindingHandler* window_binding_handler_ptr =
+      window_binding_handler.get();
+  std::unique_ptr<FlutterWindowsView> view =
+      engine->CreateView(std::move(window_binding_handler),
+                         /*is_sized_to_content=*/false, BoxConstraints());
+
+  EXPECT_CALL(*window_binding_handler_ptr, OnTextInputClientChanged(true));
+  view->OnTextInputClientChanged(true);
+}
+
 TEST(FlutterWindowsViewTest, AddSemanticsNodeUpdate) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
   EngineModifier modifier(engine.get());

--- a/engine/src/flutter/shell/platform/windows/testing/mock_text_input_manager.h
+++ b/engine/src/flutter/shell/platform/windows/testing/mock_text_input_manager.h
@@ -21,6 +21,8 @@ class MockTextInputManager : public TextInputManager {
   MockTextInputManager();
   virtual ~MockTextInputManager();
 
+  MOCK_METHOD(void, SetImeEnabled, (bool enabled), (override));
+
   MOCK_METHOD(std::optional<std::u16string>,
               GetComposingString,
               (),

--- a/engine/src/flutter/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/engine/src/flutter/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -25,6 +25,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD(PhysicalWindowBounds, GetPhysicalWindowBounds, (), (override));
   MOCK_METHOD(void, OnCursorRectUpdated, (const Rect& rect), (override));
   MOCK_METHOD(void, OnResetImeComposing, (), (override));
+  MOCK_METHOD(void, OnTextInputClientChanged, (bool active), (override));
   MOCK_METHOD(bool, OnBitmapSurfaceCleared, (), (override));
   MOCK_METHOD(bool,
               OnBitmapSurfaceUpdated,

--- a/engine/src/flutter/shell/platform/windows/text_input_manager.cc
+++ b/engine/src/flutter/shell/platform/windows/text_input_manager.cc
@@ -48,6 +48,45 @@ void TextInputManager::SetWindowHandle(HWND window_handle) {
   window_handle_ = window_handle;
 }
 
+void TextInputManager::SetImeEnabled(bool enabled) {
+  if (window_handle_ == nullptr) {
+    return;
+  }
+
+  HIMC previous_context = ::ImmGetContext(window_handle_);
+  if (previous_context != nullptr) {
+    ime_open_status_ = ::ImmGetOpenStatus(previous_context) != FALSE;
+    ::ImmReleaseContext(window_handle_, previous_context);
+  }
+
+  if (!enabled) {
+    ::ImmAssociateContextEx(window_handle_, nullptr, 0);
+    return;
+  }
+
+  // Reassociate rather than reusing the current context. Windows can rebuild
+  // the TSF document for a window while leaving its legacy IMM32 context
+  // association stale after the window regains focus.
+  ::ImmAssociateContextEx(window_handle_, nullptr, 0);
+  if (::ImmAssociateContextEx(window_handle_, nullptr, IACE_DEFAULT) == FALSE) {
+    if (previous_context != nullptr) {
+      ::ImmAssociateContext(window_handle_, previous_context);
+    }
+    return;
+  }
+
+  ImmContext restored_context(window_handle_);
+  if (!restored_context.IsValid()) {
+    if (previous_context != nullptr) {
+      ::ImmAssociateContext(window_handle_, previous_context);
+    }
+    return;
+  }
+  if (ime_open_status_.has_value()) {
+    ::ImmSetOpenStatus(restored_context.get(), ime_open_status_.value());
+  }
+}
+
 void TextInputManager::CreateImeWindow() {
   if (window_handle_ == nullptr) {
     return;

--- a/engine/src/flutter/shell/platform/windows/text_input_manager.cc
+++ b/engine/src/flutter/shell/platform/windows/text_input_manager.cc
@@ -44,7 +44,14 @@ class ImmContext {
   FML_DISALLOW_COPY_AND_ASSIGN(ImmContext);
 };
 
+TextInputManager::~TextInputManager() {
+  DestroyOwnedImeContext();
+}
+
 void TextInputManager::SetWindowHandle(HWND window_handle) {
+  if (window_handle_ != window_handle) {
+    DestroyOwnedImeContext();
+  }
   window_handle_ = window_handle;
 }
 
@@ -56,35 +63,98 @@ void TextInputManager::SetImeEnabled(bool enabled) {
   HIMC previous_context = ::ImmGetContext(window_handle_);
   if (previous_context != nullptr) {
     ime_open_status_ = ::ImmGetOpenStatus(previous_context) != FALSE;
+    DWORD conversion_mode = 0;
+    DWORD sentence_mode = 0;
+    if (::ImmGetConversionStatus(previous_context, &conversion_mode,
+                                 &sentence_mode) != FALSE) {
+      ime_conversion_mode_ = conversion_mode;
+      ime_sentence_mode_ = sentence_mode;
+    }
     ::ImmReleaseContext(window_handle_, previous_context);
   }
 
+  const bool previous_owned_context_destroyed = DestroyOwnedImeContext();
   if (!enabled) {
     ::ImmAssociateContextEx(window_handle_, nullptr, 0);
     return;
   }
-
-  // Reassociate rather than reusing the current context. Windows can rebuild
-  // the TSF document for a window while leaving its legacy IMM32 context
-  // association stale after the window regains focus.
-  ::ImmAssociateContextEx(window_handle_, nullptr, 0);
-  if (::ImmAssociateContextEx(window_handle_, nullptr, IACE_DEFAULT) == FALSE) {
-    if (previous_context != nullptr) {
-      ::ImmAssociateContext(window_handle_, previous_context);
-    }
+  if (!previous_owned_context_destroyed) {
     return;
   }
 
-  ImmContext restored_context(window_handle_);
-  if (!restored_context.IsValid()) {
-    if (previous_context != nullptr) {
-      ::ImmAssociateContext(window_handle_, previous_context);
+  // Restoring the thread's default HIMC is not sufficient when its TSF bridge
+  // is stale: Windows can return the same context while reporting success.
+  // Start every text-input activation with a distinct application-owned HIMC.
+  CreateAndAssociateImeContext();
+}
+
+bool TextInputManager::DestroyOwnedImeContext() {
+  if (owned_ime_context_ == nullptr) {
+    return true;
+  }
+
+  bool context_disassociated =
+      owned_ime_window_ == nullptr || ::IsWindow(owned_ime_window_) == FALSE;
+  if (!context_disassociated) {
+    HIMC current_context = ::ImmGetContext(owned_ime_window_);
+    if (current_context != nullptr) {
+      ::ImmReleaseContext(owned_ime_window_, current_context);
     }
-    return;
+    if (current_context == owned_ime_context_) {
+      ::ImmAssociateContext(owned_ime_window_, replaced_ime_context_);
+      current_context = ::ImmGetContext(owned_ime_window_);
+      if (current_context != nullptr) {
+        ::ImmReleaseContext(owned_ime_window_, current_context);
+      }
+    }
+    context_disassociated = current_context != owned_ime_context_;
   }
-  if (ime_open_status_.has_value()) {
-    ::ImmSetOpenStatus(restored_context.get(), ime_open_status_.value());
+
+  if (context_disassociated &&
+      ::ImmDestroyContext(owned_ime_context_) != FALSE) {
+    owned_ime_window_ = nullptr;
+    owned_ime_context_ = nullptr;
+    replaced_ime_context_ = nullptr;
   }
+  return owned_ime_context_ == nullptr;
+}
+
+bool TextInputManager::CreateAndAssociateImeContext() {
+  FML_DCHECK(window_handle_);
+
+  // Make the thread default context available as the context to restore when
+  // this application-owned context is disabled or destroyed.
+  ::ImmAssociateContextEx(window_handle_, nullptr, IACE_DEFAULT);
+
+  HIMC new_context = ::ImmCreateContext();
+  if (new_context == nullptr) {
+    return false;
+  }
+  if (ime_open_status_.has_value() &&
+      ::ImmSetOpenStatus(new_context, ime_open_status_.value()) == FALSE) {
+    ::ImmDestroyContext(new_context);
+    return false;
+  }
+  if (ime_conversion_mode_.has_value() && ime_sentence_mode_.has_value()) {
+    ::ImmSetConversionStatus(new_context, ime_conversion_mode_.value(),
+                             ime_sentence_mode_.value());
+  }
+
+  HIMC replaced_context = ::ImmAssociateContext(window_handle_, new_context);
+  HIMC associated_context = ::ImmGetContext(window_handle_);
+  if (associated_context != nullptr) {
+    ::ImmReleaseContext(window_handle_, associated_context);
+  }
+  if (associated_context != new_context) {
+    ::ImmAssociateContext(window_handle_, replaced_context);
+    ::ImmDestroyContext(new_context);
+    return false;
+  }
+
+  owned_ime_context_ = new_context;
+  owned_ime_window_ = window_handle_;
+  replaced_ime_context_ = replaced_context;
+  return true;
 }
 
 void TextInputManager::CreateImeWindow() {

--- a/engine/src/flutter/shell/platform/windows/text_input_manager.h
+++ b/engine/src/flutter/shell/platform/windows/text_input_manager.h
@@ -34,6 +34,12 @@ class TextInputManager {
   // Sets the window handle with which the IME is associated.
   void SetWindowHandle(HWND window_handle);
 
+  // Enables or disables IME input for the associated window.
+  //
+  // Enabling restores the window's default input context. The previous open
+  // status is preserved across disabling and re-enabling the context.
+  virtual void SetImeEnabled(bool enabled);
+
   // Creates a new IME window and system caret.
   //
   // This method should be invoked in response to the WM_IME_SETCONTEXT and
@@ -95,6 +101,10 @@ class TextInputManager {
 
   // True if IME-based composing is active.
   bool ime_active_ = false;
+
+  // The last known open status of the input context. This is retained while
+  // the context is disassociated from the window.
+  std::optional<bool> ime_open_status_;
 
   // The system caret rect.
   Rect caret_rect_ = {{0, 0}, {0, 0}};

--- a/engine/src/flutter/shell/platform/windows/text_input_manager.h
+++ b/engine/src/flutter/shell/platform/windows/text_input_manager.h
@@ -29,15 +29,16 @@ namespace flutter {
 class TextInputManager {
  public:
   TextInputManager() noexcept = default;
-  virtual ~TextInputManager() = default;
+  virtual ~TextInputManager();
 
   // Sets the window handle with which the IME is associated.
   void SetWindowHandle(HWND window_handle);
 
   // Enables or disables IME input for the associated window.
   //
-  // Enabling restores the window's default input context. The previous open
-  // status is preserved across disabling and re-enabling the context.
+  // Enabling associates a new application-owned input context. The previous
+  // open and conversion status are preserved across disabling and re-enabling
+  // the context.
   virtual void SetImeEnabled(bool enabled);
 
   // Creates a new IME window and system caret.
@@ -88,6 +89,13 @@ class TextInputManager {
   void AbortComposing();
 
  private:
+  // Restores the context replaced by |owned_ime_context_| and destroys the
+  // application-owned context.
+  bool DestroyOwnedImeContext();
+
+  // Creates and associates a new application-owned input context.
+  bool CreateAndAssociateImeContext();
+
   // Returns either the composing string or result string based on the value of
   // the |type| parameter.
   std::optional<std::u16string> GetString(int type) const;
@@ -105,6 +113,17 @@ class TextInputManager {
   // The last known open status of the input context. This is retained while
   // the context is disassociated from the window.
   std::optional<bool> ime_open_status_;
+
+  // The last known conversion and sentence modes. These are retained while
+  // the context is disassociated from the window.
+  std::optional<DWORD> ime_conversion_mode_;
+  std::optional<DWORD> ime_sentence_mode_;
+
+  // The application-owned context, its associated window, and the previous
+  // context that must be restored before it is destroyed.
+  HWND owned_ime_window_ = nullptr;
+  HIMC owned_ime_context_ = nullptr;
+  HIMC replaced_ime_context_ = nullptr;
 
   // The system caret rect.
   Rect caret_rect_ = {{0, 0}, {0, 0}};

--- a/engine/src/flutter/shell/platform/windows/text_input_plugin.cc
+++ b/engine/src/flutter/shell/platform/windows/text_input_plugin.cc
@@ -231,6 +231,7 @@ void TextInputPlugin::HandleMethodCall(
       SendStateUpdate(*active_model_);
     }
     view->OnResetImeComposing();
+    view->OnTextInputClientChanged(false);
     active_model_ = nullptr;
   } else if (method.compare(kSetClientMethod) == 0) {
     if (!method_call.arguments() || method_call.arguments()->IsNull()) {
@@ -241,6 +242,8 @@ void TextInputPlugin::HandleMethodCall(
 
     const rapidjson::Value& client_id_json = args[0];
     const rapidjson::Value& client_config = args[1];
+    const FlutterViewId previous_view_id = view_id_;
+    const bool had_active_model = active_model_ != nullptr;
     if (client_id_json.IsNull()) {
       result->Error(kBadArgumentError, "Could not set client, ID is null.");
       return;
@@ -283,6 +286,16 @@ void TextInputPlugin::HandleMethodCall(
       }
     }
     active_model_ = std::make_unique<TextInputModel>();
+    if (had_active_model && previous_view_id != view_id_) {
+      FlutterWindowsView* previous_view = engine_->view(previous_view_id);
+      if (previous_view != nullptr) {
+        previous_view->OnTextInputClientChanged(false);
+      }
+    }
+    FlutterWindowsView* view = engine_->view(view_id_);
+    if (view != nullptr) {
+      view->OnTextInputClientChanged(true);
+    }
   } else if (method.compare(kSetEditingStateMethod) == 0) {
     if (!method_call.arguments() || method_call.arguments()->IsNull()) {
       result->Error(kBadArgumentError, "Method invoked without args");
@@ -508,10 +521,15 @@ void TextInputPlugin::OnViewRemoved(FlutterViewId view_id) {
   }
 
   // If composing, commit and end composing. Skip sending state updates and
-  // IME reset since the view is being removed.
+  // composing reset since the view is being removed.
   if (active_model_ != nullptr && active_model_->composing()) {
     active_model_->CommitComposing();
     active_model_->EndComposing();
+  }
+
+  FlutterWindowsView* view = engine_->view(view_id_);
+  if (view != nullptr) {
+    view->OnTextInputClientChanged(false);
   }
 
   active_model_ = nullptr;

--- a/engine/src/flutter/shell/platform/windows/text_input_plugin_unittest.cc
+++ b/engine/src/flutter/shell/platform/windows/text_input_plugin_unittest.cc
@@ -138,6 +138,7 @@ class MockFlutterWindowsView : public FlutterWindowsView {
 
   MOCK_METHOD(void, OnCursorRectUpdated, (const Rect&), (override));
   MOCK_METHOD(void, OnResetImeComposing, (), (override));
+  MOCK_METHOD(void, OnTextInputClientChanged, (bool), (override));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsView);
@@ -237,9 +238,28 @@ TEST_F(TextInputPluginTest, ClearClientResetsComposing) {
   modifier.SetViewId(456);
 
   EXPECT_CALL(*view(), OnResetImeComposing());
+  EXPECT_CALL(*view(), OnTextInputClientChanged(false));
 
   auto& codec = JsonMethodCodec::GetInstance();
   auto message = codec.EncodeMethodCall({"TextInput.clearClient", nullptr});
+  messenger.SimulateEngineMessage(kChannelName, message->data(),
+                                  message->size(), reply_handler);
+}
+
+TEST_F(TextInputPluginTest, SetClientEnablesIme) {
+  UseEngineWithView();
+
+  TestBinaryMessenger messenger([](const std::string& channel,
+                                   const uint8_t* message, size_t message_size,
+                                   BinaryReply reply) {});
+  BinaryReply reply_handler = [](const uint8_t* reply, size_t reply_size) {};
+
+  TextInputPlugin handler(&messenger, engine());
+  EXPECT_CALL(*view(), OnTextInputClientChanged(true));
+
+  auto message = JsonMethodCodec::GetInstance().EncodeMethodCall(
+      {"TextInput.setClient",
+       EncodedClientConfig("TextInputType.text", "TextInputAction.done")});
   messenger.SimulateEngineMessage(kChannelName, message->data(),
                                   message->size(), reply_handler);
 }
@@ -731,7 +751,8 @@ TEST_F(TextInputPluginTest, SetMarkedTextRectRequiresView) {
 
 TEST_F(TextInputPluginTest, SetAndUseMultipleClients) {
   UseEngineWithView();  // Creates the default view
-  AddViewWithId(789);   // Creates the next view
+  std::unique_ptr<MockFlutterWindowsView> second_view =
+      AddViewWithId(789);  // Creates the next view
 
   bool sent_message = false;
   TestBinaryMessenger messenger(
@@ -740,6 +761,13 @@ TEST_F(TextInputPluginTest, SetAndUseMultipleClients) {
                       BinaryReply reply) { sent_message = true; });
 
   TextInputPlugin handler(&messenger, engine());
+
+  {
+    InSequence sequence;
+    EXPECT_CALL(*view(), OnTextInputClientChanged(true));
+    EXPECT_CALL(*view(), OnTextInputClientChanged(false));
+    EXPECT_CALL(*second_view, OnTextInputClientChanged(true));
+  }
 
   auto const set_client_and_send_message = [&](int client_id, int view_id) {
     auto args = std::make_unique<rapidjson::Document>(rapidjson::kArrayType);
@@ -800,6 +828,7 @@ TEST_F(TextInputPluginTest, OnViewRemovedResetsActiveView) {
   auto set_client_message = codec.EncodeMethodCall(
       {"TextInput.setClient",
        EncodedClientConfig("TextInputType.text", "TextInputAction.done")});
+  EXPECT_CALL(*view(), OnTextInputClientChanged(true));
   messenger.SimulateEngineMessage(kChannelName, set_client_message->data(),
                                   set_client_message->size(), reply_handler);
 
@@ -807,6 +836,7 @@ TEST_F(TextInputPluginTest, OnViewRemovedResetsActiveView) {
   EXPECT_EQ(modifier.GetViewId(), 456);
 
   // Remove the active view.
+  EXPECT_CALL(*view(), OnTextInputClientChanged(false));
   handler.OnViewRemoved(456);
 
   EXPECT_FALSE(modifier.HasActiveModel());

--- a/engine/src/flutter/shell/platform/windows/window_binding_handler.h
+++ b/engine/src/flutter/shell/platform/windows/window_binding_handler.h
@@ -75,6 +75,9 @@ class WindowBindingHandler {
   // client is cleared.
   virtual void OnResetImeComposing() = 0;
 
+  // Invoked when the view gains or loses an active text input client.
+  virtual void OnTextInputClientChanged(bool active) = 0;
+
   // Returns the last known position of the primary pointer in window
   // coordinates.
   virtual PointerLocation GetPrimaryPointerLocation() = 0;

--- a/engine/src/flutter/shell/platform/windows/window_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/window_unittests.cc
@@ -4,6 +4,8 @@
 
 #include <array>
 
+#include <imm.h>
+
 #include "flutter/shell/platform/windows/testing/mock_direct_manipulation.h"
 #include "flutter/shell/platform/windows/testing/mock_text_input_manager.h"
 #include "flutter/shell/platform/windows/testing/mock_window.h"
@@ -23,6 +25,55 @@ namespace testing {
 TEST(MockWindow, CreateDestroy) {
   MockWindow window;
   ASSERT_TRUE(TRUE);
+}
+
+TEST(TextInputManager, ImeContextFollowsEnabledState) {
+  HWND window =
+      CreateWindowExW(0, L"STATIC", L"", WS_POPUP, 0, 0, 1, 1, nullptr, nullptr,
+                      GetModuleHandle(nullptr), nullptr);
+  ASSERT_NE(window, nullptr);
+
+  HIMC original_context = ImmGetContext(window);
+  ASSERT_NE(original_context, nullptr);
+  const BOOL original_open_status = ImmGetOpenStatus(original_context);
+  ImmReleaseContext(window, original_context);
+
+  TextInputManager manager;
+  manager.SetWindowHandle(window);
+  manager.SetImeEnabled(false);
+  EXPECT_EQ(ImmGetContext(window), nullptr);
+
+  manager.SetImeEnabled(true);
+  HIMC restored_context = ImmGetContext(window);
+  ASSERT_NE(restored_context, nullptr);
+  EXPECT_EQ(ImmGetOpenStatus(restored_context), original_open_status);
+  ImmReleaseContext(window, restored_context);
+
+  DestroyWindow(window);
+}
+
+TEST(MockWindow, RestoresImeContextAfterRegainingFocus) {
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
+  auto text_input_manager = std::make_unique<MockTextInputManager>();
+  MockTextInputManager* text_input_manager_ptr = text_input_manager.get();
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager));
+
+  window.OnTextInputClientChanged(true);
+
+  {
+    InSequence sequence;
+    EXPECT_CALL(window, Win32DefWindowProc(_, WM_SETFOCUS, _, _));
+    EXPECT_CALL(*text_input_manager_ptr, SetImeEnabled(true));
+  }
+  window.InjectWindowMessage(WM_SETFOCUS, 0, 0);
+
+  {
+    InSequence sequence;
+    EXPECT_CALL(*text_input_manager_ptr, SetImeEnabled(false));
+    EXPECT_CALL(window, Win32DefWindowProc(_, WM_KILLFOCUS, _, _));
+  }
+  window.InjectWindowMessage(WM_KILLFOCUS, 0, 0);
 }
 
 TEST(MockWindow, GetDpiAfterCreate) {

--- a/engine/src/flutter/shell/platform/windows/window_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/window_unittests.cc
@@ -36,6 +36,10 @@ TEST(TextInputManager, ImeContextFollowsEnabledState) {
   HIMC original_context = ImmGetContext(window);
   ASSERT_NE(original_context, nullptr);
   const BOOL original_open_status = ImmGetOpenStatus(original_context);
+  DWORD original_conversion_mode = 0;
+  DWORD original_sentence_mode = 0;
+  const BOOL original_conversion_available = ImmGetConversionStatus(
+      original_context, &original_conversion_mode, &original_sentence_mode);
   ImmReleaseContext(window, original_context);
 
   TextInputManager manager;
@@ -46,9 +50,26 @@ TEST(TextInputManager, ImeContextFollowsEnabledState) {
   manager.SetImeEnabled(true);
   HIMC restored_context = ImmGetContext(window);
   ASSERT_NE(restored_context, nullptr);
+  EXPECT_NE(restored_context, original_context);
   EXPECT_EQ(ImmGetOpenStatus(restored_context), original_open_status);
+  if (original_conversion_available != FALSE) {
+    DWORD restored_conversion_mode = 0;
+    DWORD restored_sentence_mode = 0;
+    ASSERT_NE(
+        ImmGetConversionStatus(restored_context, &restored_conversion_mode,
+                               &restored_sentence_mode),
+        FALSE);
+    EXPECT_EQ(restored_conversion_mode, original_conversion_mode);
+    EXPECT_EQ(restored_sentence_mode, original_sentence_mode);
+  }
   ImmReleaseContext(window, restored_context);
 
+  manager.SetWindowHandle(nullptr);
+  HIMC final_context = ImmGetContext(window);
+  EXPECT_EQ(final_context, original_context);
+  if (final_context != nullptr) {
+    ImmReleaseContext(window, final_context);
+  }
   DestroyWindow(window);
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/190042

## Problem

Flutter's Windows embedder keeps the HWND's legacy IMM32 input context active
independently of the framework text-input client lifecycle. `TextInput.setClient`
and `TextInput.clearClient` update the engine's text model, but they do not enable
or disable the native input context associated with the view. Window focus changes
also leave the existing context association in place.

On affected Windows systems, this can leave the Flutter view with a stale
IMM32-to-TSF session. Keyboard messages and input-profile changes continue, and
`ImmGetOpenStatus` remains true, but the view no longer receives
`WM_IME_STARTCOMPOSITION` or `WM_IME_COMPOSITION`.

This is related to #181313, which reports the opposite visible symptom: Windows
keeps IME input active when Flutter has no focused text-input client. Earlier
focus/client lifecycle work in #90503 likewise required an explicit native IME
reset when a client was cleared.

## Captured evidence

A July 27 recurrence showed that restoring the thread default HIMC after the
session is stale is a successful no-op:

- Immediately before failure, the TSF thread open/close compartment returned
  `S_OK` with value `1`.
- At failure, Windows had replaced the focused TSF document/context and the
  compartment returned `S_FALSE`.
- Detaching the view and restoring `IACE_DEFAULT` both returned success.
- The HIMC, TSF document/context, and `S_FALSE` compartment state were identical
  before and after that operation.
- The view then received 474 `WM_KEYDOWN` messages across Microsoft Pinyin and
  WeType profile changes, with zero composition start/update/end messages.

A July 28 application-side experiment tested a stronger reactive recovery on an
affected machine running the stock Flutter 3.44.8 engine:

- After the stale state was detected, the application created and associated a
  distinct HIMC.
- The associated HIMC and TSF document/context changed, and the thread
  open/close compartment changed from `S_FALSE` to `S_OK` with value `1`.
- The candidate recovery received no confirming composition message.
- After the text client was enabled again, the view received 180 `WM_KEYDOWN`
  messages, including 136 alphabetic key messages, with zero composition
  start/update/end messages.

This disproves the narrower claim that creating a fresh HIMC *after* the
IMM32-to-TSF session is already stale is sufficient to repair it. The
application-side experiment did not detach the context when `TextInput.clearClient`
or `WM_KILLFOCUS` occurred, so it does not validate or invalidate this PR's full
preventive lifecycle change.

## Change

This change ties native IME context ownership to Flutter text-input activation:

- `TextInput.setClient` enables IME input for its view, and
  `TextInput.clearClient` disables it.
- A view disassociates its input context when it loses focus.
- Enabling creates and associates a distinct application-owned input context.
- The previous IME open, conversion, and sentence state is copied to the new
  context.
- The replaced context is restored before the application-owned context is
  destroyed.
- When the active text client moves between views, the previous view is disabled
  before the new view is enabled.
- Focus-gain enablement runs after `DefWindowProc`, so Windows completes its
  native focus processing before the active text client is reattached.

The intended behavior is preventive: no IME context remains attached to the
Flutter view while the window is unfocused or the framework has no active text
client. This avoids carrying a stale context through a later client activation.

## Validation status

This PR remains draft. The complete engine change has not yet been validated on
the affected Windows machine. The July 28 result applies only to post-failure,
application-side HIMC replacement.

The decisive validation is an A/B test using the same Flutter revision and
application build, differing only by this engine patch. Success requires repeated
focus/client lifecycle transitions to continue producing `VK_PROCESSKEY` and
composition messages; successful Win32 API return values or `S_OK/value=1`
compartment state alone are not sufficient.

## Tests

Added Windows unit coverage for:

- disabling the native input context on a real Win32 window;
- associating a context distinct from the thread default context;
- preserving IME open, conversion, and sentence state;
- restoring the replaced context before the manager releases its window;
- detaching before focus loss and enabling after `DefWindowProc` on focus gain;
- propagating text input client state through the view/binding layers;
- enabling, clearing, removing, and moving clients between multiple views.

Local checks on macOS:

```text
clang-format --style=file --dry-run --Werror <changed C++ files>
```

The Windows engine unit tests cannot run on this macOS host. This PR remains
draft until Windows presubmit and the affected-machine A/B validation complete.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed one or more issues that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/about
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
