### PR TITLE
Never use a header bar in the Linux application template

### DIFF
--- a/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
+++ b/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
@@ -28,10 +28,10 @@ static void my_application_activate(GApplication* application) {
   // Header bars are commonly used in GNOME based desktop environments and
   // allow additional widgets to be added to the title bar.
   // See https://developer.gnome.org/gtk3/stable/GtkHeaderBar.html
-  //GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
-  //gtk_widget_show(GTK_WIDGET(header_bar));
-  //gtk_header_bar_set_show_close_button(header_bar, TRUE);
-  //gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  // GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+  // gtk_widget_show(GTK_WIDGET(header_bar));
+  // gtk_header_bar_set_show_close_button(header_bar, TRUE);
+  // gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
 
   gtk_window_set_title(window, "{{projectName}}");
 

--- a/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
+++ b/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
@@ -27,7 +27,7 @@ static void my_application_activate(GApplication* application) {
   // If you want to use a header bar, uncomment the following lines.
   // Header bars are commonly used in GNOME based desktop environments and
   // allow additional widgets to be added to the title bar.
-  // See https://developer.gnome.org/gtk3/stable/GtkHeaderBar.html
+  // See https://docs.gtk.org/gtk3/class.HeaderBar.html
   // GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
   // gtk_widget_show(GTK_WIDGET(header_bar));
   // gtk_header_bar_set_show_close_button(header_bar, TRUE);

--- a/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
+++ b/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
@@ -1,9 +1,6 @@
 #include "my_application.h"
 
 #include <flutter_linux/flutter_linux.h>
-#ifdef GDK_WINDOWING_X11
-#include <gdk/gdkx.h>
-#endif
 
 #include "flutter/generated_plugin_registrant.h"
 
@@ -22,37 +19,21 @@ static void first_frame_cb(MyApplication* self, FlView* view) {
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
+
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
-
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  if (use_header_bar) {
-    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
-    gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "{{projectName}}");
-    gtk_header_bar_set_show_close_button(header_bar, TRUE);
-    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
-  } else {
-    gtk_window_set_title(window, "{{projectName}}");
-  }
-
   gtk_window_set_default_size(window, 1280, 720);
+
+  // If you want to use a header bar, uncomment the following lines.
+  // Header bars are commonly used in GNOME based desktop environments and
+  // allow additional widgets to be added to the title bar.
+  // See https://developer.gnome.org/gtk3/stable/GtkHeaderBar.html
+  //GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+  //gtk_widget_show(GTK_WIDGET(header_bar));
+  //gtk_header_bar_set_show_close_button(header_bar, TRUE);
+  //gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+
+  gtk_window_set_title(window, "{{projectName}}");
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(


### PR DESCRIPTION
The original intention was to use a header bar, as this would mean a Flutter application looked the most consistent with other GNOME apps. However, over time this was found to be problematic when using X11, using some tiling window managers and undesirable on other desktops that didn't use this style.

This change defaults to not using a header bar and leaves it to the application author to decide if they want to change this either by editing the runner or making use of a plugin that does this for them. This seems like a more manageable solution long term.

Fixes https://github.com/flutter/flutter/issues/111453
