### PR TITLE
fix(logger): preserve Unicode check and cross symbols in log output

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -734,8 +734,6 @@ class WindowsStdoutLogger extends StdoutLogger {
         : message
               .replaceAll('🔥', '')
               .replaceAll('🖼️', '')
-              .replaceAll('✗', 'X')
-              .replaceAll('✓', '√')
               .replaceAll('🔨', '')
               .replaceAll('💪', '')
               .replaceAll('⚠️', '!')


### PR DESCRIPTION
- exclude ✓ and ✗ from emoji replacement
- prevent incorrect conversion to alternate Unicode symbols
- preserve original log formatting when these symbols are used

This PR fixes an issue in the logger's emoji replacement logic where the Unicode symbols `✓` (CHECK MARK) and `✗` (BALLOT X) were incorrectly identified as emojis and replaced with different Unicode characters.

These characters are standard Unicode symbols rather than emoji and are commonly used in log output to indicate success and failure. Preserving them prevents unintended substitutions and ensures log messages are rendered exactly as intended.

### Changes

* Excluded `✓` and `✗` from the emoji replacement logic.
* Prevented incorrect conversion of these symbols to alternate Unicode characters.
* Preserved the original formatting and semantics of log output containing these symbols.

**Issue:** N/A (trivial bug fix)