### PR TITLE
ci: mac-must-wait part duex

### DIFF
--- a/.github/workflows/mac-verify-binaries.yml
+++ b/.github/workflows/mac-verify-binaries.yml
@@ -46,7 +46,7 @@ jobs:
         uses: ./.github/actions/wait-for-engine-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          check-name: 'Mac mac_host_engine,Linux linux_host_engine'
+          check-name: 'Mac mac_host_engine,Mac mac_ios_engine,Linux linux_host_engine'
 
       - uses: ./.github/actions/composite-flutter-setup
 


### PR DESCRIPTION
Test still racy: "ios/artifacts.zip" required by flutter tool in the test, but not actually verified.
