### PR TITLE
[windows]: Uses offscreen MSAA when implicit msaa isn't available.

### DIFF
--- a/engine/src/flutter/shell/platform/windows/compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl.cc
@@ -106,6 +106,10 @@ bool CompositorOpenGL::CreateBackingStore(
       gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
                                    GL_RENDERBUFFER, store->depth_stencil_id);
     } else {
+      // TODO(190362): I suspect this branch is never taken since ANGLE will
+      // support offscreen MSAA. We should investigate removing this branch and
+      // the implicit MSAA branch.
+      FML_LOG(WARNING) << "Running without MSAA.";
       gl_->GenTextures(1, &store->texture_id);
       gl_->BindTexture(GL_TEXTURE_2D, store->texture_id);
       gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);

--- a/engine/src/flutter/shell/platform/windows/compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl.cc
@@ -106,10 +106,6 @@ bool CompositorOpenGL::CreateBackingStore(
       gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
                                    GL_RENDERBUFFER, store->depth_stencil_id);
     } else {
-      // TODO(190362): I suspect this branch is never taken since ANGLE will
-      // support offscreen MSAA. We should investigate removing this branch and
-      // the implicit MSAA branch.
-      FML_LOG(WARNING) << "Running without MSAA.";
       gl_->GenTextures(1, &store->texture_id);
       gl_->BindTexture(GL_TEXTURE_2D, store->texture_id);
       gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
@@ -294,6 +290,14 @@ bool CompositorOpenGL::Initialize() {
   supports_implicit_msaa_ =
       gl_->GetCapabilities()->SupportsImplicitResolvingMSAA();
   supports_offscreen_msaa_ = gl_->GetCapabilities()->SupportsOffscreenMSAA();
+
+  if (enable_impeller_ && !supports_implicit_msaa_ &&
+      !supports_offscreen_msaa_) {
+    // TODO(190362): I suspect this branch is never taken since ANGLE will
+    // support offscreen MSAA. We should investigate removing this branch and
+    // the implicit MSAA branch in the rendering functions.
+    FML_LOG(WARNING) << "Rendering without MSAA.";
+  }
 
   is_initialized_ = true;
   return true;

--- a/engine/src/flutter/shell/platform/windows/compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/windows/compositor_opengl.h"
 
 #include "GLES3/gl3.h"
+#include "flutter/fml/logging.h"
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 
@@ -18,6 +19,7 @@ constexpr uint32_t kWindowFrameBufferId = 0;
 struct FramebufferBackingStore {
   uint32_t framebuffer_id = 0;
   uint32_t texture_id = 0;
+  uint32_t color_renderbuffer_id = 0;
   uint32_t depth_stencil_id = 0;
 };
 
@@ -51,48 +53,94 @@ bool CompositorOpenGL::CreateBackingStore(
 
   auto store = std::make_unique<FramebufferBackingStore>();
 
-  gl_->GenTextures(1, &store->texture_id);
   gl_->GenFramebuffers(1, &store->framebuffer_id);
-
   gl_->BindFramebuffer(GL_FRAMEBUFFER, store->framebuffer_id);
-
-  gl_->BindTexture(GL_TEXTURE_2D, store->texture_id);
-  gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  gl_->TexImage2D(GL_TEXTURE_2D, 0, format_.general_format, config.size.width,
-                  config.size.height, 0, format_.general_format,
-                  GL_UNSIGNED_BYTE, nullptr);
-  gl_->BindTexture(GL_TEXTURE_2D, 0);
 
   if (enable_impeller_) {
     if (supports_implicit_msaa_) {
+      gl_->GenTextures(1, &store->texture_id);
+      gl_->BindTexture(GL_TEXTURE_2D, store->texture_id);
+      gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+      gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+      gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      gl_->TexImage2D(GL_TEXTURE_2D, 0, format_.sized_format, config.size.width,
+                      config.size.height, 0, format_.general_format,
+                      GL_UNSIGNED_BYTE, nullptr);
+      gl_->BindTexture(GL_TEXTURE_2D, 0);
+
       // MSAA color attachment
       gl_->FramebufferTexture2DMultisampleEXT(
           GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
           store->texture_id, 0, 4);
-    } else {
-      gl_->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                                GL_TEXTURE_2D, store->texture_id, 0);
-    }
 
-    // Impeller always requires depth/stencil attachment.
-    gl_->GenRenderbuffers(1, &store->depth_stencil_id);
-    gl_->BindRenderbuffer(GL_RENDERBUFFER, store->depth_stencil_id);
-    if (supports_implicit_msaa_) {
+      // Impeller always requires depth/stencil attachment.
+      gl_->GenRenderbuffers(1, &store->depth_stencil_id);
+      gl_->BindRenderbuffer(GL_RENDERBUFFER, store->depth_stencil_id);
       gl_->RenderbufferStorageMultisampleEXT(
           GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, config.size.width,
           config.size.height);
+      gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                   GL_RENDERBUFFER, store->depth_stencil_id);
+      gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                   GL_RENDERBUFFER, store->depth_stencil_id);
+    } else if (supports_offscreen_msaa_) {
+      // MSAA color renderbuffer attachment
+      gl_->GenRenderbuffers(1, &store->color_renderbuffer_id);
+      gl_->BindRenderbuffer(GL_RENDERBUFFER, store->color_renderbuffer_id);
+      gl_->RenderbufferStorageMultisample(
+          GL_RENDERBUFFER, 4, format_.sized_format, config.size.width,
+          config.size.height);
+      gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                   GL_RENDERBUFFER,
+                                   store->color_renderbuffer_id);
+
+      // MSAA depth/stencil attachment
+      gl_->GenRenderbuffers(1, &store->depth_stencil_id);
+      gl_->BindRenderbuffer(GL_RENDERBUFFER, store->depth_stencil_id);
+      gl_->RenderbufferStorageMultisample(
+          GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, config.size.width,
+          config.size.height);
+      gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                   GL_RENDERBUFFER, store->depth_stencil_id);
+      gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                   GL_RENDERBUFFER, store->depth_stencil_id);
     } else {
+      gl_->GenTextures(1, &store->texture_id);
+      gl_->BindTexture(GL_TEXTURE_2D, store->texture_id);
+      gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+      gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+      gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      gl_->TexImage2D(GL_TEXTURE_2D, 0, format_.sized_format, config.size.width,
+                      config.size.height, 0, format_.general_format,
+                      GL_UNSIGNED_BYTE, nullptr);
+      gl_->BindTexture(GL_TEXTURE_2D, 0);
+
+      gl_->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                GL_TEXTURE_2D, store->texture_id, 0);
+
+      gl_->GenRenderbuffers(1, &store->depth_stencil_id);
+      gl_->BindRenderbuffer(GL_RENDERBUFFER, store->depth_stencil_id);
       gl_->RenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8,
                                config.size.width, config.size.height);
