### PR TITLE
Remove deprecated `tolerance` getter

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -17,10 +17,8 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/painting.dart' show AxisDirection;
 import 'package:flutter/physics.dart';
 
-import 'binding.dart' show WidgetsBinding;
 import 'framework.dart';
 import 'overscroll_indicator.dart';
 import 'scroll_metrics.dart';
@@ -416,24 +414,6 @@ class ScrollPhysics {
 
   /// The spring to use for ballistic simulations.
   SpringDescription get spring => parent?.spring ?? _kDefaultSpring;
-
-  /// Deprecated. Call [toleranceFor] instead.
-  @Deprecated(
-    'Call toleranceFor instead. '
-    'This feature was deprecated after v3.7.0-13.0.pre.',
-  )
-  Tolerance get tolerance {
-    return toleranceFor(
-      FixedScrollMetrics(
-        minScrollExtent: null,
-        maxScrollExtent: null,
-        pixels: null,
-        viewportDimension: null,
-        axisDirection: AxisDirection.down,
-        devicePixelRatio: WidgetsBinding.instance.window.devicePixelRatio,
-      ),
-    );
-  }
 
   /// The tolerance to use for ballistic simulations.
   Tolerance toleranceFor(ScrollMetrics metrics) {

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -1512,7 +1512,16 @@ final class _HighFrictionClampingScrollPhysics extends ScrollPhysics {
       position: position.pixels,
       velocity: velocity,
       friction: 0.94,
-      tolerance: tolerance,
+      tolerance: toleranceFor(
+        FixedScrollMetrics(
+          minScrollExtent: null,
+          maxScrollExtent: null,
+          pixels: null,
+          viewportDimension: null,
+          axisDirection: AxisDirection.down,
+          devicePixelRatio: WidgetsBinding.instance.window.devicePixelRatio,
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
