### PR TITLE
ci: mac verify binaries still has to wait on linux_host_engine

### DIFF
--- a/.github/workflows/mac-verify-binaries.yml
+++ b/.github/workflows/mac-verify-binaries.yml
@@ -46,7 +46,7 @@ jobs:
         uses: ./.github/actions/wait-for-engine-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          check-name: 'Mac mac_host_engine'
+          check-name: 'Mac mac_host_engine,Linux linux_host_engine'
 
       - uses: ./.github/actions/composite-flutter-setup
 


### PR DESCRIPTION
The `Linux linux_host_engine` builds the required engine stamp file; this is required for the tool to work correctly... without this extra wait, the workflow races mac builds vs linux builds.