+      gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                   GL_RENDERBUFFER, store->depth_stencil_id);
+      gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                   GL_RENDERBUFFER, store->depth_stencil_id);
     }
-    gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                                 GL_RENDERBUFFER, store->depth_stencil_id);
-    gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
-                                 GL_RENDERBUFFER, store->depth_stencil_id);
   } else {
+    gl_->GenTextures(1, &store->texture_id);
+    gl_->BindTexture(GL_TEXTURE_2D, store->texture_id);
+    gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    gl_->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    gl_->TexImage2D(GL_TEXTURE_2D, 0, format_.sized_format, config.size.width,
+                    config.size.height, 0, format_.general_format,
+                    GL_UNSIGNED_BYTE, nullptr);
+    gl_->BindTexture(GL_TEXTURE_2D, 0);
+
     gl_->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                               GL_TEXTURE_2D, store->texture_id, 0);
   }
@@ -118,8 +166,12 @@ bool CompositorOpenGL::CollectBackingStore(const FlutterBackingStore* store) {
       store->open_gl.framebuffer.user_data);
 
   gl_->DeleteFramebuffers(1, &user_data->framebuffer_id);
-  gl_->DeleteTextures(1, &user_data->texture_id);
-
+  if (user_data->texture_id != 0) {
+    gl_->DeleteTextures(1, &user_data->texture_id);
+  }
+  if (user_data->color_renderbuffer_id != 0) {
+    gl_->DeleteRenderbuffers(1, &user_data->color_renderbuffer_id);
+  }
   if (user_data->depth_stencil_id != 0) {
     gl_->DeleteRenderbuffers(1, &user_data->depth_stencil_id);
   }
