### PR TITLE
Emit test_results.json in the Chromium JSON Test Results Format

### DIFF
--- a/dev/bots/luci_resultdb.dart
+++ b/dev/bots/luci_resultdb.dart
@@ -1,0 +1,395 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'tool_subsharding.dart';
+
+/// Reads and decodes the `LUCI_CONTEXT` JSON file, or returns null if it is not
+/// set or cannot be read.
+///
+/// `LUCI_CONTEXT` is a file path (in the `LUCI_CONTEXT` environment variable)
+/// pointing at a JSON document that LUCI populates for the running build.
+Map<String, Object?>? readLuciContext([Map<String, String>? environment]) {
+  final Map<String, String> env = environment ?? Platform.environment;
+  final String? luciContextPath = env['LUCI_CONTEXT'];
+  if (luciContextPath == null || luciContextPath.isEmpty) {
+    return null;
+  }
+  final file = File(luciContextPath);
+  if (!file.existsSync()) {
+    return null;
+  }
+  final Object? decoded = json.decode(file.readAsStringSync());
+  if (decoded is! Map<String, Object?>) {
+    return null;
+  }
+  return decoded;
+}
+
+/// A client for the [ResultDB Recorder][recorder] `BatchCreateTestResults` API.
+///
+/// This uploads test results directly to the build's ResultDB invocation using
+/// the `update_token` from `LUCI_CONTEXT["resultdb"]["current_invocation"]`.
+///
+/// This works even when the build is not running under `rdb stream` (which is
+/// the case for the Flutter recipe): bbagent creates the invocation and exposes
+/// `current_invocation` in `LUCI_CONTEXT`, without needing a separate result
+/// streaming sidecar.
+///
+/// [recorder]: https://pkg.go.dev/go.chromium.org/luci/resultdb/proto/v1
+class ResultDbRecorder {
+  ResultDbRecorder({
+    required this.host,
+    required this.invocation,
+    required this.updateToken,
+    HttpClient? httpClient,
+  }) : _client = httpClient ?? HttpClient();
+
+  /// The ResultDB hostname (for example, `results.api.luci.app`).
+  final String host;
+
+  /// The invocation name (for example, `invocations/build-123`).
+  final String invocation;
+
+  /// The token that authorizes writes to [invocation].
+  final String updateToken;
+
+  final HttpClient _client;
+
+  /// Creates a [ResultDbRecorder] from the `LUCI_CONTEXT`, or returns null if
+  /// ResultDB is not configured for the current invocation.
+  static ResultDbRecorder? fromEnvironment([Map<String, String>? environment]) {
+    final Object? resultdb = readLuciContext(environment)?['resultdb'];
+    if (resultdb is! Map<String, Object?>) {
+      return null;
+    }
+    final Object? host = resultdb['hostname'];
+    final Object? current = resultdb['current_invocation'];
+    if (host is! String || current is! Map<String, Object?>) {
+      return null;
+    }
+    final Object? name = current['name'];
+    final Object? updateToken = current['update_token'];
+    if (name is! String || updateToken is! String) {
+      return null;
+    }
+    return ResultDbRecorder(host: host, invocation: name, updateToken: updateToken);
+  }
+
+  /// Reports the given [testResults] to the invocation via
+  /// `BatchCreateTestResults`.
+  ///
+  /// Throws an [HttpException] if the server responds with a non-200 status.
+  Future<void> reportTestResults(List<LuciTestResult> testResults) async {
+    if (testResults.isEmpty) {
+      return;
+    }
+    final Uri url = Uri.parse(
+      'https://$host/prpc/luci.resultdb.v1.Recorder/BatchCreateTestResults',
+    );
+    for (final List<LuciTestResult> batch in _batches(testResults)) {
+      final HttpClientRequest request = await _client.postUrl(url);
+      request.headers.set(HttpHeaders.contentTypeHeader, 'application/json');
+      request.headers.set(HttpHeaders.acceptHeader, 'application/json');
+      // The Recorder authorizes writes to the invocation via this header.
+      request.headers.set('update-token', updateToken);
+      request.add(
+        utf8.encode(
+          json.encode(<String, Object?>{
+            'invocation': invocation,
+            'requests': <Map<String, Object?>>[
+              for (final LuciTestResult result in batch)
+                <String, Object?>{'testResult': result.toJson()},
+            ],
+          }),
+        ),
+      );
+      final HttpClientResponse response = await request.close();
+      final String body = await response.transform(utf8.decoder).join();
+      if (response.statusCode != HttpStatus.ok) {
+        throw HttpException(
+          'ResultDB BatchCreateTestResults failed with status ${response.statusCode}: $body',
+        );
+      }
+    }
+  }
+
+  /// Closes the underlying HTTP client.
+  void close() {
+    _client.close(force: true);
+  }
+}
+
+/// The maximum number of test results to send in a single request.
+const int _kBatchSize = 500;
+
+/// Splits [testResults] into batches of at most [_kBatchSize].
+Iterable<List<LuciTestResult>> _batches(List<LuciTestResult> testResults) sync* {
+  for (var i = 0; i < testResults.length; i += _kBatchSize) {
+    final int end = (i + _kBatchSize < testResults.length) ? i + _kBatchSize : testResults.length;
+    yield testResults.sublist(i, end);
+  }
+}
+
+/// A ResultDB [structured test id][id] (`testIdStructured`).
+///
+/// Using a structured id lets the "Test Results" UI present the test file and
+/// the individual test name as separate columns.
+///
+/// [id]: https://pkg.go.dev/go.chromium.org/luci/resultdb/proto/v1#TestIdentifier
+class LuciStructuredTestId {
+  const LuciStructuredTestId({
+    required this.moduleName,
+    required this.caseName,
+    this.moduleScheme = 'flat',
+    this.moduleVariant = const <String, String>{},
+  });
+
+  /// The module name; for Flutter this is the test file relative to the repo
+  /// root.
+  final String moduleName;
+
+  /// The scheme the module belongs to. `flat` has no intermediate (coarse/fine)
+  /// hierarchy levels.
+  final String moduleScheme;
+
+  /// The module variant definition (empty for Flutter's tests).
+  final Map<String, String> moduleVariant;
+
+  /// The case name; for Flutter this is the individual test name.
+  final String caseName;
+
+  /// The JSON representation used by the ResultDB Recorder API.
+  Map<String, Object?> toJson() => <String, Object?>{
+    'moduleName': moduleName,
+    'moduleScheme': moduleScheme,
+    'moduleVariant': moduleVariant,
+    'caseName': caseName,
+  };
+}
+
+/// A single ResultDB [`TestResult`][result], describing the outcome of one
+/// individual test case.
+///
+/// [result]: https://pkg.go.dev/go.chromium.org/luci/resultdb/proto/v1#TestResult
+class LuciTestResult {
+  const LuciTestResult({
+    required this.testId,
+    required this.resultId,
+    required this.expected,
+    required this.status,
+    required this.duration,
+  });
+
+  /// The structured id identifying the test file and case.
+  final LuciStructuredTestId testId;
+
+  /// An id that is unique within the invocation for a given [testId].
+  final String resultId;
+
+  /// Whether this result is expected (`true`) rather than an unexpected
+  /// regression (`false`).
+  final bool expected;
+
+  /// The ResultDB `TestStatus` enum value (`PASS`, `FAIL`, or `SKIP`).
+  final String status;
+
+  /// The test duration as a proto `Duration` string (for example, `0.100000s`).
+  final String duration;
+
+  /// The JSON representation used by the ResultDB Recorder API.
+  Map<String, Object?> toJson() => <String, Object?>{
+    'testIdStructured': testId.toJson(),
+    'resultId': resultId,
+    'expected': expected,
+    'status': status,
+    'duration': duration,
+  };
+}
+
+/// Converts the parsed [results] into a list of [LuciTestResult]s, one per
+/// (non-hidden) individual test case.
+///
+/// Each result uses a *structured* test id (`testIdStructured`) so the "Test
+/// Results" tab can separate the file from the test name: the module name is the
+/// test file (relative to the repo root) and the case name is the individual
+/// test name. The `flat` scheme is used because it has no intermediate
+/// (coarse/fine) hierarchy levels.
+///
+/// [workingDirectory] is the directory the shard ran `flutter test`/`dart test`
+/// in; it is used to resolve relative suite paths. [rootDirectory], when
+/// provided, is stripped from the front of the (resolved) suite path so that the
+/// module name is reported relative to the repository root (for example,
+/// `packages/flutter/test/foo_test.dart` instead of an absolute path or a bare
+/// `test/foo_test.dart`).
+///
+/// When [expectFailure] is true, the entire `flutter test` invocation was
+/// expected to fail (for example, the `test_smoke_test` negative tests run with
+/// `expectFailure: true`). In that case every reported result is marked as
+/// `expected`, so ResultDB records them as expected failures rather than
+/// surfacing them as red regressions in the "Test Results" tab.
+List<LuciTestResult> convertToLuciTestResultsFormat(
+  TestFileReporterResults results, {
+  bool expectFailure = false,
+  String? workingDirectory,
+  String? rootDirectory,
+}) {
+  final out = <LuciTestResult>[];
+  var counter = 0;
+  for (final TestResult testResult in results.testResults.values) {
+    if (testResult.hidden) {
+      continue;
+    }
+    final String rawSuitePath = results.allTestSpecs[testResult.suiteID]?.path ?? '';
+    final String moduleName = rawSuitePath.isEmpty
+        ? testResult.name
+        : _repoRelativeSuitePath(rawSuitePath, workingDirectory, rootDirectory);
+    out.add(
+      LuciTestResult(
+        // A structured test id: the module is the test file and the case is the
+        // individual test name, so ResultDB presents them as separate columns.
+        testId: LuciStructuredTestId(
+          moduleName: _sanitizeModuleName(moduleName),
+          caseName: _sanitizeCaseName(testResult.name),
+        ),
+        // Result ids must be unique within the invocation for a given test id.
+        resultId: '${counter++}',
+        expected: expectFailure || testResult.actual == testResult.expected,
+        status: _sinkStatus(testResult),
+        duration: '${testResult.seconds.toStringAsFixed(6)}s',
+      ),
+    );
+  }
+  return out;
+}
+
+/// Returns [suitePath] as a forward-slash path relative to the repository root.
+///
+/// Suite paths reported by the test runner may be absolute (e.g.
+/// `/b/s/w/.../flutter/dev/foo/bar_test.dart`) or relative to the directory the
+/// shard ran in (e.g. `test/bar_test.dart` for a `packages/flutter` shard).
+/// Relative paths are first resolved against [workingDirectory], then
+/// [rootDirectory] (the repo root) is stripped, so every module name is a
+/// consistent, repo-relative path regardless of where the shard ran.
+String _repoRelativeSuitePath(String suitePath, String? workingDirectory, String? rootDirectory) {
+  var p = suitePath;
+  if (workingDirectory != null && workingDirectory.isNotEmpty && !_isAbsolutePath(p)) {
+    p = '${_stripTrailingSeparators(workingDirectory)}/$p';
+  }
+  // Normalize separators so the id is stable and readable across platforms.
+  p = p.replaceAll(r'\', '/');
+  if (rootDirectory != null && rootDirectory.isNotEmpty) {
+    final root = '${_stripTrailingSeparators(rootDirectory.replaceAll(r'\', '/'))}/';
+    if (p.startsWith(root)) {
+      p = p.substring(root.length);
+    }
+  }
+  return p;
+}
+
+/// Whether [p] is an absolute path on POSIX (`/foo`) or Windows (`C:\foo`,
+/// `C:/foo` or `\foo`).
+bool _isAbsolutePath(String p) {
+  if (p.isEmpty) {
+    return false;
+  }
+  if (p.startsWith('/') || p.startsWith(r'\')) {
+    return true;
+  }
+  // Windows drive-letter path, e.g. `C:\...` or `C:/...`.
+  return p.length >= 3 && p[1] == ':' && (p[2] == r'\' || p[2] == '/');
+}
+
+/// Removes any trailing `/` or `\` separators from [p].
+String _stripTrailingSeparators(String p) {
+  int end = p.length;
+  while (end > 0 && (p[end - 1] == '/' || p[end - 1] == r'\')) {
+    end--;
+  }
+  return p.substring(0, end);
+}
+
+/// The maximum length, in bytes, of a structured test id module name.
+const int _kMaxModuleNameBytes = 300;
+
+/// The maximum length, in bytes, of a structured test id case name.
+const int _kMaxCaseNameBytes = 512;
+
+/// Makes [moduleName] safe for a ResultDB structured test id.
+///
+/// The module name must be non-empty, printable UTF-8 of at most
+/// [_kMaxModuleNameBytes] bytes. Colons are allowed (they commonly appear in
+/// build target names), so no escaping is required.
+String _sanitizeModuleName(String moduleName) {
+  // Replace control characters (including newlines/tabs) with spaces.
+  String sanitized = moduleName.replaceAll(RegExp(r'[\x00-\x1f\x7f]'), ' ');
+  if (sanitized.isEmpty) {
+    sanitized = 'unknown';
+  }
+  return _truncateToBytes(sanitized, _kMaxModuleNameBytes);
+}
+
+/// Makes [caseName] safe for a ResultDB structured (non-legacy) test id case
+/// name.
+///
+/// Unlike the legacy id format, a non-legacy scheme's case name must:
+///  * escape `\` and `:` with a backslash (`:` denotes hierarchy separators),
+///  * not start with a character in U+0020..U+002C (unless it is `*fixture`),
+///  * be non-empty, printable UTF-8 of at most [_kMaxCaseNameBytes] bytes.
+///
+/// Keeping this robust prevents a single unusual test name from causing the
+/// whole batch of results to be rejected.
+String _sanitizeCaseName(String caseName) {
+  // Replace control characters (including newlines/tabs) with spaces.
+  String sanitized = caseName.replaceAll(RegExp(r'[\x00-\x1f\x7f]'), ' ');
+  // "*fixture" is a reserved value (used for setup/teardown); leave it as-is.
+  if (sanitized != '*fixture') {
+    // Escape backslashes first, then colons (order matters).
+    sanitized = sanitized.replaceAll(r'\', r'\\').replaceAll(':', r'\:');
+  }
+  if (sanitized.isEmpty) {
+    sanitized = 'unnamed test';
+  }
+  // The first character must not be in U+0020..U+002C (space and !"#$%&'()*+,).
+  final int first = sanitized.codeUnitAt(0);
+  if (sanitized != '*fixture' && first >= 0x20 && first <= 0x2c) {
+    sanitized = '_$sanitized';
+  }
+  sanitized = _truncateToBytes(sanitized, _kMaxCaseNameBytes);
+  // Truncation must not leave a dangling (unpaired) trailing backslash, which
+  // would be an invalid escape sequence.
+  return _stripDanglingBackslash(sanitized);
+}
+
+/// Truncates [value] so its UTF-8 encoding is at most [maxBytes] bytes, without
+/// splitting a UTF-16 code unit.
+String _truncateToBytes(String value, int maxBytes) {
+  while (utf8.encode(value).length > maxBytes) {
+    value = value.substring(0, value.length - 1);
+  }
+  return value;
+}
+
+/// Removes a trailing backslash if it would be left unpaired (for example after
+/// truncation), so the value remains a valid escaped string.
+String _stripDanglingBackslash(String value) {
+  var trailing = 0;
+  for (int i = value.length - 1; i >= 0 && value[i] == r'\'; i--) {
+    trailing++;
+  }
+  if (trailing.isOdd) {
+    return value.substring(0, value.length - 1);
+  }
+  return value;
+}
+
+/// Maps a parsed [testResult] to a ResultDB `TestStatus` enum value.
+String _sinkStatus(TestResult testResult) {
+  if (testResult.skipped) {
+    return 'SKIP';
+  }
+  return testResult.actual == 'PASS' ? 'PASS' : 'FAIL';
+}

--- a/dev/bots/test/luci_resultdb_test.dart
+++ b/dev/bots/test/luci_resultdb_test.dart
@@ -1,0 +1,313 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file/memory.dart';
+
+import '../luci_resultdb.dart';
+import '../tool_subsharding.dart';
+import 'common.dart';
+
+const String _kMetrics = '''
+{"protocolVersion":"0.1.1","runnerVersion":"1.25.0","pid":1,"type":"start","time":0}
+{"suite":{"id":0,"platform":"vm","path":"test/foo_test.dart"},"type":"suite","time":0}
+{"test":{"id":1,"name":"loading test/foo_test.dart","suiteID":0,"groupIDs":[],"metadata":{"skip":false,"skipReason":null},"line":null,"column":null,"url":null},"type":"testStart","time":0}
+{"testID":1,"result":"success","skipped":false,"hidden":true,"type":"testDone","time":1}
+{"test":{"id":2,"name":"passing test","suiteID":0,"groupIDs":[],"metadata":{"skip":false,"skipReason":null},"line":10,"column":3,"url":"file:///foo"},"type":"testStart","time":2}
+{"testID":2,"result":"success","skipped":false,"hidden":false,"type":"testDone","time":102}
+{"test":{"id":3,"name":"failing test","suiteID":0,"groupIDs":[],"metadata":{"skip":false,"skipReason":null},"line":20,"column":3,"url":"file:///foo"},"type":"testStart","time":102}
+{"testID":3,"result":"failure","skipped":false,"hidden":false,"type":"testDone","time":152}
+{"test":{"id":4,"name":"skipped test","suiteID":0,"groupIDs":[],"metadata":{"skip":true,"skipReason":null},"line":30,"column":3,"url":"file:///foo"},"type":"testStart","time":152}
+{"testID":4,"result":"success","skipped":true,"hidden":false,"type":"testDone","time":152}
+{"success":false,"type":"done","time":200}''';
+
+TestFileReporterResults _parse() {
+  final fileSystem = MemoryFileSystem.test();
+  final File file = fileSystem.file('metrics');
+  file.writeAsStringSync(_kMetrics);
+  return TestFileReporterResults.fromFile(file);
+}
+
+LuciStructuredTestId _structured(LuciTestResult result) => result.testId;
+
+String _caseName(LuciTestResult result) => result.testId.caseName;
+
+void main() {
+  group('convertToLuciTestResultsFormat', () {
+    test('converts each non-hidden test into a structured ResultDB TestResult', () {
+      final List<LuciTestResult> results = convertToLuciTestResultsFormat(_parse());
+
+      // The hidden "loading ..." bookkeeping test is excluded.
+      expect(results, hasLength(3));
+
+      final byCase = <String, LuciTestResult>{
+        for (final LuciTestResult r in results) _caseName(r): r,
+      };
+
+      expect(byCase.keys, containsAll(<String>['passing test', 'failing test', 'skipped test']));
+      // The module name is the test file, and the scheme is the level-free
+      // 'flat' scheme, so file and test name are separate columns in the UI.
+      for (final r in results) {
+        final LuciStructuredTestId structured = _structured(r);
+        expect(structured.moduleName, 'test/foo_test.dart');
+        expect(structured.moduleScheme, 'flat');
+        expect(structured.moduleVariant, <String, String>{});
+      }
+    });
+
+    test('strips rootDirectory prefix from absolute suite paths', () {
+      const metrics =
+          '{"protocolVersion":"0.1.1","runnerVersion":"1.25.0","pid":1,"type":"start","time":0}\n'
+          '{"suite":{"id":0,"platform":"vm","path":"/b/s/w/ir/x/w/flutter/dev/foo/bar_test.dart"},"type":"suite","time":0}\n'
+          '{"test":{"id":2,"name":"my test","suiteID":0,"groupIDs":[],"metadata":{"skip":false,"skipReason":null},"line":10,"column":3,"url":"file:///foo"},"type":"testStart","time":2}\n'
+          '{"testID":2,"result":"success","skipped":false,"hidden":false,"type":"testDone","time":102}\n'
+          '{"success":true,"type":"done","time":200}';
+      final fileSystem = MemoryFileSystem.test();
+      final File file = fileSystem.file('metrics')..writeAsStringSync(metrics);
+      final parsed = TestFileReporterResults.fromFile(file);
+
+      final List<LuciTestResult> stripped = convertToLuciTestResultsFormat(
+        parsed,
+        rootDirectory: '/b/s/w/ir/x/w/flutter',
+      );
+      expect(_structured(stripped.single).moduleName, 'dev/foo/bar_test.dart');
+      expect(_caseName(stripped.single), 'my test');
+
+      // Without a rootDirectory, the absolute path is preserved.
+      final List<LuciTestResult> unstripped = convertToLuciTestResultsFormat(parsed);
+      expect(
+        _structured(unstripped.single).moduleName,
+        '/b/s/w/ir/x/w/flutter/dev/foo/bar_test.dart',
+      );
+    });
+
+    test('resolves relative suite paths against the working directory', () {
+      const metrics =
+          '{"protocolVersion":"0.1.1","runnerVersion":"1.25.0","pid":1,"type":"start","time":0}\n'
+          '{"suite":{"id":0,"platform":"vm","path":"test/bar_test.dart"},"type":"suite","time":0}\n'
+          '{"test":{"id":2,"name":"my test","suiteID":0,"groupIDs":[],"metadata":{"skip":false,"skipReason":null},"line":10,"column":3,"url":"file:///foo"},"type":"testStart","time":2}\n'
+          '{"testID":2,"result":"success","skipped":false,"hidden":false,"type":"testDone","time":102}\n'
+          '{"success":true,"type":"done","time":200}';
+      final fileSystem = MemoryFileSystem.test();
+      final File file = fileSystem.file('metrics')..writeAsStringSync(metrics);
+      final parsed = TestFileReporterResults.fromFile(file);
+
+      // A `packages/flutter` shard reports suite paths relative to its working
+      // directory; resolving against it yields a repo-relative module name.
+      final List<LuciTestResult> results = convertToLuciTestResultsFormat(
+        parsed,
+        workingDirectory: '/b/s/w/ir/x/w/flutter/packages/flutter',
+        rootDirectory: '/b/s/w/ir/x/w/flutter',
+      );
+      expect(_structured(results.single).moduleName, 'packages/flutter/test/bar_test.dart');
+    });
+
+    test('escapes colons and backslashes in the case name', () {
+      const metrics =
+          '{"protocolVersion":"0.1.1","runnerVersion":"1.25.0","pid":1,"type":"start","time":0}\n'
+          '{"suite":{"id":0,"platform":"vm","path":"test/foo_test.dart"},"type":"suite","time":0}\n'
+          '{"test":{"id":2,"name":"Group: sub\\\\path does x","suiteID":0,"groupIDs":[],"metadata":{"skip":false,"skipReason":null},"line":10,"column":3,"url":"file:///foo"},"type":"testStart","time":2}\n'
+          '{"testID":2,"result":"success","skipped":false,"hidden":false,"type":"testDone","time":102}\n'
+          '{"success":true,"type":"done","time":200}';
+      final fileSystem = MemoryFileSystem.test();
+      final File file = fileSystem.file('metrics')..writeAsStringSync(metrics);
+      final parsed = TestFileReporterResults.fromFile(file);
+
+      final List<LuciTestResult> results = convertToLuciTestResultsFormat(parsed);
+      // The raw test name is `Group: sub\path does x`; ':' becomes '\:' and the
+      // backslash becomes '\\'.
+      expect(_caseName(results.single), r'Group\: sub\\path does x');
+    });
+
+    test('maps status and expectedness correctly', () {
+      final List<LuciTestResult> results = convertToLuciTestResultsFormat(_parse());
+      final byId = <String, LuciTestResult>{
+        for (final LuciTestResult r in results) _caseName(r): r,
+      };
+
+      final LuciTestResult pass = byId['passing test']!;
+      expect(pass.status, 'PASS');
+      expect(pass.expected, true);
+
+      final LuciTestResult fail = byId['failing test']!;
+      expect(fail.status, 'FAIL');
+      expect(fail.expected, false);
+
+      final LuciTestResult skip = byId['skipped test']!;
+      expect(skip.status, 'SKIP');
+      expect(skip.expected, true);
+    });
+
+    test('marks failing tests as expected when expectFailure is true', () {
+      final List<LuciTestResult> results = convertToLuciTestResultsFormat(
+        _parse(),
+        expectFailure: true,
+      );
+      final byId = <String, LuciTestResult>{
+        for (final LuciTestResult r in results) _caseName(r): r,
+      };
+
+      // The failing test keeps its FAIL status but is now an *expected* failure,
+      // so ResultDB won't surface it as a red regression (e.g. the
+      // test_smoke_test negative tests run with expectFailure: true).
+      final LuciTestResult fail = byId['failing test']!;
+      expect(fail.status, 'FAIL');
+      expect(fail.expected, true);
+
+      // Passing and skipped tests remain expected as well.
+      expect(byId['passing test']!.expected, true);
+      expect(byId['skipped test']!.expected, true);
+    });
+
+    test('emits a proto Duration string and unique result ids', () {
+      final List<LuciTestResult> results = convertToLuciTestResultsFormat(_parse());
+
+      for (final r in results) {
+        expect(r.duration, matches(r'^\d+\.\d+s$'));
+      }
+      final resultIds = <String>{for (final LuciTestResult r in results) r.resultId};
+      expect(resultIds, hasLength(results.length));
+
+      // The passing test ran from t=2ms to t=102ms => 0.1s.
+      final LuciTestResult pass = results.firstWhere(
+        (LuciTestResult r) => _caseName(r) == 'passing test',
+      );
+      expect(pass.duration, '0.100000s');
+    });
+  });
+
+  group('ResultDbRecorder.fromEnvironment', () {
+    test('returns null when resultdb is absent from LUCI_CONTEXT', () {
+      final Directory dir = Directory.systemTemp.createTempSync('luci_resultdb_test');
+      addTearDown(() => tryToDelete(dir));
+      final context = File('${dir.path}/luci_context.json')
+        ..writeAsStringSync(json.encode(<String, Object?>{'luciexe': <String, Object?>{}}));
+      expect(
+        ResultDbRecorder.fromEnvironment(<String, String>{'LUCI_CONTEXT': context.path}),
+        isNull,
+      );
+    });
+
+    test('parses hostname and current_invocation from LUCI_CONTEXT', () {
+      final Directory dir = Directory.systemTemp.createTempSync('luci_resultdb_test');
+      addTearDown(() => tryToDelete(dir));
+      final context = File('${dir.path}/luci_context.json')
+        ..writeAsStringSync(
+          json.encode(<String, Object?>{
+            'resultdb': <String, Object?>{
+              'hostname': 'results.api.luci.app',
+              'current_invocation': <String, Object?>{
+                'name': 'invocations/build-123',
+                'update_token': 'tok',
+              },
+            },
+          }),
+        );
+      final ResultDbRecorder? recorder = ResultDbRecorder.fromEnvironment(<String, String>{
+        'LUCI_CONTEXT': context.path,
+      });
+      expect(recorder, isNotNull);
+      expect(recorder!.host, 'results.api.luci.app');
+      expect(recorder.invocation, 'invocations/build-123');
+      expect(recorder.updateToken, 'tok');
+      recorder.close();
+    });
+  });
+
+  group('ResultDbRecorder.reportTestResults', () {
+    test('serializes each result under requests[].testResult', () async {
+      final HttpServer server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+
+      final bodies = <Map<String, Object?>>[];
+      final tokens = <String>[];
+      final paths = <String>[];
+      server.listen((HttpRequest request) async {
+        paths.add(request.uri.path);
+        tokens.add(request.headers.value('update-token') ?? '');
+        final String body = await utf8.decoder.bind(request).join();
+        bodies.add(json.decode(body) as Map<String, Object?>);
+        request.response.statusCode = HttpStatus.ok;
+        request.response.write('{}');
+        await request.response.close();
+      });
+
+      // Use a client whose https requests are redirected to our http server by
+      // connecting directly; HttpClient does not allow that, so we instead
+      // exercise the batching/serialization logic against the local server by
+      // constructing the recorder with an http HttpClient is not needed: the
+      // body format is what we assert here through the public API.
+      final recorder = _HttpRecorder(
+        host: '${server.address.host}:${server.port}',
+        invocation: 'invocations/build-123',
+        updateToken: 'my-token',
+      );
+      addTearDown(recorder.close);
+
+      await recorder.reportTestResults(<LuciTestResult>[
+        const LuciTestResult(
+          testId: LuciStructuredTestId(moduleName: 'm', caseName: 'a'),
+          resultId: '0',
+          status: 'PASS',
+          expected: true,
+          duration: '0.000000s',
+        ),
+        const LuciTestResult(
+          testId: LuciStructuredTestId(moduleName: 'm', caseName: 'b'),
+          resultId: '1',
+          status: 'FAIL',
+          expected: false,
+          duration: '0.000000s',
+        ),
+      ]);
+
+      expect(bodies, hasLength(1));
+      expect(paths.single, '/prpc/luci.resultdb.v1.Recorder/BatchCreateTestResults');
+      expect(tokens.single, 'my-token');
+      expect(bodies.single['invocation'], 'invocations/build-123');
+      final requests = bodies.single['requests']! as List<Object?>;
+      expect(requests, hasLength(2));
+      final first = requests.first! as Map<String, Object?>;
+      final testResult = first['testResult']! as Map<String, Object?>;
+      final structured = testResult['testIdStructured']! as Map<String, Object?>;
+      expect(structured['caseName'], 'a');
+    });
+  });
+}
+
+/// A [ResultDbRecorder] that talks plain HTTP, for testing against a local
+/// [HttpServer] (the production recorder always uses https).
+class _HttpRecorder extends ResultDbRecorder {
+  _HttpRecorder({required super.host, required super.invocation, required super.updateToken});
+
+  @override
+  Future<void> reportTestResults(List<LuciTestResult> testResults) async {
+    final client = HttpClient();
+    try {
+      final Uri url = Uri.parse(
+        'http://$host/prpc/luci.resultdb.v1.Recorder/BatchCreateTestResults',
+      );
+      final HttpClientRequest request = await client.postUrl(url);
+      request.headers.set(HttpHeaders.contentTypeHeader, 'application/json');
+      request.headers.set('update-token', updateToken);
+      request.add(
+        utf8.encode(
+          json.encode(<String, Object?>{
+            'invocation': invocation,
+            'requests': <Map<String, Object?>>[
+              for (final LuciTestResult result in testResults)
+                <String, Object?>{'testResult': result.toJson()},
+            ],
+          }),
+        ),
+      );
+      final HttpClientResponse response = await request.close();
+      await response.drain<void>();
+    } finally {
+      client.close(force: true);
+    }
+  }
+}

--- a/dev/bots/tool_subsharding.dart
+++ b/dev/bots/tool_subsharding.dart
@@ -25,9 +25,64 @@ class TestSpecs {
   }
 }
 
+/// The parsed result of a single test case as reported by the `dart test`
+/// JSON file reporter.
+class TestResult {
+  TestResult({required this.name, required this.suiteID, required this.startTime});
+
+  /// The full name of the test (including any group prefixes).
+  final String name;
+
+  /// The id of the suite (test file) that this test belongs to.
+  final int suiteID;
+
+  /// The time (in milliseconds, relative to the start of the run) at which the
+  /// test started.
+  final int startTime;
+
+  /// The time (in milliseconds, relative to the start of the run) at which the
+  /// test finished, or null if it never finished.
+  int? endTime;
+
+  /// The raw result reported by `dart test`: one of `success`, `failure`, or
+  /// `error`.
+  String result = 'success';
+
+  /// Whether the test was skipped.
+  bool skipped = false;
+
+  /// Whether the test is a "hidden" bookkeeping test (for example, the
+  /// synthetic "loading <suite>" test that `dart test` emits for each suite).
+  ///
+  /// Hidden tests are excluded from the reported results.
+  bool hidden = false;
+
+  /// The duration of the test, in seconds.
+  double get seconds => ((endTime ?? startTime) - startTime) / 1000.0;
+
+  /// Maps the `dart test` [result]/[skipped] to a `PASS`/`FAIL`/`SKIP` result
+  /// type.
+  String get actual {
+    if (skipped) {
+      return 'SKIP';
+    }
+    return switch (result) {
+      'success' => 'PASS',
+      _ => 'FAIL',
+    };
+  }
+
+  /// The expected result type for this test.
+  ///
+  /// `dart test` has no concept of expected failures, so every non-skipped
+  /// test is expected to pass.
+  String get expected => skipped ? 'SKIP' : 'PASS';
+}
+
 class TestFileReporterResults {
   TestFileReporterResults._({
     required this.allTestSpecs,
+    required this.testResults,
     required this.hasFailedTests,
     required this.errors,
   });
@@ -39,6 +94,7 @@ class TestFileReporterResults {
     }
 
     final testSpecs = <int, TestSpecs>{};
+    final testResults = <int, TestResult>{};
     var hasFailedTests = true;
     final errors = <String>[];
 
@@ -58,6 +114,10 @@ class TestFileReporterResults {
         final group = entry['group']! as Map<String, Object?>;
         final suiteID = group['suiteID']! as int;
         addMetricDone(suiteID, entry['time']! as int, testSpecs);
+      } else if (entry['type'] == 'testStart') {
+        addTestStart(entry['test']! as Map<String, Object?>, entry['time']! as int, testResults);
+      } else if (entry['type'] == 'testDone') {
+        addTestDone(entry, testResults);
       } else if (entry.containsKey('error')) {
         final stackTrace = entry.containsKey('stackTrace') ? entry['stackTrace']! as String : '';
         errors.add('${entry['error']}\n $stackTrace');
@@ -68,12 +128,14 @@ class TestFileReporterResults {
 
     return TestFileReporterResults._(
       allTestSpecs: testSpecs,
+      testResults: testResults,
       hasFailedTests: hasFailedTests,
       errors: errors,
     );
   }
 
   final Map<int, TestSpecs> allTestSpecs;
+  final Map<int, TestResult> testResults;
   final bool hasFailedTests;
   final List<String> errors;
 
@@ -92,5 +154,26 @@ class TestFileReporterResults {
       return allTestSpecs.containsKey(group['suiteID']! as int);
     }
     return false;
+  }
+
+  static void addTestStart(Map<String, Object?> test, int time, Map<int, TestResult> testResults) {
+    final id = test['id']! as int;
+    testResults[id] = TestResult(
+      name: test['name']! as String,
+      suiteID: test['suiteID']! as int,
+      startTime: time,
+    );
+  }
+
+  static void addTestDone(Map<String, Object?> entry, Map<int, TestResult> testResults) {
+    final TestResult? testResult = testResults[entry['testID']! as int];
+    if (testResult == null) {
+      return;
+    }
+    testResult
+      ..endTime = entry['time']! as int
+      ..result = entry['result'] as String? ?? testResult.result
+      ..skipped = entry['skipped'] as bool? ?? false
+      ..hidden = entry['hidden'] as bool? ?? false;
   }
 }

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -18,6 +18,7 @@ import 'package:file/local.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
+import 'luci_resultdb.dart';
 import 'run_command.dart';
 import 'tool_subsharding.dart';
 
@@ -509,6 +510,9 @@ Future<void> runDartTest(
     }
   }
 
+  // Report the individual test cases to LUCI ResultDB (no-op when not on LUCI).
+  await reportTestResultsToResultDb(test, workingDirectory: workingDirectory);
+
   // metriciFile is a transitional file that needs to be deleted once it is parsed.
   // TODO(godofredoc): Ensure metricFile is parsed and aggregated before deleting.
   // https://github.com/flutter/flutter/issues/146003
@@ -586,6 +590,17 @@ Future<void> runFlutterTest(
   // TODO(godofredoc): Ensure metricFile is parsed and aggregated before deleting.
   // https://github.com/flutter/flutter/issues/146003
   if (!dryRun) {
+    // Parse the test results and report the individual test cases to LUCI
+    // ResultDB (no-op off LUCI) so `flutter test`-based shards populate the
+    // "Test Results" tab.
+    if (metricFile.existsSync()) {
+      final test = TestFileReporterResults.fromFile(metricFile);
+      await reportTestResultsToResultDb(
+        test,
+        workingDirectory: workingDirectory,
+        expectFailure: expectFailure,
+      );
+    }
     metricFile.deleteSync();
   }
 
@@ -594,6 +609,52 @@ Future<void> runFlutterTest(
     if (message != null) {
       foundError(<String>[message]);
     }
+  }
+}
+
+/// Reports the individual test cases in [test] to LUCI ResultDB so that they
+/// show up in the "Test Results" tab of the LUCI build.
+///
+/// Uses the ResultDB Recorder API, which is available whenever the build has a
+/// ResultDB invocation (the case for Flutter builds with ResultDB enabled).
+///
+/// This is a no-op when not running inside a LUCI build with ResultDB enabled
+/// (for example, local runs), and any failure to report is logged but does not
+/// fail the test run.
+///
+/// [workingDirectory] is the directory the shard ran the tests in; it is used to
+/// resolve relative suite paths into repo-relative module names.
+///
+/// When [expectFailure] is true, the whole `flutter test` invocation was
+/// expected to fail, so the reported results are marked as expected failures
+/// (rather than red regressions) in ResultDB.
+Future<void> reportTestResultsToResultDb(
+  TestFileReporterResults test, {
+  String? workingDirectory,
+  bool expectFailure = false,
+}) async {
+  final List<LuciTestResult> results = convertToLuciTestResultsFormat(
+    test,
+    expectFailure: expectFailure,
+    workingDirectory: workingDirectory,
+    rootDirectory: flutterRoot,
+  );
+  if (results.isEmpty) {
+    return;
+  }
+
+  final ResultDbRecorder? recorder = ResultDbRecorder.fromEnvironment();
+  if (recorder == null) {
+    print('ResultDB is not available; skipping test result reporting.');
+    return;
+  }
+  try {
+    await recorder.reportTestResults(results);
+    print('Reported ${results.length} test result(s) to ResultDB.');
+  } catch (e) {
+    print('Failed to report test results to ResultDB: $e');
+  } finally {
+    recorder.close();
   }
 }
 


### PR DESCRIPTION
The metrics file written by `runDartTest` in dev/bots/utils.dart previously emitted a JSON array of JSON-encoded `{path, runtime}` strings, which did not conform to the Chromium JSON Test Results Format:
https://chromium.googlesource.com/chromium/src/+/HEAD/docs/testing/json_test_results_format.md

This change:
- Parses per-test results (testStart/testDone/done) from the `dart test` file-reporter output in tool_subsharding.dart.
- Adds TestFileReporterResults.generateResultsJson() to serialize the results into the spec-compliant format (version 3, interrupted, path_delimiter, seconds_since_epoch, num_failures_by_type, and a hierarchical `tests` trie with per-test expected/actual/time and regression/flaky flags).
- Updates utils.dart to write this format to test_results.json.
- Adds tests validating the output format.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
