### PR TITLE
[Tool] Handle WDAC block error code 4551 for impellerc

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -336,7 +336,9 @@ class ShaderCompiler {
       return false;
     }
     const winErrorAccessDisabledByPolicy = 1260;
-    return exception.errorCode == winErrorAccessDisabledByPolicy;
+    const winErrorSystemIntegrityPolicyViolation = 4551;
+    return exception.errorCode == winErrorAccessDisabledByPolicy ||
+        exception.errorCode == winErrorSystemIntegrityPolicyViolation;
   }
 
   void _logSecurityBlockError(String impellercPath) {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -831,6 +831,53 @@ void main() {
     );
 
     testWithoutContext(
+      'compileShader throws ToolExit and logs friendly message when impellerc is blocked by WDAC (4551)',
+      () async {
+        final blockedException = ProcessException(
+          impellerc,
+          <String>[],
+          'An Application Control policy has blocked this file',
+          4551,
+        );
+        final processManager = FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: <String>[
+              impellerc,
+              '--runtime-stage-metal',
+              '--iplr',
+              '--sl=$outputPath',
+              '--spirv=$outputPath.spirv',
+              '--input=$fragPath',
+              '--input-type=frag',
+              '--include=$fragDir',
+              '--include=$shaderLibDir',
+            ],
+            exception: blockedException,
+          ),
+        ]);
+        final shaderCompiler = ShaderCompiler(
+          processManager: processManager,
+          logger: logger,
+          fileSystem: fileSystem,
+          artifacts: artifacts,
+          platform: FakePlatform(operatingSystem: 'windows'),
+        );
+
+        await expectLater(
+          shaderCompiler.compileShader(
+            input: fileSystem.file(fragPath),
+            outputPath: outputPath,
+            targetPlatform: TargetPlatform.ios,
+          ),
+          throwsToolExit(message: 'Impeller shader compiler was blocked by security policy.'),
+        );
+
+        expect(logger.errorText, contains('blocked by system'));
+        expect(logger.errorText, contains(impellerc));
+      },
+    );
+
+    testWithoutContext(
       'compileShader throws ToolExit and logs friendly message when impellerc is blocked by group policy',
       () async {
         final blockedException = ProcessException(


### PR DESCRIPTION
[Tool] Handle WDAC block error code 4551 for impellerc

On Windows systems with Windows Defender Application Control (WDAC) or
Smart App Control (SAC) enabled, blocking of `impellerc.exe` throws a
`ProcessException` with error code `4551` (`ERROR_SYSTEM_INTEGRITY_POLICY_VIOLATION`).

This is similar to error code `1260` (`ERROR_ACCESS_DISABLED_BY_POLICY`)
which is already handled.

This change:
1. Defines the constant `winErrorSystemIntegrityPolicyViolation` with value `4551` in `shader_compiler.dart`.
2. Updates `ShaderCompiler._isBlockedBySecurityPolicy` to check for this error code.
3. Ensures that when this exception is thrown, the tool prints a helpful message instructing the user to allowlist the binary and exits gracefully.
