### PR TITLE
[flutter_tools] Fix Impeller shader compiler Windows crash and improve diagnostics

### DIFF
--- a/engine/src/flutter/impeller/compiler/switches.cc
+++ b/engine/src/flutter/impeller/compiler/switches.cc
@@ -239,7 +239,7 @@ Switches::Switches(const fml::CommandLine& command_line)
     }
 
     auto dir = std::make_shared<fml::UniqueFD>(fml::OpenDirectoryReadOnly(
-        *working_directory, include_dir_absolute.string().c_str()));
+        *working_directory, Utf8FromPath(include_dir_absolute).c_str()));
     if (!dir || !dir->is_valid()) {
       continue;
     }

--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -265,7 +265,7 @@ class ShaderCompiler {
       final List<String> shaderTargets = _shaderTargetsFromTargetPlatform(targetPlatform);
       final List<String> cmd = makeImpellercCommand(shaderTargets);
       _logger.printTrace('impellerc command: $cmd');
-      final ProcessResult result = await _runCommand(cmd);
+      ProcessResult result = await _runCommand(cmd);
       if (result.exitCode != 0) {
         // Maybe retry impellerc command without --sksl.
         if (!(shaderTargets.length > 1 && shaderTargets.contains('--sksl'))) {
@@ -286,6 +286,7 @@ class ShaderCompiler {
         if (retryResult.exitCode != 0) {
           // Retry failed.
           _logger.printError('impellerc failure: ${retryResult.stderr}');
+          result = retryResult;
           failure = true;
         } else {
           // Retry succeeded. Don't fail, but log a warning message and the sksl
@@ -302,9 +303,15 @@ class ShaderCompiler {
 
       if (failure) {
         if (fatal) {
+          final String? hint = _getHelpfulHint(result, input, outputPath, impellerc.path);
+          final message =
+              'Shader compilation of "${input.path}" to "$outputPath" '
+              'failed with exit code ${result.exitCode}.'
+              '${hint != null ? '\n$hint' : ''}';
           throw ShaderCompilerException._(
-            'Shader compilation of "${input.path}" to "$outputPath" '
-            'failed with exit code ${result.exitCode}.',
+            message,
+            stdout: result.stdout as String?,
+            stderr: result.stderr as String?,
           );
         }
         return false;
@@ -320,9 +327,42 @@ class ShaderCompiler {
     return true;
   }
 
+  String? _getHelpfulHint(
+    ProcessResult result,
+    File input,
+    String outputPath,
+    String impellercPath,
+  ) {
+    final int exitCode = result.exitCode;
+    if (_platform.isMacOS && exitCode == -9) {
+      return 'The shader compiler (impellerc) may have been blocked by macOS Gatekeeper or run out of memory (OOM).\n'
+          'To resolve Gatekeeper issues, try running:\n'
+          '  xattr -d com.apple.quarantine "$impellercPath"';
+    }
+
+    final bool isWindowsAbort = _platform.isWindows && exitCode == 3;
+    final bool isPosixAbort = (_platform.isMacOS || _platform.isLinux) && exitCode == -6;
+
+    if (isWindowsAbort || isPosixAbort) {
+      var hint = 'The shader compiler aborted.';
+      if (_platform.isWindows) {
+        final bool hasNonAscii =
+            RegExp(r'[^\x00-\x7F]').hasMatch(input.path) ||
+            RegExp(r'[^\x00-\x7F]').hasMatch(outputPath);
+        if (hasNonAscii) {
+          hint +=
+              '\nWarning: The path contains non-ASCII characters, which is known to cause crashes on Windows.\n'
+              'Try moving your project to a path containing only ASCII characters.';
+        }
+      }
+      return hint;
+    }
+    return null;
+  }
+
   Future<ProcessResult> _runCommand(List<String> command) async {
     try {
-      return await _processManager.run(command, stderrEncoding: utf8);
+      return await _processManager.run(command, stdoutEncoding: utf8, stderrEncoding: utf8);
     } on ProcessException catch (e) {
       if (_isBlockedBySecurityPolicy(e)) {
         throw _SecurityPolicyBlockException(e);
@@ -363,10 +403,24 @@ class _SecurityPolicyBlockException implements Exception {
 }
 
 class ShaderCompilerException implements Exception {
-  ShaderCompilerException._(this.message);
+  ShaderCompilerException._(this.message, {this.stdout, this.stderr});
 
   final String message;
+  final String? stdout;
+  final String? stderr;
 
   @override
-  String toString() => 'ShaderCompilerException: $message\n\n';
+  String toString() {
+    final buffer = StringBuffer();
+    buffer.write('ShaderCompilerException: $message\n');
+    if (stdout != null && stdout!.trim().isNotEmpty) {
+      buffer.writeln('Stdout:');
+      buffer.writeln(stdout);
+    }
+    if (stderr != null && stderr!.trim().isNotEmpty) {
+      buffer.writeln('Stderr:');
+      buffer.writeln(stderr);
+    }
+    return buffer.toString();
+  }
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -244,6 +244,10 @@ void main() {
           '"/output/shaders/my_shader.frag" failed with exit code 1.',
         ),
       );
+      expect(e.stdout, 'impellerc stdout');
+      expect(e.stderr, 'impellerc stderr');
+      expect(e.toString(), contains('Stdout:\nimpellerc stdout'));
+      expect(e.toString(), contains('Stderr:\nimpellerc stderr'));
     }
 
     expect(fileSystem.file(outputPath).existsSync(), false);
@@ -783,99 +787,93 @@ void main() {
   });
 
   group('blocked shader compiler', () {
-    testWithoutContext(
-      'compileShader throws ToolExit and logs friendly message when impellerc is blocked by Windows Application Control',
-      () async {
-        final blockedException = ProcessException(
-          impellerc,
-          <String>[],
-          'An Application Control policy has blocked this file',
-          1260,
-        );
-        final processManager = FakeProcessManager.list(<FakeCommand>[
-          FakeCommand(
-            command: <String>[
-              impellerc,
-              '--runtime-stage-metal',
-              '--iplr',
-              '--sl=$outputPath',
-              '--spirv=$outputPath.spirv',
-              '--input=$fragPath',
-              '--input-type=frag',
-              '--include=$fragDir',
-              '--include=$shaderLibDir',
-            ],
-            exception: blockedException,
-          ),
-        ]);
-        final shaderCompiler = ShaderCompiler(
-          processManager: processManager,
-          logger: logger,
-          fileSystem: fileSystem,
-          artifacts: artifacts,
-          platform: FakePlatform(operatingSystem: 'windows'),
-        );
+    testWithoutContext('compileShader throws ToolExit and logs friendly message when impellerc is blocked by Windows Application Control', () async {
+      final blockedException = ProcessException(
+        impellerc,
+        <String>[],
+        'An Application Control policy has blocked this file',
+        1260,
+      );
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--runtime-stage-metal',
+            '--iplr',
+            '--sl=$outputPath',
+            '--spirv=$outputPath.spirv',
+            '--input=$fragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exception: blockedException,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(operatingSystem: 'windows'),
+      );
 
-        await expectLater(
-          shaderCompiler.compileShader(
-            input: fileSystem.file(fragPath),
-            outputPath: outputPath,
-            targetPlatform: TargetPlatform.ios,
-          ),
-          throwsToolExit(message: 'Impeller shader compiler was blocked by security policy.'),
-        );
+      await expectLater(
+        shaderCompiler.compileShader(
+          input: fileSystem.file(fragPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.ios,
+        ),
+        throwsToolExit(message: 'Impeller shader compiler was blocked by security policy.'),
+      );
 
-        expect(logger.errorText, contains('blocked by system'));
-        expect(logger.errorText, contains(impellerc));
-      },
-    );
+      expect(logger.errorText, contains('blocked by system'));
+      expect(logger.errorText, contains(impellerc));
+    });
 
-    testWithoutContext(
-      'compileShader throws ToolExit and logs friendly message when impellerc is blocked by group policy',
-      () async {
-        final blockedException = ProcessException(
-          impellerc,
-          <String>[],
-          'blocked by group policy',
-          1260,
-        );
-        final processManager = FakeProcessManager.list(<FakeCommand>[
-          FakeCommand(
-            command: <String>[
-              impellerc,
-              '--runtime-stage-metal',
-              '--iplr',
-              '--sl=$outputPath',
-              '--spirv=$outputPath.spirv',
-              '--input=$fragPath',
-              '--input-type=frag',
-              '--include=$fragDir',
-              '--include=$shaderLibDir',
-            ],
-            exception: blockedException,
-          ),
-        ]);
-        final shaderCompiler = ShaderCompiler(
-          processManager: processManager,
-          logger: logger,
-          fileSystem: fileSystem,
-          artifacts: artifacts,
-          platform: FakePlatform(operatingSystem: 'windows'),
-        );
+    testWithoutContext('compileShader throws ToolExit and logs friendly message when impellerc is blocked by group policy', () async {
+      final blockedException = ProcessException(
+        impellerc,
+        <String>[],
+        'blocked by group policy',
+        1260,
+      );
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--runtime-stage-metal',
+            '--iplr',
+            '--sl=$outputPath',
+            '--spirv=$outputPath.spirv',
+            '--input=$fragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exception: blockedException,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(operatingSystem: 'windows'),
+      );
 
-        await expectLater(
-          shaderCompiler.compileShader(
-            input: fileSystem.file(fragPath),
-            outputPath: outputPath,
-            targetPlatform: TargetPlatform.ios,
-          ),
-          throwsToolExit(message: 'Impeller shader compiler was blocked by security policy.'),
-        );
+      await expectLater(
+        shaderCompiler.compileShader(
+          input: fileSystem.file(fragPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.ios,
+        ),
+        throwsToolExit(message: 'Impeller shader compiler was blocked by security policy.'),
+      );
 
-        expect(logger.errorText, contains('blocked by system'));
-        expect(logger.errorText, contains(impellerc));
-      },
-    );
+      expect(logger.errorText, contains('blocked by system'));
+      expect(logger.errorText, contains(impellerc));
+    });
 
     testWithoutContext(
       'compileShader handles non-fatal security policy block gracefully',
@@ -1032,6 +1030,171 @@ void main() {
       expect(success2, false);
 
       expect(headerLine.allMatches(logger.errorText).length, 2);
+    });
+  });
+
+  group('ShaderCompiler hints and diagnostics', () {
+    testWithoutContext('macOS and exit code -9 adds Gatekeeper/OOM hint', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: -9,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(operatingSystem: 'macos'),
+      );
+
+      try {
+        await shaderCompiler.compileShader(
+          input: fileSystem.file(notFragPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.web_javascript,
+        );
+        fail('unreachable');
+      } on ShaderCompilerException catch (e) {
+        expect(e.toString(), contains('blocked by macOS Gatekeeper'));
+        expect(e.toString(), contains('xattr -d com.apple.quarantine'));
+      }
+    });
+
+    testWithoutContext('Windows and exit code 3 adds abort hint', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: 3,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(operatingSystem: 'windows'),
+      );
+
+      try {
+        await shaderCompiler.compileShader(
+          input: fileSystem.file(notFragPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.web_javascript,
+        );
+        fail('unreachable');
+      } on ShaderCompilerException catch (e) {
+        expect(e.toString(), contains('The shader compiler aborted.'));
+        expect(e.toString(), isNot(contains('non-ASCII (Unicode) characters')));
+      }
+    });
+
+    testWithoutContext(
+      'Windows and exit code 3 with Unicode path adds Unicode path warning',
+      () async {
+        const unicodeFragPath = '/shaders/my_shåder.frag';
+        const unicodeOutputPath = '/output/shaders/my_shåder.frag';
+        const unicodeOutputSpirvPath = '/output/shaders/my_shåder.frag.spirv';
+        fileSystem.file(unicodeFragPath).createSync(recursive: true);
+
+        final processManager = FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: <String>[
+              impellerc,
+              '--sksl',
+              '--iplr',
+              '--json',
+              '--sl=$unicodeOutputPath',
+              '--spirv=$unicodeOutputSpirvPath',
+              '--input=$unicodeFragPath',
+              '--input-type=frag',
+              '--include=$fragDir',
+              '--include=$shaderLibDir',
+            ],
+            exitCode: 3,
+          ),
+        ]);
+        final shaderCompiler = ShaderCompiler(
+          processManager: processManager,
+          logger: logger,
+          fileSystem: fileSystem,
+          artifacts: artifacts,
+          platform: FakePlatform(operatingSystem: 'windows'),
+        );
+
+        try {
+          await shaderCompiler.compileShader(
+            input: fileSystem.file(unicodeFragPath),
+            outputPath: unicodeOutputPath,
+            targetPlatform: TargetPlatform.web_javascript,
+          );
+          fail('unreachable');
+        } on ShaderCompilerException catch (e) {
+          expect(e.toString(), contains('The shader compiler aborted.'));
+          expect(e.toString(), contains('contains non-ASCII characters'));
+        }
+      },
+    );
+
+    testWithoutContext('Linux and exit code -6 adds abort hint', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: -6,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(),
+      );
+
+      try {
+        await shaderCompiler.compileShader(
+          input: fileSystem.file(notFragPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.web_javascript,
+        );
+        fail('unreachable');
+      } on ShaderCompilerException catch (e) {
+        expect(e.toString(), contains('The shader compiler aborted.'));
+      }
     });
   });
 }


### PR DESCRIPTION
Fixes a crash in impellerc on Windows when paths contain non-ASCII characters, and improves diagnostics/hints in flutter_tools for compiler failures.