@@ -237,6 +289,7 @@ bool CompositorOpenGL::Initialize() {
 
   supports_implicit_msaa_ =
       gl_->GetCapabilities()->SupportsImplicitResolvingMSAA();
+  supports_offscreen_msaa_ = gl_->GetCapabilities()->SupportsOffscreenMSAA();
 
   is_initialized_ = true;
   return true;

--- a/engine/src/flutter/shell/platform/windows/compositor_opengl.h
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl.h
@@ -66,6 +66,9 @@ class CompositorOpenGL : public Compositor {
   // Whether the OpenGL context supports implicit MSAA.
   bool supports_implicit_msaa_ = false;
 
+  // Whether the OpenGL context supports offscreen MSAA.
+  bool supports_offscreen_msaa_ = false;
+
   // Initialize the compositor. This must run on the raster thread.
   bool Initialize();
 

--- a/engine/src/flutter/shell/platform/windows/compositor_opengl_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/compositor_opengl_unittests.cc
@@ -104,6 +104,39 @@ const impeller::ProcTableGLES::Resolver kMockResolverWithMSAA =
       return kMockResolver(name);
     };
 
+void MockGetIntegervWithOffscreenMSAA(GLenum name, int* value) {
+  if (name == GL_NUM_EXTENSIONS) {
+    *value = 1;
+  } else if (name == GL_MAX_SAMPLES) {
+    *value = 4;
+  } else {
+    *value = 0;
+  }
+}
+
+const unsigned char* MockGetStringWithOffscreenMSAA(GLenum name) {
+  switch (name) {
+    case GL_VERSION:
+      return reinterpret_cast<const unsigned char*>("OpenGL ES 3.0");
+    case GL_SHADING_LANGUAGE_VERSION:
+      return reinterpret_cast<const unsigned char*>("OpenGL ES GLSL ES 3.0");
+    default:
+      return reinterpret_cast<const unsigned char*>("");
+  }
+}
+
+const impeller::ProcTableGLES::Resolver kMockResolverWithOffscreenMSAA =
+    [](const char* name) -> void* {
+  std::string_view function_name{name};
+
+  if (function_name == "glGetString") {
+    return reinterpret_cast<void*>(&MockGetStringWithOffscreenMSAA);
+  } else if (function_name == "glGetIntegerv") {
+    return reinterpret_cast<void*>(&MockGetIntegervWithOffscreenMSAA);
+  }
+  return kMockResolver(name);
+};
+
 class CompositorOpenGLTest : public WindowsTest {
  public:
   CompositorOpenGLTest() = default;
@@ -252,6 +285,90 @@ TEST_F(CompositorOpenGLTest, CreateBackingStoreImpellerMSAA) {
   EXPECT_EQ(framebuffer_texture2d_calls, 0);
   EXPECT_EQ(framebuffer_texture2d_multisample_calls, 1);
   ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
+}
+
+// Verifies that when implicit MSAA is unsupported but offscreen MSAA is
+// supported (OpenGL ES 3.0+ with GL_MAX_SAMPLES >= 4), CompositorOpenGL
+// creates 4x MSAA color and depth/stencil renderbuffers.
+TEST_F(CompositorOpenGLTest, CreateBackingStoreImpellerOffscreenMSAA) {
+  UseHeadlessEngine();
+
+  static int framebuffer_texture2d_calls = 0;
+  static int framebuffer_texture2d_multisample_calls = 0;
+  static int renderbuffer_storage_multisample_calls = 0;
+  static int renderbuffer_storage_multisample_samples = 0;
+  static int framebuffer_renderbuffer_calls = 0;
+  static int delete_renderbuffers_calls = 0;
+  static int delete_textures_calls = 0;
+
+  framebuffer_texture2d_calls = 0;
+  framebuffer_texture2d_multisample_calls = 0;
+  renderbuffer_storage_multisample_calls = 0;
+  renderbuffer_storage_multisample_samples = 0;
+  framebuffer_renderbuffer_calls = 0;
+  delete_renderbuffers_calls = 0;
+  delete_textures_calls = 0;
+
+  const impeller::ProcTableGLES::Resolver resolver =
+      [](const char* name) -> void* {
+    std::string_view function_name{name};
+    if (function_name == "glFramebufferTexture2D") {
+      return reinterpret_cast<void*>(
+          +[](GLenum, GLenum, GLenum, GLuint, GLint) {
+            framebuffer_texture2d_calls++;
+          });
+    } else if (function_name == "glFramebufferTexture2DMultisampleEXT") {
+      return reinterpret_cast<void*>(
+          +[](GLenum, GLenum, GLenum, GLuint, GLint, GLsizei) {
+            framebuffer_texture2d_multisample_calls++;
+          });
+    } else if (function_name == "glGenRenderbuffers") {
+      return reinterpret_cast<void*>(+[](GLsizei n, GLuint* renderbuffers) {
+        static GLuint next_id = 1;
+        for (GLsizei i = 0; i < n; i++) {
+          renderbuffers[i] = next_id++;
+        }
+      });
+    } else if (function_name == "glRenderbufferStorageMultisample") {
+      return reinterpret_cast<void*>(+[](GLenum target, GLsizei samples,
+                                         GLenum internalformat, GLsizei width,
+                                         GLsizei height) {
+        renderbuffer_storage_multisample_calls++;
+        renderbuffer_storage_multisample_samples = samples;
+      });
+    } else if (function_name == "glFramebufferRenderbuffer") {
+      return reinterpret_cast<void*>(+[](GLenum, GLenum, GLenum, GLuint) {
+        framebuffer_renderbuffer_calls++;
+      });
+    } else if (function_name == "glDeleteRenderbuffers") {
+      return reinterpret_cast<void*>(
+          +[](GLsizei n, const GLuint* renderbuffers) {
+            delete_renderbuffers_calls += n;
+          });
+    } else if (function_name == "glDeleteTextures") {
+      return reinterpret_cast<void*>(+[](GLsizei n, const GLuint* textures) {
+        delete_textures_calls += n;
+      });
+    }
+    return kMockResolverWithOffscreenMSAA(name);
+  };
+
+  auto compositor =
+      CompositorOpenGL{engine(), resolver, /*enable_impeller=*/true};
+  FlutterBackingStoreConfig config = {};
+  FlutterBackingStore backing_store = {};
+
+  EXPECT_CALL(*render_context(), MakeCurrent).WillOnce(Return(true));
+  ASSERT_TRUE(compositor.CreateBackingStore(config, &backing_store));
+  EXPECT_EQ(framebuffer_texture2d_calls, 0);
+  EXPECT_EQ(framebuffer_texture2d_multisample_calls, 0);
+  EXPECT_EQ(renderbuffer_storage_multisample_calls, 2);
+  EXPECT_EQ(renderbuffer_storage_multisample_samples, 4);
+  EXPECT_EQ(framebuffer_renderbuffer_calls, 3);
+
+  ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
+  EXPECT_EQ(delete_renderbuffers_calls, 2);
+  EXPECT_EQ(delete_textures_calls, 0);
 }
 
 TEST_F(CompositorOpenGLTest, InitializationFailure) {


### PR DESCRIPTION
fixes the portion of https://github.com/flutter/flutter/issues/190060 that deals with MSAA

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
