### PR TITLE
[Impeller] Do not acquire an unneeded image in KHRSwapchainVK if the swapchain must be recreated due to a size change

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_vk.cc
@@ -57,9 +57,13 @@ std::unique_ptr<Surface> KHRSwapchainVK::AcquireNextDrawable(
 
   TRACE_EVENT0("impeller", __FUNCTION__);
 
-  auto result = impl_->AcquireNextDrawable();
-  if (!result.out_of_date && size_ == impl_->GetSize()) {
-    return std::move(result.surface);
+  // Do not call AcquireNextDrawable if the impl_ has a mismatched size.
+  // Acquiring an image without presenting it can cause leaks.
+  if (size_ == impl_->GetSize()) {
+    auto result = impl_->AcquireNextDrawable();
+    if (!result.out_of_date) {
+      return std::move(result.surface);
+    }
   }
 
 // When the swapchain says its out-of-date, we attempt to read the underlying

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
@@ -163,5 +163,40 @@ TEST(SwapchainTest, NoFenceWaitAfterAcquireNextImageFailure) {
   EXPECT_FALSE(wait_for_fences_called);
 }
 
+TEST(SwapchainTest, SwapchainSizeChangeDoesNotAcquireDrawable) {
+  int acquire_call_count = 0;
+  auto const context =
+      MockVulkanContextBuilder()
+          .SetAcquireNextImageCallback([&](VkDevice, VkSwapchainKHR, uint64_t,
+                                           VkSemaphore, VkFence,
+                                           uint32_t* pImageIndex) -> VkResult {
+            *pImageIndex = 0;
+            acquire_call_count++;
+            return VK_SUCCESS;
+          })
+          .Build();
+
+  auto surface = CreateSurface(*context);
+  ISize original_size(1, 1);
+  SetSwapchainImageSize(original_size);
+  auto swapchain =
+      KHRSwapchainVK::Create(context, std::move(surface), original_size,
+                             /*enable_msaa=*/false);
+  auto image = swapchain->AcquireNextDrawable();
+  EXPECT_EQ(image->GetSize(), original_size);
+
+  ISize new_size(100, 100);
+  SetSwapchainImageSize(new_size);
+  swapchain->UpdateSurfaceSize(new_size);
+
+  acquire_call_count = 0;
+  image = swapchain->AcquireNextDrawable();
+  EXPECT_EQ(image->GetSize(), new_size);
+
+  // Verify that the call to AcquireNextDrawable after the resize did not make
+  // any extra calls to the underlying Vulkan API.
+  EXPECT_EQ(acquire_call_count, 1);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
@@ -183,6 +183,7 @@ TEST(SwapchainTest, SwapchainSizeChangeDoesNotAcquireDrawable) {
       KHRSwapchainVK::Create(context, std::move(surface), original_size,
                              /*enable_msaa=*/false);
   auto image = swapchain->AcquireNextDrawable();
+  ASSERT_NE(image, nullptr);
   EXPECT_EQ(image->GetSize(), original_size);
 
   ISize new_size(100, 100);
@@ -191,6 +192,7 @@ TEST(SwapchainTest, SwapchainSizeChangeDoesNotAcquireDrawable) {
 
   acquire_call_count = 0;
   image = swapchain->AcquireNextDrawable();
+  ASSERT_NE(image, nullptr);
   EXPECT_EQ(image->GetSize(), new_size);
 
   // Verify that the call to AcquireNextDrawable after the resize did not make


### PR DESCRIPTION
KHRSwapchainVK::AcquireNextDrawable was calling vkAcquireNextImageKHR regardless of whether the KHRSwapchainImplVK's size matched the current size of the KHRSwapchainVK.  If there was a size change, then the resulting image would never be presented, which can cause resource leaks even after the old swapchain is destroyed.

This PR avoids the call to KHRSwapchainImplVK::AcquireNextDrawable and vkAcquireNextImageKHR if there is a size mismatch.

Fixes https://github.com/flutter/flutter/issues/190114