### PR TITLE
iOS: Configure test task runner thread at display QoS

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.mm
@@ -10,8 +10,8 @@
 #include "flutter/fml/thread.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner+FML.h"
 
-// Configures the worker thread to match the QoS of the real platform/UI thread,
-// which is `kDisplay` (user-interactive).
+// Set the thread to user-interactive QoS to match the real value used in
+// the actual embedder.
 static void ConfigureThread(const fml::Thread::ThreadConfig& config) {
   fml::Thread::SetCurrentThreadName(config);
   pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
@@ -26,9 +26,8 @@ static void ConfigureThread(const fml::Thread::ThreadConfig& config) {
 }
 
 - (instancetype)initWithLabel:(NSString*)label {
-  _thread = std::make_unique<fml::Thread>(
-      ConfigureThread, fml::Thread::ThreadConfig(label ? label.UTF8String : "",
-                                                 fml::Thread::ThreadPriority::kDisplay));
+  _thread = std::make_unique<fml::Thread>(ConfigureThread,
+                                          fml::Thread::ThreadConfig(label ? label.UTF8String : ""));
   self = [super initWithTaskRunner:_thread->GetTaskRunner()];
   return self;
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.mm
@@ -4,9 +4,18 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.h"
 
+#include <pthread/qos.h>
+
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/thread.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner+FML.h"
+
+// Configures the worker thread to match the QoS of the real platform/UI thread,
+// which is `kDisplay` (user-interactive).
+static void ConfigureThread(const fml::Thread::ThreadConfig& config) {
+  fml::Thread::SetCurrentThreadName(config);
+  pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+}
 
 // A FlutterFMLTaskRunner that owns the fml::Thread it runs on.
 @interface FlutterFMLThreadTaskRunner : FlutterFMLTaskRunner
@@ -17,7 +26,9 @@
 }
 
 - (instancetype)initWithLabel:(NSString*)label {
-  _thread = std::make_unique<fml::Thread>(label.UTF8String);
+  _thread = std::make_unique<fml::Thread>(
+      ConfigureThread,
+      fml::Thread::ThreadConfig(label.UTF8String, fml::Thread::ThreadPriority::kDisplay));
   self = [super initWithTaskRunner:_thread->GetTaskRunner()];
   return self;
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunnerTestHelper.mm
@@ -27,8 +27,8 @@ static void ConfigureThread(const fml::Thread::ThreadConfig& config) {
 
 - (instancetype)initWithLabel:(NSString*)label {
   _thread = std::make_unique<fml::Thread>(
-      ConfigureThread,
-      fml::Thread::ThreadConfig(label.UTF8String, fml::Thread::ThreadPriority::kDisplay));
+      ConfigureThread, fml::Thread::ThreadConfig(label ? label.UTF8String : "",
+                                                 fml::Thread::ThreadPriority::kDisplay));
   self = [super initWithTaskRunner:_thread->GetTaskRunner()];
   return self;
 }


### PR DESCRIPTION
The iOS unit tests for VSyncClient run it on a worker thread and block the test thread waiting on that worker. Xcode's Thread Performance Checker flags this as a priority inversion: the waiting thread runs at a higher quality-of-service class than the worker it is blocked on, producing the following error message:

    Thread Performance Checker: Thread running at User-interactive
    quality-of-service class waiting on a lower QoS thread running at
    Default quality-of-service class. Investigate ways to avoid priority
    inversions

FlutterFMLTaskRunnerTestHelper creates the worker with a bare fml::Thread, which by default is configured only with a thread name but leaves the thread at the default QoS. In production, the platform/UI thread that a VSyncClient posts to is created at ThreadPriority::kDisplay (user-interactive) by IOSPlatformThreadConfigSetter in FlutterEngine.mm, so the test worker was running below the priority of the real thread it's attempting to represent in the tests.

This adds a config setter to raises it to QOS_CLASS_USER_INTERACTIVE (i.e. kDisplay). This prevents the priority inversion since the worker is now at least as high-priority as any thread that waits on it, which accurately reflects how it's used in the real embedder.

Issue: https://github.com/flutter/flutter/issues/181684
Issue: https://github.com/flutter/flutter/issues/112232

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
