### PR TITLE
[flutter_tools] Handle WDAC block error code 4551 in shader compiler

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -336,7 +336,9 @@ class ShaderCompiler {
       return false;
     }
     const winErrorAccessDisabledByPolicy = 1260;
-    return exception.errorCode == winErrorAccessDisabledByPolicy;
+    const winErrorSystemIntegrityPolicyViolation = 4551;
+    return exception.errorCode == winErrorAccessDisabledByPolicy ||
+        exception.errorCode == winErrorSystemIntegrityPolicyViolation;
   }
 
   void _logSecurityBlockError(String impellercPath) {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -831,6 +831,53 @@ void main() {
     );
 
     testWithoutContext(
+      'compileShader throws ToolExit and logs friendly message when impellerc is blocked by WDAC (error code 4551)',
+      () async {
+        final blockedException = ProcessException(
+          impellerc,
+          <String>[],
+          'An Application Control policy has blocked this file',
+          4551,
+        );
+        final processManager = FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: <String>[
+              impellerc,
+              '--runtime-stage-metal',
+              '--iplr',
+              '--sl=$outputPath',
+              '--spirv=$outputPath.spirv',
+              '--input=$fragPath',
+              '--input-type=frag',
+              '--include=$fragDir',
+              '--include=$shaderLibDir',
+            ],
+            exception: blockedException,
+          ),
+        ]);
+        final shaderCompiler = ShaderCompiler(
+          processManager: processManager,
+          logger: logger,
+          fileSystem: fileSystem,
+          artifacts: artifacts,
+          platform: FakePlatform(operatingSystem: 'windows'),
+        );
+
+        await expectLater(
+          shaderCompiler.compileShader(
+            input: fileSystem.file(fragPath),
+            outputPath: outputPath,
+            targetPlatform: TargetPlatform.ios,
+          ),
+          throwsToolExit(message: 'Impeller shader compiler was blocked by security policy.'),
+        );
+
+        expect(logger.errorText, contains('blocked by system'));
+        expect(logger.errorText, contains(impellerc));
+      },
+    );
+
+    testWithoutContext(
       'compileShader throws ToolExit and logs friendly message when impellerc is blocked by group policy',
       () async {
         final blockedException = ProcessException(


### PR DESCRIPTION
Handle Win32 error code 4551 (ERROR_SYSTEM_INTEGRITY_POLICY_VIOLATION) which is returned when Windows Defender Application Control (WDAC) blocks impellerc.exe. This ensures the tool exits gracefully with a ToolExit and prints a helpful message instructing the user to allowlist the binary.