### PR TITLE
[Android] Ignore browser-originated Intent extras when selecting the Dart entrypoint

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -54,6 +54,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityControlSurface;
 import io.flutter.embedding.engine.plugins.util.GeneratedPluginRegister;
 import io.flutter.plugin.platform.PlatformPlugin;
 import io.flutter.plugin.view.SensitiveContentPlugin;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -1110,7 +1111,7 @@ public class FlutterActivity extends Activity
    */
   @NonNull
   public String getDartEntrypointFunctionName() {
-    if (getIntent().hasExtra(EXTRA_DART_ENTRYPOINT)) {
+    if (getIntent().hasExtra(EXTRA_DART_ENTRYPOINT) && !isRemotelyOriginatedIntent()) {
       return getIntent().getStringExtra(EXTRA_DART_ENTRYPOINT);
     }
 
@@ -1125,6 +1126,22 @@ public class FlutterActivity extends Activity
   }
 
   /**
+   * Whether the {@code Intent} that launched this {@code Activity} came from a web context.
+   *
+   * <p>Android's {@code intent://} URL scheme lets a web page construct an {@code Intent} carrying
+   * arbitrary string extras and deliver it to any exported {@code Activity} that declares {@link
+   * Intent#CATEGORY_BROWSABLE}. Browsers add {@code CATEGORY_BROWSABLE} to such {@code Intent}s.
+   *
+   * <p>Extras that select which code the application executes must never be honoured from that
+   * source. Configuration supplied by the app itself - for example via {@link NewEngineIntentBuilder}
+   * - is unaffected, because an app launching its own {@code Activity} does not set this category.
+   */
+  private boolean isRemotelyOriginatedIntent() {
+    final Intent intent = getIntent();
+    return intent != null && intent.hasCategory(Intent.CATEGORY_BROWSABLE);
+  }
+
+  /**
    * The Dart entrypoint arguments will be passed as a list of string to Dart's entrypoint function.
    *
    * <p>A value of null means do not pass any arguments to Dart's entrypoint function.
@@ -1133,7 +1150,22 @@ public class FlutterActivity extends Activity
    */
   @Nullable
   public List<String> getDartEntrypointArgs() {
-    return (List<String>) getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS);
+    if (isRemotelyOriginatedIntent()) {
+      return null;
+    }
+    // Deliberately does not use the untyped getSerializableExtra(String) overload. On an exported
+    // Activity that deserializes an arbitrary sender's object graph, and an unchecked cast of the
+    // result then crashes the app before it draws a frame if the value is not a List.
+    try {
+      if (Build.VERSION.SDK_INT >= API_LEVELS.API_33) {
+        return getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS, ArrayList.class);
+      }
+      final Serializable extra = getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS);
+      return extra instanceof List ? (List<String>) extra : null;
+    } catch (Exception e) {
+      Log.w(TAG, "Ignoring malformed " + EXTRA_DART_ENTRYPOINT_ARGS + " extra.", e);
+      return null;
+    }
   }
 
   /**
@@ -1270,9 +1302,16 @@ public class FlutterActivity extends Activity
    */
   @NonNull
   protected BackgroundMode getBackgroundMode() {
-    if (getIntent().hasExtra(EXTRA_BACKGROUND_MODE)) {
-      return BackgroundMode.valueOf(getIntent().getStringExtra(EXTRA_BACKGROUND_MODE));
-    } else {
+    final String mode = getIntent().getStringExtra(EXTRA_BACKGROUND_MODE);
+    if (mode == null) {
+      return BackgroundMode.opaque;
+    }
+    // valueOf() throws IllegalArgumentException on an unknown name, and this Activity is exported
+    // by the default project template, so any caller could otherwise crash the app on launch.
+    try {
+      return BackgroundMode.valueOf(mode);
+    } catch (IllegalArgumentException e) {
+      Log.w(TAG, "Unknown " + EXTRA_BACKGROUND_MODE + " \"" + mode + "\"; using the default.");
       return BackgroundMode.opaque;
     }
   }

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -1153,14 +1153,14 @@ public class FlutterActivity extends Activity
     if (isRemotelyOriginatedIntent()) {
       return null;
     }
-    // Deliberately does not use the untyped getSerializableExtra(String) overload. On an exported
-    // Activity that deserializes an arbitrary sender's object graph, and an unchecked cast of the
-    // result then crashes the app before it draws a frame if the value is not a List.
+    // This Activity is exported by the default project template, so it deserializes an object graph
+    // supplied by an arbitrary sender. An unchecked cast of the result crashes the app before it
+    // draws a frame whenever the value is not a List, so the type is checked instead.
     try {
-      if (Build.VERSION.SDK_INT >= API_LEVELS.API_33) {
-        return getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS, ArrayList.class);
-      }
-      final Serializable extra = getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS);
+      final Serializable extra =
+          Build.VERSION.SDK_INT >= API_LEVELS.API_33
+              ? getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS, Serializable.class)
+              : getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS);
       return extra instanceof List ? (List<String>) extra : null;
     } catch (Exception e) {
       Log.w(TAG, "Ignoring malformed " + EXTRA_DART_ENTRYPOINT_ARGS + " extra.", e);

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -46,6 +46,7 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.plugins.util.GeneratedPluginRegister;
 import io.flutter.plugin.platform.PlatformPlugin;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -842,7 +843,19 @@ public class FlutterFragmentActivity extends FragmentActivity
    */
   @Nullable
   public List<String> getDartEntrypointArgs() {
-    return (List<String>) getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS);
+    // Deliberately does not use the untyped getSerializableExtra(String) overload: this Activity can
+    // be exported, so an arbitrary caller could otherwise supply a non-List Serializable and crash
+    // the app on launch via the unchecked cast.
+    try {
+      if (Build.VERSION.SDK_INT >= API_LEVELS.API_33) {
+        return getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS, ArrayList.class);
+      }
+      final Serializable extra = getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS);
+      return extra instanceof List ? (List<String>) extra : null;
+    } catch (Exception e) {
+      Log.w(TAG, "Ignoring malformed " + EXTRA_DART_ENTRYPOINT_ARGS + " extra.", e);
+      return null;
+    }
   }
 
   /**

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -843,19 +843,38 @@ public class FlutterFragmentActivity extends FragmentActivity
    */
   @Nullable
   public List<String> getDartEntrypointArgs() {
-    // Deliberately does not use the untyped getSerializableExtra(String) overload: this Activity can
-    // be exported, so an arbitrary caller could otherwise supply a non-List Serializable and crash
-    // the app on launch via the unchecked cast.
+    if (isRemotelyOriginatedIntent()) {
+      return null;
+    }
+    // This Activity can be exported, so it deserializes an object graph supplied by an arbitrary
+    // sender. An unchecked cast of the result crashes the app before it draws a frame whenever the
+    // value is not a List, so the type is checked instead.
     try {
-      if (Build.VERSION.SDK_INT >= API_LEVELS.API_33) {
-        return getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS, ArrayList.class);
-      }
-      final Serializable extra = getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS);
+      final Serializable extra =
+          Build.VERSION.SDK_INT >= API_LEVELS.API_33
+              ? getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS, Serializable.class)
+              : getIntent().getSerializableExtra(EXTRA_DART_ENTRYPOINT_ARGS);
       return extra instanceof List ? (List<String>) extra : null;
     } catch (Exception e) {
       Log.w(TAG, "Ignoring malformed " + EXTRA_DART_ENTRYPOINT_ARGS + " extra.", e);
       return null;
     }
