### PR TITLE
iOS,macOS: Rename Swift test files to end in Tests.swift

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
@@ -244,8 +244,8 @@ executable("framework_common_swift_unittests") {
     ":swift_testing_config",
   ]
   sources = [
-    "framework/Source/LoggerTest.swift",
-    "framework/Source/TracingTest.swift",
+    "framework/Source/LoggerTests.swift",
+    "framework/Source/TracingTests.swift",
   ]
   deps = [
     ":framework_common",

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTests.swift
@@ -8,7 +8,7 @@ import Testing
 import InternalFlutterSwiftCommon
 import test_utils_swift
 
-@Suite struct LoggerTest {
+@Suite struct LoggerTests {
 
   @Test func testInitialization() {
     let writer = StringOutputWriter()

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/TracingTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/TracingTests.swift
@@ -6,7 +6,7 @@ import Foundation
 import InternalFlutterSwiftCommon
 import Testing
 
-@Suite struct TracingTest {
+@Suite struct TracingTests {
 
   @Test func testTracePlatformVsyncDoesNotCrash() {
     Tracing.tracePlatformVsync(

--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -255,13 +255,13 @@ if (enable_ios_unittests) {
     bridge_header = "FlutterTests-Bridging-Header.h"
     sources = [
       "framework/Source/AccessibilityFeaturesTests.swift",
-      "framework/Source/ConnectionCollectionTest.swift",
-      "framework/Source/DisplayLinkManagerTest.swift",
+      "framework/Source/ConnectionCollectionTests.swift",
+      "framework/Source/DisplayLinkManagerTests.swift",
       "framework/Source/FakeUIPressProxy.swift",
-      "framework/Source/LaunchEngineTest.swift",
+      "framework/Source/LaunchEngineTests.swift",
       "framework/Source/SplashScreenManagerTests.swift",
       "framework/Source/TaskRunnerTests.swift",
-      "framework/Source/VSyncClientTest.swift",
+      "framework/Source/VSyncClientTests.swift",
     ]
     frameworks = [ "Testing.framework" ]
     deps = [

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/ConnectionCollectionTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/ConnectionCollectionTests.swift
@@ -5,7 +5,7 @@
 import InternalFlutterSwift
 import Testing
 
-struct ConnectionCollectionTest {
+struct ConnectionCollectionTests {
   @Test func acquireAndRelease() {
     let connections = ConnectionCollection()
     let connectionID = connections.acquireConnection(forChannel: "foo")

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManagerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/DisplayLinkManagerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 @testable import InternalFlutterSwift
 
 @MainActor
-class DisplayLinkManagerTest: XCTestCase {
+class DisplayLinkManagerTests: XCTestCase {
 
   func testDisplayLinkManagerCanBeInstantiatedWithMockValues() {
     let manager = DisplayLinkManager(maxRefreshRateEnabled: true, refreshRate: 120.0)

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngineTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngineTests.swift
@@ -6,7 +6,7 @@ import InternalFlutterSwift
 import Testing
 
 @MainActor
-struct LaunchEngineTest {
+struct LaunchEngineTests {
 
   /// Verifies that the engine is lazily created on first access, cached on subsequent accesses, and
   /// successfully transferred when taken, leaving the container empty.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VSyncClientTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VSyncClientTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 @testable import InternalFlutterSwift
 
-class VSyncClientTest: XCTestCase {
+class VSyncClientTests: XCTestCase {
   var threadTaskRunner: TaskRunner!
 
   override func setUp() {

--- a/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
@@ -201,7 +201,7 @@ executable("flutter_desktop_darwin_swift_unittests") {
     "//flutter/shell/platform/darwin/common:test_config",
     "//flutter/shell/platform/darwin/common:swift_testing_config",
   ]
-  sources = [ "framework/Source/ResizeSynchronizerTest.swift" ]
+  sources = [ "framework/Source/ResizeSynchronizerTests.swift" ]
   deps = [
     ":flutter_framework_source",
     "//flutter/shell/platform/darwin/common:swift_testing_main",

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/ResizeSynchronizerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/ResizeSynchronizerTests.swift
@@ -11,7 +11,7 @@ import Testing
 // in effect, a source of implicit shared state/behaviour. Because `beginResize` is a blocking call
 // performed on the main thread, we serialise to avoid potential interactions between tests.
 @Suite("ResizeSynchronizer tests", .serialized)
-struct ResizeSynchronizerTest {
+struct ResizeSynchronizerTests {
 
   @MainActor
   @Test("performCommit callback executes when no resize is active")


### PR DESCRIPTION
Standardizes our Swift test file naming and migrates all `FooTest.swift` files to use the `FooTests.swift` naming used by Xcode's test templates and the rest of the Swift ecosystem.

Previously we used a mix of both.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
