### PR TITLE
[Impeller/Tool] Fix shader compiler crashes and improve diagnostics

### DIFF
--- a/engine/src/flutter/impeller/compiler/switches.cc
+++ b/engine/src/flutter/impeller/compiler/switches.cc
@@ -239,7 +239,7 @@ Switches::Switches(const fml::CommandLine& command_line)
     }
 
     auto dir = std::make_shared<fml::UniqueFD>(fml::OpenDirectoryReadOnly(
-        *working_directory, include_dir_absolute.string().c_str()));
+        *working_directory, Utf8FromPath(include_dir_absolute).c_str()));
     if (!dir || !dir->is_valid()) {
       continue;
     }

--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -265,7 +265,7 @@ class ShaderCompiler {
       final List<String> shaderTargets = _shaderTargetsFromTargetPlatform(targetPlatform);
       final List<String> cmd = makeImpellercCommand(shaderTargets);
       _logger.printTrace('impellerc command: $cmd');
-      final ProcessResult result = await _runCommand(cmd);
+      ProcessResult result = await _runCommand(cmd);
       if (result.exitCode != 0) {
         // Maybe retry impellerc command without --sksl.
         if (!(shaderTargets.length > 1 && shaderTargets.contains('--sksl'))) {
@@ -286,6 +286,7 @@ class ShaderCompiler {
         if (retryResult.exitCode != 0) {
           // Retry failed.
           _logger.printError('impellerc failure: ${retryResult.stderr}');
+          result = retryResult;
           failure = true;
         } else {
           // Retry succeeded. Don't fail, but log a warning message and the sksl
@@ -302,9 +303,38 @@ class ShaderCompiler {
 
       if (failure) {
         if (fatal) {
+          final hintBuffer = StringBuffer();
+          if (_platform.isMacOS && result.exitCode == -9) {
+            hintBuffer.write(
+              'The shader compiler may have been killed by the OS (e.g. out of memory) or blocked by macOS Gatekeeper.\n'
+              'To allow the binary to run, try running:\n'
+              '  xattr -d com.apple.quarantine "${impellerc.path}"',
+            );
+          } else if ((_platform.isWindows && result.exitCode == 3) ||
+              ((_platform.isMacOS || _platform.isLinux) && result.exitCode == -6)) {
+            hintBuffer.write('The shader compiler aborted.');
+            if (_platform.isWindows) {
+              final bool hasNonAscii =
+                  RegExp(r'[^\x00-\x7F]').hasMatch(input.path) ||
+                  RegExp(r'[^\x00-\x7F]').hasMatch(outputPath);
+              if (hasNonAscii) {
+                hintBuffer.write(
+                  '\nThis may be caused by non-ASCII (Unicode) characters in the project path.\n'
+                  'Please try moving the project to a directory containing only ASCII characters in its path.',
+                );
+              }
+            }
+          }
+
+          final message =
+              'Shader compilation of "${input.path}" to "$outputPath" '
+              'failed with exit code ${result.exitCode}.'
+              '${hintBuffer.isNotEmpty ? '\n\n$hintBuffer' : ''}';
+
           throw ShaderCompilerException._(
-            'Shader compilation of "${input.path}" to "$outputPath" '
-            'failed with exit code ${result.exitCode}.',
+            message,
+            stderr: result.stderr as String?,
+            stdout: result.stdout as String?,
           );
         }
         return false;
@@ -363,10 +393,21 @@ class _SecurityPolicyBlockException implements Exception {
 }
 
 class ShaderCompilerException implements Exception {
-  ShaderCompilerException._(this.message);
+  ShaderCompilerException._(this.message, {this.stderr, this.stdout});
 
   final String message;
+  final String? stderr;
+  final String? stdout;
 
   @override
-  String toString() => 'ShaderCompilerException: $message\n\n';
+  String toString() {
+    final buffer = StringBuffer('ShaderCompilerException: $message\n');
+    if (stdout != null && stdout!.isNotEmpty) {
+      buffer.writeln('stdout:\n$stdout');
+    }
+    if (stderr != null && stderr!.isNotEmpty) {
+      buffer.writeln('stderr:\n$stderr');
+    }
+    return buffer.toString();
+  }
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -244,6 +244,10 @@ void main() {
           '"/output/shaders/my_shader.frag" failed with exit code 1.',
         ),
       );
+      expect(e.stdout, 'impellerc stdout');
+      expect(e.stderr, 'impellerc stderr');
+      expect(e.toString(), contains('stdout:\nimpellerc stdout'));
+      expect(e.toString(), contains('stderr:\nimpellerc stderr'));
     }
 
     expect(fileSystem.file(outputPath).existsSync(), false);
@@ -1032,6 +1036,171 @@ void main() {
       expect(success2, false);
 
       expect(headerLine.allMatches(logger.errorText).length, 2);
+    });
+  });
+
+  group('ShaderCompiler hints and diagnostics', () {
+    testWithoutContext('macOS and exit code -9 adds Gatekeeper/OOM hint', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: -9,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(operatingSystem: 'macos'),
+      );
+
+      try {
+        await shaderCompiler.compileShader(
+          input: fileSystem.file(notFragPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.web_javascript,
+        );
+        fail('unreachable');
+      } on ShaderCompilerException catch (e) {
+        expect(e.toString(), contains('blocked by macOS Gatekeeper'));
+        expect(e.toString(), contains('xattr -d com.apple.quarantine'));
+      }
+    });
+
+    testWithoutContext('Windows and exit code 3 adds abort hint', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: 3,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(operatingSystem: 'windows'),
+      );
+
+      try {
+        await shaderCompiler.compileShader(
+          input: fileSystem.file(notFragPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.web_javascript,
+        );
+        fail('unreachable');
+      } on ShaderCompilerException catch (e) {
+        expect(e.toString(), contains('The shader compiler aborted.'));
+        expect(e.toString(), isNot(contains('non-ASCII (Unicode) characters')));
+      }
+    });
+
+    testWithoutContext(
+      'Windows and exit code 3 with Unicode path adds Unicode path warning',
+      () async {
+        const unicodeFragPath = '/shaders/my_shåder.frag';
+        const unicodeOutputPath = '/output/shaders/my_shåder.frag';
+        const unicodeOutputSpirvPath = '/output/shaders/my_shåder.frag.spirv';
+        fileSystem.file(unicodeFragPath).createSync(recursive: true);
+
+        final processManager = FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: <String>[
+              impellerc,
+              '--sksl',
+              '--iplr',
+              '--json',
+              '--sl=$unicodeOutputPath',
+              '--spirv=$unicodeOutputSpirvPath',
+              '--input=$unicodeFragPath',
+              '--input-type=frag',
+              '--include=$fragDir',
+              '--include=$shaderLibDir',
+            ],
+            exitCode: 3,
+          ),
+        ]);
+        final shaderCompiler = ShaderCompiler(
+          processManager: processManager,
+          logger: logger,
+          fileSystem: fileSystem,
+          artifacts: artifacts,
+          platform: FakePlatform(operatingSystem: 'windows'),
+        );
+
+        try {
+          await shaderCompiler.compileShader(
+            input: fileSystem.file(unicodeFragPath),
+            outputPath: unicodeOutputPath,
+            targetPlatform: TargetPlatform.web_javascript,
+          );
+          fail('unreachable');
+        } on ShaderCompilerException catch (e) {
+          expect(e.toString(), contains('The shader compiler aborted.'));
+          expect(e.toString(), contains('non-ASCII (Unicode) characters in the project path'));
+        }
+      },
+    );
+
+    testWithoutContext('Linux and exit code -6 adds abort hint', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: -6,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(),
+      );
+
+      try {
+        await shaderCompiler.compileShader(
+          input: fileSystem.file(notFragPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.web_javascript,
+        );
+        fail('unreachable');
+      } on ShaderCompilerException catch (e) {
+        expect(e.toString(), contains('The shader compiler aborted.'));
+      }
     });
   });
 }


### PR DESCRIPTION
This PR implements a fix and diagnostics improvement for `ShaderCompilerException` crashes.

### Engine Fix
In `engine/src/flutter/impeller/compiler/switches.cc` (around line 242), replaced `include_dir_absolute.string().c_str()` with `Utf8FromPath(include_dir_absolute).c_str()`. This ensures the path is correctly passed as a UTF-8 string on Windows, preventing crashes during wide conversion in `fml::Utf8ToWideString` when paths contain non-ASCII characters.

### Tool Diagnostics Fix
In `packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart`:
- Modified `ShaderCompilerException` to include the `stdout` and `stderr` of the failed compilation.
- Updated `result` in `compileShader` to the retry result if the retry fails, so the correct failure output is reported.

### Helpful Hints
In `ShaderCompiler.compileShader`, checked the exit code and host platform to add helpful hints:
- macOS and exit code `-9` (SIGKILL): Adds hint that it might be blocked by Gatekeeper/quarantine or OOM, and suggests running `xattr -d com.apple.quarantine`.
- Windows and exit code `3` / macOS/Linux and exit code `-6` (SIGABRT): Adds hint that it aborted. If on Windows and paths contain non-ASCII characters, warns about Unicode path issues and suggests moving to an ASCII-only path.
