### PR TITLE
feat: add support for automatically switching text to RTL or LTR based on first character typed

### DIFF
--- a/engine/src/flutter/lib/ui/dart_ui.cc
+++ b/engine/src/flutter/lib/ui/dart_ui.cc
@@ -237,6 +237,7 @@ typedef CanvasPath Path;
   V(Paragraph, getPositionForOffset)             \
   V(Paragraph, getRectsForPlaceholders)          \
   V(Paragraph, getRectsForRange)                 \
+  V(Paragraph, getTextResolvedDirection)         \
   V(Paragraph, getWordBoundary)                  \
   V(Paragraph, height)                           \
   V(Paragraph, ideographicBaseline)              \

--- a/engine/src/flutter/lib/ui/text.dart
+++ b/engine/src/flutter/lib/ui/text.dart
@@ -1940,6 +1940,7 @@ class TextStyle {
 Int32List _encodeParagraphStyle(
   TextAlign? textAlign,
   TextDirection? textDirection,
+  TextDirection? defaultTextDirection,
   int? maxLines,
   String? fontFamily,
   double? fontSize,
@@ -1951,7 +1952,7 @@ Int32List _encodeParagraphStyle(
   String? ellipsis,
   Locale? locale,
 ) {
-  final result = Int32List(7); // also update paragraph_builder.cc
+  final Int32List result = Int32List(14); // also update paragraph_builder.cc
   if (textAlign != null) {
     result[0] |= 1 << 1;
     result[1] = textAlign.index;
@@ -2001,6 +2002,10 @@ Int32List _encodeParagraphStyle(
   if (locale != null) {
     result[0] |= 1 << 12;
     // Passed separately to native.
+  }
+  if (defaultTextDirection != null) {
+    result[0] |= 1 << 13;
+    result[13] = defaultTextDirection.index;
   }
   return result;
 }
@@ -2071,6 +2076,7 @@ class ParagraphStyle {
   ParagraphStyle({
     TextAlign? textAlign,
     TextDirection? textDirection,
+    TextDirection? defaultTextDirection,
     int? maxLines,
     String? fontFamily,
     double? fontSize,
@@ -2084,6 +2090,7 @@ class ParagraphStyle {
   }) : _encoded = _encodeParagraphStyle(
          textAlign,
          textDirection,
+         defaultTextDirection,
          maxLines,
          fontFamily,
          fontSize,
@@ -2153,6 +2160,7 @@ class ParagraphStyle {
         'maxLines: ${_encoded[0] & 0x020 == 0x020 ? _encoded[5] : "unspecified"}, '
         'textHeightBehavior: ${_encoded[0] & 0x040 == 0x040 ? TextHeightBehavior._fromEncoded(_encoded[6], _leadingDistribution).toString() : "unspecified"}, '
         'fontFamily: ${_encoded[0] & 0x080 == 0x080 ? _fontFamily : "unspecified"}, '
+        'defaultTextDirection: ${_encoded[0] & 0x2000 == 0x2000 ? TextDirection.values[_encoded[13]] : "unspecified"}, '
         'fontSize: ${_encoded[0] & 0x100 == 0x100 ? _fontSize : "unspecified"}, '
         'height: ${_encoded[0] & 0x200 == 0x200 ? "${_height}x" : "unspecified"}, '
         'strutStyle: ${_encoded[0] & 0x400 == 0x400 ? _strutStyle : "unspecified"}, '
@@ -3053,6 +3061,24 @@ abstract class Paragraph {
   /// [ParagraphStyle.new].
   bool get didExceedMaxLines;
 
+  /// The resolved paragraph base direction.
+  ///
+  /// When the corresponding [ParagraphStyle.textDirection] was set
+  /// explicitly to LTR or RTL, this returns the value that was passed
+  /// in. When the value was `null` (i.e. `TextDirection.Auto`), the
+  /// engine resolves the direction by scanning the text content
+  /// (first-strong-character rule) before constructing the underlying
+  /// Skia paragraph, and this getter returns the resolved value. If
+  /// no strong-direction character was found, this returns
+  /// [TextDirection.ltr] as a conservative fallback.
+  ///
+  /// Used by [TextPainter.getOffsetForCaret] and other caret
+  /// calculations to render the caret correctly under
+  /// [TextDirection.Auto]. See also
+  /// `ParagraphBuilderSkia::ResolveEffectiveDirection` in
+  /// `txt/src/skia/paragraph_builder_skia.cc`.
+  TextDirection get direction => TextDirection.ltr;
+
   /// Computes the size and position of each glyph in the paragraph.
   ///
   /// The [ParagraphConstraints] control how wide the text is allowed to be.
@@ -3223,6 +3249,13 @@ base class _NativeParagraph extends NativeFieldWrapperClass1 implements Paragrap
   @override
   @Native<Bool Function(Pointer<Void>)>(symbol: 'Paragraph::didExceedMaxLines', isLeaf: true)
   external bool get didExceedMaxLines;
+
+  @Native<Int32 Function(Pointer<Void>)>(symbol: 'Paragraph::getTextResolvedDirection', isLeaf: true)
+  external int get _resolvedDirection;
+
+  @override
+  TextDirection get direction =>
+      TextDirection.values[_resolvedDirection.clamp(0, TextDirection.values.length - 1)];
 
   @override
   void layout(ParagraphConstraints constraints) {

--- a/engine/src/flutter/lib/ui/text/paragraph.cc
+++ b/engine/src/flutter/lib/ui/text/paragraph.cc
@@ -58,6 +58,10 @@ bool Paragraph::didExceedMaxLines() {
   return m_paragraph_->DidExceedMaxLines();
 }
 
+int32_t Paragraph::getTextResolvedDirection() {
+  return static_cast<int32_t>(m_paragraph_->GetTextDirection());
+}
+
 void Paragraph::layout(double width) {
   m_paragraph_->Layout(width);
 }

--- a/engine/src/flutter/lib/ui/text/paragraph.h
+++ b/engine/src/flutter/lib/ui/text/paragraph.h
@@ -33,6 +33,7 @@ class Paragraph : public RefCountedDartWrappable<Paragraph> {
   double alphabeticBaseline();
   double ideographicBaseline();
   bool didExceedMaxLines();
+  int32_t getTextResolvedDirection();
 
   void layout(double width);
   void paint(Canvas* canvas, double x, double y);

--- a/engine/src/flutter/lib/ui/text/paragraph_builder.cc
+++ b/engine/src/flutter/lib/ui/text/paragraph_builder.cc
@@ -5,6 +5,7 @@
 #include "flutter/lib/ui/text/paragraph_builder.h"
 
 #include <cstring>
+#include <optional>
 
 #include "flutter/common/settings.h"
 #include "flutter/common/task_runners.h"
@@ -90,6 +91,7 @@ const int kPSHeightIndex = 9;
 const int kPSStrutStyleIndex = 10;
 const int kPSEllipsisIndex = 11;
 const int kPSLocaleIndex = 12;
+const int kPSDefaultTextDirectionIndex = 13;
 
 const int kPSTextAlignMask = 1 << kPSTextAlignIndex;
 const int kPSTextDirectionMask = 1 << kPSTextDirectionIndex;
@@ -97,6 +99,7 @@ const int kPSFontWeightMask = 1 << kPSFontWeightIndex;
 const int kPSFontStyleMask = 1 << kPSFontStyleIndex;
 const int kPSMaxLinesMask = 1 << kPSMaxLinesIndex;
 const int kPSFontFamilyMask = 1 << kPSFontFamilyIndex;
+const int kPSDefaultTextDirectionMask = 1 << kPSDefaultTextDirectionIndex;
 const int kPSFontSizeMask = 1 << kPSFontSizeIndex;
 const int kPSHeightMask = 1 << kPSHeightIndex;
 const int kPSTextHeightBehaviorMask = 1 << kPSTextHeightBehaviorIndex;
@@ -242,6 +245,15 @@ ParagraphBuilder::ParagraphBuilder(
     if (mask & kPSTextDirectionMask) {
       style.text_direction =
           static_cast<txt::TextDirection>(encoded[kPSTextDirectionIndex]);
+    } else {
+      style.text_direction = std::nullopt;
+    }
+
+    if (mask & kPSDefaultTextDirectionMask) {
+      style.default_text_direction = static_cast<txt::TextDirection>(
+          encoded[kPSDefaultTextDirectionIndex]);
+    } else {
+      style.default_text_direction = std::nullopt;
     }
 
     if (mask & kPSFontWeightMask) {

--- a/engine/src/flutter/txt/BUILD.gn
+++ b/engine/src/flutter/txt/BUILD.gn
@@ -62,6 +62,8 @@ source_set("txt") {
     "src/txt/text_baseline.h",
     "src/txt/text_decoration.cc",
     "src/txt/text_decoration.h",
+    "src/txt/text_direction_util.cc",
+    "src/txt/text_direction_util.h",
     "src/txt/text_shadow.cc",
     "src/txt/text_shadow.h",
     "src/txt/text_style.cc",

--- a/engine/src/flutter/txt/src/skia/paragraph_builder_skia.cc
+++ b/engine/src/flutter/txt/src/skia/paragraph_builder_skia.cc
@@ -5,10 +5,13 @@
 #include "paragraph_builder_skia.h"
 #include "paragraph_skia.h"
 
+#include <unicode/ustring.h>
+
 #include "third_party/skia/modules/skparagraph/include/ParagraphStyle.h"
 #include "third_party/skia/modules/skparagraph/include/TextStyle.h"
 #include "third_party/skia/modules/skunicode/include/SkUnicode_icu.h"
 #include "txt/paragraph_style.h"
+#include "txt/text_direction_util.h"
 
 namespace skt = skia::textlayout;
 
@@ -36,20 +39,39 @@ ParagraphBuilderSkia::ParagraphBuilderSkia(
     const ParagraphStyle& style,
     const std::shared_ptr<FontCollection>& font_collection,
     const bool impeller_enabled)
-    : base_style_(style.GetTextStyle()), impeller_enabled_(impeller_enabled) {
+    : base_style_(style.GetTextStyle()),
+      original_style_(style),
+      font_collection_(font_collection),
+      direction_is_auto_(!style.text_direction.has_value()),
+      impeller_enabled_(impeller_enabled) {
+  if (direction_is_auto_) {
+    original_style_.text_direction =
+        style.default_text_direction.value_or(TextDirection::ltr);
+  }
   builder_ = skt::ParagraphBuilder::make(
-      TxtToSkia(style), font_collection->CreateSktFontCollection(),
+      TxtToSkia(original_style_), font_collection->CreateSktFontCollection(),
       SkUnicodes::ICU::Make());
 }
 
 ParagraphBuilderSkia::~ParagraphBuilderSkia() = default;
 
 void ParagraphBuilderSkia::PushStyle(const TextStyle& style) {
+  if (direction_is_auto_) {
+    RecordedOp op;
+    op.kind = RecordedOp::Kind::kPushStyle;
+    op.style = style;
+    recorded_ops_.push_back(std::move(op));
+  }
   builder_->pushStyle(TxtToSkia(style));
   txt_style_stack_.push(style);
 }
 
 void ParagraphBuilderSkia::Pop() {
+  if (direction_is_auto_) {
+    RecordedOp op;
+    op.kind = RecordedOp::Kind::kPop;
+    recorded_ops_.push_back(std::move(op));
+  }
   builder_->pop();
   txt_style_stack_.pop();
 }
@@ -59,15 +81,49 @@ const TextStyle& ParagraphBuilderSkia::PeekStyle() {
 }
 
 void ParagraphBuilderSkia::AddText(const std::u16string& text) {
+  if (direction_is_auto_) {
+    RecordedOp op;
+    op.kind = RecordedOp::Kind::kUtf16;
+    op.utf16_text = text;
+    recorded_ops_.push_back(std::move(op));
+    accumulated_text_.append(text);
+  }
   builder_->addText(text);
 }
 
 void ParagraphBuilderSkia::AddText(const uint8_t* utf8_data,
                                    size_t byte_length) {
+  if (direction_is_auto_) {
+    RecordedOp op;
+    op.kind = RecordedOp::Kind::kUtf8;
+    op.utf8_text.assign(reinterpret_cast<const char*>(utf8_data), byte_length);
+    recorded_ops_.push_back(std::move(op));
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t destCapacity = 0;
+    // 先计算所需长度
+    u_strFromUTF8(nullptr, 0, &destCapacity,
+                  reinterpret_cast<const char*>(utf8_data), byte_length, &status);
+    if (destCapacity > 0) {
+      status = U_ZERO_ERROR;
+      auto dest = std::make_unique<UChar[]>(destCapacity + 1);
+      u_strFromUTF8(dest.get(), destCapacity + 1, nullptr,
+                    reinterpret_cast<const char*>(utf8_data), byte_length, &status);
+      if (U_SUCCESS(status)) {
+        accumulated_text_.append(reinterpret_cast<const char16_t*>(dest.get()), destCapacity);
+      }
+    }
+  }
   builder_->addText(reinterpret_cast<const char*>(utf8_data), byte_length);
 }
 
 void ParagraphBuilderSkia::AddPlaceholder(PlaceholderRun& span) {
+  if (direction_is_auto_) {
+    RecordedOp op;
+    op.kind = RecordedOp::Kind::kPlaceholder;
+    op.placeholder = span;
+    recorded_ops_.push_back(std::move(op));
+  }
+
   skt::PlaceholderStyle placeholder_style;
   placeholder_style.fHeight = span.height;
   placeholder_style.fWidth = span.width;
@@ -79,9 +135,79 @@ void ParagraphBuilderSkia::AddPlaceholder(PlaceholderRun& span) {
   builder_->addPlaceholder(placeholder_style);
 }
 
+TextDirection ParagraphBuilderSkia::ResolveEffectiveDirection() const {
+  if (!direction_is_auto_) {
+    return original_style_.text_direction.value();
+  }
+  std::optional<TextDirection> resolved =
+      ResolveTextDirectionByContent(accumulated_text_);
+  if (resolved.has_value()) {
+    return resolved.value();
+  }
+  return original_style_.default_text_direction.value_or(TextDirection::ltr);
+}
+
+void ParagraphBuilderSkia::ReplayOperations(
+    skia::textlayout::ParagraphBuilder& target) {
+  for (const auto& op : recorded_ops_) {
+    switch (op.kind) {
+      case RecordedOp::Kind::kPushStyle:
+        target.pushStyle(TxtToSkia(op.style));
+        break;
+      case RecordedOp::Kind::kPop:
+        target.pop();
+        break;
+      case RecordedOp::Kind::kUtf16:
+        target.addText(op.utf16_text);
+        break;
+      case RecordedOp::Kind::kUtf8:
+        target.addText(op.utf8_text.data(), op.utf8_text.size());
+        break;
+      case RecordedOp::Kind::kPlaceholder: {
+        const auto& span = op.placeholder.value();
+        skt::PlaceholderStyle placeholder_style;
+        placeholder_style.fHeight = span.height;
+        placeholder_style.fWidth = span.width;
+        placeholder_style.fBaseline =
+            static_cast<skt::TextBaseline>(span.baseline);
+        placeholder_style.fBaselineOffset = span.baseline_offset;
+        placeholder_style.fAlignment =
+            static_cast<skt::PlaceholderAlignment>(span.alignment);
+        target.addPlaceholder(placeholder_style);
+        break;
+      }
+    }
+  }
+}
+
 std::unique_ptr<Paragraph> ParagraphBuilderSkia::Build() {
-  return std::make_unique<ParagraphSkia>(
-      builder_->Build(), std::move(dl_paints_), impeller_enabled_);
+  if (!direction_is_auto_) {
+    return std::make_unique<ParagraphSkia>(
+        builder_->Build(), std::move(dl_paints_), impeller_enabled_,
+        original_style_.text_direction.value());
+  }
+
+  TextDirection resolved_direction = ResolveEffectiveDirection();
+
+  if (resolved_direction == original_style_.text_direction.value()) {
+    return std::make_unique<ParagraphSkia>(
+        builder_->Build(), std::move(dl_paints_), impeller_enabled_,
+        resolved_direction);
+  }
+
+  original_style_.text_direction = resolved_direction;
+
+  dl_paints_.clear();
+
+  builder_ = skt::ParagraphBuilder::make(
+      TxtToSkia(original_style_), font_collection_->CreateSktFontCollection(),
+      SkUnicodes::ICU::Make());
+
+  ReplayOperations(*builder_);
+
+  return std::make_unique<ParagraphSkia>(builder_->Build(),
+                                         std::move(dl_paints_),
+                                         impeller_enabled_, resolved_direction);
 }
 
 skt::ParagraphPainter::PaintID ParagraphBuilderSkia::CreatePaintID(
@@ -130,7 +256,9 @@ skt::ParagraphStyle ParagraphBuilderSkia::TxtToSkia(const ParagraphStyle& txt) {
   skia.setStrutStyle(strut_style);
 
   skia.setTextAlign(static_cast<skt::TextAlign>(txt.text_align));
-  skia.setTextDirection(static_cast<skt::TextDirection>(txt.text_direction));
+  skia.setTextDirection(
+      static_cast<skt::TextDirection>(txt.text_direction.value_or(
+          txt.default_text_direction.value_or(TextDirection::ltr))));
   skia.setMaxLines(txt.max_lines);
   skia.setEllipsis(txt.ellipsis);
   skia.setTextHeightBehavior(

--- a/engine/src/flutter/txt/src/skia/paragraph_builder_skia.h
+++ b/engine/src/flutter/txt/src/skia/paragraph_builder_skia.h
@@ -5,6 +5,10 @@
 #ifndef FLUTTER_TXT_SRC_SKIA_PARAGRAPH_BUILDER_SKIA_H_
 #define FLUTTER_TXT_SRC_SKIA_PARAGRAPH_BUILDER_SKIA_H_
 
+#include <optional>
+#include <string>
+#include <vector>
+
 #include "txt/paragraph_builder.h"
 
 #include "flutter/display_list/dl_paint.h"
@@ -36,13 +40,29 @@ class ParagraphBuilderSkia : public ParagraphBuilder {
  private:
   friend class SkiaParagraphBuilderTests_ParagraphStrutStyle_Test;
 
+  struct RecordedOp {
+    enum class Kind { kPushStyle, kPop, kUtf16, kUtf8, kPlaceholder };
+    Kind kind;
+    TextStyle style;
+    std::u16string utf16_text;
+    std::string utf8_text;
+    std::optional<PlaceholderRun> placeholder;
+  };
+
   skia::textlayout::ParagraphPainter::PaintID CreatePaintID(
       const flutter::DlPaint& dl_paint);
   skia::textlayout::ParagraphStyle TxtToSkia(const ParagraphStyle& txt);
   skia::textlayout::TextStyle TxtToSkia(const TextStyle& txt);
+  TextDirection ResolveEffectiveDirection() const;
+  void ReplayOperations(skia::textlayout::ParagraphBuilder& target);
 
   std::shared_ptr<skia::textlayout::ParagraphBuilder> builder_;
   TextStyle base_style_;
+  ParagraphStyle original_style_;
+  std::shared_ptr<FontCollection> font_collection_;
+  bool direction_is_auto_ = false;
+  std::vector<RecordedOp> recorded_ops_;
+  std::u16string accumulated_text_;
 
   /// @brief      Whether Impeller is enabled in the runtime.
   ///

--- a/engine/src/flutter/txt/src/skia/paragraph_skia.cc
+++ b/engine/src/flutter/txt/src/skia/paragraph_skia.cc
@@ -205,10 +205,12 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
 
 ParagraphSkia::ParagraphSkia(std::unique_ptr<skt::Paragraph> paragraph,
                              std::vector<flutter::DlPaint>&& dl_paints,
-                             bool impeller_enabled)
+                             bool impeller_enabled,
+                             TextDirection resolved_direction)
     : paragraph_(std::move(paragraph)),
       dl_paints_(dl_paints),
-      impeller_enabled_(impeller_enabled) {}
+      impeller_enabled_(impeller_enabled),
+      resolved_direction_(resolved_direction) {}
 
 double ParagraphSkia::GetMaxWidth() {
   return SkScalarToDouble(paragraph_->getMaxWidth());
@@ -366,6 +368,10 @@ size_t ParagraphSkia::GetNumberOfLines() const {
 
 int ParagraphSkia::GetLineNumberAt(size_t codeUnitIndex) const {
   return paragraph_->getLineNumberAtUTF16Offset(codeUnitIndex);
+}
+
+TextDirection ParagraphSkia::GetTextDirection() const {
+  return resolved_direction_;
 }
 
 TextStyle ParagraphSkia::SkiaToTxt(const skt::TextStyle& skia) {

--- a/engine/src/flutter/txt/src/skia/paragraph_skia.h
+++ b/engine/src/flutter/txt/src/skia/paragraph_skia.h
@@ -18,7 +18,8 @@ class ParagraphSkia : public Paragraph {
  public:
   ParagraphSkia(std::unique_ptr<skia::textlayout::Paragraph> paragraph,
                 std::vector<flutter::DlPaint>&& dl_paints,
-                bool impeller_enabled);
+                bool impeller_enabled,
+                TextDirection resolved_direction);
 
   virtual ~ParagraphSkia() = default;
 
@@ -47,6 +48,8 @@ class ParagraphSkia : public Paragraph {
   int GetLineNumberAt(size_t utf16Offset) const override;
 
   bool DidExceedMaxLines() override;
+
+  TextDirection GetTextDirection() const override;
 
   void Layout(double width) override;
 
@@ -82,6 +85,7 @@ class ParagraphSkia : public Paragraph {
   std::optional<std::vector<LineMetrics>> line_metrics_;
   std::vector<TextStyle> line_metrics_styles_;
   const bool impeller_enabled_;
+  const TextDirection resolved_direction_;
 };
 
 }  // namespace txt

--- a/engine/src/flutter/txt/src/txt/paragraph.h
+++ b/engine/src/flutter/txt/src/txt/paragraph.h
@@ -194,6 +194,22 @@ class Paragraph {
   // number of the line this hard line break breaks, intead of the new line it
   // creates.
   virtual int GetLineNumberAt(size_t utf16Offset) const = 0;
+
+  // Returns the resolved paragraph base direction.
+  //
+  // When the paragraph was built with an explicit LTR/RTL paragraph style,
+  // this returns the value that was passed in. When the paragraph was built
+  // with `std::nullopt` (i.e. `TextDirection.Auto`), the builder scans the
+  // actual text content (first-strong-character rule) to determine the
+  // direction before constructing the underlying Skia paragraph, and this
+  // method returns the resolved value. If no strong-direction character
+  // was found, this returns `TextDirection::ltr` as a conservative
+  // fallback.
+  //
+  // Used by `ui.Paragraph` to expose the resolved direction to the
+  // framework, so that `TextPainter.getOffsetForCaret` and other caret
+  // calculations can render the caret correctly under `TextDirection.Auto`.
+  virtual TextDirection GetTextDirection() const = 0;
 };
 
 }  // namespace txt

--- a/engine/src/flutter/txt/src/txt/paragraph_style.cc
+++ b/engine/src/flutter/txt/src/txt/paragraph_style.cc
@@ -31,12 +31,13 @@ bool ParagraphStyle::ellipsized() const {
 }
 
 TextAlign ParagraphStyle::effective_align() const {
+  const TextDirection resolved = text_direction.value_or(
+      default_text_direction.value_or(TextDirection::ltr));
+  const bool is_ltr = resolved == TextDirection::ltr;
   if (text_align == TextAlign::start) {
-    return (text_direction == TextDirection::ltr) ? TextAlign::left
-                                                  : TextAlign::right;
+    return is_ltr ? TextAlign::left : TextAlign::right;
   } else if (text_align == TextAlign::end) {
-    return (text_direction == TextDirection::ltr) ? TextAlign::right
-                                                  : TextAlign::left;
+    return is_ltr ? TextAlign::right : TextAlign::left;
   } else {
     return text_align;
   }

--- a/engine/src/flutter/txt/src/txt/paragraph_style.h
+++ b/engine/src/flutter/txt/src/txt/paragraph_style.h
@@ -6,6 +6,7 @@
 #define FLUTTER_TXT_SRC_TXT_PARAGRAPH_STYLE_H_
 
 #include <climits>
+#include <optional>
 #include <string>
 
 #include "font_style.h"
@@ -82,7 +83,8 @@ class ParagraphStyle {
 
   // General paragraph properties.
   TextAlign text_align = TextAlign::start;
-  TextDirection text_direction = TextDirection::ltr;
+  std::optional<TextDirection> text_direction = std::nullopt;
+  std::optional<TextDirection> default_text_direction = std::nullopt;
   size_t max_lines = std::numeric_limits<size_t>::max();
   std::u16string ellipsis;
   std::string locale;
@@ -92,7 +94,10 @@ class ParagraphStyle {
   bool unlimited_lines() const;
   bool ellipsized() const;
 
-  // Return a text alignment value that is not dependent on the text direction.
+  // Return a text alignment value that is not dependent on the text
+  // direction. When `text_direction` is unset (Auto), this assumes LTR
+  // so that alignment is well-defined for layout; the final direction
+  // is resolved later by the builder from the text content.
   TextAlign effective_align() const;
 };
 

--- a/engine/src/flutter/txt/src/txt/text_direction_util.cc
+++ b/engine/src/flutter/txt/src/txt/text_direction_util.cc
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "text_direction_util.h"
+
+#include <unicode/uchar.h>
+#include <unicode/utf16.h>
+
+namespace txt {
+
+bool IsStrongLeftToRight(int32_t codepoint) {
+  return u_charDirection(codepoint) == U_LEFT_TO_RIGHT;
+}
+
+bool IsStrongRightToLeft(int32_t codepoint) {
+  return u_charDirection(codepoint) == U_RIGHT_TO_LEFT;
+}
+
+bool IsStrongRightToLeftArabic(int32_t codepoint) {
+  return u_charDirection(codepoint) == U_RIGHT_TO_LEFT_ARABIC;
+}
+
+std::optional<TextDirection> ResolveTextDirectionByContent(
+    const std::u16string& text) {
+  // Scan the text for the first strong-direction character, mirroring
+  // the original ICU "first strong character" rule for paragraph direction
+  // detection.
+  int32_t i = 0;
+  const int32_t length = static_cast<int32_t>(text.size());
+  while (i < length) {
+    UChar32 cp;
+    U16_NEXT(text.data(), i, length, cp);
+    if (IsStrongLeftToRight(cp)) {
+      return TextDirection::ltr;
+    }
+    if (IsStrongRightToLeft(cp) || IsStrongRightToLeftArabic(cp)) {
+      return TextDirection::rtl;
+    }
+  }
+  // No strong-direction character found (e.g. text is empty or contains
+  // only digits / punctuation / neutral marks). The caller is expected to
+  // resolve a fallback direction (typically the ambient
+  // `Directionality.of(context)`).
+  return std::nullopt;
+}
+
+}  // namespace txt

--- a/engine/src/flutter/txt/src/txt/text_direction_util.h
+++ b/engine/src/flutter/txt/src/txt/text_direction_util.h
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_TXT_SRC_TXT_TEXT_DIRECTION_UTIL_H_
+#define FLUTTER_TXT_SRC_TXT_TEXT_DIRECTION_UTIL_H_
+
+#include <optional>
+#include <string>
+
+#include "paragraph_style.h"
+
+namespace txt {
+
+// Returns true if the given unicode code point has a strong left-to-right
+// direction (e.g. Latin letters, Han characters that are treated as LTR by
+// ICU's `u_charDirection`).
+bool IsStrongLeftToRight(int32_t codepoint);
+
+// Returns true if the given unicode code point has a strong right-to-left
+// direction (e.g. Hebrew letters).
+bool IsStrongRightToLeft(int32_t codepoint);
+
+// Returns true if the given unicode code point has a strong right-to-left
+// Arabic direction (e.g. Arabic letters, Arabic-Indic digits).
+bool IsStrongRightToLeftArabic(int32_t codepoint);
+
+// Resolves the text direction of the given UTF-16 text by scanning for the
+// first strong-direction character. If the text is empty or contains no
+// strong-direction characters, returns `std::nullopt` so the caller can fall
+// back to the system / ambient direction.
+std::optional<TextDirection> ResolveTextDirectionByContent(
+    const std::u16string& text);
+
+}  // namespace txt
+
+#endif  // FLUTTER_TXT_SRC_TXT_TEXT_DIRECTION_UTIL_H_

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -295,6 +295,11 @@ class _UntilTextBoundary extends TextBoundary {
 class _TextLayout {
   _TextLayout._(this._paragraph, this.writingDirection, this._painter);
 
+  // Exposed so `getOffsetForCaret` (and similar) can read
+  // `paragraph.direction` to get the engine-resolved direction in
+  // `TextDirection.Auto` mode without re-querying the cache.
+  ui.Paragraph get paragraph => _paragraph;
+
   final TextDirection writingDirection;
 
   // Computing plainText is a bit expensive and is currently not needed for
@@ -641,7 +646,7 @@ class TextPainter {
   /// text or get other information about it.
   static double computeWidth({
     required InlineSpan text,
-    required TextDirection textDirection,
+    TextDirection? textDirection,
     TextAlign textAlign = TextAlign.start,
     @Deprecated(
       'Use textScaler instead. '
@@ -695,7 +700,7 @@ class TextPainter {
   /// text or get other information about it.
   static double computeMaxIntrinsicWidth({
     required InlineSpan text,
-    required TextDirection textDirection,
+    TextDirection? textDirection,
     TextAlign textAlign = TextAlign.start,
     @Deprecated(
       'Use textScaler instead. '
@@ -877,6 +882,49 @@ class TextPainter {
     _layoutTemplate?.dispose();
     _layoutTemplate = null; // Shouldn't really matter, but for strict correctness...
   }
+
+  /// The default paragraph direction, supplied internally as the
+  /// ambient `Directionality.of(context)` value.
+  ///
+  /// This is an internal implementation detail of the text layout
+  /// pipeline; the application should set [textDirection] instead.
+  /// It is exposed only so that [RenderParagraph] and
+  /// [RenderEditable] can forward the ambient direction captured at
+  /// build time. When `null`, the engine falls back to LTR after the
+  /// first-strong-character scan in `TextDirection.Auto` mode.
+  @internal
+  TextDirection get defaultTextDirection => _defaultTextDirection;
+  TextDirection _defaultTextDirection = TextDirection.ltr;
+  @internal
+  set defaultTextDirection(TextDirection value) {
+    assert(value != null);
+    if (_defaultTextDirection == value) {
+      return;
+    }
+    _defaultTextDirection = value;
+    markNeedsLayout();
+    _layoutTemplate?.dispose();
+    _layoutTemplate = null;
+  }
+
+  /// The paragraph base direction resolved by the engine after [layout].
+  ///
+  /// Unlike [textDirection] (which returns the user-supplied value, possibly
+  /// `null` for `TextDirection.Auto`), this getter returns the actual
+  /// direction Skia used to lay out the glyphs: the explicit value when
+  /// [textDirection] was set, or the first-strong-character scan result
+  /// for `TextDirection.Auto`.
+  ///
+  /// Returns `null` before [layout] is called, when no layout cache exists,
+  /// or when the underlying engine binding does not yet expose direction
+  /// resolution (e.g. older engine versions where `Paragraph.direction`
+  /// always returns LTR).
+  ///
+  /// Use this when you need the resolved direction in `RenderParagraph` /
+  /// `RenderEditable` / `_SelectableFragment` — it is always consistent
+  /// with what [getOffsetForCaret] and other caret calculations use.
+  @internal
+  TextDirection? get resolvedDirection => _layoutCache?.layout._paragraph.direction;
 
   /// Deprecated. Will be removed in a future version of Flutter. Use
   /// [textScaler] instead.
@@ -1082,14 +1130,11 @@ class TextPainter {
   List<PlaceholderDimensions>? _placeholderDimensions;
 
   ui.ParagraphStyle _createParagraphStyle([TextAlign? textAlignOverride]) {
-    assert(
-      textDirection != null,
-      'TextPainter.textDirection must be set to a non-null value before using the TextPainter.',
-    );
     final TextStyle baseStyle = _text?.style ?? const TextStyle();
     return baseStyle.getParagraphStyle(
       textAlign: textAlignOverride ?? textAlign,
       textDirection: textDirection,
+      defaultTextDirection: _defaultTextDirection,
       textScaler: textScaler,
       maxLines: _maxLines,
       textHeightBehavior: _textHeightBehavior,
@@ -1237,22 +1282,26 @@ class TextPainter {
         'TextPainter.text must be set to a non-null value before using the TextPainter.',
       );
     }
-    final TextDirection? textDirection = this.textDirection;
-    if (textDirection == null) {
-      throw StateError(
-        'TextPainter.textDirection must be set to a non-null value before using the TextPainter.',
-      );
-    }
-
-    final double paintOffsetAlignment = _computePaintOffsetFraction(textAlign, textDirection);
+    // When `textDirection` is `null` (i.e. `TextDirection.Auto`), the
+    // engine resolves the paragraph direction from the text content
+    // (first-strong-character rule). We therefore have to do a
+    // tentative layout first to obtain the resolved direction, then
+    // recompute `paintOffsetAlignment` (used to decide
+    // `layoutMaxWidth` when the caller passes an infinite `maxWidth`)
+    // and re-layout if the resolved direction differs from the
+    // tentative value. This guarantees that
+    // `_TextLayout.writingDirection` (and therefore
+    // `getOffsetForCaret`) reflects the actual rendered direction.
+    final TextDirection effectiveDirection = this.textDirection ?? this.resolvedDirection ?? this.defaultTextDirection;
+    double paintOffsetAlignment = _computePaintOffsetFraction(textAlign, effectiveDirection);
     // Try to avoid laying out the paragraph with maxWidth=double.infinity
     // when the text is not left-aligned, so we don't have to deal with an
     // infinite paint offset.
-    final bool adjustMaxWidth = !maxWidth.isFinite && paintOffsetAlignment != 0;
+    bool adjustMaxWidth = !maxWidth.isFinite && paintOffsetAlignment != 0;
     final double? adjustedMaxWidth = !adjustMaxWidth
         ? maxWidth
         : cachedLayout?.layout.maxIntrinsicLineExtent;
-    final double layoutMaxWidth = adjustedMaxWidth ?? maxWidth;
+    double layoutMaxWidth = adjustedMaxWidth ?? maxWidth;
 
     // Only rebuild the paragraph when there're layout changes, even when
     // `_rebuildParagraphForPaint` is true. It's best to not eagerly rebuild
@@ -1263,7 +1312,43 @@ class TextPainter {
     //    called.
     final ui.Paragraph paragraph = (cachedLayout?.paragraph ?? _createParagraph(text))
       ..layout(ui.ParagraphConstraints(width: layoutMaxWidth));
-    final layout = _TextLayout._(paragraph, textDirection, this);
+    // `paragraph.direction` returns the engine-resolved direction
+    // (which is the explicit value when `textDirection` was set, or
+    // the first-strong-character scan result for `TextDirection.Auto`).
+    // The internal `_TextLayout.writingDirection` is non-nullable for
+    // its switch statements, so we read from `paragraph.direction`
+    // (which is always non-null) instead of falling back to LTR
+    // unconditionally. The fallback to LTR remains a safety net in
+    // case the engine binding is unavailable (e.g. older engine
+    // versions).
+    //
+    // If the resolved direction differs from the tentative value we
+    // used to compute `paintOffsetAlignment` (e.g. user passed `null`
+    // and the engine detected an RTL first-strong character), and the
+    // `maxWidth` is infinite (the only case where
+    // `paintOffsetAlignment` matters), relayout the paragraph with
+    // the corrected `layoutMaxWidth` so that `getOffsetForCaret` and
+    // text alignment reflect the actual rendered direction. If the
+    // resolved direction matches the tentative value (or `maxWidth` is
+    // finite, in which case `paintOffsetAlignment` is unused), the
+    // relayout is a no-op.
+    if (paragraph.direction != effectiveDirection) {
+      final double resolvedPaintOffsetAlignment = _computePaintOffsetFraction(
+        textAlign,
+        paragraph.direction,
+      );
+      if (resolvedPaintOffsetAlignment != paintOffsetAlignment) {
+        paintOffsetAlignment = resolvedPaintOffsetAlignment;
+        adjustMaxWidth = !maxWidth.isFinite && paintOffsetAlignment != 0;
+        // The original first pass used `cachedLayout?.layout.maxIntrinsicLineExtent`
+        // (which is null on a cold layout). After a tentative layout we now
+        // have a paragraph and can read its `maxIntrinsicWidth` instead.
+        final double? maxIntrinsic = !adjustMaxWidth ? null : paragraph.maxIntrinsicWidth;
+        layoutMaxWidth = maxIntrinsic ?? maxWidth;
+        paragraph.layout(ui.ParagraphConstraints(width: layoutMaxWidth));
+      }
+    }
+    final _TextLayout layout = _TextLayout._(paragraph, paragraph.direction, this);
     final double contentWidth = layout._contentWidthFor(minWidth, maxWidth, textWidthBasis);
 
     final _TextPainterLayoutCacheWithOffset newLayoutCache;
@@ -1449,7 +1534,12 @@ class TextPainter {
     final _LineCaretMetrics? caretMetrics = _computeCaretMetrics(position);
 
     if (caretMetrics == null) {
-      final double paintOffsetAlignment = _computePaintOffsetFraction(textAlign, textDirection!);
+      // Use the engine-resolved direction (which reflects the
+      // first-strong-character scan for `TextDirection.Auto`).
+      final double paintOffsetAlignment = _computePaintOffsetFraction(
+        textAlign,
+        layoutCache.layout._paragraph.direction,
+      );
       // The full width is not (width - caretPrototype.width), because
       // RenderEditable reserves cursor width on the right. Ideally this
       // should be handled by RenderEditable instead.

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -1392,6 +1392,7 @@ class TextStyle with Diagnosticable {
   ui.ParagraphStyle getParagraphStyle({
     TextAlign? textAlign,
     TextDirection? textDirection,
+    @internal TextDirection? defaultTextDirection,
     TextScaler textScaler = TextScaler.noScaling,
     String? ellipsis,
     int? maxLines,
@@ -1416,6 +1417,7 @@ class TextStyle with Diagnosticable {
     return ui.ParagraphStyle(
       textAlign: textAlign,
       textDirection: textDirection,
+      defaultTextDirection: defaultTextDirection,
       // Here, we establish the contents of this TextStyle as the paragraph's default font
       // unless an override is passed in.
       fontWeight: fontWeight ?? this.fontWeight,

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -284,7 +284,8 @@ class RenderEditable extends RenderBox
   /// scrolling.
   RenderEditable({
     InlineSpan? text,
-    required TextDirection textDirection,
+    TextDirection? textDirection,
+    required TextDirection defaultTextDirection,
     TextAlign textAlign = TextAlign.start,
     Color? cursorColor,
     Color? backgroundCursorColor,
@@ -360,7 +361,7 @@ class RenderEditable extends RenderBox
          strutStyle: strutStyle,
          textHeightBehavior: textHeightBehavior,
          textWidthBasis: textWidthBasis,
-       ),
+       )..defaultTextDirection = defaultTextDirection,
        _showCursor = showCursor ?? ValueNotifier<bool>(false),
        _maxLines = maxLines,
        _minLines = minLines,
@@ -799,6 +800,7 @@ class RenderEditable extends RenderBox
       ..text = _textPainter.text
       ..textAlign = _textPainter.textAlign
       ..textDirection = _textPainter.textDirection
+      ..defaultTextDirection = _textPainter.defaultTextDirection
       ..textScaler = _textPainter.textScaler
       ..maxLines = _textPainter.maxLines
       ..ellipsis = _textPainter.ellipsis
@@ -829,11 +831,10 @@ class RenderEditable extends RenderBox
   /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
   /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
-  // TextPainter.textDirection is nullable, but it is set to a
-  // non-null value in the RenderEditable constructor and we refuse to
-  // set it to null here, so _textPainter.textDirection cannot be null.
-  TextDirection get textDirection => _textPainter.textDirection!;
-  set textDirection(TextDirection value) {
+  // `textDirection` may be `null` to support `TextDirection.Auto`
+  // (resolved at the engine layer via first-strong-character scan).
+  TextDirection? get textDirection => _textPainter.textDirection;
+  set textDirection(TextDirection? value) {
     if (_textPainter.textDirection == value) {
       return;
     }
@@ -841,6 +842,37 @@ class RenderEditable extends RenderBox
     markNeedsLayout();
     markNeedsSemanticsUpdate();
   }
+
+  /// The default paragraph direction, supplied as the ambient
+  /// `Directionality.of(context)` value when the render object was
+  /// created. Forwarded to the engine as a fallback direction when
+  /// [textDirection] is `null` and the first-strong-character scan
+  /// finds no strong character.
+  @internal
+  TextDirection get defaultTextDirection => _textPainter.defaultTextDirection;
+  @internal
+  set defaultTextDirection(TextDirection value) {
+    assert(value != null);
+    if (_textPainter.defaultTextDirection == value) {
+      return;
+    }
+    _textPainter.defaultTextDirection = value;
+    markNeedsLayout();
+    markNeedsSemanticsUpdate();
+  }
+
+  /// The paragraph base direction resolved by the engine after layout.
+  ///
+  /// Unlike [textDirection] (which returns the user-supplied value, possibly
+  /// `null` for `TextDirection.Auto`), this getter returns the actual
+  /// direction Skia used to lay out the glyphs: the explicit value when
+  /// [textDirection] was set, or the first-strong-character scan result
+  /// for `TextDirection.Auto`.
+  ///
+  /// Falls back through [defaultTextDirection]. Always returns a non-null
+  /// value once [layout] has been performed.
+  TextDirection get resolvedDirection =>
+      _textPainter.resolvedDirection ?? defaultTextDirection;
 
   /// Used by this renderer's internal [TextPainter] to select a locale-specific
   /// font.
@@ -1424,7 +1456,13 @@ class RenderEditable extends RenderBox
   ) {
     assert(_semanticsInfo != null && _semanticsInfo!.isNotEmpty);
     final newChildren = <SemanticsNode>[];
-    TextDirection currentDirection = textDirection;
+    // When the paragraph direction is Auto, fall back to LTR for
+    // semantics direction reporting. The actual rendered direction is
+    // resolved at the engine layer; this only affects the accessibility
+    // tree. Use the engine-resolved direction (with fallback through
+    // `defaultTextDirection` and LTR) so that an empty content paragraph
+    // under a system RTL locale still reports RTL.
+    TextDirection? currentDirection = textDirection ?? resolvedDirection;
     Rect currentRect;
     var ordinal = 0.0;
     var start = 0;
@@ -1453,7 +1491,11 @@ class RenderEditable extends RenderBox
         child = childAfter(child!);
         placeholderIndex += 1;
       } else {
-        final initialDirection = currentDirection;
+        // `currentDirection` is `TextDirection?` to support
+        // `TextDirection.Auto`. Fall back to LTR for semantics
+        // direction reporting; this only affects the accessibility
+        // tree.
+        final TextDirection initialDirection = currentDirection ?? TextDirection.ltr;
         final List<ui.TextBox> rects = _textPainter.getBoxesForSelection(selection);
         if (rects.isEmpty) {
           continue;

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -337,7 +337,8 @@ class RenderParagraph extends RenderBox
   RenderParagraph(
     InlineSpan text, {
     TextAlign textAlign = TextAlign.start,
-    required TextDirection textDirection,
+    TextDirection? textDirection,
+    required TextDirection defaultTextDirection,
     bool softWrap = true,
     TextOverflow overflow = TextOverflow.clip,
     @Deprecated(
@@ -380,6 +381,7 @@ class RenderParagraph extends RenderBox
          textWidthBasis: textWidthBasis,
          textHeightBehavior: textHeightBehavior,
        ) {
+    _textPainter.defaultTextDirection = defaultTextDirection;
     addAll(children);
     this.registrar = registrar;
   }
@@ -403,6 +405,7 @@ class RenderParagraph extends RenderBox
       ..text = _textPainter.text
       ..textAlign = _textPainter.textAlign
       ..textDirection = _textPainter.textDirection
+      ..defaultTextDirection = _textPainter.defaultTextDirection
       ..textScaler = _textPainter.textScaler
       ..maxLines = _textPainter.maxLines
       ..ellipsis = _textPainter.ellipsis
@@ -593,13 +596,56 @@ class RenderParagraph extends RenderBox
   /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
   /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
-  TextDirection get textDirection => _textPainter.textDirection!;
+  ///
+  /// May be `null` if the paragraph was constructed with
+  /// [TextDirection.Auto] semantics. In that case, the engine resolves
+  /// the direction from the text content at layout time.
+  TextDirection? get textDirection => _textPainter.textDirection;
 
-  set textDirection(TextDirection value) {
+  set textDirection(TextDirection? value) {
     if (_textPainter.textDirection == value) {
       return;
     }
     _textPainter.textDirection = value;
+    markNeedsLayout();
+  }
+
+  /// The paragraph base direction resolved by the engine after layout.
+  ///
+  /// Unlike [textDirection] (which returns the user-supplied value, possibly
+  /// `null` for `TextDirection.Auto`), this getter returns the actual
+  /// direction Skia used to lay out the glyphs: the explicit value when
+  /// [textDirection] was set, or the first-strong-character scan result
+  /// for `TextDirection.Auto`.
+  ///
+  /// Use this when you need the *resolved* direction (e.g. for selection
+  /// handle placement, drag-offset adjustment, bidi caret flipping) — it
+  /// is always consistent with what `TextPainter.getOffsetForCaret` and
+  /// other caret calculations use.
+  ///
+  /// When the engine has not yet resolved a direction (e.g. before
+  /// [layout] was called, or when the underlying engine binding is too
+  /// old to expose direction resolution), falls back through
+  /// [defaultTextDirection] (the ambient `Directionality.of(context)`
+  /// direction captured at render-object attach time). Always returns a
+  /// non-null value once [layout] has been performed.
+  TextDirection get resolvedDirection =>
+      _textPainter.resolvedDirection ?? defaultTextDirection;
+
+  /// The default paragraph direction, supplied as the ambient
+  /// `Directionality.of(context)` value when the render object was
+  /// created. Forwarded to the engine as a fallback direction when
+  /// [textDirection] is `null` and the first-strong-character scan
+  /// finds no strong character.
+  @internal
+  TextDirection get defaultTextDirection => _textPainter.defaultTextDirection;
+  @internal
+  set defaultTextDirection(TextDirection value) {
+    assert(value != null);
+    if (_textPainter.defaultTextDirection == value) {
+      return;
+    }
+    _textPainter.defaultTextDirection = value;
     markNeedsLayout();
   }
 
@@ -995,7 +1041,12 @@ class RenderParagraph extends RenderBox
             locale: locale,
           )..layout();
           if (didOverflowWidth) {
-            final (double fadeStart, double fadeEnd) = switch (textDirection) {
+            // When [textDirection] is null (Auto), fall back to LTR for
+            // the fade geometry. The actual paragraph direction is
+            // resolved at the engine layer at layout time; this only
+            // affects the gradient stops for the overflow fade.
+            final TextDirection fadeDirection = textDirection ?? resolvedDirection;
+            final (double fadeStart, double fadeEnd) = switch (fadeDirection) {
               TextDirection.rtl => (fadeSizePainter.width, 0.0),
               TextDirection.ltr => (size.width - fadeSizePainter.width, size.width),
             };
@@ -1350,7 +1401,12 @@ class RenderParagraph extends RenderBox
   ) {
     assert(_semanticsInfo != null && _semanticsInfo!.isNotEmpty);
     final newChildren = <SemanticsNode>[];
-    TextDirection currentDirection = textDirection;
+    // `textDirection` is nullable to support `TextDirection.Auto`.
+    // Use the engine-resolved direction (with fallback through
+    // `defaultTextDirection` and LTR) so the semantics tree reflects the
+    // direction the paragraph is actually rendered in, even for empty
+    // paragraphs in a system RTL locale.
+    TextDirection currentDirection = textDirection ?? resolvedDirection;
     Rect currentRect;
     var ordinal = 0.0;
     var start = 0;
@@ -1560,7 +1616,14 @@ class _SelectableFragment
     final Offset endOffsetInParagraphCoordinates = selectionStart == selectionEnd
         ? startOffsetInParagraphCoordinates
         : paragraph._getOffsetForPosition(_textSelectionEnd!);
-    final flipHandles = isReversed != (TextDirection.rtl == paragraph.textDirection);
+    // In Auto mode, [paragraph.textDirection] is null. Use
+    // [paragraph.resolvedDirection] to pick up the engine-resolved
+    // direction (the result of the first-strong-character scan), so
+    // that selection handles flip correctly even when [TextDirection.Auto]
+    // resolves to RTL (e.g. when the paragraph contains Arabic, Hebrew,
+    // or Uyghur text).
+    final bool flipHandles =
+        isReversed != (TextDirection.rtl == paragraph.resolvedDirection);
     final selection = TextSelection(baseOffset: selectionStart, extentOffset: selectionEnd);
     final selectionRects = <Rect>[];
     for (final TextBox textBox in paragraph.getBoxesForSelection(selection)) {
@@ -1917,7 +1980,7 @@ class _SelectableFragment
     final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
       _rect,
       localPosition,
-      direction: paragraph.textDirection,
+      direction: paragraph.resolvedDirection,
     );
 
     final TextPosition position = paragraph.getPositionForOffset(adjustedOffset);
@@ -1990,7 +2053,7 @@ class _SelectableFragment
     final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
       _rect,
       localPosition,
-      direction: paragraph.textDirection,
+      direction: paragraph.resolvedDirection,
     );
 
     final TextPosition position = _clampTextPosition(
@@ -2495,7 +2558,7 @@ class _SelectableFragment
         final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
           originParagraph.paintBounds,
           originParagraphLocalPosition,
-          direction: paragraph.textDirection,
+          direction: originParagraph.resolvedDirection,
         );
         final TextPosition adjustedPositionRelativeToOriginParagraph = originParagraph
             .getPositionForOffset(adjustedOffset);
@@ -2747,7 +2810,7 @@ class _SelectableFragment
         final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
           originParagraph.paintBounds,
           originParagraphLocalPosition,
-          direction: paragraph.textDirection,
+          direction: originParagraph.resolvedDirection,
         );
         final TextPosition adjustedPositionRelativeToOriginParagraph = originParagraph
             .getPositionForOffset(adjustedOffset);
@@ -2905,12 +2968,12 @@ class _SelectableFragment
     final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
       _rect,
       localPosition,
-      direction: paragraph.textDirection,
+      direction: paragraph.resolvedDirection,
     );
     final Offset adjustedOffsetRelativeToParagraph = SelectionUtils.adjustDragOffset(
       paragraph.paintBounds,
       localPosition,
-      direction: paragraph.textDirection,
+      direction: paragraph.resolvedDirection,
     );
 
     final TextPosition position = paragraph.getPositionForOffset(adjustedOffset);

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6499,8 +6499,14 @@ class RichText extends MultiChildRenderObjectWidget {
   /// The [maxLines] property may be null (and indeed defaults to null), but if
   /// it is not null, it must be greater than zero.
   ///
-  /// The [textDirection], if null, defaults to the ambient [Directionality],
-  /// which in that case must not be null.
+  // / The [textDirection], if null, is forwarded as-is to the engine
+  // / layer. The engine then resolves the paragraph direction by
+  // / scanning the actual text content via the first-strong-character
+  // / rule.
+  ///
+  /// To opt back into the previous behavior (fall back to the ambient
+  /// [Directionality]), explicitly pass the resolved value at the
+  /// call site (e.g. `Text(text, textDirection: Directionality.of(context))`).
   RichText({
     super.key,
     required this.text,
@@ -6562,8 +6568,11 @@ class RichText extends MultiChildRenderObjectWidget {
   /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
-  /// Defaults to the ambient [Directionality], if any. If there is no ambient
-  /// [Directionality], then this must not be null.
+  /// When `null`, the engine resolves the paragraph direction by scanning
+  /// the text content (first-strong-character rule). To opt into the
+  /// previous behavior of falling back to the ambient [Directionality],
+  /// explicitly pass the resolved value (e.g.
+  /// `textDirection: Directionality.of(context)`).
   final TextDirection? textDirection;
 
   /// Whether the text should break at soft line breaks.
@@ -6636,11 +6645,12 @@ class RichText extends MultiChildRenderObjectWidget {
 
   @override
   RenderParagraph createRenderObject(BuildContext context) {
-    assert(textDirection != null || debugCheckHasDirectionality(context));
     return RenderParagraph(
       text,
       textAlign: textAlign,
-      textDirection: textDirection ?? Directionality.of(context),
+      textDirection: textDirection,
+      defaultTextDirection:
+          Directionality.maybeOf(context) ?? TextDirection.ltr,
       softWrap: softWrap,
       overflow: overflow,
       textScaler: textScaler,
@@ -6657,11 +6667,12 @@ class RichText extends MultiChildRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, RenderParagraph renderObject) {
-    assert(textDirection != null || debugCheckHasDirectionality(context));
     renderObject
       ..text = text
       ..textAlign = textAlign
-      ..textDirection = textDirection ?? Directionality.of(context)
+      ..textDirection = textDirection
+      ..defaultTextDirection =
+          Directionality.maybeOf(context) ?? TextDirection.ltr
       ..softWrap = softWrap
       ..overflow = overflow
       ..textScaler = textScaler

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1146,7 +1146,10 @@ class EditableText extends StatefulWidget {
   /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
-  /// Defaults to the ambient [Directionality], if any.
+  /// When `null`, the engine resolves the paragraph direction by scanning
+  /// the text content (first-strong-character rule). To opt into the
+  /// previous behavior of falling back to the ambient [Directionality],
+  /// explicitly pass the resolved value at the call site.
   /// {@endtemplate}
   final TextDirection? textDirection;
 
@@ -3594,7 +3597,12 @@ class EditableTextState extends State<EditableText>
       fontFamily: _style.fontFamily,
       fontSize: _style.fontSize,
       fontWeight: _style.fontWeight,
-      textDirection: _textDirection,
+      // `setStyle` requires a non-null textDirection; in Auto
+      // mode fall back to the resolved direction (with fallback
+      // through `defaultTextDirection` and LTR) for the platform
+      // text input style.
+      textDirection: _textDirection ?? renderEditable?.resolvedDirection
+          ?? Directionality.of(context),
       textAlign: widget.textAlign,
       letterSpacing: letterSpacingOverride ?? _style.letterSpacing,
       wordSpacing: wordSpacingOverride ?? _style.wordSpacing,
@@ -5131,7 +5139,12 @@ class EditableTextState extends State<EditableText>
     _textInputConnection!.setCaretRect(caretRect);
   }
 
-  TextDirection get _textDirection => widget.textDirection ?? Directionality.of(context);
+  // Forwarded as-is. When `widget.textDirection` is `null`, the engine
+  // resolves the paragraph direction from the text content (first-strong
+  // character rule). The previous fallback to `Directionality.of(context)`
+  // has been removed; callers that want that behavior must resolve the
+  // value at the call site.
+  TextDirection? get _textDirection => widget.textDirection;
 
   /// The renderer for this widget's descendant.
   ///
@@ -6122,7 +6135,7 @@ class _Editable extends MultiChildRenderObjectWidget {
     this.selectionColor,
     required this.textScaler,
     required this.textAlign,
-    required this.textDirection,
+    this.textDirection,
     this.locale,
     required this.obscuringCharacter,
     required this.obscureText,
@@ -6162,7 +6175,7 @@ class _Editable extends MultiChildRenderObjectWidget {
   final Color? selectionColor;
   final TextScaler textScaler;
   final TextAlign textAlign;
-  final TextDirection textDirection;
+  final TextDirection? textDirection;
   final Locale? locale;
   final String obscuringCharacter;
   final bool obscureText;
@@ -6204,6 +6217,8 @@ class _Editable extends MultiChildRenderObjectWidget {
       textScaler: textScaler,
       textAlign: textAlign,
       textDirection: textDirection,
+      defaultTextDirection:
+          Directionality.maybeOf(context) ?? TextDirection.ltr,
       locale: locale ?? Localizations.maybeLocaleOf(context),
       selection: value.selection,
       offset: offset,
@@ -6248,6 +6263,8 @@ class _Editable extends MultiChildRenderObjectWidget {
       ..textScaler = textScaler
       ..textAlign = textAlign
       ..textDirection = textDirection
+      ..defaultTextDirection =
+          Directionality.maybeOf(context) ?? TextDirection.ltr
       ..locale = locale ?? Localizations.maybeLocaleOf(context)
       ..selection = value.selection
       ..offset = offset
@@ -6301,7 +6318,7 @@ class _ScribbleCacheKey {
   });
 
   final TextAlign textAlign;
-  final TextDirection textDirection;
+  final TextDirection? textDirection;
   final TextScaler textScaler;
   final TextHeightBehavior? textHeightBehavior;
   final Locale? locale;

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -615,7 +615,11 @@ class Text extends StatelessWidget {
   /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
-  /// Defaults to the ambient [Directionality], if any.
+  /// When `null`, the engine resolves the paragraph direction by scanning
+  /// the text content (first-strong-character rule). To opt into the
+  /// previous behavior of falling back to the ambient [Directionality],
+  /// explicitly pass the resolved value (e.g.
+  /// `textDirection: Directionality.of(context)`).
   final TextDirection? textDirection;
 
   /// Used to select a font when the same Unicode character can
@@ -623,8 +627,6 @@ class Text extends StatelessWidget {
   ///
   /// It's rarely necessary to set this property. By default its value
   /// is inherited from the enclosing app with `Localizations.localeOf(context)`.
-  ///
-  /// See [RenderParagraph.locale] for more information.
   final Locale? locale;
 
   /// Whether the text should break at soft line breaks.
@@ -779,8 +781,7 @@ class Text extends StatelessWidget {
     } else {
       result = RichText(
         textAlign: textAlign ?? defaultTextStyle.textAlign ?? TextAlign.start,
-        textDirection:
-            textDirection, // RichText uses Directionality.of to obtain a default if this is null.
+        textDirection: textDirection, // Forwarded as-is; null triggers engine-level auto-resolve.
         locale: locale, // RichText uses Localizations.localeOf to obtain a default if this is null
         softWrap: softWrap ?? defaultTextStyle.softWrap,
         overflow: overflow ?? effectiveTextStyle?.overflow ?? defaultTextStyle.overflow,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -548,16 +548,23 @@ class TextSelectionOverlay {
   }
 
   void _updateSelectionOverlay() {
+    // `renderObject.textDirection` is nullable to support
+    // `TextDirection.Auto` (resolved at the engine layer).
+    // Use the engine-resolved direction (which falls
+    // back through `defaultTextDirection` and LTR) so the handle
+    // orientation tracks the actual rendered direction, not a hard-
+    // coded LTR default.
+    final TextDirection direction = renderObject.textDirection ?? renderObject.resolvedDirection;
     _selectionOverlay
       // Update selection handle metrics.
       ..startHandleType = _chooseType(
-        renderObject.textDirection,
+        direction,
         TextSelectionHandleType.left,
         TextSelectionHandleType.right,
       )
       ..lineHeightAtStart = _getStartGlyphHeight()
       ..endHandleType = _chooseType(
-        renderObject.textDirection,
+        direction,
         TextSelectionHandleType.right,
         TextSelectionHandleType.left,
       )


### PR DESCRIPTION
feat: add support for automatically switching text to RTL or LTR based on first character typed

Prior to this change, every Flutter text-bearing widget that accepts a `TextDirection` parameter required the application to resolve the direction explicitly. `TextPainter` and `RenderParagraph`/`RenderEditable` both hard-asserted that `textDirection` was non-null at layout time, and the framework transparently fell back to the ambient
`Directionality.of(context)` whenever the caller passed `null`. This change adds support for automatically switching text direction. The engine is expected to scan the actual text content and pick a direction based on the **first strong-direction Unicode character** (the same rule used by the CSS `unicode-bidi: plaintext` value and the W3C HTML5 "first strong character" algorithm). This patch implements that semantics end-to-end, from the Skia/txt engine layer up through the framework's `Text`/`RichText`/ `EditableText` widgets, without changing the default behavior for callers that pass an explicit direction.

1. The widget layer forwards `widget.textDirection` as-is (no longer forces a fallback to `Directionality.of`).
2. The render objects forward both the nullable `textDirection` and a separate non-null `defaultTextDirection` to the `TextPainter`.
3. `TextPainter._layout` builds the paragraph and reads back the engine-resolved direction via the new `paragraph.direction` getter.
4. The engine (`ParagraphBuilderSkia`) records every builder op, builds the paragraph once tentatively, calls `ResolveTextDirectionByContent(accumulated_text)`, and — if the resolved direction differs from the tentative one — rebuilds the paragraph with the corrected direction and replays the recorded ops.
5. Framework consumers that previously used `paragraph.textDirection` for caret/selection/fade purposes now use `paragraph.resolvedDirection`, which never returns `null` post-layout.

add support for #91738

test:

https://github.com/user-attachments/assets/13afdb8f-793c-4391-a0d3-1e3c49ad9bd8

https://github.com/user-attachments/assets/c9590a01-c45f-4c80-adc1-69f8edd06f9f

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