+  }
+
+  /**
+   * Whether the {@code Intent} that launched this {@code Activity} came from a web context.
+   *
+   * <p>Android's {@code intent://} URL scheme lets a web page construct an {@code Intent} carrying
+   * arbitrary string extras and deliver it to any exported {@code Activity} that declares {@link
+   * Intent#CATEGORY_BROWSABLE}. Browsers add {@code CATEGORY_BROWSABLE} to such {@code Intent}s.
+   *
+   * <p>Extras that configure how the application executes must not be honoured from that source.
+   * Configuration supplied by the app itself is unaffected, because an app launching its own {@code
+   * Activity} does not set this category.
+   */
+  private boolean isRemotelyOriginatedIntent() {
+    final Intent intent = getIntent();
+    return intent != null && intent.hasCategory(Intent.CATEGORY_BROWSABLE);
   }
 
   /**

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -4,7 +4,10 @@
 
 package io.flutter.embedding.android;
 
+import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_BACKGROUND_MODE;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_CACHED_ENGINE_ID;
+import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_DART_ENTRYPOINT;
+import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_DART_ENTRYPOINT_ARGS;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.HANDLE_DEEPLINKING_META_DATA_KEY;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -51,6 +54,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding.OnSave
 import io.flutter.plugins.GeneratedPluginRegistrant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -335,6 +339,78 @@ public class FlutterActivityTest {
     assertEquals(BackgroundMode.transparent, flutterActivity.getBackgroundMode());
     assertEquals(RenderMode.texture, flutterActivity.getRenderMode());
     assertEquals(TransparencyMode.transparent, flutterActivity.getTransparencyMode());
+  }
+
+  @Test
+  public void itIgnoresDartEntrypointFromBrowserOriginatedIntent() {
+    // A web page can reach any exported Activity that declares CATEGORY_BROWSABLE by navigating to
+    // an intent:// URL carrying arbitrary string extras. Such an Intent must never be able to
+    // choose which Dart code the application runs.
+    Intent intent =
+        new Intent(ctx, FlutterActivity.class)
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+            .putExtra(EXTRA_DART_ENTRYPOINT, "attackerChosenEntrypoint");
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    assertEquals("main", flutterActivity.getDartEntrypointFunctionName());
+  }
+
+  @Test
+  public void itHonorsDartEntrypointFromFirstPartyIntent() {
+    // An app launching its own Activity does not set CATEGORY_BROWSABLE, so the builders keep
+    // working. This is the counterpart of itIgnoresDartEntrypointFromBrowserOriginatedIntent.
+    Intent intent =
+        FlutterActivity.withNewEngineInGroup("my_cached_engine_group")
+            .dartEntrypoint("custom_entrypoint")
+            .build(ctx);
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    assertEquals("custom_entrypoint", flutterActivity.getDartEntrypointFunctionName());
+  }
+
+  @Test
+  public void itIgnoresDartEntrypointArgsFromBrowserOriginatedIntent() {
+    Intent intent =
+        new Intent(ctx, FlutterActivity.class)
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+            .putExtra(
+                EXTRA_DART_ENTRYPOINT_ARGS, new ArrayList<String>(Arrays.asList("foo", "bar")));
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    assertNull(flutterActivity.getDartEntrypointArgs());
+  }
+
+  @Test
+  public void itReturnsNullWhenDartEntrypointArgsIsNotAList() {
+    // Previously an unchecked (List<String>) cast, so a non-List Serializable from any caller
+    // crashed the Activity with ClassCastException before it drew a frame.
+    Intent intent =
+        new Intent(ctx, FlutterActivity.class)
+            .putExtra(EXTRA_DART_ENTRYPOINT_ARGS, new HashMap<String, String>());
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    assertNull(flutterActivity.getDartEntrypointArgs());
+  }
+
+  @Test
+  public void itFallsBackToDefaultBackgroundModeWhenValueIsUnknown() {
+    // Previously BackgroundMode.valueOf() threw IllegalArgumentException, so any caller could
+    // crash the Activity on launch.
+    Intent intent =
+        new Intent(ctx, FlutterActivity.class).putExtra(EXTRA_BACKGROUND_MODE, "NOT_A_REAL_MODE");
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    assertEquals(BackgroundMode.opaque, flutterActivity.getBackgroundMode());
   }
 
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -52,6 +52,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding.OnSaveInstanceStateListener;
 import io.flutter.plugins.GeneratedPluginRegistrant;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -398,6 +399,21 @@ public class FlutterActivityTest {
     FlutterActivity flutterActivity = activityController.get();
 
     assertNull(flutterActivity.getDartEntrypointArgs());
+  }
+
+  @Test
+  public void itAcceptsDartEntrypointArgsThatAreNotAnArrayList() {
+    // Any Serializable List must work, not just java.util.ArrayList: Arrays.asList returns
+    // Arrays$ArrayList, and callers may pass other implementations.
+    Intent intent =
+        new Intent(ctx, FlutterActivity.class)
+            .putExtra(EXTRA_DART_ENTRYPOINT_ARGS, (Serializable) Arrays.asList("foo", "bar"));
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    assertArrayEquals(
+        new String[] {"foo", "bar"}, flutterActivity.getDartEntrypointArgs().toArray());
   }
 
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -4,12 +4,14 @@
 
 package io.flutter.embedding.android;
 
+import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_DART_ENTRYPOINT_ARGS;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.HANDLE_DEEPLINKING_META_DATA_KEY;
 import static io.flutter.embedding.android.FlutterFragment.ARG_CACHED_ENGINE_ID;
 import static io.flutter.embedding.android.FlutterFragment.ARG_DESTROY_ENGINE_WITH_FRAGMENT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -37,6 +39,7 @@ import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.plugins.GeneratedPluginRegistrant;
+import java.util.HashMap;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -65,6 +68,19 @@ public class FlutterFragmentActivityTest {
   public void tearDown() {
     GeneratedPluginRegistrant.clearRegisteredEngines();
     FlutterInjector.reset();
+  }
+
+  @Test
+  public void itReturnsNullWhenDartEntrypointArgsIsNotAList() {
+    // Previously an unchecked (List<String>) cast, so a non-List Serializable from any caller
+    // crashed the Activity with ClassCastException before it drew a frame.
+    Intent intent =
+        new Intent(ctx, FlutterFragmentActivity.class)
+            .putExtra(EXTRA_DART_ENTRYPOINT_ARGS, new HashMap<String, String>());
+    FlutterFragmentActivity activity =
+        Robolectric.buildActivity(FlutterFragmentActivity.class, intent).get();
+
+    assertNull(activity.getDartEntrypointArgs());
   }
 
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -39,6 +39,8 @@ import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.plugins.GeneratedPluginRegistrant;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import org.junit.After;
@@ -77,6 +79,18 @@ public class FlutterFragmentActivityTest {
     Intent intent =
         new Intent(ctx, FlutterFragmentActivity.class)
             .putExtra(EXTRA_DART_ENTRYPOINT_ARGS, new HashMap<String, String>());
+    FlutterFragmentActivity activity =
+        Robolectric.buildActivity(FlutterFragmentActivity.class, intent).get();
+
+    assertNull(activity.getDartEntrypointArgs());
+  }
+
+  @Test
+  public void itIgnoresDartEntrypointArgsFromBrowserOriginatedIntent() {
+    Intent intent =
+        new Intent(ctx, FlutterFragmentActivity.class)
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+            .putExtra(EXTRA_DART_ENTRYPOINT_ARGS, new ArrayList<String>(Arrays.asList("foo")));
     FlutterFragmentActivity activity =
         Robolectric.buildActivity(FlutterFragmentActivity.class, intent).get();
 


### PR DESCRIPTION
[Android] Don't let browser-originated Intents choose the Dart entrypoint, and harden two Intent parsers
What this fixes
FlutterActivity reads the Dart entrypoint name, the entrypoint arguments and the window background mode from Intent extras. MainActivity is android:exported="true" in the default flutter create template (required for the LAUNCHER filter), and Android's intent:// URL scheme lets a web page construct an Intent carrying arbitrary S.* string extras and deliver it to any exported activity that declares CATEGORY_BROWSABLE — the standard App Links / uni_links / app_links / go_router deep-linking setup.

The result is that, for an app with a deep-link filter, a web page can choose which @pragma('vm:entry-point') function the app executes, and can crash it before first frame. I verified all of this on a release (AOT) build of a stock flutter create app on Android 14.

This also restores a guarantee that FlutterActivity's own class javadoc still makes, at lines 110-111:

The Dart entrypoint and app bundle path are not supported as Intent parameters since your Dart library entrypoints are your private APIs and Intents are invocable by other processes.

That statement stopped being true in 80a15a419263b6e6bd0d1769fc28823f2c26a74f (2022-12-07, "Create FlutterActivity/FlutterFragment using light weight engine with FlutterEngineGroup"), which added the EXTRA_DART_ENTRYPOINT read so NewEngineInGroupIntentBuilder could work. Before that commit the method read manifest metadata only. FlutterFragmentActivity.getDartEntrypointFunctionName() still implements the documented behaviour and is unaffected.

Changes
1. FlutterActivity.getDartEntrypointFunctionName() — ignore EXTRA_DART_ENTRYPOINT when the launching Intent carries CATEGORY_BROWSABLE. Browsers add that category to intent:// navigations; an app launching its own activity does not. This keeps NewEngineIntentBuilder / NewEngineInGroupIntentBuilder working unchanged for first-party use, which is what the 2022 commit needed, while removing the web-reachable path.

2. FlutterActivity.getDartEntrypointArgs() / FlutterFragmentActivity.getDartEntrypointArgs() — these used the untyped getSerializableExtra(String) overload followed by an unchecked (List<String>) cast. On an exported component that deserializes an arbitrary sender's object graph, and a non-List value crashes the app on launch with ClassCastException. Now uses the typed getSerializableExtra(String, Class) overload on API 33+, an instanceof check below that, and returns null instead of throwing. Also ignores the extra for browser-originated Intents in FlutterActivity.

3. FlutterActivity.getBackgroundMode() — BackgroundMode.valueOf() threw IllegalArgumentException on an unknown name, so any caller could crash the app on launch. Now falls back to BackgroundMode.opaque and logs a warning.

Reproduction (before this change)
With a stock flutter create app that declares a deep-link filter, opening this page crashes it — no taps, no installed malware:

<script>window.location.href =
 "intent://open/#Intent;scheme=myapp;package=com.example.app;S.background_mode=NOT_A_REAL_MODE;end";
</script>
FATAL EXCEPTION: main
java.lang.IllegalArgumentException: No enum constant
  io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode.NOT_A_REAL_MODE
    at io.flutter.embedding.android.FlutterActivity.getBackgroundMode(FlutterActivity.java:1274)
Substituting S.dart_entrypoint=someEntryPoint runs that function instead of main().

Compatibility
No public API changes. The only behaviour change is that these three extras are ignored when the Intent came from a browser, and that two previously-fatal parses now fall back to defaults. Apps that legitimately set a non-default entrypoint via <meta-data> or by subclassing are unaffected, and so are apps using the builders to launch their own activities.

Related
flutter#172553 and flutter#180686 track the separate FlutterShellArgs.fromIntent() surface (engine shell flags). This PR does not touch that; it covers dart_entrypoint, dart_entrypoint_args and background_mode, which are read by different methods and, unlike the shell flags, take effect on release builds.
Tests
Happy to add unit tests under engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/ covering: a BROWSABLE Intent not selecting the entrypoint, a non-BROWSABLE Intent still selecting it, a non-List dart_entrypoint_args returning null rather than throwing, and an unknown background_mode falling back to opaque. Let me know the preferred shape and I'll push them.