### PR TITLE
[Impeller] Execute PipelineCompileQueue jobs in the order that they were added

### DIFF
--- a/engine/src/flutter/impeller/renderer/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/BUILD.gn
@@ -98,6 +98,7 @@ impeller_component("renderer") {
 
   deps = [
     "//flutter/fml",
+    "//third_party/abseil-cpp/absl/container:linked_hash_map",
     "//third_party/abseil-cpp/absl/strings",
   ]
 }

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -5,12 +5,11 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_PIPELINE_COMPILE_QUEUE_H_
 #define FLUTTER_IMPELLER_RENDERER_PIPELINE_COMPILE_QUEUE_H_
 
-#include <unordered_map>
-
 #include "flutter/fml/closure.h"
 #include "flutter/fml/concurrent_message_loop.h"
 #include "impeller/base/thread.h"
 #include "impeller/renderer/pipeline_descriptor.h"
+#include "third_party/abseil-cpp/absl/container/linked_hash_map.h"
 
 namespace impeller {
 
@@ -125,10 +124,10 @@ class PipelineCompileQueue
 
  private:
   Mutex pending_jobs_mutex_;
-  std::unordered_map<PipelineDescriptor,
-                     fml::closure,
-                     ComparableHash<PipelineDescriptor>,
-                     ComparableEqual<PipelineDescriptor>>
+  absl::linked_hash_map<PipelineDescriptor,
+                        fml::closure,
+                        ComparableHash<PipelineDescriptor>,
+                        ComparableEqual<PipelineDescriptor>>
       pending_jobs_ IPLR_GUARDED_BY(pending_jobs_mutex_);
   size_t priorities_elevated_ = {};
   fml::closure TakeJob(const PipelineDescriptor& desc);

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue_unittests.cc
@@ -102,8 +102,8 @@ TEST(PipelineCompileQueueTest, ExecutesJobsInInsertionOrder) {
   for (size_t i = 0; i < kJobCount; i++) {
     PipelineDescriptor desc;
     desc.SetLabel(std::to_string(i));
-    queue->AddJobForTest(
-        desc, [&job_order, index = i] { job_order.push_back(index); });
+    ASSERT_TRUE(queue->AddJobForTest(
+        desc, [&job_order, index = i] { job_order.push_back(index); }));
   }
 
   for (size_t i = 0; i < kJobCount; i++) {

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue_unittests.cc
@@ -27,6 +27,8 @@ class TestPipelineCompileQueue : public PipelineCompileQueue {
   }
 
   bool HasPendingJobsForTest() { return HasPendingJobs(); }
+
+  void DoOneJobForTest() { DoOneJob(); }
 };
 
 TEST(PipelineCompileQueueTest, AddJobReturnsTrueForNewDescriptor) {
@@ -90,6 +92,28 @@ TEST(PipelineCompileQueueTest, FinishAllJobsDrainsQueue) {
   queue.reset();
 
   EXPECT_TRUE(job_executed);
+}
+
+TEST(PipelineCompileQueueTest, ExecutesJobsInInsertionOrder) {
+  constexpr size_t kJobCount = 10;
+  auto queue = std::make_shared<TestPipelineCompileQueue>();
+
+  std::vector<size_t> job_order;
+  for (size_t i = 0; i < kJobCount; i++) {
+    PipelineDescriptor desc;
+    desc.SetLabel(std::to_string(i));
+    queue->AddJobForTest(
+        desc, [&job_order, index = i] { job_order.push_back(index); });
+  }
+
+  for (size_t i = 0; i < kJobCount; i++) {
+    queue->DoOneJobForTest();
+  }
+
+  EXPECT_EQ(job_order.size(), kJobCount);
+  for (size_t i = 0; i < kJobCount; i++) {
+    EXPECT_EQ(i, job_order[i]);
+  }
 }
 
 }  // namespace testing


### PR DESCRIPTION
ContentContext tries to create the most commonly used shaders first. But previously the PipelineCompileQueue was using an unordered map to store the shader compilation jobs, which made it iterate through the jobs in arbitrary order.

This means that the queue may not build the most needed shaders earliest in the background.  If these shaders are not built before the raster thread needs them, then the raster thread will need to spend time building them on demand.

This PR changes PipelineCompileQueue to use an Abseil linked hash map that retains the order in which elements are inserted. PipelineCompileQueue will then build the shaders in the order that they were added by ContentContext.