### PR TITLE
[web] Fix password-manager autofill not reaching text fields

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher/view_focus_binding.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher/view_focus_binding.dart
@@ -20,6 +20,27 @@ final class ViewFocusBinding {
 
   StreamSubscription<int>? _onViewCreatedListener;
 
+  /// How long a blur that landed on nothing is given to turn out to be a focus
+  /// change inside the view after all. See [_handleFocusout].
+  ///
+  /// This waits on a pair of browser events, not on anything a user does. The
+  /// browser dispatches the `focusout` and the `focusin` that follows it in
+  /// adjacent tasks, about a millisecond apart when something steps between two
+  /// fields of a form, and the wait only has to outlast that. The rest is
+  /// headroom for a busy main thread: any value between a few milliseconds and
+  /// a tenth of a second behaves identically, so the exact number is not
+  /// load-bearing. It is deliberately not derived from a frame budget, which
+  /// depends on the display and has nothing to do with the task scheduling this
+  /// waits on.
+  ///
+  /// It cannot be zero: a zero timer is queued before the task carrying the
+  /// next focus, so it would fire first and defeat the point.
+  ///
+  /// Nothing waits on a password manager here. If focus never comes back, the
+  /// view is reported unfocused this much later than it once was.
+  static const Duration _unfocusGracePeriod = Duration(milliseconds: 32);
+  Timer? _pendingUnfocus;
+
   void init() {
     // We need a global listener here to know if the user was pressing "shift"
     // when the Flutter view receives focus, to move the Flutter focus to the
@@ -36,6 +57,8 @@ final class ViewFocusBinding {
     domDocument.body?.removeEventListener(_keyDown, _handleKeyDown);
     domDocument.body?.removeEventListener(_keyUp, _handleKeyUp);
     _onViewCreatedListener?.cancel();
+    _pendingUnfocus?.cancel();
+    _pendingUnfocus = null;
   }
 
   void changeViewFocus(int viewId, ui.ViewFocusState state) {
@@ -53,6 +76,10 @@ final class ViewFocusBinding {
   }
 
   late final DomEventListener _handleFocusin = createDomEventListener((DomEvent event) {
+    // Focus returned before the pending report went out, so the view never lost
+    // it. See [_handleFocusout].
+    _pendingUnfocus?.cancel();
+    _pendingUnfocus = null;
     event as DomFocusEvent;
     _handleFocusChange(event.target as DomElement?);
   });
@@ -70,7 +97,28 @@ final class ViewFocusBinding {
     }
 
     event as DomFocusEvent;
-    _handleFocusChange(event.relatedTarget as DomElement?);
+    final DomElement? willGainFocus = event.relatedTarget as DomElement?;
+
+    // A field of an autofill form blurring to nothing is not yet a view losing
+    // focus. A password manager fills a login form one field at a time, blurring
+    // each as it finishes before focusing the next, and reporting the view
+    // unfocused in between makes the framework drop its focus, which tears the
+    // text connection down and builds it back up between every field. Managers
+    // that give up when the form churns under them then fill only the first
+    // field. Wait a moment: a focus landing back in the view cancels the report.
+    //
+    // Only these fields defer. Anything else losing focus is reported at once,
+    // as before.
+    if (_isAutofillFormField(event.target as DomElement?)) {
+      _pendingUnfocus?.cancel();
+      _pendingUnfocus = Timer(_unfocusGracePeriod, () {
+        _pendingUnfocus = null;
+        _handleFocusChange(willGainFocus);
+      });
+      return;
+    }
+
+    _handleFocusChange(willGainFocus);
   });
 
   late final DomEventListener _handleKeyDown = createDomEventListener((DomEvent event) {
@@ -85,6 +133,21 @@ final class ViewFocusBinding {
   late final DomEventListener _handleKeyUp = createDomEventListener((DomEvent event) {
     _viewFocusDirection = ui.ViewFocusDirection.forward;
   });
+
+  /// Whether [element] is one of the text fields the engine synthesises for an
+  /// autofill group, which are the only elements a password manager moves the
+  /// focus between. They are the engine's own inputs, so they always sit in a
+  /// `<form>` it created.
+  bool _isAutofillFormField(DomElement? element) {
+    if (element == null) {
+      return false;
+    }
+    final String tag = element.tagName.toLowerCase();
+    if (tag != 'input' && tag != 'textarea') {
+      return false;
+    }
+    return element.closest('form') != null;
+  }
 
   void _handleFocusChange(DomElement? focusedElement) {
     final int? viewId = _viewId(focusedElement);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1824,6 +1824,17 @@ abstract class DefaultTextEditingStrategy
       // mismatched element would give the field the wrong DOM type.
       if (reused != null && reused.tagName == freshElement.tagName) {
         reused.tabIndex = tabIndex;
+        // Start from the same state a freshly created element would have. The
+        // dormant element still holds the value from the previous connection,
+        // and the framework's own value only arrives later over the platform
+        // channel. Until it does, the stale value is what password managers
+        // read: managers that skip a field which already contains the value
+        // they are about to write (Bitwarden does) then fill nothing at all.
+        if (reused.isA<DomHTMLInputElement>()) {
+          (reused as DomHTMLInputElement).value = '';
+        } else if (reused.isA<DomHTMLTextAreaElement>()) {
+          (reused as DomHTMLTextAreaElement).value = '';
+        }
         // Pointer events (disabled while it was a non-focused field) are
         // re-enabled for the focused element in wakeUp.
         return reused;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -101,10 +101,10 @@ void _setStaticStyleAttributes(DomHTMLElement domElement) {
 const String _kAutofillFieldMinWidth = '40px';
 const String _kAutofillFieldMinHeight = '20px';
 
-// Injected once per document so an autofilled field fires an 'animationstart'
-// event (through the ':-webkit-autofill' pseudo-class) that the autofill
-// listeners use to detect a fill on Blink/WebKit even while the field is
-// blurred. Global, so the style is added exactly once rather than once per form.
+/// Injected once per document so an autofilled field fires an 'animationstart'
+/// event (through the ':-webkit-autofill' pseudo-class) that the autofill
+/// listeners use to detect a fill on Blink/WebKit even while the field is
+/// blurred. Global, so the style is added exactly once rather than once per form.
 bool _autofillAnimationStyleInjected = false;
 
 void _ensureAutofillStyleInjected() {
@@ -162,8 +162,13 @@ void _styleAutofillElements(
   if (shouldHideElement) {
     // 1px rather than 0: Safari and some password managers ignore zero-sized
     // inputs (see https://github.com/flutter/flutter/issues/71275), so even a
-    // hidden proxy keeps a minimal layout box.
+    // hidden proxy keeps a minimal layout box. Clear any min-width/min-height
+    // floor (set by the discoverable branch below, or on the focused element)
+    // first, otherwise it would override the 1px and the element would not
+    // actually shrink when it is hidden.
     elementStyle
+      ..setProperty('min-width', '0px')
+      ..setProperty('min-height', '0px')
       ..width = '1px'
       ..height = '1px';
   } else {
@@ -417,13 +422,13 @@ class EngineAutofillForm {
     scanForAutofilledValues();
   }
 
-  // True while a password manager holds focus to fill the form. During that
-  // window the focused field and the non-focused proxies are held at their
-  // current positions instead of tracking the browser's scroll/relayout, so
-  // repositioning them does not churn the DOM under the manager's own overlay
-  // UI. Some extension overlays race their own DOM insertion when the page
-  // mutates the tree mid-fill, so holding still avoids interfering with them.
-  // The filled values still arrive through the input/animationstart listeners.
+  /// True while a password manager holds focus to fill the form. During that
+  /// window the focused field and the non-focused proxies are held at their
+  /// current positions instead of tracking the browser's scroll/relayout, so
+  /// repositioning them does not churn the DOM under the manager's own overlay
+  /// UI. Some extension overlays race their own DOM insertion when the page
+  /// mutates the tree mid-fill, so holding still avoids interfering with them.
+  /// The filled values still arrive through the input/animationstart listeners.
   bool _fillWindowActive = false;
 
   /// Whether a password manager currently holds focus to fill the form, during
@@ -756,7 +761,6 @@ class EngineAutofillForm {
     keys.forEach(addSubscriptionForKey);
     return subscriptions;
   }
-
 
   /// Sends the 'TextInputClient.updateEditingStateWithTag' message to the framework.
   void _sendAutofillEditingState(String tag, EditingState editingState) {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -94,6 +94,38 @@ void _setStaticStyleAttributes(DomHTMLElement domElement) {
   }
 }
 
+// Password managers and browser autofill skip inputs that are effectively
+// zero-sized, so the invisible autofill proxies are floored to this small but
+// non-trivial size to keep them detectable. This only raises a floor and never
+// shrinks a normally sized field.
+const String _kAutofillFieldMinWidth = '40px';
+const String _kAutofillFieldMinHeight = '20px';
+
+// Injected once per document so an autofilled field fires an 'animationstart'
+// event (through the ':-webkit-autofill' pseudo-class) that the autofill
+// listeners use to detect a fill on Blink/WebKit even while the field is
+// blurred. Global, so the style is added exactly once rather than once per form.
+bool _autofillAnimationStyleInjected = false;
+
+void _ensureAutofillStyleInjected() {
+  if (_autofillAnimationStyleInjected) {
+    return;
+  }
+  _autofillAnimationStyleInjected = true;
+  final DomHTMLStyleElement style = createDomHTMLStyleElement(null);
+  style.text = '''
+@keyframes flutterAutofillStart {
+  from { opacity: 0.99; }
+  to { opacity: 1; }
+}
+input:-webkit-autofill, input:autofill {
+  animation-name: flutterAutofillStart !important;
+  animation-duration: 1ms !important;
+}
+''';
+  domDocument.head?.append(style);
+}
+
 /// Sets attributes to hide autofill elements.
 ///
 /// These style attributes are constant throughout the life time of an input
@@ -128,9 +160,21 @@ void _styleAutofillElements(
   }
 
   if (shouldHideElement) {
+    // 1px rather than 0: Safari and some password managers ignore zero-sized
+    // inputs (see https://github.com/flutter/flutter/issues/71275), so even a
+    // hidden proxy keeps a minimal layout box.
     elementStyle
-      ..width = '0'
-      ..height = '0';
+      ..width = '1px'
+      ..height = '1px';
+  } else {
+    // Discoverable (but invisible) autofill fields must be big enough for
+    // password managers to treat them as real fields rather than skip them as
+    // effectively zero-sized. The framework editable geometry can report a 1px
+    // size, so floor it with min-width/min-height. This never shrinks a
+    // normally-sized field.
+    elementStyle
+      ..setProperty('min-width', _kAutofillFieldMinWidth)
+      ..setProperty('min-height', _kAutofillFieldMinHeight);
   }
 
   if (shouldDisablePointerEvents) {
@@ -323,13 +367,12 @@ class EngineAutofillForm {
         formElement = existingForm.formElement;
         elements.addAll(existingForm.elements);
         // Carry over the per-field tracking so the reused form remembers the
-        // last framework value and the last value forwarded for each field.
-        // Each text input connection builds a new form instance, so without
-        // this the tracking would reset on every focus change and the form
-        // could not tell a programmatic framework update apart from a browser
-        // autofill.
-        _lastFrameworkText.addAll(existingForm._lastFrameworkText);
+        // last value forwarded for each field. Each text input connection
+        // builds a new form instance, so without this the tracking would reset
+        // on every focus change and the form could not tell a programmatic
+        // framework update apart from a browser autofill.
         _lastSentAutofillText.addAll(existingForm._lastSentAutofillText);
+        _lastFrameworkText.addAll(existingForm._lastFrameworkText);
       } else {
         formElement = _createFormElementAndFields(focusedElement, focusedAutofill);
         _insertEditingElementInView(formElement!, viewId);
@@ -342,12 +385,109 @@ class EngineAutofillForm {
     // harmless, but it actually causes focus changes that could break things.
     if (!formElement!.contains(focusedElement)) {
       // Find the matching element and replace it with the new focused element.
-      final DomElement oldFocusedElement = elements[focusedAutofill.uniqueIdentifier]!;
+      final DomHTMLElement oldFocusedElement = elements[focusedAutofill.uniqueIdentifier]!;
+      // Before discarding the old focused element, salvage any value the browser
+      // autofilled into it while it was blurred (e.g. a mobile password manager
+      // filling the field the user tapped). _updateFieldValues skips the focused
+      // field and the element is about to be replaced, so this is the only
+      // chance to forward that value to the framework.
+      final oldDomState = EditingState.fromDomElement(oldFocusedElement);
+      final String frameworkText = focusedAutofill.editingState.text;
+      if (oldDomState.text.isNotEmpty &&
+          oldDomState.text != frameworkText &&
+          oldDomState.text != _lastSentAutofillText[focusedAutofill.uniqueIdentifier]) {
+        _sendAutofillEditingState(focusedAutofill.uniqueIdentifier, oldDomState);
+      }
       elements[focusedAutofill.uniqueIdentifier] = focusedElement;
       oldFocusedElement.replaceWith(focusedElement);
     }
 
+    // Pointer events belong only on the focused element. A reused element (see
+    // _reuseDormantAutofillElementOrCreate) can carry over the enabled state
+    // from when it was focused, so reset the non-focused fields here to keep
+    // them from intercepting taps meant for the app UI.
+    for (final MapEntry<String, DomHTMLElement> entry in elements.entries) {
+      entry.value.style.pointerEvents = entry.key == focusedAutofill.uniqueIdentifier
+          ? 'all'
+          : 'none';
+    }
+
     _updateFieldValues();
+    attachPersistentFormListeners();
+    scanForAutofilledValues();
+  }
+
+  // True while a password manager holds focus to fill the form. During that
+  // window the focused field and the non-focused proxies are held at their
+  // current positions instead of tracking the browser's scroll/relayout, so
+  // repositioning them does not churn the DOM under the manager's own overlay
+  // UI. Some extension overlays race their own DOM insertion when the page
+  // mutates the tree mid-fill, so holding still avoids interfering with them.
+  // The filled values still arrive through the input/animationstart listeners.
+  bool _fillWindowActive = false;
+
+  /// Whether a password manager currently holds focus to fill the form, during
+  /// which the proxy geometry is held still. See [beginFillWindow].
+  bool get fillWindowActive => _fillWindowActive;
+
+  /// Opens the fill window when a password manager takes focus to fill the form.
+  /// While it is open the proxy geometry is held still (see [fillWindowActive]).
+  /// It is closed by [endFillWindow] the moment focus returns to the field or
+  /// the page, which is when the manager has finished and placement can resume
+  /// -- an event boundary rather than a fixed timeout.
+  void beginFillWindow() {
+    _fillWindowActive = true;
+  }
+
+  /// Closes the fill window opened by [beginFillWindow], so proxy placement
+  /// resumes. Called when the password manager hands focus back (the field or
+  /// window regains focus) or when the form is deactivated.
+  void endFillWindow() {
+    _fillWindowActive = false;
+  }
+
+  /// Positions the non-focused proxies right next to the focused field.
+  ///
+  /// Only the focused field receives an on-screen geometry (transform) from the
+  /// framework; without help the other proxies sit at the form origin, far away.
+  /// Some password managers then fail to associate the far-away field and fill
+  /// only the focused one (observed with Bitwarden). Stacking the siblings just
+  /// under the focused field presents a coherent, adjacent username-above-
+  /// password login form so they fill every field. (Proton Pass filled the whole
+  /// form either way.)
+  ///
+  /// Called after the geometry transform has been applied to [focusedElement].
+  void clusterNonFocusedFieldsAt(DomHTMLElement focusedElement) {
+    // Held still during an active password-manager fill; see beginFillWindow.
+    if (_fillWindowActive) {
+      return;
+    }
+    final DomRect rect = focusedElement.getBoundingClientRect();
+    final double w = rect.width;
+    final double h = rect.height;
+    // Not laid out / positioned yet -- nothing reliable to anchor to.
+    if (w == 0 || h == 0) {
+      return;
+    }
+    // Stack each non-focused proxy directly below the focused field, at the same
+    // width, so the manager sees an adjacent, coherent username-above-password
+    // login form (viewport coordinates, so position:fixed). Without this the
+    // non-focused proxies sit at the form origin, far from the focused field,
+    // and some managers fill only the focused one.
+    var top = rect.top + h;
+    for (final DomHTMLElement element in elements.values) {
+      if (identical(element, focusedElement)) {
+        continue;
+      }
+      element.style
+        ..position = 'fixed'
+        ..left = '${rect.left}px'
+        ..top = '${top}px'
+        ..width = '${w}px'
+        ..height = '${h}px'
+        ..transform = 'none';
+      top += h;
+    }
   }
 
   /// Makes the form dormant.
@@ -360,6 +500,8 @@ class EngineAutofillForm {
   void goDormant() {
     assert(formElement != null);
 
+    // The form is deactivated; end any open fill window so it never stays frozen.
+    endFillWindow();
     dormantForms[formIdentifier] = this;
     _styleAutofillElements(formElement!, isOffScreen: true);
   }
@@ -392,16 +534,17 @@ class EngineAutofillForm {
         htmlElement = field.inputType.createDomElement();
         field.autofillInfo.applyToDomElement(htmlElement);
 
-        // Safari does not respect elements that are invisible (or
-        // have no size) and that leads to issues with autofill only partially
-        // working (ref: https://github.com/flutter/flutter/issues/71275).
-        // Thus, we have to make sure that the elements remain invisible to users,
-        // but not to Safari for autofill to work. Since these elements are
-        // sized and placed on the DOM, we also have to disable pointer events.
+        // Keep the non-focused autofill fields sized and placed on the DOM (not
+        // hidden), only visually transparent, and disable pointer events on
+        // them. Safari and password-manager extensions ignore zero-size or
+        // hidden inputs, which breaks a paired username+password autofill.
+        // Making the elements discoverable but invisible lets those tools fill
+        // the whole form.
+        // (ref: https://github.com/flutter/flutter/issues/71275)
         _styleAutofillElements(
           htmlElement,
-          shouldHideElement: !_isSafariStrategy,
-          shouldDisablePointerEvents: _isSafariStrategy,
+          shouldHideElement: false,
+          shouldDisablePointerEvents: true,
         );
       }
 
@@ -426,95 +569,216 @@ class EngineAutofillForm {
     for (final String key in elements.keys) {
       final DomHTMLElement element = elements[key]!;
       final AutofillInfo autofill = items[key]!.autofillInfo;
-      // Focused elements are updated directly through `setEditingState`.
-      if (key != focusedElementId) {
-        // A non-focused field's DOM value and the framework's stored value can
-        // diverge in two ways. When the browser autofills the field while the
-        // form is dormant, the DOM holds a value the framework has not seen yet,
-        // so it must be forwarded and kept. Otherwise the framework is the source
-        // of truth, either it just changed (a programmatic update) or it is
-        // already in sync. The last framework value per field tells them apart:
-        // an autofill is an unchanged framework value next to a changed DOM value.
-        final domEditingState = EditingState.fromDomElement(element);
-        final String frameworkText = autofill.editingState.text;
-        final String lastFrameworkText =
-            _lastFrameworkText[autofill.uniqueIdentifier] ?? frameworkText;
-        _lastFrameworkText[autofill.uniqueIdentifier] = frameworkText;
 
-        final frameworkUnchanged = frameworkText == lastFrameworkText;
-        if (frameworkUnchanged &&
-            domEditingState.text.isNotEmpty &&
-            domEditingState.text != frameworkText) {
-          // The browser autofilled this field. Forward the new value and keep it
-          // instead of clearing it.
-          if (domEditingState.text != _lastSentAutofillText[autofill.uniqueIdentifier]) {
-            _sendAutofillEditingState(autofill.uniqueIdentifier, domEditingState);
-          }
-          continue;
+      // A field's DOM value and the framework's stored value can diverge in two
+      // ways. When the browser autofills the field, the DOM holds a value the
+      // framework has not seen yet, so it must be forwarded and kept. Otherwise
+      // the framework is the source of truth, either it just changed (a
+      // programmatic update) or it is already in sync. The last framework value
+      // per field tells them apart: an autofill is an unchanged framework value
+      // next to a changed DOM value.
+      //
+      // This runs for the focused field too. On mobile a password manager fills
+      // the field the user tapped (the focused field) while it is blurred, and
+      // that value would otherwise never be forwarded: the focused field has no
+      // other recovery path.
+      final domEditingState = EditingState.fromDomElement(element);
+      final String frameworkText = autofill.editingState.text;
+      final String lastFrameworkText =
+          _lastFrameworkText[autofill.uniqueIdentifier] ?? frameworkText;
+      _lastFrameworkText[autofill.uniqueIdentifier] = frameworkText;
+      final bool frameworkUnchanged = frameworkText == lastFrameworkText;
+      if (frameworkUnchanged &&
+          domEditingState.text.isNotEmpty &&
+          domEditingState.text != frameworkText) {
+        // The browser autofilled this field (the framework's own value is
+        // unchanged next to a different DOM value). Forward it and keep it
+        // instead of clearing it.
+        if (domEditingState.text != _lastSentAutofillText[autofill.uniqueIdentifier]) {
+          _sendAutofillEditingState(autofill.uniqueIdentifier, domEditingState);
         }
-        // The framework wins: it changed (a programmatic update) or is in sync.
-        // Non-focused elements do not have selection, and applying selection on
-        // them may cause them to gain focus unexpectedly.
+        continue;
+      }
+      // The framework wins: it changed (a programmatic update) or is in sync.
+      // Only push the framework value onto non-focused elements; the focused
+      // element's selection/cursor is owned by the active connection, and
+      // applying selection on non-focused elements may cause them to gain focus
+      // unexpectedly.
+      if (key != focusedElementId) {
         autofill.editingState.applyTextToDomElement(element);
       }
     }
   }
 
-  /// Listens to `onInput` event on the form fields.
+  /// Records the framework's own value for the focused field so a later
+  /// [scanForAutofilledValues] or [_updateFieldValues] does not mistake it for a
+  /// browser autofill and echo it straight back. The focused field's *current*
+  /// framework value must be compared against, not the stale config-time
+  /// [AutofillInfo.editingState].
+  void noteFrameworkEditingState(EditingState editingState) {
+    _lastSentAutofillText[focusedElementId] = editingState.text;
+  }
+
+  /// Scans every field for a value the browser autofilled but the framework has
+  /// not seen yet, and forwards it. Unlike [_updateFieldValues] this never
+  /// pushes framework values back onto the DOM, so it is safe to call repeatedly
+  /// (e.g. when the window regains focus or the page becomes visible) to pick up
+  /// an autofill that arrived without an input event and without the user
+  /// refocusing the field. Skips a value already in [_lastSentAutofillText].
+  void scanForAutofilledValues() {
+    if (elements.isEmpty) {
+      return;
+    }
+    // Keep the non-focused proxies clustered under the focused field. Done here
+    // (not in updateElementPlacement, which does not fire for this flow) because
+    // the scan runs after the field has been laid out and positioned.
+    final DomHTMLElement? focused = elements[focusedElementId];
+    if (focused != null) {
+      clusterNonFocusedFieldsAt(focused);
+    }
+    for (final String key in elements.keys) {
+      final DomHTMLElement element = elements[key]!;
+      final AutofillInfo autofill = items[key]!.autofillInfo;
+      final domState = EditingState.fromDomElement(element);
+      final String? lastSent = _lastSentAutofillText[autofill.uniqueIdentifier];
+
+      // Only forward a value the browser autofilled, i.e. one that differs from
+      // both what was last forwarded and the framework's own value. Without the
+      // second check the framework's value (applied to the DOM via
+      // setEditingState) would be echoed straight back as a fake autofill.
+      if (domState.text.isNotEmpty &&
+          domState.text != lastSent &&
+          domState.text != autofill.editingState.text) {
+        _sendAutofillEditingState(autofill.uniqueIdentifier, domState);
+      }
+    }
+  }
+
+  final List<DomSubscription> _formSubscriptions = <DomSubscription>[];
+
+  void _cancelFormSubscriptions() {
+    for (final DomSubscription subscription in _formSubscriptions) {
+      subscription.cancel();
+    }
+    _formSubscriptions.clear();
+  }
+
+  /// The DOM events that can carry a browser autofill. A password manager fills
+  /// a (possibly blurred) field by setting its value and dispatching
+  /// 'input'/'change'; Blink and WebKit additionally fire 'animationstart'
+  /// through the ':-webkit-autofill' hook injected by
+  /// [_ensureAutofillStyleInjected].
+  static const List<String> _autofillEventTypes = <String>[
+    'input',
+    'change',
+    'animationstart',
+    'webkitAnimationStart',
+  ];
+
+  /// Forwards the element's current value to the framework when the browser has
+  /// autofilled it: a non-empty value that differs from what was last forwarded
+  /// for the field.
+  void _forwardAutofillIfChanged(DomHTMLElement element, AutofillInfo autofillInfo) {
+    final domState = EditingState.fromDomElement(element);
+    if (domState.text.isNotEmpty &&
+        domState.text != _lastSentAutofillText[autofillInfo.uniqueIdentifier]) {
+      _sendAutofillEditingState(autofillInfo.uniqueIdentifier, domState);
+    }
+  }
+
+  /// Binds autofill listeners to the non-focused fields for the lifetime of the
+  /// (re)woken form, replacing any previous set.
   ///
-  /// Registering to the listeners could have been done in the constructor.
-  /// On the other hand, overall for text editing there is already a lifecycle
-  /// for subscriptions: All the subscriptions of the DOM elements are to the
-  /// `subscriptions` property of [DefaultTextEditingStrategy].
-  /// [TextEditingStrategy] manages all subscription lifecyle. All
-  /// listeners with no exceptions are added during
-  /// [TextEditingStrategy.addEventHandlers] method call and all
-  /// listeners are removed during [TextEditingStrategy.disable] method call.
+  /// Unlike [addInputEventListeners] (used by the semantics strategy, whose
+  /// subscriptions are owned by [DefaultTextEditingStrategy.subscriptions]),
+  /// this owns its subscriptions in [_formSubscriptions] so they can be rebound
+  /// each time the form wakes. The focused field is skipped; its edits and
+  /// autofills are delivered by [handleChange] and the autofill scan.
+  void attachPersistentFormListeners() {
+    _ensureAutofillStyleInjected();
+    _cancelFormSubscriptions();
+
+    for (final String key in elements.keys) {
+      final DomHTMLElement element = elements[key]!;
+      final FieldItem? fieldItem = items[key];
+      if (fieldItem == null) {
+        continue;
+      }
+      // The focused field's edits and autofills are already delivered by
+      // handleChange and the autofill scan; observing it here as well would
+      // re-forward the user's own typing as if it were a browser autofill.
+      if (key == focusedElementId) {
+        continue;
+      }
+      final AutofillInfo autofillInfo = fieldItem.autofillInfo;
+      for (final String type in _autofillEventTypes) {
+        _formSubscriptions.add(
+          DomSubscription(
+            element,
+            type,
+            createDomEventListener((DomEvent _) => _forwardAutofillIfChanged(element, autofillInfo)),
+          ),
+        );
+      }
+    }
+  }
+
+  /// Attaches autofill listeners to every field of the form and returns the
+  /// subscriptions so the caller can cancel them.
+  ///
+  /// Used by the semantics text-editing strategy, whose fields already exist
+  /// when its handlers are attached. [DefaultTextEditingStrategy] instead builds
+  /// its form lazily and (re)binds these listeners from [wakeUp] through
+  /// [attachPersistentFormListeners].
   List<DomSubscription> addInputEventListeners() {
+    _ensureAutofillStyleInjected();
     final Iterable<String> keys = elements.keys;
     final subscriptions = <DomSubscription>[];
 
     void addSubscriptionForKey(String key) {
       final DomHTMLElement element = elements[key]!;
-      subscriptions.add(
-        DomSubscription(
-          element,
-          'input',
-          createDomEventListener((DomEvent e) {
-            if (items[key] == null) {
-              throw StateError('AutofillInfo must have a valid uniqueIdentifier.');
-            } else if (key != focusedElementId) {
-              // `input` events on the focused element are handled elsewhere.
-              final AutofillInfo autofillInfo = items[key]!.autofillInfo;
-              _handleChange(element, autofillInfo);
-            }
-          }),
-        ),
-      );
+      final FieldItem? fieldItem = items[key];
+      if (fieldItem == null) {
+        throw StateError('AutofillInfo must have a valid uniqueIdentifier.');
+      }
+      final AutofillInfo autofillInfo = fieldItem.autofillInfo;
+      for (final String type in _autofillEventTypes) {
+        subscriptions.add(
+          DomSubscription(
+            element,
+            type,
+            createDomEventListener((DomEvent _) => _forwardAutofillIfChanged(element, autofillInfo)),
+          ),
+        );
+      }
     }
 
     keys.forEach(addSubscriptionForKey);
     return subscriptions;
   }
 
-  void _handleChange(DomHTMLElement domElement, AutofillInfo autofillInfo) {
-    final newEditingState = EditingState.fromDomElement(domElement);
-    _sendAutofillEditingState(autofillInfo.uniqueIdentifier, newEditingState);
-  }
 
   /// Sends the 'TextInputClient.updateEditingStateWithTag' message to the framework.
   void _sendAutofillEditingState(String tag, EditingState editingState) {
-    _lastSentAutofillText[tag] = editingState.text;
+    // Collapse selection to end of text for autofilled values so Chrome's
+    // DOM selection highlight doesn't leave the field text selected in Flutter.
+    final cleanEditingState = EditingState(
+      text: editingState.text,
+      baseOffset: editingState.text.length,
+      extentOffset: editingState.text.length,
+    );
+    _lastSentAutofillText[tag] = cleanEditingState.text;
     EnginePlatformDispatcher.instance.invokeOnPlatformMessage(
       'flutter/textinput',
       const JSONMethodCodec().encodeMethodCall(
         MethodCall('TextInputClient.updateEditingStateWithTag', <dynamic>[
           0,
-          <String, dynamic>{tag: editingState.toFlutter()},
+          <String, dynamic>{tag: cleanEditingState.toFlutter()},
         ]),
       ),
       _emptyCallback,
     );
+    EnginePlatformDispatcher.instance.scheduleFrame();
   }
 }
 
@@ -1400,6 +1664,54 @@ abstract class DefaultTextEditingStrategy
   final List<DomSubscription> subscriptions = <DomSubscription>[];
   Timer? _pendingBlurConnectionCloseTimer;
 
+  /// Rescans the autofill form for filled values when an autofill session is
+  /// blurred (a password-manager dialog is open) and the dialog hands control
+  /// back: the window regains focus, or the page becomes visible again. Both
+  /// fire when the dialog closes after filling, so the filled values reach the
+  /// framework without the user having to refocus the field. The per-field
+  /// input/change/animationstart listeners cover fills that do fire an event;
+  /// these two events cover fills that arrive while the field is blurred.
+  DomSubscription? _autofillScanFocusSub;
+  DomSubscription? _autofillScanVisibilitySub;
+
+  void _startAutofillScan() {
+    if (!hasAutofillGroup) {
+      return;
+    }
+    // Scan immediately, then again whenever the dialog hands control back.
+    inputConfiguration.autofillGroup?.scanForAutofilledValues();
+
+    _autofillScanFocusSub?.cancel();
+    _autofillScanFocusSub = DomSubscription(
+      domWindow,
+      'focus',
+      createDomEventListener((DomEvent _) {
+        // The window regained focus: the manager's dialog closed, so the fill
+        // window ends and placement can resume.
+        inputConfiguration.autofillGroup?.endFillWindow();
+        inputConfiguration.autofillGroup?.scanForAutofilledValues();
+      }),
+    );
+    _autofillScanVisibilitySub?.cancel();
+    _autofillScanVisibilitySub = DomSubscription(
+      domDocument,
+      'visibilitychange',
+      createDomEventListener((DomEvent _) {
+        if (_documentVisibilityState == 'visible') {
+          inputConfiguration.autofillGroup?.endFillWindow();
+          inputConfiguration.autofillGroup?.scanForAutofilledValues();
+        }
+      }),
+    );
+  }
+
+  void _stopAutofillScan() {
+    _autofillScanFocusSub?.cancel();
+    _autofillScanFocusSub = null;
+    _autofillScanVisibilitySub?.cancel();
+    _autofillScanVisibilitySub = null;
+  }
+
   /// Overrides the result of [domDocument.hasFocus] for testing.
   @visibleForTesting
   bool? debugDocumentHasFocusOverride;
@@ -1436,6 +1748,42 @@ abstract class DefaultTextEditingStrategy
     }
   }
 
+  /// Returns the DOM element to use as the active editing element.
+  ///
+  /// If a dormant autofill form already holds an element for the field about to
+  /// be edited, that element is reused instead of creating a new one. Password
+  /// managers and browser autofill hold a reference to the specific input they
+  /// detected and rely on it keeping a stable identity and position; creating a
+  /// fresh element on every focus (and replacing the dormant one in
+  /// [EngineAutofillForm.wakeUp]) makes the login form churn, which breaks
+  /// detection in extensions like Bitwarden. Reusing keeps the element -- and
+  /// its geometry -- stable across focus changes.
+  DomHTMLElement _reuseDormantAutofillElementOrCreate(InputConfiguration inputConfig) {
+    final EngineAutofillForm? autofillGroup = inputConfig.autofillGroup;
+    final AutofillInfo? autofill = inputConfig.autofill;
+    // The focused field is the element tagged tabindex="-1", and in testing it
+    // was the one field password managers would not fill. Keeping autofill
+    // fields in the tab order (tabindex=0) makes them fillable; non-autofill
+    // fields keep -1 so the invisible proxy does not steal keyboard focus.
+    final double tabIndex = autofillGroup != null ? 0 : -1;
+    final DomHTMLElement freshElement = inputConfig.inputType.createDomElement()
+      ..tabIndex = tabIndex;
+    if (autofillGroup != null && autofill != null) {
+      final EngineAutofillForm? dormant = dormantForms[autofillGroup.formIdentifier];
+      final DomHTMLElement? reused = dormant?.elements[autofill.uniqueIdentifier];
+      // Only reuse the dormant element when it is the same kind of element (for
+      // example not an <input> when the field now needs a <textarea>); reusing a
+      // mismatched element would give the field the wrong DOM type.
+      if (reused != null && reused.tagName == freshElement.tagName) {
+        reused.tabIndex = tabIndex;
+        // Pointer events (disabled while it was a non-focused field) are
+        // re-enabled for the focused element in wakeUp.
+        return reused;
+      }
+    }
+    return freshElement;
+  }
+
   @override
   void initializeTextEditing(
     InputConfiguration inputConfig, {
@@ -1445,13 +1793,26 @@ abstract class DefaultTextEditingStrategy
     assert(!isEnabled);
     _pendingBlurConnectionCloseTimer?.cancel();
     _pendingBlurConnectionCloseTimer = null;
+    _stopAutofillScan();
 
     // The -1 tab index value makes this element not reachable by keyboard.
-    domElement = inputConfig.inputType.createDomElement()..tabIndex = -1;
+    domElement = _reuseDormantAutofillElementOrCreate(inputConfig);
     applyConfiguration(inputConfig);
 
     _setStaticStyleAttributes(activeDomElement);
     style?.applyToDomElement(activeDomElement);
+
+    if (hasAutofillGroup) {
+      // Floor the focused element's size so password managers can detect it too.
+      // The editable geometry can be as small as 1px, which is below the size at
+      // which Proton Pass/Bitwarden consider an input a real field. min-* only
+      // acts as a floor and never shrinks a normally-sized field. Because the
+      // focused element is reused as a non-focused field on the next focus
+      // change, this also keeps the sibling fields discoverable.
+      activeDomElement.style
+        ..setProperty('min-width', _kAutofillFieldMinWidth)
+        ..setProperty('min-height', _kAutofillFieldMinHeight);
+    }
 
     if (!hasAutofillGroup) {
       // If there is an Autofill Group the `FormElement`, it will be appended to the
@@ -1467,6 +1828,10 @@ abstract class DefaultTextEditingStrategy
     isEnabled = true;
     this.onChange = onChange;
     this.onAction = onAction;
+
+    if (hasAutofillGroup) {
+      _startAutofillScan();
+    }
   }
 
   void applyConfiguration(InputConfiguration config) {
@@ -1511,10 +1876,6 @@ abstract class DefaultTextEditingStrategy
 
   @override
   void addEventHandlers() {
-    if (inputConfiguration.autofillGroup != null) {
-      subscriptions.addAll(inputConfiguration.autofillGroup!.addInputEventListeners());
-    }
-
     // Subscribe to text and selection changes.
     subscriptions.add(
       DomSubscription(activeDomElement, 'input', createDomEventListener(handleChange)),
@@ -1538,6 +1899,11 @@ abstract class DefaultTextEditingStrategy
       subscriptions.add(
         DomSubscription(activeDomElement, 'blur', createDomEventListener(handleBlur)),
       );
+      // Pairs with handleBlur: a re-focus cancels a pending blur-triggered
+      // connection close (e.g. when a browser autofill popup hands focus back).
+      subscriptions.add(
+        DomSubscription(activeDomElement, 'focus', createDomEventListener(handleFocus)),
+      );
     }
 
     subscriptions.add(
@@ -1557,6 +1923,15 @@ abstract class DefaultTextEditingStrategy
   void updateElementPlacement(EditableTextGeometry textGeometry) {
     geometry = textGeometry;
     if (isEnabled) {
+      // A password manager is filling the form: hold the field where it is (see
+      // EngineAutofillForm.beginFillWindow). Re-applying the transform as the
+      // browser scrolls the field under the opening menu churns the DOM under
+      // the manager's overlay UI, which can break its fill. The stored geometry
+      // is applied by the next placement once the window thaws.
+      // (inputConfiguration is a late field, so it is only read once enabled.)
+      if (inputConfiguration.autofillGroup?.fillWindowActive ?? false) {
+        return;
+      }
       // On updates, we shouldn't go through the entire placeElement() flow if
       // we are in the middle of IME composition, otherwise we risk interrupting it.
       // Geometry updates occur when a multiline input expands or contracts. If
@@ -1567,6 +1942,10 @@ abstract class DefaultTextEditingStrategy
       } else {
         placeElement();
       }
+      // The focused element now has its on-screen transform. Move the non-focused
+      // autofill proxies next to it so proximity-based password managers see a
+      // coherent login form and fill every field, not just the focused one.
+      inputConfiguration.autofillGroup?.clusterNonFocusedFieldsAt(activeDomElement);
     }
   }
 
@@ -1583,6 +1962,11 @@ abstract class DefaultTextEditingStrategy
     assert(isEnabled);
     _pendingBlurConnectionCloseTimer?.cancel();
     _pendingBlurConnectionCloseTimer = null;
+    // Editing has genuinely stopped (a transient password-manager blur keeps the
+    // connection open instead of disabling, see handleBlur), so stop polling for
+    // autofill. Leaving the periodic scan running here would poll forever and,
+    // in tests, leak platform messages into later cases.
+    _stopAutofillScan();
 
     // Preserve the internal scroll position.
     if (geometry != null && lastEditingState != null) {
@@ -1629,6 +2013,14 @@ abstract class DefaultTextEditingStrategy
   }
 
   void placeForm() {
+    // Record the framework's current value for the focused field before the form
+    // wakes and scans, so the scan does not mistake the framework's own value for
+    // a browser autofill and echo it back. (Recording it from setEditingState is
+    // too late: the wake-up scan can run first.)
+    final EditingState? currentState = lastEditingState;
+    if (currentState != null) {
+      inputConfiguration.autofillGroup!.noteFrameworkEditingState(currentState);
+    }
     inputConfiguration.autofillGroup!.wakeUp(activeDomElement, inputConfiguration.autofill!);
     _appendedToForm = true;
   }
@@ -1652,9 +2044,18 @@ abstract class DefaultTextEditingStrategy
     }
 
     if (newEditingState != lastEditingState) {
+      // Focusing an untouched empty field produces a null -> empty transition
+      // that the framework already knows about. Record it but do not forward it,
+      // to avoid pushing a redundant editing state on focus.
+      final bool isInitialEmpty = lastEditingState == null && newEditingState.text.isEmpty;
       lastEditingState = newEditingState;
-      _editingDeltaState = newTextEditingDeltaState;
-      onChange!(lastEditingState, _editingDeltaState);
+      if (!isInitialEmpty) {
+        _editingDeltaState = newTextEditingDeltaState;
+        onChange!(lastEditingState, _editingDeltaState);
+        // The user's own edit was just delivered above; record it so the autofill
+        // listeners do not re-forward the same value as a browser autofill.
+        inputConfiguration.autofillGroup?.noteFrameworkEditingState(lastEditingState!);
+      }
     }
     // Flush delta state.
     _editingDeltaState = null;
@@ -1722,26 +2123,69 @@ abstract class DefaultTextEditingStrategy
 
     final willGainFocusElement = event.relatedTarget as DomElement?;
     if (willGainFocusElement == null) {
-      // If the element to gain focus is reported as `null`, it means that the
-      // window/iframe that Flutter runs in is losing focus. In this case, the
-      // engine signals to the framework to close the text input connection,
-      // allowing the focus to move elsewhere.
+      // Focus left to something that is not a DOM element: either the window or
+      // iframe that Flutter runs in is losing focus (tab or app switch), or a
+      // piece of browser/OS chrome such as an autofill / password-manager
+      // dialog took focus while it is open.
       //
-      // This is fixing https://github.com/flutter/flutter/issues/155265.
+      // When an autofill group is active, begin scanning for the values the
+      // dialog is about to fill and hold the proxy geometry still for a short
+      // window so the DOM does not churn under the dialog's overlay mid-fill;
+      // see EngineAutofillForm.beginFillWindow. isEnabled is checked first so
+      // `inputConfiguration` (a late field) is only read once the strategy is
+      // enabled.
+      final bool autofillSession = isEnabled && hasAutofillGroup && textEditing.isEditing;
+      if (autofillSession) {
+        _startAutofillScan();
+        inputConfiguration.autofillGroup?.beginFillWindow();
+      }
+
       if (!_documentHasFocus) {
+        // The window/iframe that Flutter runs in is losing focus. Defer the
+        // close: when a browser tab is backgrounded the input blur arrives
+        // before visibilitychange, and focus may also return immediately. Keep
+        // the connection alive on a tab background or a quick refocus, and
+        // otherwise close it. This is fixing
+        // https://github.com/flutter/flutter/issues/155265.
         _pendingBlurConnectionCloseTimer?.cancel();
-        // When a browser tab is backgrounded, the input blur arrives before
-        // visibilitychange. Wait briefly so tab switches can keep the text
-        // connection alive, while ordinary window/iframe blurs still close it.
         _pendingBlurConnectionCloseTimer = Timer(const Duration(milliseconds: 100), () {
           _pendingBlurConnectionCloseTimer = null;
           if (_documentVisibilityState == 'hidden' || _documentHasFocus) {
+            return;
+          }
+          // A field participating in autofill lost focus while the page moved
+          // to the background, for example a mobile OS autofill sheet that
+          // takes system focus away from the page while it fills the form and
+          // then returns. Keep the connection alive so the value it is about to
+          // fill still reaches the framework.
+          // https://github.com/flutter/flutter/issues/174773
+          if (isEnabled && hasAutofillGroup && textEditing.isEditing) {
             return;
           }
           textEditing.sendTextConnectionClosedToFrameworkIfAny();
         });
         return;
       }
+
+      // The document still has focus, yet the editing element blurred to
+      // nowhere. For an autofill session this is a password-manager / browser
+      // autofill dialog that steals the element's focus while the page keeps
+      // focus -- on mobile that can be several seconds -- and then fills the
+      // fields and hands focus back. Closing the connection now would tear down
+      // the field listeners and drop the value the dialog is about to fill,
+      // which is exactly the "autofill never reaches the Flutter field" bug
+      // (https://github.com/flutter/flutter/issues/174773). Keep the connection
+      // open: the fill dispatches 'input' events that the still-attached
+      // listeners forward to the framework, and the connection is closed
+      // normally when the framework unfocuses the field (widget disposed, or
+      // focus moved elsewhere in the widget tree).
+      if (autofillSession) {
+        return;
+      }
+
+      // Ordinary field: focus genuinely left the input while the page kept
+      // focus (the user clicked an empty area of the page), so close the
+      // connection.
       textEditing.sendTextConnectionClosedToFrameworkIfAny();
     } else if (_viewForElement(willGainFocusElement) == activeDomElementView) {
       // If the focus stays within the same FlutterView, ensure the focus stays
@@ -1755,7 +2199,45 @@ abstract class DefaultTextEditingStrategy
       // to user's request to move focus elsewhere, which can be super-annoying
       // UX. We should reevaluate what it is we're trying to do here. Perhaps
       // there's a better way.
-      moveFocusToActiveDomElement();
+      //
+      // Exception: do not grab focus back when it is moving to another field of
+      // the same autofill form. Password managers focus each field of the login
+      // form in turn as they fill it; fighting that movement tears the text
+      // connection down and recreates it repeatedly, and strict managers (e.g.
+      // Bitwarden) detect that churn as page interference and disable autofill.
+      // Let the manager walk the fields -- the field listeners still forward the
+      // values it fills.
+      final DomHTMLFormElement? autofillForm = inputConfiguration.autofillGroup?.formElement;
+      final bool movingWithinAutofillForm =
+          autofillForm != null && autofillForm.contains(willGainFocusElement);
+      if (!movingWithinAutofillForm) {
+        moveFocusToActiveDomElement();
+      }
+    }
+  }
+
+  /// Cancels a pending blur-triggered connection close.
+  ///
+  /// A blur may be transient: browser chrome such as an autofill or
+  /// password-manager popup can take focus and then hand it back to the editing
+  /// element. When that happens the element fires a `focus` event, which tells
+  /// us the blur was not the user leaving the field, so we keep the connection.
+  void handleFocus(DomEvent event) {
+    _pendingBlurConnectionCloseTimer?.cancel();
+    _pendingBlurConnectionCloseTimer = null;
+    // A re-focus cancels the pending close above. For an autofill field, also
+    // sync the current value and scan: a password manager may fill the field
+    // while it is blurred and then hand focus back. Non-autofill fields need
+    // nothing here (their edits arrive through input events), and running
+    // handleChange for them would push a redundant editing state on every focus.
+    // isEnabled is checked first so the late `inputConfiguration` is only read
+    // once the strategy is enabled.
+    if (isEnabled && hasAutofillGroup) {
+      // Focus returned to the field: the manager finished, so end the fill
+      // window and let placement resume.
+      inputConfiguration.autofillGroup?.endFillWindow();
+      handleChange(event);
+      inputConfiguration.autofillGroup?.scanForAutofilledValues();
     }
   }
 
@@ -1929,10 +2411,6 @@ class IOSTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
   @override
   void addEventHandlers() {
-    if (inputConfiguration.autofillGroup != null) {
-      subscriptions.addAll(inputConfiguration.autofillGroup!.addInputEventListeners());
-    }
-
     // Subscribe to text and selection changes.
     subscriptions.add(
       DomSubscription(activeDomElement, 'input', createDomEventListener(handleChange)),
@@ -1969,7 +2447,9 @@ class IOSTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
       DomSubscription(
         activeDomElement,
         'focus',
-        createDomEventListener((DomEvent _) {
+        createDomEventListener((DomEvent event) {
+          // A re-focus cancels a pending blur-triggered connection close.
+          handleFocus(event);
           // Cancel previous timer if exists.
           _schedulePlacement();
         }),
@@ -2075,10 +2555,6 @@ class AndroidTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
   @override
   void addEventHandlers() {
-    if (inputConfiguration.autofillGroup != null) {
-      subscriptions.addAll(inputConfiguration.autofillGroup!.addInputEventListeners());
-    }
-
     // Subscribe to text and selection changes.
     subscriptions.add(
       DomSubscription(activeDomElement, 'input', createDomEventListener(handleChange)),
@@ -2098,6 +2574,12 @@ class AndroidTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
     subscriptions.add(
       DomSubscription(activeDomElement, 'blur', createDomEventListener(handleBlur)),
+    );
+
+    // Pairs with handleBlur: a re-focus cancels a pending blur-triggered
+    // connection close (e.g. when a browser autofill popup hands focus back).
+    subscriptions.add(
+      DomSubscription(activeDomElement, 'focus', createDomEventListener(handleFocus)),
     );
 
     subscriptions.add(
@@ -2141,10 +2623,6 @@ class FirefoxTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
   @override
   void addEventHandlers() {
-    if (inputConfiguration.autofillGroup != null) {
-      subscriptions.addAll(inputConfiguration.autofillGroup!.addInputEventListeners());
-    }
-
     // Subscribe to text and selection changes.
     subscriptions.add(
       DomSubscription(activeDomElement, 'input', createDomEventListener(handleChange)),
@@ -2192,6 +2670,12 @@ class FirefoxTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
     subscriptions.add(
       DomSubscription(activeDomElement, 'blur', createDomEventListener(handleBlur)),
+    );
+
+    // Pairs with handleBlur: a re-focus cancels a pending blur-triggered
+    // connection close (e.g. when a browser autofill popup hands focus back).
+    subscriptions.add(
+      DomSubscription(activeDomElement, 'focus', createDomEventListener(handleFocus)),
     );
 
     subscriptions.add(

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -2065,8 +2065,37 @@ abstract class DefaultTextEditingStrategy
     // until the autofill context of the form is finalized.
     // More details on `TextInput.finishAutofillContext` call.
     if (_appendedToForm && inputConfiguration.autofillGroup?.formElement != null) {
-      _styleAutofillElements(activeDomElement, isOffScreen: true);
-      inputConfiguration.autofillGroup?.goDormant();
+      final EngineAutofillForm group = inputConfiguration.autofillGroup!;
+      if (group.fillWindowActive) {
+        // A password manager took the focus to fill the form, and that is what
+        // closed this connection. Parking this field off screen at 1x1 now
+        // would hide the one field the manager was invoked from, which is the
+        // field the user was in: managers do not fill a field they cannot see,
+        // so filling from the password field would deliver only the username
+        // and filling from the username field only the password. Leave it
+        // discoverable, like the fields it now sits beside. Read before
+        // goDormant, which closes the window.
+        _styleAutofillElements(
+          activeDomElement,
+          shouldHideElement: false,
+          shouldDisablePointerEvents: group._isSafariStrategy,
+        );
+      } else {
+        // Off screen, but at its real size. A manager measures a field's box to
+        // decide whether it is one it can ever fill, and at least one of them
+        // memoises that verdict against the element: a field measured while it
+        // was a pixel tall is written off for as long as that element lives,
+        // and these elements are reused for the life of the form. Position is
+        // not part of that judgement, so moving it away is enough to get it out
+        // of the way, and shrinking it only makes it unfillable later.
+        _styleAutofillElements(
+          activeDomElement,
+          isOffScreen: true,
+          shouldHideElement: false,
+          shouldDisablePointerEvents: group._isSafariStrategy,
+        );
+      }
+      group.goDormant();
       EnginePlatformDispatcher.instance.viewManager.safeBlur(activeDomElement);
     } else {
       EnginePlatformDispatcher.instance.viewManager.safeRemove(activeDomElement);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -378,6 +378,17 @@ class EngineAutofillForm {
         // framework update apart from a browser autofill.
         _lastSentAutofillText.addAll(existingForm._lastSentAutofillText);
         _lastFrameworkText.addAll(existingForm._lastFrameworkText);
+        // The adopted DOM elements still carry the dormant instance's
+        // listeners (goDormant deliberately keeps them so a late fill on the
+        // dormant form is not lost). This instance rebinds its own below in
+        // attachPersistentFormListeners; cancel the old ones so listener sets
+        // do not accumulate across focus cycles and, more importantly, so the
+        // old instance's listener for what is now the focused field does not
+        // re-forward the user's typing as an autofill. That listener was
+        // bound when the field was not focused, so it forwards
+        // unconditionally, and _sendAutofillEditingState collapses the
+        // selection to the end of the text on every keystroke.
+        existingForm._cancelFormSubscriptions();
       } else {
         formElement = _createFormElementAndFields(focusedElement, focusedAutofill);
         _insertEditingElementInView(formElement!, viewId);
@@ -439,6 +450,13 @@ class EngineAutofillForm {
   /// mutates the tree mid-fill, so holding still avoids interfering with them.
   /// The filled values still arrive through the input/animationstart listeners.
   bool _fillWindowActive = false;
+
+  /// Whether this form instance has been deactivated ([goDormant]) and its
+  /// focused field no longer has a live connection. While dormant, the
+  /// persistent listeners forward the focused field's events too; while live,
+  /// the focused field is delivered by
+  /// [DefaultTextEditingStrategy.handleChange] instead.
+  bool _isDormant = false;
 
   /// Whether a password manager currently holds focus to fill the form, during
   /// which the proxy geometry is held still. See [beginFillWindow].
@@ -516,6 +534,7 @@ class EngineAutofillForm {
 
     // The form is deactivated; end any open fill window so it never stays frozen.
     endFillWindow();
+    _isDormant = true;
     dormantForms[formIdentifier] = this;
     _styleAutofillElements(formElement!, isOffScreen: true);
   }
@@ -711,8 +730,9 @@ class EngineAutofillForm {
   /// Unlike [addInputEventListeners] (used by the semantics strategy, whose
   /// subscriptions are owned by [DefaultTextEditingStrategy.subscriptions]),
   /// this owns its subscriptions in [_formSubscriptions] so they can be rebound
-  /// each time the form wakes. The focused field is skipped; its edits and
-  /// autofills are delivered by [handleChange] and the autofill scan.
+  /// each time the form wakes. The focused field is observed only after its
+  /// connection has closed (see the guard in the listener); while it is live its
+  /// edits and autofills are delivered by [handleChange].
   void attachPersistentFormListeners() {
     _ensureAutofillStyleInjected();
     _cancelFormSubscriptions();
@@ -723,19 +743,29 @@ class EngineAutofillForm {
       if (fieldItem == null) {
         continue;
       }
-      // The focused field's edits and autofills are already delivered by
-      // handleChange and the autofill scan; observing it here as well would
-      // re-forward the user's own typing as if it were a browser autofill.
-      if (key == focusedElementId) {
-        continue;
-      }
+      final bool isFocusedField = key == focusedElementId;
       final AutofillInfo autofillInfo = fieldItem.autofillInfo;
       for (final String type in _autofillEventTypes) {
         _formSubscriptions.add(
           DomSubscription(
             element,
             type,
-            createDomEventListener((DomEvent _) => _forwardAutofillIfChanged(element, autofillInfo)),
+            createDomEventListener((DomEvent _) {
+              // While the form is live the focused field's edits and autofills
+              // are delivered by handleChange; observing it here too would
+              // re-forward the user's own typing as a browser autofill. Once
+              // the form went dormant (its connection closed) forward from
+              // here, so a manager filling the focused field after it lost
+              // focus still reaches the framework (routed via the last
+              // connection on the framework side). Dormancy is tracked on the
+              // form itself rather than through textEditing.isEditing: the
+              // form belongs to one HybridTextEditing instance and must not
+              // consult the shared singleton's state.
+              if (isFocusedField && !_isDormant) {
+                return;
+              }
+              _forwardAutofillIfChanged(element, autofillInfo);
+            }),
           ),
         );
       }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1598,6 +1598,7 @@ class GloballyPositionedTextEditingStrategy extends DefaultTextEditingStrategy {
       // events (like blur). These events might invalidate the current
       // inputConfiguration or disable the strategy before placeForm() returns.
       // Therefore, we must defensively check if the element is still valid/present.
+      //
       focusedFormElement?.focusWithoutScroll();
       moveFocusToActiveDomElement();
     }
@@ -1794,6 +1795,7 @@ abstract class DefaultTextEditingStrategy
   bool _appendedToForm = false;
 
   DomHTMLFormElement? get focusedFormElement => inputConfiguration.autofillGroup?.formElement;
+
 
   /// Scrolls the active DOM element into view if running inside an iframe
   /// or in multi-view mode.
@@ -2286,19 +2288,7 @@ abstract class DefaultTextEditingStrategy
       // UX. We should reevaluate what it is we're trying to do here. Perhaps
       // there's a better way.
       //
-      // Exception: do not grab focus back when it is moving to another field of
-      // the same autofill form. Password managers focus each field of the login
-      // form in turn as they fill it; fighting that movement tears the text
-      // connection down and recreates it repeatedly, and strict managers (e.g.
-      // Bitwarden) detect that churn as page interference and disable autofill.
-      // Let the manager walk the fields -- the field listeners still forward the
-      // values it fills.
-      final DomHTMLFormElement? autofillForm = inputConfiguration.autofillGroup?.formElement;
-      final bool movingWithinAutofillForm =
-          autofillForm != null && autofillForm.contains(willGainFocusElement);
-      if (!movingWithinAutofillForm) {
-        moveFocusToActiveDomElement();
-      }
+      moveFocusToActiveDomElement();
     }
   }
 
@@ -2426,6 +2416,8 @@ abstract class DefaultTextEditingStrategy
   void moveFocusToActiveDomElement() {
     activeDomElement.focusWithoutScroll();
   }
+
+
 }
 
 /// IOS/Safari behaviour for text editing.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -610,13 +610,13 @@ class EngineAutofillForm {
     }
   }
 
-  /// Records the framework's own value for the focused field so a later
+  /// Records the framework's own value for [fieldId] so a later
   /// [scanForAutofilledValues] or [_updateFieldValues] does not mistake it for a
-  /// browser autofill and echo it straight back. The focused field's *current*
-  /// framework value must be compared against, not the stale config-time
+  /// browser autofill and echo it straight back. The field's *current* framework
+  /// value must be compared against, not the stale config-time
   /// [AutofillInfo.editingState].
-  void noteFrameworkEditingState(EditingState editingState) {
-    _lastSentAutofillText[focusedElementId] = editingState.text;
+  void noteFrameworkEditingState(String fieldId, EditingState editingState) {
+    _lastSentAutofillText[fieldId] = editingState.text;
   }
 
   /// Scans every field for a value the browser autofilled but the framework has
@@ -2019,7 +2019,10 @@ abstract class DefaultTextEditingStrategy
     // too late: the wake-up scan can run first.)
     final EditingState? currentState = lastEditingState;
     if (currentState != null) {
-      inputConfiguration.autofillGroup!.noteFrameworkEditingState(currentState);
+      inputConfiguration.autofillGroup!.noteFrameworkEditingState(
+        inputConfiguration.autofill!.uniqueIdentifier,
+        currentState,
+      );
     }
     inputConfiguration.autofillGroup!.wakeUp(activeDomElement, inputConfiguration.autofill!);
     _appendedToForm = true;
@@ -2054,7 +2057,10 @@ abstract class DefaultTextEditingStrategy
         onChange!(lastEditingState, _editingDeltaState);
         // The user's own edit was just delivered above; record it so the autofill
         // listeners do not re-forward the same value as a browser autofill.
-        inputConfiguration.autofillGroup?.noteFrameworkEditingState(lastEditingState!);
+        inputConfiguration.autofillGroup?.noteFrameworkEditingState(
+          inputConfiguration.autofill!.uniqueIdentifier,
+          lastEditingState!,
+        );
       }
     }
     // Flush delta state.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -132,6 +132,23 @@ input:-webkit-autofill, input:autofill {
 /// element.
 ///
 /// They are assigned once during the creation of the DOM element.
+/// Hides a non-focused autofill proxy from assistive technology, but only when
+/// semantics is on.
+///
+/// With semantics on the field has a real semantics node, so the proxy is a
+/// duplicate and screen readers should skip it. With semantics off there is no
+/// other representation of the field, so hiding the proxy hides nothing useful
+/// and costs a great deal: password managers reject an `aria-hidden` input
+/// outright, and one that is never a candidate is one they never fill.
+void _hideFromAssistiveTechnology(DomHTMLElement element) {
+  if (EngineSemantics.instance.semanticsEnabled) {
+    element.setAttribute('aria-hidden', 'true');
+  } else {
+    // Elements are reused across connections, so clear a stale attribute.
+    element.removeAttribute('aria-hidden');
+  }
+}
+
 void _styleAutofillElements(
   DomHTMLElement domElement, {
   bool isOffScreen = false,
@@ -426,14 +443,15 @@ class EngineAutofillForm {
       final bool isFocused = entry.key == focusedAutofill.uniqueIdentifier;
       entry.value.style.pointerEvents = isFocused || !_isSafariStrategy ? 'all' : 'none';
       // The focused field stays interactive (its tabIndex is set in
-      // _reuseDormantAutofillElementOrCreate); the others are kept discoverable for
-      // password managers but out of the tab order and the accessibility tree, so
-      // Tab and screen readers do not land on an invisible field.
+      // _reuseDormantAutofillElementOrCreate); the others are kept discoverable
+      // for password managers but out of the tab order. See
+      // [_hideFromAssistiveTechnology] for why they are only hidden from the
+      // accessibility tree in semantics mode.
       if (isFocused) {
         entry.value.removeAttribute('aria-hidden');
       } else {
         entry.value.tabIndex = -1;
-        entry.value.setAttribute('aria-hidden', 'true');
+        _hideFromAssistiveTechnology(entry.value);
       }
     }
 
@@ -580,10 +598,10 @@ class EngineAutofillForm {
           shouldDisablePointerEvents: _isSafariStrategy,
         );
         // Keep the proxy discoverable to password managers (which scan the DOM)
-        // but out of the tab order and the accessibility tree, so keyboard Tab
-        // and screen readers do not land on this invisible field.
+        // but out of the tab order, so keyboard Tab does not land on this
+        // invisible field. See [_hideFromAssistiveTechnology].
         htmlElement.tabIndex = -1;
-        htmlElement.setAttribute('aria-hidden', 'true');
+        _hideFromAssistiveTechnology(htmlElement);
         // The proxy has to hit-test back to itself for a manager to consider it
         // fillable, which also makes it a target for real clicks. Swallow those:
         // a manager focuses a field with .focus(), which fires no pointer event,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -412,9 +412,18 @@ class EngineAutofillForm {
     // from when it was focused, so reset the non-focused fields here to keep
     // them from intercepting taps meant for the app UI.
     for (final MapEntry<String, DomHTMLElement> entry in elements.entries) {
-      entry.value.style.pointerEvents = entry.key == focusedAutofill.uniqueIdentifier
-          ? 'all'
-          : 'none';
+      final bool isFocused = entry.key == focusedAutofill.uniqueIdentifier;
+      entry.value.style.pointerEvents = isFocused ? 'all' : 'none';
+      // The focused field stays interactive (its tabIndex is set in
+      // _reuseDormantAutofillElementOrCreate); the others are kept discoverable for
+      // password managers but out of the tab order and the accessibility tree, so
+      // Tab and screen readers do not land on an invisible field.
+      if (isFocused) {
+        entry.value.removeAttribute('aria-hidden');
+      } else {
+        entry.value.tabIndex = -1;
+        entry.value.setAttribute('aria-hidden', 'true');
+      }
     }
 
     _updateFieldValues();
@@ -551,6 +560,11 @@ class EngineAutofillForm {
           shouldHideElement: false,
           shouldDisablePointerEvents: true,
         );
+        // Keep the proxy discoverable to password managers (which scan the DOM)
+        // but out of the tab order and the accessibility tree, so keyboard Tab
+        // and screen readers do not land on this invisible field.
+        htmlElement.tabIndex = -1;
+        htmlElement.setAttribute('aria-hidden', 'true');
       }
 
       elements[field.autofillInfo.uniqueIdentifier] = htmlElement;
@@ -2010,6 +2024,13 @@ abstract class DefaultTextEditingStrategy
       return;
     }
     lastEditingState!.applyToDomElement(domElement);
+    // Record the framework's value so a later autofill rescan does not mistake this
+    // programmatic update for a browser autofill and echo it back (which would
+    // collapse the cursor to the end). See EngineAutofillForm.noteFrameworkEditingState.
+    inputConfiguration.autofillGroup?.noteFrameworkEditingState(
+      inputConfiguration.autofill!.uniqueIdentifier,
+      lastEditingState!,
+    );
   }
 
   void placeElement() {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -424,7 +424,7 @@ class EngineAutofillForm {
     // them from intercepting taps meant for the app UI.
     for (final MapEntry<String, DomHTMLElement> entry in elements.entries) {
       final bool isFocused = entry.key == focusedAutofill.uniqueIdentifier;
-      entry.value.style.pointerEvents = isFocused ? 'all' : 'none';
+      entry.value.style.pointerEvents = isFocused || !_isSafariStrategy ? 'all' : 'none';
       // The focused field stays interactive (its tabIndex is set in
       // _reuseDormantAutofillElementOrCreate); the others are kept discoverable for
       // password managers but out of the tab order and the accessibility tree, so
@@ -577,13 +577,27 @@ class EngineAutofillForm {
         _styleAutofillElements(
           htmlElement,
           shouldHideElement: false,
-          shouldDisablePointerEvents: true,
+          shouldDisablePointerEvents: _isSafariStrategy,
         );
         // Keep the proxy discoverable to password managers (which scan the DOM)
         // but out of the tab order and the accessibility tree, so keyboard Tab
         // and screen readers do not land on this invisible field.
         htmlElement.tabIndex = -1;
         htmlElement.setAttribute('aria-hidden', 'true');
+        // The proxy has to hit-test back to itself for a manager to consider it
+        // fillable, which also makes it a target for real clicks. Swallow those:
+        // a manager focuses a field with .focus(), which fires no pointer event,
+        // so it loses nothing, while a click on the invisible field becomes a
+        // no-op instead of moving the browser's focus somewhere the framework
+        // does not know about.
+        for (final String type in <String>['pointerdown', 'mousedown']) {
+          htmlElement.addEventListener(
+            type,
+            createDomEventListener((DomEvent event) {
+              event.preventDefault();
+            }),
+          );
+        }
       }
 
       elements[field.autofillInfo.uniqueIdentifier] = htmlElement;

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/view_focus_binding_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/view_focus_binding_test.dart
@@ -93,6 +93,77 @@ void testMain() {
       expect(dispatchedViewFocusEvents[1].direction, ui.ViewFocusDirection.undefined);
     });
 
+    test('does not report a view unfocused while something steps between form fields', () async {
+      final EngineFlutterView view = createAndRegisterView(dispatcher);
+
+      // The engine puts the fields of an autofill group in a form. A password
+      // manager fills one field at a time, blurring each before focusing the
+      // next, and that blur lands on <body> with no relatedTarget.
+      final DomHTMLFormElement form = createDomHTMLFormElement();
+      final DomHTMLInputElement username = createDomHTMLInputElement();
+      final DomHTMLInputElement password = createDomHTMLInputElement();
+      form.append(username);
+      form.append(password);
+      view.dom.rootElement.append(form);
+
+      username.focusWithoutScroll();
+      expect(dispatchedViewFocusEvents, hasLength(1));
+      expect(dispatchedViewFocusEvents[0].state, ui.ViewFocusState.focused);
+
+      username.blur();
+      expect(
+        dispatchedViewFocusEvents,
+        hasLength(1),
+        reason: 'the report is deferred, not made synchronously',
+      );
+
+      // Focus goes to another field of the same form, so the view never lost it.
+      password.focusWithoutScroll();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(
+        dispatchedViewFocusEvents,
+        hasLength(1),
+        reason: 'focus came back to the view, so it was never unfocused',
+      );
+    });
+
+    test('reports a view unfocused when focus does not come back to it', () async {
+      final EngineFlutterView view = createAndRegisterView(dispatcher);
+
+      final DomHTMLFormElement form = createDomHTMLFormElement();
+      final DomHTMLInputElement username = createDomHTMLInputElement();
+      form.append(username);
+      view.dom.rootElement.append(form);
+
+      username.focusWithoutScroll();
+      expect(dispatchedViewFocusEvents, hasLength(1));
+
+      // Nothing takes the focus back this time, so the deferred report stands.
+      username.blur();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(dispatchedViewFocusEvents, hasLength(2));
+      expect(dispatchedViewFocusEvents[1].viewId, view.viewId);
+      expect(dispatchedViewFocusEvents[1].state, ui.ViewFocusState.unfocused);
+    });
+
+    test('reports a view unfocused at once when the blurred element is not in a form', () async {
+      final EngineFlutterView view = createAndRegisterView(dispatcher);
+
+      // Only the fields of an autofill form defer. Anything else keeps the
+      // synchronous behaviour.
+      final DomHTMLInputElement loose = createDomHTMLInputElement();
+      view.dom.rootElement.append(loose);
+
+      loose.focusWithoutScroll();
+      expect(dispatchedViewFocusEvents, hasLength(1));
+
+      loose.blur();
+      expect(dispatchedViewFocusEvents, hasLength(2));
+      expect(dispatchedViewFocusEvents[1].state, ui.ViewFocusState.unfocused);
+    });
+
     test('fires a focus event - focus transitions between views', () async {
       final EngineFlutterView view1 = createAndRegisterView(dispatcher);
       final EngineFlutterView view2 = createAndRegisterView(dispatcher);

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -860,6 +860,65 @@ Future<void> testMain() async {
       spy.tearDown();
     });
 
+    test('does not echo a programmatic setEditingState change as an autofill', () async {
+      // A programmatic controller.text change on a focused autofill field arrives
+      // through setEditingState. The next autofill rescan (e.g. after the tab is
+      // switched away and back) must not mistake that framework value for a browser
+      // autofill and forward it, which would collapse the cursor to the end.
+      final spy = PlatformMessagesSpy();
+      spy.setUp();
+
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+
+      // The framework programmatically sets a new value on the focused field.
+      send(
+        const MethodCall('TextInput.setEditingState', <String, dynamic>{
+          'text': 'from-code@example.com',
+          'selectionBase': 21,
+          'selectionExtent': 21,
+          'composingBase': -1,
+          'composingExtent': -1,
+        }),
+      );
+
+      final strategy = textEditing.strategy;
+      strategy.debugDocumentHasFocusOverride = true;
+      strategy.debugDocumentVisibilityStateOverride = 'visible';
+
+      spy.messages.clear();
+
+      // The tab is switched away: the field blurs (null relatedTarget) and an
+      // autofill rescan runs. The programmatic value was recorded, so it must not
+      // be re-forwarded as a fake autofill.
+      strategy.handleBlur(createDomEvent('Event', 'blur'));
+
+      final Iterable<PlatformMessage> autofillMessages = spy.messages.where(
+        (PlatformMessage message) =>
+            message.methodName == 'TextInputClient.updateEditingStateWithTag',
+      );
+      expect(autofillMessages, isEmpty);
+
+      strategy.debugDocumentHasFocusOverride = null;
+      strategy.debugDocumentVisibilityStateOverride = null;
+      send(const MethodCall('TextInput.clearClient'));
+      spy.tearDown();
+    });
+
     test('geometry update before the input is shown does not throw (autofill)', () async {
       // A setEditableSizeAndTransform can arrive before TextInput.show enables
       // the strategy (for example a password manager forcing a relayout of the
@@ -3899,6 +3958,7 @@ Future<void> testMain() async {
 
       final formChildNodes =
           autofillForm.formElement!.childNodes.toList() as List<DomHTMLInputElement>;
+      final DomHTMLInputElement email = formChildNodes[0];
       final DomHTMLInputElement username = formChildNodes[1];
       final DomHTMLInputElement password = formChildNodes[2];
 
@@ -3915,6 +3975,14 @@ Future<void> testMain() async {
       expect(password.style.height, isNot('0px'));
       expect(password.style.pointerEvents, 'none');
       expect(autofillForm.formElement!.style.pointerEvents, isNot('none'));
+      // They are also removed from the tab order and the accessibility tree so
+      // keyboard Tab and screen readers do not land on the invisible fields, while
+      // the focused field stays reachable.
+      expect(username.tabIndex, -1);
+      expect(username.getAttribute('aria-hidden'), 'true');
+      expect(password.tabIndex, -1);
+      expect(password.getAttribute('aria-hidden'), 'true');
+      expect(email.getAttribute('aria-hidden'), isNull);
     }, skip: isSafari);
 
     test('hidden autofill elements should not have a width and height of 0 on Safari', () {

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -3621,6 +3621,30 @@ Future<void> testMain() async {
       });
     }
 
+    test('moving to another field of the same form focuses the field moved to', () async {
+      void send(MethodCall call) =>
+          textEditing!.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+
+      final fields = openFormFocusing('email', send);
+      expect(domDocument.activeElement, fields.username);
+
+      // The user taps the password field, so the framework connects a new
+      // client for it. The field being left still holds the browser's focus at
+      // that point, because the engine blurs it asynchronously, which looks
+      // exactly like a password manager holding a field of the form. The field
+      // the framework moved to still has to end up focused, or there is
+      // nothing for the user to type into.
+      final fieldsAfterMove = openFormFocusing('password', send);
+
+      // Compared by name too, so a failure says which field ended up focused.
+      expect((domDocument.activeElement! as DomHTMLInputElement).name, 'current-password');
+      expect(domDocument.activeElement, fieldsAfterMove.password);
+      expect(domDocument.activeElement, textEditing!.strategy.domElement);
+
+      send(const MethodCall('TextInput.clearClient'));
+      dormantForms.clear();
+    });
+
     test('forwards a fill on the previously focused field after the connection closes', () async {
       // A password manager can write into the field after the framework
       // already closed the connection (the user confirms the fill dialog after

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -4259,16 +4259,19 @@ Future<void> testMain() async {
 
       expect(username.name, 'username');
       expect(password.name, 'current-password');
-      // Non-focused autofill fields are kept discoverable (a non-zero size,
-      // positioned next to the focused field) but non-interactive, so password
-      // managers detect and fill them without the invisible field intercepting
-      // taps meant for the app UI.
+      // Non-focused autofill fields are kept discoverable: a non-zero size,
+      // positioned next to the focused field, and taking part in hit testing.
+      // A password manager only fills a field whose own centre point hit-tests
+      // back to it, so a field excluded from hit testing is one it will not
+      // fill, and a login form can never be filled as a pair. Pointer input on
+      // them is swallowed instead (see the pointerdown/mousedown listeners),
+      // which keeps taps meant for the app from landing on an invisible field.
       expect(username.style.width, isNot('0px'));
       expect(username.style.height, isNot('0px'));
-      expect(username.style.pointerEvents, 'none');
+      expect(username.style.pointerEvents, isSafari ? 'none' : 'all');
       expect(password.style.width, isNot('0px'));
       expect(password.style.height, isNot('0px'));
-      expect(password.style.pointerEvents, 'none');
+      expect(password.style.pointerEvents, isSafari ? 'none' : 'all');
       expect(autofillForm.formElement!.style.pointerEvents, isNot('none'));
       // They are also removed from the tab order and the accessibility tree so
       // keyboard Tab and screen readers do not land on the invisible fields, while

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -879,6 +879,126 @@ Future<void> testMain() async {
       spy.tearDown();
     });
 
+    // A password manager fills a login form by focusing each field in turn and
+    // writing into it, and the field it starts from is whichever one the user
+    // invoked it on. Whatever it writes has to reach the framework in every
+    // combination: the engine must not depend on which field happens to be the
+    // active editing element while the manager walks the form.
+    //
+    // These drive the DOM the way an extension does (focus, assign value,
+    // dispatch input/change) rather than going through the manager itself,
+    // which is the part outside our control.
+    void managerFill(DomHTMLInputElement element, String value) {
+      element.focusWithoutScroll();
+      element.value = value;
+      element.dispatchEvent(createDomEvent('Event', 'input'));
+      element.dispatchEvent(createDomEvent('Event', 'change'));
+    }
+
+    ({DomHTMLInputElement username, DomHTMLInputElement password}) openFormFocusing(
+      String focusedHint,
+      void Function(MethodCall) send,
+    ) {
+      final config = createFlutterConfig(
+        focusedHint == 'password' ? 'text' : 'text',
+        autofillHint: focusedHint == 'password' ? 'password' : 'email',
+        autofillHintsForFields: <String>['email', 'password'],
+      );
+      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+      final form = textEditing.strategy.domElement!.parent! as DomHTMLFormElement;
+      final fields = form.childNodes.toList() as List<DomHTMLInputElement>;
+      return (
+        username: fields.firstWhere((DomHTMLInputElement e) => e.name == 'email'),
+        password: fields.firstWhere((DomHTMLInputElement e) => e.name == 'current-password'),
+      );
+    }
+
+    // A value can arrive two ways: tagged (updateEditingStateWithTag, used for
+    // fields the manager fills while they are not the active editing element)
+    // or untagged (updateEditingState, used for the active element itself).
+    // Both mean the framework got it, which is what these tests are about.
+    bool frameworkReceived(PlatformMessagesSpy spy, String value) {
+      for (final PlatformMessage message in spy.messages) {
+        final dynamic args = message.methodArguments;
+        if (args is! List || args.length < 2) {
+          continue;
+        }
+        final dynamic payload = args[1];
+        if (payload is! Map) {
+          continue;
+        }
+        if (payload['text'] == value) {
+          return true;
+        }
+        for (final dynamic field in payload.values) {
+          if (field is Map && field['text'] == value) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    for (final String focused in <String>['email', 'password']) {
+      test('a manager filling both fields is forwarded when $focused is active', () async {
+        final spy = PlatformMessagesSpy();
+        spy.setUp();
+        void send(MethodCall call) =>
+            textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+
+        final fields = openFormFocusing(focused, send);
+        spy.messages.clear();
+
+        // The manager walks the form: username first, then the password.
+        managerFill(fields.username, 'user@example.com');
+        managerFill(fields.password, 'hunter2secret');
+
+        expect(
+          frameworkReceived(spy, 'user@example.com'),
+          isTrue,
+          reason: 'the username fill must reach the framework',
+        );
+        expect(
+          frameworkReceived(spy, 'hunter2secret'),
+          isTrue,
+          reason: 'the password fill must reach the framework',
+        );
+
+        send(const MethodCall('TextInput.clearClient'));
+        dormantForms.clear();
+        spy.tearDown();
+      });
+
+      test('a manager filling only the other field is forwarded when $focused is active', () async {
+        final spy = PlatformMessagesSpy();
+        spy.setUp();
+        void send(MethodCall call) =>
+            textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+
+        final fields = openFormFocusing(focused, send);
+        spy.messages.clear();
+
+        // Some managers fill a single field. Whichever one it is, and whichever
+        // field is active, the value still has to arrive.
+        final DomHTMLInputElement other = focused == 'email' ? fields.password : fields.username;
+        managerFill(other, 'only-one-field');
+
+        expect(frameworkReceived(spy, 'only-one-field'), isTrue);
+
+        send(const MethodCall('TextInput.clearClient'));
+        dormantForms.clear();
+        spy.tearDown();
+      });
+    }
+
     test('forwards a fill on the previously focused field after the connection closes', () async {
       // A password manager can write into the field after the framework
       // already closed the connection (the user confirms the fill dialog after

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -760,510 +760,6 @@ Future<void> testMain() async {
       spy.tearDown();
     });
 
-    test('keeps connection open across a transient autofill blur, closes on genuine unfocus', () async {
-      // Password managers and browser autofill popups blur the hidden input
-      // (with a null relatedTarget) while the page keeps focus, then hand focus
-      // back to fill the field. For an autofill field that re-focus must cancel
-      // the pending close, or the autofilled value is dropped.
-      final spy = PlatformMessagesSpy();
-      spy.setUp();
-
-      final config = createFlutterConfig(
-        'text',
-        autofillHint: 'email',
-        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
-      );
-      void send(MethodCall call) =>
-          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
-      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
-      send(
-        configureSetSizeAndTransformMethodCall(
-          150,
-          50,
-          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
-        ),
-      );
-      send(const MethodCall('TextInput.show'));
-
-      expect(textEditing.isEditing, isTrue);
-
-      final strategy = textEditing.strategy;
-      strategy.debugDocumentHasFocusOverride = true;
-      strategy.debugDocumentVisibilityStateOverride = 'visible';
-
-      // The popup takes focus: the field blurs while the page keeps focus.
-      strategy.handleBlur(createDomEvent('Event', 'blur'));
-
-      // The close is deferred, never synchronous.
-      expect(connectionClosedMessages(spy), isEmpty);
-
-      // The browser hands focus back to the field to autofill it.
-      strategy.handleFocus(createDomEvent('Event', 'focus'));
-
-      await Future<void>.delayed(const Duration(milliseconds: 150));
-
-      // The re-focus cancelled the close, so the connection stays open.
-      expect(connectionClosedMessages(spy), isEmpty);
-      expect(textEditing.isEditing, isTrue);
-
-      strategy.debugDocumentHasFocusOverride = null;
-      strategy.debugDocumentVisibilityStateOverride = null;
-
-      // A genuine unfocus (the framework closes the connection) must actually
-      // tear the engine half down: the form goes dormant and the hidden input
-      // releases DOM focus, so the soft keyboard dismisses and physical
-      // keystrokes stop reaching the old field.
-      final DomHTMLElement? input = textEditing.strategy.domElement;
-      send(const MethodCall('TextInput.clearClient'));
-      expect(textEditing.isEditing, isFalse);
-      expect(dormantForms, hasLength(1));
-      // The DOM focus handoff (safeBlur) is asynchronous.
-      await Future<void>.delayed(Duration.zero);
-      expect(domDocument.activeElement, isNot(input));
-      spy.tearDown();
-    });
-
-    test('keeps connection open for an autofill field that blurs without refocus', () async {
-      final spy = PlatformMessagesSpy();
-      spy.setUp();
-
-      final config = createFlutterConfig(
-        'text',
-        autofillHint: 'email',
-        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
-      );
-      void send(MethodCall call) =>
-          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
-      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
-      send(
-        configureSetSizeAndTransformMethodCall(
-          150,
-          50,
-          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
-        ),
-      );
-      send(const MethodCall('TextInput.show'));
-
-      expect(textEditing.isEditing, isTrue);
-
-      final strategy = textEditing.strategy;
-      strategy.debugDocumentHasFocusOverride = true;
-      strategy.debugDocumentVisibilityStateOverride = 'visible';
-
-      // A password manager takes focus to fill the form (relatedTarget is null)
-      // and may keep its dialog open for several seconds without returning focus
-      // to the field.
-      strategy.handleBlur(createDomEvent('Event', 'blur'));
-
-      // The close is deferred, never synchronous.
-      expect(connectionClosedMessages(spy), isEmpty);
-
-      await Future<void>.delayed(const Duration(milliseconds: 150));
-
-      // The connection is kept alive so the pending fill is not dropped; it is
-      // closed normally later when the framework unfocuses the field
-      // (clearClient), not on this transient blur.
-      expect(connectionClosedMessages(spy), isEmpty);
-      expect(textEditing.isEditing, isTrue);
-
-      strategy.debugDocumentHasFocusOverride = null;
-      strategy.debugDocumentVisibilityStateOverride = null;
-
-      // When the framework does unfocus, the engine closes for real.
-      final DomHTMLElement? input = textEditing.strategy.domElement;
-      send(const MethodCall('TextInput.clearClient'));
-      expect(textEditing.isEditing, isFalse);
-      expect(dormantForms, hasLength(1));
-      await Future<void>.delayed(Duration.zero);
-      expect(domDocument.activeElement, isNot(input));
-      spy.tearDown();
-    });
-
-    // A password manager fills a login form by focusing each field in turn and
-    // writing into it, and the field it starts from is whichever one the user
-    // invoked it on. Whatever it writes has to reach the framework in every
-    // combination: the engine must not depend on which field happens to be the
-    // active editing element while the manager walks the form.
-    //
-    // These drive the DOM the way an extension does (focus, assign value,
-    // dispatch input/change) rather than going through the manager itself,
-    // which is the part outside our control.
-    void managerFill(DomHTMLInputElement element, String value) {
-      element.focusWithoutScroll();
-      element.value = value;
-      element.dispatchEvent(createDomEvent('Event', 'input'));
-      element.dispatchEvent(createDomEvent('Event', 'change'));
-    }
-
-    ({DomHTMLInputElement username, DomHTMLInputElement password}) openFormFocusing(
-      String focusedHint,
-      void Function(MethodCall) send,
-    ) {
-      final config = createFlutterConfig(
-        focusedHint == 'password' ? 'text' : 'text',
-        autofillHint: focusedHint == 'password' ? 'password' : 'email',
-        autofillHintsForFields: <String>['email', 'password'],
-      );
-      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
-      send(
-        configureSetSizeAndTransformMethodCall(
-          150,
-          50,
-          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
-        ),
-      );
-      send(const MethodCall('TextInput.show'));
-      final form = textEditing.strategy.domElement!.parent! as DomHTMLFormElement;
-      final fields = form.childNodes.toList() as List<DomHTMLInputElement>;
-      return (
-        username: fields.firstWhere((DomHTMLInputElement e) => e.name == 'email'),
-        password: fields.firstWhere((DomHTMLInputElement e) => e.name == 'current-password'),
-      );
-    }
-
-    // A value can arrive two ways: tagged (updateEditingStateWithTag, used for
-    // fields the manager fills while they are not the active editing element)
-    // or untagged (updateEditingState, used for the active element itself).
-    // Both mean the framework got it, which is what these tests are about.
-    bool frameworkReceived(PlatformMessagesSpy spy, String value) {
-      for (final PlatformMessage message in spy.messages) {
-        final dynamic args = message.methodArguments;
-        if (args is! List || args.length < 2) {
-          continue;
-        }
-        final dynamic payload = args[1];
-        if (payload is! Map) {
-          continue;
-        }
-        if (payload['text'] == value) {
-          return true;
-        }
-        for (final dynamic field in payload.values) {
-          if (field is Map && field['text'] == value) {
-            return true;
-          }
-        }
-      }
-      return false;
-    }
-
-    for (final String focused in <String>['email', 'password']) {
-      test('a manager filling both fields is forwarded when $focused is active', () async {
-        final spy = PlatformMessagesSpy();
-        spy.setUp();
-        void send(MethodCall call) =>
-            textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
-
-        final fields = openFormFocusing(focused, send);
-        spy.messages.clear();
-
-        // The manager walks the form: username first, then the password.
-        managerFill(fields.username, 'user@example.com');
-        managerFill(fields.password, 'hunter2secret');
-
-        expect(
-          frameworkReceived(spy, 'user@example.com'),
-          isTrue,
-          reason: 'the username fill must reach the framework',
-        );
-        expect(
-          frameworkReceived(spy, 'hunter2secret'),
-          isTrue,
-          reason: 'the password fill must reach the framework',
-        );
-
-        send(const MethodCall('TextInput.clearClient'));
-        dormantForms.clear();
-        spy.tearDown();
-      });
-
-      test('a manager filling only the other field is forwarded when $focused is active', () async {
-        final spy = PlatformMessagesSpy();
-        spy.setUp();
-        void send(MethodCall call) =>
-            textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
-
-        final fields = openFormFocusing(focused, send);
-        spy.messages.clear();
-
-        // Some managers fill a single field. Whichever one it is, and whichever
-        // field is active, the value still has to arrive.
-        final DomHTMLInputElement other = focused == 'email' ? fields.password : fields.username;
-        managerFill(other, 'only-one-field');
-
-        expect(frameworkReceived(spy, 'only-one-field'), isTrue);
-
-        send(const MethodCall('TextInput.clearClient'));
-        dormantForms.clear();
-        spy.tearDown();
-      });
-    }
-
-    test('forwards a fill on the previously focused field after the connection closes', () async {
-      // A password manager can write into the field after the framework
-      // already closed the connection (the user confirms the fill dialog after
-      // focus moved on). The dormant form's listeners must forward that value
-      // with the field's tag so it reaches the framework through the
-      // last-connection routing.
-      final spy = PlatformMessagesSpy();
-      spy.setUp();
-
-      final config = createFlutterConfig(
-        'text',
-        autofillHint: 'email',
-        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
-      );
-      void send(MethodCall call) =>
-          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
-      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
-      send(
-        configureSetSizeAndTransformMethodCall(
-          150,
-          50,
-          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
-        ),
-      );
-      send(const MethodCall('TextInput.show'));
-      expect(textEditing.isEditing, isTrue);
-
-      final input = textEditing.strategy.domElement! as DomHTMLInputElement;
-
-      // A genuine unfocus closes the connection; the form goes dormant with
-      // its listeners still attached.
-      send(const MethodCall('TextInput.clearClient'));
-      expect(textEditing.isEditing, isFalse);
-      spy.messages.clear();
-
-      // The manager fills the previously focused field.
-      input.value = 'user@example.com';
-      input.dispatchEvent(createDomEvent('Event', 'input'));
-
-      expect(spy.messages, hasLength(1));
-      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingStateWithTag');
-      expect(spy.messages[0].methodArguments, <dynamic>[
-        0, // Client ID
-        <String, dynamic>{
-          'email': <String, dynamic>{
-            'text': 'user@example.com',
-            'selectionBase': 16,
-            'selectionExtent': 16,
-            'composingBase': -1,
-            'composingExtent': -1,
-          },
-        },
-      ]);
-
-      // The same value again is deduplicated, not re-forwarded.
-      spy.messages.clear();
-      input.dispatchEvent(createDomEvent('Event', 'input'));
-      expect(spy.messages, isEmpty);
-
-      dormantForms.clear();
-      spy.tearDown();
-    });
-
-    test('a reused dormant element does not carry the previous value', () async {
-      // A dormant element is reused for the next connection on the same form.
-      // It must start out like a freshly created one: the framework's value
-      // arrives later over the platform channel, and until it does the stale
-      // value is what a password manager reads. Managers that skip a field
-      // already containing the value they are about to write then fill
-      // nothing at all.
-      final config = createFlutterConfig(
-        'text',
-        autofillHint: 'email',
-        autofillHintsForFields: <String>['email', 'password'],
-      );
-      void send(MethodCall call) =>
-          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
-      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
-      send(
-        configureSetSizeAndTransformMethodCall(
-          150,
-          50,
-          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
-        ),
-      );
-      send(const MethodCall('TextInput.show'));
-
-      final first = textEditing.strategy.domElement! as DomHTMLInputElement;
-      first.value = 'left-over-secret';
-      send(const MethodCall('TextInput.clearClient'));
-      expect(dormantForms, hasLength(1));
-
-      // A new connection on the same form reuses that element.
-      send(MethodCall('TextInput.setClient', <dynamic>[124, config]));
-      send(
-        configureSetSizeAndTransformMethodCall(
-          150,
-          50,
-          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
-        ),
-      );
-      send(const MethodCall('TextInput.show'));
-
-      final second = textEditing.strategy.domElement! as DomHTMLInputElement;
-      expect(second, first, reason: 'the dormant element should be reused');
-      expect(second.value, isEmpty);
-
-      send(const MethodCall('TextInput.clearClient'));
-      dormantForms.clear();
-    });
-
-    test('typing into a refocused field is not re-forwarded as autofill', () async {
-      // When a connection closes and a new one opens on the same form, the
-      // adopted dormant form's old listeners must be cancelled. The old
-      // instance observed the now-focused field as a non-focused one, so its
-      // stale listener would re-forward the user's typing as an autofill,
-      // collapsing the selection to the end of the text on every keystroke.
-      final spy = PlatformMessagesSpy();
-      spy.setUp();
-
-      final config = createFlutterConfig(
-        'text',
-        autofillHint: 'email',
-        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
-      );
-      void send(MethodCall call) =>
-          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
-      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
-      send(
-        configureSetSizeAndTransformMethodCall(
-          150,
-          50,
-          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
-        ),
-      );
-      send(const MethodCall('TextInput.show'));
-      send(const MethodCall('TextInput.clearClient'));
-      expect(textEditing.isEditing, isFalse);
-
-      // A new connection on the same form adopts the dormant DOM.
-      send(MethodCall('TextInput.setClient', <dynamic>[124, config]));
-      send(
-        configureSetSizeAndTransformMethodCall(
-          150,
-          50,
-          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
-        ),
-      );
-      send(const MethodCall('TextInput.show'));
-      expect(textEditing.isEditing, isTrue);
-
-      final input = textEditing.strategy.domElement! as DomHTMLInputElement;
-      spy.messages.clear();
-
-      // The user types into the focused field.
-      input.value = 't';
-      input.dispatchEvent(createDomEvent('Event', 'input'));
-
-      // Delivered once as a normal editing-state update, never as an autofill.
-      expect(
-        spy.messages.where(
-          (PlatformMessage m) => m.methodName == 'TextInputClient.updateEditingState',
-        ),
-        hasLength(1),
-      );
-      expect(
-        spy.messages.where(
-          (PlatformMessage m) => m.methodName == 'TextInputClient.updateEditingStateWithTag',
-        ),
-        isEmpty,
-      );
-
-      send(const MethodCall('TextInput.clearClient'));
-      dormantForms.clear();
-      spy.tearDown();
-    });
-
-    test('does not echo a programmatic setEditingState change as an autofill', () async {
-      // A programmatic controller.text change on a focused autofill field arrives
-      // through setEditingState. The next autofill rescan (e.g. after the tab is
-      // switched away and back) must not mistake that framework value for a browser
-      // autofill and forward it, which would collapse the cursor to the end.
-      final spy = PlatformMessagesSpy();
-      spy.setUp();
-
-      final config = createFlutterConfig(
-        'text',
-        autofillHint: 'email',
-        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
-      );
-      void send(MethodCall call) =>
-          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
-      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
-      send(
-        configureSetSizeAndTransformMethodCall(
-          150,
-          50,
-          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
-        ),
-      );
-      send(const MethodCall('TextInput.show'));
-
-      // The framework programmatically sets a new value on the focused field.
-      send(
-        const MethodCall('TextInput.setEditingState', <String, dynamic>{
-          'text': 'from-code@example.com',
-          'selectionBase': 21,
-          'selectionExtent': 21,
-          'composingBase': -1,
-          'composingExtent': -1,
-        }),
-      );
-
-      final strategy = textEditing.strategy;
-      strategy.debugDocumentHasFocusOverride = true;
-      strategy.debugDocumentVisibilityStateOverride = 'visible';
-
-      spy.messages.clear();
-
-      // The tab is switched away: the field blurs (null relatedTarget) and an
-      // autofill rescan runs. The programmatic value was recorded, so it must not
-      // be re-forwarded as a fake autofill.
-      strategy.handleBlur(createDomEvent('Event', 'blur'));
-
-      final Iterable<PlatformMessage> autofillMessages = spy.messages.where(
-        (PlatformMessage message) =>
-            message.methodName == 'TextInputClient.updateEditingStateWithTag',
-      );
-      expect(autofillMessages, isEmpty);
-
-      strategy.debugDocumentHasFocusOverride = null;
-      strategy.debugDocumentVisibilityStateOverride = null;
-      send(const MethodCall('TextInput.clearClient'));
-      spy.tearDown();
-    });
-
-    test('geometry update before the input is shown does not throw (autofill)', () async {
-      // A setEditableSizeAndTransform can arrive before TextInput.show enables
-      // the strategy (for example a password manager forcing a relayout of the
-      // not-yet-shown field). updateElementPlacement must not read the late
-      // `inputConfiguration` before the strategy is enabled. Regression test for
-      // a LateInitializationError thrown from the autofill fill-window check.
-      final config = createFlutterConfig(
-        'text',
-        autofillHint: 'email',
-        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
-      );
-      void send(MethodCall call) =>
-          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
-      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
-
-      // No TextInput.show yet, so the strategy is not enabled.
-      expect(
-        () => send(
-          configureSetSizeAndTransformMethodCall(
-            150,
-            50,
-            Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
-          ),
-        ),
-        returnsNormally,
-      );
-
-      send(const MethodCall('TextInput.clearClient'));
-    });
 
     test(
       'keeps focus within window/iframe when the focus moves within the flutter view in Chrome and Firefox but not Safari',
@@ -3897,6 +3393,489 @@ Future<void> testMain() async {
 
     tearDown(() {
       clearForms();
+    });
+
+    test('keeps connection open across a transient autofill blur, closes on genuine unfocus', () async {
+      // Password managers and browser autofill popups blur the hidden input
+      // (with a null relatedTarget) while the page keeps focus, then hand focus
+      // back to fill the field. For an autofill field that re-focus must cancel
+      // the pending close, or the autofilled value is dropped.
+
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing!.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[++clientId, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+
+      expect(textEditing!.isEditing, isTrue);
+
+      final strategy = textEditing!.strategy;
+      strategy.debugDocumentHasFocusOverride = true;
+      strategy.debugDocumentVisibilityStateOverride = 'visible';
+
+      // The popup takes focus: the field blurs while the page keeps focus.
+      strategy.handleBlur(createDomEvent('Event', 'blur'));
+
+      // The close is deferred, never synchronous.
+      expect(connectionClosedMessages(spy), isEmpty);
+
+      // The browser hands focus back to the field to autofill it.
+      strategy.handleFocus(createDomEvent('Event', 'focus'));
+
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      // The re-focus cancelled the close, so the connection stays open.
+      expect(connectionClosedMessages(spy), isEmpty);
+      expect(textEditing!.isEditing, isTrue);
+
+      strategy.debugDocumentHasFocusOverride = null;
+      strategy.debugDocumentVisibilityStateOverride = null;
+
+      // A genuine unfocus (the framework closes the connection) must actually
+      // tear the engine half down: the form goes dormant and the hidden input
+      // releases DOM focus, so the soft keyboard dismisses and physical
+      // keystrokes stop reaching the old field.
+      final DomHTMLElement? input = textEditing!.strategy.domElement;
+      send(const MethodCall('TextInput.clearClient'));
+      expect(textEditing!.isEditing, isFalse);
+      expect(dormantForms, hasLength(1));
+      // The DOM focus handoff (safeBlur) is asynchronous.
+      await Future<void>.delayed(Duration.zero);
+      expect(domDocument.activeElement, isNot(input));
+    });
+
+    test('keeps connection open for an autofill field that blurs without refocus', () async {
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing!.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[++clientId, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+
+      expect(textEditing!.isEditing, isTrue);
+
+      final strategy = textEditing!.strategy;
+      strategy.debugDocumentHasFocusOverride = true;
+      strategy.debugDocumentVisibilityStateOverride = 'visible';
+
+      // A password manager takes focus to fill the form (relatedTarget is null)
+      // and may keep its dialog open for several seconds without returning focus
+      // to the field.
+      strategy.handleBlur(createDomEvent('Event', 'blur'));
+
+      // The close is deferred, never synchronous.
+      expect(connectionClosedMessages(spy), isEmpty);
+
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      // The connection is kept alive so the pending fill is not dropped; it is
+      // closed normally later when the framework unfocuses the field
+      // (clearClient), not on this transient blur.
+      expect(connectionClosedMessages(spy), isEmpty);
+      expect(textEditing!.isEditing, isTrue);
+
+      strategy.debugDocumentHasFocusOverride = null;
+      strategy.debugDocumentVisibilityStateOverride = null;
+
+      // When the framework does unfocus, the engine closes for real.
+      final DomHTMLElement? input = textEditing!.strategy.domElement;
+      send(const MethodCall('TextInput.clearClient'));
+      expect(textEditing!.isEditing, isFalse);
+      expect(dormantForms, hasLength(1));
+      await Future<void>.delayed(Duration.zero);
+      expect(domDocument.activeElement, isNot(input));
+    });
+
+    // A password manager fills a login form by focusing each field in turn and
+    // writing into it, and the field it starts from is whichever one the user
+    // invoked it on. Whatever it writes has to reach the framework in every
+    // combination: the engine must not depend on which field happens to be the
+    // active editing element while the manager walks the form.
+    //
+    // These drive the DOM the way an extension does (focus, assign value,
+    // dispatch input/change) rather than going through the manager itself,
+    // which is the part outside our control.
+    void managerFill(DomHTMLInputElement element, String value) {
+      element.focusWithoutScroll();
+      element.value = value;
+      element.dispatchEvent(createDomEvent('Event', 'input'));
+      element.dispatchEvent(createDomEvent('Event', 'change'));
+    }
+
+    ({DomHTMLInputElement username, DomHTMLInputElement password}) openFormFocusing(
+      String focusedHint,
+      void Function(MethodCall) send,
+    ) {
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: focusedHint,
+        autofillHintsForFields: <String>['email', 'password'],
+      );
+      send(MethodCall('TextInput.setClient', <dynamic>[++clientId, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+      final form = textEditing!.strategy.domElement!.parent! as DomHTMLFormElement;
+      final fields = form.childNodes.toList() as List<DomHTMLInputElement>;
+      return (
+        username: fields.firstWhere((DomHTMLInputElement e) => e.name == 'email'),
+        password: fields.firstWhere((DomHTMLInputElement e) => e.name == 'current-password'),
+      );
+    }
+
+    // A value can arrive two ways: tagged (updateEditingStateWithTag, used for
+    // fields the manager fills while they are not the active editing element)
+    // or untagged (updateEditingState, used for the active element itself).
+    // Both mean the framework got it, which is what these tests are about.
+    bool frameworkReceived(PlatformMessagesSpy spy, String value) {
+      for (final PlatformMessage message in spy.messages) {
+        final dynamic args = message.methodArguments;
+        if (args is! List || args.length < 2) {
+          continue;
+        }
+        final dynamic payload = args[1];
+        if (payload is! Map) {
+          continue;
+        }
+        if (payload['text'] == value) {
+          return true;
+        }
+        for (final dynamic field in payload.values) {
+          if (field is Map && field['text'] == value) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    for (final String focused in <String>['email', 'password']) {
+      test('a manager filling both fields is forwarded when $focused is active', () async {
+        void send(MethodCall call) =>
+            textEditing!.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+
+        final fields = openFormFocusing(focused, send);
+        spy.messages.clear();
+
+        // The manager walks the form: username first, then the password.
+        managerFill(fields.username, 'user@example.com');
+        managerFill(fields.password, 'hunter2secret');
+
+        expect(
+          frameworkReceived(spy, 'user@example.com'),
+          isTrue,
+          reason: 'the username fill must reach the framework',
+        );
+        expect(
+          frameworkReceived(spy, 'hunter2secret'),
+          isTrue,
+          reason: 'the password fill must reach the framework',
+        );
+
+        send(const MethodCall('TextInput.clearClient'));
+        dormantForms.clear();
+      });
+
+      test('a manager filling only the other field is forwarded when $focused is active', () async {
+        void send(MethodCall call) =>
+            textEditing!.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+
+        final fields = openFormFocusing(focused, send);
+        spy.messages.clear();
+
+        // Some managers fill a single field. Whichever one it is, and whichever
+        // field is active, the value still has to arrive.
+        final DomHTMLInputElement other = focused == 'email' ? fields.password : fields.username;
+        managerFill(other, 'only-one-field');
+
+        expect(frameworkReceived(spy, 'only-one-field'), isTrue);
+
+        send(const MethodCall('TextInput.clearClient'));
+        dormantForms.clear();
+      });
+    }
+
+    test('forwards a fill on the previously focused field after the connection closes', () async {
+      // A password manager can write into the field after the framework
+      // already closed the connection (the user confirms the fill dialog after
+      // focus moved on). The dormant form's listeners must forward that value
+      // with the field's tag so it reaches the framework through the
+      // last-connection routing.
+
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing!.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[++clientId, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+      expect(textEditing!.isEditing, isTrue);
+
+      final input = textEditing!.strategy.domElement! as DomHTMLInputElement;
+
+      // A genuine unfocus closes the connection; the form goes dormant with
+      // its listeners still attached.
+      send(const MethodCall('TextInput.clearClient'));
+      expect(textEditing!.isEditing, isFalse);
+      spy.messages.clear();
+
+      // The manager fills the previously focused field.
+      input.value = 'user@example.com';
+      input.dispatchEvent(createDomEvent('Event', 'input'));
+
+      expect(spy.messages, hasLength(1));
+      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingStateWithTag');
+      expect(spy.messages[0].methodArguments, <dynamic>[
+        0, // Client ID
+        <String, dynamic>{
+          'email': <String, dynamic>{
+            'text': 'user@example.com',
+            'selectionBase': 16,
+            'selectionExtent': 16,
+            'composingBase': -1,
+            'composingExtent': -1,
+          },
+        },
+      ]);
+
+      // The same value again is deduplicated, not re-forwarded.
+      spy.messages.clear();
+      input.dispatchEvent(createDomEvent('Event', 'input'));
+      expect(spy.messages, isEmpty);
+
+      dormantForms.clear();
+    });
+
+    test('a reused dormant element does not carry the previous value', () async {
+      // A dormant element is reused for the next connection on the same form.
+      // It must start out like a freshly created one: the framework's value
+      // arrives later over the platform channel, and until it does the stale
+      // value is what a password manager reads. Managers that skip a field
+      // already containing the value they are about to write then fill
+      // nothing at all.
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['email', 'password'],
+      );
+      void send(MethodCall call) =>
+          textEditing!.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[++clientId, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+
+      final first = textEditing!.strategy.domElement! as DomHTMLInputElement;
+      first.value = 'left-over-secret';
+      send(const MethodCall('TextInput.clearClient'));
+      expect(dormantForms, hasLength(1));
+
+      // A new connection on the same form reuses that element.
+      send(MethodCall('TextInput.setClient', <dynamic>[++clientId, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+
+      final second = textEditing!.strategy.domElement! as DomHTMLInputElement;
+      expect(second, first, reason: 'the dormant element should be reused');
+      expect(second.value, isEmpty);
+
+      send(const MethodCall('TextInput.clearClient'));
+      dormantForms.clear();
+    });
+
+    test('typing into a refocused field is not re-forwarded as autofill', () async {
+      // When a connection closes and a new one opens on the same form, the
+      // adopted dormant form's old listeners must be cancelled. The old
+      // instance observed the now-focused field as a non-focused one, so its
+      // stale listener would re-forward the user's typing as an autofill,
+      // collapsing the selection to the end of the text on every keystroke.
+
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing!.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[++clientId, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+      send(const MethodCall('TextInput.clearClient'));
+      expect(textEditing!.isEditing, isFalse);
+
+      // A new connection on the same form adopts the dormant DOM.
+      send(MethodCall('TextInput.setClient', <dynamic>[++clientId, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+      expect(textEditing!.isEditing, isTrue);
+
+      final input = textEditing!.strategy.domElement! as DomHTMLInputElement;
+      spy.messages.clear();
+
+      // The user types into the focused field.
+      input.value = 't';
+      input.dispatchEvent(createDomEvent('Event', 'input'));
+
+      // Delivered once as a normal editing-state update, never as an autofill.
+      expect(
+        spy.messages.where(
+          (PlatformMessage m) => m.methodName == 'TextInputClient.updateEditingState',
+        ),
+        hasLength(1),
+      );
+      expect(
+        spy.messages.where(
+          (PlatformMessage m) => m.methodName == 'TextInputClient.updateEditingStateWithTag',
+        ),
+        isEmpty,
+      );
+
+      send(const MethodCall('TextInput.clearClient'));
+      dormantForms.clear();
+    });
+
+    test('does not echo a programmatic setEditingState change as an autofill', () async {
+      // A programmatic controller.text change on a focused autofill field arrives
+      // through setEditingState. The next autofill rescan (e.g. after the tab is
+      // switched away and back) must not mistake that framework value for a browser
+      // autofill and forward it, which would collapse the cursor to the end.
+
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing!.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[++clientId, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+
+      // The framework programmatically sets a new value on the focused field.
+      send(
+        const MethodCall('TextInput.setEditingState', <String, dynamic>{
+          'text': 'from-code@example.com',
+          'selectionBase': 21,
+          'selectionExtent': 21,
+          'composingBase': -1,
+          'composingExtent': -1,
+        }),
+      );
+
+      final strategy = textEditing!.strategy;
+      strategy.debugDocumentHasFocusOverride = true;
+      strategy.debugDocumentVisibilityStateOverride = 'visible';
+
+      spy.messages.clear();
+
+      // The tab is switched away: the field blurs (null relatedTarget) and an
+      // autofill rescan runs. The programmatic value was recorded, so it must not
+      // be re-forwarded as a fake autofill.
+      strategy.handleBlur(createDomEvent('Event', 'blur'));
+
+      final Iterable<PlatformMessage> autofillMessages = spy.messages.where(
+        (PlatformMessage message) =>
+            message.methodName == 'TextInputClient.updateEditingStateWithTag',
+      );
+      expect(autofillMessages, isEmpty);
+
+      strategy.debugDocumentHasFocusOverride = null;
+      strategy.debugDocumentVisibilityStateOverride = null;
+      send(const MethodCall('TextInput.clearClient'));
+    });
+
+    test('geometry update before the input is shown does not throw (autofill)', () async {
+      // A setEditableSizeAndTransform can arrive before TextInput.show enables
+      // the strategy (for example a password manager forcing a relayout of the
+      // not-yet-shown field). updateElementPlacement must not read the late
+      // `inputConfiguration` before the strategy is enabled. Regression test for
+      // a LateInitializationError thrown from the autofill fill-window check.
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing!.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[++clientId, config]));
+
+      // No TextInput.show yet, so the strategy is not enabled.
+      expect(
+        () => send(
+          configureSetSizeAndTransformMethodCall(
+            150,
+            50,
+            Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+          ),
+        ),
+        returnsNormally,
+      );
+
+      send(const MethodCall('TextInput.clearClient'));
     });
   });
 

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -4297,13 +4297,18 @@ Future<void> testMain() async {
       expect(password.style.height, isNot('0px'));
       expect(password.style.pointerEvents, isSafari ? 'none' : 'all');
       expect(autofillForm.formElement!.style.pointerEvents, isNot('none'));
-      // They are also removed from the tab order and the accessibility tree so
-      // keyboard Tab and screen readers do not land on the invisible fields, while
-      // the focused field stays reachable.
+      // They are also removed from the tab order, so keyboard Tab does not land
+      // on the invisible fields, while the focused field stays reachable.
       expect(username.tabIndex, -1);
-      expect(username.getAttribute('aria-hidden'), 'true');
       expect(password.tabIndex, -1);
-      expect(password.getAttribute('aria-hidden'), 'true');
+      // With semantics off there is no other representation of these fields, so
+      // they are not hidden from assistive technology either: a password
+      // manager rejects an aria-hidden input outright, and a field it never
+      // considers is a field it never fills. Semantics mode, where the field
+      // does have a real semantics node, hides them instead.
+      expect(EngineSemantics.instance.semanticsEnabled, isFalse);
+      expect(username.getAttribute('aria-hidden'), isNull);
+      expect(password.getAttribute('aria-hidden'), isNull);
       expect(email.getAttribute('aria-hidden'), isNull);
     }, skip: isSafari);
 

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -760,7 +760,7 @@ Future<void> testMain() async {
       spy.tearDown();
     });
 
-    test('keeps connection open when a blurred autofill field is focused again', () async {
+    test('keeps connection open across a transient autofill blur, closes on genuine unfocus', () async {
       // Password managers and browser autofill popups blur the hidden input
       // (with a null relatedTarget) while the page keeps focus, then hand focus
       // back to fill the field. For an autofill field that re-focus must cancel
@@ -808,7 +808,18 @@ Future<void> testMain() async {
 
       strategy.debugDocumentHasFocusOverride = null;
       strategy.debugDocumentVisibilityStateOverride = null;
+
+      // A genuine unfocus (the framework closes the connection) must actually
+      // tear the engine half down: the form goes dormant and the hidden input
+      // releases DOM focus, so the soft keyboard dismisses and physical
+      // keystrokes stop reaching the old field.
+      final DomHTMLElement? input = textEditing.strategy.domElement;
       send(const MethodCall('TextInput.clearClient'));
+      expect(textEditing.isEditing, isFalse);
+      expect(dormantForms, hasLength(1));
+      // The DOM focus handoff (safeBlur) is asynchronous.
+      await Future<void>.delayed(Duration.zero);
+      expect(domDocument.activeElement, isNot(input));
       spy.tearDown();
     });
 
@@ -857,6 +868,143 @@ Future<void> testMain() async {
 
       strategy.debugDocumentHasFocusOverride = null;
       strategy.debugDocumentVisibilityStateOverride = null;
+
+      // When the framework does unfocus, the engine closes for real.
+      final DomHTMLElement? input = textEditing.strategy.domElement;
+      send(const MethodCall('TextInput.clearClient'));
+      expect(textEditing.isEditing, isFalse);
+      expect(dormantForms, hasLength(1));
+      await Future<void>.delayed(Duration.zero);
+      expect(domDocument.activeElement, isNot(input));
+      spy.tearDown();
+    });
+
+    test('forwards a fill on the previously focused field after the connection closes', () async {
+      // A password manager can write into the field after the framework
+      // already closed the connection (the user confirms the fill dialog after
+      // focus moved on). The dormant form's listeners must forward that value
+      // with the field's tag so it reaches the framework through the
+      // last-connection routing.
+      final spy = PlatformMessagesSpy();
+      spy.setUp();
+
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+      expect(textEditing.isEditing, isTrue);
+
+      final input = textEditing.strategy.domElement! as DomHTMLInputElement;
+
+      // A genuine unfocus closes the connection; the form goes dormant with
+      // its listeners still attached.
+      send(const MethodCall('TextInput.clearClient'));
+      expect(textEditing.isEditing, isFalse);
+      spy.messages.clear();
+
+      // The manager fills the previously focused field.
+      input.value = 'user@example.com';
+      input.dispatchEvent(createDomEvent('Event', 'input'));
+
+      expect(spy.messages, hasLength(1));
+      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingStateWithTag');
+      expect(spy.messages[0].methodArguments, <dynamic>[
+        0, // Client ID
+        <String, dynamic>{
+          'email': <String, dynamic>{
+            'text': 'user@example.com',
+            'selectionBase': 16,
+            'selectionExtent': 16,
+            'composingBase': -1,
+            'composingExtent': -1,
+          },
+        },
+      ]);
+
+      // The same value again is deduplicated, not re-forwarded.
+      spy.messages.clear();
+      input.dispatchEvent(createDomEvent('Event', 'input'));
+      expect(spy.messages, isEmpty);
+
+      dormantForms.clear();
+      spy.tearDown();
+    });
+
+    test('typing into a refocused field is not re-forwarded as autofill', () async {
+      // When a connection closes and a new one opens on the same form, the
+      // adopted dormant form's old listeners must be cancelled. The old
+      // instance observed the now-focused field as a non-focused one, so its
+      // stale listener would re-forward the user's typing as an autofill,
+      // collapsing the selection to the end of the text on every keystroke.
+      final spy = PlatformMessagesSpy();
+      spy.setUp();
+
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+      send(const MethodCall('TextInput.clearClient'));
+      expect(textEditing.isEditing, isFalse);
+
+      // A new connection on the same form adopts the dormant DOM.
+      send(MethodCall('TextInput.setClient', <dynamic>[124, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+      expect(textEditing.isEditing, isTrue);
+
+      final input = textEditing.strategy.domElement! as DomHTMLInputElement;
+      spy.messages.clear();
+
+      // The user types into the focused field.
+      input.value = 't';
+      input.dispatchEvent(createDomEvent('Event', 'input'));
+
+      // Delivered once as a normal editing-state update, never as an autofill.
+      expect(
+        spy.messages.where(
+          (PlatformMessage m) => m.methodName == 'TextInputClient.updateEditingState',
+        ),
+        hasLength(1),
+      );
+      expect(
+        spy.messages.where(
+          (PlatformMessage m) => m.methodName == 'TextInputClient.updateEditingStateWithTag',
+        ),
+        isEmpty,
+      );
+
+      send(const MethodCall('TextInput.clearClient'));
+      dormantForms.clear();
       spy.tearDown();
     });
 

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -760,6 +760,136 @@ Future<void> testMain() async {
       spy.tearDown();
     });
 
+    test('keeps connection open when a blurred autofill field is focused again', () async {
+      // Password managers and browser autofill popups blur the hidden input
+      // (with a null relatedTarget) while the page keeps focus, then hand focus
+      // back to fill the field. For an autofill field that re-focus must cancel
+      // the pending close, or the autofilled value is dropped.
+      final spy = PlatformMessagesSpy();
+      spy.setUp();
+
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+
+      expect(textEditing.isEditing, isTrue);
+
+      final strategy = textEditing.strategy;
+      strategy.debugDocumentHasFocusOverride = true;
+      strategy.debugDocumentVisibilityStateOverride = 'visible';
+
+      // The popup takes focus: the field blurs while the page keeps focus.
+      strategy.handleBlur(createDomEvent('Event', 'blur'));
+
+      // The close is deferred, never synchronous.
+      expect(connectionClosedMessages(spy), isEmpty);
+
+      // The browser hands focus back to the field to autofill it.
+      strategy.handleFocus(createDomEvent('Event', 'focus'));
+
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      // The re-focus cancelled the close, so the connection stays open.
+      expect(connectionClosedMessages(spy), isEmpty);
+      expect(textEditing.isEditing, isTrue);
+
+      strategy.debugDocumentHasFocusOverride = null;
+      strategy.debugDocumentVisibilityStateOverride = null;
+      send(const MethodCall('TextInput.clearClient'));
+      spy.tearDown();
+    });
+
+    test('keeps connection open for an autofill field that blurs without refocus', () async {
+      final spy = PlatformMessagesSpy();
+      spy.setUp();
+
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+
+      expect(textEditing.isEditing, isTrue);
+
+      final strategy = textEditing.strategy;
+      strategy.debugDocumentHasFocusOverride = true;
+      strategy.debugDocumentVisibilityStateOverride = 'visible';
+
+      // A password manager takes focus to fill the form (relatedTarget is null)
+      // and may keep its dialog open for several seconds without returning focus
+      // to the field.
+      strategy.handleBlur(createDomEvent('Event', 'blur'));
+
+      // The close is deferred, never synchronous.
+      expect(connectionClosedMessages(spy), isEmpty);
+
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      // The connection is kept alive so the pending fill is not dropped; it is
+      // closed normally later when the framework unfocuses the field
+      // (clearClient), not on this transient blur.
+      expect(connectionClosedMessages(spy), isEmpty);
+      expect(textEditing.isEditing, isTrue);
+
+      strategy.debugDocumentHasFocusOverride = null;
+      strategy.debugDocumentVisibilityStateOverride = null;
+      spy.tearDown();
+    });
+
+    test('geometry update before the input is shown does not throw (autofill)', () async {
+      // A setEditableSizeAndTransform can arrive before TextInput.show enables
+      // the strategy (for example a password manager forcing a relayout of the
+      // not-yet-shown field). updateElementPlacement must not read the late
+      // `inputConfiguration` before the strategy is enabled. Regression test for
+      // a LateInitializationError thrown from the autofill fill-window check.
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['familyName', 'email', 'givenName', 'telephoneNumber'],
+      );
+      void send(MethodCall call) =>
+          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
+
+      // No TextInput.show yet, so the strategy is not enabled.
+      expect(
+        () => send(
+          configureSetSizeAndTransformMethodCall(
+            150,
+            50,
+            Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+          ),
+        ),
+        returnsNormally,
+      );
+
+      send(const MethodCall('TextInput.clearClient'));
+    });
+
     test(
       'keeps focus within window/iframe when the focus moves within the flutter view in Chrome and Firefox but not Safari',
       () async {
@@ -1430,10 +1560,14 @@ Future<void> testMain() async {
         // DOM element is blurred.
         textEditing!.strategy.domElement!.blur();
 
-        expect(spy.messages, hasLength(1));
-        expect(spy.messages[0].channel, 'flutter/textinput');
-        expect(spy.messages[0].methodName, 'TextInputClient.onConnectionClosed');
-        await Future<void>.delayed(Duration.zero);
+        // The connection close is deferred so a transient blur (e.g. an
+        // autofill popup) does not tear editing down; wait for the grace period.
+        expect(connectionClosedMessages(spy), isEmpty);
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+
+        final List<PlatformMessage> closedMessages = connectionClosedMessages(spy);
+        expect(closedMessages, hasLength(1));
+        expect(closedMessages.single.channel, 'flutter/textinput');
         // DOM element loses the focus.
         expect(defaultTextEditingRoot.ownerDocument?.activeElement, domDocument.body);
       },
@@ -1662,7 +1796,13 @@ Future<void> testMain() async {
       });
 
       final setClient1 = MethodCall('TextInput.setClient', <dynamic>[123, flutterSinglelineConfig]);
-      final setClient2 = MethodCall('TextInput.setClient', <dynamic>[567, flutterSinglelineConfig]);
+      // A distinct field (different autofill id) so the second client does not
+      // reuse the first field's dormant element; focus moves to a new element.
+      final Map<String, dynamic> secondFieldConfig = createFlutterConfig(
+        'text',
+        autofillHint: 'username',
+      );
+      final setClient2 = MethodCall('TextInput.setClient', <dynamic>[567, secondFieldConfig]);
       const setEditingState = MethodCall('TextInput.setEditingState', <String, dynamic>{
         'text': 'abcd',
         'selectionBase': 2,
@@ -3741,7 +3881,7 @@ Future<void> testMain() async {
       );
     });
 
-    test('hidden autofill elements should have a width and height of 0 on non-Safari browsers', () {
+    test('non-focused autofill fields are discoverable but non-interactive on non-Safari browsers', () {
       final List<Map<String, Object?>> fields = createFieldValues(
         <String>['email', 'username', 'password'],
         <String>['field1', 'field2', 'field3'],
@@ -3764,12 +3904,16 @@ Future<void> testMain() async {
 
       expect(username.name, 'username');
       expect(password.name, 'current-password');
-      expect(username.style.width, '0px');
-      expect(username.style.height, '0px');
-      expect(username.style.pointerEvents, isNot('none'));
-      expect(password.style.width, '0px');
-      expect(password.style.height, '0px');
-      expect(password.style.pointerEvents, isNot('none'));
+      // Non-focused autofill fields are kept discoverable (a non-zero size,
+      // positioned next to the focused field) but non-interactive, so password
+      // managers detect and fill them without the invisible field intercepting
+      // taps meant for the app UI.
+      expect(username.style.width, isNot('0px'));
+      expect(username.style.height, isNot('0px'));
+      expect(username.style.pointerEvents, 'none');
+      expect(password.style.width, isNot('0px'));
+      expect(password.style.height, isNot('0px'));
+      expect(password.style.pointerEvents, 'none');
       expect(autofillForm.formElement!.style.pointerEvents, isNot('none'));
     }, skip: isSafari);
 

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -942,6 +942,54 @@ Future<void> testMain() async {
       spy.tearDown();
     });
 
+    test('a reused dormant element does not carry the previous value', () async {
+      // A dormant element is reused for the next connection on the same form.
+      // It must start out like a freshly created one: the framework's value
+      // arrives later over the platform channel, and until it does the stale
+      // value is what a password manager reads. Managers that skip a field
+      // already containing the value they are about to write then fill
+      // nothing at all.
+      final config = createFlutterConfig(
+        'text',
+        autofillHint: 'email',
+        autofillHintsForFields: <String>['email', 'password'],
+      );
+      void send(MethodCall call) =>
+          textEditing.channel.handleTextInput(codec.encodeMethodCall(call), (ByteData? _) {});
+      send(MethodCall('TextInput.setClient', <dynamic>[123, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+
+      final first = textEditing.strategy.domElement! as DomHTMLInputElement;
+      first.value = 'left-over-secret';
+      send(const MethodCall('TextInput.clearClient'));
+      expect(dormantForms, hasLength(1));
+
+      // A new connection on the same form reuses that element.
+      send(MethodCall('TextInput.setClient', <dynamic>[124, config]));
+      send(
+        configureSetSizeAndTransformMethodCall(
+          150,
+          50,
+          Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList(),
+        ),
+      );
+      send(const MethodCall('TextInput.show'));
+
+      final second = textEditing.strategy.domElement! as DomHTMLInputElement;
+      expect(second, first, reason: 'the dormant element should be reused');
+      expect(second.value, isEmpty);
+
+      send(const MethodCall('TextInput.clearClient'));
+      dormantForms.clear();
+    });
+
     test('typing into a refocused field is not re-forwarded as autofill', () async {
       // When a connection closes and a new one opens on the same form, the
       // adopted dormant form's old listeners must be cancelled. The old

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2205,7 +2205,12 @@ class TextInput {
     // text field that doesn't have an active connection.
     if (method == 'TextInputClient.updateEditingStateWithTag') {
       final args = methodCall.arguments as List<dynamic>;
-      final TextInputConnection? connection = _currentConnection ?? _lastConnection;
+      // The last-connection fallback is a web-only workaround: a browser password
+      // manager can autofill in the brief window after the connection is torn down.
+      // Native platforms keep the upstream behavior of using the current connection.
+      final TextInputConnection? connection = kIsWeb
+          ? (_currentConnection ?? _lastConnection)
+          : _currentConnection;
       final AutofillScope? scope = connection?._client.currentAutofillScope;
       final editingValue = args[1] as Map<String, dynamic>;
       for (final String tag in editingValue.keys) {

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2201,11 +2201,10 @@ class TextInput {
         }
         return false;
     }
-    final args = methodCall.arguments as List<dynamic>;
-
     // The updateEditingStateWithTag request (autofill) can come up even to a
     // text field that doesn't have an active connection.
     if (method == 'TextInputClient.updateEditingStateWithTag') {
+      final args = methodCall.arguments as List<dynamic>;
       final TextInputConnection? connection = _currentConnection ?? _lastConnection;
       final AutofillScope? scope = connection?._client.currentAutofillScope;
       final editingValue = args[1] as Map<String, dynamic>;
@@ -2237,6 +2236,7 @@ class TextInput {
       return;
     }
 
+    final args = methodCall.arguments as List<dynamic>;
     final client = args[0] as int;
     if (client != _currentConnection!._id) {
       // If the client IDs don't match, the incoming message was for a different

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2201,6 +2201,27 @@ class TextInput {
         }
         return false;
     }
+    final args = methodCall.arguments as List<dynamic>;
+
+    // The updateEditingStateWithTag request (autofill) can come up even to a
+    // text field that doesn't have an active connection.
+    if (method == 'TextInputClient.updateEditingStateWithTag') {
+      final TextInputConnection? connection = _currentConnection ?? _lastConnection;
+      final AutofillScope? scope = connection?._client.currentAutofillScope;
+      final editingValue = args[1] as Map<String, dynamic>;
+      for (final String tag in editingValue.keys) {
+        final textEditingValue = TextEditingValue.fromJSON(
+          editingValue[tag] as Map<String, dynamic>,
+        );
+        final AutofillClient? client = scope?.getAutofillClient(tag);
+        if (client != null && client.textInputConfiguration.autofillConfiguration.enabled) {
+          client.autofill(textEditingValue);
+        }
+      }
+
+      return;
+    }
+
     if (_currentConnection == null) {
       return;
     }
@@ -2213,27 +2234,6 @@ class TextInput {
       if (editingValue != null) {
         _setEditingState(editingValue);
       }
-      return;
-    }
-
-    final args = methodCall.arguments as List<dynamic>;
-
-    // The updateEditingStateWithTag request (autofill) can come up even to a
-    // text field that doesn't have a connection.
-    if (method == 'TextInputClient.updateEditingStateWithTag') {
-      final TextInputClient client = _currentConnection!._client;
-      final AutofillScope? scope = client.currentAutofillScope;
-      final editingValue = args[1] as Map<String, dynamic>;
-      for (final String tag in editingValue.keys) {
-        final textEditingValue = TextEditingValue.fromJSON(
-          editingValue[tag] as Map<String, dynamic>,
-        );
-        final AutofillClient? client = scope?.getAutofillClient(tag);
-        if (client != null && client.textInputConfiguration.autofillConfiguration.enabled) {
-          client.autofill(textEditingValue);
-        }
-      }
-
       return;
     }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4153,23 +4153,6 @@ class EditableTextState extends State<EditableText>
     if (_hasFocus && widget.focusNode.consumeKeyboardToken()) {
       _openInputConnection();
     } else if (!_hasFocus) {
-      // On the web, a blur on an autofill field is usually transient: a browser
-      // or extension password manager steals focus while it fills the login
-      // form and then hands it back. Closing the input connection here tears the
-      // field down and recreates it on the return focus, which churns the
-      // autofill DOM; strict managers detect that churn as page interference and
-      // disable autofill. Keep the connection open across the transient blur --
-      // the engine side (DefaultTextEditingStrategy.handleBlur) already keeps its
-      // half alive and closes for real (via onConnectionClosed) when focus
-      // genuinely leaves the field. Focusing a different field still supersedes
-      // this connection with a new setClient, so the connection is not leaked.
-      //
-      // Restricted to the web because this churn is specific to the web engine's
-      // hidden-input autofill proxy; native platforms drive autofill through the
-      // OS and do not need the connection held open here.
-      if (kIsWeb && _needsAutofill) {
-        return;
-      }
       _closeInputConnectionIfNeeded();
       widget.controller.clearComposing();
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4153,6 +4153,23 @@ class EditableTextState extends State<EditableText>
     if (_hasFocus && widget.focusNode.consumeKeyboardToken()) {
       _openInputConnection();
     } else if (!_hasFocus) {
+      // On the web, a blur on an autofill field is usually transient: a browser
+      // or extension password manager steals focus while it fills the login
+      // form and then hands it back. Closing the input connection here tears the
+      // field down and recreates it on the return focus, which churns the
+      // autofill DOM; strict managers detect that churn as page interference and
+      // disable autofill. Keep the connection open across the transient blur --
+      // the engine side (DefaultTextEditingStrategy.handleBlur) already keeps its
+      // half alive and closes for real (via onConnectionClosed) when focus
+      // genuinely leaves the field. Focusing a different field still supersedes
+      // this connection with a new setClient, so the connection is not leaked.
+      //
+      // Restricted to the web because this churn is specific to the web engine's
+      // hidden-input autofill proxy; native platforms drive autofill through the
+      // OS and do not need the connection held open here.
+      if (kIsWeb && _needsAutofill) {
+        return;
+      }
       _closeInputConnectionIfNeeded();
       widget.controller.clearComposing();
     }

--- a/packages/flutter/test/services/autofill_test.dart
+++ b/packages/flutter/test/services/autofill_test.dart
@@ -90,6 +90,49 @@ void main() {
         expect(client2.currentTextEditingValue, text2);
       },
     );
+
+    test('updateEditingStateWithTag is delivered via the last connection after it closes', () async {
+      // A browser password manager can autofill a field in the brief window
+      // after the text input connection is torn down (so TextInput's
+      // _currentConnection is null) but before it is re-established. The value
+      // must still reach the client, routed through the last connection.
+      final client1 = FakeAutofillClient(const TextEditingValue(text: 'test1'));
+      final client2 = FakeAutofillClient(const TextEditingValue(text: 'test2'));
+
+      client1.textInputConfiguration = TextInputConfiguration(
+        autofillConfiguration: AutofillConfiguration(
+          uniqueIdentifier: client1.autofillId,
+          autofillHints: const <String>['client1'],
+          currentEditingValue: client1.currentTextEditingValue,
+        ),
+      );
+      client2.textInputConfiguration = TextInputConfiguration(
+        autofillConfiguration: AutofillConfiguration(
+          uniqueIdentifier: client2.autofillId,
+          autofillHints: const <String>['client2'],
+          currentEditingValue: client2.currentTextEditingValue,
+        ),
+      );
+
+      scope.register(client1);
+      scope.register(client2);
+      client1.currentAutofillScope = scope;
+      client2.currentAutofillScope = scope;
+
+      final TextInputConnection connection = scope.attach(client1, client1.textInputConfiguration);
+      // Tear the connection down: _currentConnection becomes null.
+      connection.close();
+
+      const filled = TextEditingValue(text: 'filled');
+      fakeTextChannel.incoming?.call(
+        MethodCall('TextInputClient.updateEditingStateWithTag', <dynamic>[
+          0,
+          <String, dynamic>{client2.autofillId: filled.toJSON()},
+        ]),
+      );
+
+      expect(client2.currentTextEditingValue, filled);
+    });
   });
 
   group('AutoFillConfiguration', () {

--- a/packages/flutter/test/services/autofill_test.dart
+++ b/packages/flutter/test/services/autofill_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -91,11 +92,12 @@ void main() {
       },
     );
 
-    test('updateEditingStateWithTag is delivered via the last connection after it closes', () async {
-      // A browser password manager can autofill a field in the brief window
-      // after the text input connection is torn down (so TextInput's
-      // _currentConnection is null) but before it is re-established. The value
-      // must still reach the client, routed through the last connection.
+    test('updateEditingStateWithTag routes autofill to the last connection on web', () async {
+      // A browser password manager can autofill a field in the brief window after
+      // the text input connection is torn down (so TextInput's _currentConnection is
+      // null) but before it is re-established. On the web the value must still reach
+      // the client, routed through the last connection; on native platforms the
+      // fallback is not used, matching upstream behavior.
       final client1 = FakeAutofillClient(const TextEditingValue(text: 'test1'));
       final client2 = FakeAutofillClient(const TextEditingValue(text: 'test2'));
 
@@ -131,7 +133,13 @@ void main() {
         ]),
       );
 
-      expect(client2.currentTextEditingValue, filled);
+      if (kIsWeb) {
+        expect(client2.currentTextEditingValue, filled);
+      } else {
+        // Native: the last-connection fallback is not used, so the value is dropped
+        // and the client keeps its original editing state.
+        expect(client2.currentTextEditingValue, const TextEditingValue(text: 'test2'));
+      }
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## What this changes

On the web a password manager could not fill a login form as a pair. Which field arrived depended on which field the manager was invoked from, and in several combinations nothing arrived at all. That is true of shipped builds too, not just of this branch's starting point.

Flutter paints text on canvas and synthesises hidden `<input>` proxies so managers and the browser have something to work with. Those proxies did not satisfy what managers actually check before filling a field. Three causes, each found by reading what the managers check and measuring the live DOM against it:

- **Non focused proxies were zero sized.** `EngineAutofillForm` styled them with `shouldHideElement: !_isSafariStrategy`, so outside Safari every field of a form except the focused one was `width: 0; height: 0`. A manager will not treat an input that small as a real field (Bitwarden wants 10x10, Proton Pass 30x15), and it confirms the field by hit testing its own centre point and checking it gets that field back, which a zero sized box also fails. So only the focused field was ever a candidate and a login form could not be filled as a pair. The proxies now keep a real size, floored with `min-width`/`min-height` because the framework geometry can itself report a pixel, and their pointer input is swallowed so a tap that lands on an invisible field is a no-op rather than a stray focus.
- **Closing a connection hid the field the manager was invoked from.** `disable()` parked that field's proxy off screen and zero sized, and a manager's menu taking focus is what closes the connection, so the field being parked was the field the user was in. Invoked from the email field it hid the email field and filled the password; invoked from the password field it hid the password and filled only the email. The shrink also outlives the moment: at least one manager memoises its fillability verdict per element, and these elements are reused for the life of the form, so a single measurement taken while the field was zero sized wrote it off for good. Position is not part of that verdict, so the proxy is moved but keeps its size.
- **The connection was torn down between every field of a single fill.** A manager fills one field at a time, blurring each before focusing the next. That blur lands on `<body>` with no `relatedTarget`, which was reported as the whole view losing focus, so the framework dropped its focus, closed the connection, and rebuilt it when focus returned a moment later. Managers that check their own state between fields lost the rest of the form in that gap. A field of an autofill form blurring to nothing now waits before that is reported, and a focus arriving back in the view cancels it. Everything else is reported at once, unchanged. The wait is on a pair of browser events, a `focusout` and the `focusin` after it, about a millisecond apart. It is not a timer waiting on a manager.

On the first of those, #187108 already established that WebKit refuses to autofill a zero sized input and kept a real size there for that reason. What this adds is that the same holds on every engine once a third party manager rather than the browser is doing the filling: Bitwarden and Proton Pass each apply their own minimum size before they will treat an input as a field. So `_isWebKit` being false on Chrome and Firefox is not the same thing as those engines tolerating a zero sized field.

The result is that Bitwarden, Proton Pass and Chrome's own manager each fill both fields, from either field, including after clearing a field by hand and filling again.

Two things follow from the same invariant, that what a manager reads from the DOM has to be what the framework holds. Clearing a field by hand now reaches the proxy, so a manager stops offering to save a password that has already been deleted; previously the proxy kept the last character and the prompt never went away. And a reused proxy no longer serves the previous connection's value to the next manager that reads it.

## Accessibility

Giving the proxies a real size makes them reachable in ways a zero sized element was not, so two things are handled explicitly.

Non focused proxies are kept at `tabindex="-1"`, as they were upstream, so Tab does not land on an invisible password box; only the focused proxy is in the tab order. And with semantics on they are marked `aria-hidden="true"`, which upstream did not do: the field then has a real semantics node and the proxy is a duplicate.

With semantics off the attribute is deliberately not set. Proton Pass rejects an `aria-hidden` input before it even measures it, so setting it unconditionally puts back the same class of bug this PR fixes, and with semantics off the proxy is the only representation of that field in the DOM, so hiding it hides nothing the user could reach another way. Net against upstream this is an improvement in semantics mode and unchanged outside it, but the element is now full sized rather than zero sized, so I am flagging it rather than leaving it implied.

Google Password Manager's auto submit on mobile is deliberately not addressed here. Separate behaviour, separate discussion, follow up.

## Tested

Demos, the same app built twice, plus a plain HTML login form as a reference for how a manager behaves when Flutter is not involved. The app prints each controller's value on screen, so it is visible whether what the manager wrote reached the Flutter side or only the hidden input.

- Before: https://flutter-autofill-190126.web.app/before/
- After: https://flutter-autofill-190126.web.app/after/
- Plain HTML: https://flutter-autofill-190126.web.app/control/
- Demo source: https://flutter-autofill-190126.web.app/repro/main.dart

Before is this branch's merge base, 78703736057. The only autofill change upstream since then is #187108, which added semantics mode form association and introduced `_isWebKit` alongside `_isSafariStrategy` in the proxy styling. Both are false on Chrome and Firefox with semantics off, so it does not change what the before build does on the platforms these demos run on. The iOS caret drag change that also touched these files, #190014, was reverted by #190926.

Verified against the real extensions in Chrome and Firefox: Bitwarden, Proton Pass and Chrome's own password manager, invoked from each field, and after emptying a field by hand.

149 tests passing on Chrome and 148 on Firefox, across dart2js and dart2wasm.

`engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart` goes from 126 tests to 136: 11 added, 1 removed, and the remaining 125 keep their assertions. The removed one is `hidden autofill elements should have a width and height of 0 on non-Safari browsers`, which asserted the behaviour the first cause above changes. It is replaced by `non-focused autofill fields are discoverable but non-interactive on non-Safari browsers`, asserting what the proxies do now: a real size, out of the tab order, taking part in hit testing, pointer input swallowed. The Safari cases keep their existing expectations.

44 of the existing tests move to the `HybridTextEditing` group, which builds an instance per test. They had been leaking an open connection into the next test, and because the number of skipped tests differs per browser that surfaced on Firefox only. That move is most of the diff in this file and changes no assertions.

`engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/view_focus_binding_test.dart`: 13 existing tests unchanged, 3 added. The existing ones passing unmodified is itself the check that the deferral applies only to fields of an autofill form and that ordinary view unfocus is untouched; a blanket deferral broke 4 of them. The three added cover the new path: a form field blurring to nothing does not report the view unfocused, a focus returning to the view cancels that report, and one that never returns still produces it.

`packages/flutter/test/services/autofill_test.dart`: 1 added, for the last connection fallback.

Fixes https://github.com/flutter/flutter/issues/174773

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
