### PR TITLE
[web] Fix deferred loading with wasm

### DIFF
--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -178,6 +178,9 @@ class WebTestsSuite {
         useWasm: false,
       ),
 
+      () => _runWebE2eTest('deferred_loading_integration', buildMode: 'release', useWasm: false),
+      () => _runWebE2eTest('deferred_loading_integration', buildMode: 'release', useWasm: true),
+
       () => _runWebTreeshakeTest(),
 
       () => _runFlutterDriverWebTest(

--- a/dev/integration_tests/web_e2e_tests/lib/deferred_loading_lib.dart
+++ b/dev/integration_tests/web_e2e_tests/lib/deferred_loading_lib.dart
@@ -1,0 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+int getDeferredValue() {
+  return int.parse('42');
+}

--- a/dev/integration_tests/web_e2e_tests/test_driver/deferred_loading_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/deferred_loading_integration.dart
@@ -20,5 +20,6 @@ void main() {
 
     final int value = deferred_lib.getDeferredValue();
     expect(value, equals(42));
+    await tester.pumpAndSettle();
   });
 }

--- a/dev/integration_tests/web_e2e_tests/test_driver/deferred_loading_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/deferred_loading_integration.dart
@@ -1,0 +1,24 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:web_e2e_tests/deferred_loading_lib.dart' deferred as deferred_lib;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('deferred library loading works on web', (WidgetTester tester) async {
+    runApp(const MaterialApp(home: Scaffold(body: Text('Initial State'))));
+    await tester.pumpAndSettle();
+
+    // Load the deferred library and call code within it.
+    await deferred_lib.loadLibrary();
+
+    final int value = deferred_lib.getDeferredValue();
+    expect(value, equals(42));
+  });
+}

--- a/dev/integration_tests/web_e2e_tests/test_driver/deferred_loading_integration_test.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/deferred_loading_integration_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:integration_test/integration_test_driver.dart' as test;
+
+Future<void> main() async => test.integrationDriver();

--- a/engine/src/flutter/lib/web_ui/flutter_js/src/entrypoint_loader.js
+++ b/engine/src/flutter/lib/web_ui/flutter_js/src/entrypoint_loader.js
@@ -185,10 +185,7 @@ export class FlutterEntrypointLoader {
       const defaultLoadDeferredModules = (moduleNames, handleModule) =>
         Promise.all(
           moduleNames.map((moduleName) =>
-            handleModule(
-              moduleName,
-              fetch(resolveUrlWithSegments(entrypointBaseUrl, moduleName))
-            )
+            fetch(resolveUrlWithSegments(entrypointBaseUrl, moduleName)).then((response) => handleModule(moduleName, response))
           )
         );
       const dartApp = await compiledDartApp.instantiate(await importsPromise, {


### PR DESCRIPTION
It seemed deferred loading via the recently added ([0]) `--enable-wasm-deferred-loading` never really worked.

The embedder (flutter in this case) needs to invoke the callback function with either the wasm module bytes or a response object (which is a stream of bytes).

Currently it invokes it with a promise of a response object which does not work atm.

[0] flutter/flutter@80157ee66cdc2ffd0d61b3f8ca586a245c4fd040