### PR TITLE
Migrates the platform_channel example to material_ui

### DIFF
--- a/dev/bots/check_examples_cross_imports.dart
+++ b/dev/bots/check_examples_cross_imports.dart
@@ -593,7 +593,6 @@ class ExamplesCrossImportChecker {
     'examples/multiple_windows/lib/app/window_settings_dialog.dart',
     'examples/multiple_windows/lib/main.dart',
     'examples/multiple_windows/test/multiple_windows_test.dart',
-    'examples/platform_channel/lib/main.dart',
     'examples/platform_channel_swift/lib/main.dart',
     'examples/platform_view/lib/main.dart',
     'examples/splash/lib/main.dart',

--- a/examples/platform_channel/lib/main.dart
+++ b/examples/platform_channel/lib/main.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 class PlatformChannel extends StatefulWidget {
   const PlatformChannel({super.key});

--- a/examples/platform_channel/pubspec.yaml
+++ b/examples/platform_channel/pubspec.yaml
@@ -8,6 +8,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
+  material_ui: ^0.0.2
 
 
 dev_dependencies:

--- a/examples/platform_channel/pubspec.yaml
+++ b/examples/platform_channel/pubspec.yaml
@@ -22,4 +22,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: f9g2jl
+# PUBSPEC CHECKSUM: kujv36

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -218,6 +218,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: "427360789a03b76eaf659c37131570d2fc98e381f80d55f252bd9e30f37e7126"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
   dap:
     dependency: transitive
     description:
@@ -658,6 +666,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: transitive
+    description:
+      name: material_ui
+      sha256: e1fa67393d807bd1841e5ece1ec260ed84f440ae7351e40b6406f733e4fe31cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
   meta:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Migrates the platform_channel example to import material_ui. 

Related to https://github.com/flutter/flutter/issues/190093.
I ran:
* dart fix --apply --code=migrate_design_widgets
* dart fix --apply --code=directives_ordering  

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
