### PR TITLE
[flutter_tools] Fix PathExistsException crash when creating plugin symlinks on Windows

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1269,9 +1269,26 @@ void _createPlatformPluginSymlinks(
     final name = pluginInfo[_kFlutterPluginsNameKey]! as String;
     final path = pluginInfo[_kFlutterPluginsPathKey]! as String;
     final Link link = symlinkDirectory.childLink(name);
-    if (link.existsSync()) {
+    final FileSystemEntityType type = link.fileSystem.typeSync(link.path, followLinks: false);
+    var skipCreation = false;
+    if (type == FileSystemEntityType.link) {
+      try {
+        if (link.targetSync() == path) {
+          skipCreation = true;
+        }
+      } on FileSystemException catch (_) {
+        // If targetSync fails (e.g. broken link), proceed to delete and recreate.
+      }
+    }
+
+    if (skipCreation) {
       continue;
     }
+
+    if (type != FileSystemEntityType.notFound) {
+      ErrorHandlingFileSystem.deleteIfExists(link, recursive: true);
+    }
+
     try {
       link.createSync(path);
     } on FileSystemException catch (e) {

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -492,9 +492,9 @@ dependencies:
             'bad_plugin',
           ]);
           // Write bytes that are not valid UTF-8, so readAsString throws a FileSystemException.
-          pluginDirs[1].childFile('pubspec.yaml').writeAsBytesSync(
-            Uint8List.fromList(<int>[0xff, 0xfe, 0xfd]),
-          );
+          pluginDirs[1]
+              .childFile('pubspec.yaml')
+              .writeAsBytesSync(Uint8List.fromList(<int>[0xff, 0xfe, 0xfd]));
 
           // The tool must not crash when a plugin's pubspec.yaml cannot be read.
           final Future<List<Plugin>> pluginsFuture = findPlugins(flutterProject);
@@ -1961,6 +1961,111 @@ flutter:
 
           for (final link in links) {
             expect(link, exists);
+          }
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => featureFlags,
+        },
+      );
+
+      testUsingContext(
+        'createPluginSymlinks repairs broken links',
+        () async {
+          linuxProject.exists = true;
+          windowsProject.exists = true;
+          createFakePlugin(fs);
+          await refreshPluginsList(flutterProject);
+
+          final links = <Link>[
+            linuxProject.pluginSymlinkDirectory.childLink('some_plugin'),
+            windowsProject.pluginSymlinkDirectory.childLink('some_plugin'),
+          ];
+          for (final link in links) {
+            // Delete target to make it a broken link
+            final String targetPath = link.targetSync();
+            ErrorHandlingFileSystem.deleteIfExists(fs.directory(targetPath), recursive: true);
+
+            // Verify link exists but target does not
+            expect(fs.typeSync(link.path, followLinks: false), FileSystemEntityType.link);
+            expect(fs.typeSync(link.path), FileSystemEntityType.notFound);
+          }
+
+          createPluginSymlinks(flutterProject);
+
+          for (final link in links) {
+            // Re-create target first so existsSync returns true
+            final String targetPath = link.targetSync();
+            fs.directory(targetPath).createSync(recursive: true);
+            expect(link, exists);
+          }
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => featureFlags,
+        },
+      );
+
+      testUsingContext(
+        'createPluginSymlinks repairs links pointing to wrong target',
+        () async {
+          linuxProject.exists = true;
+          windowsProject.exists = true;
+          createFakePlugin(fs);
+          await refreshPluginsList(flutterProject);
+
+          final links = <Link>[
+            linuxProject.pluginSymlinkDirectory.childLink('some_plugin'),
+            windowsProject.pluginSymlinkDirectory.childLink('some_plugin'),
+          ];
+          for (final link in links) {
+            final String wrongTarget = fs.systemTempDirectory.childDirectory('wrong_target').path;
+            link.deleteSync();
+            link.createSync(wrongTarget);
+
+            expect(link.targetSync(), wrongTarget);
+          }
+
+          createPluginSymlinks(flutterProject);
+
+          for (final link in links) {
+            expect(link, exists);
+            // Verify it was updated to point back to the correct path.
+            expect(link.targetSync(), isNot(contains('wrong_target')));
+          }
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          FeatureFlags: () => featureFlags,
+        },
+      );
+
+      testUsingContext(
+        'createPluginSymlinks repairs path occupied by a file',
+        () async {
+          linuxProject.exists = true;
+          windowsProject.exists = true;
+          createFakePlugin(fs);
+          await refreshPluginsList(flutterProject);
+
+          final links = <Link>[
+            linuxProject.pluginSymlinkDirectory.childLink('some_plugin'),
+            windowsProject.pluginSymlinkDirectory.childLink('some_plugin'),
+          ];
+          for (final link in links) {
+            link.deleteSync();
+            fs.file(link.path).createSync(recursive: true);
+            expect(fs.typeSync(link.path, followLinks: false), FileSystemEntityType.file);
+          }
+
+          createPluginSymlinks(flutterProject);
+
+          for (final link in links) {
+            expect(link, exists);
+            expect(fs.typeSync(link.path, followLinks: false), FileSystemEntityType.link);
           }
         },
         overrides: <Type, Generator>{


### PR DESCRIPTION
Checks for the symlink's existence without following it using `link.fileSystem.typeSync(link.path, followLinks: false)`.
If a link exists but points to a wrong target, is broken, or is a different file type, deletes it using `ErrorHandlingFileSystem.deleteIfExists(link, recursive: true)` before recreating it.
If the link exists and points to the correct target, skips creation.

This prevents `PathExistsException` on Windows where `Link.existsSync()` returns `false` for broken symlinks, causing the tool to attempt recreation over the existing link.
