### PR TITLE
[Impeller] Generate mipmaps with render passes on devices with broken blit generation

### DIFF
--- a/engine/src/flutter/impeller/core/texture.cc
+++ b/engine/src/flutter/impeller/core/texture.cc
@@ -74,4 +74,8 @@ bool Texture::NeedsMipmapGeneration() const {
   return !mipmap_generated_ && desc_.mip_count > 1;
 }
 
+void Texture::SetMipmapGenerated() {
+  mipmap_generated_ = true;
+}
+
 }  // namespace impeller

--- a/engine/src/flutter/impeller/core/texture.h
+++ b/engine/src/flutter/impeller/core/texture.h
@@ -60,6 +60,10 @@ class Texture {
   /// `array_layer_count` for 2D array textures).
   bool IsSliceValid(size_t slice) const;
 
+  /// Marks the mip chain contents valid. Called by whatever populates the
+  /// chain, either blit-based generation or the render-pass generator.
+  void SetMipmapGenerated();
+
  protected:
   explicit Texture(TextureDescriptor desc);
 

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -56,6 +56,7 @@
 #include "impeller/entity/geometry/shadow_path_geometry.h"
 #include "impeller/entity/geometry/stroke_path_geometry.h"
 #include "impeller/entity/geometry/uber_sdf_geometry.h"
+#include "impeller/entity/mipmap_generator.h"
 #include "impeller/entity/save_layer_utils.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/constants.h"
@@ -2593,12 +2594,13 @@ bool Canvas::EnsureFinalMipmapGeneration() const {
   if (!cmd_buffer) {
     return false;
   }
-  std::shared_ptr<BlitPass> blit_pass = cmd_buffer->CreateBlitPass();
-  if (!blit_pass) {
+  if (!AddMipmapGeneration(cmd_buffer, renderer_.GetContext(),
+                           render_target_.GetRenderTargetTexture(),
+                           *renderer_.GetRenderTargetCache(),
+                           renderer_.GetTransientsDataBuffer())
+           .ok()) {
     return false;
   }
-  blit_pass->GenerateMipmap(render_target_.GetRenderTargetTexture());
-  blit_pass->EncodeCommands();
   return renderer_.GetContext()->EnqueueCommandBuffer(std::move(cmd_buffer));
 }
 

--- a/engine/src/flutter/impeller/entity/BUILD.gn
+++ b/engine/src/flutter/impeller/entity/BUILD.gn
@@ -248,6 +248,8 @@ impeller_component("entity") {
     "geometry/vertices_geometry.h",
     "inline_pass_context.cc",
     "inline_pass_context.h",
+    "mipmap_generator.cc",
+    "mipmap_generator.h",
     "render_target_cache.cc",
     "render_target_cache.h",
     "save_layer_utils.cc",

--- a/engine/src/flutter/impeller/entity/contents/content_context.cc
+++ b/engine/src/flutter/impeller/entity/contents/content_context.cc
@@ -13,17 +13,19 @@
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
+#include "impeller/entity/contents/contents.h"
 #include "impeller/entity/contents/framebuffer_blend_contents.h"
 #include "impeller/entity/contents/pipelines.h"
 #include "impeller/entity/contents/text_shadow_cache.h"
 #include "impeller/entity/entity.h"
+#include "impeller/entity/mipmap_generator.h"
 #include "impeller/entity/render_target_cache.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/pipeline.h"
 #include "impeller/renderer/pipeline_descriptor.h"
 #include "impeller/renderer/pipeline_library.h"
 #include "impeller/renderer/render_target.h"
-#include "impeller/renderer/texture_util.h"
+#include "impeller/renderer/vertex_buffer_builder.h"
 #include "impeller/tessellator/tessellator.h"
 #include "impeller/typographer/typographer_context.h"
 
@@ -955,7 +957,8 @@ fml::StatusOr<RenderTarget> ContentContext::MakeSubpass(
       subpass_target.GetRenderTargetTexture();
   if (target_texture->GetMipCount() > 1) {
     fml::Status mipmap_status =
-        AddMipmapGeneration(command_buffer, context, target_texture);
+        AddMipmapGeneration(command_buffer, context, target_texture,
+                            *GetRenderTargetCache(), GetTransientsDataBuffer());
     if (!mipmap_status.ok()) {
       return mipmap_status;
     }

--- a/engine/src/flutter/impeller/entity/entity_unittests.cc
+++ b/engine/src/flutter/impeller/entity/entity_unittests.cc
@@ -11,6 +11,7 @@
 
 #include "flutter/display_list/geometry/dl_path_builder.h"
 #include "flutter/display_list/testing/dl_test_snippets.h"
+#include "flutter/fml/synchronization/waitable_event.h"
 #include "fml/logging.h"
 #include "gtest/gtest.h"
 #include "impeller/core/device_buffer.h"
@@ -44,6 +45,9 @@
 #include "impeller/entity/geometry/stroke_path_geometry.h"
 #include "impeller/entity/geometry/superellipse_geometry.h"
 #include "impeller/entity/geometry/uber_sdf_geometry.h"
+#include "impeller/entity/mipmap_generator.h"
+#include "impeller/entity/texture_fill.frag.h"
+#include "impeller/entity/texture_fill.vert.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/geometry_asserts.h"
 #include "impeller/geometry/point.h"
@@ -52,6 +56,7 @@
 #include "impeller/playground/playground.h"
 #include "impeller/playground/widgets.h"
 #include "impeller/renderer/command.h"
+#include "impeller/renderer/pipeline_builder.h"
 #include "impeller/renderer/pipeline_descriptor.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
@@ -2984,6 +2989,321 @@ TEST_P(EntityTest, RoundSuperellipseGetPositionBufferFlushes) {
   auto device_buffer = reinterpret_cast<const FlushTestDeviceBuffer*>(
       result.vertex_buffer.vertex_buffer.GetBuffer());
   EXPECT_TRUE(device_buffer->flush_called());
+}
+
+namespace {
+
+// Returns no functions, so pipeline construction fails after dispatch.
+class EmptyShaderLibrary : public ShaderLibrary {
+ public:
+  bool IsValid() const override { return true; }
+  std::shared_ptr<const ShaderFunction> GetFunction(
+      std::string_view name,
+      ShaderStage stage) override {
+    return nullptr;
+  }
+  void UnregisterFunction(std::string name, ShaderStage stage) override {}
+};
+
+struct MipmapDispatchHarness {
+  std::shared_ptr<::testing::NiceMock<MockCapabilities>> capabilities;
+  std::shared_ptr<const Capabilities> capabilities_base;
+  std::shared_ptr<::testing::NiceMock<MockImpellerContext>> context;
+  std::shared_ptr<::testing::NiceMock<MockAllocator>> allocator;
+  std::shared_ptr<::testing::NiceMock<MockCommandBuffer>> command_buffer;
+  std::shared_ptr<::testing::NiceMock<MockBlitPass>> blit_pass;
+  std::shared_ptr<HostBuffer> data_host_buffer;
+  std::unique_ptr<RenderTargetAllocator> render_target_allocator;
+
+  explicit MipmapDispatchHarness(bool blit_generation_supported) {
+    using ::testing::NiceMock;
+    using ::testing::Return;
+    using ::testing::ReturnRef;
+    capabilities = std::make_shared<NiceMock<MockCapabilities>>();
+    ON_CALL(*capabilities, SupportsBlitMipmapGeneration)
+        .WillByDefault(Return(blit_generation_supported));
+    capabilities_base = capabilities;
+    context = std::make_shared<NiceMock<MockImpellerContext>>();
+    ON_CALL(*context, GetCapabilities)
+        .WillByDefault(ReturnRef(capabilities_base));
+    ON_CALL(*context, GetShaderLibrary).WillByDefault([]() {
+      return std::make_shared<EmptyShaderLibrary>();
+    });
+    allocator = std::make_shared<NiceMock<MockAllocator>>();
+    ON_CALL(*allocator, OnCreateBuffer)
+        .WillByDefault([](const DeviceBufferDescriptor& desc) {
+          return std::make_shared<NiceMock<MockDeviceBuffer>>(desc);
+        });
+    command_buffer = std::make_shared<NiceMock<MockCommandBuffer>>(context);
+    blit_pass = std::make_shared<NiceMock<MockBlitPass>>();
+    ON_CALL(*command_buffer, OnCreateBlitPass).WillByDefault(Return(blit_pass));
+    // CreateBlitPass drops passes that report invalid.
+    ON_CALL(*blit_pass, IsValid).WillByDefault(Return(true));
+    ON_CALL(*blit_pass, EncodeCommands).WillByDefault(Return(true));
+    data_host_buffer = HostBuffer::Create(allocator, /*idle_waiter=*/nullptr,
+                                          /*minimum_uniform_alignment=*/16u);
+    render_target_allocator =
+        std::make_unique<RenderTargetAllocator>(allocator);
+  }
+
+  std::shared_ptr<Texture> MakeTexture(TextureType type) {
+    TextureDescriptor desc;
+    desc.size = {8, 8};
+    desc.mip_count = 4;
+    desc.type = type;
+    return std::make_shared<::testing::NiceMock<MockTexture>>(desc);
+  }
+};
+
+}  // namespace
+
+TEST(MipmapGeneratorTest, DispatchesToBlitGenerationWhenSupported) {
+  MipmapDispatchHarness harness(/*blit_generation_supported=*/true);
+  EXPECT_CALL(*harness.blit_pass, OnGenerateMipmapCommand)
+      .WillOnce(::testing::Return(true));
+  EXPECT_TRUE(AddMipmapGeneration(harness.command_buffer, harness.context,
+                                  harness.MakeTexture(TextureType::kTexture2D),
+                                  *harness.render_target_allocator,
+                                  *harness.data_host_buffer)
+                  .ok());
+}
+
+TEST(MipmapGeneratorTest, DoesNotBlitWhereBlitGenerationIsBroken) {
+  MipmapDispatchHarness harness(/*blit_generation_supported=*/false);
+  // Routed to the render-pass generator, which fails on the empty shader
+  // library before recording anything. No blit pass may be created.
+  EXPECT_CALL(*harness.command_buffer, OnCreateBlitPass).Times(0);
+  EXPECT_FALSE(AddMipmapGeneration(harness.command_buffer, harness.context,
+                                   harness.MakeTexture(TextureType::kTexture2D),
+                                   *harness.render_target_allocator,
+                                   *harness.data_host_buffer)
+                   .ok());
+}
+
+TEST(MipmapGeneratorTest, NonTwoDimensionalTexturesKeepBlitGeneration) {
+  MipmapDispatchHarness harness(/*blit_generation_supported=*/false);
+  EXPECT_CALL(*harness.blit_pass, OnGenerateMipmapCommand)
+      .WillOnce(::testing::Return(true));
+  EXPECT_TRUE(AddMipmapGeneration(
+                  harness.command_buffer, harness.context,
+                  harness.MakeTexture(TextureType::kTextureCube),
+                  *harness.render_target_allocator, *harness.data_host_buffer)
+                  .ok());
+}
+
+TEST_P(EntityTest, GenerateMipmapRenderPassDownsamples) {
+  // Renders the mip chain instead of blitting it. Runs on backends whose
+  // render passes execute on the host GPU (Metal, GLES); the Vulkan playground
+  // is skipped where MoltenVK is unavailable.
+  if (GetBackend() == PlaygroundBackend::kOpenGLES ||
+      GetBackend() == PlaygroundBackend::kOpenGLESSDF) {
+    GTEST_SKIP() << "Render-pass mipmap generation targets Vulkan and Metal.";
+  }
+  ContentContext content_context(GetContext(), /*typographer_context=*/nullptr);
+  const std::shared_ptr<Context>& context = content_context.GetContext();
+
+  // 8x8 base split black (left) and white (right). A correct mip chain
+  // averages toward mid-gray; a broken or absent chain does not.
+  constexpr int kSize = 8;
+  TextureDescriptor desc;
+  desc.storage_mode = StorageMode::kDevicePrivate;
+  desc.format = PixelFormat::kR8G8B8A8UNormInt;
+  desc.size = {kSize, kSize};
+  desc.mip_count = desc.size.MipCount();
+  // No render-target usage. The generated levels are stored with copies, so
+  // generation must work on sample-only textures like decoded images.
+  desc.usage = TextureUsage::kShaderRead;
+  std::shared_ptr<Texture> texture =
+      context->GetResourceAllocator()->CreateTexture(desc);
+  ASSERT_TRUE(texture);
+
+  std::vector<uint8_t> base(kSize * kSize * 4, 0);
+  for (int y = 0; y < kSize; y++) {
+    for (int x = 0; x < kSize; x++) {
+      uint8_t v = ((x + y) % 2 == 0) ? 0 : 255;
+      int o = (y * kSize + x) * 4;
+      base[o] = base[o + 1] = base[o + 2] = v;
+      base[o + 3] = 255;
+    }
+  }
+  auto base_mapping =
+      std::make_shared<fml::NonOwnedMapping>(base.data(), base.size());
+  auto base_buffer =
+      context->GetResourceAllocator()->CreateBufferWithCopy(*base_mapping);
+
+  auto cmd = context->CreateCommandBuffer();
+  auto blit = cmd->CreateBlitPass();
+  blit->AddCopy(DeviceBuffer::AsBufferView(base_buffer), texture);
+  ASSERT_TRUE(blit->EncodeCommands());
+  ASSERT_TRUE(
+      AddRenderPassMipmapGeneration(cmd, context, texture,
+                                    *content_context.GetRenderTargetCache(),
+                                    content_context.GetTransientsDataBuffer())
+          .ok());
+  ASSERT_TRUE(context->GetCommandQueue()->Submit({cmd}).ok());
+  EXPECT_FALSE(texture->NeedsMipmapGeneration());
+
+  DeviceBufferDescriptor readback_desc;
+  readback_desc.storage_mode = StorageMode::kHostVisible;
+  readback_desc.size = 8u;
+  std::shared_ptr<DeviceBuffer> readback =
+      context->GetResourceAllocator()->CreateBuffer(readback_desc);
+
+  auto cmd2 = context->CreateCommandBuffer();
+  auto blit2 = cmd2->CreateBlitPass();
+  // Read a mip-1 (4x4) texel. Each averages a 2x2 checker block, so a correct
+  // downsample is ~mid gray; a base copy would be pure 0 or 255.
+  blit2->AddCopy(texture, readback, IRect::MakeXYWH(1, 1, 1, 1),
+                 /*destination_offset=*/0u, /*label=*/"",
+                 /*source_mip_level=*/1u);
+  // Read the deepest (1x1) level, the average of the whole image.
+  const uint32_t deepest_mip = desc.mip_count - 1u;
+  blit2->AddCopy(texture, readback, IRect::MakeXYWH(0, 0, 1, 1),
+                 /*destination_offset=*/4u, /*label=*/"",
+                 /*source_mip_level=*/deepest_mip);
+  ASSERT_TRUE(blit2->EncodeCommands());
+  fml::AutoResetWaitableEvent latch;
+  ASSERT_TRUE(
+      context->GetCommandQueue()
+          ->Submit({cmd2}, [&latch](CommandBuffer::Status) { latch.Signal(); })
+          .ok());
+  latch.Wait();
+
+  const uint8_t* pixels = readback->OnGetContents();
+  ASSERT_NE(pixels, nullptr);
+  for (int offset : {0, 4}) {
+    EXPECT_NEAR(pixels[offset + 0], 128, 48) << "at offset " << offset;
+    EXPECT_NEAR(pixels[offset + 1], 128, 48) << "at offset " << offset;
+    EXPECT_NEAR(pixels[offset + 2], 128, 48) << "at offset " << offset;
+  }
+}
+
+TEST_P(EntityTest, RenderPassGeneratedMipsSampleCorrectly) {
+  // Samples a render-pass generated chain through a minifying mip sampler,
+  // the path the sampler workaround used to clamp to the base level.
+  if (GetBackend() == PlaygroundBackend::kOpenGLES ||
+      GetBackend() == PlaygroundBackend::kOpenGLESSDF) {
+    GTEST_SKIP() << "Render-pass mipmap generation targets Vulkan and Metal.";
+  }
+  using VS = TextureFillVertexShader;
+  using FS = TextureFillFragmentShader;
+  ContentContext content_context(GetContext(), /*typographer_context=*/nullptr);
+  const std::shared_ptr<Context>& context = content_context.GetContext();
+
+  constexpr int kSize = 8;
+  TextureDescriptor desc;
+  desc.storage_mode = StorageMode::kDevicePrivate;
+  desc.format = PixelFormat::kR8G8B8A8UNormInt;
+  desc.size = {kSize, kSize};
+  desc.mip_count = desc.size.MipCount();
+  desc.usage = TextureUsage::kShaderRead;
+  std::shared_ptr<Texture> texture =
+      context->GetResourceAllocator()->CreateTexture(desc);
+  ASSERT_TRUE(texture);
+
+  std::vector<uint8_t> base(kSize * kSize * 4, 0);
+  for (int y = 0; y < kSize; y++) {
+    for (int x = 0; x < kSize; x++) {
+      uint8_t v = ((x + y) % 2 == 0) ? 0 : 255;
+      int o = (y * kSize + x) * 4;
+      base[o] = base[o + 1] = base[o + 2] = v;
+      base[o + 3] = 255;
+    }
+  }
+  auto base_mapping =
+      std::make_shared<fml::NonOwnedMapping>(base.data(), base.size());
+  auto base_buffer =
+      context->GetResourceAllocator()->CreateBufferWithCopy(*base_mapping);
+
+  auto cmd = context->CreateCommandBuffer();
+  auto blit = cmd->CreateBlitPass();
+  blit->AddCopy(DeviceBuffer::AsBufferView(base_buffer), texture);
+  ASSERT_TRUE(blit->EncodeCommands());
+  ASSERT_TRUE(
+      AddRenderPassMipmapGeneration(cmd, context, texture,
+                                    *content_context.GetRenderTargetCache(),
+                                    content_context.GetTransientsDataBuffer())
+          .ok());
+
+  // Draw the whole 8x8 texture into a 2x2 target. Minification selects a deep
+  // mip, so a correct chain lands near mid-gray while base-only sampling
+  // yields checker extremes.
+  std::optional<PipelineDescriptor> pipeline_desc =
+      PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(*context);
+  ASSERT_TRUE(pipeline_desc.has_value());
+  ColorAttachmentDescriptor color0;
+  color0.format = desc.format;
+  color0.blending_enabled = false;
+  pipeline_desc->SetColorAttachmentDescriptor(0u, color0);
+  pipeline_desc->ClearDepthAttachment();
+  pipeline_desc->ClearStencilAttachments();
+  pipeline_desc->SetSampleCount(SampleCount::kCount1);
+  pipeline_desc->SetPrimitiveType(PrimitiveType::kTriangleStrip);
+  std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline =
+      context->GetPipelineLibrary()
+          ->GetPipeline(std::move(pipeline_desc), /*async=*/false)
+          .Get();
+  ASSERT_TRUE(pipeline && pipeline->IsValid());
+
+  RenderTarget target = content_context.GetRenderTargetCache()->CreateOffscreen(
+      *context, ISize(2, 2), /*mip_count=*/1, "Minified Sample",
+      RenderTarget::AttachmentConfig{
+          .storage_mode = StorageMode::kDevicePrivate,
+          .load_action = LoadAction::kDontCare,
+          .store_action = StoreAction::kStore,
+      },
+      /*stencil_attachment_config=*/std::nullopt,
+      /*existing_color_texture=*/nullptr,
+      /*existing_depth_stencil_texture=*/nullptr,
+      /*target_pixel_format=*/desc.format);
+  ASSERT_TRUE(target.IsValid());
+  std::shared_ptr<RenderPass> pass = cmd->CreateRenderPass(target);
+  ASSERT_TRUE(pass);
+  pass->SetPipeline(pipeline);
+  HostBuffer& host_buffer = content_context.GetTransientsDataBuffer();
+  VS::FrameInfo frame_info;
+  frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
+  FS::FragInfo frag_info;
+  frag_info.alpha = 1.0f;
+  std::array<VS::PerVertexData, 4> vertices = {
+      VS::PerVertexData{Point(0, 0), Point(0, 0)},
+      VS::PerVertexData{Point(1, 0), Point(1, 0)},
+      VS::PerVertexData{Point(0, 1), Point(0, 1)},
+      VS::PerVertexData{Point(1, 1), Point(1, 1)},
+  };
+  pass->SetVertexBuffer(CreateVertexBuffer(vertices, host_buffer));
+  SamplerDescriptor sampler_desc;
+  sampler_desc.min_filter = MinMagFilter::kLinear;
+  sampler_desc.mag_filter = MinMagFilter::kLinear;
+  sampler_desc.mip_filter = MipFilter::kLinear;
+  VS::BindFrameInfo(*pass, host_buffer.EmplaceUniform(frame_info));
+  FS::BindFragInfo(*pass, host_buffer.EmplaceUniform(frag_info));
+  FS::BindTextureSampler(
+      *pass, texture, context->GetSamplerLibrary()->GetSampler(sampler_desc));
+  ASSERT_TRUE(pass->Draw().ok());
+  ASSERT_TRUE(pass->EncodeCommands());
+
+  DeviceBufferDescriptor readback_desc;
+  readback_desc.storage_mode = StorageMode::kHostVisible;
+  readback_desc.size = 4u;
+  std::shared_ptr<DeviceBuffer> readback =
+      context->GetResourceAllocator()->CreateBuffer(readback_desc);
+  auto blit2 = cmd->CreateBlitPass();
+  blit2->AddCopy(target.GetRenderTargetTexture(), readback,
+                 IRect::MakeXYWH(0, 0, 1, 1));
+  ASSERT_TRUE(blit2->EncodeCommands());
+  fml::AutoResetWaitableEvent latch;
+  ASSERT_TRUE(
+      context->GetCommandQueue()
+          ->Submit({cmd}, [&latch](CommandBuffer::Status) { latch.Signal(); })
+          .ok());
+  latch.Wait();
+
+  const uint8_t* pixel = readback->OnGetContents();
+  ASSERT_NE(pixel, nullptr);
+  EXPECT_NEAR(pixel[0], 128, 48);
+  EXPECT_NEAR(pixel[1], 128, 48);
+  EXPECT_NEAR(pixel[2], 128, 48);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/entity/inline_pass_context.cc
+++ b/engine/src/flutter/impeller/entity/inline_pass_context.cc
@@ -11,9 +11,9 @@
 #include "impeller/core/formats.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity_pass_target.h"
+#include "impeller/entity/mipmap_generator.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/render_pass.h"
-#include "impeller/renderer/texture_util.h"
 
 namespace impeller {
 
@@ -56,7 +56,8 @@ bool InlinePassContext::EndPass(bool is_onscreen) {
       GetPassTarget().GetRenderTarget().GetRenderTargetTexture();
   if (target_texture->GetMipCount() > 1) {
     fml::Status mip_status = AddMipmapGeneration(
-        command_buffer_, renderer_.GetContext(), target_texture);
+        command_buffer_, renderer_.GetContext(), target_texture,
+        *renderer_.GetRenderTargetCache(), renderer_.GetTransientsDataBuffer());
     if (!mip_status.ok()) {
       return false;
     }

--- a/engine/src/flutter/impeller/entity/mipmap_generator.cc
+++ b/engine/src/flutter/impeller/entity/mipmap_generator.cc
@@ -1,0 +1,177 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/entity/mipmap_generator.h"
+
+#include "impeller/core/formats.h"
+#include "impeller/entity/texture_fill.frag.h"
+#include "impeller/entity/texture_fill.vert.h"
+#include "impeller/renderer/blit_pass.h"
+#include "impeller/renderer/pipeline_builder.h"
+#include "impeller/renderer/pipeline_library.h"
+#include "impeller/renderer/render_pass.h"
+#include "impeller/renderer/vertex_buffer_builder.h"
+
+namespace impeller {
+
+fml::Status AddMipmapGeneration(
+    const std::shared_ptr<CommandBuffer>& command_buffer,
+    const std::shared_ptr<Context>& context,
+    const std::shared_ptr<Texture>& texture,
+    RenderTargetAllocator& render_target_allocator,
+    HostBuffer& data_host_buffer) {
+  // TODO(bdero): Render cube and array mip chains too. Blit generation
+  // remains corrupt for them on affected devices, but no engine path
+  // generates mipmaps for anything but 2D textures today.
+  if (context->GetCapabilities()->SupportsBlitMipmapGeneration() ||
+      texture->GetTextureDescriptor().type != TextureType::kTexture2D) {
+    std::shared_ptr<BlitPass> blit_pass = command_buffer->CreateBlitPass();
+    if (!blit_pass->GenerateMipmap(texture) || !blit_pass->EncodeCommands()) {
+      return fml::Status(fml::StatusCode::kUnknown, "");
+    }
+    return fml::Status();
+  }
+  return AddRenderPassMipmapGeneration(command_buffer, context, texture,
+                                       render_target_allocator,
+                                       data_host_buffer);
+}
+
+fml::Status AddRenderPassMipmapGeneration(
+    const std::shared_ptr<CommandBuffer>& command_buffer,
+    const std::shared_ptr<Context>& context,
+    const std::shared_ptr<Texture>& texture,
+    RenderTargetAllocator& render_target_allocator,
+    HostBuffer& data_host_buffer) {
+  using VS = TextureFillVertexShader;
+  using FS = TextureFillFragmentShader;
+
+  const TextureDescriptor& desc = texture->GetTextureDescriptor();
+  const uint32_t mip_count = desc.mip_count;
+  if (mip_count < 2u) {
+    return fml::Status();
+  }
+  if (desc.type != TextureType::kTexture2D) {
+    return fml::Status(fml::StatusCode::kUnimplemented,
+                       "Only 2D mip chains can be rendered.");
+  }
+  const ISize base_size = desc.size;
+  auto level_size = [&](uint32_t mip) -> ISize {
+    return ISize(std::max<int64_t>(base_size.width >> mip, 1),
+                 std::max<int64_t>(base_size.height >> mip, 1));
+  };
+
+  std::optional<PipelineDescriptor> pipeline_desc =
+      PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(*context);
+  if (!pipeline_desc.has_value()) {
+    return fml::Status(fml::StatusCode::kUnknown,
+                       "Could not build the downsample pipeline descriptor.");
+  }
+  ColorAttachmentDescriptor color0;
+  color0.format = desc.format;
+  color0.blending_enabled = false;
+  pipeline_desc->SetColorAttachmentDescriptor(0u, color0);
+  pipeline_desc->ClearDepthAttachment();
+  pipeline_desc->ClearStencilAttachments();
+  pipeline_desc->SetSampleCount(SampleCount::kCount1);
+  pipeline_desc->SetPrimitiveType(PrimitiveType::kTriangleStrip);
+  std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline =
+      context->GetPipelineLibrary()
+          ->GetPipeline(std::move(pipeline_desc), /*async=*/false)
+          .Get();
+  if (!pipeline || !pipeline->IsValid()) {
+    return fml::Status(fml::StatusCode::kUnknown,
+                       "Could not build the downsample pipeline.");
+  }
+
+  // Build the downsample chain in scratch offscreens. Each level samples a
+  // separate texture, so no pass ever reads the image it is writing.
+  std::vector<std::shared_ptr<Texture>> levels;
+  levels.reserve(mip_count - 1u);
+  std::shared_ptr<Texture> source = texture;
+  for (uint32_t mip = 1u; mip < mip_count; mip++) {
+    RenderTarget target = render_target_allocator.CreateOffscreen(
+        *context, level_size(mip), /*mip_count=*/1, "Mipmap Downsample",
+        RenderTarget::AttachmentConfig{
+            .storage_mode = StorageMode::kDevicePrivate,
+            .load_action = LoadAction::kDontCare,
+            .store_action = StoreAction::kStore,
+        },
+        /*stencil_attachment_config=*/std::nullopt,
+        /*existing_color_texture=*/nullptr,
+        /*existing_depth_stencil_texture=*/nullptr,
+        /*target_pixel_format=*/desc.format);
+    if (!target.IsValid()) {
+      return fml::Status(fml::StatusCode::kUnknown,
+                         "Could not allocate a downsample target.");
+    }
+    std::shared_ptr<RenderPass> pass = command_buffer->CreateRenderPass(target);
+    if (!pass) {
+      return fml::Status(fml::StatusCode::kUnknown,
+                         "Could not begin a downsample pass.");
+    }
+    pass->SetLabel("Mipmap Downsample");
+    pass->SetPipeline(pipeline);
+
+    // Drawing the source across the whole half-size target with a linear
+    // filter performs a correct 2x2 box downsample.
+    VS::FrameInfo frame_info;
+    frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
+    FS::FragInfo frag_info;
+    frag_info.alpha = 1.0f;
+    std::array<VS::PerVertexData, 4> vertices = {
+        VS::PerVertexData{Point(0, 0), Point(0, 0)},
+        VS::PerVertexData{Point(1, 0), Point(1, 0)},
+        VS::PerVertexData{Point(0, 1), Point(0, 1)},
+        VS::PerVertexData{Point(1, 1), Point(1, 1)},
+    };
+    pass->SetVertexBuffer(CreateVertexBuffer(vertices, data_host_buffer));
+
+    SamplerDescriptor sampler_desc;
+    sampler_desc.min_filter = MinMagFilter::kLinear;
+    sampler_desc.mag_filter = MinMagFilter::kLinear;
+    // Read only the base level of the still-mipped source; its higher levels
+    // are the ones being generated and must not be sampled. Scratch levels
+    // have a single level to read.
+    sampler_desc.mip_filter =
+        mip == 1u ? MipFilter::kBase : MipFilter::kNearest;
+
+    VS::BindFrameInfo(*pass, data_host_buffer.EmplaceUniform(frame_info));
+    FS::BindFragInfo(*pass, data_host_buffer.EmplaceUniform(frag_info));
+    FS::BindTextureSampler(
+        *pass, source, context->GetSamplerLibrary()->GetSampler(sampler_desc));
+    if (!pass->Draw().ok() || !pass->EncodeCommands()) {
+      return fml::Status(fml::StatusCode::kUnknown,
+                         "Could not record a downsample pass.");
+    }
+    source = target.GetRenderTargetTexture();
+    levels.push_back(source);
+  }
+
+  // Copy each downsampled level into the matching level of the target. Only
+  // scaled blits corrupt on devices with broken generation; same-size copies
+  // are safe.
+  std::shared_ptr<BlitPass> blit_pass = command_buffer->CreateBlitPass();
+  if (!blit_pass) {
+    return fml::Status(fml::StatusCode::kUnknown,
+                       "Could not begin the mip store pass.");
+  }
+  blit_pass->SetLabel("Mipmap Store");
+  for (uint32_t mip = 1u; mip < mip_count; mip++) {
+    if (!blit_pass->AddCopy(levels[mip - 1u], texture,
+                            /*source_region=*/std::nullopt,
+                            /*destination_origin=*/{}, "Mipmap Store",
+                            /*destination_mip_level=*/mip)) {
+      return fml::Status(fml::StatusCode::kUnknown,
+                         "Could not record a mip store copy.");
+    }
+  }
+  if (!blit_pass->EncodeCommands()) {
+    return fml::Status(fml::StatusCode::kUnknown,
+                       "Could not encode the mip store pass.");
+  }
+  texture->SetMipmapGenerated();
+  return fml::Status();
+}
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/entity/mipmap_generator.h
+++ b/engine/src/flutter/impeller/entity/mipmap_generator.h
@@ -1,0 +1,57 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_ENTITY_MIPMAP_GENERATOR_H_
+#define FLUTTER_IMPELLER_ENTITY_MIPMAP_GENERATOR_H_
+
+#include "flutter/fml/status.h"
+#include "impeller/core/host_buffer.h"
+#include "impeller/core/texture.h"
+#include "impeller/renderer/command_buffer.h"
+#include "impeller/renderer/context.h"
+#include "impeller/renderer/render_target.h"
+
+namespace impeller {
+
+//------------------------------------------------------------------------------
+/// @brief      Records commands that regenerate the mip chain of `texture`.
+///
+///             Uses `BlitPass::GenerateMipmap` where the device supports it
+///             and falls back to rendering the chain where the driver's blit
+///             generation is broken (see
+///             `Capabilities::SupportsBlitMipmapGeneration`).
+///
+///             Scratch render targets come from `render_target_allocator` and
+///             transient geometry and uniforms come from `data_host_buffer`,
+///             so frame-loop callers get buffer recycling for free.
+///
+[[nodiscard]] fml::Status AddMipmapGeneration(
+    const std::shared_ptr<CommandBuffer>& command_buffer,
+    const std::shared_ptr<Context>& context,
+    const std::shared_ptr<Texture>& texture,
+    RenderTargetAllocator& render_target_allocator,
+    HostBuffer& data_host_buffer);
+
+//------------------------------------------------------------------------------
+/// @brief      Records commands that regenerate the mip chain of `texture`
+///             without blit-based generation.
+///
+///             Each level is drawn into a scratch offscreen by sampling the
+///             previous level with a linear filter (a 2x2 box downsample)
+///             and then copied into the corresponding level of `texture`.
+///             Only scaled blits corrupt on affected devices; copies do not.
+///
+///             `AddMipmapGeneration` dispatches here when needed and is what
+///             production callers use.
+///
+[[nodiscard]] fml::Status AddRenderPassMipmapGeneration(
+    const std::shared_ptr<CommandBuffer>& command_buffer,
+    const std::shared_ptr<Context>& context,
+    const std::shared_ptr<Texture>& texture,
+    RenderTargetAllocator& render_target_allocator,
+    HostBuffer& data_host_buffer);
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_ENTITY_MIPMAP_GENERATOR_H_

--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.cc
@@ -8,6 +8,7 @@
 
 #include "flutter/fml/trace_event.h"
 #include "fml/closure.h"
+#include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/gles/blit_command_gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
@@ -95,7 +96,17 @@ bool BlitPassGLES::OnCopyTextureToTextureCommand(
     std::shared_ptr<Texture> destination,
     IRect source_region,
     IPoint destination_origin,
-    std::string_view label) {
+    std::string_view label,
+    uint32_t destination_mip_level) {
+  if (destination_mip_level != 0u) {
+    // TODO(bdero): Thread the destination mip level through the GLES texture
+    // copy paths. Nothing routes a non-zero level here today; render-pass
+    // mipmap generation is never dispatched on GLES.
+    VALIDATION_LOG
+        << "Texture to texture blits to a non-zero mip level are not "
+           "supported on GLES.";
+    return false;
+  }
   auto command = std::make_unique<BlitCopyTextureToTextureCommandGLES>();
   command->label = label;
   command->source = std::move(source);
@@ -113,7 +124,8 @@ bool BlitPassGLES::OnCopyTextureToBufferCommand(
     std::shared_ptr<DeviceBuffer> destination,
     IRect source_region,
     size_t destination_offset,
-    std::string_view label) {
+    std::string_view label,
+    uint32_t source_mip_level) {
   auto command = std::make_unique<BlitCopyTextureToBufferCommandGLES>();
   command->label = label;
   command->source = std::move(source);

--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_pass_gles.h
@@ -49,14 +49,16 @@ class BlitPassGLES final : public BlitPass,
                                      std::shared_ptr<Texture> destination,
                                      IRect source_region,
                                      IPoint destination_origin,
-                                     std::string_view label) override;
+                                     std::string_view label,
+                                     uint32_t destination_mip_level) override;
 
   // |BlitPass|
   bool OnCopyTextureToBufferCommand(std::shared_ptr<Texture> source,
                                     std::shared_ptr<DeviceBuffer> destination,
                                     IRect source_region,
                                     size_t destination_offset,
-                                    std::string_view label) override;
+                                    std::string_view label,
+                                    uint32_t source_mip_level) override;
 
   // |BlitPass|
   bool OnCopyBufferToTextureCommand(BufferView source,

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -341,6 +341,12 @@ bool CapabilitiesGLES::SupportsManuallyMippedTextures() const {
   return supports_texture_max_level_;
 }
 
+bool CapabilitiesGLES::SupportsBlitMipmapGeneration() const {
+  // The blit pass generates mipmaps with glGenerateMipmap, a driver path
+  // separate from the broken Vulkan blit chains.
+  return true;
+}
+
 bool CapabilitiesGLES::SupportsExtendedRangeFormats() const {
   return false;
 }

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
@@ -142,6 +142,9 @@ class CapabilitiesGLES final
   bool SupportsManuallyMippedTextures() const override;
 
   // |Capabilities|
+  bool SupportsBlitMipmapGeneration() const override;
+
+  // |Capabilities|
   bool SupportsExtendedRangeFormats() const override;
 
   // |Capabilities|

--- a/engine/src/flutter/impeller/renderer/backend/metal/blit_pass_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/blit_pass_mtl.h
@@ -49,14 +49,16 @@ class BlitPassMTL final : public BlitPass {
                                      std::shared_ptr<Texture> destination,
                                      IRect source_region,
                                      IPoint destination_origin,
-                                     std::string_view label) override;
+                                     std::string_view label,
+                                     uint32_t destination_mip_level) override;
 
   // |BlitPass|
   bool OnCopyTextureToBufferCommand(std::shared_ptr<Texture> source,
                                     std::shared_ptr<DeviceBuffer> destination,
                                     IRect source_region,
                                     size_t destination_offset,
-                                    std::string_view label) override;
+                                    std::string_view label,
+                                    uint32_t source_mip_level) override;
   // |BlitPass|
   bool OnCopyBufferToTextureCommand(BufferView source,
                                     std::shared_ptr<Texture> destination,

--- a/engine/src/flutter/impeller/renderer/backend/metal/blit_pass_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/blit_pass_mtl.mm
@@ -70,7 +70,8 @@ bool BlitPassMTL::OnCopyTextureToTextureCommand(
     std::shared_ptr<Texture> destination,
     IRect source_region,
     IPoint destination_origin,
-    std::string_view label) {
+    std::string_view label,
+    uint32_t destination_mip_level) {
   auto source_mtl = TextureMTL::Cast(*source).GetMTLTexture();
   if (!source_mtl) {
     return false;
@@ -100,7 +101,7 @@ bool BlitPassMTL::OnCopyTextureToTextureCommand(
                  sourceSize:source_size_mtl
                   toTexture:destination_mtl
            destinationSlice:0
-           destinationLevel:0
+           destinationLevel:destination_mip_level
           destinationOrigin:destination_origin_mtl];
 
 #ifdef IMPELLER_DEBUG
@@ -139,7 +140,8 @@ bool BlitPassMTL::OnCopyTextureToBufferCommand(
     std::shared_ptr<DeviceBuffer> destination,
     IRect source_region,
     size_t destination_offset,
-    std::string_view label) {
+    std::string_view label,
+    uint32_t source_mip_level) {
   auto source_mtl = TextureMTL::Cast(*source).GetMTLTexture();
   if (!source_mtl) {
     return false;
@@ -169,7 +171,7 @@ bool BlitPassMTL::OnCopyTextureToBufferCommand(
 #endif  // IMPELLER_DEBUG
   [encoder_ copyFromTexture:source_mtl
                    sourceSlice:0
-                   sourceLevel:0
+                   sourceLevel:source_mip_level
                   sourceOrigin:source_origin_mtl
                     sourceSize:source_size_mtl
                       toBuffer:destination_mtl

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/barrier_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/barrier_vk.h
@@ -50,6 +50,17 @@ struct BarrierVK {
 
   /// The base mip level to apply the barrier to in the subresource range.
   uint32_t base_mip_level = 0;
+
+  /// The number of mip levels to apply the barrier to. 0 means "to the last
+  /// level" (`mip_count - base_mip_level`).
+  uint32_t mip_level_count = 0;
+
+  /// The base array layer to apply the barrier to.
+  uint32_t base_array_layer = 0;
+
+  /// The number of array layers to apply the barrier to. 0 means "all layers"
+  /// (`layer_count - base_array_layer`).
+  uint32_t array_layer_count = 0;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
@@ -528,7 +528,7 @@ bool BlitPassVK::OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
   // We modified the layouts of this image from underneath it. Tell it its new
   // state so it doesn't try to perform redundant transitions under the hood.
   src.SetLayoutWithoutEncoding(vk::ImageLayout::eShaderReadOnlyOptimal);
-  src.SetMipMapGenerated();
+  src.SetMipmapGenerated();
 
   return true;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc
@@ -68,7 +68,8 @@ bool BlitPassVK::OnCopyTextureToTextureCommand(
     std::shared_ptr<Texture> destination,
     IRect source_region,
     IPoint destination_origin,
-    std::string_view label) {
+    std::string_view label,
+    uint32_t destination_mip_level) {
   const auto& cmd_buffer = command_buffer_->GetCommandBuffer();
 
   const auto& src = TextureVK::Cast(*source);
@@ -109,8 +110,8 @@ bool BlitPassVK::OnCopyTextureToTextureCommand(
 
   image_copy.setSrcSubresource(
       vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1));
-  image_copy.setDstSubresource(
-      vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1));
+  image_copy.setDstSubresource(vk::ImageSubresourceLayers(
+      vk::ImageAspectFlagBits::eColor, destination_mip_level, 0, 1));
 
   image_copy.srcOffset =
       vk::Offset3D(source_region.GetX(), source_region.GetY(), 0);
@@ -151,7 +152,8 @@ bool BlitPassVK::OnCopyTextureToBufferCommand(
     std::shared_ptr<DeviceBuffer> destination,
     IRect source_region,
     size_t destination_offset,
-    std::string_view label) {
+    std::string_view label,
+    uint32_t source_mip_level) {
   const auto& cmd_buffer = command_buffer_->GetCommandBuffer();
 
   // cast source and destination to TextureVK
@@ -180,8 +182,8 @@ bool BlitPassVK::OnCopyTextureToBufferCommand(
   image_copy.setBufferOffset(destination_offset);
   image_copy.setBufferRowLength(0);
   image_copy.setBufferImageHeight(0);
-  image_copy.setImageSubresource(
-      vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1));
+  image_copy.setImageSubresource(vk::ImageSubresourceLayers(
+      vk::ImageAspectFlagBits::eColor, source_mip_level, 0, 1));
   image_copy.setImageOffset(
       vk::Offset3D(source_region.GetX(), source_region.GetY(), 0));
   image_copy.setImageExtent(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/blit_pass_vk.h
@@ -54,14 +54,16 @@ class BlitPassVK final : public BlitPass {
                                      std::shared_ptr<Texture> destination,
                                      IRect source_region,
                                      IPoint destination_origin,
-                                     std::string_view label) override;
+                                     std::string_view label,
+                                     uint32_t destination_mip_level) override;
 
   // |BlitPass|
   bool OnCopyTextureToBufferCommand(std::shared_ptr<Texture> source,
                                     std::shared_ptr<DeviceBuffer> destination,
                                     IRect source_region,
                                     size_t destination_offset,
-                                    std::string_view label) override;
+                                    std::string_view label,
+                                    uint32_t source_mip_level) override;
 
   // |BlitPass|
   bool OnCopyBufferToTextureCommand(BufferView source,

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -549,6 +549,10 @@ bool CapabilitiesVK::SupportsManuallyMippedTextures() const {
   return true;
 }
 
+bool CapabilitiesVK::SupportsBlitMipmapGeneration() const {
+  return has_blit_mipmap_generation_;
+}
+
 void CapabilitiesVK::SetOffscreenFormat(PixelFormat pixel_format) const {
   default_color_format_ = pixel_format;
 }
@@ -893,6 +897,7 @@ uint32_t CapabilitiesVK::GetMaxSamplerAnisotropy() const {
 void CapabilitiesVK::ApplyWorkarounds(const WorkaroundsVK& workarounds) {
   has_primitive_restart_ = !workarounds.slow_primitive_restart_performance;
   has_framebuffer_fetch_ = !workarounds.input_attachment_self_dependency_broken;
+  has_blit_mipmap_generation_ = !workarounds.broken_mipmap_generation;
 }
 
 bool CapabilitiesVK::SupportsExternalSemaphoreExtensions() const {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -276,6 +276,9 @@ class CapabilitiesVK final : public Capabilities,
   bool SupportsManuallyMippedTextures() const override;
 
   // |Capabilities|
+  bool SupportsBlitMipmapGeneration() const override;
+
+  // |Capabilities|
   bool SupportsExtendedRangeFormats() const override;
 
   // |Capabilities|
@@ -363,6 +366,7 @@ class CapabilitiesVK final : public Capabilities,
   bool has_triangle_fans_ = true;
   bool has_primitive_restart_ = true;
   bool has_framebuffer_fetch_ = true;
+  bool has_blit_mipmap_generation_ = true;
   bool supports_external_fence_and_semaphore_ = false;
   bool supports_texture_compression_bc_ = false;
   bool supports_texture_compression_etc2_ = false;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -470,7 +470,6 @@ void ContextVK::Setup(Settings settings) {
       std::make_unique<DriverInfoVK>(device_holder->physical_device);
   workarounds_ = GetWorkaroundsFromDriverInfo(*driver_info);
   caps->ApplyWorkarounds(workarounds_);
-  sampler_library->ApplyWorkarounds(workarounds_);
 
   device_holder_ = std::move(device_holder);
   idle_waiter_vk_ = std::make_shared<IdleWaiterVK>(device_holder_);

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
@@ -152,6 +152,30 @@ TEST(DriverInfoVKTest, CanGenerateMipMaps) {
   EXPECT_TRUE(CanUseMipgeneration("Mali-G51", false));
 }
 
+TEST(DriverInfoVKTest, BrokenMipGenerationTurnsOffBlitMipmapCapability) {
+  auto make_context = [](std::string_view driver_name, bool qc) {
+    return MockVulkanContextBuilder()
+        .SetPhysicalPropertiesCallback(
+            [&driver_name, qc](VkPhysicalDevice device,
+                               VkPhysicalDeviceProperties* prop) {
+              if (qc) {
+                prop->vendorID = 0x168C;  // Qualcomm
+              } else {
+                prop->vendorID = 0x13B5;  // ARM
+              }
+              driver_name.copy(prop->deviceName, driver_name.size());
+              prop->deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+            })
+        .Build();
+  };
+  EXPECT_FALSE(make_context("Adreno (TM) 630", true)
+                   ->GetCapabilities()
+                   ->SupportsBlitMipmapGeneration());
+  EXPECT_TRUE(make_context("Mali-G51", false)
+                  ->GetCapabilities()
+                  ->SupportsBlitMipmapGeneration());
+}
+
 TEST(DriverInfoVKTest, DriverParsingMali) {
   EXPECT_EQ(GetMaliVersion("Mali-G51-MORE STUFF"), MaliGPU::kG51);
   EXPECT_EQ(GetMaliVersion("Mali-G51"), MaliGPU::kG51);

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -102,19 +102,20 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
   }
 
   RenderPassBuilderVK builder;
-  render_target_.IterateAllColorAttachments([&](size_t bind_point,
-                                                const ColorAttachment&
-                                                    attachment) -> bool {
-    builder.SetColorAttachment(
-        bind_point,                                                           //
-        attachment.texture->GetTextureDescriptor().format,                    //
-        attachment.texture->GetTextureDescriptor().sample_count,              //
-        attachment.load_action,                                               //
-        attachment.store_action,                                              //
-        /*current_layout=*/TextureVK::Cast(*attachment.texture).GetLayout(),  //
-        /*is_swapchain=*/is_swapchain);
-    return true;
-  });
+  render_target_.IterateAllColorAttachments(
+      [&](size_t bind_point, const ColorAttachment& attachment) -> bool {
+        builder.SetColorAttachment(
+            bind_point,                                               //
+            attachment.texture->GetTextureDescriptor().format,        //
+            attachment.texture->GetTextureDescriptor().sample_count,  //
+            attachment.load_action,                                   //
+            attachment.store_action,                                  //
+            /*current_layout=*/
+            TextureVK::Cast(*attachment.texture)
+                .GetLayout(attachment.mip_level, attachment.slice),  //
+            /*is_swapchain=*/is_swapchain);
+        return true;
+      });
 
   if (auto depth = render_target_.GetDepthAttachment(); depth.has_value()) {
     builder.SetDepthStencilAttachment(
@@ -240,11 +241,16 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
 
   command_buffer_vk_.beginRenderPass(pass_info, vk::SubpassContents::eInline);
 
+  // The render pass's implicit finalLayout applies only to the attached
+  // (mip_level, slice) subresource, so mirror it there rather than across the
+  // whole image (which matters when rendering into a single mip level).
   if (resolve_image_vk_) {
     TextureVK::Cast(*resolve_image_vk_)
         .SetLayoutWithoutEncoding(
             is_swapchain ? vk::ImageLayout::eGeneral
-                         : vk::ImageLayout::eShaderReadOnlyOptimal);
+                         : vk::ImageLayout::eShaderReadOnlyOptimal,
+            cache_mip_level, /*level_count=*/1u, cache_slice,
+            /*layer_count=*/1u);
   }
   if (color_image_vk_) {
     // Mirror the Vulkan render pass's `finalLayout` for the color attachment
@@ -258,7 +264,9 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
         .SetLayoutWithoutEncoding(
             (is_swapchain || sample_count != SampleCount::kCount1)
                 ? vk::ImageLayout::eGeneral
-                : vk::ImageLayout::eShaderReadOnlyOptimal);
+                : vk::ImageLayout::eShaderReadOnlyOptimal,
+            cache_mip_level, /*level_count=*/1u, cache_slice,
+            /*layer_count=*/1u);
   }
 
   // Set the initial viewport.

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/sampler_library_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/sampler_library_vk.cc
@@ -19,16 +19,9 @@ SamplerLibraryVK::SamplerLibraryVK(
 
 SamplerLibraryVK::~SamplerLibraryVK() = default;
 
-void SamplerLibraryVK::ApplyWorkarounds(const WorkaroundsVK& workarounds) {
-  mips_disabled_workaround_ = workarounds.broken_mipmap_generation;
-}
-
 raw_ptr<const Sampler> SamplerLibraryVK::GetSampler(
     const SamplerDescriptor& desc) {
   SamplerDescriptor desc_copy = desc;
-  if (mips_disabled_workaround_) {
-    desc_copy.mip_filter = MipFilter::kBase;
-  }
   // Clamp to the device limit before keying the cache so that all values
   // beyond the limit share one sampler. The limit is 1 (disabled) when the
   // samplerAnisotropy feature is unavailable. The upper bound is floored at 1

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/sampler_library_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/sampler_library_vk.h
@@ -9,7 +9,6 @@
 #include "impeller/core/sampler.h"
 #include "impeller/core/sampler_descriptor.h"
 #include "impeller/renderer/backend/vulkan/device_holder_vk.h"
-#include "impeller/renderer/backend/vulkan/workarounds_vk.h"
 #include "impeller/renderer/sampler_library.h"
 
 namespace impeller {
@@ -24,15 +23,12 @@ class SamplerLibraryVK final
   SamplerLibraryVK(const std::weak_ptr<DeviceHolderVK>& device_holder,
                    uint32_t max_sampler_anisotropy);
 
-  void ApplyWorkarounds(const WorkaroundsVK& workarounds);
-
  private:
   friend class ContextVK;
 
   std::weak_ptr<DeviceHolderVK> device_holder_;
   std::vector<std::pair<uint64_t, std::shared_ptr<const Sampler>>> samplers_;
   uint32_t max_sampler_anisotropy_ = 1;
-  bool mips_disabled_workaround_ = false;
 
   // |SamplerLibrary|
   raw_ptr<const Sampler> GetSampler(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/sampler_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/sampler_vk.h
@@ -37,7 +37,6 @@ class SamplerVK final : public Sampler, public BackendCast<SamplerVK, Sampler> {
   const vk::Device device_;
   SharedHandleVK<vk::Sampler> sampler_;
   std::shared_ptr<YUVConversionVK> yuv_conversion_;
-  bool mips_disabled_workaround_ = false;
   bool is_valid_ = false;
 
   SamplerVK(const SamplerVK&) = delete;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/sampler_library_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/sampler_library_vk_unittests.cc
@@ -10,29 +10,23 @@
 #include "impeller/renderer/backend/vulkan/command_pool_vk.h"
 #include "impeller/renderer/backend/vulkan/sampler_library_vk.h"
 #include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
-#include "impeller/renderer/backend/vulkan/workarounds_vk.h"
 
 namespace impeller {
 namespace testing {
 
-TEST(SamplerLibraryVK, WorkaroundsCanDisableReadingFromMipLevels) {
+TEST(SamplerLibraryVK, MipFiltersAreNeverRewritten) {
+  // Mip sampling stays enabled on devices with broken blit-based mip
+  // generation; the mip chain is rendered instead.
   auto const context = MockVulkanContextBuilder().Build();
 
-  auto library_vk = std::make_shared<SamplerLibraryVK>(
+  std::shared_ptr<SamplerLibrary> library = std::make_shared<SamplerLibraryVK>(
       context->GetDeviceHolder(), /*max_sampler_anisotropy=*/1u);
-  std::shared_ptr<SamplerLibrary> library = library_vk;
 
   SamplerDescriptor desc;
   desc.mip_filter = MipFilter::kLinear;
 
   auto sampler = library->GetSampler(desc);
   EXPECT_EQ(sampler->GetDescriptor().mip_filter, MipFilter::kLinear);
-
-  // Apply mips disabled workaround.
-  library_vk->ApplyWorkarounds(WorkaroundsVK{.broken_mipmap_generation = true});
-
-  sampler = library->GetSampler(desc);
-  EXPECT_EQ(sampler->GetDescriptor().mip_filter, MipFilter::kBase);
 }
 
 TEST(SamplerLibraryVK, MaxAnisotropyIsClampedToTheDeviceLimit) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
@@ -4,9 +4,15 @@
 
 #include "impeller/renderer/backend/vulkan/texture_source_vk.h"
 
+#include <algorithm>
+
 namespace impeller {
 
-TextureSourceVK::TextureSourceVK(TextureDescriptor desc) : desc_(desc) {}
+TextureSourceVK::TextureSourceVK(TextureDescriptor desc) : desc_(desc) {
+  const uint32_t subresource_count =
+      std::max<uint32_t>(desc_.mip_count, 1u) * LayerCount();
+  layouts_.resize(subresource_count, vk::ImageLayout::eUndefined);
+}
 
 TextureSourceVK::~TextureSourceVK() = default;
 
@@ -18,20 +24,63 @@ std::shared_ptr<YUVConversionVK> TextureSourceVK::GetYUVConversion() const {
   return nullptr;
 }
 
-vk::ImageLayout TextureSourceVK::GetLayout() const {
-  return layout_;
+uint32_t TextureSourceVK::LayerCount() const {
+  return ToArrayLayerCount(desc_);
+}
+
+vk::ImageLayout TextureSourceVK::GetLayout(uint32_t mip_level,
+                                           uint32_t array_layer) const {
+  const size_t index =
+      static_cast<size_t>(mip_level) * LayerCount() + array_layer;
+  return index < layouts_.size() ? layouts_[index]
+                                 : vk::ImageLayout::eUndefined;
 }
 
 vk::ImageLayout TextureSourceVK::SetLayoutWithoutEncoding(
-    vk::ImageLayout layout) const {
-  const auto old_layout = layout_;
-  layout_ = layout;
+    vk::ImageLayout layout,
+    uint32_t base_mip_level,
+    uint32_t level_count,
+    uint32_t base_array_layer,
+    uint32_t layer_count) const {
+  const uint32_t layers = LayerCount();
+  const uint32_t mip_count = std::max<uint32_t>(desc_.mip_count, 1u);
+  if (level_count == 0u) {
+    level_count = mip_count - base_mip_level;
+  }
+  if (layer_count == 0u) {
+    layer_count = layers - base_array_layer;
+  }
+  const vk::ImageLayout old_layout =
+      GetLayout(base_mip_level, base_array_layer);
+  for (uint32_t mip = base_mip_level; mip < base_mip_level + level_count;
+       mip++) {
+    for (uint32_t layer = base_array_layer;
+         layer < base_array_layer + layer_count; layer++) {
+      const size_t index = static_cast<size_t>(mip) * layers + layer;
+      if (index < layouts_.size()) {
+        layouts_[index] = layout;
+      }
+    }
+  }
   return old_layout;
 }
 
 fml::Status TextureSourceVK::SetLayout(const BarrierVK& barrier) const {
-  const vk::ImageLayout old_layout =
-      SetLayoutWithoutEncoding(barrier.new_layout);
+  const uint32_t mip_count = std::max<uint32_t>(desc_.mip_count, 1u);
+  const uint32_t layers = LayerCount();
+  const uint32_t level_count = barrier.mip_level_count == 0u
+                                   ? mip_count - barrier.base_mip_level
+                                   : barrier.mip_level_count;
+  const uint32_t layer_count = barrier.array_layer_count == 0u
+                                   ? layers - barrier.base_array_layer
+                                   : barrier.array_layer_count;
+  // Records the new layout for the whole targeted range and returns the old
+  // layout of the first subresource. Callers transition ranges that share one
+  // layout (a single subresource, or a freshly created/uniform image), so one
+  // barrier with that old layout is correct.
+  const vk::ImageLayout old_layout = SetLayoutWithoutEncoding(
+      barrier.new_layout, barrier.base_mip_level, level_count,
+      barrier.base_array_layer, layer_count);
   vk::ImageMemoryBarrier image_barrier;
   image_barrier.srcAccessMask = barrier.src_access;
   image_barrier.dstAccessMask = barrier.dst_access;
@@ -42,10 +91,9 @@ fml::Status TextureSourceVK::SetLayout(const BarrierVK& barrier) const {
   image_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
   image_barrier.subresourceRange.aspectMask = ToImageAspectFlags(desc_.format);
   image_barrier.subresourceRange.baseMipLevel = barrier.base_mip_level;
-  image_barrier.subresourceRange.levelCount =
-      desc_.mip_count - barrier.base_mip_level;
-  image_barrier.subresourceRange.baseArrayLayer = 0u;
-  image_barrier.subresourceRange.layerCount = ToArrayLayerCount(desc_);
+  image_barrier.subresourceRange.levelCount = level_count;
+  image_barrier.subresourceRange.baseArrayLayer = barrier.base_array_layer;
+  image_barrier.subresourceRange.layerCount = layer_count;
 
   barrier.cmd_buffer.pipelineBarrier(barrier.src_stage,  // src stage
                                      barrier.dst_stage,  // dst stage

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
@@ -106,17 +106,29 @@ class TextureSourceVK {
   ///
   /// @return     The old layout.
   ///
-  vk::ImageLayout SetLayoutWithoutEncoding(vk::ImageLayout layout) const;
+  ///             By default the whole image is updated. Pass a subresource
+  ///             range (a `level_count`/`layer_count` of 0 means "to the end")
+  ///             to update only part of it; mip levels and array layers can
+  ///             hold different layouts.
+  ///
+  vk::ImageLayout SetLayoutWithoutEncoding(vk::ImageLayout layout,
+                                           uint32_t base_mip_level = 0u,
+                                           uint32_t level_count = 0u,
+                                           uint32_t base_array_layer = 0u,
+                                           uint32_t layer_count = 0u) const;
 
   //----------------------------------------------------------------------------
-  /// @brief      Get the last layout assigned to the TextureSourceVK.
+  /// @brief      Get the last layout assigned to a subresource of the
+  ///             TextureSourceVK.
   ///
   ///             This value is synchronized with the GPU via SetLayout so it
-  ///             may not reflect the actual layout.
+  ///             may not reflect the actual layout. Layouts are tracked per
+  ///             (mip level, array layer) subresource.
   ///
-  /// @return     The last known layout of the texture source.
+  /// @return     The last known layout of the subresource.
   ///
-  vk::ImageLayout GetLayout() const;
+  vk::ImageLayout GetLayout(uint32_t mip_level = 0u,
+                            uint32_t array_layer = 0u) const;
 
   //----------------------------------------------------------------------------
   /// @brief      When sampling from textures whose formats are not known to
@@ -177,7 +189,13 @@ class TextureSourceVK {
   // are rendered to across many subresources (e.g. a fully populated cube
   // mip chain).
   std::vector<CachedFrameDataEntry> frame_data_;
-  mutable vk::ImageLayout layout_ = vk::ImageLayout::eUndefined;
+  // One layout per (mip level, array layer) subresource, row-major by mip
+  // (`mip * layer_count + layer`). Sized `mip_count * layer_count`; a plain
+  // 2D texture has a single entry.
+  mutable std::vector<vk::ImageLayout> layouts_;
+
+  // Number of array layers (6 for cube maps, 1 otherwise).
+  uint32_t LayerCount() const;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -219,10 +219,6 @@ FramebufferAndRenderPass TextureVK::GetCachedFrameData(SampleCount sample_count,
   return source_->GetCachedFrameData(sample_count, mip_level, slice);
 }
 
-void TextureVK::SetMipMapGenerated() {
-  mipmap_generated_ = true;
-}
-
 bool TextureVK::IsSwapchainImage() const {
   return source_->IsSwapchainImage();
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -184,13 +184,21 @@ bool TextureVK::SetLayout(const BarrierVK& barrier) const {
 }
 
 vk::ImageLayout TextureVK::SetLayoutWithoutEncoding(
-    vk::ImageLayout layout) const {
-  return source_ ? source_->SetLayoutWithoutEncoding(layout)
+    vk::ImageLayout layout,
+    uint32_t base_mip_level,
+    uint32_t level_count,
+    uint32_t base_array_layer,
+    uint32_t layer_count) const {
+  return source_ ? source_->SetLayoutWithoutEncoding(
+                       layout, base_mip_level, level_count, base_array_layer,
+                       layer_count)
                  : vk::ImageLayout::eUndefined;
 }
 
-vk::ImageLayout TextureVK::GetLayout() const {
-  return source_ ? source_->GetLayout() : vk::ImageLayout::eUndefined;
+vk::ImageLayout TextureVK::GetLayout(uint32_t mip_level,
+                                     uint32_t array_layer) const {
+  return source_ ? source_->GetLayout(mip_level, array_layer)
+                 : vk::ImageLayout::eUndefined;
 }
 
 vk::ImageView TextureVK::GetRenderTargetView(uint32_t mip_level,

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
@@ -48,8 +48,6 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
   // |Texture|
   ISize GetSize() const override;
 
-  void SetMipMapGenerated();
-
   bool IsSwapchainImage() const;
 
   std::shared_ptr<SamplerVK> GetImmutableSamplerVariant(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
@@ -34,9 +34,14 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
 
   bool SetLayout(const BarrierVK& barrier) const;
 
-  vk::ImageLayout SetLayoutWithoutEncoding(vk::ImageLayout layout) const;
+  vk::ImageLayout SetLayoutWithoutEncoding(vk::ImageLayout layout,
+                                           uint32_t base_mip_level = 0u,
+                                           uint32_t level_count = 0u,
+                                           uint32_t base_array_layer = 0u,
+                                           uint32_t layer_count = 0u) const;
 
-  vk::ImageLayout GetLayout() const;
+  vk::ImageLayout GetLayout(uint32_t mip_level = 0u,
+                            uint32_t array_layer = 0u) const;
 
   std::shared_ptr<const TextureSourceVK> GetTextureSource() const;
 

--- a/engine/src/flutter/impeller/renderer/blit_pass.cc
+++ b/engine/src/flutter/impeller/renderer/blit_pass.cc
@@ -28,13 +28,21 @@ bool BlitPass::AddCopy(std::shared_ptr<Texture> source,
                        std::shared_ptr<Texture> destination,
                        std::optional<IRect> source_region,
                        IPoint destination_origin,
-                       std::string_view label) {
+                       std::string_view label,
+                       uint32_t destination_mip_level) {
   if (!source) {
     VALIDATION_LOG << "Attempted to add a texture blit with no source.";
     return false;
   }
   if (!destination) {
     VALIDATION_LOG << "Attempted to add a texture blit with no destination.";
+    return false;
+  }
+  if (destination_mip_level >= destination->GetTextureDescriptor().mip_count) {
+    VALIDATION_LOG << std::format(
+        "The destination mip level ({}) must be less than the destination mip "
+        "count ({}) for blits.",
+        destination_mip_level, destination->GetTextureDescriptor().mip_count);
     return false;
   }
 
@@ -71,14 +79,15 @@ bool BlitPass::AddCopy(std::shared_ptr<Texture> source,
 
   return OnCopyTextureToTextureCommand(
       std::move(source), std::move(destination), source_region.value(),
-      destination_origin, label);
+      destination_origin, label, destination_mip_level);
 }
 
 bool BlitPass::AddCopy(std::shared_ptr<Texture> source,
                        std::shared_ptr<DeviceBuffer> destination,
                        std::optional<IRect> source_region,
                        size_t destination_offset,
-                       std::string_view label) {
+                       std::string_view label,
+                       uint32_t source_mip_level) {
   if (!source) {
     VALIDATION_LOG << "Attempted to add a texture blit with no source.";
     return false;
@@ -111,7 +120,7 @@ bool BlitPass::AddCopy(std::shared_ptr<Texture> source,
 
   return OnCopyTextureToBufferCommand(std::move(source), std::move(destination),
                                       source_region.value(), destination_offset,
-                                      label);
+                                      label, source_mip_level);
 }
 
 bool BlitPass::AddCopy(BufferView source,

--- a/engine/src/flutter/impeller/renderer/blit_pass.h
+++ b/engine/src/flutter/impeller/renderer/blit_pass.h
@@ -64,6 +64,8 @@ class BlitPass {
   ///                                 destination texture.
   /// @param[in]  label               The optional debug label to give the
   ///                                 command.
+  /// @param[in]  destination_mip_level  The mip level of the destination to
+  ///                                 write to.
   ///
   /// @return     If the command was valid for subsequent commitment.
   ///
@@ -71,7 +73,8 @@ class BlitPass {
                std::shared_ptr<Texture> destination,
                std::optional<IRect> source_region = std::nullopt,
                IPoint destination_origin = {},
-               std::string_view label = "");
+               std::string_view label = "",
+               uint32_t destination_mip_level = 0);
 
   //----------------------------------------------------------------------------
   /// @brief      Record a command to copy the contents of a texture to a
@@ -94,7 +97,8 @@ class BlitPass {
                std::shared_ptr<DeviceBuffer> destination,
                std::optional<IRect> source_region = std::nullopt,
                size_t destination_offset = 0,
-               std::string_view label = "");
+               std::string_view label = "",
+               uint32_t source_mip_level = 0);
 
   //----------------------------------------------------------------------------
   /// @brief      Record a command to copy the contents of a buffer to a
@@ -161,14 +165,16 @@ class BlitPass {
       std::shared_ptr<Texture> destination,
       IRect source_region,
       IPoint destination_origin,
-      std::string_view label) = 0;
+      std::string_view label,
+      uint32_t destination_mip_level = 0) = 0;
 
   virtual bool OnCopyTextureToBufferCommand(
       std::shared_ptr<Texture> source,
       std::shared_ptr<DeviceBuffer> destination,
       IRect source_region,
       size_t destination_offset,
-      std::string_view label) = 0;
+      std::string_view label,
+      uint32_t source_mip_level = 0) = 0;
 
   virtual bool OnCopyBufferToTextureCommand(
       BufferView source,

--- a/engine/src/flutter/impeller/renderer/capabilities.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities.cc
@@ -102,6 +102,9 @@ class StandardCapabilities final : public Capabilities {
   bool SupportsManuallyMippedTextures() const override { return true; }
 
   // |Capabilities|
+  bool SupportsBlitMipmapGeneration() const override { return true; }
+
+  // |Capabilities|
   bool SupportsExtendedRangeFormats() const override {
     return supports_extended_range_formats_;
   }

--- a/engine/src/flutter/impeller/renderer/capabilities.h
+++ b/engine/src/flutter/impeller/renderer/capabilities.h
@@ -100,6 +100,12 @@ class Capabilities {
   ///        bounded to the levels the texture declares.
   virtual bool SupportsManuallyMippedTextures() const = 0;
 
+  /// @brief Whether `BlitPass::GenerateMipmap` produces a correct mip chain
+  ///        on this device. False where the driver's blit-based generation
+  ///        corrupts the generated levels, in which case the mip chain must
+  ///        be rendered instead (see `AddMipmapGeneration`).
+  virtual bool SupportsBlitMipmapGeneration() const = 0;
+
   /// @brief  Returns a supported `PixelFormat` for textures that store
   ///         4-channel colors (red/green/blue/alpha).
   virtual PixelFormat GetDefaultColorFormat() const = 0;

--- a/engine/src/flutter/impeller/renderer/testing/mocks.h
+++ b/engine/src/flutter/impeller/renderer/testing/mocks.h
@@ -77,7 +77,8 @@ class MockBlitPass : public BlitPass {
                std::shared_ptr<Texture> destination,
                IRect source_region,
                IPoint destination_origin,
-               std::string_view label),
+               std::string_view label,
+               uint32_t destination_mip_level),
               (override));
 
   MOCK_METHOD(bool,
@@ -86,7 +87,8 @@ class MockBlitPass : public BlitPass {
                std::shared_ptr<DeviceBuffer> destination,
                IRect source_region,
                size_t destination_offset,
-               std::string_view label),
+               std::string_view label,
+               uint32_t source_mip_level),
               (override));
   MOCK_METHOD(bool,
               OnCopyBufferToTextureCommand,

--- a/engine/src/flutter/impeller/renderer/testing/mocks.h
+++ b/engine/src/flutter/impeller/renderer/testing/mocks.h
@@ -254,6 +254,7 @@ class MockCapabilities : public Capabilities {
   MOCK_METHOD(bool, SupportsPrimitiveRestart, (), (const override));
   MOCK_METHOD(bool, Supports32BitPrimitiveIndices, (), (const override));
   MOCK_METHOD(bool, SupportsManuallyMippedTextures, (), (const override));
+  MOCK_METHOD(bool, SupportsBlitMipmapGeneration, (), (const override));
   MOCK_METHOD(bool, SupportsExtendedRangeFormats, (), (const override));
   MOCK_METHOD(bool, SupportsFramebufferRenderMipmap, (), (const override));
   MOCK_METHOD(bool,

--- a/engine/src/flutter/impeller/renderer/texture_util.cc
+++ b/engine/src/flutter/impeller/renderer/texture_util.cc
@@ -34,20 +34,4 @@ std::shared_ptr<Texture> CreateTexture(
   return texture;
 }
 
-fml::Status AddMipmapGeneration(
-    const std::shared_ptr<CommandBuffer>& command_buffer,
-    const std::shared_ptr<Context>& context,
-    const std::shared_ptr<Texture>& texture) {
-  std::shared_ptr<BlitPass> blit_pass = command_buffer->CreateBlitPass();
-  bool success = blit_pass->GenerateMipmap(texture);
-  if (!success) {
-    return fml::Status(fml::StatusCode::kUnknown, "");
-  }
-  success = blit_pass->EncodeCommands();
-  if (!success) {
-    return fml::Status(fml::StatusCode::kUnknown, "");
-  }
-  return fml::Status();
-}
-
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/texture_util.h
+++ b/engine/src/flutter/impeller/renderer/texture_util.h
@@ -18,12 +18,6 @@ std::shared_ptr<Texture> CreateTexture(
     const std::shared_ptr<impeller::Context>& context,
     std::string_view debug_label);
 
-/// Adds a blit command to the render pass.
-[[nodiscard]] fml::Status AddMipmapGeneration(
-    const std::shared_ptr<CommandBuffer>& command_buffer,
-    const std::shared_ptr<Context>& context,
-    const std::shared_ptr<Texture>& texture);
-
 }  // namespace impeller
 
 #endif  // FLUTTER_IMPELLER_RENDERER_TEXTURE_UTIL_H_

--- a/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
@@ -17,9 +17,12 @@
 #include "flutter/impeller/renderer/context.h"
 #include "impeller/core/device_buffer.h"
 #include "impeller/core/formats.h"
+#include "impeller/core/host_buffer.h"
 #include "impeller/core/texture_descriptor.h"
 #include "impeller/display_list/skia_conversions.h"
+#include "impeller/entity/mipmap_generator.h"
 #include "impeller/geometry/size.h"
+#include "impeller/renderer/render_target.h"
 #include "third_party/skia/include/core/SkAlphaType.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
@@ -499,9 +502,6 @@ ImageDecoderImpeller::UnsafeUploadTextureToPrivate(
   blit_pass->SetLabel("Mipmap Blit Pass");
   blit_pass->AddCopy(impeller::DeviceBuffer::AsBufferView(buffer),
                      dest_texture);
-  if (texture_descriptor.mip_count > 1) {
-    blit_pass->GenerateMipmap(dest_texture);
-  }
 
   std::shared_ptr<impeller::Texture> result_texture = dest_texture;
   if (resize_info.has_value()) {
@@ -526,13 +526,41 @@ ImageDecoderImpeller::UnsafeUploadTextureToPrivate(
 
     blit_pass->ResizeTexture(/*source=*/dest_texture,
                              /*destination=*/resize_texture);
-    if (resize_desc.mip_count > 1) {
-      blit_pass->GenerateMipmap(resize_texture);
-    }
 
     result_texture = std::move(resize_texture);
   }
   blit_pass->EncodeCommands();
+
+  // Mipmap generation happens after the upload pass. Resizes read only the
+  // source base level, so generation order does not affect them.
+  {
+    impeller::RenderTargetAllocator render_target_allocator(
+        context->GetResourceAllocator());
+    std::shared_ptr<impeller::HostBuffer> data_host_buffer;
+    auto generate_mips =
+        [&](const std::shared_ptr<impeller::Texture>& texture) -> bool {
+      if (texture->GetTextureDescriptor().mip_count <= 1u) {
+        return true;
+      }
+      if (!data_host_buffer) {
+        data_host_buffer = impeller::HostBuffer::Create(
+            context->GetResourceAllocator(), context->GetIdleWaiter(),
+            context->GetCapabilities()->GetMinimumUniformAlignment(),
+            context->GetSubmissionTracker());
+      }
+      return impeller::AddMipmapGeneration(command_buffer, context, texture,
+                                           render_target_allocator,
+                                           *data_host_buffer)
+          .ok();
+    };
+    if (!generate_mips(dest_texture) ||
+        (result_texture != dest_texture && !generate_mips(result_texture))) {
+      std::string decode_error("Could not generate mipmaps.");
+      FML_DLOG(ERROR) << decode_error;
+      return std::make_pair(nullptr, decode_error);
+    }
+  }
+
   if (!context->GetCommandQueue()
            ->Submit(
                {command_buffer},


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/161283.

Adreno drivers corrupt blit-based mipmap generation, and the existing workaround clamps every Vulkan sampler to the base mip level, which disables mip sampling for all mipped textures on affected devices, including hand-uploaded chains sampled through Flutter GPU. This change generates the mip chain with render passes where the blit path is broken, then removes the sampler clamp so mip filters pass through unmodified.

The generator draws the downsample chain into scratch offscreens and stores each level into the target with same-size copies (only scaled blits corrupt on affected devices), so target textures need no additional usage flags. Dispatch sits behind a new SupportsBlitMipmapGeneration capability inside the shared AddMipmapGeneration helper; healthy devices keep blit generation and GLES keeps glGenerateMipmap. Vulkan image layouts are now tracked per subresource, which rendering into individual mip levels requires and which also fixes a latent attachment layout desync.

Supersedes #189897 and #189966.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
