### PR TITLE
iOS: Fix use-after-free race during shell teardown

### DIFF
--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -2405,9 +2405,9 @@ fml::Status Shell::WaitForFirstFrame(fml::TimeDelta timeout) {
       lock, duration,
       [&waiting_for_first_frame = waiting_for_first_frame_,
        &cancelled = wait_for_first_frame_cancelled_] {
-        return !waiting_for_first_frame.load() || cancelled.load();
+        return !waiting_for_first_frame.load() || cancelled;
       });
-  if (wait_for_first_frame_cancelled_.load()) {
+  if (wait_for_first_frame_cancelled_) {
     return fml::Status(fml::StatusCode::kAborted, "Shell is shutting down.");
   } else if (success) {
     return fml::Status();
@@ -2419,7 +2419,7 @@ fml::Status Shell::WaitForFirstFrame(fml::TimeDelta timeout) {
 void Shell::CancelWaitForFirstFrame() {
   {
     std::scoped_lock lock(waiting_for_first_frame_mutex_);
-    wait_for_first_frame_cancelled_.store(true);
+    wait_for_first_frame_cancelled_ = true;
   }
   waiting_for_first_frame_condition_.notify_all();
 }

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -2402,14 +2402,26 @@ fml::Status Shell::WaitForFirstFrame(fml::TimeDelta timeout) {
 
   std::unique_lock<std::mutex> lock(waiting_for_first_frame_mutex_);
   bool success = waiting_for_first_frame_condition_.wait_until(
-      lock, duration, [&waiting_for_first_frame = waiting_for_first_frame_] {
-        return !waiting_for_first_frame.load();
+      lock, duration,
+      [&waiting_for_first_frame = waiting_for_first_frame_,
+       &cancelled = wait_for_first_frame_cancelled_] {
+        return !waiting_for_first_frame.load() || cancelled.load();
       });
-  if (success) {
+  if (wait_for_first_frame_cancelled_.load()) {
+    return fml::Status(fml::StatusCode::kAborted, "Shell is shutting down.");
+  } else if (success) {
     return fml::Status();
   } else {
     return fml::Status(fml::StatusCode::kDeadlineExceeded, "timeout");
   }
+}
+
+void Shell::CancelWaitForFirstFrame() {
+  {
+    std::scoped_lock lock(waiting_for_first_frame_mutex_);
+    wait_for_first_frame_cancelled_.store(true);
+  }
+  waiting_for_first_frame_condition_.notify_all();
 }
 
 bool Shell::ReloadSystemFonts() {

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -522,8 +522,19 @@ class Shell final : public PlatformView::Delegate,
   uint64_t next_pointer_flow_id_ = 0;
 
   bool first_frame_rasterized_ = false;
+
+  // True if a first frame has not yet been rendered.
+  //
+  // This is read and written lock-free on the raster thread, and read under
+  // waiting_for_first_frame_mutex_ in WaitForFirstFrame.
   std::atomic<bool> waiting_for_first_frame_ = true;
-  std::atomic<bool> wait_for_first_frame_cancelled_ = false;
+
+  // True when WaitForFirstFrame has been cancelled because the shell is
+  // shutting down and waiting threads should be unblocked.
+  //
+  // Guarded by waiting_for_first_frame_mutex_.
+  bool wait_for_first_frame_cancelled_ = false;
+
   std::mutex waiting_for_first_frame_mutex_;
   std::condition_variable waiting_for_first_frame_condition_;
 

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -353,6 +353,21 @@ class Shell final : public PlatformView::Delegate,
   fml::Status WaitForFirstFrame(fml::TimeDelta timeout);
 
   //----------------------------------------------------------------------------
+  /// @brief      Unblocks any call to WaitForFirstFrame(), causing it to
+  ///             immediately return 'kAborted' instead of blocking for the
+  ///             full timeout.
+  ///
+  ///             Embedders that pass a reference to the Shell to a thread they
+  ///             do not otherwise synchronize with the shell's destruction
+  ///             must call this, and wait for that thread to finish with the
+  ///             shell, before destroying it. This method only prevents
+  ///             WaitForFirstFrame() from blocking; it does not by itself
+  ///             make it safe to destroy the Shell out from under a caller
+  ///             that has not yet returned from WaitForFirstFrame().
+  ///
+  void CancelWaitForFirstFrame();
+
+  //----------------------------------------------------------------------------
   /// @brief      Used by embedders to reload the system fonts in
   ///             FontCollection.
   ///             It also clears the cached font families and send system
@@ -508,6 +523,7 @@ class Shell final : public PlatformView::Delegate,
 
   bool first_frame_rasterized_ = false;
   std::atomic<bool> waiting_for_first_frame_ = true;
+  std::atomic<bool> wait_for_first_frame_cancelled_ = false;
   std::mutex waiting_for_first_frame_mutex_;
   std::condition_variable waiting_for_first_frame_condition_;
 

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -1728,6 +1728,68 @@ TEST_F(ShellTest, WaitForFirstFrameTimeout) {
   DestroyShell(std::move(shell));
 }
 
+// Ensure CancelWaitForFirstFrame() correctly causes all tasks blocked on
+// WaitForFirstFrame() to return kAborted.
+//
+// See: b/521830222
+TEST_F(ShellTest, CancelWaitForFirstFrameAllowsSafeShellDestruction) {
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+  RunEngine(shell.get(), std::move(configuration));
+  // No PumpOneFrame: waiting_for_first_frame_ stays true, so
+  // WaitForFirstFrame would otherwise park on the condvar for the full
+  // timeout below.
+
+  fml::AutoResetWaitableEvent bg_has_ref;
+  fml::AutoResetWaitableEvent proceed_with_wait;
+
+  // Background thread holds a raw Shell* obtained while the shell was still
+  // live -- exactly what `strongSelf.shell` (-> `*_shell`) hands the GCD
+  // block in -[FlutterEngine waitForFirstFrame:callback:].
+  Shell* raw_shell = shell.get();
+  fml::Status background_result;
+  std::thread background(
+      [raw_shell, &bg_has_ref, &proceed_with_wait, &background_result] {
+        bg_has_ref.Signal();
+        proceed_with_wait.Wait();
+        // A well-behaved caller must not still be here once the owner has
+        // finished destroying the Shell. CancelWaitForFirstFrame() below makes
+        // sure this call returns promptly instead of blocking for 30 seconds.
+        background_result =
+            raw_shell->WaitForFirstFrame(fml::TimeDelta::FromSeconds(30));
+      });
+
+  bg_has_ref.Wait();
+  proceed_with_wait.Signal();
+
+  // Give the background thread a chance to actually call WaitForFirstFrame()
+  // before it is cancelled below. If it hasn't gotten there yet, cancellation
+  // is still observed safely (and just as fast) the moment it does.
+  std::this_thread::yield();
+
+  fml::TimePoint cancel_start = fml::TimePoint::Now();
+  // Models -[FlutterEngine destroyContext]: cancel any in-flight waiter,
+  // then join it, before freeing the Shell.
+  raw_shell->CancelWaitForFirstFrame();
+  background.join();
+  fml::TimeDelta elapsed = fml::TimePoint::Now() - cancel_start;
+
+  // The whole point of CancelWaitForFirstFrame() is to avoid blocking the
+  // owner for anywhere near the caller's requested timeout.
+  EXPECT_LT(elapsed.ToSecondsF(), 5.0);
+  ASSERT_FALSE(background_result.ok());
+  ASSERT_EQ(background_result.code(), fml::StatusCode::kAborted);
+
+  // Only safe to destroy now that the background thread has been joined,
+  // i.e. is guaranteed to no longer be touching the Shell.
+  DestroyShell(std::move(shell));
+}
+
 TEST_F(ShellTest, WaitForFirstFrameMultiple) {
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell(settings);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -196,6 +196,10 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   std::shared_ptr<flutter::ThreadHost> _threadHost;
   std::unique_ptr<flutter::Shell> _shell;
 
+  // Callers to -waitForFirstFrame:callback: that are currently queued/processing.
+  // -destroyContext must wait for this group to drain before it is safe to free _shell.
+  dispatch_group_t _firstFrameWaiters;
+
   flutter::IOSRenderingAPI _renderingApi;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
@@ -571,6 +575,13 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 }
 
 - (void)destroyContext {
+  // Clear any tasks waiting on first frame prior to destroying _shell.
+  if (_shell) {
+    _shell->CancelWaitForFirstFrame();
+  }
+  if (_firstFrameWaiters) {
+    dispatch_group_wait(_firstFrameWaiters, DISPATCH_TIME_FOREVER);
+  }
   [self resetChannels];
   self.isolateId = nil;
   _shell.reset();
@@ -1535,17 +1546,28 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0);
   dispatch_group_t group = dispatch_group_create();
 
+  // Increment count of tasks waiting for first frame callback. Decrement below
+  // on completion or timeout. In -destroyContext we block until all pending
+  // first frame waiter tasks are cancelled.
+  if (!_firstFrameWaiters) {
+    _firstFrameWaiters = dispatch_group_create();
+  }
+  dispatch_group_t firstFrameWaiters = _firstFrameWaiters;
+  dispatch_group_enter(firstFrameWaiters);
+
   __weak FlutterEngine* weakSelf = self;
   __block BOOL didTimeout = NO;
   dispatch_group_async(group, queue, ^{
     FlutterEngine* strongSelf = weakSelf;
-    if (!strongSelf) {
+    if (!strongSelf || !strongSelf->_shell) {
+      dispatch_group_leave(firstFrameWaiters);
       return;
     }
 
     fml::TimeDelta waitTime = fml::TimeDelta::FromMilliseconds(timeout * 1000);
     fml::Status status = strongSelf.shell.WaitForFirstFrame(waitTime);
     didTimeout = status.code() == fml::StatusCode::kDeadlineExceeded;
+    dispatch_group_leave(firstFrameWaiters);
   });
 
   // Only execute the main queue task once the background task has completely finished executing.


### PR DESCRIPTION
-[FlutterEngine waitForFirstFrame:callback:] dispatches a block to a QOS_CLASS_BACKGROUND queue that dereferences the `_shell` unique_ptr and blocks in `Shell::WaitForFirstFrame()` on Shell-owned `waiting_for_first_frame_mutex_`/`waiting_for_first_frame_condition_`.

Previously, nothing prevented `-destroyContext` from running concurrently on the main thread and calling `_shell.reset()` while that background block was still running, or hadn't started yet. `Shell::~Shell` only joins the platform/UI/raster/IO task runners. It has no idea a separate GCD thread might be parked (or about to park) inside the object, so `_shell.reset()` can free the Shell out from under the block, which then reads and locks/unlocks freed memory.

Specifically:
* We dispatch the background block in `-[FlutterEngine waitForFirstFrame:callback:]`, which captures `weakSelf`.
* Before the block runs, or while it's blocked on the condition variable, the main thread calls `destroyContext`, which resets `_shell`.
* The block resolves `strongSelf` which is still valid -- that's the FlutterEngine wrapper, not `_shell`, and calls `strongSelf.shell.WaitForFirstFrame(...)` on a Shell that's already been freed.

This is reachable via -sendDeepLinkToFramework:completionHandler:, which calls waitForFirstFrame: with a 3s timeout, racing any concurrent lifecycle teardown (scene disconnect, view controller dealloc).

This adds `Shell::CancelWaitForFirstFrame()`, which flips a cancelled flag under `waiting_for_first_frame_mutex_` and notifies the condition var, causing any current/upcoming `WaitForFirstFrame()` call to return `kAborted` promptly instead of blocking out its timeout. We call this before resetting the shell in `-destroyContext`, then wait on a dispatch_group for that block to actually finish touching `_shell` before freeing it.

This is a separate dispatch_group to the one that already blocks the completion callback, so that concurrent waitForFirstFrame: calls don't have their callbacks coupled to each other.

The unit tests was copied (near-)verbatim from repro on the bug.

Issue: b/521830222

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
