### PR TITLE
Support reduceMotion accessibility feature in MediaQuery

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -101,6 +101,9 @@ enum _MediaQueryAspect {
   /// Specifies the aspect corresponding to [MediaQueryData.disableAnimations].
   disableAnimations,
 
+  /// Specifies the aspect corresponding to [MediaQueryData.reduceMotion].
+  reduceMotion,
+
   /// Specifies the aspect corresponding to [MediaQueryData.boldText].
   boldText,
 
@@ -228,6 +231,7 @@ class MediaQueryData {
     this.highContrast = false,
     this.onOffSwitchLabels = false,
     this.disableAnimations = false,
+    this.reduceMotion = false,
     this.boldText = false,
     this.supportsAnnounce = false,
     this.navigationMode = NavigationMode.traditional,
@@ -319,6 +323,8 @@ class MediaQueryData {
       disableAnimations =
           platformData?.disableAnimations ??
           view.platformDispatcher.accessibilityFeatures.disableAnimations,
+      reduceMotion =
+          platformData?.reduceMotion ?? view.platformDispatcher.accessibilityFeatures.reduceMotion,
       boldText = platformData?.boldText ?? view.platformDispatcher.accessibilityFeatures.boldText,
       supportsAnnounce =
           platformData?.supportsAnnounce ??
@@ -692,6 +698,29 @@ class MediaQueryData {
   ///    originates.
   final bool disableAnimations;
 
+  /// Whether the platform is requesting that animations be reduced or replaced
+  /// with cross-fades in preference to motion effects.
+  ///
+  /// This corresponds to the iOS "Reduce Motion" accessibility setting.
+  ///
+  /// Unlike [disableAnimations], this flag does not automatically alter
+  /// framework animations such as those controlled via [AnimationController].
+  /// Instead, it is intended to be read by widgets that want to tone down or
+  /// replace non-essential motion, for example by substituting a cross-fade
+  /// for a slide transition.
+  ///
+  /// When implementing custom animations, you should check this property and
+  /// adjust behavior accordingly; for example, by preferring a fade over
+  /// movement when it is true.
+  ///
+  /// See also:
+  ///
+  ///  * [dart:ui.AccessibilityFeatures.reduceMotion], the underlying primitive
+  ///    flag provided by the platform.
+  ///  * [dart:ui.PlatformDispatcher.accessibilityFeatures], where the setting
+  ///    originates.
+  final bool reduceMotion;
+
   /// Whether the platform is requesting that text be drawn with a bold font
   /// weight.
   ///
@@ -852,6 +881,7 @@ class MediaQueryData {
     bool? highContrast,
     bool? onOffSwitchLabels,
     bool? disableAnimations,
+    bool? reduceMotion,
     bool? invertColors,
     bool? accessibleNavigation,
     bool? boldText,
@@ -879,6 +909,7 @@ class MediaQueryData {
       highContrast: highContrast ?? this.highContrast,
       onOffSwitchLabels: onOffSwitchLabels ?? this.onOffSwitchLabels,
       disableAnimations: disableAnimations ?? this.disableAnimations,
+      reduceMotion: reduceMotion ?? this.reduceMotion,
       accessibleNavigation: accessibleNavigation ?? this.accessibleNavigation,
       boldText: boldText ?? this.boldText,
       supportsAnnounce: supportsAnnounce ?? this.supportsAnnounce,
@@ -927,6 +958,7 @@ class MediaQueryData {
       highContrast: highContrast,
       onOffSwitchLabels: onOffSwitchLabels,
       disableAnimations: disableAnimations,
+      reduceMotion: reduceMotion,
       accessibleNavigation: accessibleNavigation,
       boldText: boldText,
       supportsAnnounce: supportsAnnounce,
@@ -962,6 +994,7 @@ class MediaQueryData {
       highContrast: highContrast,
       onOffSwitchLabels: onOffSwitchLabels,
       disableAnimations: disableAnimations,
+      reduceMotion: reduceMotion,
       accessibleNavigation: accessibleNavigation,
       boldText: boldText,
       supportsAnnounce: supportsAnnounce,
@@ -1165,6 +1198,7 @@ class MediaQueryData {
         other.highContrast == highContrast &&
         other.onOffSwitchLabels == onOffSwitchLabels &&
         other.disableAnimations == disableAnimations &&
+        other.reduceMotion == reduceMotion &&
         other.invertColors == invertColors &&
         other.accessibleNavigation == accessibleNavigation &&
         other.boldText == boldText &&
@@ -1193,6 +1227,7 @@ class MediaQueryData {
     highContrast,
     onOffSwitchLabels,
     disableAnimations,
+    reduceMotion,
     invertColors,
     accessibleNavigation,
     boldText,
@@ -1225,6 +1260,7 @@ class MediaQueryData {
       'highContrast: $highContrast',
       'onOffSwitchLabels: $onOffSwitchLabels',
       'disableAnimations: $disableAnimations',
+      'reduceMotion: $reduceMotion',
       'invertColors: $invertColors',
       'boldText: $boldText',
       'navigationMode: ${navigationMode.name}',
@@ -2026,6 +2062,28 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   static bool? maybeDisableAnimationsOf(BuildContext context) =>
       _maybeOf(context, _MediaQueryAspect.disableAnimations)?.disableAnimations;
 
+  /// Returns [MediaQueryData.reduceMotion] for the nearest [MediaQuery]
+  /// ancestor or false, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.reduceMotion] property of the ancestor
+  /// [MediaQuery] changes.
+  ///
+  /// {@macro flutter.widgets.media_query.MediaQuery.dontUseOf}
+  static bool reduceMotionOf(BuildContext context) =>
+      _of(context, _MediaQueryAspect.reduceMotion).reduceMotion;
+
+  /// Returns [MediaQueryData.reduceMotion] for the nearest [MediaQuery]
+  /// ancestor or null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.reduceMotion] property of the ancestor
+  /// [MediaQuery] changes.
+  ///
+  /// {@macro flutter.widgets.media_query.MediaQuery.dontUseMaybeOf}
+  static bool? maybeReduceMotionOf(BuildContext context) =>
+      _maybeOf(context, _MediaQueryAspect.reduceMotion)?.reduceMotion;
+
   /// Returns the [MediaQueryData.boldText] accessibility setting for the
   /// nearest [MediaQuery] ancestor or false, if no such ancestor exists.
   ///
@@ -2273,6 +2331,7 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
               data.onOffSwitchLabels != oldWidget.data.onOffSwitchLabels,
             _MediaQueryAspect.disableAnimations =>
               data.disableAnimations != oldWidget.data.disableAnimations,
+            _MediaQueryAspect.reduceMotion => data.reduceMotion != oldWidget.data.reduceMotion,
             _MediaQueryAspect.boldText => data.boldText != oldWidget.data.boldText,
             _MediaQueryAspect.supportsAnnounce =>
               data.supportsAnnounce != oldWidget.data.supportsAnnounce,

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -155,6 +155,7 @@ void main() {
     expect(data.accessibleNavigation, false);
     expect(data.invertColors, false);
     expect(data.disableAnimations, false);
+    expect(data.reduceMotion, false);
     expect(data.boldText, false);
     expect(data.highContrast, false);
     expect(data.onOffSwitchLabels, false);
@@ -172,6 +173,7 @@ void main() {
       accessibleNavigation: true,
       invertColors: true,
       disableAnimations: true,
+      reduceMotion: true,
       boldText: true,
       highContrast: true,
       onOffSwitchLabels: true,
@@ -206,6 +208,7 @@ void main() {
     expect(data.accessibleNavigation, platformData.accessibleNavigation);
     expect(data.invertColors, platformData.invertColors);
     expect(data.disableAnimations, platformData.disableAnimations);
+    expect(data.reduceMotion, platformData.reduceMotion);
     expect(data.boldText, platformData.boldText);
     expect(data.highContrast, platformData.highContrast);
     expect(data.onOffSwitchLabels, platformData.onOffSwitchLabels);
@@ -257,6 +260,7 @@ void main() {
         data.disableAnimations,
         tester.platformDispatcher.accessibilityFeatures.disableAnimations,
       );
+      expect(data.reduceMotion, tester.platformDispatcher.accessibilityFeatures.reduceMotion);
       expect(data.boldText, tester.platformDispatcher.accessibilityFeatures.boldText);
       expect(data.highContrast, tester.platformDispatcher.accessibilityFeatures.highContrast);
       expect(
@@ -283,6 +287,7 @@ void main() {
         accessibleNavigation: true,
         invertColors: true,
         disableAnimations: true,
+        reduceMotion: true,
         boldText: true,
         highContrast: true,
         onOffSwitchLabels: true,
@@ -331,6 +336,7 @@ void main() {
       expect(data.accessibleNavigation, platformData.accessibleNavigation);
       expect(data.invertColors, platformData.invertColors);
       expect(data.disableAnimations, platformData.disableAnimations);
+      expect(data.reduceMotion, platformData.reduceMotion);
       expect(data.boldText, platformData.boldText);
       expect(data.highContrast, platformData.highContrast);
       expect(data.onOffSwitchLabels, platformData.onOffSwitchLabels);
@@ -401,6 +407,7 @@ void main() {
         data.disableAnimations,
         tester.platformDispatcher.accessibilityFeatures.disableAnimations,
       );
+      expect(data.reduceMotion, tester.platformDispatcher.accessibilityFeatures.reduceMotion);
       expect(data.boldText, tester.platformDispatcher.accessibilityFeatures.boldText);
       expect(data.highContrast, tester.platformDispatcher.accessibilityFeatures.highContrast);
       expect(
@@ -592,6 +599,7 @@ void main() {
     expect(copied.accessibleNavigation, data.accessibleNavigation);
     expect(copied.invertColors, data.invertColors);
     expect(copied.disableAnimations, data.disableAnimations);
+    expect(copied.reduceMotion, data.reduceMotion);
     expect(copied.boldText, data.boldText);
     expect(copied.highContrast, data.highContrast);
     expect(copied.onOffSwitchLabels, data.onOffSwitchLabels);
@@ -634,6 +642,7 @@ void main() {
       accessibleNavigation: true,
       invertColors: true,
       disableAnimations: true,
+      reduceMotion: true,
       boldText: true,
       highContrast: true,
       onOffSwitchLabels: true,
@@ -654,6 +663,7 @@ void main() {
     expect(copied.accessibleNavigation, true);
     expect(copied.invertColors, true);
     expect(copied.disableAnimations, true);
+    expect(copied.reduceMotion, true);
     expect(copied.boldText, true);
     expect(copied.highContrast, true);
     expect(copied.onOffSwitchLabels, true);
@@ -703,6 +713,7 @@ void main() {
     expect(updatedData.accessibleNavigation, data.accessibleNavigation);
     expect(updatedData.invertColors, data.invertColors);
     expect(updatedData.disableAnimations, data.disableAnimations);
+    expect(updatedData.reduceMotion, data.reduceMotion);
     expect(updatedData.boldText, data.boldText);
     expect(updatedData.highContrast, data.highContrast);
     expect(updatedData.onOffSwitchLabels, data.onOffSwitchLabels);
@@ -747,6 +758,7 @@ void main() {
     expect(updatedData.accessibleNavigation, data.accessibleNavigation);
     expect(updatedData.invertColors, data.invertColors);
     expect(updatedData.disableAnimations, data.disableAnimations);
+    expect(updatedData.reduceMotion, data.reduceMotion);
     expect(updatedData.boldText, data.boldText);
     expect(updatedData.highContrast, data.highContrast);
     expect(updatedData.onOffSwitchLabels, data.onOffSwitchLabels);
@@ -791,6 +803,7 @@ void main() {
           accessibleNavigation: true,
           invertColors: true,
           disableAnimations: true,
+          reduceMotion: true,
           boldText: true,
           highContrast: true,
           onOffSwitchLabels: true,
@@ -828,6 +841,7 @@ void main() {
     expect(unpadded.accessibleNavigation, true);
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
+    expect(unpadded.reduceMotion, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
     expect(unpadded.onOffSwitchLabels, true);
@@ -867,6 +881,7 @@ void main() {
           accessibleNavigation: true,
           invertColors: true,
           disableAnimations: true,
+          reduceMotion: true,
           boldText: true,
           highContrast: true,
           onOffSwitchLabels: true,
@@ -901,6 +916,7 @@ void main() {
     expect(unpadded.accessibleNavigation, true);
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
+    expect(unpadded.reduceMotion, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
     expect(unpadded.onOffSwitchLabels, true);
@@ -940,6 +956,7 @@ void main() {
           accessibleNavigation: true,
           invertColors: true,
           disableAnimations: true,
+          reduceMotion: true,
           boldText: true,
           highContrast: true,
           onOffSwitchLabels: true,
@@ -977,6 +994,7 @@ void main() {
     expect(unpadded.accessibleNavigation, true);
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
+    expect(unpadded.reduceMotion, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
     expect(unpadded.onOffSwitchLabels, true);
@@ -1016,6 +1034,7 @@ void main() {
           accessibleNavigation: true,
           invertColors: true,
           disableAnimations: true,
+          reduceMotion: true,
           boldText: true,
           highContrast: true,
           onOffSwitchLabels: true,
@@ -1050,6 +1069,7 @@ void main() {
     expect(unpadded.accessibleNavigation, true);
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
+    expect(unpadded.reduceMotion, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
     expect(unpadded.onOffSwitchLabels, true);
@@ -1089,6 +1109,7 @@ void main() {
           accessibleNavigation: true,
           invertColors: true,
           disableAnimations: true,
+          reduceMotion: true,
           boldText: true,
           highContrast: true,
           onOffSwitchLabels: true,
@@ -1126,6 +1147,7 @@ void main() {
     expect(unpadded.accessibleNavigation, true);
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
+    expect(unpadded.reduceMotion, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
     expect(unpadded.onOffSwitchLabels, true);
@@ -1165,6 +1187,7 @@ void main() {
           accessibleNavigation: true,
           invertColors: true,
           disableAnimations: true,
+          reduceMotion: true,
           boldText: true,
           highContrast: true,
           onOffSwitchLabels: true,
@@ -1199,6 +1222,7 @@ void main() {
     expect(unpadded.accessibleNavigation, true);
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
+    expect(unpadded.reduceMotion, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
     expect(unpadded.onOffSwitchLabels, true);
@@ -1531,6 +1555,7 @@ void main() {
           accessibleNavigation: true,
           invertColors: true,
           disableAnimations: true,
+          reduceMotion: true,
           boldText: true,
           highContrast: true,
           onOffSwitchLabels: true,
@@ -1563,6 +1588,7 @@ void main() {
     expect(subScreenMediaQuery.accessibleNavigation, true);
     expect(subScreenMediaQuery.invertColors, true);
     expect(subScreenMediaQuery.disableAnimations, true);
+    expect(subScreenMediaQuery.reduceMotion, true);
     expect(subScreenMediaQuery.boldText, true);
     expect(subScreenMediaQuery.highContrast, true);
     expect(subScreenMediaQuery.onOffSwitchLabels, true);
@@ -1610,6 +1636,7 @@ void main() {
           accessibleNavigation: true,
           invertColors: true,
           disableAnimations: true,
+          reduceMotion: true,
           boldText: true,
           highContrast: true,
           onOffSwitchLabels: true,
@@ -1648,6 +1675,7 @@ void main() {
     expect(subScreenMediaQuery.accessibleNavigation, true);
     expect(subScreenMediaQuery.invertColors, true);
     expect(subScreenMediaQuery.disableAnimations, true);
+    expect(subScreenMediaQuery.reduceMotion, true);
     expect(subScreenMediaQuery.boldText, true);
     expect(subScreenMediaQuery.highContrast, true);
     expect(subScreenMediaQuery.onOffSwitchLabels, true);
@@ -1928,6 +1956,11 @@ void main() {
         const _MediaQueryAspectCase(
           MediaQuery.maybeDisableAnimationsOf,
           MediaQueryData(disableAnimations: true),
+        ),
+        const _MediaQueryAspectCase(MediaQuery.reduceMotionOf, MediaQueryData(reduceMotion: true)),
+        const _MediaQueryAspectCase(
+          MediaQuery.maybeReduceMotionOf,
+          MediaQueryData(reduceMotion: true),
         ),
         const _MediaQueryAspectCase(MediaQuery.boldTextOf, MediaQueryData(boldText: true)),
         const _MediaQueryAspectCase(MediaQuery.maybeBoldTextOf, MediaQueryData(boldText: true)),


### PR DESCRIPTION
Exposes the platform's "Reduce Motion" accessibility setting through MediaQueryData, so widgets can react to it with proper dependency tracking instead of reading it ad hoc off the platform dispatcher.

The reduceMotion flag tracking the iOS "Reduce Motion" setting already exists at the engine layer as
`dart:ui.AccessibilityFeatures.reduceMotion`, but it was never surfaced on MediaQueryData. This mirrors the existing disableAnimations support, which corresponds to Android's "Remove animations" setting.

Unlike disableAnimations, reduceMotion is not consulted by framework-level animation APIs such as AnimationController. It is intended for widgets that want to tone down or replace non-essential motion, for example, by substituting a cross-fade for a slide.

No engine or SemanticsBinding changes are required: as with disableAnimations, MediaQueryData reads reduceMotion directly from platformDispatcher.accessibilityFeatures, and FakeAccessibilityFeatures already supports the flag.

Issue: https://github.com/flutter/flutter/issues/4827
Issue: https://github.com/flutter/flutter/issues/65874

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
