### PR TITLE
Reland Split the platform and cpuArch part of TargetPlatform

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_asset_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_asset_builder.dart
@@ -66,7 +66,7 @@ Future<void> run(List<String> args) async {
     packageConfigPath:
         argResults[_kOptionPackages] as String? ??
         findPackageConfigFileOrDefault(globals.fs.currentDirectory).path,
-    targetPlatform: TargetPlatform.fuchsia_arm64, // This is not arch specific.
+    targetPlatform: const TargetPlatform(.fuchsia, .arm64), // This is not arch specific.
   );
 
   if (assets == null) {

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -191,16 +191,6 @@ class AndroidDevice extends Device {
   }
 
   @override
-  late final Future<TargetPlatform> targetPlatform = () async {
-    return switch (await cpuArch) {
-      CpuArch.arm64 => TargetPlatform.android_arm64,
-      CpuArch.armv7 => TargetPlatform.android_arm,
-      CpuArch.x64 => TargetPlatform.android_x64,
-      CpuArch.x86 || CpuArch.riscv64 || CpuArch.unknown => TargetPlatform.unsupported,
-    };
-  }();
-
-  @override
   late final Future<CpuArch> cpuArch = () async {
     // http://developer.android.com/ndk/guides/abis.html (x86, armeabi-v7a, ...)
     final String? abi = await _getProperty('ro.product.cpu.abi');
@@ -227,26 +217,7 @@ class AndroidDevice extends Device {
 
   @override
   Future<bool> supportsRuntimeMode(BuildMode buildMode) async {
-    switch (await targetPlatform) {
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
-        return buildMode != BuildMode.jitRelease;
-      case TargetPlatform.android:
-      case TargetPlatform.darwin:
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.ios:
-      case TargetPlatform.linux_arm64:
-      case TargetPlatform.linux_riscv64:
-      case TargetPlatform.linux_x64:
-      case TargetPlatform.tester:
-      case TargetPlatform.web_javascript:
-      case TargetPlatform.windows_x64:
-      case TargetPlatform.windows_arm64:
-      case TargetPlatform.unsupported:
-        throw UnsupportedError('Invalid target platform for Android');
-    }
+    return buildMode != .jitRelease;
   }
 
   @override
@@ -873,13 +844,9 @@ class AndroidDevice extends Device {
 
   @override
   Future<bool> isSupported() async {
-    final TargetPlatform platform = await targetPlatform;
-    return switch (platform) {
-      TargetPlatform.android ||
-      TargetPlatform.android_arm ||
-      TargetPlatform.android_arm64 ||
-      TargetPlatform.android_x64 => true,
-      _ => false,
+    return switch (await cpuArch) {
+      .arm64 || .armv7 || .x64 => true,
+      .x86 || .riscv64 || .unknown => false,
     };
   }
 

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -13,6 +13,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
+import '../build_info.dart';
 import '../device.dart';
 import '../emulator.dart';
 import 'android_sdk.dart';

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -1191,13 +1191,13 @@ void updateLocalProperties({
   if (buildInfo != null) {
     changeIfNecessary('flutter.buildMode', buildInfo.modeName);
     final String? buildName = validatedBuildNameForPlatform(
-      TargetPlatform.android_arm,
+      PlatformType.android,
       buildInfo.buildName ?? project.manifest.buildName,
       globals.logger,
     );
     changeIfNecessary('flutter.versionName', buildName);
     final String? buildNumber = validatedBuildNumberForPlatform(
-      TargetPlatform.android_arm,
+      PlatformType.android,
       buildInfo.buildNumber ?? project.manifest.buildNumber,
       globals.logger,
     );

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -197,35 +197,16 @@ enum HostArtifact {
 
 // TODO(knopp): Remove once darwin artifacts are universal and moved out of darwin-x64
 String _enginePlatformDirectoryName(TargetPlatform platform) {
-  if (platform == TargetPlatform.darwin) {
+  if (platform.type == .macos) {
     return 'darwin-x64';
   }
-  return platform.getName();
-}
-
-// Remove android target platform type.
-TargetPlatform? _mapTargetPlatform(TargetPlatform? targetPlatform) {
-  switch (targetPlatform) {
-    case TargetPlatform.android:
-      return TargetPlatform.android_arm64;
-    case TargetPlatform.ios:
-    case TargetPlatform.darwin:
-    case TargetPlatform.linux_x64:
-    case TargetPlatform.linux_arm64:
-    case TargetPlatform.linux_riscv64:
-    case TargetPlatform.windows_x64:
-    case TargetPlatform.windows_arm64:
-    case TargetPlatform.fuchsia_arm64:
-    case TargetPlatform.fuchsia_x64:
-    case TargetPlatform.tester:
-    case TargetPlatform.web_javascript:
-    case TargetPlatform.android_arm:
-    case TargetPlatform.android_arm64:
-    case TargetPlatform.android_x64:
-    case TargetPlatform.unsupported:
-    case null:
-      return targetPlatform;
+  // iOS engine artifacts live in a single `ios` directory regardless of the
+  // target architecture, so the arch-qualified name from [getName] is not used
+  // here.
+  if (platform.type == .ios) {
+    return 'ios';
   }
+  return platform.getName();
 }
 
 class EngineBuildPaths {
@@ -421,35 +402,34 @@ class CachedArtifacts implements Artifacts {
     BuildMode? mode,
     EnvironmentType? environmentType,
   }) {
-    platform = _mapTargetPlatform(platform);
-    switch (platform) {
-      case TargetPlatform.android:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
-        assert(platform != TargetPlatform.android);
-        return _getAndroidArtifactPath(artifact, platform!, mode!);
-      case TargetPlatform.ios:
+    switch (platform?.type) {
+      case .android:
+        // A generic Android target has an unknown CPU architecture (e.g. the
+        // architecture-independent patched SDK requested when compiling the
+        // app's Dart kernel). Default to arm64 in that case, matching the
+        // historical behavior of the removed `_mapTargetPlatform` helper.
+        final TargetPlatform androidPlatform = platform!.cpuArch == .unknown
+            ? const TargetPlatform(.android, .arm64)
+            : platform;
+        return _getAndroidArtifactPath(artifact, androidPlatform, mode!);
+      case .ios:
         return _getIosArtifactPath(artifact, platform!, mode, environmentType);
-      case TargetPlatform.darwin:
-      case TargetPlatform.linux_x64:
-      case TargetPlatform.linux_arm64:
-      case TargetPlatform.linux_riscv64:
-      case TargetPlatform.windows_x64:
-      case TargetPlatform.windows_arm64:
+      case .macos:
+      case .linux:
+      case .windows:
         return _getDesktopArtifactPath(artifact, platform!, mode);
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
+      case .fuchsia:
         return _getFuchsiaArtifactPath(artifact, platform!, mode!);
-      case TargetPlatform.tester:
-      case TargetPlatform.web_javascript:
+      case .tester:
+      case .web:
+      case .custom:
       case null:
         return _getHostArtifactPath(
           artifact,
           platform ?? _currentHostPlatform(_platform, _operatingSystemUtils),
           mode,
         );
-      case TargetPlatform.unsupported:
+      case .unsupported:
         TargetPlatform.throwUnsupportedTarget();
     }
   }
@@ -677,7 +657,11 @@ class CachedArtifacts implements Artifacts {
       case Artifact.genSnapshotX64:
         // For script snapshots any gen_snapshot binary will do. Returning gen_snapshot for
         // android_arm in profile mode because it is available on all supported host platforms.
-        return _getAndroidArtifactPath(artifact, TargetPlatform.android_arm, BuildMode.profile);
+        return _getAndroidArtifactPath(
+          artifact,
+          const TargetPlatform(.android, .armv7),
+          BuildMode.profile,
+        );
       case Artifact.frontendServerSnapshotForEngineDartSdk:
         return _fileSystem.path.join(
           _dartSdkPath(_cache),
@@ -785,13 +769,10 @@ class CachedArtifacts implements Artifacts {
   String? _getEngineArtifactsPath(TargetPlatform platform, [BuildMode? mode]) {
     final String engineDir = _cache.getArtifactDirectory('engine').path;
     final String platformName = _enginePlatformDirectoryName(platform);
-    switch (platform) {
-      case TargetPlatform.linux_x64:
-      case TargetPlatform.linux_arm64:
-      case TargetPlatform.linux_riscv64:
-      case TargetPlatform.darwin:
-      case TargetPlatform.windows_x64:
-      case TargetPlatform.windows_arm64:
+    switch (platform.type) {
+      case .linux:
+      case .macos:
+      case .windows:
         // TODO(zanderso): remove once debug desktop artifacts are uploaded
         // under a separate directory from the host artifacts.
         // https://github.com/flutter/flutter/issues/38935
@@ -800,23 +781,25 @@ class CachedArtifacts implements Artifacts {
         }
         final suffix = mode != BuildMode.debug ? '-${kebabCase(mode.cliName)}' : '';
         return _fileSystem.path.join(engineDir, platformName + suffix);
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.tester:
-      case TargetPlatform.web_javascript:
+      case .fuchsia:
+      case .tester:
+      case .web:
         assert(mode == null, 'Platform $platform does not support different build modes.');
         return _fileSystem.path.join(engineDir, platformName);
-      case TargetPlatform.ios:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
+      case .ios:
         assert(mode != null, 'Need to specify a build mode for platform $platform.');
         final suffix = mode != BuildMode.debug ? '-${kebabCase(mode!.cliName)}' : '';
         return _fileSystem.path.join(engineDir, platformName + suffix);
-      case TargetPlatform.android:
-        assert(false, 'cannot use TargetPlatform.android to look up artifacts');
-        return null;
-      case TargetPlatform.unsupported:
+      case .android:
+        assert(
+          platform.cpuArch != .unknown,
+          'cannot use a generic Android platform to look up artifacts',
+        );
+        assert(mode != null, 'Need to specify a build mode for platform $platform.');
+        final suffix = mode != BuildMode.debug ? '-${kebabCase(mode!.cliName)}' : '';
+        return _fileSystem.path.join(engineDir, platformName + suffix);
+      case .custom:
+      case .unsupported:
         TargetPlatform.throwUnsupportedTarget();
     }
   }
@@ -826,20 +809,15 @@ class CachedArtifacts implements Artifacts {
 }
 
 TargetPlatform _currentHostPlatform(Platform platform, OperatingSystemUtils operatingSystemUtils) {
+  final cpuArch = CpuArch.fromHostPlatform(operatingSystemUtils.hostPlatform);
   if (platform.isMacOS) {
-    return TargetPlatform.darwin;
+    return TargetPlatform(.macos, cpuArch);
   }
   if (platform.isLinux) {
-    return switch (operatingSystemUtils.hostPlatform) {
-      HostPlatform.linux_x64 => TargetPlatform.linux_x64,
-      HostPlatform.linux_riscv64 => TargetPlatform.linux_riscv64,
-      _ => TargetPlatform.linux_arm64,
-    };
+    return TargetPlatform(.linux, cpuArch);
   }
   if (platform.isWindows) {
-    return operatingSystemUtils.hostPlatform == HostPlatform.windows_arm64
-        ? TargetPlatform.windows_arm64
-        : TargetPlatform.windows_x64;
+    return TargetPlatform(.windows, cpuArch);
   }
   throw UnimplementedError('Host OS not supported.');
 }
@@ -1061,7 +1039,6 @@ class CachedLocalEngineArtifacts implements Artifacts {
     EnvironmentType? environmentType,
   }) {
     platform ??= _currentHostPlatform(_platform, _operatingSystemUtils);
-    platform = _mapTargetPlatform(platform);
     final isDirectoryArtifact = artifact == Artifact.flutterPatchedSdkPath;
     final String? artifactFileName = isDirectoryArtifact
         ? null
@@ -1073,7 +1050,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
       case Artifact.genSnapshotX64:
         return _genSnapshotPath(artifact);
       case Artifact.flutterTester:
-        return _flutterTesterPath(platform!);
+        return _flutterTesterPath(platform);
       case Artifact.isolateSnapshotData:
       case Artifact.vmSnapshotData:
         return _fileSystem.path.join(
@@ -1089,7 +1066,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
       case Artifact.flutterMacOSXcframework:
         return _fileSystem.path.join(localEngineInfo.targetOutPath, artifactFileName);
       case Artifact.platformKernelDill:
-        if (platform == TargetPlatform.fuchsia_x64 || platform == TargetPlatform.fuchsia_arm64) {
+        if (platform.type == .fuchsia) {
           return _fileSystem.path.join(
             localEngineInfo.targetOutPath,
             'flutter_runner_patched_sdk',
@@ -1122,7 +1099,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
         // what was specified in [mode] argument because local engine will
         // have only one flutter_patched_sdk in standard location, that
         // is happen to be what debug(non-release) mode is using.
-        if (platform == TargetPlatform.fuchsia_x64 || platform == TargetPlatform.fuchsia_arm64) {
+        if (platform.type == .fuchsia) {
           return _fileSystem.path.join(localEngineInfo.targetOutPath, 'flutter_runner_patched_sdk');
         }
         return _getFlutterPatchedSdkPath(BuildMode.debug);
@@ -1260,7 +1237,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
     BuildMode? mode,
     EnvironmentType? environmentType,
   }) {
-    if (platform == TargetPlatform.web_javascript) {
+    if (platform?.type == .web) {
       switch (artifact) {
         case Artifact.engineDartSdkPath:
           return _getDartSdkPath();
@@ -1467,7 +1444,7 @@ class _TestArtifacts implements Artifacts {
     final buffer = StringBuffer();
     buffer.write(artifact);
     if (platform != null) {
-      buffer.write('.$platform');
+      buffer.write('.${_enginePlatformDirectoryName(platform)}');
     }
     if (mode != null) {
       buffer.write('.$mode');
@@ -1576,30 +1553,25 @@ String _getFlutterPrebuiltsPath(String baseOutPath, FileSystem fileSystem) {
 
 String _getPrebuiltTarget(Platform platform, OperatingSystemUtils operatingSystemUtils) {
   final TargetPlatform hostPlatform = _currentHostPlatform(platform, operatingSystemUtils);
-  switch (hostPlatform) {
-    case TargetPlatform.darwin:
+  switch (hostPlatform.type) {
+    case .macos:
       return 'macos-x64';
-    case TargetPlatform.linux_riscv64:
-      return 'linux-riscv64';
-    case TargetPlatform.linux_arm64:
-      return 'linux-arm64';
-    case TargetPlatform.linux_x64:
-      return 'linux-x64';
-    case TargetPlatform.windows_x64:
-      return 'windows-x64';
-    case TargetPlatform.windows_arm64:
-      return 'windows-arm64';
-    case TargetPlatform.ios:
-    case TargetPlatform.android:
-    case TargetPlatform.android_arm:
-    case TargetPlatform.android_arm64:
-    case TargetPlatform.android_x64:
-    case TargetPlatform.fuchsia_arm64:
-    case TargetPlatform.fuchsia_x64:
-    case TargetPlatform.web_javascript:
-    case TargetPlatform.tester:
+    case .linux:
+      return switch (hostPlatform.cpuArch) {
+        .riscv64 => 'linux-riscv64',
+        .arm64 => 'linux-arm64',
+        _ => 'linux-x64',
+      };
+    case .windows:
+      return hostPlatform.cpuArch == .arm64 ? 'windows-arm64' : 'windows-x64';
+    case .ios:
+    case .android:
+    case .fuchsia:
+    case .web:
+    case .tester:
+    case .custom:
       throwToolExit('Unsupported host platform: $hostPlatform');
-    case TargetPlatform.unsupported:
+    case .unsupported:
       TargetPlatform.throwUnsupportedTarget();
   }
 }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -356,7 +356,7 @@ class ManifestAssetBundle implements AssetBundle {
         transformers: const <AssetTransformerEntry>[],
       );
       // Create .bin.json on web builds.
-      if (targetPlatform == TargetPlatform.web_javascript) {
+      if (targetPlatform.type == .web) {
         entries[_kAssetManifestBinJsonFilename] = AssetBundleEntry(
           DevFSStringContent('""'),
           kind: AssetKind.regular,
@@ -660,7 +660,7 @@ class ManifestAssetBundle implements AssetBundle {
 
     _setIfChanged(_kAssetManifestBinFilename, assetManifestBinary, AssetKind.regular);
     // Create .bin.json on web builds.
-    if (targetPlatform == TargetPlatform.web_javascript) {
+    if (targetPlatform.type == .web) {
       final assetManifestBinaryJson = DevFSStringContent(
         json.encode(base64.encode(assetManifestBinary.bytes)),
       );
@@ -719,7 +719,7 @@ class ManifestAssetBundle implements AssetBundle {
     // On the web, don't compress the NOTICES file since the client doesn't have
     // dart:io to decompress it. So use the standard _setIfChanged to check if
     // the strings still match.
-    if (targetPlatform == TargetPlatform.web_javascript) {
+    if (targetPlatform.type == .web) {
       _setIfChanged(_kNoticeFile, DevFSStringContent(combinedLicenses), AssetKind.regular);
       return;
     }
@@ -1398,7 +1398,11 @@ class ManifestAssetBundle implements AssetBundle {
     required Set<String> platforms,
     required List<AssetTransformerEntry> transformers,
   }) {
-    _ensureAssetPathIsValid(assetsBaseDir: assetsBaseDir, assetUri: assetUri, packageName: packageName);
+    _ensureAssetPathIsValid(
+      assetsBaseDir: assetsBaseDir,
+      assetUri: assetUri,
+      packageName: packageName,
+    );
     if (assetUri.pathSegments.first == 'packages' &&
         !_fileSystem.isFileSync(
           _fileSystem.path.join(assetsBaseDir, _fileSystem.path.fromUri(assetUri)),
@@ -1542,7 +1546,7 @@ class _Asset {
   }
 
   bool matchesPlatform(TargetPlatform targetPlatform) {
-    if (platforms.isEmpty || targetPlatform == TargetPlatform.tester) {
+    if (platforms.isEmpty || targetPlatform.type == .tester) {
       return true;
     }
 

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -57,26 +57,18 @@ class GenSnapshot {
 
   Future<int> run({
     required SnapshotType snapshotType,
-    // TODO(chingjun): The [CpuArch] parameter is only used for iOS builds (to
-    // select the correct per-architecture gen_snapshot). This architecture
-    // information should instead be consolidated into [TargetPlatform] so that
-    // callers do not need to pass it separately.
-    CpuArch? cpuArch,
     Iterable<String> additionalArgs = const <String>[],
   }) {
-    assert(cpuArch != CpuArch.armv7);
-    assert(snapshotType.platform != TargetPlatform.ios || cpuArch != null);
     final args = <String>[...additionalArgs];
 
     // iOS and macOS have separate gen_snapshot binaries for each target
-    // architecture (iOS: armv7, arm64; macOS: x86_64, arm64). Select the right
+    // architecture (iOS: arm64; macOS: x86_64, arm64). Select the right
     // one for the target architecture in question.
     Artifact genSnapshotArtifact;
-    if (snapshotType.platform == TargetPlatform.ios ||
-        snapshotType.platform == TargetPlatform.darwin) {
-      genSnapshotArtifact = cpuArch == CpuArch.arm64
-          ? Artifact.genSnapshotArm64
-          : Artifact.genSnapshotX64;
+    if (snapshotType.platform.type == .ios || snapshotType.platform.type == .macos) {
+      final CpuArch cpuArch = snapshotType.platform.cpuArch;
+      assert(cpuArch == .arm64 || cpuArch == .x64);
+      genSnapshotArtifact = cpuArch == .arm64 ? Artifact.genSnapshotArm64 : Artifact.genSnapshotX64;
     } else {
       genSnapshotArtifact = Artifact.genSnapshot;
     }
@@ -117,15 +109,12 @@ class AOTSnapshotter {
     required BuildMode buildMode,
     required String mainPath,
     required String outputPath,
-    CpuArch? cpuArch,
     String? sdkRoot,
     List<String> extraGenSnapshotOptions = const <String>[],
     String? splitDebugInfo,
     required bool dartObfuscation,
     bool quiet = false,
   }) async {
-    assert(platform != TargetPlatform.ios || cpuArch != null);
-
     if (!_isValidAotPlatform(platform, buildMode)) {
       _logger.printError('${platform.getName()} does not support AOT compilation.');
       return 1;
@@ -136,19 +125,14 @@ class AOTSnapshotter {
 
     final genSnapshotArgs = <String>['--deterministic'];
 
-    final bool targetingApplePlatform =
-        platform == TargetPlatform.ios || platform == TargetPlatform.darwin;
+    final bool targetingApplePlatform = platform.type == .ios || platform.type == .macos;
     _logger.printTrace('targetingApplePlatform = $targetingApplePlatform');
 
     final bool extractAppleDebugSymbols =
         buildMode == BuildMode.profile || buildMode == BuildMode.release;
     _logger.printTrace('extractAppleDebugSymbols = $extractAppleDebugSymbols');
 
-    final bool targetingAndroidPlatform =
-        platform == TargetPlatform.android ||
-        platform == TargetPlatform.android_arm ||
-        platform == TargetPlatform.android_arm64 ||
-        platform == TargetPlatform.android_x64;
+    final targetingAndroidPlatform = platform.type == .android;
     _logger.printTrace('targetingAndroidPlatform = $targetingAndroidPlatform');
 
     // We strip snapshot by default, but allow to suppress this behavior
@@ -172,7 +156,7 @@ class AOTSnapshotter {
       // library that the end-developer can link into their app.
       const frameworkName = 'App.framework';
       if (!quiet) {
-        final String targetArch = cpuArch!.darwinArchName;
+        final String targetArch = platform.cpuArch.darwinArchName;
         _logger.printStatus('Building $frameworkName for $targetArch...');
       }
       frameworkPath = _fileSystem.path.join(outputPath, frameworkName);
@@ -184,7 +168,7 @@ class AOTSnapshotter {
       // When the minimum version is updated, remember to update
       // template MinimumOSVersion.
       // https://github.com/flutter/flutter/pull/62902
-      final minOSVersion = platform == TargetPlatform.ios
+      final minOSVersion = platform.type == .ios
           ? FlutterDarwinPlatform.ios.deploymentTarget().toString()
           : FlutterDarwinPlatform.macos.deploymentTarget().toString();
       genSnapshotArgs.addAll(<String>[
@@ -218,7 +202,7 @@ class AOTSnapshotter {
       }
     }
 
-    if (platform == TargetPlatform.android_arm) {
+    if (platform == const TargetPlatform(.android, .armv7)) {
       // Use softfp for Android armv7 devices.
       // TODO(cbracken): eliminate this when we fix https://github.com/flutter/flutter/issues/17489
       genSnapshotArgs.add('--no-sim-use-hardfp');
@@ -229,8 +213,9 @@ class AOTSnapshotter {
 
     // The name of the debug file must contain additional information about
     // the architecture, since a single build command may produce
-    // multiple debug files.
-    final String archName = platform.getName(cpuArch: cpuArch);
+    // multiple debug files. [TargetPlatform.getName] already includes the
+    // architecture for the platforms that need it (e.g. `ios-arm64`).
+    final String archName = platform.getName();
     final debugFilename = 'app.$archName.symbols';
     final bool shouldSplitDebugInfo = splitDebugInfo?.isNotEmpty ?? false;
     if (shouldSplitDebugInfo) {
@@ -253,7 +238,6 @@ class AOTSnapshotter {
     final int genSnapshotExitCode = await _genSnapshot.run(
       snapshotType: snapshotType,
       additionalArgs: genSnapshotArgs,
-      cpuArch: cpuArch,
     );
     if (genSnapshotExitCode != 0) {
       _logger.printError('Dart snapshot generator failed with exit code $genSnapshotExitCode');
@@ -301,17 +285,9 @@ class AOTSnapshotter {
     if (buildMode == BuildMode.debug) {
       return false;
     }
-    return const <TargetPlatform>[
-      TargetPlatform.android_arm,
-      TargetPlatform.android_arm64,
-      TargetPlatform.android_x64,
-      TargetPlatform.ios,
-      TargetPlatform.darwin,
-      TargetPlatform.linux_x64,
-      TargetPlatform.linux_arm64,
-      TargetPlatform.linux_riscv64,
-      TargetPlatform.windows_x64,
-      TargetPlatform.windows_arm64,
-    ].contains(platform);
+    return switch (platform.type) {
+      .android || .ios || .macos || .linux || .windows => true,
+      _ => false,
+    };
   }
 }

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -215,7 +215,18 @@ class AOTSnapshotter {
     // the architecture, since a single build command may produce
     // multiple debug files. [TargetPlatform.getName] already includes the
     // architecture for the platforms that need it (e.g. `ios-arm64`).
-    final String archName = platform.getName();
+    //
+    // On Apple platforms, use the Darwin architecture name (e.g. `x86_64`
+    // rather than `x64`) so the symbol file name matches the architecture of
+    // the produced binaries and the naming convention used by the Apple
+    // toolchain.
+    final String archName;
+    if (targetingApplePlatform) {
+      final platformName = platform.type == .macos ? 'darwin' : 'ios';
+      archName = '$platformName-${platform.cpuArch.darwinArchName}';
+    } else {
+      archName = platform.getName();
+    }
     final debugFilename = 'app.$archName.symbols';
     final bool shouldSplitDebugInfo = splitDebugInfo?.isNotEmpty ?? false;
     if (shouldSplitDebugInfo) {

--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -10,7 +10,6 @@ import 'package:dds/dds_launcher.dart';
 import 'package:meta/meta.dart';
 
 import '../artifacts.dart';
-import '../build_info.dart';
 import '../device.dart';
 import '../globals.dart' as globals;
 import '../resident_runner.dart';
@@ -267,7 +266,7 @@ mixin DartDevelopmentServiceLocalOperationsMixin {
     if (!(await _waitForExtensionsForDevice(device, method))) {
       return;
     }
-    if (device.targetPlatform == TargetPlatform.web_javascript) {
+    if (device.targetPlatform.type == .web) {
       await device.vmService!.callMethodWrapper(method, args: params);
       return;
     }

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -513,14 +513,14 @@ enum BuildMode {
 enum EnvironmentType { physical, simulator }
 
 String? validatedBuildNumberForPlatform(
-  TargetPlatform targetPlatform,
+  PlatformType platformType,
   String? buildNumber,
   Logger logger,
 ) {
   if (buildNumber == null) {
     return null;
   }
-  if (targetPlatform == TargetPlatform.ios || targetPlatform == TargetPlatform.darwin) {
+  if (platformType == .ios || platformType == .macos) {
     // See CFBundleVersion at https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
     final disallowed = RegExp(r'[^\d\.]');
     String tmpBuildNumber = buildNumber.replaceAll(disallowed, '');
@@ -543,9 +543,7 @@ String? validatedBuildNumberForPlatform(
     }
     return tmpBuildNumber;
   }
-  if (targetPlatform == TargetPlatform.android_arm ||
-      targetPlatform == TargetPlatform.android_arm64 ||
-      targetPlatform == TargetPlatform.android_x64) {
+  if (platformType == .android) {
     // See versionCode at https://developer.android.com/studio/publish/versioning
     final disallowed = RegExp(r'[^\d]');
     String tmpBuildNumberStr = buildNumber.replaceAll(disallowed, '');
@@ -565,15 +563,11 @@ String? validatedBuildNumberForPlatform(
   return buildNumber;
 }
 
-String? validatedBuildNameForPlatform(
-  TargetPlatform targetPlatform,
-  String? buildName,
-  Logger logger,
-) {
+String? validatedBuildNameForPlatform(PlatformType platformType, String? buildName, Logger logger) {
   if (buildName == null) {
     return null;
   }
-  if (targetPlatform == TargetPlatform.ios || targetPlatform == TargetPlatform.darwin) {
+  if (platformType == .ios || platformType == .macos) {
     // See CFBundleShortVersionString at https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
     final disallowed = RegExp(r'[^\d\.]');
     String tmpBuildName = buildName.replaceAll(disallowed, '');
@@ -596,13 +590,7 @@ String? validatedBuildNameForPlatform(
     }
     return tmpBuildName;
   }
-  if (targetPlatform == TargetPlatform.android ||
-      targetPlatform == TargetPlatform.android_arm ||
-      targetPlatform == TargetPlatform.android_arm64 ||
-      targetPlatform == TargetPlatform.android_x64) {
-    // See versionName at https://developer.android.com/studio/publish/versioning
-    return buildName;
-  }
+  // See versionName at https://developer.android.com/studio/publish/versioning for Android.
   return buildName;
 }
 
@@ -695,108 +683,161 @@ enum CpuArch {
   };
 }
 
-enum TargetPlatform {
-  android('android'),
-  ios('ios'),
-  darwin('darwin'),
-  linux_x64('linux-x64'),
-  linux_arm64('linux-arm64'),
-  linux_riscv64('linux-riscv64'),
-  windows_x64('windows-x64'),
-  windows_arm64('windows-arm64'),
-  fuchsia_arm64('fuchsia-arm64'),
-  fuchsia_x64('fuchsia-x64'),
-  tester('flutter-tester'),
-  web_javascript('web-javascript'),
-  // The arch specific android target platforms are soft-deprecated.
-  // Instead of using TargetPlatform as a combination arch + platform
-  // the code will be updated to carry arch information in [CpuArch].
-  android_arm('android-arm'),
-  android_arm64('android-arm64'),
-  android_x64('android-x64'),
-  unsupported('unsupported');
+/// The type of platform (OS / runtime family) that a target or device
+/// represents.
+///
+/// This is combined with a [CpuArch] to form a [TargetPlatform].
+enum PlatformType {
+  web,
+  android,
+  ios,
+  linux,
+  macos,
+  windows,
+  fuchsia,
+  custom,
+  tester,
+  unsupported;
 
-  const TargetPlatform(this._defaultName);
+  @override
+  String toString() => name;
+
+  static PlatformType? fromString(String platformType) => values.asNameMap()[platformType];
+}
+
+/// The platform a Flutter application is built for.
+///
+/// A [TargetPlatform] is the combination of a [PlatformType] (the OS / runtime
+/// family, e.g. Android or macOS) and a [CpuArch] (the CPU architecture, e.g.
+/// arm64).
+///
+/// Code that needs to branch on the platform should generally inspect [type]
+/// and/or [cpuArch].
+@immutable
+final class TargetPlatform {
+  const TargetPlatform(this.type, this.cpuArch);
 
   factory TargetPlatform.fromName(String name) {
     return switch (name) {
-      'android' => TargetPlatform.android,
-      'android-arm' => TargetPlatform.android_arm,
-      'android-arm64' => TargetPlatform.android_arm64,
-      'android-x64' => TargetPlatform.android_x64,
-      'fuchsia-arm64' => TargetPlatform.fuchsia_arm64,
-      'fuchsia-x64' => TargetPlatform.fuchsia_x64,
-      'ios' => TargetPlatform.ios,
-      // For backward-compatibility and also for Tester, where it must match
-      // host platform name (HostPlatform.darwin_x64)
-      'darwin' || 'darwin-x64' || 'darwin-arm64' => TargetPlatform.darwin,
-      'linux-x64' => TargetPlatform.linux_x64,
-      'linux-arm64' => TargetPlatform.linux_arm64,
-      'linux-riscv64' => TargetPlatform.linux_riscv64,
-      'windows-x64' => TargetPlatform.windows_x64,
-      'windows-arm64' => TargetPlatform.windows_arm64,
-      'web-javascript' => TargetPlatform.web_javascript,
-      'flutter-tester' => TargetPlatform.tester,
+      'android' => const TargetPlatform(.android, .unknown),
+      'android-arm' => const TargetPlatform(.android, .armv7),
+      'android-arm64' => const TargetPlatform(.android, .arm64),
+      'android-x64' => const TargetPlatform(.android, .x64),
+      'fuchsia-arm64' => const TargetPlatform(.fuchsia, .arm64),
+      'fuchsia-x64' => const TargetPlatform(.fuchsia, .x64),
+      // `ios` is architecture-agnostic and defaults to arm64; `ios-arm64` and
+      // `ios-x64` (simulator) name a specific architecture.
+      'ios' || 'ios-arm64' => const TargetPlatform(.ios, .arm64),
+      'ios-x64' => const TargetPlatform(.ios, .x64),
+      'ios-armv7' => const TargetPlatform(.ios, .armv7),
+      // `darwin` is architecture-agnostic and defaults to arm64 (Apple
+      // Silicon); `darwin-x64` and `darwin-arm64` name a specific architecture.
+      'darwin' || 'darwin-arm64' => const TargetPlatform(.macos, .arm64),
+      'darwin-x64' => const TargetPlatform(.macos, .x64),
+      'linux-x64' => const TargetPlatform(.linux, .x64),
+      'linux-arm64' => const TargetPlatform(.linux, .arm64),
+      'linux-riscv64' => const TargetPlatform(.linux, .riscv64),
+      'windows-x64' => const TargetPlatform(.windows, .x64),
+      'windows-arm64' => const TargetPlatform(.windows, .arm64),
+      'web-javascript' => const TargetPlatform(.web, .unknown),
+      'flutter-tester' => const TargetPlatform(.tester, .unknown),
       _ => throw Exception('Unsupported platform name "$name"'),
     };
   }
 
-  final String _defaultName;
+  /// The platform type (OS / runtime family).
+  final PlatformType type;
 
-  String getName({CpuArch? cpuArch}) {
-    return switch (this) {
-      TargetPlatform.ios when cpuArch != null => 'ios-${cpuArch.darwinArchName}',
-      TargetPlatform.darwin when cpuArch != null => 'darwin-${cpuArch.darwinArchName}',
-      _ => _defaultName,
+  /// The CPU architecture of the target.
+  ///
+  /// This is [CpuArch.unknown] only when a CPU architecture is not applicable
+  /// (e.g. web) or has not yet been resolved (e.g. a generic Android target).
+  final CpuArch cpuArch;
+
+  /// The canonical set of known target platforms.
+  ///
+  /// This mirrors the values that used to exist when [TargetPlatform] was an
+  /// enum, and is primarily useful for tests that need to iterate over all
+  /// known platforms.
+  static const List<TargetPlatform> values = <TargetPlatform>[
+    TargetPlatform(.android, .unknown),
+    TargetPlatform(.ios, .arm64),
+    TargetPlatform(.macos, .arm64),
+    TargetPlatform(.linux, .x64),
+    TargetPlatform(.linux, .arm64),
+    TargetPlatform(.linux, .riscv64),
+    TargetPlatform(.windows, .x64),
+    TargetPlatform(.windows, .arm64),
+    TargetPlatform(.fuchsia, .arm64),
+    TargetPlatform(.fuchsia, .x64),
+    TargetPlatform(.tester, .unknown),
+    TargetPlatform(.web, .unknown),
+    TargetPlatform(.android, .armv7),
+    TargetPlatform(.android, .arm64),
+    TargetPlatform(.android, .x64),
+    TargetPlatform(.unsupported, .unknown),
+  ];
+
+  @override
+  bool operator ==(Object other) =>
+      other is TargetPlatform && other.type == type && other.cpuArch == cpuArch;
+
+  @override
+  int get hashCode => Object.hash(type, cpuArch);
+
+  /// The canonical string name for this target platform.
+  ///
+  /// The name generally follows the `<platform>-<arch>` convention (e.g.
+  /// `linux-x64`, `android-arm64`, `ios-arm64`, `darwin-x64`), with a few
+  /// historical exceptions retained for backward compatibility (e.g. the macOS
+  /// platform is named `darwin`, and `flutter-tester`). When the architecture
+  /// is not known ([CpuArch.unknown]), the bare platform name is used (e.g.
+  /// `ios`, `darwin`, `android`).
+  String getName() {
+    return switch (type) {
+      .android => cpuArch == .unknown ? 'android' : cpuArch.androidPlatformName,
+      .ios => cpuArch == .unknown ? 'ios' : 'ios-${cpuArch.dartName}',
+      .macos => cpuArch == .unknown ? 'darwin' : 'darwin-${cpuArch.dartName}',
+      .linux || .windows || .fuchsia => '${type.name}-${cpuArch.dartName}',
+      .tester => 'flutter-tester',
+      .web => 'web-javascript',
+      .unsupported => 'unsupported',
+      .custom => throw UnsupportedError('Unexpected target platform $this'),
     };
   }
 
-  String get fuchsiaArchForTargetPlatform => switch (this) {
-    fuchsia_arm64 => 'arm64',
-    fuchsia_x64 => 'x64',
-    android ||
-    android_arm ||
-    android_arm64 ||
-    android_x64 ||
-    darwin ||
-    ios ||
-    linux_arm64 ||
-    linux_riscv64 ||
-    linux_x64 ||
-    tester ||
-    web_javascript ||
-    windows_x64 ||
-    windows_arm64 ||
-    unsupported => throw UnsupportedError('Unexpected Fuchsia platform $this'),
+  /// The platform name used to identify a device, e.g. in the `flutter devices`
+  /// output, the daemon protocol, and analytics.
+  ///
+  /// This is like [getName], but omits the CPU architecture for iOS and macOS,
+  /// preserving the historical device platform identifiers (`ios`, `darwin`).
+  /// The architecture of a device is reported separately (e.g. via the device's
+  /// `cpuArch`), so it is not duplicated here.
+  String get devicePlatformName => switch (type) {
+    .ios => 'ios',
+    .macos => 'darwin',
+    _ => getName(),
   };
 
-  String get osName => switch (this) {
-    linux_x64 || linux_arm64 || linux_riscv64 => 'linux',
-    darwin => 'macos',
-    windows_x64 || windows_arm64 => 'windows',
-    android || android_arm || android_arm64 || android_x64 => 'android',
-    fuchsia_arm64 || fuchsia_x64 => 'fuchsia',
-    ios => 'ios',
-    tester => 'flutter-tester',
-    web_javascript => 'web',
-    unsupported => throw UnsupportedError('Unexpected target platform $this'),
+  String get fuchsiaArchForTargetPlatform => switch (type) {
+    .fuchsia => cpuArch == .arm64 ? 'arm64' : 'x64',
+    _ => throw UnsupportedError('Unexpected Fuchsia platform $this'),
   };
 
-  String get simpleName => switch (this) {
-    linux_x64 || darwin || windows_x64 => 'x64',
-    linux_arm64 || windows_arm64 => 'arm64',
-    linux_riscv64 => 'riscv64',
-    android ||
-    android_arm ||
-    android_arm64 ||
-    android_x64 ||
-    fuchsia_arm64 ||
-    fuchsia_x64 ||
-    ios ||
-    tester ||
-    web_javascript ||
-    unsupported => throw UnsupportedError('Unexpected target platform $this'),
+  String get osName => switch (type) {
+    .linux => 'linux',
+    .macos => 'macos',
+    .windows => 'windows',
+    .android => 'android',
+    .fuchsia => 'fuchsia',
+    .ios => 'ios',
+    .tester => 'flutter-tester',
+    .web => 'web',
+    .custom || .unsupported => throw UnsupportedError('Unexpected target platform $this'),
   };
+
+  @override
+  String toString() => getName();
 
   static Never throwUnsupportedTarget() =>
       throw UnsupportedError('Target platform is unsupported.');
@@ -951,7 +992,7 @@ String getWebBuildDirectory() {
 String getLinuxBuildDirectory([TargetPlatform? targetPlatform, String? flavor]) {
   final String arch = (targetPlatform == null)
       ? _getCurrentHostPlatformArchName()
-      : targetPlatform.simpleName;
+      : targetPlatform.cpuArch.dartName;
   final String subDirs = (flavor != null && flavor.isNotEmpty)
       ? globals.fs.path.join('linux', arch, flavor)
       : globals.fs.path.join('linux', arch);
@@ -963,7 +1004,7 @@ String getLinuxBuildDirectory([TargetPlatform? targetPlatform, String? flavor]) 
 /// When [flavor] is non-empty, a `/<flavor>` segment is inserted so that
 /// different flavors can coexist on disk without overwriting each other.
 String getWindowsBuildDirectory(TargetPlatform targetPlatform, [String? flavor]) {
-  final String arch = targetPlatform.simpleName;
+  final String arch = targetPlatform.cpuArch.dartName;
   final String subDirs = (flavor != null && flavor.isNotEmpty)
       ? globals.fs.path.join('windows', arch, flavor)
       : globals.fs.path.join('windows', arch);
@@ -1222,8 +1263,8 @@ String? _uncapitalize(String? s) {
 
 // flutter_ignore: deprecation_syntax (see analyze.dart)
 @Deprecated('Use TargetPlatform.getName() instead')
-String getNameForTargetPlatform(TargetPlatform platform, {CpuArch? cpuArch}) {
-  return platform.getName(cpuArch: cpuArch);
+String getNameForTargetPlatform(TargetPlatform platform) {
+  return platform.getName();
 }
 
 // flutter_ignore: deprecation_syntax (see analyze.dart)

--- a/packages/flutter_tools/lib/src/build_system/targets/android.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/android.dart
@@ -77,7 +77,7 @@ abstract class AndroidAssetBundle extends Target {
       environment,
       outputDirectory,
       dartHookResult: dartHookResult,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
       buildMode: buildMode,
       flavor: environment.defines[kFlavor],
       additionalContent: <String, DevFSContent>{
@@ -141,7 +141,7 @@ class ProfileAndroidApplication extends CopyFlutterAotBundle {
 
   @override
   List<Target> get dependencies => const <Target>[
-    AotElfProfile(TargetPlatform.android_arm),
+    AotElfProfile(TargetPlatform(.android, .armv7)),
     AotAndroidAssetBundle(),
   ];
 }
@@ -155,7 +155,7 @@ class ReleaseAndroidApplication extends CopyFlutterAotBundle {
 
   @override
   List<Target> get dependencies => const <Target>[
-    AotElfRelease(TargetPlatform.android_arm),
+    AotElfRelease(TargetPlatform(.android, .armv7)),
     AotAndroidAssetBundle(),
   ];
 }
@@ -287,12 +287,12 @@ class AndroidAot extends AotElfBase {
 }
 
 // AndroidAot instances used by the bundle rules below.
-const androidArmProfile = AndroidAot(TargetPlatform.android_arm, BuildMode.profile);
-const androidArm64Profile = AndroidAot(TargetPlatform.android_arm64, BuildMode.profile);
-const androidx64Profile = AndroidAot(TargetPlatform.android_x64, BuildMode.profile);
-const androidArmRelease = AndroidAot(TargetPlatform.android_arm, BuildMode.release);
-const androidArm64Release = AndroidAot(TargetPlatform.android_arm64, BuildMode.release);
-const androidx64Release = AndroidAot(TargetPlatform.android_x64, BuildMode.release);
+const androidArmProfile = AndroidAot(TargetPlatform(.android, .armv7), BuildMode.profile);
+const androidArm64Profile = AndroidAot(TargetPlatform(.android, .arm64), BuildMode.profile);
+const androidx64Profile = AndroidAot(TargetPlatform(.android, .x64), BuildMode.profile);
+const androidArmRelease = AndroidAot(TargetPlatform(.android, .armv7), BuildMode.release);
+const androidArm64Release = AndroidAot(TargetPlatform(.android, .arm64), BuildMode.release);
+const androidx64Release = AndroidAot(TargetPlatform(.android, .x64), BuildMode.release);
 
 /// A rule paired with [AndroidAot] that copies the produced so file and manifest.json (if present) into the output directory.
 class AndroidAotBundle extends Target {

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -295,7 +295,7 @@ class CopyAssets extends Target {
   @override
   Future<void> build(
     Environment environment, {
-    TargetPlatform targetPlatform = TargetPlatform.android,
+    TargetPlatform targetPlatform = const TargetPlatform(.android, .unknown),
   }) async {
     final String? buildModeEnvironment = environment.defines[kBuildMode];
     if (buildModeEnvironment == null) {

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -92,7 +92,7 @@ class CopyFlutterBundle extends Target {
       environment,
       environment.outputDir,
       dartHookResult: dartHookResult,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
       buildMode: buildMode,
       flavor: flavor,
       additionalContent: <String, DevFSContent>{
@@ -229,50 +229,28 @@ class KernelSnapshot extends Target {
     final String? fileSystemScheme = environment.defines[kFileSystemScheme];
 
     TargetModel targetModel = TargetModel.flutter;
-    if (targetPlatform == TargetPlatform.fuchsia_x64 ||
-        targetPlatform == TargetPlatform.fuchsia_arm64) {
+    if (targetPlatform.type == .fuchsia) {
       targetModel = TargetModel.flutterRunner;
     }
     // Force linking of the platform for desktop embedder targets since these
     // do not correctly load the core snapshots in debug mode.
     // See https://github.com/flutter/flutter/issues/44724
-    final bool forceLinkPlatform;
-    switch (targetPlatform) {
-      case TargetPlatform.darwin:
-      case TargetPlatform.windows_x64:
-      case TargetPlatform.windows_arm64:
-      case TargetPlatform.linux_x64:
-        forceLinkPlatform = true;
-      case TargetPlatform.android:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.ios:
-      case TargetPlatform.linux_arm64:
-      case TargetPlatform.linux_riscv64:
-      case TargetPlatform.tester:
-      case TargetPlatform.web_javascript:
-        forceLinkPlatform = false;
-      case TargetPlatform.unsupported:
-        TargetPlatform.throwUnsupportedTarget();
-    }
+    final bool forceLinkPlatform = switch (targetPlatform.type) {
+      .macos || .windows => true,
+      .linux => targetPlatform.cpuArch == .x64,
+      .unsupported => TargetPlatform.throwUnsupportedTarget(),
+      .web || .android || .ios || .fuchsia || .custom || .tester => false,
+    };
 
-    final String? targetOS = switch (targetPlatform) {
-      TargetPlatform.fuchsia_arm64 || TargetPlatform.fuchsia_x64 => 'fuchsia',
-      TargetPlatform.android ||
-      TargetPlatform.android_arm ||
-      TargetPlatform.android_arm64 ||
-      TargetPlatform.android_x64 => 'android',
-      TargetPlatform.darwin => 'macos',
-      TargetPlatform.ios => 'ios',
-      TargetPlatform.linux_arm64 ||
-      TargetPlatform.linux_riscv64 ||
-      TargetPlatform.linux_x64 => 'linux',
-      TargetPlatform.windows_arm64 || TargetPlatform.windows_x64 => 'windows',
-      TargetPlatform.tester || TargetPlatform.web_javascript => null,
-      TargetPlatform.unsupported => TargetPlatform.throwUnsupportedTarget(),
+    final String? targetOS = switch (targetPlatform.type) {
+      .fuchsia => 'fuchsia',
+      .android => 'android',
+      .macos => 'macos',
+      .ios => 'ios',
+      .linux => 'linux',
+      .windows => 'windows',
+      .tester || .web || .custom => null,
+      .unsupported => TargetPlatform.throwUnsupportedTarget(),
     };
 
     final PackageConfig packageConfig = await loadPackageConfigWithLogging(

--- a/packages/flutter_tools/lib/src/build_system/targets/dart_plugin_registrant.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart_plugin_registrant.dart
@@ -56,9 +56,7 @@ class DartPluginRegistrantTarget extends Target {
     // code should just do the right thing on every platform.
     // Failing that, consider throwing if `targetPlatform` isn't set and finding
     // all violations, as it's not consistently set here.
-    return targetPlatform == TargetPlatform.fuchsia_arm64 ||
-        targetPlatform == TargetPlatform.fuchsia_x64 ||
-        targetPlatform == TargetPlatform.web_javascript;
+    return targetPlatform?.type == .fuchsia || targetPlatform?.type == .web;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
@@ -140,9 +140,7 @@ class IconTreeShaker {
       }
 
       // Add space as an optional code point, as web uses it to measure the font height.
-      final optionalCodePoints = _targetPlatform == TargetPlatform.web_javascript
-          ? <int>[kSpacePoint]
-          : <int>[];
+      final optionalCodePoints = _targetPlatform.type == .web ? <int>[kSpacePoint] : <int>[];
       result[entry.value] = _IconTreeShakerData(
         family: entry.key,
         relativePath: entry.value,

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -75,7 +75,7 @@ abstract class AotAssemblyBase extends Target {
     final List<CpuArch> cpuArchs =
         environment.defines[kIosArchs]?.split(' ').map(getCpuArchForName).toList() ??
         <CpuArch>[CpuArch.arm64];
-    if (targetPlatform != TargetPlatform.ios) {
+    if (targetPlatform.type != .ios) {
       throw Exception('aot_assembly is only supported for iOS applications.');
     }
 
@@ -108,11 +108,10 @@ abstract class AotAssemblyBase extends Target {
       }
       pending.add(
         snapshotter.build(
-          platform: targetPlatform,
+          platform: TargetPlatform(.ios, cpuArch),
           buildMode: buildMode,
           mainPath: environment.buildDir.childFile('app.dill').path,
           outputPath: environment.fileSystem.path.join(buildOutputPath, cpuArch.darwinArchName),
-          cpuArch: cpuArch,
           sdkRoot: sdkRoot,
           quiet: true,
           splitDebugInfo: splitDebugInfo,
@@ -163,7 +162,7 @@ class AotAssemblyRelease extends AotAssemblyBase {
     // it resolves to a file (ios/gen_snapshot) that never exists. This was
     // split into gen_snapshot_arm64 and gen_snapshot_armv7.
     // Source.artifact(Artifact.genSnapshot,
-    //   platform: TargetPlatform.ios,
+    //   platform: TargetPlatform(.ios, .arm64),
     //   mode: BuildMode.release,
     // ),
   ];
@@ -192,7 +191,7 @@ class AotAssemblyProfile extends AotAssemblyBase {
     // it resolves to a file (ios/gen_snapshot) that never exists. This was
     // split into gen_snapshot_arm64 and gen_snapshot_armv7.
     // Source.artifact(Artifact.genSnapshot,
-    //   platform: TargetPlatform.ios,
+    //   platform: TargetPlatform(.ios, .arm64),
     //   mode: BuildMode.profile,
     // ),
   ];
@@ -250,7 +249,11 @@ abstract class UnpackIOS extends UnpackDarwin {
     const Source.pattern(
       '{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/ios.dart',
     ),
-    Source.artifact(Artifact.flutterXcframework, platform: TargetPlatform.ios, mode: buildMode),
+    Source.artifact(
+      Artifact.flutterXcframework,
+      platform: darwinPlatform.targetPlatform,
+      mode: buildMode,
+    ),
   ];
 
   @override
@@ -285,7 +288,7 @@ abstract class UnpackIOS extends UnpackDarwin {
       environment,
       environmentType: environmentType,
       framework: Artifact.flutterFramework,
-      targetPlatform: TargetPlatform.ios,
+      targetPlatform: darwinPlatform.targetPlatform,
       buildMode: buildMode,
     );
     await _copyFrameworkDysm(environment, sdkRoot: sdkRoot, environmentType: environmentType);
@@ -311,7 +314,7 @@ abstract class UnpackIOS extends UnpackDarwin {
     final Directory frameworkDsym = environment.fileSystem.directory(
       environment.artifacts.getArtifactPath(
         Artifact.flutterFrameworkDsym,
-        platform: TargetPlatform.ios,
+        platform: darwinPlatform.targetPlatform,
         mode: buildMode,
         environmentType: environmentType,
       ),
@@ -715,7 +718,7 @@ abstract class IosAssetBundle extends Target {
       environment,
       assetDirectory,
       dartHookResult: dartHookResult,
-      targetPlatform: TargetPlatform.ios,
+      targetPlatform: FlutterDarwinPlatform.ios.targetPlatform,
       buildMode: buildMode,
       additionalInputs: <File>[
         flutterProject.ios.infoPlist,

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -140,7 +140,7 @@ class ReleaseUnpackMacOS extends UnpackMacOS {
     final Directory frameworkDsym = environment.fileSystem.directory(
       environment.artifacts.getArtifactPath(
         Artifact.flutterMacOSFrameworkDsym,
-        platform: TargetPlatform.darwin,
+        platform: darwinPlatform.targetPlatform,
         mode: buildMode,
       ),
     );
@@ -288,7 +288,7 @@ class CompileMacOSFramework extends Target {
     );
     final targetPlatform = TargetPlatform.fromName(targetPlatformEnvironment);
     final List<CpuArch> cpuArchs = getCpuArchsFromEnv(environment.defines);
-    if (targetPlatform != TargetPlatform.darwin) {
+    if (targetPlatform.type != .macos) {
       throw Exception('compile_macos_framework is only supported for darwin TargetPlatform.');
     }
 
@@ -321,8 +321,7 @@ class CompileMacOSFramework extends Target {
           buildMode: buildMode,
           mainPath: environment.buildDir.childFile('app.dill').path,
           outputPath: environment.fileSystem.path.join(buildOutputPath, cpuArch.darwinArchName),
-          platform: TargetPlatform.darwin,
-          cpuArch: cpuArch,
+          platform: TargetPlatform(.macos, cpuArch),
           splitDebugInfo: splitDebugInfo,
           dartObfuscation: dartObfuscation,
           extraGenSnapshotOptions: extraGenSnapshotOptions,
@@ -359,10 +358,16 @@ class CompileMacOSFramework extends Target {
   List<Target> get dependencies => const <Target>[KernelSnapshot()];
 
   @override
-  List<Source> get inputs => const <Source>[
-    Source.pattern('{BUILD_DIR}/app.dill'),
-    Source.pattern('{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/macos.dart'),
-    Source.artifact(Artifact.genSnapshot, mode: BuildMode.release, platform: TargetPlatform.darwin),
+  List<Source> get inputs => <Source>[
+    const Source.pattern('{BUILD_DIR}/app.dill'),
+    const Source.pattern(
+      '{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/macos.dart',
+    ),
+    Source.artifact(
+      Artifact.genSnapshot,
+      mode: BuildMode.release,
+      platform: FlutterDarwinPlatform.macos.targetPlatform,
+    ),
   ];
 
   @override
@@ -451,7 +456,7 @@ abstract class MacOSBundleFlutterAssets extends Target {
       environment,
       assetDirectory,
       dartHookResult: dartHookResult,
-      targetPlatform: TargetPlatform.darwin,
+      targetPlatform: FlutterDarwinPlatform.macos.targetPlatform,
       buildMode: buildMode,
       flavor: flavor,
       additionalContent: <String, DevFSContent>{
@@ -505,12 +510,12 @@ abstract class MacOSBundleFlutterAssets extends Target {
       try {
         final String vmSnapshotData = environment.artifacts.getArtifactPath(
           Artifact.vmSnapshotData,
-          platform: TargetPlatform.darwin,
+          platform: FlutterDarwinPlatform.macos.targetPlatform,
           mode: BuildMode.debug,
         );
         final String isolateSnapshotData = environment.artifacts.getArtifactPath(
           Artifact.isolateSnapshotData,
-          platform: TargetPlatform.darwin,
+          platform: FlutterDarwinPlatform.macos.targetPlatform,
           mode: BuildMode.debug,
         );
         environment.fileSystem
@@ -582,14 +587,14 @@ class DebugMacOSBundleFlutterAssets extends MacOSBundleFlutterAssets {
   List<Source> get inputs => <Source>[
     ...super.inputs,
     const Source.pattern('{BUILD_DIR}/app.dill'),
-    const Source.artifact(
+    Source.artifact(
       Artifact.isolateSnapshotData,
-      platform: TargetPlatform.darwin,
+      platform: FlutterDarwinPlatform.macos.targetPlatform,
       mode: BuildMode.debug,
     ),
-    const Source.artifact(
+    Source.artifact(
       Artifact.vmSnapshotData,
-      platform: TargetPlatform.darwin,
+      platform: FlutterDarwinPlatform.macos.targetPlatform,
       mode: BuildMode.debug,
     ),
   ];

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -46,7 +46,7 @@ class BuildHooks extends Target {
     final FileSystem fileSystem = environment.fileSystem;
 
     final TargetPlatform targetPlatform = platform == HookPlatform.web
-        ? TargetPlatform.web_javascript
+        ? const TargetPlatform(.web, .unknown)
         : _getTargetPlatformFromEnvironment(environment, name);
     final Uri projectUri = environment.projectDir.uri;
 
@@ -193,7 +193,7 @@ class LinkHooks extends Target {
     final Uri projectUri = environment.projectDir.uri;
     final FileSystem fileSystem = environment.fileSystem;
     final TargetPlatform targetPlatform = platform == HookPlatform.web
-        ? TargetPlatform.web_javascript
+        ? const TargetPlatform(.web, .unknown)
         : _getTargetPlatformFromEnvironment(environment, name);
 
     final String? buildModeEnvironment = environment.defines[kBuildMode];

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -187,7 +187,10 @@ class Dart2JSTarget extends Dart2WebTarget {
         .getHostArtifact(HostArtifact.webPlatformKernelFolder)
         .path;
     final sharedCommandOptions = <String>[
-      artifacts.getArtifactPath(Artifact.engineDartBinary, platform: TargetPlatform.web_javascript),
+      artifacts.getArtifactPath(
+        Artifact.engineDartBinary,
+        platform: const TargetPlatform(.web, .unknown),
+      ),
       'compile',
       'js',
       '--platform-binaries=$platformBinariesPath',
@@ -360,7 +363,10 @@ class Dart2WasmTarget extends Dart2WebTarget {
     final List<String> dartDefines = computeDartDefines(environment);
 
     final compilationArgs = <String>[
-      artifacts.getArtifactPath(Artifact.engineDartBinary, platform: TargetPlatform.web_javascript),
+      artifacts.getArtifactPath(
+        Artifact.engineDartBinary,
+        platform: const TargetPlatform(.web, .unknown),
+      ),
       'compile',
       'wasm',
       '--packages=${findPackageConfigFileOrDefault(environment.projectDir).path}',
@@ -665,7 +671,7 @@ class WebReleaseBundle extends Target {
       environment,
       environment.outputDir.childDirectory('assets'),
       dartHookResult: dartHookResult,
-      targetPlatform: TargetPlatform.web_javascript,
+      targetPlatform: const TargetPlatform(.web, .unknown),
       buildMode: buildMode,
     );
     final Depfile bundledDepfile = _bundleLocalRobotoFallback(environment, depfile);

--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -175,16 +175,10 @@ class ShaderCompiler {
   bool _hasLoggedSecurityBlockError = false;
 
   List<String> _shaderTargetsFromTargetPlatform(TargetPlatform targetPlatform) {
-    switch (targetPlatform) {
-      case TargetPlatform.android_x64:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android:
-      case TargetPlatform.linux_x64:
-      case TargetPlatform.linux_arm64:
-      case TargetPlatform.linux_riscv64:
-      case TargetPlatform.windows_x64:
-      case TargetPlatform.windows_arm64:
+    switch (targetPlatform.type) {
+      case .android:
+      case .linux:
+      case .windows:
         return <String>[
           '--sksl',
           '--runtime-stage-gles',
@@ -192,20 +186,20 @@ class ShaderCompiler {
           '--runtime-stage-vulkan',
         ];
 
-      case TargetPlatform.ios:
+      case .ios:
         return <String>['--runtime-stage-metal'];
-      case TargetPlatform.darwin:
+      case .macos:
         return <String>['--sksl', '--runtime-stage-metal'];
 
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.tester:
+      case .fuchsia:
+      case .tester:
         return <String>['--sksl', '--runtime-stage-vulkan'];
 
-      case TargetPlatform.web_javascript:
+      case .web:
         return <String>['--sksl'];
 
-      case TargetPlatform.unsupported:
+      case .custom:
+      case .unsupported:
         TargetPlatform.throwUnsupportedTarget();
     }
   }
@@ -248,7 +242,7 @@ class ShaderCompiler {
       impellerc.path,
       ...targets,
       '--iplr',
-      if (targetPlatform == TargetPlatform.web_javascript) '--json',
+      if (targetPlatform.type == .web) '--json',
       '--sl=$outputPath',
       '--spirv=$outputPath.spirv',
       '--input=${input.path}',

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -31,8 +31,8 @@ var _kDefaultTargets = <Target>[
   // Shared targets
   const CopyAssets(),
   const KernelSnapshot(),
-  const AotElfProfile(TargetPlatform.android_arm),
-  const AotElfRelease(TargetPlatform.android_arm),
+  const AotElfProfile(TargetPlatform(.android, .armv7)),
+  const AotElfRelease(TargetPlatform(.android, .armv7)),
   const AotAssemblyProfile(),
   const AotAssemblyRelease(),
   // macOS targets
@@ -44,15 +44,15 @@ var _kDefaultTargets = <Target>[
   const ProfileUnpackMacOS(),
   const ReleaseUnpackMacOS(),
   // Linux targets
-  const DebugBundleLinuxAssets(TargetPlatform.linux_x64),
-  const DebugBundleLinuxAssets(TargetPlatform.linux_arm64),
-  const DebugBundleLinuxAssets(TargetPlatform.linux_riscv64),
-  const ProfileBundleLinuxAssets(TargetPlatform.linux_x64),
-  const ProfileBundleLinuxAssets(TargetPlatform.linux_arm64),
-  const ProfileBundleLinuxAssets(TargetPlatform.linux_riscv64),
-  const ReleaseBundleLinuxAssets(TargetPlatform.linux_x64),
-  const ReleaseBundleLinuxAssets(TargetPlatform.linux_arm64),
-  const ReleaseBundleLinuxAssets(TargetPlatform.linux_riscv64),
+  const DebugBundleLinuxAssets(TargetPlatform(.linux, .x64)),
+  const DebugBundleLinuxAssets(TargetPlatform(.linux, .arm64)),
+  const DebugBundleLinuxAssets(TargetPlatform(.linux, .riscv64)),
+  const ProfileBundleLinuxAssets(TargetPlatform(.linux, .x64)),
+  const ProfileBundleLinuxAssets(TargetPlatform(.linux, .arm64)),
+  const ProfileBundleLinuxAssets(TargetPlatform(.linux, .riscv64)),
+  const ReleaseBundleLinuxAssets(TargetPlatform(.linux, .x64)),
+  const ReleaseBundleLinuxAssets(TargetPlatform(.linux, .arm64)),
+  const ReleaseBundleLinuxAssets(TargetPlatform(.linux, .riscv64)),
   const ReleaseAndroidApplication(),
   // This is a one-off rule for bundle and aot compat.
   const CopyFlutterBundle(),
@@ -81,14 +81,14 @@ var _kDefaultTargets = <Target>[
   const ProfileUnpackIOS(),
   const ReleaseUnpackIOS(),
   // Windows targets
-  const UnpackWindows(TargetPlatform.windows_x64),
-  const UnpackWindows(TargetPlatform.windows_arm64),
-  const DebugBundleWindowsAssets(TargetPlatform.windows_x64),
-  const DebugBundleWindowsAssets(TargetPlatform.windows_arm64),
-  const ProfileBundleWindowsAssets(TargetPlatform.windows_x64),
-  const ProfileBundleWindowsAssets(TargetPlatform.windows_arm64),
-  const ReleaseBundleWindowsAssets(TargetPlatform.windows_x64),
-  const ReleaseBundleWindowsAssets(TargetPlatform.windows_arm64),
+  const UnpackWindows(TargetPlatform(.windows, .x64)),
+  const UnpackWindows(TargetPlatform(.windows, .arm64)),
+  const DebugBundleWindowsAssets(TargetPlatform(.windows, .x64)),
+  const DebugBundleWindowsAssets(TargetPlatform(.windows, .arm64)),
+  const ProfileBundleWindowsAssets(TargetPlatform(.windows, .x64)),
+  const ProfileBundleWindowsAssets(TargetPlatform(.windows, .arm64)),
+  const ReleaseBundleWindowsAssets(TargetPlatform(.windows, .x64)),
+  const ReleaseBundleWindowsAssets(TargetPlatform(.windows, .arm64)),
 ];
 
 /// Assemble provides a low level API to interact with the flutter tool build

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -111,33 +111,27 @@ class BuildBundleCommand extends BuildSubCommand {
     final String targetPlatform = stringArg('target-platform')!;
     final platform = TargetPlatform.fromName(targetPlatform);
     // Check for target platforms that are only allowed via feature flags.
-    switch (platform) {
-      case TargetPlatform.darwin:
+    switch (platform.type) {
+      case .macos:
         if (!featureFlags.isMacOSEnabled) {
           throwToolExit('macOS is not a supported target platform.');
         }
-      case TargetPlatform.windows_x64:
-      case TargetPlatform.windows_arm64:
+      case .windows:
         if (!featureFlags.isWindowsEnabled) {
           throwToolExit('Windows is not a supported target platform.');
         }
-      case TargetPlatform.linux_x64:
-      case TargetPlatform.linux_arm64:
-      case TargetPlatform.linux_riscv64:
+      case .linux:
         if (!featureFlags.isLinuxEnabled) {
           throwToolExit('Linux is not a supported target platform.');
         }
-      case TargetPlatform.android:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.ios:
-      case TargetPlatform.tester:
-      case TargetPlatform.web_javascript:
+      case .android:
+      case .fuchsia:
+      case .ios:
+      case .tester:
+      case .web:
+      case .custom:
         break;
-      case TargetPlatform.unsupported:
+      case .unsupported:
         TargetPlatform.throwUnsupportedTarget();
     }
 

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -936,7 +936,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
   late final Future<BuildableIOSApp> buildableIOSApp = () async {
     final app =
         await applicationPackages?.getPackageForPlatform(
-              TargetPlatform.ios,
+              FlutterDarwinPlatform.ios.targetPlatform,
               buildInfo: await cachedBuildInfo,
             )
             as BuildableIOSApp?;
@@ -978,7 +978,10 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
     final BuildableIOSApp app = await buildableIOSApp;
 
     final logTarget = environmentType == EnvironmentType.simulator ? 'simulator' : 'device';
-    final String typeName = globals.artifacts!.getEngineType(TargetPlatform.ios, buildInfo.mode);
+    final String typeName = globals.artifacts!.getEngineType(
+      FlutterDarwinPlatform.ios.targetPlatform,
+      buildInfo.mode,
+    );
     globals.printStatus(switch (xcodeBuildAction) {
       XcodeBuildAction.build => 'Building $app for $logTarget ($typeName)...',
       XcodeBuildAction.archive => 'Archiving $app...',

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -744,7 +744,7 @@ end
     final Status status = globals.logger.startProgress(' ├─Copying Flutter.xcframework...');
     final String engineCacheFlutterFrameworkDirectory = globals.artifacts!.getArtifactPath(
       Artifact.flutterXcframework,
-      platform: TargetPlatform.ios,
+      platform: FlutterDarwinPlatform.ios.targetPlatform,
       mode: buildInfo.mode,
     );
     final String flutterFrameworkFileName = globals.fs.path.basename(
@@ -798,7 +798,7 @@ end
           flutterRootDir: globals.fs.directory(Cache.flutterRoot),
           defines: <String, String>{
             kTargetFile: targetFile,
-            kTargetPlatform: TargetPlatform.ios.getName(),
+            kTargetPlatform: FlutterDarwinPlatform.ios.targetPlatform.getName(),
             kIosArchs: defaultIOSArchsForEnvironment(
               sdkType,
               globals.artifacts!,

--- a/packages/flutter_tools/lib/src/commands/build_linux.dart
+++ b/packages/flutter_tools/lib/src/commands/build_linux.dart
@@ -72,7 +72,7 @@ class BuildLinuxCommand extends BuildSubCommand {
     final BuildInfo buildInfo = await getBuildInfo();
     final targetPlatform = TargetPlatform.fromName(stringArg('target-platform')!);
     final needCrossBuild =
-        _operatingSystemUtils.hostPlatform.platformName != targetPlatform.simpleName;
+        _operatingSystemUtils.hostPlatform.platformName != targetPlatform.cpuArch.dartName;
 
     if (!featureFlags.isLinuxEnabled) {
       throwToolExit(
@@ -88,14 +88,14 @@ class BuildLinuxCommand extends BuildSubCommand {
     }
     // TODO(fujino): https://github.com/flutter/flutter/issues/74929
     if (_operatingSystemUtils.hostPlatform == HostPlatform.linux_x64 &&
-        targetPlatform == TargetPlatform.linux_arm64) {
+        targetPlatform == const TargetPlatform(.linux, .arm64)) {
       throwToolExit(
         'Cross-build from Linux x64 host to Linux arm64 target is not currently supported.',
       );
     }
     // Building for riscv64 (on a non-riscv64 host) is experimental
     if (_operatingSystemUtils.hostPlatform != HostPlatform.linux_riscv64 &&
-        targetPlatform == TargetPlatform.linux_riscv64 &&
+        targetPlatform == const TargetPlatform(.linux, .riscv64) &&
         !featureFlags.isRiscv64SupportEnabled) {
       throwToolExit(
         'Building for Linux riscv64 is currently an experimental feature. To enable, run "flutter config --enable-riscv64"',

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -258,7 +258,7 @@ end
         flutterRootDir: globals.fs.directory(Cache.flutterRoot),
         defines: <String, String>{
           kTargetFile: targetFile,
-          kTargetPlatform: TargetPlatform.darwin.getName(),
+          kTargetPlatform: FlutterDarwinPlatform.macos.targetPlatform.getName(),
           kDarwinArchs: defaultMacOSArchsForEnvironment(
             globals.artifacts!,
           ).map((CpuArch e) => e.darwinArchName).join(' '),
@@ -316,7 +316,7 @@ end
     final Status status = globals.logger.startProgress(' ├─Copying FlutterMacOS.xcframework...');
     final String engineCacheFlutterFrameworkDirectory = globals.artifacts!.getArtifactPath(
       Artifact.flutterMacOSXcframework,
-      platform: TargetPlatform.darwin,
+      platform: FlutterDarwinPlatform.macos.targetPlatform,
       mode: buildInfo.mode,
     );
     final String flutterFrameworkFileName = globals.fs.path.basename(

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -468,7 +468,11 @@ class DaemonDomain extends Domain {
       void handlePlatformType(PlatformType platform) {
         final reasons = <Map<String, Object>>[];
         switch (platform) {
-          case PlatformType.linux:
+          case .tester:
+          case .unsupported:
+            // Not user-facing project platforms.
+            return;
+          case .linux:
             if (!featureFlags.isLinuxEnabled) {
               reasons.add(<String, Object>{
                 'reasonText': 'the Linux feature is not enabled',
@@ -483,7 +487,7 @@ class DaemonDomain extends Domain {
                 'fixCode': _ReasonCode.create.name,
               });
             }
-          case PlatformType.macos:
+          case .macos:
             if (!featureFlags.isMacOSEnabled) {
               reasons.add(<String, Object>{
                 'reasonText': 'the macOS feature is not enabled',
@@ -498,7 +502,7 @@ class DaemonDomain extends Domain {
                 'fixCode': _ReasonCode.create.name,
               });
             }
-          case PlatformType.windows:
+          case .windows:
             if (!featureFlags.isWindowsEnabled) {
               reasons.add(<String, Object>{
                 'reasonText': 'the Windows feature is not enabled',
@@ -514,7 +518,7 @@ class DaemonDomain extends Domain {
                 'fixCode': _ReasonCode.create.name,
               });
             }
-          case PlatformType.ios:
+          case .ios:
             if (!featureFlags.isIOSEnabled) {
               reasons.add(<String, Object>{
                 'reasonText': 'the iOS feature is not enabled',
@@ -529,7 +533,7 @@ class DaemonDomain extends Domain {
                 'fixCode': _ReasonCode.create.name,
               });
             }
-          case PlatformType.android:
+          case .android:
             if (!featureFlags.isAndroidEnabled) {
               reasons.add(<String, Object>{
                 'reasonText': 'the Android feature is not enabled',
@@ -545,7 +549,7 @@ class DaemonDomain extends Domain {
                 'fixCode': _ReasonCode.create.name,
               });
             }
-          case PlatformType.web:
+          case .web:
             if (!featureFlags.isWebEnabled) {
               reasons.add(<String, Object>{
                 'reasonText': 'the Web feature is not enabled',
@@ -560,7 +564,7 @@ class DaemonDomain extends Domain {
                 'fixCode': _ReasonCode.create.name,
               });
             }
-          case PlatformType.fuchsia:
+          case .fuchsia:
             if (!featureFlags.isFuchsiaEnabled) {
               reasons.add(<String, Object>{
                 'reasonText': 'the Fuchsia feature is not enabled',
@@ -576,7 +580,7 @@ class DaemonDomain extends Domain {
                 'fixCode': _ReasonCode.create.name,
               });
             }
-          case PlatformType.custom:
+          case .custom:
             if (!featureFlags.areCustomDevicesEnabled) {
               reasons.add(<String, Object>{
                 'reasonText': 'the custom devices feature is not enabled',
@@ -697,7 +701,7 @@ class AppDomain extends Domain {
 
     ResidentRunner runner;
 
-    if (await device.targetPlatform == TargetPlatform.web_javascript) {
+    if ((await device.targetPlatform).type == .web) {
       runner = webRunnerFactory!.createWebRunner(
         flutterDevice,
         flutterProject: flutterProject,
@@ -1416,7 +1420,7 @@ Future<Map<String, Object?>> _deviceToMap(Device device) async {
   return <String, Object?>{
     'id': device.id,
     'name': device.displayName,
-    'platform': (await device.targetPlatform).getName(),
+    'platform': (await device.targetPlatform).devicePlatformName,
     'emulator': await device.isLocalEmulator,
     'category': device.category?.toString(),
     'platformType': device.platformType?.toString(),

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -556,7 +556,7 @@ class RunCommand extends RunCommandBase {
     if (featureFlags.isWebEnabled &&
         devices != null &&
         devices!.length == 1 &&
-        await devices!.single.targetPlatform == TargetPlatform.web_javascript) {
+        (await devices!.single.targetPlatform).type == .web) {
       final WebDevServerConfig webDevServerConfig = await webDevServerConfigCore();
       return webDevServerConfig;
     }
@@ -578,7 +578,7 @@ class RunCommand extends RunCommandBase {
     if (devices!.length > 1) {
       return '$command/all';
     }
-    return '$command/${(await devices![0].targetPlatform).getName()}';
+    return '$command/${(await devices![0].targetPlatform).devicePlatformName}';
   }
 
   @override
@@ -616,12 +616,12 @@ class RunCommand extends RunCommandBase {
     } else if (devices!.length == 1) {
       final Device device = devices![0];
       final TargetPlatform platform = await device.targetPlatform;
-      anyAndroidDevices = platform == TargetPlatform.android;
-      anyIOSDevices = platform == TargetPlatform.ios;
+      anyAndroidDevices = platform.type == .android;
+      anyIOSDevices = platform.type == .ios;
       if (device is IOSDevice && device.isWirelesslyConnected) {
         anyWirelessIOSDevices = true;
       }
-      deviceType = platform.getName();
+      deviceType = platform.devicePlatformName;
       deviceOsVersion = await device.sdkNameAndVersion;
       isEmulator = await device.isLocalEmulator;
     } else {
@@ -630,8 +630,8 @@ class RunCommand extends RunCommandBase {
       isEmulator = false;
       for (final Device device in devices!) {
         final TargetPlatform platform = await device.targetPlatform;
-        anyAndroidDevices = anyAndroidDevices || (platform == TargetPlatform.android);
-        anyIOSDevices = anyIOSDevices || (platform == TargetPlatform.ios);
+        anyAndroidDevices = anyAndroidDevices || (platform.type == .android);
+        anyIOSDevices = anyIOSDevices || (platform.type == .ios);
         if (device is IOSDevice && device.isWirelesslyConnected) {
           anyWirelessIOSDevices = true;
         }
@@ -723,7 +723,7 @@ class RunCommand extends RunCommandBase {
     }
 
     if (userIdentifier != null &&
-        devices!.every((Device device) => device.platformType != PlatformType.android)) {
+        devices!.every((Device device) => device.platformType != .android)) {
       throwToolExit(
         '--${FlutterOptions.kDeviceUser} is only supported for Android. At least one Android device is required.',
       );
@@ -967,7 +967,10 @@ class RunCommand extends RunCommandBase {
       timingLabelParts: <String?>[
         if (hotMode) 'hot' else 'cold',
         getBuildMode().cliName,
-        if (devices!.length == 1) (await devices![0].targetPlatform).getName() else 'multiple',
+        if (devices!.length == 1)
+          (await devices![0].targetPlatform).devicePlatformName
+        else
+          'multiple',
         if (devices!.length == 1 && await devices![0].isLocalEmulator) 'emulator' else null,
       ],
       endTimeOverride: appStartedTime,

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -640,7 +640,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
           'Ensure that `flutter doctor` shows at least one connected device',
         );
       }
-      if (integrationTestDevice.platformType == PlatformType.web) {
+      if (integrationTestDevice.platformType == .web) {
         // TODO(jiahaog): Support web. https://github.com/flutter/flutter/issues/66264
         throwToolExit('Web devices are not supported for integration tests yet.');
       }
@@ -802,7 +802,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       packageConfigPath: packageConfigPath,
       flavor: flavor,
       includeAssetsFromDevDependencies: true,
-      targetPlatform: TargetPlatform.tester,
+      targetPlatform: const TargetPlatform(.tester, .unknown),
     );
     if (build != 0) {
       throwToolExit('Error: Failed to build asset bundle');
@@ -811,7 +811,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       await writeBundle(
         globals.fs.directory(globals.fs.path.join('build', 'unit_test_assets')),
         assetBundle.entries,
-        targetPlatform: TargetPlatform.tester,
+        targetPlatform: const TargetPlatform(.tester, .unknown),
         impellerStatus: impellerStatus,
         processManager: globals.processManager,
         fileSystem: globals.fs,

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -65,9 +65,9 @@ class TargetModel {
 
   /// Infers the appropriate [TargetModel] from a given [TargetPlatform].
   static TargetModel fromTargetPlatform(TargetPlatform? platform) {
-    return switch (platform) {
-      TargetPlatform.web_javascript => TargetModel.dartdevc,
-      TargetPlatform.fuchsia_arm64 || TargetPlatform.fuchsia_x64 => TargetModel.flutterRunner,
+    return switch (platform?.type) {
+      .web => TargetModel.dartdevc,
+      .fuchsia => TargetModel.flutterRunner,
       _ => TargetModel.flutter,
     };
   }
@@ -280,7 +280,7 @@ class KernelCompiler {
     String? nativeAssets,
   }) async {
     final TargetPlatform? platform = targetModel == TargetModel.dartdevc
-        ? TargetPlatform.web_javascript
+        ? const TargetPlatform(.web, .unknown)
         : null;
     // This is a URI, not a file path, so the forward slash is correct even on Windows.
     if (!sdkRoot.endsWith('/')) {
@@ -545,7 +545,7 @@ class ResidentCompilerFactory {
     TargetModel targetModel = targetModelOverride ?? .flutter;
 
     // Configure the compiler to target the DDC runtime.
-    if (targetPlatform case .web_javascript) {
+    if (targetPlatform.type == .web) {
       sdkRoot = artifacts.getHostArtifact(HostArtifact.flutterWebSdk).path;
       targetModel = .dartdevc;
 
@@ -578,7 +578,7 @@ class ResidentCompilerFactory {
         ],
       );
     } else {
-      if (targetPlatform case .fuchsia_arm64 || .fuchsia_x64) {
+      if (targetPlatform.type == .fuchsia) {
         targetModel = .flutterRunner;
       }
       buildInfo = buildInfo.copyWith(
@@ -935,7 +935,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     String? nativeAssetsUri,
   }) async {
     final TargetPlatform? platform = (targetModel == TargetModel.dartdevc)
-        ? TargetPlatform.web_javascript
+        ? const TargetPlatform(.web, .unknown)
         : null;
     late final List<String> commandToStartFrontendServer;
     if (frontendServerStarterPath != null && frontendServerStarterPath!.isNotEmpty) {

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -776,14 +776,15 @@ class CustomDevice extends Device {
   }
 
   @override
-  Future<TargetPlatform> get targetPlatform async => _config.platform ?? TargetPlatform.linux_arm64;
+  Future<TargetPlatform> get targetPlatform async =>
+      _config.platform ?? const TargetPlatform(.linux, .arm64);
 
   @override
   Future<CpuArch> get cpuArch async {
     // Custom devices only support Linux target platforms (see
     // CustomDeviceConfig), so the arch is derived from that.
-    return switch (_config.platform) {
-      TargetPlatform.linux_x64 => CpuArch.x64,
+    return switch (_config.platform?.cpuArch) {
+      .x64 => CpuArch.x64,
       _ => CpuArch.arm64,
     };
   }

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
@@ -98,8 +98,8 @@ class CustomDeviceConfig {
   }) : assert(forwardPortCommand == null || forwardPortSuccessRegex != null),
        assert(
          platform == null ||
-             platform == TargetPlatform.linux_x64 ||
-             platform == TargetPlatform.linux_arm64,
+             platform == const TargetPlatform(.linux, .x64) ||
+             platform == const TargetPlatform(.linux, .arm64),
        );
 
   /// Create a CustomDeviceConfig from some JSON value.
@@ -144,8 +144,8 @@ class CustomDeviceConfig {
     }
 
     if (platform != null &&
-        platform != TargetPlatform.linux_arm64 &&
-        platform != TargetPlatform.linux_x64) {
+        platform != const TargetPlatform(.linux, .arm64) &&
+        platform != const TargetPlatform(.linux, .x64)) {
       throw const CustomDeviceRevivalException.fromDescriptions(
         _kPlatform,
         'null or one of linux-arm64, linux-x64',
@@ -243,7 +243,7 @@ class CustomDeviceConfig {
     id: 'pi',
     label: 'Raspberry Pi',
     sdkNameAndVersion: 'Raspberry Pi 4 Model B+',
-    platform: TargetPlatform.linux_arm64,
+    platform: const TargetPlatform(.linux, .arm64),
     enabled: false,
     pingCommand: const <String>['ping', '-w', '500', '-n', '1', 'raspberrypi'],
     pingSuccessRegex: RegExp(r'[<=]\d+ms'),

--- a/packages/flutter_tools/lib/src/darwin/darwin.dart
+++ b/packages/flutter_tools/lib/src/darwin/darwin.dart
@@ -18,7 +18,7 @@ import '../project.dart';
 enum FlutterDarwinPlatform {
   ios(
     binaryName: 'Flutter',
-    targetPlatform: TargetPlatform.ios,
+    targetPlatform: TargetPlatform(.ios, .arm64),
     swiftPackagePlatform: SwiftPackagePlatform.ios,
     artifactName: 'ios',
     artifactZip: 'artifacts.zip',
@@ -27,7 +27,7 @@ enum FlutterDarwinPlatform {
   ),
   macos(
     binaryName: 'FlutterMacOS',
-    targetPlatform: TargetPlatform.darwin,
+    targetPlatform: TargetPlatform(.macos, .x64),
     swiftPackagePlatform: SwiftPackagePlatform.macos,
     artifactName: 'darwin-x64',
     artifactZip: 'framework.zip',
@@ -110,7 +110,10 @@ enum FlutterDarwinPlatform {
   /// Returns corresponding [FlutterDarwinPlatform] for the [targetPlatform].
   static FlutterDarwinPlatform? fromTargetPlatform(TargetPlatform targetPlatform) {
     for (final FlutterDarwinPlatform darwinPlatform in FlutterDarwinPlatform.values) {
-      if (targetPlatform == darwinPlatform.targetPlatform) {
+      // Match on the platform type (family) only. A [FlutterDarwinPlatform]
+      // describes an OS (iOS or macOS) and is architecture-agnostic, whereas
+      // [TargetPlatform] equality also considers the CPU architecture.
+      if (targetPlatform.type == darwinPlatform.targetPlatform.type) {
         return darwinPlatform;
       }
     }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -41,23 +41,6 @@ enum Category {
   }
 }
 
-/// The platform sub-folder that a device type supports.
-enum PlatformType {
-  web,
-  android,
-  ios,
-  linux,
-  macos,
-  windows,
-  fuchsia,
-  custom;
-
-  @override
-  String toString() => name;
-
-  static PlatformType? fromString(String platformType) => values.asNameMap()[platformType];
-}
-
 /// A discovery mechanism for flutter-supported development devices.
 abstract class DeviceManager {
   DeviceManager({required Logger logger}) : _logger = logger;
@@ -356,9 +339,8 @@ class DeviceDiscoverySupportFilter {
   Future<bool> isDeviceSupportedForAll(Device device) async {
     final TargetPlatform devicePlatform = await device.targetPlatform;
     return await device.isSupported() &&
-        devicePlatform != TargetPlatform.fuchsia_arm64 &&
-        devicePlatform != TargetPlatform.fuchsia_x64 &&
-        devicePlatform != TargetPlatform.web_javascript &&
+        devicePlatform.type != .fuchsia &&
+        devicePlatform.type != .web &&
         await isDeviceSupportedForProject(device);
   }
 
@@ -705,13 +687,16 @@ abstract class Device {
   Future<String> supportMessage() async => await isSupported() ? 'Supported' : 'Unsupported';
 
   /// The device's platform.
-  Future<TargetPlatform> get targetPlatform;
+  ///
+  /// By default this is derived from [platformType] and [cpuArch]. Subclasses
+  /// may override this if they need custom behavior.
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform(platformType!, await cpuArch);
 
   /// The CPU architecture of the device.
   Future<CpuArch> get cpuArch;
 
   /// Platform name for display only.
-  Future<String> get targetPlatformDisplayName async => (await targetPlatform).getName();
+  Future<String> get targetPlatformDisplayName async => (await targetPlatform).devicePlatformName;
 
   Future<String> get sdkNameAndVersion;
 
@@ -849,7 +834,7 @@ abstract class Device {
       var supportIndicator = await device.isSupported() ? '' : ' (unsupported)';
       final TargetPlatform targetPlatform = await device.targetPlatform;
       if (await device.isLocalEmulator) {
-        final type = targetPlatform == TargetPlatform.ios ? 'simulator' : 'emulator';
+        final type = targetPlatform.type == .ios ? 'simulator' : 'emulator';
         supportIndicator += ' ($type)';
       }
       table.add(<String>[
@@ -885,7 +870,7 @@ abstract class Device {
       'name': name,
       'id': id,
       'isSupported': await isSupported(),
-      'targetPlatform': (await targetPlatform).getName(),
+      'targetPlatform': (await targetPlatform).devicePlatformName,
       'cpuArch': (await cpuArch).name,
       'emulator': isLocalEmu,
       'sdk': await sdkNameAndVersion,

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -15,6 +15,7 @@ import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'base/process.dart';
+import 'build_info.dart';
 import 'device.dart';
 import 'ios/ios_emulators.dart';
 

--- a/packages/flutter_tools/lib/src/flutter_application_package.dart
+++ b/packages/flutter_tools/lib/src/flutter_application_package.dart
@@ -49,11 +49,8 @@ class FlutterApplicationPackageFactory extends ApplicationPackageFactory {
     BuildInfo? buildInfo,
     File? applicationBinary,
   }) async {
-    switch (platform) {
-      case TargetPlatform.android:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
+    switch (platform.type) {
+      case .android:
         if (applicationBinary == null) {
           return AndroidApk.fromAndroidProject(
             FlutterProject.current().android,
@@ -74,35 +71,32 @@ class FlutterApplicationPackageFactory extends ApplicationPackageFactory {
           userMessages: _userMessages,
           processUtils: _processUtils,
         );
-      case TargetPlatform.ios:
+      case .ios:
         return applicationBinary == null
             ? await IOSApp.fromIosProject(FlutterProject.current().ios, buildInfo)
             : IOSApp.fromPrebuiltApp(applicationBinary);
-      case TargetPlatform.tester:
+      case .tester:
         return FlutterTesterApp.fromCurrentDirectory(globals.fs);
-      case TargetPlatform.darwin:
+      case .macos:
         return applicationBinary == null
             ? MacOSApp.fromMacOSProject(FlutterProject.current().macos)
             : MacOSApp.fromPrebuiltApp(applicationBinary);
-      case TargetPlatform.web_javascript:
+      case .web:
         if (!FlutterProject.current().web.existsSync()) {
           return null;
         }
         return WebApplicationPackage(FlutterProject.current());
-      case TargetPlatform.linux_x64:
-      case TargetPlatform.linux_arm64:
-      case TargetPlatform.linux_riscv64:
+      case .linux:
         return applicationBinary == null
             ? LinuxApp.fromLinuxProject(FlutterProject.current().linux)
             : LinuxApp.fromPrebuiltApp(applicationBinary);
-      case TargetPlatform.windows_x64:
-      case TargetPlatform.windows_arm64:
+      case .windows:
         return applicationBinary == null
             ? WindowsApp.fromWindowsProject(FlutterProject.current().windows)
             : WindowsApp.fromPrebuiltApp(applicationBinary);
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.unsupported:
+      case .fuchsia:
+      case .custom:
+      case .unsupported:
         TargetPlatform.throwUnsupportedTarget();
     }
   }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -1238,9 +1238,6 @@ class IOSDevice extends Device {
   }
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
-
-  @override
   Future<String> get sdkNameAndVersion async => 'iOS ${_sdkVersion ?? 'unknown version'}';
 
   @override

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -4,6 +4,7 @@
 
 import '../base/common.dart';
 import '../base/process.dart';
+import '../build_info.dart';
 import '../device.dart';
 import '../emulator.dart';
 import '../globals.dart' as globals;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -463,7 +463,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     if (!hasWatchCompanion) {
       // ONLY_ACTIVE_ARCH specifies whether the product includes only code for
       // the native architecture.
-      final onlyActiveArch = activeArch == CpuArch.fromHostPlatform(getCurrentHostPlatform());
+      final onlyActiveArch = activeArch == .fromHostPlatform(getCurrentHostPlatform());
 
       buildCommands.add('ONLY_ACTIVE_ARCH=${onlyActiveArch ? 'YES' : 'NO'}');
       buildCommands.add('ARCHS=${activeArch.darwinArchName}');
@@ -729,7 +729,7 @@ bool publicHeadersChanged({
 }) {
   final String? basePath = artifacts?.getArtifactPath(
     Artifact.flutterFramework,
-    platform: TargetPlatform.ios,
+    platform: FlutterDarwinPlatform.ios.targetPlatform,
     mode: mode,
     environmentType: environmentType,
   );

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -623,9 +623,6 @@ class IOSSimulator extends Device {
   }
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
-
-  @override
   Future<String> get sdkNameAndVersion async => simulatorCategory;
 
   final _iosSdkRegExp = RegExp(r'iOS( |-)(\d+)');

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -7,6 +7,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
 import '../cache.dart';
+import '../darwin/darwin.dart';
 import '../flutter_manifest.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
@@ -15,7 +16,7 @@ import 'xcodeproj.dart';
 String flutterMacOSFrameworkDir(BuildMode mode, FileSystem fileSystem, Artifacts artifacts) {
   final String flutterMacOSFramework = artifacts.getArtifactPath(
     Artifact.flutterMacOSFramework,
-    platform: TargetPlatform.darwin,
+    platform: FlutterDarwinPlatform.macos.targetPlatform,
     mode: mode,
   );
   return fileSystem.path.normalize(fileSystem.path.dirname(flutterMacOSFramework));
@@ -133,14 +134,14 @@ void _updateGeneratedEnvironmentVariablesScript({
 /// Build name parsed and validated from build info and manifest. Used for CFBundleShortVersionString.
 String? parsedBuildName({required FlutterManifest manifest, BuildInfo? buildInfo}) {
   final String? buildNameToParse = buildInfo?.buildName ?? manifest.buildName;
-  return validatedBuildNameForPlatform(TargetPlatform.ios, buildNameToParse, globals.logger);
+  return validatedBuildNameForPlatform(PlatformType.ios, buildNameToParse, globals.logger);
 }
 
 /// Build number parsed and validated from build info and manifest. Used for CFBundleVersion.
 String? parsedBuildNumber({required FlutterManifest manifest, BuildInfo? buildInfo}) {
   String? buildNumberToParse = buildInfo?.buildNumber ?? manifest.buildNumber;
   final String? buildNumber = validatedBuildNumberForPlatform(
-    TargetPlatform.ios,
+    PlatformType.ios,
     buildNumberToParse,
     globals.logger,
   );
@@ -150,7 +151,7 @@ String? parsedBuildNumber({required FlutterManifest manifest, BuildInfo? buildIn
   // Drop back to parsing build name if build number is not present. Build number is optional in the manifest, but
   // FLUTTER_BUILD_NUMBER is required as the backing value for the required CFBundleVersion.
   buildNumberToParse = buildInfo?.buildName ?? manifest.buildName;
-  return validatedBuildNumberForPlatform(TargetPlatform.ios, buildNumberToParse, globals.logger);
+  return validatedBuildNumberForPlatform(PlatformType.ios, buildNumberToParse, globals.logger);
 }
 
 /// List of lines of build settings. Example: 'FLUTTER_BUILD_DIR=build'

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -480,7 +480,7 @@ class WebDevFS implements DevFS {
     fileSystem.path.join(
       globals.artifacts!.getArtifactPath(
         Artifact.engineDartSdkPath,
-        platform: TargetPlatform.web_javascript,
+        platform: const TargetPlatform(.web, .unknown),
       ),
       'lib',
       'dev_compiler',
@@ -494,7 +494,7 @@ class WebDevFS implements DevFS {
     fileSystem.path.join(
       globals.artifacts!.getArtifactPath(
         Artifact.engineDartSdkPath,
-        platform: TargetPlatform.web_javascript,
+        platform: const TargetPlatform(.web, .unknown),
       ),
       'lib',
       'dev_compiler',
@@ -516,7 +516,7 @@ class WebDevFS implements DevFS {
     fileSystem.path.join(
       globals.artifacts!.getArtifactPath(
         Artifact.engineDartSdkPath,
-        platform: TargetPlatform.web_javascript,
+        platform: const TargetPlatform(.web, .unknown),
       ),
       'lib',
       'dev_compiler',

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -97,10 +97,7 @@ Future<DartHooksResult> runFlutterSpecificHooks({
     buildDataAssets: buildDataAssets,
   );
 
-  final BuildMode buildMode = _getBuildMode(
-    environmentDefines,
-    targetPlatform == TargetPlatform.tester,
-  );
+  final BuildMode buildMode = _getBuildMode(environmentDefines, targetPlatform.type == .tester);
   final bool linkingEnabled = _nativeAssetsLinkingEnabled(buildMode);
   final DartHooksResult linkResult;
   if (linkingEnabled) {
@@ -225,10 +222,7 @@ List<AssetBuildTarget> _getTargets({
     if (featureFlags.isDartDataAssetsEnabled && buildDataAssets) SupportedAssetTypes.dataAssets,
   ];
 
-  final BuildMode buildMode = _getBuildMode(
-    environmentDefines,
-    targetPlatform == TargetPlatform.tester,
-  );
+  final BuildMode buildMode = _getBuildMode(environmentDefines, targetPlatform.type == .tester);
 
   return AssetBuildTarget.targetsFor(
     targetPlatform: targetPlatform,
@@ -262,10 +256,7 @@ Future<({List<AssetBuildTarget> targets, BuildMode buildMode, bool linkingEnable
     if (featureFlags.isDartDataAssetsEnabled && buildDataAssets) SupportedAssetTypes.dataAssets,
   ];
 
-  final BuildMode buildMode = _getBuildMode(
-    environmentDefines,
-    targetPlatform == TargetPlatform.tester,
-  );
+  final BuildMode buildMode = _getBuildMode(environmentDefines, targetPlatform.type == .tester);
 
   if (supportedAssetTypes.contains(SupportedAssetTypes.codeAssets)) {
     for (final CodeAssetTarget target in targets.whereType<CodeAssetTarget>()) {
@@ -485,7 +476,7 @@ Future<List<File>> installCodeAssets({
   required Uri targetUri,
 }) async {
   final OS targetOS = getNativeOSFromTargetPlatform(targetPlatform);
-  final flutterTester = targetPlatform == TargetPlatform.tester;
+  final flutterTester = targetPlatform.type == .tester;
   final BuildMode buildMode = _getBuildMode(environmentDefines, flutterTester);
 
   final String? codesignIdentity = environmentDefines[kCodesignIdentity];
@@ -962,27 +953,20 @@ Never _throwNativeAssetsLinkFailed() {
 }
 
 OS getNativeOSFromTargetPlatform(TargetPlatform platform) {
-  switch (platform) {
-    case TargetPlatform.ios:
+  switch (platform.type) {
+    case .ios:
       return OS.iOS;
-    case TargetPlatform.darwin:
+    case .macos:
       return OS.macOS;
-    case TargetPlatform.linux_x64:
-    case TargetPlatform.linux_arm64:
-    case TargetPlatform.linux_riscv64:
+    case .linux:
       return OS.linux;
-    case TargetPlatform.windows_x64:
-    case TargetPlatform.windows_arm64:
+    case .windows:
       return OS.windows;
-    case TargetPlatform.fuchsia_arm64:
-    case TargetPlatform.fuchsia_x64:
+    case .fuchsia:
       return OS.fuchsia;
-    case TargetPlatform.android:
-    case TargetPlatform.android_arm:
-    case TargetPlatform.android_arm64:
-    case TargetPlatform.android_x64:
+    case .android:
       return OS.android;
-    case TargetPlatform.tester:
+    case .tester:
       if (const LocalPlatform().isMacOS) {
         return OS.macOS;
       } else if (const LocalPlatform().isLinux) {
@@ -992,9 +976,10 @@ OS getNativeOSFromTargetPlatform(TargetPlatform platform) {
       } else {
         throw StateError('Unknown operating system');
       }
-    case TargetPlatform.web_javascript:
+    case .web:
       throw StateError('No dart builds for web yet.');
-    case TargetPlatform.unsupported:
+    case .custom:
+    case .unsupported:
       TargetPlatform.throwUnsupportedTarget();
   }
 }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -67,33 +67,32 @@ sealed class AssetBuildTarget {
     required List<SupportedAssetTypes> supportedAssetTypes,
     required Directory? buildDirectory,
   }) {
-    switch (targetPlatform) {
-      case TargetPlatform.windows_x64:
-        return _windowsTarget(supportedAssetTypes, Architecture.x64);
-      case TargetPlatform.linux_x64:
-        return _linuxTarget(supportedAssetTypes, Architecture.x64, buildMode, buildDirectory);
-      case TargetPlatform.linux_arm64:
-        return _linuxTarget(supportedAssetTypes, Architecture.arm64, buildMode, buildDirectory);
-      case TargetPlatform.linux_riscv64:
-        return _linuxTarget(supportedAssetTypes, Architecture.riscv64, buildMode, buildDirectory);
-      case TargetPlatform.windows_arm64:
-        return _windowsTarget(supportedAssetTypes, Architecture.arm64);
-      case TargetPlatform.darwin:
+    switch (targetPlatform.type) {
+      case .windows:
+        return _windowsTarget(
+          supportedAssetTypes,
+          targetPlatform.cpuArch == .arm64 ? Architecture.arm64 : Architecture.x64,
+        );
+      case .linux:
+        final Architecture architecture = switch (targetPlatform.cpuArch) {
+          .arm64 => Architecture.arm64,
+          .riscv64 => Architecture.riscv64,
+          _ => Architecture.x64,
+        };
+        return _linuxTarget(supportedAssetTypes, architecture, buildMode, buildDirectory);
+      case .macos:
         return _macTargets(environmentDefines, supportedAssetTypes);
-      case TargetPlatform.android:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
+      case .android:
         return _androidTargets(targetPlatform, environmentDefines, supportedAssetTypes);
-      case TargetPlatform.ios:
+      case .ios:
         return _iosTargets(environmentDefines, fileSystem, supportedAssetTypes);
-      case TargetPlatform.web_javascript:
+      case .web:
         return _webTarget(supportedAssetTypes);
-      case TargetPlatform.tester:
+      case .tester:
         return _flutterTesterTarget(supportedAssetTypes);
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.unsupported:
+      case .fuchsia:
+      case .custom:
+      case .unsupported:
         throwToolExit('No targets defined for target platform $targetPlatform.');
     }
   }
@@ -419,32 +418,16 @@ final class FlutterTesterAssetTarget extends CodeAssetTarget {
 }
 
 List<CpuArch> _androidArchs(TargetPlatform targetPlatform, String? androidArchsEnvironment) {
-  switch (targetPlatform) {
-    case TargetPlatform.android_arm:
-      return <CpuArch>[CpuArch.armv7];
-    case TargetPlatform.android_arm64:
-      return <CpuArch>[CpuArch.arm64];
-    case TargetPlatform.android_x64:
-      return <CpuArch>[CpuArch.x64];
-    case TargetPlatform.android:
-      if (androidArchsEnvironment == null) {
-        throw MissingDefineException(kAndroidArchs, 'native_assets');
-      }
-      return androidArchsEnvironment.split(' ').map(getCpuArchForName).toList();
-    case TargetPlatform.darwin:
-    case TargetPlatform.fuchsia_arm64:
-    case TargetPlatform.fuchsia_x64:
-    case TargetPlatform.ios:
-    case TargetPlatform.linux_arm64:
-    case TargetPlatform.linux_riscv64:
-    case TargetPlatform.linux_x64:
-    case TargetPlatform.tester:
-    case TargetPlatform.web_javascript:
-    case TargetPlatform.windows_x64:
-    case TargetPlatform.windows_arm64:
-    case TargetPlatform.unsupported:
-      throwToolExit('Unsupported Android target platform: $targetPlatform.');
+  if (targetPlatform.type != .android) {
+    throwToolExit('Unsupported Android target platform: $targetPlatform.');
   }
+  return switch (targetPlatform.cpuArch) {
+    .armv7 || .arm64 || .x64 => <CpuArch>[targetPlatform.cpuArch],
+    CpuArch.unknown when androidArchsEnvironment != null =>
+      androidArchsEnvironment.split(' ').map(getCpuArchForName).toList(),
+    .unknown => throw MissingDefineException(kAndroidArchs, 'native_assets'),
+    .x86 || .riscv64 => throwToolExit('Unsupported Android target platform: $targetPlatform.'),
+  };
 }
 
 String? _emptyToNull(String? input) {

--- a/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
@@ -62,7 +62,7 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
   // Only `flutter test` uses the
   // `build/native_assets/<os>/native_assets.json` file which uses absolute
   // paths to the shared libraries.
-  final OS targetOS = getNativeOSFromTargetPlatform(TargetPlatform.tester);
+  final OS targetOS = getNativeOSFromTargetPlatform(const TargetPlatform(.tester, .unknown));
   final String buildDir = getBuildDirectory();
   final String osName = targetOS.name;
   final Uri buildUri = projectUri.resolve('$buildDir/native_assets/$osName/');
@@ -74,7 +74,7 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
   final DartHooksResult dartHookResult = await runFlutterSpecificHooks(
     environmentDefines: environmentDefines,
     buildRunner: buildRunner,
-    targetPlatform: TargetPlatform.tester,
+    targetPlatform: const TargetPlatform(.tester, .unknown),
     projectUri: projectUri,
     fileSystem: globals.fs,
     buildCodeAssets: const BuildCodeAssetsOptions(
@@ -89,7 +89,7 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
   await installCodeAssets(
     dartHookResult: dartHookResult,
     environmentDefines: environmentDefines,
-    targetPlatform: TargetPlatform.tester,
+    targetPlatform: const TargetPlatform(.tester, .unknown),
     projectUri: projectUri,
     fileSystem: globals.fs,
     nativeAssetsFileUri: nativeAssetsFileUri,

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -263,7 +263,7 @@ class ResidentWebRunner extends ResidentRunner {
   }) async {
     final ApplicationPackage? package = await ApplicationPackageFactory.instance!
         .getPackageForPlatform(
-          TargetPlatform.web_javascript,
+          const TargetPlatform(.web, .unknown),
           buildInfo: debuggingOptions.buildInfo,
         );
     if (package == null) {
@@ -292,7 +292,9 @@ class ResidentWebRunner extends ResidentRunner {
             ? WebExpressionCompiler(flutterDevice!.generator!, fileSystem: _fileSystem)
             : null;
 
-        flutterDevice!.developmentShaderCompiler.configureCompiler(TargetPlatform.web_javascript);
+        flutterDevice!.developmentShaderCompiler.configureCompiler(
+          const TargetPlatform(.web, .unknown),
+        );
 
         flutterDevice!.devFS = WebDevFS(
           webDevServerConfig: updatedConfig,
@@ -461,7 +463,7 @@ class ResidentWebRunner extends ResidentRunner {
       status = _logger.startProgress('Performing hot reload...', progressId: 'hot.reload');
     }
 
-    final String targetPlatform = TargetPlatform.web_javascript.getName();
+    final String targetPlatform = const TargetPlatform(.web, .unknown).getName();
     final String sdkName = await flutterDevice!.device!.sdkNameAndVersion;
 
     // Will be null if there is no report.
@@ -750,12 +752,12 @@ class ResidentWebRunner extends ResidentRunner {
       _logger.printTrace('Updating assets');
       final int result = await assetBundle.build(
         flutterHookResult: await dartBuilder?.runHooks(
-          targetPlatform: TargetPlatform.web_javascript,
+          targetPlatform: const TargetPlatform(.web, .unknown),
           environment: environment,
           logger: _logger,
         ),
         packageConfigPath: debuggingOptions.buildInfo.packageConfigPath,
-        targetPlatform: TargetPlatform.web_javascript,
+        targetPlatform: const TargetPlatform(.web, .unknown),
       );
       if (result != 0) {
         return UpdateFSReport();

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -737,7 +737,7 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
         .directory(
           globals.artifacts!.getArtifactPath(
             Artifact.engineDartSdkPath,
-            platform: TargetPlatform.web_javascript,
+            platform: const TargetPlatform(.web, .unknown),
           ),
         )
         .parent;

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -168,10 +168,8 @@ Future<void> _runCmake(
   await buildDir.create(recursive: true);
 
   final String buildFlag = sentenceCase(buildModeName);
-  final bool needCrossBuildOptionsForArm64 =
-      needCrossBuild && targetPlatform == TargetPlatform.linux_arm64;
-  final bool needCrossBuildOptionsForRiscv64 =
-      needCrossBuild && targetPlatform == TargetPlatform.linux_riscv64;
+  final bool needCrossBuildOptionsForArm64 = needCrossBuild && targetPlatform.cpuArch == .arm64;
+  final bool needCrossBuildOptionsForRiscv64 = needCrossBuild && targetPlatform.cpuArch == .riscv64;
   int result;
   if (!globals.processManager.canRun('cmake')) {
     throwToolExit(globals.userMessages.cmakeMissing);

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -41,16 +41,6 @@ class LinuxDevice extends DesktopDevice {
   String get name => 'Linux';
 
   @override
-  late final Future<TargetPlatform> targetPlatform = () async {
-    if (_operatingSystemUtils.hostPlatform == HostPlatform.linux_x64) {
-      return TargetPlatform.linux_x64;
-    } else if (_operatingSystemUtils.hostPlatform == HostPlatform.linux_riscv64) {
-      return TargetPlatform.linux_riscv64;
-    }
-    return TargetPlatform.linux_arm64;
-  }();
-
-  @override
   Future<CpuArch> get cpuArch async => CpuArch.fromHostPlatform(_operatingSystemUtils.hostPlatform);
 
   @override

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -43,9 +43,6 @@ class MacOSDevice extends DesktopDevice {
   bool get supportsFlavors => true;
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.darwin;
-
-  @override
   Future<CpuArch> get cpuArch async => CpuArch.fromHostPlatform(_operatingSystemUtils.hostPlatform);
 
   @override

--- a/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
@@ -35,9 +35,6 @@ class MacOSDesignedForIPadDevice extends DesktopDevice {
   @override
   String get name => 'Mac Designed for iPad';
 
-  @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.darwin;
-
   // "Designed for iPad" apps are only supported on Apple Silicon Macs.
   @override
   Future<CpuArch> get cpuArch async => CpuArch.arm64;

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -579,8 +579,8 @@ class MDnsVmServiceDiscovery {
       return;
     }
     final TargetPlatform targetPlatform = await device.targetPlatform;
-    switch (targetPlatform) {
-      case TargetPlatform.ios:
+    switch (targetPlatform.type) {
+      case .ios:
         _analytics.send(
           Event.appleUsageEvent(workflow: 'ios-mdns', parameter: 'no-ipv4-link-local'),
         );
@@ -591,22 +591,16 @@ class MDnsVmServiceDiscovery {
           'under System Preferences > Network > iPhone USB. '
           'See https://github.com/flutter/flutter/issues/46698 for details.',
         );
-      case TargetPlatform.android:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
-      case TargetPlatform.darwin:
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.linux_arm64:
-      case TargetPlatform.linux_riscv64:
-      case TargetPlatform.linux_x64:
-      case TargetPlatform.tester:
-      case TargetPlatform.web_javascript:
-      case TargetPlatform.windows_x64:
-      case TargetPlatform.windows_arm64:
+      case .android:
+      case .macos:
+      case .fuchsia:
+      case .linux:
+      case .tester:
+      case .web:
+      case .windows:
+      case .custom:
         _logger.printTrace('No interface with an ipv4 link local address was found.');
-      case TargetPlatform.unsupported:
+      case .unsupported:
         TargetPlatform.throwUnsupportedTarget();
     }
   }

--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -493,7 +493,7 @@ class ProxiedDevice extends Device {
 
     final String id = _cast<String>(
       await connection.sendRequest('device.uploadApplicationPackage', <String, Object>{
-        'targetPlatform': _targetPlatform.getName(),
+        'targetPlatform': _targetPlatform.devicePlatformName,
         'applicationBinary': fileName,
       }),
     );

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -738,7 +738,7 @@ abstract class ResidentHandlers {
       return false;
     }
     for (final FlutterDevice? device in flutterDevices) {
-      if (device!.targetPlatform == TargetPlatform.web_javascript) {
+      if (device!.targetPlatform.type == .web) {
         continue;
       }
       final List<FlutterView> views = await device.vmService!.getFlutterViews();
@@ -891,7 +891,7 @@ abstract class ResidentHandlers {
   }
 
   Future<bool> _takeVmServiceScreenshot(FlutterDevice device, File outputFile) async {
-    if (device.targetPlatform != TargetPlatform.web_javascript) {
+    if (device.targetPlatform.type != .web) {
       return false;
     }
     assert(supportsServiceProtocol);
@@ -1487,7 +1487,7 @@ abstract class ResidentRunner extends ResidentHandlers {
         commandHelp.b.print();
       } else {
         final bool isRunningOnWeb = flutterDevices.every((FlutterDevice? flutterDevice) {
-          return flutterDevice?.targetPlatform == TargetPlatform.web_javascript;
+          return flutterDevice?.targetPlatform.type == .web;
         });
 
         if (!isRunningOnWeb) {
@@ -1556,7 +1556,7 @@ abstract class ResidentRunner extends ResidentHandlers {
       }
 
       // 3. Perform the standard, cross-platform eviction calls.
-      final supportsShaderReload = device.targetPlatform != TargetPlatform.web_javascript;
+      final supportsShaderReload = device.targetPlatform.type != .web;
       for (final String assetPath in devFS.assetPathsToEvict) {
         // Flutter GPU shader bundles reload the compiled ShaderLibrary in place
         // via the `ext.ui.gpu.reinitializeShaderLibrary` extension. It is
@@ -1578,7 +1578,7 @@ abstract class ResidentRunner extends ResidentHandlers {
       // this throws an internal RPCError (-32603) instead of a standard MethodNotFound
       // error, which would break the hot reload.
       // See https://github.com/flutter/flutter/issues/137265
-      if (device.targetPlatform != TargetPlatform.web_javascript) {
+      if (device.targetPlatform.type != .web) {
         for (final String assetPath in devFS.shaderPathsToEvict) {
           futures.add(vmService.flutterEvictShader(assetPath, isolateId: firstUiIsolate.id!));
         }
@@ -1637,28 +1637,25 @@ class OperationResultExtraTiming {
 }
 
 Future<String?> getMissingPackageHintForPlatform(TargetPlatform platform) async {
-  switch (platform) {
-    case TargetPlatform.android_arm:
-    case TargetPlatform.android_arm64:
-    case TargetPlatform.android_x64:
+  switch (platform.type) {
+    case .android:
+      if (platform.cpuArch == .unknown) {
+        return null;
+      }
       final FlutterProject project = FlutterProject.current();
       final String manifestPath = globals.fs.path.relative(project.android.appManifestFile.path);
       return 'Is your project missing an $manifestPath?\nConsider running "flutter create ." to create one.';
-    case TargetPlatform.ios:
+    case .ios:
       return 'Is your project missing an ios/Runner/Info.plist?\nConsider running "flutter create ." to create one.';
-    case TargetPlatform.android:
-    case TargetPlatform.darwin:
-    case TargetPlatform.fuchsia_arm64:
-    case TargetPlatform.fuchsia_x64:
-    case TargetPlatform.linux_arm64:
-    case TargetPlatform.linux_riscv64:
-    case TargetPlatform.linux_x64:
-    case TargetPlatform.tester:
-    case TargetPlatform.web_javascript:
-    case TargetPlatform.windows_x64:
-    case TargetPlatform.windows_arm64:
+    case .macos:
+    case .fuchsia:
+    case .linux:
+    case .tester:
+    case .web:
+    case .windows:
+    case .custom:
       return null;
-    case TargetPlatform.unsupported:
+    case .unsupported:
       TargetPlatform.throwUnsupportedTarget();
   }
 }
@@ -1914,14 +1911,12 @@ class TerminalHandler {
         final bool isRunningOnWeb = residentRunner.flutterDevices.every((
           FlutterDevice? flutterDevice,
         ) {
-          return flutterDevice?.targetPlatform == TargetPlatform.web_javascript;
+          return flutterDevice?.targetPlatform.type == .web;
         });
         if (residentRunner.isRunningDebug || !isRunningOnWeb) {
           // DevTools are only supported in debug mode for web, see https://docs.flutter.dev/testing/build-modes#profile
           return residentRunner.flutterDevices
-              .where(
-                (FlutterDevice? device) => device?.targetPlatform != TargetPlatform.web_javascript,
-              )
+              .where((FlutterDevice? device) => device?.targetPlatform.type != .web)
               .fold<bool>(
                 true,
                 (bool s, FlutterDevice? device) =>

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -156,7 +156,7 @@ class HotRunner extends ResidentRunner {
       case 1:
         final Device device = flutterDevices.first.device!;
         final TargetPlatform targetPlatform = await device.targetPlatform;
-        _targetPlatformName = targetPlatform.getName();
+        _targetPlatformName = targetPlatform.devicePlatformName;
         _targetPlatforms.add(targetPlatform);
         _sdkName = await device.sdkNameAndVersion;
         _emulator = await device.isLocalEmulator;
@@ -1124,9 +1124,8 @@ class HotRunner extends ResidentRunner {
             uiIsolateId: view.uiIsolate!.id,
             viewId: view.id,
             windows:
-                (device.targetPlatform == TargetPlatform.tester && globals.platform.isWindows) ||
-                device.targetPlatform == TargetPlatform.windows_x64 ||
-                device.targetPlatform == TargetPlatform.windows_arm64,
+                (device.targetPlatform.type == .tester && globals.platform.isWindows) ||
+                device.targetPlatform.type == .windows,
           ),
         ),
       );

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -2201,38 +2201,32 @@ mixin DeviceBasedDevelopmentArtifacts on FlutterCommand {
 // if none is supported
 @protected
 DevelopmentArtifact? artifactFromTargetPlatform(TargetPlatform targetPlatform) {
-  switch (targetPlatform) {
-    case TargetPlatform.android:
-    case TargetPlatform.android_arm:
-    case TargetPlatform.android_arm64:
-    case TargetPlatform.android_x64:
+  switch (targetPlatform.type) {
+    case .android:
       return DevelopmentArtifact.androidGenSnapshot;
-    case TargetPlatform.web_javascript:
+    case .web:
       return DevelopmentArtifact.web;
-    case TargetPlatform.ios:
+    case .ios:
       return DevelopmentArtifact.iOS;
-    case TargetPlatform.darwin:
+    case .macos:
       if (featureFlags.isMacOSEnabled) {
         return DevelopmentArtifact.macOS;
       }
       return null;
-    case TargetPlatform.windows_x64:
-    case TargetPlatform.windows_arm64:
+    case .windows:
       if (featureFlags.isWindowsEnabled) {
         return DevelopmentArtifact.windows;
       }
       return null;
-    case TargetPlatform.linux_x64:
-    case TargetPlatform.linux_arm64:
-    case TargetPlatform.linux_riscv64:
+    case .linux:
       if (featureFlags.isLinuxEnabled) {
         return DevelopmentArtifact.linux;
       }
       return null;
-    case TargetPlatform.fuchsia_arm64:
-    case TargetPlatform.fuchsia_x64:
-    case TargetPlatform.tester:
-    case TargetPlatform.unsupported:
+    case .fuchsia:
+    case .tester:
+    case .custom:
+    case .unsupported:
       return null;
   }
 }

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -246,7 +246,7 @@ class FlutterWebPlatform extends PlatformPlugin {
     _fileSystem.path.join(
       _artifacts!.getArtifactPath(
         Artifact.engineDartSdkPath,
-        platform: TargetPlatform.web_javascript,
+        platform: const TargetPlatform(.web, .unknown),
       ),
       'lib',
       'dev_compiler',
@@ -260,7 +260,7 @@ class FlutterWebPlatform extends PlatformPlugin {
     _fileSystem.path.join(
       _artifacts!.getArtifactPath(
         Artifact.engineDartSdkPath,
-        platform: TargetPlatform.web_javascript,
+        platform: const TargetPlatform(.web, .unknown),
       ),
       'lib',
       'dev_compiler',
@@ -274,7 +274,7 @@ class FlutterWebPlatform extends PlatformPlugin {
     _fileSystem.path.join(
       _artifacts!.getArtifactPath(
         Artifact.engineDartSdkPath,
-        platform: TargetPlatform.web_javascript,
+        platform: const TargetPlatform(.web, .unknown),
       ),
       'lib',
       'dev_compiler',

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -554,7 +554,7 @@ class SpawnPlugin extends PlatformPlugin {
     final Stopwatch? testTimeRecorderStopwatch = testTimeRecorder?.start(TestTimePhases.Compile);
 
     final ResidentCompiler residentCompiler = residentCompilerFactory.create(
-      targetPlatform: .tester,
+      targetPlatform: const TargetPlatform(.tester, .unknown),
       artifacts: globals.artifacts!,
       logger: globals.logger,
       processManager: globals.processManager,

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -201,7 +201,7 @@ class TestCompiler {
       fileSystem: globals.fs,
       shutdownHooks: globals.shutdownHooks,
       config: globals.config,
-      targetPlatform: .tester,
+      targetPlatform: const TargetPlatform(.tester, .unknown),
     );
     return residentCompiler;
   }

--- a/packages/flutter_tools/lib/src/test/web_test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/web_test_compiler.dart
@@ -149,7 +149,7 @@ class WebTestCompiler {
       fileSystem: _fileSystem,
       shutdownHooks: _shutdownHooks,
       config: _config,
-      targetPlatform: .web_javascript,
+      targetPlatform: const TargetPlatform(.web, .unknown),
     );
 
     final CompilerOutput? output = await residentCompiler.recompile(
@@ -204,7 +204,7 @@ class WebTestCompiler {
     final compilationArgs = <String>[
       _artifacts.getArtifactPath(
         Artifact.engineDartBinary,
-        platform: TargetPlatform.web_javascript,
+        platform: const TargetPlatform(.web, .unknown),
       ),
       'compile',
       'wasm',

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -94,7 +94,7 @@ class FlutterTesterDevice extends Device {
   bool get supportsFlavors => true;
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.tester;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.tester, .unknown);
 
   @override
   Future<CpuArch> get cpuArch async => CpuArch.unknown;
@@ -152,7 +152,7 @@ class FlutterTesterDevice extends Device {
       buildInfo: buildInfo,
       mainPath: mainPath,
       applicationKernelFilePath: applicationKernelFilePath,
-      platform: TargetPlatform.tester,
+      platform: const TargetPlatform(.tester, .unknown),
       assetDirPath: assetDirectory.path,
     );
 

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -168,9 +168,6 @@ abstract class ChromiumDevice extends WebDevice {
   }
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.web_javascript;
-
-  @override
   Future<bool> uninstallApp(ApplicationPackage app, {String? userIdentifier}) async => true;
 
   @override
@@ -468,9 +465,6 @@ class WebServerDevice extends WebDevice {
   Future<bool> stopApp(ApplicationPackage? app, {String? userIdentifier}) async {
     return true;
   }
-
-  @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.web_javascript;
 
   @override
   Future<bool> uninstallApp(ApplicationPackage app, {String? userIdentifier}) async {

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -170,10 +170,12 @@ Future<void> buildWindows(
 }
 
 String getCmakeWindowsArch(TargetPlatform targetPlatform) {
-  return switch (targetPlatform) {
-    TargetPlatform.windows_x64 => 'x64',
-    TargetPlatform.windows_arm64 => 'ARM64',
-    _ => throw Exception('Unsupported target platform "$targetPlatform".'),
+  if (targetPlatform.type != .windows) {
+    throw Exception('Unsupported target platform "$targetPlatform".');
+  }
+  return switch (targetPlatform.cpuArch) {
+    .arm64 => 'ARM64',
+    _ => 'x64',
   };
 }
 

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -38,12 +38,9 @@ class WindowsDevice extends DesktopDevice {
   @override
   String get name => 'Windows';
 
-  @override
-  Future<TargetPlatform> get targetPlatform async => _targetPlatform;
-
   TargetPlatform get _targetPlatform => switch (_operatingSystemUtils.hostPlatform) {
-    HostPlatform.windows_arm64 => TargetPlatform.windows_arm64,
-    _ => TargetPlatform.windows_x64,
+    HostPlatform.windows_arm64 => const TargetPlatform(.windows, .arm64),
+    _ => const TargetPlatform(.windows, .x64),
   };
 
   @override

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -1882,7 +1882,7 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
   Future<String> get targetPlatformDisplayName async => 'android';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.android, .armv7);
 
   @override
   DeviceConnectionInterface get connectionInterface => DeviceConnectionInterface.attached;
@@ -1996,7 +1996,7 @@ class FakeIOSDevice extends Fake implements IOSDevice {
   String get displayName => name;
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.ios, .arm64);
 
   @override
   final PlatformType platformType = PlatformType.ios;
@@ -2075,7 +2075,7 @@ class FakeIOSSimulator extends Fake implements IOSSimulator {
   bool get ephemeral => true;
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.ios, .arm64);
 
   @override
   final PlatformType platformType = PlatformType.ios;

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -442,7 +442,7 @@ void main() {
 
         // Mock engine artifacts. _TestArtifacts uses a string like this for getArtifactPath.
         memoryFileSystem
-            .directory('Artifact.flutterXcframework.TargetPlatform.ios.debug')
+            .directory('Artifact.flutterXcframework.ios.debug')
             .createSync(recursive: true);
 
         final Directory buildDir =
@@ -528,7 +528,7 @@ void main() {
 
         // Mock engine artifacts
         memoryFileSystem
-            .directory('Artifact.flutterXcframework.TargetPlatform.ios.debug')
+            .directory('Artifact.flutterXcframework.ios.debug')
             .createSync(recursive: true);
 
         final Directory buildDir =

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -740,7 +740,7 @@ let package = Package(
                 expectedEngineVersion: _engineVersion,
                 expectedDefines: <String, String>{
                   'TargetFile': 'lib/main.dart',
-                  'TargetPlatform': 'darwin',
+                  'TargetPlatform': 'darwin-x64',
                   'DarwinArchs': 'x86_64 arm64',
                   'BuildMode': 'debug',
                   'DartObfuscation': 'false',
@@ -848,7 +848,7 @@ let package = Package(
                 expectedEngineVersion: _engineVersion,
                 expectedDefines: <String, String>{
                   'TargetFile': 'lib/main.dart',
-                  'TargetPlatform': 'darwin',
+                  'TargetPlatform': 'darwin-x64',
                   'DarwinArchs': 'x86_64 arm64',
                   'BuildMode': 'release',
                   'DartObfuscation': 'false',
@@ -974,7 +974,7 @@ let package = Package(
                 expectedEngineVersion: _engineVersion,
                 expectedDefines: <String, String>{
                   'TargetFile': 'lib/main.dart',
-                  'TargetPlatform': 'darwin',
+                  'TargetPlatform': 'darwin-x64',
                   'DarwinArchs': 'x86_64 arm64',
                   'BuildMode': 'release',
                   'DartObfuscation': 'false',
@@ -1085,7 +1085,7 @@ let package = Package(
                 expectedEngineVersion: _engineVersion,
                 expectedDefines: <String, String>{
                   'TargetFile': 'lib/main.dart',
-                  'TargetPlatform': 'ios',
+                  'TargetPlatform': 'ios-arm64',
                   'IosArchs': 'arm64',
                   'SdkRoot': _iosSdkRoot,
                   'BuildMode': 'debug',
@@ -1107,7 +1107,7 @@ let package = Package(
                 expectedEngineVersion: _engineVersion,
                 expectedDefines: <String, String>{
                   'TargetFile': 'lib/main.dart',
-                  'TargetPlatform': 'ios',
+                  'TargetPlatform': 'ios-arm64',
                   'IosArchs': 'x86_64 arm64',
                   'SdkRoot': _iosSdkRoot,
                   'BuildMode': 'debug',
@@ -1219,7 +1219,7 @@ let package = Package(
                   expectedEngineVersion: _engineVersion,
                   expectedDefines: <String, String>{
                     'TargetFile': 'lib/main.dart',
-                    'TargetPlatform': 'ios',
+                    'TargetPlatform': 'ios-arm64',
                     'IosArchs': 'arm64',
                     'SdkRoot': _iosSdkRoot,
                     'BuildMode': 'debug',
@@ -1241,7 +1241,7 @@ let package = Package(
                   expectedEngineVersion: _engineVersion,
                   expectedDefines: <String, String>{
                     'TargetFile': 'lib/main.dart',
-                    'TargetPlatform': 'ios',
+                    'TargetPlatform': 'ios-arm64',
                     'IosArchs': 'x86_64 arm64',
                     'SdkRoot': _iosSdkRoot,
                     'BuildMode': 'debug',
@@ -2917,7 +2917,7 @@ public func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
                 expectedEngineVersion: _engineVersion,
                 expectedDefines: <String, String>{
                   'TargetFile': 'lib/main.dart',
-                  'TargetPlatform': 'ios',
+                  'TargetPlatform': 'ios-arm64',
                   'IosArchs': 'arm64',
                   'SdkRoot': _iosSdkRoot,
                   'BuildMode': 'debug',
@@ -2939,7 +2939,7 @@ public func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
                 expectedEngineVersion: _engineVersion,
                 expectedDefines: <String, String>{
                   'TargetFile': 'lib/main.dart',
-                  'TargetPlatform': 'ios',
+                  'TargetPlatform': 'ios-arm64',
                   'IosArchs': 'x86_64 arm64',
                   'SdkRoot': _iosSdkRoot,
                   'BuildMode': 'debug',

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -79,7 +79,7 @@ void main() {
   FakeCommand cmakeGenerationCommand({
     void Function(List<String> command)? onRun,
     String generator = _defaultGenerator,
-    TargetPlatform targetPlatform = TargetPlatform.windows_x64,
+    TargetPlatform targetPlatform = const TargetPlatform(.windows, .x64),
   }) {
     return FakeCommand(
       command: <String>[

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -577,7 +577,10 @@ void main() {
         );
         expect(applicationPackageIdResponse.data['id'], 0);
         expect(applicationPackageFactory.applicationBinaryRequested!.basename, 'test_file');
-        expect(applicationPackageFactory.platformRequested, TargetPlatform.android);
+        expect(
+          applicationPackageFactory.platformRequested,
+          const TargetPlatform(.android, .unknown),
+        );
         final applicationPackageId = applicationPackageIdResponse.data['result'] as String?;
 
         // Try starting the app.
@@ -1162,7 +1165,7 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
   Future<String> get emulatorId async => 'device';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.android, .armv7);
 
   @override
   Future<CpuArch> get cpuArch async => CpuArch.armv7;

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -114,176 +114,148 @@ void main() {
   });
 
   group('doctor with fake validators', () {
-    testUsingContext(
-      'validate non-verbose output format for run without issues',
-      () async {
-        expect(await FakeQuietDoctor(logger).diagnose(verbose: false), isTrue);
-        expect(
-          logger.statusText,
-          equals(
-            'Doctor summary (to see all details, run flutter doctor -v):\n'
-            '[✓] Passing Validator (with statusInfo)\n'
-            '[✓] Another Passing Validator (with statusInfo)\n'
-            '[✓] Validators are fun (with statusInfo)\n'
-            '[✓] Four score and seven validators ago (with statusInfo)\n'
-            '\n'
-            '• No issues found!\n',
-          ),
-        );
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate non-verbose output format for run without issues', () async {
+      expect(await FakeQuietDoctor(logger).diagnose(verbose: false), isTrue);
+      expect(
+        logger.statusText,
+        equals(
+          'Doctor summary (to see all details, run flutter doctor -v):\n'
+          '[✓] Passing Validator (with statusInfo)\n'
+          '[✓] Another Passing Validator (with statusInfo)\n'
+          '[✓] Validators are fun (with statusInfo)\n'
+          '[✓] Four score and seven validators ago (with statusInfo)\n'
+          '\n'
+          '• No issues found!\n',
+        ),
+      );
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate non-verbose output format for run with crash',
-      () async {
-        expect(await FakeCrashingDoctor(logger).diagnose(verbose: false), isFalse);
-        expect(
-          logger.statusText,
-          equals(
-            'Doctor summary (to see all details, run flutter doctor -v):\n'
-            '[✓] Passing Validator (with statusInfo)\n'
-            '[✓] Another Passing Validator (with statusInfo)\n'
-            '[☠] Crashing validator (the doctor check crashed)\n'
-            '    ✗ Due to an error, the doctor check did not complete. If the error message below is not helpful, '
-            'please let us know about this issue at https://github.com/flutter/flutter/issues.\n'
-            '    ✗ Bad state: fatal error\n'
-            '[✓] Validators are fun (with statusInfo)\n'
-            '[✓] Four score and seven validators ago (with statusInfo)\n'
-            '\n'
-            '! Doctor found issues in 1 category.\n',
-          ),
-        );
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate non-verbose output format for run with crash', () async {
+      expect(await FakeCrashingDoctor(logger).diagnose(verbose: false), isFalse);
+      expect(
+        logger.statusText,
+        equals(
+          'Doctor summary (to see all details, run flutter doctor -v):\n'
+          '[✓] Passing Validator (with statusInfo)\n'
+          '[✓] Another Passing Validator (with statusInfo)\n'
+          '[☠] Crashing validator (the doctor check crashed)\n'
+          '    ✗ Due to an error, the doctor check did not complete. If the error message below is not helpful, '
+          'please let us know about this issue at https://github.com/flutter/flutter/issues.\n'
+          '    ✗ Bad state: fatal error\n'
+          '[✓] Validators are fun (with statusInfo)\n'
+          '[✓] Four score and seven validators ago (with statusInfo)\n'
+          '\n'
+          '! Doctor found issues in 1 category.\n',
+        ),
+      );
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
     testUsingContext('validate verbose output format contains trace for run with crash', () async {
       expect(await FakeCrashingDoctor(logger).diagnose(), isFalse);
       expect(logger.statusText, contains('#0      CrashingValidator.validate'));
     });
 
-    testUsingContext(
-      'validate tool exit when exceeding timeout',
-      () async {
-        FakeAsync().run<void>((FakeAsync time) {
-          final Doctor doctor = FakeAsyncStuckDoctor(logger);
-          doctor.diagnose(verbose: false);
-          time.elapse(const Duration(minutes: 5));
-          time.flushMicrotasks();
-        });
+    testUsingContext('validate tool exit when exceeding timeout', () async {
+      FakeAsync().run<void>((FakeAsync time) {
+        final Doctor doctor = FakeAsyncStuckDoctor(logger);
+        doctor.diagnose(verbose: false);
+        time.elapse(const Duration(minutes: 5));
+        time.flushMicrotasks();
+      });
 
-        expect(
-          logger.statusText,
-          contains('Stuck validator that never completes exceeded maximum allowed duration of '),
-        );
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+      expect(
+        logger.statusText,
+        contains('Stuck validator that never completes exceeded maximum allowed duration of '),
+      );
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate non-verbose output format for run with an async crash',
-      () async {
-        final completer = Completer<void>();
-        await FakeAsync().run((FakeAsync time) {
-          unawaited(
-            FakeAsyncCrashingDoctor(time, logger).diagnose(verbose: false).then((bool r) {
-              expect(r, isFalse);
-              completer.complete();
-            }),
-          );
-          time.elapse(const Duration(seconds: 1));
-          time.flushMicrotasks();
-          return completer.future;
-        });
-        expect(
-          logger.statusText,
-          equals(
-            'Doctor summary (to see all details, run flutter doctor -v):\n'
-            '[✓] Passing Validator (with statusInfo)\n'
-            '[✓] Another Passing Validator (with statusInfo)\n'
-            '[☠] Async crashing validator (the doctor check crashed)\n'
-            '    ✗ Due to an error, the doctor check did not complete. If the error message below is not helpful, '
-            'please let us know about this issue at https://github.com/flutter/flutter/issues.\n'
-            '    ✗ Bad state: fatal error\n'
-            '[✓] Validators are fun (with statusInfo)\n'
-            '[✓] Four score and seven validators ago (with statusInfo)\n'
-            '\n'
-            '! Doctor found issues in 1 category.\n',
-          ),
+    testUsingContext('validate non-verbose output format for run with an async crash', () async {
+      final completer = Completer<void>();
+      await FakeAsync().run((FakeAsync time) {
+        unawaited(
+          FakeAsyncCrashingDoctor(time, logger).diagnose(verbose: false).then((bool r) {
+            expect(r, isFalse);
+            completer.complete();
+          }),
         );
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+        time.elapse(const Duration(seconds: 1));
+        time.flushMicrotasks();
+        return completer.future;
+      });
+      expect(
+        logger.statusText,
+        equals(
+          'Doctor summary (to see all details, run flutter doctor -v):\n'
+          '[✓] Passing Validator (with statusInfo)\n'
+          '[✓] Another Passing Validator (with statusInfo)\n'
+          '[☠] Async crashing validator (the doctor check crashed)\n'
+          '    ✗ Due to an error, the doctor check did not complete. If the error message below is not helpful, '
+          'please let us know about this issue at https://github.com/flutter/flutter/issues.\n'
+          '    ✗ Bad state: fatal error\n'
+          '[✓] Validators are fun (with statusInfo)\n'
+          '[✓] Four score and seven validators ago (with statusInfo)\n'
+          '\n'
+          '! Doctor found issues in 1 category.\n',
+        ),
+      );
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate non-verbose output format when only one category fails',
-      () async {
-        expect(await FakeSinglePassingDoctor(logger).diagnose(verbose: false), isTrue);
-        expect(
-          logger.statusText,
-          equals(
-            'Doctor summary (to see all details, run flutter doctor -v):\n'
-            '[!] Partial Validator with only a Hint\n'
-            '    ! There is a hint here\n'
-            '\n'
-            '! Doctor found issues in 1 category.\n',
-          ),
-        );
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate non-verbose output format when only one category fails', () async {
+      expect(await FakeSinglePassingDoctor(logger).diagnose(verbose: false), isTrue);
+      expect(
+        logger.statusText,
+        equals(
+          'Doctor summary (to see all details, run flutter doctor -v):\n'
+          '[!] Partial Validator with only a Hint\n'
+          '    ! There is a hint here\n'
+          '\n'
+          '! Doctor found issues in 1 category.\n',
+        ),
+      );
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate non-verbose output format for a passing run',
-      () async {
-        expect(await FakePassingDoctor(logger).diagnose(verbose: false), isTrue);
-        expect(
-          logger.statusText,
-          equals(
-            'Doctor summary (to see all details, run flutter doctor -v):\n'
-            '[✓] Passing Validator (with statusInfo)\n'
-            '[!] Partial Validator with only a Hint\n'
-            '    ! There is a hint here\n'
-            '[!] Partial Validator with Errors\n'
-            '    ✗ An error message indicating partial installation\n'
-            '    ! Maybe a hint will help the user\n'
-            '[✓] Another Passing Validator (with statusInfo)\n'
-            '\n'
-            '! Doctor found issues in 2 categories.\n',
-          ),
-        );
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate non-verbose output format for a passing run', () async {
+      expect(await FakePassingDoctor(logger).diagnose(verbose: false), isTrue);
+      expect(
+        logger.statusText,
+        equals(
+          'Doctor summary (to see all details, run flutter doctor -v):\n'
+          '[✓] Passing Validator (with statusInfo)\n'
+          '[!] Partial Validator with only a Hint\n'
+          '    ! There is a hint here\n'
+          '[!] Partial Validator with Errors\n'
+          '    ✗ An error message indicating partial installation\n'
+          '    ! Maybe a hint will help the user\n'
+          '[✓] Another Passing Validator (with statusInfo)\n'
+          '\n'
+          '! Doctor found issues in 2 categories.\n',
+        ),
+      );
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate non-verbose output format',
-      () async {
-        expect(await FakeDoctor(logger).diagnose(verbose: false), isFalse);
-        expect(
-          logger.statusText,
-          equals(
-            'Doctor summary (to see all details, run flutter doctor -v):\n'
-            '[✓] Passing Validator (with statusInfo)\n'
-            '[✗] Missing Validator\n'
-            '    ✗ A useful error message\n'
-            '    ! A hint message\n'
-            '[!] Not Available Validator\n'
-            '    ✗ A useful error message\n'
-            '    ! A hint message\n'
-            '[!] Partial Validator with only a Hint\n'
-            '    ! There is a hint here\n'
-            '[!] Partial Validator with Errors\n'
-            '    ✗ An error message indicating partial installation\n'
-            '    ! Maybe a hint will help the user\n'
-            '\n'
-            '! Doctor found issues in 4 categories.\n',
-          ),
-        );
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate non-verbose output format', () async {
+      expect(await FakeDoctor(logger).diagnose(verbose: false), isFalse);
+      expect(
+        logger.statusText,
+        equals(
+          'Doctor summary (to see all details, run flutter doctor -v):\n'
+          '[✓] Passing Validator (with statusInfo)\n'
+          '[✗] Missing Validator\n'
+          '    ✗ A useful error message\n'
+          '    ! A hint message\n'
+          '[!] Not Available Validator\n'
+          '    ✗ A useful error message\n'
+          '    ! A hint message\n'
+          '[!] Partial Validator with only a Hint\n'
+          '    ! There is a hint here\n'
+          '[!] Partial Validator with Errors\n'
+          '    ✗ An error message indicating partial installation\n'
+          '    ! Maybe a hint will help the user\n'
+          '\n'
+          '! Doctor found issues in 4 categories.\n',
+        ),
+      );
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
     testUsingContext('validate verbose output format', () async {
       expect(await FakeDoctor(logger).diagnose(), isFalse);
@@ -405,45 +377,41 @@ void main() {
     });
   });
 
-  testUsingContext(
-    'validate non-verbose output wrapping',
-    () async {
-      final wrapLogger = BufferLogger.test(
-        outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 30),
-      );
-      expect(await FakeDoctor(wrapLogger).diagnose(verbose: false), isFalse);
-      expect(
-        wrapLogger.statusText,
-        equals(
-          'Doctor summary (to see all\n'
-          'details, run flutter doctor\n'
-          '-v):\n'
-          '[✓] Passing Validator (with\n'
-          '    statusInfo)\n'
-          '[✗] Missing Validator\n'
-          '    ✗ A useful error message\n'
-          '    ! A hint message\n'
-          '[!] Not Available Validator\n'
-          '    ✗ A useful error message\n'
-          '    ! A hint message\n'
-          '[!] Partial Validator with\n'
-          '    only a Hint\n'
-          '    ! There is a hint here\n'
-          '[!] Partial Validator with\n'
-          '    Errors\n'
-          '    ✗ An error message\n'
-          '      indicating partial\n'
-          '      installation\n'
-          '    ! Maybe a hint will help\n'
-          '      the user\n'
-          '\n'
-          '! Doctor found issues in 4\n'
-          '  categories.\n',
-        ),
-      );
-    },
-    overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-  );
+  testUsingContext('validate non-verbose output wrapping', () async {
+    final wrapLogger = BufferLogger.test(
+      outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 30),
+    );
+    expect(await FakeDoctor(wrapLogger).diagnose(verbose: false), isFalse);
+    expect(
+      wrapLogger.statusText,
+      equals(
+        'Doctor summary (to see all\n'
+        'details, run flutter doctor\n'
+        '-v):\n'
+        '[✓] Passing Validator (with\n'
+        '    statusInfo)\n'
+        '[✗] Missing Validator\n'
+        '    ✗ A useful error message\n'
+        '    ! A hint message\n'
+        '[!] Not Available Validator\n'
+        '    ✗ A useful error message\n'
+        '    ! A hint message\n'
+        '[!] Partial Validator with\n'
+        '    only a Hint\n'
+        '    ! There is a hint here\n'
+        '[!] Partial Validator with\n'
+        '    Errors\n'
+        '    ✗ An error message\n'
+        '      indicating partial\n'
+        '      installation\n'
+        '    ! Maybe a hint will help\n'
+        '      the user\n'
+        '\n'
+        '! Doctor found issues in 4\n'
+        '  categories.\n',
+      ),
+    );
+  }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
   testUsingContext('validate verbose output wrapping', () async {
     final wrapLogger = BufferLogger.test(
@@ -494,46 +462,38 @@ void main() {
   }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
   group('doctor with grouped validators', () {
-    testUsingContext(
-      'validate diagnose combines validator output',
-      () async {
-        expect(await FakeGroupedDoctor(logger).diagnose(), isTrue);
-        expect(
-          logger.statusText,
-          equals(
-            '[✓] Category 1 [0ms]\n'
-            '    • A helpful message\n'
-            '    • A helpful message\n'
-            '\n'
-            '[!] Category 2 [0ms]\n'
-            '    • A helpful message\n'
-            '    ✗ A useful error message\n'
-            '\n'
-            '! Doctor found issues in 1 category.\n',
-          ),
-        );
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate diagnose combines validator output', () async {
+      expect(await FakeGroupedDoctor(logger).diagnose(), isTrue);
+      expect(
+        logger.statusText,
+        equals(
+          '[✓] Category 1 [0ms]\n'
+          '    • A helpful message\n'
+          '    • A helpful message\n'
+          '\n'
+          '[!] Category 2 [0ms]\n'
+          '    • A helpful message\n'
+          '    ✗ A useful error message\n'
+          '\n'
+          '! Doctor found issues in 1 category.\n',
+        ),
+      );
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate merging assigns statusInfo and title',
-      () async {
-        // There are two subvalidators. Only the second contains statusInfo.
-        expect(await FakeGroupedDoctorWithStatus(logger).diagnose(), isTrue);
-        expect(
-          logger.statusText,
-          equals(
-            '[✓] First validator title (A status message) [0ms]\n'
-            '    • A helpful message\n'
-            '    • A different message\n'
-            '\n'
-            '• No issues found!\n',
-          ),
-        );
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate merging assigns statusInfo and title', () async {
+      // There are two subvalidators. Only the second contains statusInfo.
+      expect(await FakeGroupedDoctorWithStatus(logger).diagnose(), isTrue);
+      expect(
+        logger.statusText,
+        equals(
+          '[✓] First validator title (A status message) [0ms]\n'
+          '    • A helpful message\n'
+          '    • A different message\n'
+          '\n'
+          '• No issues found!\n',
+        ),
+      );
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
   });
 
   group('grouped validator merging results', () {
@@ -541,86 +501,50 @@ void main() {
     final partial = PartialGroupedValidator('Category');
     final missing = MissingGroupedValidator('Category');
 
-    testUsingContext(
-      'validate installed + installed = installed',
-      () async {
-        expect(await FakeSmallGroupDoctor(logger, installed, installed).diagnose(), isTrue);
-        expect(logger.statusText, startsWith('[✓]'));
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate installed + installed = installed', () async {
+      expect(await FakeSmallGroupDoctor(logger, installed, installed).diagnose(), isTrue);
+      expect(logger.statusText, startsWith('[✓]'));
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate installed + partial = partial',
-      () async {
-        expect(await FakeSmallGroupDoctor(logger, installed, partial).diagnose(), isTrue);
-        expect(logger.statusText, startsWith('[!]'));
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate installed + partial = partial', () async {
+      expect(await FakeSmallGroupDoctor(logger, installed, partial).diagnose(), isTrue);
+      expect(logger.statusText, startsWith('[!]'));
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate installed + missing = partial',
-      () async {
-        expect(await FakeSmallGroupDoctor(logger, installed, missing).diagnose(), isTrue);
-        expect(logger.statusText, startsWith('[!]'));
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate installed + missing = partial', () async {
+      expect(await FakeSmallGroupDoctor(logger, installed, missing).diagnose(), isTrue);
+      expect(logger.statusText, startsWith('[!]'));
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate partial + installed = partial',
-      () async {
-        expect(await FakeSmallGroupDoctor(logger, partial, installed).diagnose(), isTrue);
-        expect(logger.statusText, startsWith('[!]'));
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate partial + installed = partial', () async {
+      expect(await FakeSmallGroupDoctor(logger, partial, installed).diagnose(), isTrue);
+      expect(logger.statusText, startsWith('[!]'));
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate partial + partial = partial',
-      () async {
-        expect(await FakeSmallGroupDoctor(logger, partial, partial).diagnose(), isTrue);
-        expect(logger.statusText, startsWith('[!]'));
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate partial + partial = partial', () async {
+      expect(await FakeSmallGroupDoctor(logger, partial, partial).diagnose(), isTrue);
+      expect(logger.statusText, startsWith('[!]'));
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate partial + missing = partial',
-      () async {
-        expect(await FakeSmallGroupDoctor(logger, partial, missing).diagnose(), isTrue);
-        expect(logger.statusText, startsWith('[!]'));
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate partial + missing = partial', () async {
+      expect(await FakeSmallGroupDoctor(logger, partial, missing).diagnose(), isTrue);
+      expect(logger.statusText, startsWith('[!]'));
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate missing + installed = partial',
-      () async {
-        expect(await FakeSmallGroupDoctor(logger, missing, installed).diagnose(), isTrue);
-        expect(logger.statusText, startsWith('[!]'));
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate missing + installed = partial', () async {
+      expect(await FakeSmallGroupDoctor(logger, missing, installed).diagnose(), isTrue);
+      expect(logger.statusText, startsWith('[!]'));
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate missing + partial = partial',
-      () async {
-        expect(await FakeSmallGroupDoctor(logger, missing, partial).diagnose(), isTrue);
-        expect(logger.statusText, startsWith('[!]'));
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate missing + partial = partial', () async {
+      expect(await FakeSmallGroupDoctor(logger, missing, partial).diagnose(), isTrue);
+      expect(logger.statusText, startsWith('[!]'));
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
 
-    testUsingContext(
-      'validate missing + missing = missing',
-      () async {
-        expect(await FakeSmallGroupDoctor(logger, missing, missing).diagnose(), isFalse);
-        expect(logger.statusText, startsWith('[✗]'));
-      },
-      overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()},
-    );
+    testUsingContext('validate missing + missing = missing', () async {
+      expect(await FakeSmallGroupDoctor(logger, missing, missing).diagnose(), isFalse);
+      expect(logger.statusText, startsWith('[✗]'));
+    }, overrides: <Type, Generator>{AnsiTerminal: () => FakeTerminal()});
   });
 
   testUsingContext(
@@ -638,17 +562,13 @@ void main() {
     },
   );
 
-  testUsingContext(
-    'CustomDevicesWorkflow is a part of validator workflows if enabled',
-    () async {
-      final List<Workflow> workflows = DoctorValidatorsProvider.test(
-        featureFlags: TestFeatureFlags(areCustomDevicesEnabled: true),
-        platform: FakePlatform(),
-      ).workflows;
-      expect(workflows, contains(isA<CustomDeviceWorkflow>()));
-    },
-    overrides: <Type, Generator>{FileSystem: () => fs, ProcessManager: () => fakeProcessManager},
-  );
+  testUsingContext('CustomDevicesWorkflow is a part of validator workflows if enabled', () async {
+    final List<Workflow> workflows = DoctorValidatorsProvider.test(
+      featureFlags: TestFeatureFlags(areCustomDevicesEnabled: true),
+      platform: FakePlatform(),
+    ).workflows;
+    expect(workflows, contains(isA<CustomDeviceWorkflow>()));
+  }, overrides: <Type, Generator>{FileSystem: () => fs, ProcessManager: () => fakeProcessManager});
 
   group('FlutterValidator', () {
     late FakeFlutterVersion initialVersion;
@@ -714,14 +634,10 @@ void main() {
       );
     });
 
-    testUsingContext(
-      'ensure fake is being used and initialized',
-      () {
-        expect(fakeAnalytics.sentEvents.length, 0);
-        expect(fakeAnalytics.okToSend, true);
-      },
-      overrides: <Type, Generator>{Analytics: () => fakeAnalytics},
-    );
+    testUsingContext('ensure fake is being used and initialized', () {
+      expect(fakeAnalytics.sentEvents.length, 0);
+      expect(fakeAnalytics.okToSend, true);
+    }, overrides: <Type, Generator>{Analytics: () => fakeAnalytics});
 
     testUsingContext(
       'contains installed',
@@ -879,26 +795,22 @@ void main() {
       },
     );
 
-    testUsingContext(
-      'grouped validator subresult and subvalidators different lengths',
-      () async {
-        final fakeDoctor = FakeGroupedDoctorWithCrash(logger, clock: fakeSystemClock);
-        await fakeDoctor.diagnose(verbose: false);
+    testUsingContext('grouped validator subresult and subvalidators different lengths', () async {
+      final fakeDoctor = FakeGroupedDoctorWithCrash(logger, clock: fakeSystemClock);
+      await fakeDoctor.diagnose(verbose: false);
 
-        expect(fakeDoctor.validators, hasLength(1));
-        expect(fakeDoctor.validators.first.runtimeType == FakeGroupedValidatorWithCrash, true);
-        expect(fakeAnalytics.sentEvents, hasLength(0));
+      expect(fakeDoctor.validators, hasLength(1));
+      expect(fakeDoctor.validators.first.runtimeType == FakeGroupedValidatorWithCrash, true);
+      expect(fakeAnalytics.sentEvents, hasLength(0));
 
-        // Attempt to send a random event to ensure that the
-        // analytics package is still working, despite not sending
-        // above (as expected)
-        final testEvent = Event.analyticsCollectionEnabled(status: true);
-        fakeAnalytics.send(testEvent);
-        expect(fakeAnalytics.sentEvents, hasLength(1));
-        expect(fakeAnalytics.sentEvents, contains(testEvent));
-      },
-      overrides: <Type, Generator>{Analytics: () => fakeAnalytics},
-    );
+      // Attempt to send a random event to ensure that the
+      // analytics package is still working, despite not sending
+      // above (as expected)
+      final testEvent = Event.analyticsCollectionEnabled(status: true);
+      fakeAnalytics.send(testEvent);
+      expect(fakeAnalytics.sentEvents, hasLength(1));
+      expect(fakeAnalytics.sentEvents, contains(testEvent));
+    }, overrides: <Type, Generator>{Analytics: () => fakeAnalytics});
 
     testUsingContext('sending events can be skipped', () async {
       await FakePassingDoctor(logger).diagnose(verbose: false, sendEvent: false);
@@ -1326,7 +1238,8 @@ class FakeDevice extends Fake implements Device {
   Future<String> get sdkNameAndVersion async => '1.2.3';
 
   @override
-  Future<TargetPlatform> get targetPlatform => Future<TargetPlatform>.value(TargetPlatform.android);
+  Future<TargetPlatform> get targetPlatform =>
+      Future<TargetPlatform>.value(const TargetPlatform(.android, .unknown));
 }
 
 class FakeTerminal extends Fake implements AnsiTerminal {

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -935,7 +935,7 @@ class ScreenshotDevice extends Fake implements Device {
   final id = 'fake_device';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.android, .unknown);
 
   @override
   bool supportsScreenshot = true;
@@ -1130,7 +1130,7 @@ class FakeIosDevice extends Fake implements IOSDevice {
   bool get isWirelesslyConnected => connectionInterface == DeviceConnectionInterface.wireless;
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.ios, .arm64);
 }
 
 class FakeChromiumDriveDevice extends Fake implements ChromiumDevice {
@@ -1162,7 +1162,7 @@ class FakeChromiumDriveDevice extends Fake implements ChromiumDevice {
   Future<String> get sdkNameAndVersion async => 'Google Chrome 0.0';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.web_javascript;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.web, .unknown);
 
   @override
   DeviceLogReader getLogReader({ApplicationPackage? app, bool includePastLogs = false}) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
@@ -180,7 +180,7 @@ class FakeAndroidApk extends Fake implements AndroidApk {}
 
 class FakeIOSDevice extends Fake implements IOSDevice {
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.ios, .arm64);
 
   @override
   Future<bool> isAppInstalled(ApplicationPackage app, {String? userIdentifier}) async => false;
@@ -194,7 +194,7 @@ class FakeIOSDevice extends Fake implements IOSDevice {
 
 class FakeAndroidDevice extends Fake implements AndroidDevice {
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.android, .armv7);
 
   @override
   Future<bool> isAppInstalled(ApplicationPackage app, {String? userIdentifier}) async => false;

--- a/packages/flutter_tools/test/commands.shard/hermetic/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/proxied_devices_test.dart
@@ -169,7 +169,7 @@ void main() {
           applicationPackageFactory.applicationBinaryRequested!.readAsStringSync(),
           'dummy content',
         );
-        expect(applicationPackageFactory.platformRequested, TargetPlatform.android_arm);
+        expect(applicationPackageFactory.platformRequested, const TargetPlatform(.android, .armv7));
 
         expect(fakeDevice.startAppPackage, applicationPackage);
 
@@ -254,7 +254,7 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
   Future<String> get emulatorId async => 'device';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.android, .armv7);
 
   @override
   Future<CpuArch> get cpuArch async => CpuArch.arm64;

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -286,7 +286,7 @@ void main() {
         () async {
           final command = RunCommand();
           final mockDevice = FakeDevice(
-            targetPlatform: TargetPlatform.android_arm,
+            targetPlatform: const TargetPlatform(.android, .armv7),
             isLocalEmulator: true,
             sdkNameAndVersion: 'api-14',
             isSupported: false,
@@ -545,7 +545,7 @@ void main() {
               final command = RunCommand();
               final device = FakeDevice(
                 platformType: PlatformType.web,
-                targetPlatform: TargetPlatform.web_javascript,
+                targetPlatform: const TargetPlatform(.web, .unknown),
               );
               testDeviceManager.devices = <Device>[device];
 
@@ -691,7 +691,7 @@ void main() {
       'should only request artifacts corresponding to connected devices',
       () async {
         testDeviceManager.devices = <Device>[
-          FakeDevice(targetPlatform: TargetPlatform.android_arm),
+          FakeDevice(targetPlatform: const TargetPlatform(.android, .armv7)),
         ];
 
         expect(
@@ -714,7 +714,7 @@ void main() {
 
         testDeviceManager.devices = <Device>[
           FakeDevice(),
-          FakeDevice(targetPlatform: TargetPlatform.android_arm),
+          FakeDevice(targetPlatform: const TargetPlatform(.android, .armv7)),
         ];
 
         expect(
@@ -727,7 +727,7 @@ void main() {
         );
 
         testDeviceManager.devices = <Device>[
-          FakeDevice(targetPlatform: TargetPlatform.web_javascript),
+          FakeDevice(targetPlatform: const TargetPlatform(.web, .unknown)),
         ];
 
         expect(
@@ -752,7 +752,7 @@ void main() {
         () async {
           final devices = <Device>[
             FakeDevice(
-              targetPlatform: TargetPlatform.android_arm,
+              targetPlatform: const TargetPlatform(.android, .armv7),
               platformType: PlatformType.android,
             ),
           ];
@@ -986,7 +986,7 @@ void main() {
         final device = FakeDevice(
           isLocalEmulator: true,
           platformType: PlatformType.web,
-          targetPlatform: TargetPlatform.web_javascript,
+          targetPlatform: const TargetPlatform(.web, .unknown),
         );
         testDeviceManager.devices = <Device>[device];
       });
@@ -1160,7 +1160,7 @@ void main() {
         final device = FakeDevice(
           isLocalEmulator: true,
           platformType: PlatformType.web,
-          targetPlatform: TargetPlatform.web_javascript,
+          targetPlatform: const TargetPlatform(.web, .unknown),
         );
         testDeviceManager.devices = <Device>[device];
       });
@@ -1425,7 +1425,7 @@ server:
         final device = FakeDevice(
           isLocalEmulator: true,
           platformType: PlatformType.web,
-          targetPlatform: TargetPlatform.web_javascript,
+          targetPlatform: const TargetPlatform(.web, .unknown),
         );
         testDeviceManager.devices = <Device>[device];
       });
@@ -1931,7 +1931,7 @@ class TestDeviceManager extends DeviceManager {
 class FakeDevice extends Fake implements Device {
   FakeDevice({
     bool isLocalEmulator = false,
-    TargetPlatform targetPlatform = TargetPlatform.ios,
+    TargetPlatform targetPlatform = const TargetPlatform(.ios, .arm64),
     String sdkNameAndVersion = '',
     PlatformType platformType = PlatformType.ios,
     bool isSupported = true,
@@ -1999,7 +1999,7 @@ class FakeDevice extends Fake implements Device {
   Future<String> get sdkNameAndVersion => Future<String>.value(_sdkNameAndVersion);
 
   @override
-  Future<String> get targetPlatformDisplayName async => (await targetPlatform).getName();
+  Future<String> get targetPlatformDisplayName async => (await targetPlatform).devicePlatformName;
 
   @override
   DeviceLogReader getLogReader({ApplicationPackage? app, bool includePastLogs = false}) {
@@ -2086,7 +2086,7 @@ class FakeIOSDevice extends Fake implements IOSDevice {
   bool get isWirelesslyConnected => connectionInterface == DeviceConnectionInterface.wireless;
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.ios, .arm64);
 }
 
 class TestRunCommandForUsageValues extends RunCommand {

--- a/packages/flutter_tools/test/commands.shard/hermetic/screenshot_command_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/screenshot_command_test.dart
@@ -147,53 +147,45 @@ void main() {
       testDeviceManager = _TestDeviceManager(logger: BufferLogger.test());
     });
 
-    testUsingContext(
-      'should not throw for a single device',
-      () async {
-        final command = ScreenshotCommand(fs: MemoryFileSystem.test());
+    testUsingContext('should not throw for a single device', () async {
+      final command = ScreenshotCommand(fs: MemoryFileSystem.test());
 
-        final deviceUnsupportedForProject = _ScreenshotDevice(
-          id: '123',
-          name: 'Device 1',
-          isSupportedForProject: false,
-        );
+      final deviceUnsupportedForProject = _ScreenshotDevice(
+        id: '123',
+        name: 'Device 1',
+        isSupportedForProject: false,
+      );
 
-        testDeviceManager.devices = <Device>[deviceUnsupportedForProject];
+      testDeviceManager.devices = <Device>[deviceUnsupportedForProject];
 
-        await createTestCommandRunner(command).run(<String>['screenshot']);
-      },
-      overrides: <Type, Generator>{DeviceManager: () => testDeviceManager},
-    );
+      await createTestCommandRunner(command).run(<String>['screenshot']);
+    }, overrides: <Type, Generator>{DeviceManager: () => testDeviceManager});
 
-    testUsingContext(
-      'should tool exit for multiple devices',
-      () async {
-        final command = ScreenshotCommand(fs: MemoryFileSystem.test());
+    testUsingContext('should tool exit for multiple devices', () async {
+      final command = ScreenshotCommand(fs: MemoryFileSystem.test());
 
-        final devicesUnsupportedForProject = <_ScreenshotDevice>[
-          _ScreenshotDevice(id: '123', name: 'Device 1', isSupportedForProject: false),
-          _ScreenshotDevice(id: '456', name: 'Device 2', isSupportedForProject: false),
-        ];
+      final devicesUnsupportedForProject = <_ScreenshotDevice>[
+        _ScreenshotDevice(id: '123', name: 'Device 1', isSupportedForProject: false),
+        _ScreenshotDevice(id: '456', name: 'Device 2', isSupportedForProject: false),
+      ];
 
-        testDeviceManager.devices = devicesUnsupportedForProject;
+      testDeviceManager.devices = devicesUnsupportedForProject;
 
-        await expectLater(
-          () => createTestCommandRunner(command).run(<String>['screenshot']),
-          throwsToolExit(message: 'Must have a connected device for screenshot type device'),
-        );
+      await expectLater(
+        () => createTestCommandRunner(command).run(<String>['screenshot']),
+        throwsToolExit(message: 'Must have a connected device for screenshot type device'),
+      );
 
-        expect(
-          testLogger.statusText,
-          contains('''
+      expect(
+        testLogger.statusText,
+        contains('''
 More than one device connected; please specify a device with the '-d <deviceId>' flag, or use '-d all' to act on all devices.
 
 Device 1 (mobile) • 123 • android • 1.2.3
 Device 2 (mobile) • 456 • android • 1.2.3
 '''),
-        );
-      },
-      overrides: <Type, Generator>{DeviceManager: () => testDeviceManager},
-    );
+      );
+    }, overrides: <Type, Generator>{DeviceManager: () => testDeviceManager});
   });
 }
 
@@ -242,7 +234,8 @@ class _ScreenshotDevice extends Fake implements Device {
   Future<String> get sdkNameAndVersion async => '1.2.3';
 
   @override
-  Future<TargetPlatform> get targetPlatform => Future<TargetPlatform>.value(TargetPlatform.android);
+  Future<TargetPlatform> get targetPlatform =>
+      Future<TargetPlatform>.value(const TargetPlatform(.android, .unknown));
 
   @override
   Future<bool> get isLocalEmulator async => false;

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
@@ -110,7 +110,7 @@ class FakeAnalysisServer extends Fake implements AnalysisServer {
 
 class FakeGoogleChromeDevice extends Fake implements GoogleChromeDevice {
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.web_javascript;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.web, .unknown);
 
   @override
   PlatformType? get platformType => PlatformType.web;
@@ -121,7 +121,7 @@ class FakeGoogleChromeDevice extends Fake implements GoogleChromeDevice {
 
 class FakeMicrosoftEdgeDevice extends Fake implements MicrosoftEdgeDevice {
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.web_javascript;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.web, .unknown);
 
   @override
   PlatformType? get platformType => PlatformType.web;
@@ -132,7 +132,7 @@ class FakeMicrosoftEdgeDevice extends Fake implements MicrosoftEdgeDevice {
 
 class FakeCustomBrowserDevice extends Fake implements ChromiumDevice {
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.web_javascript;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.web, .unknown);
 
   @override
   PlatformType? get platformType => PlatformType.web;

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -49,9 +49,9 @@ void main() {
   });
 
   for (final targetPlatform in <TargetPlatform>[
-    TargetPlatform.android_arm,
-    TargetPlatform.android_arm64,
-    TargetPlatform.android_x64,
+    const TargetPlatform(.android, .armv7),
+    const TargetPlatform(.android, .arm64),
+    const TargetPlatform(.android, .x64),
   ]) {
     testWithoutContext('AndroidDevice.startApp allows release builds on $targetPlatform', () async {
       final String arch = getCpuArchForName(targetPlatform.getName()).androidArchName;

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -77,11 +77,11 @@ void main() {
       'abi and abiList', () async {
     // The format is [ABI, ABI list]: expected target platform.
     final values = <List<String>, TargetPlatform>{
-      <String>['x86_64', 'unknown']: TargetPlatform.android_x64,
-      <String>['armeabi-v7a', 'unknown']: TargetPlatform.android_arm,
-      <String>['arm64-v8a', 'arm64-v8a,']: TargetPlatform.android_arm64,
+      <String>['x86_64', 'unknown']: const TargetPlatform(.android, .x64),
+      <String>['armeabi-v7a', 'unknown']: const TargetPlatform(.android, .armv7),
+      <String>['arm64-v8a', 'arm64-v8a,']: const TargetPlatform(.android, .arm64),
       // The Kindle Fire runs 32 bit apps on 64 bit hardware.
-      <String>['arm64-v8a', 'arm']: TargetPlatform.android_arm,
+      <String>['arm64-v8a', 'arm']: const TargetPlatform(.android, .armv7),
     };
 
     for (final MapEntry<List<String>, TargetPlatform> entry in values.entries) {

--- a/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
@@ -7,8 +7,8 @@ import 'dart:async';
 import 'package:flutter_tools/src/android/android_emulator.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/common.dart';
-
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:test/fake.dart';
 

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -88,7 +88,7 @@ void main() {
       );
 
       await ApplicationPackageFactory.instance!.getPackageForPlatform(
-        TargetPlatform.android_arm,
+        const TargetPlatform(.android, .armv7),
         applicationBinary: apkFile,
       );
       final logger = BufferLogger.test();
@@ -158,7 +158,7 @@ void main() {
       );
 
       await ApplicationPackageFactory.instance!.getPackageForPlatform(
-        TargetPlatform.android_arm,
+        const TargetPlatform(.android, .armv7),
         applicationBinary: apkFile,
       );
       final logger = BufferLogger.test();
@@ -214,7 +214,10 @@ void main() {
         );
 
         final ApplicationPackage applicationPackage = (await ApplicationPackageFactory.instance!
-            .getPackageForPlatform(TargetPlatform.android_arm, applicationBinary: apkFile))!;
+            .getPackageForPlatform(
+              const TargetPlatform(.android, .armv7),
+              applicationBinary: apkFile,
+            ))!;
         expect(applicationPackage.name, 'app-debug.apk');
         expect(applicationPackage, isA<PrebuiltApplicationPackage>());
         expect(
@@ -242,7 +245,7 @@ void main() {
       gradleWrapperDir.childFile('gradlew.bat').writeAsStringSync('irrelevant');
 
       await ApplicationPackageFactory.instance!.getPackageForPlatform(
-        TargetPlatform.android_arm,
+        const TargetPlatform(.android, .armv7),
         applicationBinary: globals.fs.file('app-debug.apk'),
       );
       expect(fakeProcessManager, hasNoRemainingExpectations);
@@ -254,7 +257,9 @@ void main() {
         final AndroidSdkVersion sdkVersion = FakeAndroidSdkVersion();
         sdk.latestVersion = sdkVersion;
 
-        await ApplicationPackageFactory.instance!.getPackageForPlatform(TargetPlatform.android_arm);
+        await ApplicationPackageFactory.instance!.getPackageForPlatform(
+          const TargetPlatform(.android, .armv7),
+        );
         expect(fakeProcessManager, hasNoRemainingExpectations);
       },
       overrides: overrides,

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -44,7 +44,7 @@ void main() {
     testWithoutContext('getArtifactPath', () {
       final String xcframeworkPath = artifacts.getArtifactPath(
         Artifact.flutterXcframework,
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         mode: BuildMode.release,
       );
       expect(
@@ -62,7 +62,7 @@ void main() {
       expect(
         () => artifacts.getArtifactPath(
           Artifact.flutterFramework,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.release,
           environmentType: EnvironmentType.simulator,
         ),
@@ -72,7 +72,7 @@ void main() {
       expect(
         () => artifacts.getArtifactPath(
           Artifact.flutterFramework,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.release,
           environmentType: EnvironmentType.simulator,
         ),
@@ -93,7 +93,7 @@ void main() {
       expect(
         artifacts.getArtifactPath(
           Artifact.flutterFramework,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.release,
           environmentType: EnvironmentType.simulator,
         ),
@@ -101,7 +101,7 @@ void main() {
       );
       final String actualReleaseFrameworkArtifact = artifacts.getArtifactPath(
         Artifact.flutterFramework,
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         mode: BuildMode.release,
         environmentType: EnvironmentType.physical,
       );
@@ -114,7 +114,7 @@ void main() {
       expect(
         artifacts.getArtifactPath(
           Artifact.flutterXcframework,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.release,
         ),
         fileSystem.path.join(
@@ -140,7 +140,10 @@ void main() {
         ),
       );
       expect(
-        artifacts.getArtifactPath(Artifact.flutterTester, platform: TargetPlatform.linux_arm64),
+        artifacts.getArtifactPath(
+          Artifact.flutterTester,
+          platform: const TargetPlatform(.linux, .arm64),
+        ),
         fileSystem.path.join(
           'root',
           'bin',
@@ -189,7 +192,7 @@ void main() {
         expect(
           artifacts.getArtifactPath(
             Artifact.flutterMacOSXcframework,
-            platform: TargetPlatform.darwin,
+            platform: const TargetPlatform(.macos, .x64),
             mode: BuildMode.release,
           ),
           xcframeworkPath,
@@ -201,7 +204,7 @@ void main() {
         expect(
           () => artifacts.getArtifactPath(
             Artifact.flutterMacOSFramework,
-            platform: TargetPlatform.darwin,
+            platform: const TargetPlatform(.macos, .x64),
             mode: BuildMode.release,
           ),
           throwsToolExit(message: 'No xcframework found at $xcframeworkPath.'),
@@ -214,7 +217,7 @@ void main() {
         expect(
           () => artifacts.getArtifactPath(
             Artifact.flutterMacOSFramework,
-            platform: TargetPlatform.darwin,
+            platform: const TargetPlatform(.macos, .x64),
             mode: BuildMode.release,
           ),
           throwsToolExit(message: 'No macOS frameworks found in $xcframeworkPath'),
@@ -227,7 +230,7 @@ void main() {
         expect(
           artifacts.getArtifactPath(
             Artifact.flutterMacOSFramework,
-            platform: TargetPlatform.darwin,
+            platform: const TargetPlatform(.macos, .x64),
             mode: BuildMode.release,
           ),
           fileSystem.path.join(xcframeworkPath, 'macos-arm64_x86_64', 'FlutterMacOS.framework'),
@@ -263,9 +266,36 @@ void main() {
     );
 
     testWithoutContext('getEngineType', () {
-      expect(artifacts.getEngineType(TargetPlatform.android_arm, BuildMode.debug), 'android-arm');
-      expect(artifacts.getEngineType(TargetPlatform.ios, BuildMode.release), 'ios-release');
-      expect(artifacts.getEngineType(TargetPlatform.darwin), 'darwin-x64');
+      expect(
+        artifacts.getEngineType(const TargetPlatform(.android, .armv7), BuildMode.debug),
+        'android-arm',
+      );
+      expect(
+        artifacts.getEngineType(const TargetPlatform(.ios, .arm64), BuildMode.release),
+        'ios-release',
+      );
+      expect(artifacts.getEngineType(const TargetPlatform(.macos, .x64)), 'darwin-x64');
+    });
+
+    testWithoutContext('getArtifactPath resolves a generic Android target to arm64 for '
+        'architecture-independent artifacts', () {
+      // The Dart kernel / patched SDK is architecture independent, so the
+      // build system requests it with a generic Android target whose CPU
+      // architecture is unknown. This must not throw and should resolve to
+      // the same path as an explicit arm64 target. Regression test for the
+      // assertion crash introduced by the PlatformType + CpuArch refactor.
+      expect(
+        artifacts.getArtifactPath(
+          Artifact.flutterPatchedSdkPath,
+          platform: const TargetPlatform(.android, .unknown),
+          mode: BuildMode.release,
+        ),
+        artifacts.getArtifactPath(
+          Artifact.flutterPatchedSdkPath,
+          platform: const TargetPlatform(.android, .arm64),
+          mode: BuildMode.release,
+        ),
+      );
     });
 
     testWithoutContext(
@@ -335,7 +365,7 @@ void main() {
         expect(
           artifacts.getArtifactPath(
             Artifact.flutterMacOSXcframework,
-            platform: TargetPlatform.darwin,
+            platform: const TargetPlatform(.macos, .x64),
             mode: BuildMode.release,
           ),
           xcframeworkPath,
@@ -347,7 +377,7 @@ void main() {
         expect(
           () => artifacts.getArtifactPath(
             Artifact.flutterMacOSFramework,
-            platform: TargetPlatform.darwin,
+            platform: const TargetPlatform(.macos, .x64),
             mode: BuildMode.release,
           ),
           throwsToolExit(
@@ -364,7 +394,7 @@ void main() {
         expect(
           () => artifacts.getArtifactPath(
             Artifact.flutterMacOSFramework,
-            platform: TargetPlatform.darwin,
+            platform: const TargetPlatform(.macos, .x64),
             mode: BuildMode.release,
           ),
           throwsToolExit(
@@ -389,7 +419,7 @@ void main() {
         expect(
           artifacts.getArtifactPath(
             Artifact.flutterMacOSFramework,
-            platform: TargetPlatform.darwin,
+            platform: const TargetPlatform(.macos, .x64),
             mode: BuildMode.release,
           ),
           fileSystem.path.join(xcframeworkPath, 'macos-arm64_x86_64', 'FlutterMacOS.framework'),
@@ -404,7 +434,7 @@ void main() {
     testWithoutContext('getArtifactPath', () {
       final String xcframeworkPath = artifacts.getArtifactPath(
         Artifact.flutterXcframework,
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         mode: BuildMode.release,
       );
       expect(
@@ -414,7 +444,7 @@ void main() {
       expect(
         () => artifacts.getArtifactPath(
           Artifact.flutterFramework,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.release,
           environmentType: EnvironmentType.simulator,
         ),
@@ -426,7 +456,7 @@ void main() {
       expect(
         () => artifacts.getArtifactPath(
           Artifact.flutterFramework,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.release,
           environmentType: EnvironmentType.simulator,
         ),
@@ -455,7 +485,7 @@ void main() {
       expect(
         artifacts.getArtifactPath(
           Artifact.flutterFramework,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.release,
           environmentType: EnvironmentType.simulator,
         ),
@@ -464,7 +494,7 @@ void main() {
       expect(
         artifacts.getArtifactPath(
           Artifact.flutterFramework,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.release,
           environmentType: EnvironmentType.physical,
         ),
@@ -473,7 +503,7 @@ void main() {
       expect(
         artifacts.getArtifactPath(
           Artifact.flutterXcframework,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.release,
         ),
         fileSystem.path.join('/out', 'android_debug_unopt', 'Flutter.xcframework'),
@@ -572,21 +602,21 @@ void main() {
       expect(
         () => webArtifacts.getArtifactPath(
           Artifact.frontendServerSnapshotForEngineDartSdk,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         throwsToolExit(message: failureMessage),
       );
       expect(
         () => webArtifacts.getArtifactPath(
           Artifact.engineDartSdkPath,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         throwsToolExit(message: failureMessage),
       );
       expect(
         () => webArtifacts.getArtifactPath(
           Artifact.engineDartBinary,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         throwsToolExit(message: failureMessage),
       );
@@ -602,7 +632,7 @@ void main() {
       expect(
         webArtifacts.getArtifactPath(
           Artifact.frontendServerSnapshotForEngineDartSdk,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         fileSystem.path.join(
           '/flutter',
@@ -617,21 +647,21 @@ void main() {
       expect(
         webArtifacts.getArtifactPath(
           Artifact.engineDartSdkPath,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         fileSystem.path.join('/flutter', 'prebuilts', 'linux-x64', 'dart-sdk'),
       );
       expect(
         webArtifacts.getArtifactPath(
           Artifact.engineDartBinary,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         fileSystem.path.join('/flutter', 'prebuilts', 'linux-x64', 'dart-sdk', 'bin', 'dart'),
       );
       expect(
         webArtifacts.getArtifactPath(
           Artifact.engineDartAotRuntime,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         fileSystem.path.join(
           '/flutter',
@@ -654,7 +684,7 @@ void main() {
       expect(
         () => artifacts.getArtifactPath(
           Artifact.engineDartSdkPath,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         throwsToolExit(message: failureMessage),
       );
@@ -669,7 +699,7 @@ void main() {
       expect(
         artifacts.getArtifactPath(
           Artifact.engineDartSdkPath,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         fileSystem.path.join('/out', 'host_debug_unopt', 'dart-sdk'),
       );
@@ -677,11 +707,14 @@ void main() {
 
     testWithoutContext('getEngineType', () {
       expect(
-        artifacts.getEngineType(TargetPlatform.android_arm, BuildMode.debug),
+        artifacts.getEngineType(const TargetPlatform(.android, .armv7), BuildMode.debug),
         'android_debug_unopt',
       );
-      expect(artifacts.getEngineType(TargetPlatform.ios, BuildMode.release), 'android_debug_unopt');
-      expect(artifacts.getEngineType(TargetPlatform.darwin), 'android_debug_unopt');
+      expect(
+        artifacts.getEngineType(const TargetPlatform(.ios, .arm64), BuildMode.release),
+        'android_debug_unopt',
+      );
+      expect(artifacts.getEngineType(const TargetPlatform(.macos, .x64)), 'android_debug_unopt');
     });
 
     testWithoutContext('Looks up dart.exe on windows platforms', () async {
@@ -764,7 +797,7 @@ void main() {
       expect(
         artifacts.getArtifactPath(
           Artifact.engineDartBinary,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         fileSystem.path.join('/flutter', 'prebuilts', 'windows-x64', 'dart-sdk', 'bin', 'dart.exe'),
       );
@@ -802,7 +835,7 @@ void main() {
       expect(
         artifacts.getArtifactPath(
           Artifact.engineDartBinary,
-          platform: TargetPlatform.web_javascript,
+          platform: const TargetPlatform(.web, .unknown),
         ),
         fileSystem.path.join('/flutter', 'prebuilts', 'macos-x64', 'dart-sdk', 'bin', 'dart'),
       );

--- a/packages/flutter_tools/test/general.shard/asset_bundle_flavors_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_flavors_test.dart
@@ -38,7 +38,7 @@ void main() {
       packageConfigPath: '.dart_tool/package_config.json',
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       flavor: flavor,
-      targetPlatform: TargetPlatform.tester,
+      targetPlatform: const TargetPlatform(.tester, .unknown),
     );
     return bundle;
   }

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_fonts_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_fonts_test.dart
@@ -65,7 +65,7 @@ $fontsSection
     final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
     await bundle.build(
       packageConfigPath: '.dart_tool/package_config.json',
-      targetPlatform: TargetPlatform.tester,
+      targetPlatform: const TargetPlatform(.tester, .unknown),
     );
 
     for (final packageName in packages) {
@@ -120,7 +120,7 @@ $fontsSection
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
@@ -87,7 +87,7 @@ $assetsSection
     await bundle.build(
       packageConfigPath: '.dart_tool/package_config.json',
       flavor: flavor,
-      targetPlatform: TargetPlatform.tester,
+      targetPlatform: const TargetPlatform(.tester, .unknown),
     );
 
     for (final packageName in packages) {
@@ -153,7 +153,7 @@ $assetsSection
         expect(
           () => bundle.build(
             packageConfigPath: '.dart_tool/package_config.json',
-            targetPlatform: TargetPlatform.tester,
+            targetPlatform: const TargetPlatform(.tester, .unknown),
           ),
           throwsToolExit(message: 'resolves to a location outside the package directory'),
         );
@@ -178,7 +178,7 @@ $assetsSection
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,
@@ -209,7 +209,7 @@ $assetsSection
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,
@@ -711,7 +711,7 @@ $assetsSection
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
 
         expect(
@@ -803,7 +803,7 @@ $assetsSection
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
       },
       overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -47,7 +47,7 @@ void main() {
         expect(
           await ab.build(
             packageConfigPath: '.dart_tool/package_config.json',
-            targetPlatform: TargetPlatform.tester,
+            targetPlatform: const TargetPlatform(.tester, .unknown),
           ),
           0,
         );
@@ -70,7 +70,7 @@ void main() {
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(bundle.entries.keys, unorderedEquals(<String>['AssetManifest.bin']));
         const expectedBinAssetManifest = <Object, Object>{};
@@ -120,7 +120,7 @@ flutter:
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
 
         expect(
@@ -163,7 +163,7 @@ flutter:
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,
@@ -182,7 +182,7 @@ flutter:
         expect(bundle.needsBuild(), true);
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,
@@ -223,7 +223,7 @@ flutter:
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,
@@ -254,7 +254,7 @@ name: my_app''')
         expect(bundle.needsBuild(), true);
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,
@@ -295,7 +295,7 @@ flutter:
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,
@@ -350,7 +350,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           deferredComponentsEnabled: true,
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,
@@ -401,7 +401,7 @@ flutter:
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,
@@ -462,7 +462,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           deferredComponentsEnabled: true,
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(
           bundle.entries.keys,
@@ -486,7 +486,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           deferredComponentsEnabled: true,
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
 
         expect(
@@ -540,7 +540,7 @@ flutter:
         () => bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         throwsToolExit(
           message:
@@ -580,7 +580,7 @@ flutter:
         () => bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         throwsToolExit(
           message:
@@ -625,7 +625,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
 
         expect(bundle.entries['my-asset.txt']!.content.isModified, isTrue);
@@ -634,7 +634,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
 
         expect(bundle.entries['my-asset.txt']!.content.isModified, isFalse);
@@ -652,7 +652,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
 
         expect(bundle.entries['my-asset.txt']!.content.isModified, isTrue);
@@ -682,7 +682,7 @@ flutter:
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.web_javascript,
+          targetPlatform: const TargetPlatform(.web, .unknown),
         );
 
         expect(
@@ -721,7 +721,7 @@ flutter:
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.web_javascript,
+          targetPlatform: const TargetPlatform(.web, .unknown),
         );
 
         expect(
@@ -774,7 +774,7 @@ flutter:
     await writeBundle(
       directory,
       const <String, AssetBundleEntry>{},
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
       impellerStatus: ImpellerStatus.disabled,
       processManager: globals.processManager,
       fileSystem: globals.fs,
@@ -803,7 +803,7 @@ assets:
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(
         packageConfigPath: '.dart_tool/package_config.json',
-        targetPlatform: TargetPlatform.tester,
+        targetPlatform: const TargetPlatform(.tester, .unknown),
       );
 
       final AssetBundleEntry? fontManifest = bundle.entries['FontManifest.json'];
@@ -811,7 +811,7 @@ assets:
 
       await bundle.build(
         packageConfigPath: '.dart_tool/package_config.json',
-        targetPlatform: TargetPlatform.tester,
+        targetPlatform: const TargetPlatform(.tester, .unknown),
       );
 
       expect(fontManifest, bundle.entries['FontManifest.json']);
@@ -843,7 +843,7 @@ flutter:
       expect(
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         0,
       );
@@ -878,7 +878,7 @@ flutter:
       expect(
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         0,
       );
@@ -931,7 +931,7 @@ flutter:
         expect(
           await bundle.build(
             packageConfigPath: '.dart_tool/package_config.json',
-            targetPlatform: TargetPlatform.tester,
+            targetPlatform: const TargetPlatform(.tester, .unknown),
           ),
           0,
         );
@@ -939,7 +939,7 @@ flutter:
         await writeBundle(
           output,
           bundle.entries,
-          targetPlatform: TargetPlatform.android,
+          targetPlatform: const TargetPlatform(.android, .unknown),
           impellerStatus: ImpellerStatus.disabled,
           processManager: globals.processManager,
           fileSystem: globals.fs,
@@ -994,7 +994,7 @@ flutter:
         expect(
           await bundle.build(
             packageConfigPath: '.dart_tool/package_config.json',
-            targetPlatform: TargetPlatform.web_javascript,
+            targetPlatform: const TargetPlatform(.web, .unknown),
           ),
           0,
         );
@@ -1002,7 +1002,7 @@ flutter:
         await writeBundle(
           output,
           bundle.entries,
-          targetPlatform: TargetPlatform.web_javascript,
+          targetPlatform: const TargetPlatform(.web, .unknown),
           impellerStatus: ImpellerStatus.disabled,
           processManager: globals.processManager,
           fileSystem: globals.fs,
@@ -1156,7 +1156,7 @@ flutter:
         expect(
           await bundle.build(
             packageConfigPath: '.dart_tool/package_config.json',
-            targetPlatform: TargetPlatform.web_javascript,
+            targetPlatform: const TargetPlatform(.web, .unknown),
           ),
           0,
         );
@@ -1164,7 +1164,7 @@ flutter:
         await writeBundle(
           output,
           bundle.entries,
-          targetPlatform: TargetPlatform.web_javascript,
+          targetPlatform: const TargetPlatform(.web, .unknown),
           impellerStatus: ImpellerStatus.disabled,
           processManager: globals.processManager,
           fileSystem: globals.fs,
@@ -1215,7 +1215,7 @@ flutter:
       expect(
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         0,
       );
@@ -1258,7 +1258,7 @@ flutter:
 
       await bundle.build(
         packageConfigPath: '.dart_tool/package_config.json',
-        targetPlatform: TargetPlatform.tester,
+        targetPlatform: const TargetPlatform(.tester, .unknown),
       );
 
       expect(
@@ -1315,7 +1315,7 @@ flutter:
       expect(
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         1,
       );
@@ -1350,7 +1350,7 @@ flutter:
       expect(
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         1,
       );
@@ -1395,7 +1395,7 @@ flutter:
       expect(
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         0,
       );
@@ -1437,7 +1437,7 @@ flutter:
       expect(
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         0,
       );
@@ -1487,7 +1487,7 @@ flutter:
       expect(
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         0,
       );
@@ -1529,7 +1529,7 @@ flutter:
         () => bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         ),
         throwsToolExit(
           message:

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -87,7 +87,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fs.currentDirectory),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
 
         final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(
@@ -135,7 +135,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fs.currentDirectory),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
 
         final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(
@@ -179,7 +179,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
       await bundle.build(
         packageConfigPath: '.dart_tool/package_config.json',
         flutterProject: FlutterProject.fromDirectoryTest(fs.currentDirectory),
-        targetPlatform: TargetPlatform.tester,
+        targetPlatform: const TargetPlatform(.tester, .unknown),
       );
 
       final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(
@@ -219,7 +219,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
       await bundle.build(
         packageConfigPath: '.dart_tool/package_config.json',
         flutterProject: FlutterProject.fromDirectoryTest(fs.currentDirectory),
-        targetPlatform: TargetPlatform.tester,
+        targetPlatform: const TargetPlatform(.tester, .unknown),
       );
 
       final expectedManifest = <String, List<Map<String, Object>>>{
@@ -287,7 +287,7 @@ flutter:
       await bundle.build(
         packageConfigPath: '.dart_tool/package_config.json',
         flutterProject: FlutterProject.fromDirectoryTest(fs.currentDirectory),
-        targetPlatform: TargetPlatform.tester,
+        targetPlatform: const TargetPlatform(.tester, .unknown),
       );
 
       final expectedAssetManifest = <String, List<Map<String, Object>>>{

--- a/packages/flutter_tools/test/general.shard/asset_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_test.dart
@@ -96,7 +96,7 @@ dependencies:
           packageConfigPath: packageConfigPath,
           manifestPath: manifestPath,
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.directory('main')),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
 
         expect(assetBundle.entries, contains('FontManifest.json'));
@@ -255,7 +255,7 @@ flutter:
             packageConfigPath: packageConfigPath,
             manifestPath: manifestPath,
             flutterProject: FlutterProject.fromDirectoryTest(fileSystem.directory('main')),
-            targetPlatform: TargetPlatform.tester,
+            targetPlatform: const TargetPlatform(.tester, .unknown),
           );
 
           expect(assetBundle.entries, contains('FontManifest.json'));
@@ -300,7 +300,7 @@ flutter:
           manifestPath: manifestPath, // file doesn't exist
           packageConfigPath: packageConfigPath,
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.file(manifestPath).parent),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
 
         expect(assetBundle.wasBuiltOnce(), true);
@@ -343,7 +343,7 @@ flutter:
 
         await assetBundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.android_arm,
+          targetPlatform: const TargetPlatform(.android, .armv7),
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         );
 
@@ -387,7 +387,7 @@ flutter:
 
         await assetBundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
-          targetPlatform: TargetPlatform.web_javascript,
+          targetPlatform: const TargetPlatform(.web, .unknown),
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         );
 
@@ -416,7 +416,7 @@ flutter:
         final int result = await assetBundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(result, isNot(0));
         expect(
@@ -446,7 +446,7 @@ flutter:
         final int result = await assetBundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          targetPlatform: TargetPlatform.tester,
+          targetPlatform: const TargetPlatform(.tester, .unknown),
         );
         expect(result, isNot(0));
         expect(

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -43,7 +43,7 @@ void main() {
           command: <String>[
             artifacts.getArtifactPath(
               Artifact.genSnapshot,
-              platform: TargetPlatform.android_x64,
+              platform: const TargetPlatform(.android, .x64),
               mode: BuildMode.release,
             ),
             '--additional_arg',
@@ -52,7 +52,7 @@ void main() {
       );
 
       final int result = await genSnapshot.run(
-        snapshotType: SnapshotType(TargetPlatform.android_x64, BuildMode.release),
+        snapshotType: SnapshotType(const TargetPlatform(.android, .x64), BuildMode.release),
         additionalArgs: <String>['--additional_arg'],
       );
       expect(result, 0);
@@ -61,7 +61,7 @@ void main() {
     testWithoutContext('iOS arm64', () async {
       final String genSnapshotPath = artifacts.getArtifactPath(
         Artifact.genSnapshotArm64,
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         mode: BuildMode.release,
       );
       processManager.addCommand(
@@ -69,8 +69,7 @@ void main() {
       );
 
       final int result = await genSnapshot.run(
-        snapshotType: SnapshotType(TargetPlatform.ios, BuildMode.release),
-        cpuArch: CpuArch.arm64,
+        snapshotType: SnapshotType(const TargetPlatform(.ios, .arm64), BuildMode.release),
         additionalArgs: <String>['--additional_arg'],
       );
       expect(result, 0);
@@ -82,7 +81,7 @@ void main() {
           command: <String>[
             artifacts.getArtifactPath(
               Artifact.genSnapshot,
-              platform: TargetPlatform.android_x64,
+              platform: const TargetPlatform(.android, .x64),
               mode: BuildMode.release,
             ),
             '--strip',
@@ -92,7 +91,7 @@ void main() {
       );
 
       final int result = await genSnapshot.run(
-        snapshotType: SnapshotType(TargetPlatform.android_x64, BuildMode.release),
+        snapshotType: SnapshotType(const TargetPlatform(.android, .x64), BuildMode.release),
         additionalArgs: <String>['--strip'],
       );
 
@@ -129,8 +128,7 @@ void main() {
 
       expect(
         await snapshotter.build(
-          platform: TargetPlatform.ios,
-          cpuArch: CpuArch.arm64,
+          platform: const TargetPlatform(.ios, .arm64),
           sdkRoot: 'path/to/sdk',
           buildMode: BuildMode.debug,
           mainPath: 'main.dill',
@@ -146,7 +144,7 @@ void main() {
 
       expect(
         await snapshotter.build(
-          platform: TargetPlatform.android_arm,
+          platform: const TargetPlatform(.android, .armv7),
           buildMode: BuildMode.debug,
           mainPath: 'main.dill',
           outputPath: outputPath,
@@ -161,7 +159,7 @@ void main() {
 
       expect(
         await snapshotter.build(
-          platform: TargetPlatform.android_arm64,
+          platform: const TargetPlatform(.android, .arm64),
           buildMode: BuildMode.debug,
           mainPath: 'main.dill',
           outputPath: outputPath,
@@ -176,7 +174,7 @@ void main() {
       final String debugPath = fileSystem.path.join('foo', 'app.ios-arm64.symbols');
       final String genSnapshotPath = artifacts.getArtifactPath(
         Artifact.genSnapshotArm64,
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         mode: BuildMode.profile,
       );
       processManager.addCommands(<FakeCommand>[
@@ -220,11 +218,10 @@ void main() {
       ]);
 
       final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         buildMode: BuildMode.profile,
         mainPath: 'main.dill',
         outputPath: outputPath,
-        cpuArch: CpuArch.arm64,
         sdkRoot: 'path/to/sdk',
         splitDebugInfo: 'foo',
         dartObfuscation: false,
@@ -238,7 +235,7 @@ void main() {
       final String outputPath = fileSystem.path.join('build', 'foo');
       final String genSnapshotPath = artifacts.getArtifactPath(
         Artifact.genSnapshotArm64,
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         mode: BuildMode.profile,
       );
       processManager.addCommands(<FakeCommand>[
@@ -280,11 +277,10 @@ void main() {
       ]);
 
       final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         buildMode: BuildMode.profile,
         mainPath: 'main.dill',
         outputPath: outputPath,
-        cpuArch: CpuArch.arm64,
         sdkRoot: 'path/to/sdk',
         dartObfuscation: true,
       );
@@ -297,7 +293,7 @@ void main() {
       final String outputPath = fileSystem.path.join('build', 'foo');
       final String genSnapshotPath = artifacts.getArtifactPath(
         Artifact.genSnapshotArm64,
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         mode: BuildMode.release,
       );
       processManager.addCommands(<FakeCommand>[
@@ -338,11 +334,10 @@ void main() {
       ]);
 
       final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         buildMode: BuildMode.release,
         mainPath: 'main.dill',
         outputPath: outputPath,
-        cpuArch: CpuArch.arm64,
         sdkRoot: 'path/to/sdk',
         dartObfuscation: false,
       );
@@ -358,7 +353,7 @@ void main() {
           command: <String>[
             artifacts.getArtifactPath(
               Artifact.genSnapshot,
-              platform: TargetPlatform.android_arm,
+              platform: const TargetPlatform(.android, .armv7),
               mode: BuildMode.release,
             ),
             '--deterministic',
@@ -372,7 +367,7 @@ void main() {
       );
 
       final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.android_arm,
+        platform: const TargetPlatform(.android, .armv7),
         buildMode: BuildMode.release,
         mainPath: 'main.dill',
         outputPath: outputPath,
@@ -391,7 +386,7 @@ void main() {
           command: <String>[
             artifacts.getArtifactPath(
               Artifact.genSnapshot,
-              platform: TargetPlatform.android_arm,
+              platform: const TargetPlatform(.android, .armv7),
               mode: BuildMode.release,
             ),
             '--deterministic',
@@ -408,7 +403,7 @@ void main() {
       );
 
       final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.android_arm,
+        platform: const TargetPlatform(.android, .armv7),
         buildMode: BuildMode.release,
         mainPath: 'main.dill',
         outputPath: outputPath,
@@ -427,7 +422,7 @@ void main() {
           command: <String>[
             artifacts.getArtifactPath(
               Artifact.genSnapshot,
-              platform: TargetPlatform.android_arm,
+              platform: const TargetPlatform(.android, .armv7),
               mode: BuildMode.release,
             ),
             '--deterministic',
@@ -442,7 +437,7 @@ void main() {
       );
 
       final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.android_arm,
+        platform: const TargetPlatform(.android, .armv7),
         buildMode: BuildMode.release,
         mainPath: 'main.dill',
         outputPath: outputPath,
@@ -462,7 +457,7 @@ void main() {
             command: <String>[
               artifacts.getArtifactPath(
                 Artifact.genSnapshot,
-                platform: TargetPlatform.android_arm,
+                platform: const TargetPlatform(.android, .armv7),
                 mode: BuildMode.release,
               ),
               '--deterministic',
@@ -476,7 +471,7 @@ void main() {
         );
 
         final int genSnapshotExitCode = await snapshotter.build(
-          platform: TargetPlatform.android_arm,
+          platform: const TargetPlatform(.android, .armv7),
           buildMode: BuildMode.release,
           mainPath: 'main.dill',
           outputPath: outputPath,
@@ -496,7 +491,7 @@ void main() {
           command: <String>[
             artifacts.getArtifactPath(
               Artifact.genSnapshot,
-              platform: TargetPlatform.android_arm64,
+              platform: const TargetPlatform(.android, .arm64),
               mode: BuildMode.release,
             ),
             '--deterministic',
@@ -508,7 +503,7 @@ void main() {
       );
 
       final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.android_arm64,
+        platform: const TargetPlatform(.android, .arm64),
         buildMode: BuildMode.release,
         mainPath: 'main.dill',
         outputPath: outputPath,
@@ -526,7 +521,7 @@ void main() {
           command: <String>[
             artifacts.getArtifactPath(
               Artifact.genSnapshot,
-              platform: TargetPlatform.android_arm64,
+              platform: const TargetPlatform(.android, .arm64),
               mode: BuildMode.release,
             ),
             '--deterministic',
@@ -538,7 +533,7 @@ void main() {
       );
 
       final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.android_arm64,
+        platform: const TargetPlatform(.android, .arm64),
         buildMode: BuildMode.release,
         mainPath: 'main.dill',
         outputPath: outputPath,

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -231,6 +231,74 @@ void main() {
       expect(processManager, hasNoRemainingExpectations);
     });
 
+    testWithoutContext(
+      'builds macOS snapshot with dwarfStackTraces using Darwin arch name for symbols',
+      () async {
+        final String outputPath = fileSystem.path.join('build', 'foo');
+        // The symbol file must use the Darwin architecture name (`x86_64`),
+        // not the Dart architecture name (`x64`).
+        // See https://github.com/flutter/flutter/issues/190252.
+        final String debugPath = fileSystem.path.join('foo', 'app.darwin-x86_64.symbols');
+        final String genSnapshotPath = artifacts.getArtifactPath(
+          Artifact.genSnapshotX64,
+          platform: const TargetPlatform(.macos, .x64),
+          mode: BuildMode.profile,
+        );
+        processManager.addCommands(<FakeCommand>[
+          FakeCommand(
+            command: <String>[
+              genSnapshotPath,
+              '--deterministic',
+              '--snapshot_kind=app-aot-macho-dylib',
+              '--macho=$outputPath/App.framework/App',
+              '--macho-object=$outputPath/app.o',
+              '--macho-min-os-version=12.0',
+              '--macho-rpath=@executable_path/Frameworks,@loader_path/Frameworks',
+              '--macho-install-name=@rpath/App.framework/App',
+              '--dwarf-stack-traces',
+              '--resolve-dwarf-paths',
+              '--save-debugging-info=$debugPath',
+              'main.dill',
+            ],
+          ),
+          kWhichSysctlCommand,
+          kx64CheckCommand,
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'dsymutil',
+              '-o',
+              '$outputPath/App.framework.dSYM',
+              '$outputPath/App.framework/App',
+            ],
+          ),
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'strip',
+              '-x',
+              '$outputPath/App.framework/App',
+              '-o',
+              '$outputPath/App.framework/App',
+            ],
+          ),
+        ]);
+
+        final int genSnapshotExitCode = await snapshotter.build(
+          platform: const TargetPlatform(.macos, .x64),
+          buildMode: BuildMode.profile,
+          mainPath: 'main.dill',
+          outputPath: outputPath,
+          sdkRoot: 'path/to/sdk',
+          splitDebugInfo: 'foo',
+          dartObfuscation: false,
+        );
+
+        expect(genSnapshotExitCode, 0);
+        expect(processManager, hasNoRemainingExpectations);
+      },
+    );
+
     testWithoutContext('builds iOS snapshot with obfuscate', () async {
       final String outputPath = fileSystem.path.join('build', 'foo');
       final String genSnapshotPath = artifacts.getArtifactPath(

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -21,51 +21,47 @@ void main() {
 
   group('Validate build number', () {
     testWithoutContext('CFBundleVersion for iOS', () async {
-      String? buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, 'xyz', logger);
+      String? buildName = validatedBuildNumberForPlatform(PlatformType.ios, 'xyz', logger);
       expect(buildName, isNull);
-      buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, '0.0.1', logger);
+      buildName = validatedBuildNumberForPlatform(PlatformType.ios, '0.0.1', logger);
       expect(buildName, '0.0.1');
-      buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, '123.xyz', logger);
+      buildName = validatedBuildNumberForPlatform(PlatformType.ios, '123.xyz', logger);
       expect(buildName, '123');
-      buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, '123.456.xyz', logger);
+      buildName = validatedBuildNumberForPlatform(PlatformType.ios, '123.456.xyz', logger);
       expect(buildName, '123.456');
     });
 
     testWithoutContext('versionCode for Android', () async {
       String? buildName = validatedBuildNumberForPlatform(
-        TargetPlatform.android_arm,
+        PlatformType.android,
         '123.abc+-',
         logger,
       );
       expect(buildName, '123');
-      buildName = validatedBuildNumberForPlatform(TargetPlatform.android_arm, 'abc', logger);
+      buildName = validatedBuildNumberForPlatform(PlatformType.android, 'abc', logger);
       expect(buildName, '1');
     });
   });
 
   group('Validate build name', () {
     testWithoutContext('CFBundleShortVersionString for iOS', () async {
-      String? buildName = validatedBuildNameForPlatform(TargetPlatform.ios, 'xyz', logger);
+      String? buildName = validatedBuildNameForPlatform(PlatformType.ios, 'xyz', logger);
       expect(buildName, isNull);
-      buildName = validatedBuildNameForPlatform(TargetPlatform.ios, '0.0.1', logger);
+      buildName = validatedBuildNameForPlatform(PlatformType.ios, '0.0.1', logger);
       expect(buildName, '0.0.1');
 
-      buildName = validatedBuildNameForPlatform(TargetPlatform.ios, '123.456.xyz', logger);
+      buildName = validatedBuildNameForPlatform(PlatformType.ios, '123.456.xyz', logger);
       expect(logger.traceText, contains('Invalid build-name'));
       expect(buildName, '123.456.0');
 
-      buildName = validatedBuildNameForPlatform(TargetPlatform.ios, '123.xyz', logger);
+      buildName = validatedBuildNameForPlatform(PlatformType.ios, '123.xyz', logger);
       expect(buildName, '123.0.0');
     });
 
     testWithoutContext('versionName for Android', () async {
-      String? buildName = validatedBuildNameForPlatform(
-        TargetPlatform.android_arm,
-        '123.abc+-',
-        logger,
-      );
+      String? buildName = validatedBuildNameForPlatform(PlatformType.android, '123.abc+-', logger);
       expect(buildName, '123.abc+-');
-      buildName = validatedBuildNameForPlatform(TargetPlatform.android_arm, 'abc+-', logger);
+      buildName = validatedBuildNameForPlatform(PlatformType.android, 'abc+-', logger);
       expect(buildName, 'abc+-');
     });
 
@@ -106,11 +102,25 @@ void main() {
     expect(CpuArch.x64.darwinArchName, 'x86_64');
   });
 
-  testWithoutContext('getNameForTargetPlatform on Darwin arches', () {
-    expect(TargetPlatform.ios.getName(cpuArch: CpuArch.arm64), 'ios-arm64');
-    expect(TargetPlatform.ios.getName(cpuArch: CpuArch.armv7), 'ios-armv7');
-    expect(TargetPlatform.ios.getName(cpuArch: CpuArch.x64), 'ios-x86_64');
-    expect(TargetPlatform.android.getName(), isNot(contains('ios')));
+  testWithoutContext('getName derives the canonical name from the platform and arch', () {
+    // iOS and macOS include the CPU architecture in their name (e.g.
+    // `ios-arm64`, `darwin-x64`), falling back to the bare platform name when
+    // the architecture is unknown.
+    expect(const TargetPlatform(.ios, .arm64).getName(), 'ios-arm64');
+    expect(const TargetPlatform(.ios, .x64).getName(), 'ios-x64');
+    expect(const TargetPlatform(.ios, .unknown).getName(), 'ios');
+    expect(const TargetPlatform(.macos, .arm64).getName(), 'darwin-arm64');
+    expect(const TargetPlatform(.macos, .x64).getName(), 'darwin-x64');
+    expect(const TargetPlatform(.macos, .unknown).getName(), 'darwin');
+    // Desktop platforms follow the `<platform>-<arch>` convention.
+    expect(const TargetPlatform(.linux, .x64).getName(), 'linux-x64');
+    expect(const TargetPlatform(.linux, .arm64).getName(), 'linux-arm64');
+    expect(const TargetPlatform(.windows, .arm64).getName(), 'windows-arm64');
+    // Android has its own per-arch names.
+    expect(const TargetPlatform(.android, .armv7).getName(), 'android-arm');
+    expect(const TargetPlatform(.android, .arm64).getName(), 'android-arm64');
+    expect(const TargetPlatform(.android, .x64).getName(), 'android-x64');
+    expect(const TargetPlatform(.android, .unknown).getName(), 'android');
   });
 
   testUsingContext(

--- a/packages/flutter_tools/test/general.shard/build_system/source_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/source_test.dart
@@ -111,7 +111,7 @@ void main() {
       globals.fs.file(path).createSync(recursive: true);
       const fizzSource = Source.artifact(
         Artifact.windowsDesktopPath,
-        platform: TargetPlatform.windows_x64,
+        platform: TargetPlatform(.windows, .x64),
       );
       fizzSource.accept(visitor);
 
@@ -277,7 +277,7 @@ void main() {
 
       const fizzSource = Source.artifact(
         Artifact.windowsDesktopPath,
-        platform: TargetPlatform.windows_x64,
+        platform: TargetPlatform(.windows, .x64),
       );
       fizzSource.accept(visitor);
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/android_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/android_test.dart
@@ -174,7 +174,7 @@ void main() {
         command: <String>[
           artifacts.getArtifactPath(
             Artifact.genSnapshot,
-            platform: TargetPlatform.android_arm64,
+            platform: const TargetPlatform(.android, .arm64),
             mode: BuildMode.release,
           ),
           '--deterministic',
@@ -187,7 +187,7 @@ void main() {
     environment.buildDir.createSync(recursive: true);
     environment.buildDir.childFile('app.dill').createSync();
     environment.buildDir.childFile('native_assets.json').createSync();
-    const androidAot = AndroidAot(TargetPlatform.android_arm64, BuildMode.release);
+    const androidAot = AndroidAot(TargetPlatform(.android, .arm64), BuildMode.release);
 
     await androidAot.build(environment);
 
@@ -210,7 +210,7 @@ void main() {
         command: <String>[
           artifacts.getArtifactPath(
             Artifact.genSnapshot,
-            platform: TargetPlatform.android_arm64,
+            platform: const TargetPlatform(.android, .arm64),
             mode: BuildMode.release,
           ),
           '--deterministic',
@@ -225,7 +225,7 @@ void main() {
     environment.buildDir.createSync(recursive: true);
     environment.buildDir.childFile('app.dill').createSync();
     environment.buildDir.childFile('native_assets.json').createSync();
-    const androidAot = AndroidAot(TargetPlatform.android_arm64, BuildMode.release);
+    const androidAot = AndroidAot(TargetPlatform(.android, .arm64), BuildMode.release);
 
     await androidAot.build(environment);
 
@@ -252,7 +252,7 @@ void main() {
         command: <String>[
           artifacts.getArtifactPath(
             Artifact.genSnapshot,
-            platform: TargetPlatform.android_arm64,
+            platform: const TargetPlatform(.android, .arm64),
             mode: BuildMode.release,
           ),
           '--deterministic',
@@ -269,7 +269,7 @@ void main() {
     environment.buildDir.childFile('app.dill').createSync();
     environment.buildDir.childFile('native_assets.json').createSync();
 
-    await const AndroidAot(TargetPlatform.android_arm64, BuildMode.release).build(environment);
+    await const AndroidAot(TargetPlatform(.android, .arm64), BuildMode.release).build(environment);
   });
 
   testUsingContext(
@@ -294,7 +294,7 @@ void main() {
           command: <String>[
             artifacts.getArtifactPath(
               Artifact.genSnapshot,
-              platform: TargetPlatform.android_arm64,
+              platform: const TargetPlatform(.android, .arm64),
               mode: BuildMode.release,
             ),
             '--deterministic',
@@ -311,7 +311,10 @@ void main() {
       environment.buildDir.childFile('app.dill').createSync();
       environment.buildDir.childFile('native_assets.json').createSync();
 
-      await const AndroidAot(TargetPlatform.android_arm64, BuildMode.release).build(environment);
+      await const AndroidAot(
+        TargetPlatform(.android, .arm64),
+        BuildMode.release,
+      ).build(environment);
     },
   );
 
@@ -326,7 +329,7 @@ void main() {
       logger: logger,
     );
     environment.buildDir.createSync(recursive: true);
-    const androidAot = AndroidAot(TargetPlatform.android_arm64, BuildMode.release);
+    const androidAot = AndroidAot(TargetPlatform(.android, .arm64), BuildMode.release);
     const androidAotBundle = AndroidAotBundle(androidAot);
     // Create required files.
     environment.buildDir

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -844,9 +844,9 @@ flutter:
         testUsingContext(
           platform,
           () async {
-            final TargetPlatform targetPlatform = platform == 'android'
-                ? TargetPlatform.ios
-                : TargetPlatform.android;
+            final targetPlatform = platform == 'android'
+                ? const TargetPlatform(.ios, .arm64)
+                : const TargetPlatform(.android, .unknown);
             final bool didInclude = await setupAndBuildPlatformAsset(platform, targetPlatform);
 
             expect(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -49,7 +49,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kBuildMode: BuildMode.profile.cliName,
-        kTargetPlatform: TargetPlatform.android_arm.getName(),
+        kTargetPlatform: const TargetPlatform(.android, .armv7).getName(),
       },
       inputs: <String, String>{},
       artifacts: artifacts,
@@ -62,7 +62,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kBuildMode: BuildMode.profile.cliName,
-        kTargetPlatform: TargetPlatform.ios.getName(),
+        kTargetPlatform: const TargetPlatform(.ios, .arm64).getName(),
       },
       inputs: <String, String>{},
       artifacts: artifacts,
@@ -88,7 +88,7 @@ void main() {
     final String build = androidEnvironment.buildDir.path;
     final String flutterPatchedSdkPath = artifacts.getArtifactPath(
       Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
+      platform: const TargetPlatform(.android, .armv7),
       mode: BuildMode.profile,
     );
     processManager.addCommands(<FakeCommand>[
@@ -130,7 +130,7 @@ void main() {
     final String build = androidEnvironment.buildDir.path;
     final String flutterPatchedSdkPath = artifacts.getArtifactPath(
       Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
+      platform: const TargetPlatform(.android, .armv7),
       mode: BuildMode.profile,
     );
     processManager.addCommands(<FakeCommand>[
@@ -175,7 +175,7 @@ void main() {
       final String build = androidEnvironment.buildDir.path;
       final String flutterPatchedSdkPath = artifacts.getArtifactPath(
         Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android_arm,
+        platform: const TargetPlatform(.android, .armv7),
         mode: BuildMode.profile,
       );
       processManager.addCommands(<FakeCommand>[
@@ -220,7 +220,7 @@ void main() {
     final String build = androidEnvironment.buildDir.path;
     final String flutterPatchedSdkPath = artifacts.getArtifactPath(
       Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
+      platform: const TargetPlatform(.android, .armv7),
       mode: BuildMode.profile,
     );
     processManager.addCommands(<FakeCommand>[
@@ -266,7 +266,7 @@ void main() {
     final String build = androidEnvironment.buildDir.path;
     final String flutterPatchedSdkPath = artifacts.getArtifactPath(
       Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
+      platform: const TargetPlatform(.android, .armv7),
       mode: BuildMode.profile,
     );
     processManager.addCommands(<FakeCommand>[
@@ -314,7 +314,7 @@ void main() {
     final String build = androidEnvironment.buildDir.path;
     final String flutterPatchedSdkPath = artifacts.getArtifactPath(
       Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
+      platform: const TargetPlatform(.android, .armv7),
       mode: BuildMode.debug,
     );
     processManager.addCommands(<FakeCommand>[
@@ -362,7 +362,7 @@ void main() {
       final String build = androidEnvironment.buildDir.path;
       final String flutterPatchedSdkPath = artifacts.getArtifactPath(
         Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.darwin,
+        platform: const TargetPlatform(.macos, .x64),
         mode: BuildMode.debug,
       );
       processManager.addCommands(<FakeCommand>[
@@ -393,7 +393,7 @@ void main() {
 
       await const KernelSnapshot().build(
         androidEnvironment
-          ..defines[kTargetPlatform] = TargetPlatform.darwin.getName()
+          ..defines[kTargetPlatform] = const TargetPlatform(.macos, .x64).getName()
           ..defines[kBuildMode] = BuildMode.debug.cliName
           ..defines[kTrackWidgetCreation] = 'false',
       );
@@ -411,7 +411,7 @@ void main() {
       final String build = androidEnvironment.buildDir.path;
       final String flutterPatchedSdkPath = artifacts.getArtifactPath(
         Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.android,
+        platform: const TargetPlatform(.android, .unknown),
         mode: BuildMode.debug,
       );
       processManager.addCommands(<FakeCommand>[
@@ -453,7 +453,7 @@ void main() {
       final String build = iosEnvironment.buildDir.path;
       final String flutterPatchedSdkPath = artifacts.getArtifactPath(
         Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         mode: BuildMode.debug,
       );
       fileSystem.directory('/ios/Runner.xcodeproj').createSync(recursive: true);
@@ -487,7 +487,7 @@ void main() {
 
       await const KernelSnapshot().build(
         iosEnvironment
-          ..defines[kTargetPlatform] = TargetPlatform.ios.getName()
+          ..defines[kTargetPlatform] = const TargetPlatform(.ios, .arm64).getName()
           ..defines[kBuildMode] = BuildMode.debug.cliName
           ..defines[kFlavor] = 'strawberry'
           ..defines[kXcodeConfiguration] = 'Debug-chocolate'
@@ -511,7 +511,7 @@ void main() {
       final String build = iosEnvironment.buildDir.path;
       final String flutterPatchedSdkPath = artifacts.getArtifactPath(
         Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.darwin,
+        platform: const TargetPlatform(.macos, .x64),
         mode: BuildMode.debug,
       );
       fileSystem.directory('/macos/Runner.xcodeproj').createSync(recursive: true);
@@ -544,7 +544,7 @@ void main() {
 
       await const KernelSnapshot().build(
         iosEnvironment
-          ..defines[kTargetPlatform] = TargetPlatform.darwin.getName()
+          ..defines[kTargetPlatform] = const TargetPlatform(.macos, .x64).getName()
           ..defines[kBuildMode] = BuildMode.debug.cliName
           ..defines[kFlavor] = 'strawberry'
           ..defines[kXcodeConfiguration] = 'Debug-chocolate'
@@ -568,7 +568,7 @@ void main() {
       final String build = iosEnvironment.buildDir.path;
       final String flutterPatchedSdkPath = artifacts.getArtifactPath(
         Artifact.flutterPatchedSdkPath,
-        platform: TargetPlatform.darwin,
+        platform: const TargetPlatform(.macos, .x64),
         mode: BuildMode.debug,
       );
       processManager.addCommands(<FakeCommand>[
@@ -600,7 +600,7 @@ void main() {
 
       await const KernelSnapshot().build(
         iosEnvironment
-          ..defines[kTargetPlatform] = TargetPlatform.darwin.getName()
+          ..defines[kTargetPlatform] = const TargetPlatform(.macos, .x64).getName()
           ..defines[kBuildMode] = BuildMode.debug.cliName
           ..defines[kDartDefines] = base64Encode(utf8.encode('FLUTTER_APP_FLAVOR=vanilla'))
           ..defines[kFlavor] = 'strawberry'
@@ -624,7 +624,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kBuildMode: BuildMode.debug.cliName,
-        kTargetPlatform: TargetPlatform.android_arm.getName(),
+        kTargetPlatform: const TargetPlatform(.android, .armv7).getName(),
       },
       processManager: processManager,
       artifacts: artifacts,
@@ -634,7 +634,7 @@ void main() {
     final String build = testEnvironment.buildDir.path;
     final String flutterPatchedSdkPath = artifacts.getArtifactPath(
       Artifact.flutterPatchedSdkPath,
-      platform: TargetPlatform.android_arm,
+      platform: const TargetPlatform(.android, .armv7),
       mode: BuildMode.debug,
     );
     processManager.addCommands(<FakeCommand>[
@@ -678,7 +678,7 @@ void main() {
         command: <String>[
           artifacts.getArtifactPath(
             Artifact.genSnapshot,
-            platform: TargetPlatform.android_arm,
+            platform: const TargetPlatform(.android, .armv7),
             mode: BuildMode.profile,
           ),
           '--deterministic',
@@ -693,7 +693,7 @@ void main() {
     androidEnvironment.buildDir.childFile('app.dill').createSync(recursive: true);
     androidEnvironment.buildDir.childFile('native_assets.json').createSync();
 
-    await const AotElfProfile(TargetPlatform.android_arm).build(androidEnvironment);
+    await const AotElfProfile(TargetPlatform(.android, .armv7)).build(androidEnvironment);
 
     expect(processManager, hasNoRemainingExpectations);
   });
@@ -706,7 +706,7 @@ void main() {
         command: <String>[
           artifacts.getArtifactPath(
             Artifact.genSnapshot,
-            platform: TargetPlatform.android_arm,
+            platform: const TargetPlatform(.android, .armv7),
             mode: BuildMode.profile,
           ),
           '--deterministic',
@@ -723,7 +723,7 @@ void main() {
     androidEnvironment.buildDir.childFile('app.dill').createSync(recursive: true);
     androidEnvironment.buildDir.childFile('native_assets.json').createSync();
 
-    await const AotElfRelease(TargetPlatform.android_arm).build(androidEnvironment);
+    await const AotElfRelease(TargetPlatform(.android, .armv7)).build(androidEnvironment);
 
     expect(processManager, hasNoRemainingExpectations);
   });
@@ -732,7 +732,7 @@ void main() {
     androidEnvironment.defines.remove(kBuildMode);
 
     expect(
-      const AotElfProfile(TargetPlatform.android_arm).build(androidEnvironment),
+      const AotElfProfile(TargetPlatform(.android, .armv7)).build(androidEnvironment),
       throwsA(isA<MissingDefineException>()),
     );
   });
@@ -741,7 +741,7 @@ void main() {
     androidEnvironment.defines.remove(kTargetPlatform);
 
     expect(
-      const AotElfProfile(TargetPlatform.android_arm).build(androidEnvironment),
+      const AotElfProfile(TargetPlatform(.android, .armv7)).build(androidEnvironment),
       throwsA(isA<MissingDefineException>()),
     );
   });
@@ -803,7 +803,7 @@ void main() {
         FakeCommand(
           command: <String>[
             // This path is not known by the cache due to the iOS gen_snapshot split.
-            'Artifact.genSnapshotArm64.TargetPlatform.ios.profile',
+            'Artifact.genSnapshotArm64.ios.profile',
             '--deterministic',
             '--write-v8-snapshot-profile-to=code_size_1/snapshot.arm64.json',
             '--trace-precompiler-to=code_size_1/trace.arm64.json',
@@ -867,7 +867,7 @@ void main() {
         command: <String>[
           artifacts.getArtifactPath(
             Artifact.genSnapshot,
-            platform: TargetPlatform.android_arm,
+            platform: const TargetPlatform(.android, .armv7),
             mode: BuildMode.profile,
           ),
           '--deterministic',
@@ -883,7 +883,7 @@ void main() {
       ),
     ]);
 
-    await const AotElfRelease(TargetPlatform.android_arm).build(androidEnvironment);
+    await const AotElfRelease(TargetPlatform(.android, .armv7)).build(androidEnvironment);
 
     expect(processManager, hasNoRemainingExpectations);
   });

--- a/packages/flutter_tools/test/general.shard/build_system/targets/deferred_components_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/deferred_components_test.dart
@@ -38,7 +38,7 @@ void main() {
       logger: logger,
     );
     environment.buildDir.createSync(recursive: true);
-    const androidAot = AndroidAot(TargetPlatform.android_arm64, BuildMode.release);
+    const androidAot = AndroidAot(TargetPlatform(.android, .arm64), BuildMode.release);
     const androidAotBundle = AndroidAotBundle(androidAot);
     final androidDefBundle = AndroidAotDeferredComponentsBundle(androidAotBundle);
     final validatorTarget = DeferredComponentsGenSnapshotValidatorTarget(
@@ -72,7 +72,7 @@ void main() {
       logger: logger,
     );
     environment.buildDir.createSync(recursive: true);
-    const androidAot = AndroidAot(TargetPlatform.android_arm64, BuildMode.release);
+    const androidAot = AndroidAot(TargetPlatform(.android, .arm64), BuildMode.release);
     const androidAotBundle = AndroidAotBundle(androidAot);
     final androidDefBundle = AndroidAotDeferredComponentsBundle(androidAotBundle);
     final validatorTarget = DeferredComponentsGenSnapshotValidatorTarget(
@@ -105,7 +105,7 @@ void main() {
       logger: logger,
     );
     environment.buildDir.createSync(recursive: true);
-    const androidAot = AndroidAot(TargetPlatform.android_arm64, BuildMode.release);
+    const androidAot = AndroidAot(TargetPlatform(.android, .arm64), BuildMode.release);
     const androidAotBundle = AndroidAotBundle(androidAot);
     final androidDefBundle = AndroidAotDeferredComponentsBundle(androidAotBundle);
     final validatorTarget = DeferredComponentsGenSnapshotValidatorTarget(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
@@ -128,7 +128,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     expect(
@@ -160,7 +160,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     expect(logger.errorText, isEmpty);
@@ -181,7 +181,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     expect(logger.errorText, isEmpty);
@@ -202,7 +202,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     expect(
@@ -230,7 +230,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
     final stdinSink = CompleterIOSink();
     addConstFinderInvocation(appDill.path, stdout: validConstFinderResult);
@@ -280,7 +280,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     final stdinSink = CompleterIOSink();
@@ -312,7 +312,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     final stdinSink = CompleterIOSink();
@@ -330,8 +330,8 @@ void main() {
   });
 
   for (final platform in <TargetPlatform>[
-    TargetPlatform.android_arm,
-    TargetPlatform.web_javascript,
+    const TargetPlatform(.android, .armv7),
+    const TargetPlatform(.web, .unknown),
   ]) {
     testWithoutContext('Non-constant instances $platform', () async {
       final Environment environment = createEnvironment(<String, String>{
@@ -382,7 +382,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android_arm64,
+      targetPlatform: const TargetPlatform(.android, .arm64),
     );
 
     addConstFinderInvocation(
@@ -425,7 +425,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.web_javascript,
+      targetPlatform: const TargetPlatform(.web, .unknown),
     );
 
     addConstFinderInvocation(
@@ -469,7 +469,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     final stdinSink = CompleterIOSink();
@@ -501,7 +501,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     final stdinSink = CompleterIOSink(throwOnAdd: true);
@@ -535,7 +535,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     addConstFinderInvocation(appDill.path, stdout: validConstFinderResult);
@@ -568,7 +568,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     addConstFinderInvocation(appDill.path, stdout: emptyConstFinderResult);
@@ -611,7 +611,7 @@ void main() {
         processManager: processManager,
         fileSystem: fileSystem,
         artifacts: artifacts,
-        targetPlatform: TargetPlatform.android,
+        targetPlatform: const TargetPlatform(.android, .unknown),
       );
 
       addConstFinderInvocation(appDill.path, stdout: emptyConstFinderResult);
@@ -652,7 +652,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       artifacts: artifacts,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: const TargetPlatform(.android, .unknown),
     );
 
     addConstFinderInvocation(appDill.path, exitCode: -1);

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -862,7 +862,7 @@ void main() {
           '--filter',
           '- .DS_Store/',
           '--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r',
-          'Artifact.flutterFramework.TargetPlatform.ios.debug.EnvironmentType.physical',
+          'Artifact.flutterFramework.ios.debug.EnvironmentType.physical',
           outputDir.path,
         ],
       );
@@ -875,7 +875,7 @@ void main() {
           '--filter',
           '- .DS_Store/',
           '--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r',
-          'Artifact.flutterFrameworkDsym.TargetPlatform.ios.debug.EnvironmentType.physical',
+          'Artifact.flutterFrameworkDsym.ios.debug.EnvironmentType.physical',
           outputDir.path,
         ],
       );
@@ -888,7 +888,7 @@ void main() {
           '--filter',
           '- .DS_Store/',
           '--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r',
-          'Artifact.flutterFrameworkDsym.TargetPlatform.ios.debug.EnvironmentType.physical',
+          'Artifact.flutterFrameworkDsym.ios.debug.EnvironmentType.physical',
           outputDir.path,
         ],
         exitCode: 1,
@@ -932,7 +932,7 @@ void main() {
             '--filter',
             '- .DS_Store/',
             '--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r',
-            'Artifact.flutterFramework.TargetPlatform.ios.debug.EnvironmentType.simulator',
+            'Artifact.flutterFramework.ios.debug.EnvironmentType.simulator',
             outputDir.path,
           ],
           onRun: (_) => binary.createSync(recursive: true),
@@ -979,7 +979,7 @@ void main() {
       final Directory dSYM = fileSystem.directory(
         artifacts.getArtifactPath(
           Artifact.flutterFrameworkDsym,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.debug,
           environmentType: EnvironmentType.physical,
         ),
@@ -1337,7 +1337,7 @@ void main() {
       final Directory dSYM = fileSystem.directory(
         artifacts.getArtifactPath(
           Artifact.flutterFrameworkDsym,
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           mode: BuildMode.debug,
           environmentType: EnvironmentType.physical,
         ),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
@@ -38,7 +38,7 @@ void main() {
       );
       testEnvironment.buildDir.createSync(recursive: true);
 
-      await const UnpackLinux(TargetPlatform.linux_x64).build(testEnvironment);
+      await const UnpackLinux(TargetPlatform(.linux, .x64)).build(testEnvironment);
 
       expect(fileSystem.file('linux/flutter/ephemeral/libflutter_linux_gtk.so'), exists);
       expect(fileSystem.file('linux/flutter/ephemeral/unrelated-stuff'), isNot(exists));
@@ -46,12 +46,12 @@ void main() {
       // Check if the target files are copied correctly.
       final String headersPathForX64 = artifacts.getArtifactPath(
         Artifact.linuxHeaders,
-        platform: TargetPlatform.linux_x64,
+        platform: const TargetPlatform(.linux, .x64),
         mode: BuildMode.debug,
       );
       final String headersPathForArm64 = artifacts.getArtifactPath(
         Artifact.linuxHeaders,
-        platform: TargetPlatform.linux_arm64,
+        platform: const TargetPlatform(.linux, .arm64),
         mode: BuildMode.debug,
       );
       expect(fileSystem.file('linux/flutter/ephemeral/$headersPathForX64/foo.h'), exists);
@@ -59,11 +59,11 @@ void main() {
 
       final String icuDataPathForX64 = artifacts.getArtifactPath(
         Artifact.icuData,
-        platform: TargetPlatform.linux_x64,
+        platform: const TargetPlatform(.linux, .x64),
       );
       final String icuDataPathForArm64 = artifacts.getArtifactPath(
         Artifact.icuData,
-        platform: TargetPlatform.linux_arm64,
+        platform: const TargetPlatform(.linux, .arm64),
       );
       expect(fileSystem.file('linux/flutter/ephemeral/$icuDataPathForX64'), exists);
       expect(fileSystem.file('linux/flutter/ephemeral/$icuDataPathForArm64'), isNot(exists));
@@ -89,7 +89,7 @@ void main() {
       );
       testEnvironment.buildDir.createSync(recursive: true);
 
-      await const UnpackLinux(TargetPlatform.linux_arm64).build(testEnvironment);
+      await const UnpackLinux(TargetPlatform(.linux, .arm64)).build(testEnvironment);
 
       expect(fileSystem.file('linux/flutter/ephemeral/libflutter_linux_gtk.so'), exists);
       expect(fileSystem.file('linux/flutter/ephemeral/unrelated-stuff'), isNot(exists));
@@ -97,12 +97,12 @@ void main() {
       // Check if the target files are copied correctly.
       final String headersPathForX64 = artifacts.getArtifactPath(
         Artifact.linuxHeaders,
-        platform: TargetPlatform.linux_x64,
+        platform: const TargetPlatform(.linux, .x64),
         mode: BuildMode.debug,
       );
       final String headersPathForArm64 = artifacts.getArtifactPath(
         Artifact.linuxHeaders,
-        platform: TargetPlatform.linux_arm64,
+        platform: const TargetPlatform(.linux, .arm64),
         mode: BuildMode.debug,
       );
       expect(fileSystem.file('linux/flutter/ephemeral/$headersPathForX64/foo.h'), isNot(exists));
@@ -110,11 +110,11 @@ void main() {
 
       final String icuDataPathForX64 = artifacts.getArtifactPath(
         Artifact.icuData,
-        platform: TargetPlatform.linux_x64,
+        platform: const TargetPlatform(.linux, .x64),
       );
       final String icuDataPathForArm64 = artifacts.getArtifactPath(
         Artifact.icuData,
-        platform: TargetPlatform.linux_arm64,
+        platform: const TargetPlatform(.linux, .arm64),
       );
       expect(fileSystem.file('linux/flutter/ephemeral/$icuDataPathForX64'), isNot(exists));
       expect(fileSystem.file('linux/flutter/ephemeral/$icuDataPathForArm64'), exists);
@@ -147,7 +147,7 @@ void main() {
       testEnvironment.buildDir.childFile('app.dill').createSync();
       testEnvironment.buildDir.childFile('native_assets.json').createSync();
 
-      await const DebugBundleLinuxAssets(TargetPlatform.linux_x64).build(testEnvironment);
+      await const DebugBundleLinuxAssets(TargetPlatform(.linux, .x64)).build(testEnvironment);
 
       final Directory output = testEnvironment.outputDir.childDirectory('flutter_assets');
 
@@ -203,7 +203,7 @@ flutter:
       flavorFileSystem.file('assets/strawberry/ice-cream.png').createSync(recursive: true);
       writePackageConfigFiles(directory: flavorFileSystem.currentDirectory, mainLibName: 'example');
 
-      await const DebugBundleLinuxAssets(TargetPlatform.linux_x64).build(environment);
+      await const DebugBundleLinuxAssets(TargetPlatform(.linux, .x64)).build(environment);
 
       final Uint8List assetManifestData = environment.outputDir
           .childDirectory('flutter_assets')
@@ -225,11 +225,11 @@ flutter:
 
   testWithoutContext("DebugBundleLinuxAssets' name depends on target platforms", () async {
     expect(
-      const DebugBundleLinuxAssets(TargetPlatform.linux_x64).name,
+      const DebugBundleLinuxAssets(TargetPlatform(.linux, .x64)).name,
       'debug_bundle_linux-x64_assets',
     );
     expect(
-      const DebugBundleLinuxAssets(TargetPlatform.linux_arm64).name,
+      const DebugBundleLinuxAssets(TargetPlatform(.linux, .arm64)).name,
       'debug_bundle_linux-arm64_assets',
     );
   });
@@ -252,8 +252,10 @@ flutter:
       testEnvironment.buildDir.childFile('app.so').createSync();
       testEnvironment.buildDir.childFile('native_assets.json').createSync();
 
-      await const LinuxAotBundle(AotElfProfile(TargetPlatform.linux_x64)).build(testEnvironment);
-      await const ProfileBundleLinuxAssets(TargetPlatform.linux_x64).build(testEnvironment);
+      await const LinuxAotBundle(
+        AotElfProfile(TargetPlatform(.linux, .x64)),
+      ).build(testEnvironment);
+      await const ProfileBundleLinuxAssets(TargetPlatform(.linux, .x64)).build(testEnvironment);
       final Directory libDir = testEnvironment.outputDir.childDirectory('lib');
       final Directory assetsDir = testEnvironment.outputDir.childDirectory('flutter_assets');
 
@@ -270,11 +272,11 @@ flutter:
 
   testWithoutContext("ProfileBundleLinuxAssets' name depends on target platforms", () async {
     expect(
-      const ProfileBundleLinuxAssets(TargetPlatform.linux_x64).name,
+      const ProfileBundleLinuxAssets(TargetPlatform(.linux, .x64)).name,
       'profile_bundle_linux-x64_assets',
     );
     expect(
-      const ProfileBundleLinuxAssets(TargetPlatform.linux_arm64).name,
+      const ProfileBundleLinuxAssets(TargetPlatform(.linux, .arm64)).name,
       'profile_bundle_linux-arm64_assets',
     );
   });
@@ -297,8 +299,10 @@ flutter:
       testEnvironment.buildDir.childFile('app.so').createSync();
       testEnvironment.buildDir.childFile('native_assets.json').createSync();
 
-      await const LinuxAotBundle(AotElfRelease(TargetPlatform.linux_x64)).build(testEnvironment);
-      await const ReleaseBundleLinuxAssets(TargetPlatform.linux_x64).build(testEnvironment);
+      await const LinuxAotBundle(
+        AotElfRelease(TargetPlatform(.linux, .x64)),
+      ).build(testEnvironment);
+      await const ReleaseBundleLinuxAssets(TargetPlatform(.linux, .x64)).build(testEnvironment);
       final Directory libDir = testEnvironment.outputDir.childDirectory('lib');
       final Directory assetsDir = testEnvironment.outputDir.childDirectory('flutter_assets');
 
@@ -315,11 +319,11 @@ flutter:
 
   testWithoutContext("ReleaseBundleLinuxAssets' name depends on target platforms", () async {
     expect(
-      const ReleaseBundleLinuxAssets(TargetPlatform.linux_x64).name,
+      const ReleaseBundleLinuxAssets(TargetPlatform(.linux, .x64)).name,
       'release_bundle_linux-x64_assets',
     );
     expect(
-      const ReleaseBundleLinuxAssets(TargetPlatform.linux_arm64).name,
+      const ReleaseBundleLinuxAssets(TargetPlatform(.linux, .arm64)).name,
       'release_bundle_linux-arm64_assets',
     );
   });
@@ -328,12 +332,12 @@ flutter:
 void setUpCacheDirectory(FileSystem fileSystem, Artifacts artifacts) {
   final String desktopPathForX64 = artifacts.getArtifactPath(
     Artifact.linuxDesktopPath,
-    platform: TargetPlatform.linux_x64,
+    platform: const TargetPlatform(.linux, .x64),
     mode: BuildMode.debug,
   );
   final String desktopPathForArm64 = artifacts.getArtifactPath(
     Artifact.linuxDesktopPath,
-    platform: TargetPlatform.linux_arm64,
+    platform: const TargetPlatform(.linux, .arm64),
     mode: BuildMode.debug,
   );
   fileSystem.file('$desktopPathForX64/unrelated-stuff').createSync(recursive: true);
@@ -343,22 +347,29 @@ void setUpCacheDirectory(FileSystem fileSystem, Artifacts artifacts) {
 
   final String headersPathForX64 = artifacts.getArtifactPath(
     Artifact.linuxHeaders,
-    platform: TargetPlatform.linux_x64,
+    platform: const TargetPlatform(.linux, .x64),
     mode: BuildMode.debug,
   );
   final String headersPathForArm64 = artifacts.getArtifactPath(
     Artifact.linuxHeaders,
-    platform: TargetPlatform.linux_arm64,
+    platform: const TargetPlatform(.linux, .arm64),
     mode: BuildMode.debug,
   );
   fileSystem.file('$headersPathForX64/foo.h').createSync(recursive: true);
   fileSystem.file('$headersPathForArm64/foo.h').createSync(recursive: true);
 
   fileSystem
-      .file(artifacts.getArtifactPath(Artifact.icuData, platform: TargetPlatform.linux_x64))
+      .file(
+        artifacts.getArtifactPath(
+          Artifact.icuData,
+          platform: const TargetPlatform(.linux, .x64),
+        ),
+      )
       .createSync();
   fileSystem
-      .file(artifacts.getArtifactPath(Artifact.icuData, platform: TargetPlatform.linux_arm64))
+      .file(
+        artifacts.getArtifactPath(Artifact.icuData, platform: const TargetPlatform(.linux, .arm64)),
+      )
       .createSync();
 
   fileSystem

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -101,7 +101,7 @@ void main() {
         .directory(
           artifacts.getArtifactPath(
             Artifact.flutterMacOSFrameworkDsym,
-            platform: TargetPlatform.darwin,
+            platform: const TargetPlatform(.macos, .x64),
             mode: BuildMode.release,
           ),
         )
@@ -125,7 +125,7 @@ void main() {
         '--filter',
         '- .DS_Store/',
         '--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r',
-        'Artifact.flutterMacOSFrameworkDsym.TargetPlatform.darwin.release',
+        'Artifact.flutterMacOSFrameworkDsym.darwin-x64.release',
         environment.outputDir.path,
       ],
     );
@@ -358,7 +358,7 @@ void main() {
           '--filter',
           '- .DS_Store/',
           '--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r',
-          'Artifact.flutterMacOSFrameworkDsym.TargetPlatform.darwin.release',
+          'Artifact.flutterMacOSFrameworkDsym.darwin-x64.release',
           environment.outputDir.path,
         ],
         exitCode: 1,
@@ -421,7 +421,7 @@ void main() {
           .file(
             artifacts.getArtifactPath(
               Artifact.vmSnapshotData,
-              platform: TargetPlatform.darwin,
+              platform: const TargetPlatform(.macos, .x64),
               mode: BuildMode.debug,
             ),
           )
@@ -430,7 +430,7 @@ void main() {
           .file(
             artifacts.getArtifactPath(
               Artifact.isolateSnapshotData,
-              platform: TargetPlatform.darwin,
+              platform: const TargetPlatform(.macos, .x64),
               mode: BuildMode.debug,
             ),
           )
@@ -482,7 +482,7 @@ void main() {
           .file(
             artifacts.getArtifactPath(
               Artifact.vmSnapshotData,
-              platform: TargetPlatform.darwin,
+              platform: const TargetPlatform(.macos, .x64),
               mode: BuildMode.debug,
             ),
           )
@@ -491,7 +491,7 @@ void main() {
           .file(
             artifacts.getArtifactPath(
               Artifact.isolateSnapshotData,
-              platform: TargetPlatform.darwin,
+              platform: const TargetPlatform(.macos, .x64),
               mode: BuildMode.debug,
             ),
           )
@@ -813,7 +813,7 @@ void main() {
       processManager.addCommands(<FakeCommand>[
         FakeCommand(
           command: <String>[
-            'Artifact.genSnapshotArm64.TargetPlatform.darwin.release',
+            'Artifact.genSnapshotArm64.darwin-x64.release',
             '--deterministic',
             '--snapshot_kind=app-aot-macho-dylib',
             '--macho=${environment.buildDir.childFile('arm64/App.framework/App').path}',
@@ -826,7 +826,7 @@ void main() {
         ),
         FakeCommand(
           command: <String>[
-            'Artifact.genSnapshotX64.TargetPlatform.darwin.release',
+            'Artifact.genSnapshotX64.darwin-x64.release',
             '--deterministic',
             '--snapshot_kind=app-aot-macho-dylib',
             '--macho=${environment.buildDir.childFile('x86_64/App.framework/App').path}',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -74,7 +74,7 @@ void main() {
       await shaderCompiler.compileShader(
         input: fileSystem.file(fragPath),
         outputPath: outputPath,
-        targetPlatform: TargetPlatform.web_javascript,
+        targetPlatform: const TargetPlatform(.web, .unknown),
       ),
       true,
     );
@@ -114,7 +114,7 @@ void main() {
         await shaderCompiler.compileShader(
           input: fileSystem.file(fragPath),
           outputPath: outputPath,
-          targetPlatform: TargetPlatform.ios,
+          targetPlatform: const TargetPlatform(.ios, .arm64),
         ),
         true,
       );
@@ -155,7 +155,7 @@ void main() {
       await shaderCompiler.compileShader(
         input: fileSystem.file(fragPath),
         outputPath: outputPath,
-        targetPlatform: TargetPlatform.android,
+        targetPlatform: const TargetPlatform(.android, .unknown),
       ),
       true,
     );
@@ -194,7 +194,7 @@ void main() {
       await shaderCompiler.compileShader(
         input: fileSystem.file(notFragPath),
         outputPath: outputPath,
-        targetPlatform: TargetPlatform.web_javascript,
+        targetPlatform: const TargetPlatform(.web, .unknown),
       ),
       true,
     );
@@ -233,7 +233,7 @@ void main() {
       await shaderCompiler.compileShader(
         input: fileSystem.file(notFragPath),
         outputPath: outputPath,
-        targetPlatform: TargetPlatform.web_javascript,
+        targetPlatform: const TargetPlatform(.web, .unknown),
       );
       fail('unreachable');
     } on ShaderCompilerException catch (e) {
@@ -289,7 +289,7 @@ void main() {
       random: math.Random(0),
     );
 
-    developmentShaderCompiler.configureCompiler(TargetPlatform.android);
+    developmentShaderCompiler.configureCompiler(const TargetPlatform(.android, .unknown));
 
     final DevFSContent? content = await developmentShaderCompiler.recompileShader(
       DevFSFileContent(fileSystem.file(fragPath)),
@@ -340,7 +340,7 @@ void main() {
         random: math.Random(0),
       );
 
-      developmentShaderCompiler.configureCompiler(TargetPlatform.tester);
+      developmentShaderCompiler.configureCompiler(const TargetPlatform(.tester, .unknown));
 
       final DevFSContent? content = await developmentShaderCompiler.recompileShader(
         DevFSFileContent(fileSystem.file(fragPath)),
@@ -391,7 +391,7 @@ void main() {
       random: math.Random(0),
     );
 
-    developmentShaderCompiler.configureCompiler(TargetPlatform.android);
+    developmentShaderCompiler.configureCompiler(const TargetPlatform(.android, .unknown));
 
     final DevFSContent? content = await developmentShaderCompiler.recompileShader(
       DevFSFileContent(fileSystem.file(fragPath)),
@@ -442,7 +442,7 @@ void main() {
         random: math.Random(0),
       );
 
-      developmentShaderCompiler.configureCompiler(TargetPlatform.tester);
+      developmentShaderCompiler.configureCompiler(const TargetPlatform(.tester, .unknown));
 
       final DevFSContent? content = await developmentShaderCompiler.recompileShader(
         DevFSFileContent(fileSystem.file(fragPath)),
@@ -493,7 +493,7 @@ void main() {
       random: math.Random(0),
     );
 
-    developmentShaderCompiler.configureCompiler(TargetPlatform.android);
+    developmentShaderCompiler.configureCompiler(const TargetPlatform(.android, .unknown));
 
     final DevFSContent? content = await developmentShaderCompiler.recompileShader(
       DevFSFileContent(fileSystem.file(fragPath)),
@@ -542,7 +542,7 @@ void main() {
       random: math.Random(0),
     );
 
-    developmentShaderCompiler.configureCompiler(TargetPlatform.web_javascript);
+    developmentShaderCompiler.configureCompiler(const TargetPlatform(.web, .unknown));
 
     final DevFSContent? content = await developmentShaderCompiler.recompileShader(
       DevFSFileContent(fileSystem.file(fragPath)),
@@ -601,7 +601,7 @@ void main() {
       random: math.Random(0),
     );
 
-    developmentShaderCompiler.configureCompiler(TargetPlatform.android);
+    developmentShaderCompiler.configureCompiler(const TargetPlatform(.android, .unknown));
 
     final shaderContent = DevFSFileContent(fileSystem.file(fragPath));
 
@@ -659,7 +659,7 @@ void main() {
       random: math.Random(0),
     );
 
-    developmentShaderCompiler.configureCompiler(TargetPlatform.android);
+    developmentShaderCompiler.configureCompiler(const TargetPlatform(.android, .unknown));
 
     final shaderContent = DevFSFileContent(fileSystem.file(fragPath));
 
@@ -715,7 +715,7 @@ void main() {
       random: math.Random(0),
     );
 
-    developmentShaderCompiler.configureCompiler(TargetPlatform.android);
+    developmentShaderCompiler.configureCompiler(const TargetPlatform(.android, .unknown));
 
     final shaderContent = DevFSFileContent(fileSystem.file(fragPath));
 
@@ -770,7 +770,7 @@ void main() {
       random: math.Random(0),
     );
 
-    developmentShaderCompiler.configureCompiler(TargetPlatform.android);
+    developmentShaderCompiler.configureCompiler(const TargetPlatform(.android, .unknown));
 
     final shaderContent = DevFSByteContent(Uint8List.fromList(<int>[1, 2, 3, 4]));
 
@@ -820,7 +820,7 @@ void main() {
           shaderCompiler.compileShader(
             input: fileSystem.file(fragPath),
             outputPath: outputPath,
-            targetPlatform: TargetPlatform.ios,
+            targetPlatform: const TargetPlatform(.ios, .arm64),
           ),
           throwsToolExit(message: 'Impeller shader compiler was blocked by security policy.'),
         );
@@ -867,7 +867,7 @@ void main() {
           shaderCompiler.compileShader(
             input: fileSystem.file(fragPath),
             outputPath: outputPath,
-            targetPlatform: TargetPlatform.ios,
+            targetPlatform: const TargetPlatform(.ios, .arm64),
           ),
           throwsToolExit(message: 'Impeller shader compiler was blocked by security policy.'),
         );
@@ -913,7 +913,7 @@ void main() {
         final bool success = await shaderCompiler.compileShader(
           input: fileSystem.file(fragPath),
           outputPath: outputPath,
-          targetPlatform: TargetPlatform.ios,
+          targetPlatform: const TargetPlatform(.ios, .arm64),
           fatal: false,
         );
 
@@ -952,7 +952,7 @@ void main() {
         shaderCompiler.compileShader(
           input: fileSystem.file(fragPath),
           outputPath: outputPath,
-          targetPlatform: TargetPlatform.ios,
+          targetPlatform: const TargetPlatform(.ios, .arm64),
         ),
         throwsA(
           isA<ProcessException>().having(
@@ -1012,7 +1012,7 @@ void main() {
       final bool success1 = await shaderCompiler.compileShader(
         input: fileSystem.file(fragPath),
         outputPath: outputPath,
-        targetPlatform: TargetPlatform.ios,
+        targetPlatform: const TargetPlatform(.ios, .arm64),
         fatal: false,
       );
       expect(success1, false);
@@ -1026,7 +1026,7 @@ void main() {
       final bool success2 = await shaderCompiler.compileShader(
         input: fileSystem.file(fragPath),
         outputPath: outputPath,
-        targetPlatform: TargetPlatform.ios,
+        targetPlatform: const TargetPlatform(.ios, .arm64),
         fatal: false,
       );
       expect(success2, false);

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
@@ -83,7 +83,7 @@ name: my_app
           fakeFlutterVersion: FakeFlutterVersion(),
         );
         commandArgs = [
-          'Artifact.engineDartBinary.TargetPlatform.web_javascript',
+          'Artifact.engineDartBinary.web-javascript',
           'compile',
           'wasm',
           '--packages=/.dart_tool/package_config.json',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -28,7 +28,7 @@ import '../../../src/testbed.dart';
 import '../../../src/throwing_pub.dart';
 
 const _kDart2jsLinuxArgs = <String>[
-  'Artifact.engineDartBinary.TargetPlatform.web_javascript',
+  'Artifact.engineDartBinary.web-javascript',
   'compile',
   'js',
   '--platform-binaries=HostArtifact.webPlatformKernelFolder',
@@ -44,7 +44,7 @@ const _kStandardFlutterWebDefines = <String>[
 ];
 
 const _kDart2WasmLinuxArgs = <String>[
-  'Artifact.engineDartBinary.TargetPlatform.web_javascript',
+  'Artifact.engineDartBinary.web-javascript',
   'compile',
   'wasm',
   '--packages=/.dart_tool/package_config.json',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/windows_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/windows_test.dart
@@ -38,17 +38,17 @@ void main() {
 
       final String windowsDesktopPath = artifacts.getArtifactPath(
         Artifact.windowsDesktopPath,
-        platform: TargetPlatform.windows_x64,
+        platform: const TargetPlatform(.windows, .x64),
         mode: BuildMode.debug,
       );
       final String windowsCppClientWrapper = artifacts.getArtifactPath(
         Artifact.windowsCppClientWrapper,
-        platform: TargetPlatform.windows_x64,
+        platform: const TargetPlatform(.windows, .x64),
         mode: BuildMode.debug,
       );
       final String icuData = artifacts.getArtifactPath(
         Artifact.icuData,
-        platform: TargetPlatform.windows_x64,
+        platform: const TargetPlatform(.windows, .x64),
       );
       final requiredFiles = <String>[
         '$windowsDesktopPath\\flutter_export.h',
@@ -70,7 +70,7 @@ void main() {
       }
       fileSystem.directory('windows').createSync();
 
-      await const UnpackWindows(TargetPlatform.windows_x64).build(environment);
+      await const UnpackWindows(TargetPlatform(.windows, .x64)).build(environment);
 
       // Output files are copied correctly.
       expect(fileSystem.file(r'C:\windows\flutter\ephemeral\flutter_export.h'), exists);
@@ -165,7 +165,7 @@ void main() {
       environment.buildDir.childFile('app.dill').createSync(recursive: true);
       environment.buildDir.childFile('native_assets.json').createSync(recursive: true);
 
-      await const DebugBundleWindowsAssets(TargetPlatform.windows_x64).build(environment);
+      await const DebugBundleWindowsAssets(TargetPlatform(.windows, .x64)).build(environment);
 
       // Depfile is created and dill is copied.
       expect(environment.buildDir.childFile('flutter_assets.d'), exists);
@@ -214,7 +214,7 @@ flutter:
       flavorFileSystem.file('assets/strawberry/ice-cream.png').createSync(recursive: true);
       writePackageConfigFiles(directory: flavorFileSystem.currentDirectory, mainLibName: 'example');
 
-      await const DebugBundleWindowsAssets(TargetPlatform.windows_x64).build(environment);
+      await const DebugBundleWindowsAssets(TargetPlatform(.windows, .x64)).build(environment);
 
       final Uint8List assetManifestData = environment.outputDir
           .childDirectory('flutter_assets')
@@ -249,8 +249,10 @@ flutter:
       environment.buildDir.childFile('app.so').createSync(recursive: true);
       environment.buildDir.childFile('native_assets.json').createSync(recursive: true);
 
-      await const WindowsAotBundle(AotElfProfile(TargetPlatform.windows_x64)).build(environment);
-      await const ProfileBundleWindowsAssets(TargetPlatform.windows_x64).build(environment);
+      await const WindowsAotBundle(
+        AotElfProfile(TargetPlatform(.windows, .x64)),
+      ).build(environment);
+      await const ProfileBundleWindowsAssets(TargetPlatform(.windows, .x64)).build(environment);
 
       // Depfile is created and so is copied.
       expect(environment.buildDir.childFile('flutter_assets.d'), exists);
@@ -278,8 +280,10 @@ flutter:
       environment.buildDir.childFile('app.so').createSync(recursive: true);
       environment.buildDir.childFile('native_assets.json').createSync(recursive: true);
 
-      await const WindowsAotBundle(AotElfRelease(TargetPlatform.windows_x64)).build(environment);
-      await const ReleaseBundleWindowsAssets(TargetPlatform.windows_x64).build(environment);
+      await const WindowsAotBundle(
+        AotElfRelease(TargetPlatform(.windows, .x64)),
+      ).build(environment);
+      await const ReleaseBundleWindowsAssets(TargetPlatform(.windows, .x64)).build(environment);
 
       // Depfile is created and so is copied.
       expect(environment.buildDir.childFile('flutter_assets.d'), exists);

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -44,7 +44,7 @@ void main() {
       });
 
       await BundleBuilder().build(
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         buildInfo: BuildInfo.debug,
         project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
         mainPath: globals.fs.path.join('lib', 'main.dart'),
@@ -119,7 +119,7 @@ void main() {
       await writeBundle(
         bundleDir,
         bundle.entries,
-        targetPlatform: TargetPlatform.tester,
+        targetPlatform: const TargetPlatform(.tester, .unknown),
         impellerStatus: ImpellerStatus.platformDefault,
         processManager: processManager,
         fileSystem: fileSystem,
@@ -140,7 +140,7 @@ void main() {
     () {
       expect(
         () => BundleBuilder().build(
-          platform: TargetPlatform.ios,
+          platform: const TargetPlatform(.ios, .arm64),
           buildInfo: BuildInfo.debug,
           project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
           mainPath: 'lib/main.dart',
@@ -177,7 +177,7 @@ void main() {
       });
 
       await BundleBuilder().build(
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         buildInfo: const BuildInfo(
           BuildMode.debug,
           null,
@@ -200,7 +200,7 @@ void main() {
 
       expect(env, isNotNull);
       expect(env!.defines[kBuildMode], 'debug');
-      expect(env!.defines[kTargetPlatform], 'ios');
+      expect(env!.defines[kTargetPlatform], 'ios-arm64');
       expect(env!.defines[kTargetFile], mainPath);
       expect(env!.defines[kTrackWidgetCreation], 'true');
       expect(env!.defines[kFrontendServerStarterPath], 'path/to/frontend_server_starter.dart');
@@ -312,7 +312,7 @@ void main() {
         }
       });
       await BundleBuilder().build(
-        platform: TargetPlatform.ios,
+        platform: const TargetPlatform(.ios, .arm64),
         buildInfo: BuildInfo.release,
         project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
         mainPath: globals.fs.path.join('lib', 'main.dart'),

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -209,7 +209,7 @@ class FakeDevice extends Fake implements Device {
   String get displayName => name;
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.tester;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.tester, .unknown);
 
   @override
   DartDevelopmentService get dds => FakeDartDevelopmentService();
@@ -259,7 +259,7 @@ class TestFlutterDevice extends FlutterDevice {
     required this.exception,
     required ResidentCompiler generator,
   }) : super(
-         targetPlatform: .unsupported,
+         targetPlatform: const TargetPlatform(.unsupported, .unknown),
          device,
          buildInfo: BuildInfo.debug,
          generator: generator,

--- a/packages/flutter_tools/test/general.shard/compile_expression_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_expression_test.dart
@@ -36,7 +36,7 @@ void main() {
     fileSystem = MemoryFileSystem.test()
       ..file(Artifact.flutterPatchedSdkPath.toString()).createSync();
     generator = const ResidentCompilerFactory().create(
-      targetPlatform: .tester,
+      targetPlatform: const TargetPlatform(.tester, .unknown),
       buildInfo: BuildInfo.debug,
       artifacts: Artifacts.test(fileSystem: fileSystem),
       processManager: processManager,

--- a/packages/flutter_tools/test/general.shard/compile_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_test.dart
@@ -163,7 +163,7 @@ void main() {
       // Initializing the compiler with includeUnsupportedPlatformLibraryStubs for targets other
       // than DDC is not currently supported as it's limited for use with the widget previewer.
       for (final TargetPlatform target in TargetPlatform.values.where(
-        (e) => e != .web_javascript,
+        (e) => e != const TargetPlatform(.web, .unknown),
       )) {
         try {
           const ResidentCompilerFactory().create(
@@ -190,7 +190,7 @@ void main() {
       // Initializing the compiler with includeUnsupportedPlatformLibraryStubs for DDC is
       // supported.
       const ResidentCompilerFactory().create(
-        targetPlatform: .web_javascript,
+        targetPlatform: const TargetPlatform(.web, .unknown),
         buildInfo: BuildInfo.debug.copyWith(includeUnsupportedPlatformLibraryStubs: true),
         logger: BufferLogger.test(),
         processManager: FakeProcessManager.any(),
@@ -210,8 +210,8 @@ void main() {
       final processManager = FakeProcessManager.list([
         FakeCommand(
           command: const <String>[
-            'Artifact.engineDartAotRuntime.TargetPlatform.web_javascript',
-            'Artifact.frontendServerSnapshotForEngineDartSdk.TargetPlatform.web_javascript',
+            'Artifact.engineDartAotRuntime.web-javascript',
+            'Artifact.frontendServerSnapshotForEngineDartSdk.web-javascript',
             '--sdk-root',
             'sdkroot/',
             '--incremental',
@@ -285,8 +285,8 @@ void main() {
       final processManager = FakeProcessManager.list([
         FakeCommand(
           command: const <String>[
-            'Artifact.engineDartAotRuntime.TargetPlatform.web_javascript',
-            'Artifact.frontendServerSnapshotForEngineDartSdk.TargetPlatform.web_javascript',
+            'Artifact.engineDartAotRuntime.web-javascript',
+            'Artifact.frontendServerSnapshotForEngineDartSdk.web-javascript',
             '--sdk-root',
             'sdkroot/',
             '--incremental',

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -118,7 +118,7 @@ void main() {
       expect(device.name, 'testlabel');
       expect(device.platformType, PlatformType.custom);
       expect(await device.sdkNameAndVersion, 'testsdknameandversion');
-      expect(await device.targetPlatform, TargetPlatform.linux_arm64);
+      expect(await device.targetPlatform, const TargetPlatform(.linux, .arm64));
       expect(await device.installApp(linuxApp), true);
       expect(await device.uninstallApp(linuxApp), true);
       expect(await device.isLatestBuildInstalled(linuxApp), false);
@@ -537,7 +537,7 @@ void main() {
       final runDebugCompleter = Completer<void>();
 
       final CustomDeviceConfig config = testConfig.copyWith(
-        platform: TargetPlatform.linux_arm64,
+        platform: const TargetPlatform(.linux, .arm64),
         postBuildCommand: const <String>[
           'testpostbuild',
           r'--buildMode=${buildMode}',
@@ -675,12 +675,12 @@ void main() {
 
   testWithoutContext('CustomDevice returns correct target platform', () async {
     final device = CustomDevice(
-      config: testConfig.copyWith(platform: TargetPlatform.linux_x64),
+      config: testConfig.copyWith(platform: const TargetPlatform(.linux, .x64)),
       logger: BufferLogger.test(),
       processManager: FakeProcessManager.empty(),
     );
 
-    expect(await device.targetPlatform, TargetPlatform.linux_x64);
+    expect(await device.targetPlatform, const TargetPlatform(.linux, .x64));
   });
 
   testWithoutContext(

--- a/packages/flutter_tools/test/general.shard/darwin_test.dart
+++ b/packages/flutter_tools/test/general.shard/darwin_test.dart
@@ -28,10 +28,13 @@ void main() {
       });
       testWithoutContext('fromTargetPlatform', () {
         expect(
-          FlutterDarwinPlatform.fromTargetPlatform(TargetPlatform.ios),
+          FlutterDarwinPlatform.fromTargetPlatform(const TargetPlatform(.ios, .arm64)),
           FlutterDarwinPlatform.ios,
         );
-        expect(FlutterDarwinPlatform.fromTargetPlatform(TargetPlatform.android), null);
+        expect(
+          FlutterDarwinPlatform.fromTargetPlatform(const TargetPlatform(.android, .unknown)),
+          null,
+        );
       });
       testWithoutContext('fromName', () {
         expect(FlutterDarwinPlatform.fromName('ios'), FlutterDarwinPlatform.ios);
@@ -55,10 +58,13 @@ void main() {
       });
       testWithoutContext('fromTargetPlatform', () {
         expect(
-          FlutterDarwinPlatform.fromTargetPlatform(TargetPlatform.darwin),
+          FlutterDarwinPlatform.fromTargetPlatform(const TargetPlatform(.macos, .x64)),
           FlutterDarwinPlatform.macos,
         );
-        expect(FlutterDarwinPlatform.fromTargetPlatform(TargetPlatform.android), null);
+        expect(
+          FlutterDarwinPlatform.fromTargetPlatform(const TargetPlatform(.android, .unknown)),
+          null,
+        );
       });
       testWithoutContext('fromName', () {
         expect(FlutterDarwinPlatform.fromName('macos'), FlutterDarwinPlatform.macos);

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -467,7 +467,7 @@ class FakeDesktopDevice extends DesktopDevice {
   String get name => 'dummy';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.tester;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.tester, .unknown);
 
   @override
   Future<CpuArch> get cpuArch async => CpuArch.unknown;
@@ -517,7 +517,7 @@ class FakeMacOSDevice extends MacOSDevice {
   String get name => 'dummy';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.tester;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.tester, .unknown);
 
   @override
   Future<bool> isSupported() async => true;

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -288,9 +288,9 @@ void main() {
       isSupportedForProject: false,
     );
     final webDevice = FakeDevice('webby', 'webby')
-      ..targetPlatform = Future<TargetPlatform>.value(TargetPlatform.web_javascript);
+      ..targetPlatform = Future<TargetPlatform>.value(const TargetPlatform(.web, .unknown));
     final fuchsiaDevice = FakeDevice('fuchsiay', 'fuchsiay')
-      ..targetPlatform = Future<TargetPlatform>.value(TargetPlatform.fuchsia_x64);
+      ..targetPlatform = Future<TargetPlatform>.value(const TargetPlatform(.fuchsia, .x64));
     final unconnectedDevice = FakeDevice('ephemeralTwo', 'ephemeralTwo', isConnected: false);
     final wirelessDevice = FakeDevice(
       'ephemeralTwo',

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -535,7 +535,7 @@ class FakeDevice extends Fake implements Device {
   final DartDevelopmentService dds = FakeDartDevelopmentService();
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.android, .armv7);
 
   @override
   Future<DeviceLogReader> getLogReader({

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -451,5 +451,5 @@ class FakeDevice extends Fake implements Device {
   final PlatformType platformType = PlatformType.web;
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.android, .armv7);
 }

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/ios/ios_emulators.dart';

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -539,7 +539,8 @@ class _UnstartableDevice extends Fake implements Device {
   Future<void> dispose() => Future<void>.value();
 
   @override
-  Future<TargetPlatform> get targetPlatform => Future<TargetPlatform>.value(TargetPlatform.android);
+  Future<TargetPlatform> get targetPlatform =>
+      Future<TargetPlatform>.value(const TargetPlatform(.android, .unknown));
 
   @override
   Future<bool> stopApp(ApplicationPackage? app, {String? userIdentifier}) async {
@@ -568,7 +569,8 @@ class _WorkingDevice extends Fake implements Device {
   Future<void> dispose() async {}
 
   @override
-  Future<TargetPlatform> get targetPlatform => Future<TargetPlatform>.value(TargetPlatform.android);
+  Future<TargetPlatform> get targetPlatform =>
+      Future<TargetPlatform>.value(const TargetPlatform(.android, .unknown));
 
   @override
   Future<bool> stopApp(ApplicationPackage? app, {String? userIdentifier}) async => true;

--- a/packages/flutter_tools/test/general.shard/hot_shared.dart
+++ b/packages/flutter_tools/test/general.shard/hot_shared.dart
@@ -42,7 +42,7 @@ class FakeDevFs extends Fake implements DevFS {
 }
 
 class FakeDevice extends Fake implements Device {
-  FakeDevice({TargetPlatform targetPlatform = TargetPlatform.tester})
+  FakeDevice({TargetPlatform targetPlatform = const TargetPlatform(.tester, .unknown)})
     : _targetPlatform = targetPlatform;
 
   final TargetPlatform _targetPlatform;
@@ -148,7 +148,7 @@ class TestFlutterDevice extends FlutterDevice {
     required ResidentCompiler generator,
   }) : super(
          device,
-         targetPlatform: TargetPlatform.unsupported,
+         targetPlatform: const TargetPlatform(.unsupported, .unknown),
          buildInfo: BuildInfo.debug,
          generator: generator,
          developmentShaderCompiler: const FakeShaderCompiler(),

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -250,7 +250,7 @@ name: my_app
           final devices = <FlutterDevice>[
             FlutterDevice(
               device,
-              targetPlatform: .unsupported,
+              targetPlatform: const TargetPlatform(.unsupported, .unknown),
               generator: residentCompiler,
               buildInfo: BuildInfo.debug,
               developmentShaderCompiler: const FakeShaderCompiler(),
@@ -281,7 +281,7 @@ name: my_app
           final devices = <FlutterDevice>[
             FlutterDevice(
               device,
-              targetPlatform: .unsupported,
+              targetPlatform: const TargetPlatform(.unsupported, .unknown),
               generator: residentCompiler,
               buildInfo: BuildInfo.debug,
               developmentShaderCompiler: const FakeShaderCompiler(),

--- a/packages/flutter_tools/test/general.shard/integration_test_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/integration_test_device_test.dart
@@ -123,7 +123,7 @@ void main() {
         isA<TestDeviceException>().having(
           (Exception e) => e.toString(),
           'description',
-          contains('No application found for TargetPlatform.android_arm'),
+          contains('No application found for android-arm'),
         ),
       ),
     );

--- a/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
@@ -93,7 +93,7 @@ void main() {
         };
         final DartHooksResult result = await runFlutterSpecificHooks(
           environmentDefines: environmentDefines,
-          targetPlatform: TargetPlatform.android_arm64,
+          targetPlatform: const TargetPlatform(.android, .arm64),
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: buildRunner,
@@ -104,7 +104,7 @@ void main() {
         await installCodeAssets(
           dartHookResult: result,
           environmentDefines: environmentDefines,
-          targetPlatform: TargetPlatform.android_arm64,
+          targetPlatform: const TargetPlatform(.android, .arm64),
           projectUri: projectUri,
           fileSystem: fileSystem,
           nativeAssetsFileUri: nonFlutterTesterAssetUri,
@@ -142,7 +142,7 @@ void main() {
           kBuildMode: BuildMode.debug.cliName,
           kMinSdkVersion: minSdkVersion,
         },
-        targetPlatform: TargetPlatform.android_x64,
+        targetPlatform: const TargetPlatform(.android, .x64),
         projectUri: projectUri,
         fileSystem: fileSystem,
         buildRunner: _BuildRunnerWithoutNdk(),
@@ -170,7 +170,7 @@ void main() {
             kBuildMode: BuildMode.debug.cliName,
             kMinSdkVersion: minSdkVersion,
           },
-          targetPlatform: TargetPlatform.android_arm64,
+          targetPlatform: const TargetPlatform(.android, .arm64),
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: _BuildRunnerWithoutNdk(packagesWithNativeAssetsResult: <String>['bar']),

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -39,7 +39,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kBuildMode: BuildMode.profile.cliName,
-        kTargetPlatform: TargetPlatform.ios.getName(),
+        kTargetPlatform: const TargetPlatform(.ios, .arm64).getName(),
         kIosArchs: 'arm64',
         kSdkRoot: 'path/to/iPhoneOS.sdk',
       },
@@ -53,7 +53,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kBuildMode: BuildMode.profile.cliName,
-        kTargetPlatform: TargetPlatform.android.getName(),
+        kTargetPlatform: const TargetPlatform(.android, .unknown).getName(),
         kAndroidArchs: CpuArch.arm64.androidPlatformName,
       },
       inputs: <String, String>{},

--- a/packages/flutter_tools/test/general.shard/isolated/data_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/data_assets_test.dart
@@ -58,7 +58,7 @@ void main() {
       expect(
         () => runFlutterSpecificHooks(
           environmentDefines: <String, String>{kBuildMode: BuildMode.debug.cliName},
-          targetPlatform: TargetPlatform.windows_x64,
+          targetPlatform: const TargetPlatform(.windows, .x64),
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: FakeFlutterNativeAssetsBuildRunner(
@@ -100,7 +100,7 @@ void main() {
         expect(
           () async => runFlutterSpecificHooks(
             environmentDefines: <String, String>{kBuildMode: buildMode.cliName},
-            targetPlatform: TargetPlatform.linux_x64,
+            targetPlatform: const TargetPlatform(.linux, .x64),
             projectUri: projectUri,
             buildCodeAssets: const BuildCodeAssetsOptions(appBuildDirectory: null),
             buildDataAssets: true,

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -257,7 +257,7 @@ void main() {
         };
         final DartHooksResult dartHookResult = await runFlutterSpecificHooks(
           environmentDefines: environmentDefines,
-          targetPlatform: TargetPlatform.ios,
+          targetPlatform: const TargetPlatform(.ios, .arm64),
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: buildRunner,
@@ -268,7 +268,7 @@ void main() {
         await installCodeAssets(
           dartHookResult: dartHookResult,
           environmentDefines: environmentDefines,
-          targetPlatform: TargetPlatform.ios,
+          targetPlatform: const TargetPlatform(.ios, .arm64),
           projectUri: projectUri,
           fileSystem: fileSystem,
           nativeAssetsFileUri: nonFlutterTesterAssetUri,

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -59,7 +59,7 @@ void main() {
 
       await runFlutterSpecificHooks(
         environmentDefines: <String, String>{kBuildMode: BuildMode.debug.cliName},
-        targetPlatform: TargetPlatform.linux_x64,
+        targetPlatform: const TargetPlatform(.linux, .x64),
         projectUri: projectUri,
         fileSystem: fileSystem,
         buildRunner: _BuildRunnerWithoutClang(),
@@ -296,10 +296,8 @@ CMAKE_LINKER:FILEPATH=/some/path/to/ld.lld
     'cCompilerConfigLinux FileSystemException on resolveSymbolicLinks and throwIfNotFound: false',
     overrides: <Type, Generator>{
       ProcessManager: () => FakeProcessManager.empty(),
-      FileSystem: () => _ThrowingResolveFileSystem(
-            fileSystem,
-            '${environment.outputDir.path}/mock_clang++',
-          ),
+      FileSystem: () =>
+          _ThrowingResolveFileSystem(fileSystem, '${environment.outputDir.path}/mock_clang++'),
     },
     () async {
       if (!const LocalPlatform().isLinux) {
@@ -327,10 +325,8 @@ CMAKE_LINKER:FILEPATH=/some/path/to/ld.lld
     'cCompilerConfigLinux FileSystemException on resolveSymbolicLinks and throwIfNotFound: true',
     overrides: <Type, Generator>{
       ProcessManager: () => FakeProcessManager.empty(),
-      FileSystem: () => _ThrowingResolveFileSystem(
-            fileSystem,
-            '${environment.outputDir.path}/mock_clang++',
-          ),
+      FileSystem: () =>
+          _ThrowingResolveFileSystem(fileSystem, '${environment.outputDir.path}/mock_clang++'),
     },
     () async {
       if (!const LocalPlatform().isLinux) {

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -284,7 +284,7 @@ void main() {
           }
           if (flutterTester && !const LocalPlatform().isMacOS) {
             // The [runFlutterSpecificDartBuild] will - when given
-            // `TargetPlatform.tester` - enable `flutter test` mode. That means if
+            // `TargetPlatform(.tester, .unknown)` - enable `flutter test` mode. That means if
             // this test is run on linux, it's going to do a linux build.
             // Though this test is mac-specific, so we skip that.
             //
@@ -333,9 +333,9 @@ void main() {
             kBuildMode: buildMode.cliName,
             kDarwinArchs: 'arm64 x86_64',
           };
-          final TargetPlatform targetPlatform = flutterTester
-              ? TargetPlatform.tester
-              : TargetPlatform.darwin;
+          final targetPlatform = flutterTester
+              ? const TargetPlatform(.tester, .unknown)
+              : const TargetPlatform(.macos, .x64);
           final DartHooksResult dartHookResult = await runFlutterSpecificHooks(
             environmentDefines: environmentDefines,
             targetPlatform: targetPlatform,

--- a/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
@@ -72,7 +72,7 @@ void main() {
       ];
       final DartHooksResult dartHookResult = await runFlutterSpecificHooks(
         environmentDefines: environmentDefines,
-        targetPlatform: TargetPlatform.linux_x64,
+        targetPlatform: const TargetPlatform(.linux, .x64),
         projectUri: projectUri,
         fileSystem: fileSystem,
         buildRunner: FakeFlutterNativeAssetsBuildRunner(
@@ -87,7 +87,7 @@ void main() {
       await installCodeAssets(
         dartHookResult: dartHookResult,
         environmentDefines: environmentDefines,
-        targetPlatform: TargetPlatform.windows_x64,
+        targetPlatform: const TargetPlatform(.windows, .x64),
         projectUri: projectUri,
         fileSystem: fileSystem,
         nativeAssetsFileUri: nonFlutterTesterAssetUri,
@@ -111,7 +111,7 @@ void main() {
       expect(
         () => runFlutterSpecificHooks(
           environmentDefines: <String, String>{kBuildMode: BuildMode.debug.cliName},
-          targetPlatform: TargetPlatform.windows_x64,
+          targetPlatform: const TargetPlatform(.windows, .x64),
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: FakeFlutterNativeAssetsBuildRunner(
@@ -140,7 +140,7 @@ void main() {
       final environmentDefines = <String, String>{kBuildMode: BuildMode.debug.cliName};
       final DartHooksResult dartHookResult = await runFlutterSpecificHooks(
         environmentDefines: environmentDefines,
-        targetPlatform: TargetPlatform.windows_x64,
+        targetPlatform: const TargetPlatform(.windows, .x64),
         projectUri: projectUri,
         fileSystem: fileSystem,
         buildRunner: FakeFlutterNativeAssetsBuildRunner(
@@ -154,7 +154,7 @@ void main() {
       await installCodeAssets(
         dartHookResult: dartHookResult,
         environmentDefines: environmentDefines,
-        targetPlatform: TargetPlatform.windows_x64,
+        targetPlatform: const TargetPlatform(.windows, .x64),
         projectUri: projectUri,
         fileSystem: fileSystem,
         nativeAssetsFileUri: nonFlutterTesterAssetUri,
@@ -178,7 +178,7 @@ void main() {
       expect(
         () => runFlutterSpecificHooks(
           environmentDefines: <String, String>{kBuildMode: BuildMode.debug.cliName},
-          targetPlatform: TargetPlatform.linux_x64,
+          targetPlatform: const TargetPlatform(.linux, .x64),
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: FakeFlutterNativeAssetsBuildRunner(
@@ -217,7 +217,7 @@ void main() {
           // Release mode means the dart build has linking enabled.
           kBuildMode: BuildMode.release.cliName,
         },
-        targetPlatform: TargetPlatform.linux_x64,
+        targetPlatform: const TargetPlatform(.linux, .x64),
         projectUri: projectUri,
         fileSystem: fileSystem,
         buildRunner: FakeFlutterNativeAssetsBuildRunner(
@@ -267,7 +267,7 @@ void main() {
       expect(
         () => runFlutterSpecificHooks(
           environmentDefines: <String, String>{kBuildMode: BuildMode.release.cliName},
-          targetPlatform: TargetPlatform.linux_x64,
+          targetPlatform: const TargetPlatform(.linux, .x64),
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: FakeFlutterNativeAssetsBuildRunner(
@@ -338,7 +338,7 @@ void main() {
 
       await runFlutterSpecificHooks(
         environmentDefines: {},
-        targetPlatform: TargetPlatform.tester,
+        targetPlatform: const TargetPlatform(.tester, .unknown),
         projectUri: projectUri,
         fileSystem: fileSystem,
         buildRunner: target,
@@ -381,7 +381,7 @@ CMAKE_LINKER:FILEPATH=/usr/bin/ld.ldd
 
       await runFlutterSpecificHooks(
         environmentDefines: {kBuildMode: 'release'},
-        targetPlatform: TargetPlatform.linux_arm64,
+        targetPlatform: const TargetPlatform(.linux, .arm64),
         projectUri: projectUri,
         fileSystem: fileSystem,
         buildRunner: target,

--- a/packages/flutter_tools/test/general.shard/isolated/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/resident_runner_test.dart
@@ -36,14 +36,17 @@ void main() {
   testUsingContext(
     'use the nativeAssetsYamlFile when provided',
     () => testbed.run(() async {
-      final device = FakeDevice(targetPlatform: TargetPlatform.darwin, sdkNameAndVersion: 'Macos');
+      final device = FakeDevice(
+        targetPlatform: const TargetPlatform(.macos, .x64),
+        sdkNameAndVersion: 'Macos',
+      );
       final residentCompiler = FakeResidentCompiler();
       final flutterDevice = FakeFlutterDevice()
         ..testUri = testUri
         ..vmServiceHost = (() => fakeVmServiceHost)
         ..device = device
         ..fakeDevFS = devFS
-        ..targetPlatform = TargetPlatform.darwin
+        ..targetPlatform = const TargetPlatform(.macos, .x64)
         ..generator = residentCompiler;
 
       fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[listViews, listViews]);

--- a/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
@@ -99,9 +99,9 @@ void main() {
                 : FakeFlutterNativeAssetsBuilderResult.fromAssets(codeAssets: codeAssets),
           );
           final environmentDefines = <String, String>{kBuildMode: buildMode.cliName};
-          final TargetPlatform targetPlatform = flutterTester
-              ? TargetPlatform.tester
-              : TargetPlatform.windows_x64;
+          final targetPlatform = flutterTester
+              ? const TargetPlatform(.tester, .unknown)
+              : const TargetPlatform(.windows, .x64);
           final DartHooksResult dartHookResult = await runFlutterSpecificHooks(
             environmentDefines: environmentDefines,
             targetPlatform: targetPlatform,

--- a/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
@@ -31,7 +31,7 @@ void main() {
     );
 
     final linuxApp = PrebuiltLinuxApp(executable: 'foo');
-    expect(await device.targetPlatform, TargetPlatform.linux_x64);
+    expect(await device.targetPlatform, const TargetPlatform(.linux, .x64));
     expect(device.name, 'Linux');
     expect(await device.installApp(linuxApp), true);
     expect(await device.uninstallApp(linuxApp), true);
@@ -53,7 +53,7 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
       operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.linux_arm64),
     );
-    expect(await deviceArm64Host.targetPlatform, TargetPlatform.linux_arm64);
+    expect(await deviceArm64Host.targetPlatform, const TargetPlatform(.linux, .arm64));
   });
 
   testWithoutContext('LinuxDevice: no devices listed if platform unsupported', () async {

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -35,7 +35,7 @@ void main() {
     );
     final package = FakeMacOSApp();
 
-    expect(await device.targetPlatform, TargetPlatform.darwin);
+    expect(await device.targetPlatform, const TargetPlatform(.macos, .x64));
     expect(device.name, 'macOS');
     expect(await device.installApp(package), true);
     expect(await device.uninstallApp(package), true);

--- a/packages/flutter_tools/test/general.shard/macos/macos_ipad_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_ipad_device_test.dart
@@ -122,7 +122,7 @@ void main() {
     expect(await device.isLocalEmulator, isFalse);
     expect(device.name, 'Mac Designed for iPad');
     expect(device.portForwarder, isNot(isNull));
-    expect(await device.targetPlatform, TargetPlatform.darwin);
+    expect(await device.targetPlatform, const TargetPlatform(.macos, .arm64));
 
     expect(await device.installApp(FakeApplicationPackage()), isTrue);
     expect(await device.isAppInstalled(FakeApplicationPackage()), isTrue);

--- a/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
@@ -1282,7 +1282,7 @@ class FakeIOSDevice extends Fake implements IOSDevice {
   final String name;
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.ios, .arm64);
 
   @override
   Future<bool> isSupported() async => true;

--- a/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
@@ -177,7 +177,7 @@ class TestFlutterDevice extends FlutterDevice {
     : _vmServiceUris = vmServiceUris,
       super(
         generator: FakeResidentCompiler(),
-        targetPlatform: .unsupported,
+        targetPlatform: const TargetPlatform(.unsupported, .unknown),
         buildInfo: BuildInfo.debug,
         developmentShaderCompiler: const FakeShaderCompiler(),
       );
@@ -220,7 +220,7 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   DevelopmentShaderCompiler get developmentShaderCompiler => const FakeShaderCompiler();
 
   @override
-  TargetPlatform targetPlatform = TargetPlatform.android;
+  TargetPlatform targetPlatform = const TargetPlatform(.android, .unknown);
 
   @override
   Stream<Uri?> get vmServiceUris => Stream<Uri?>.value(testUri);
@@ -310,7 +310,7 @@ class FakeDelegateFlutterDevice extends FlutterDevice {
     ResidentCompiler residentCompiler,
     this.fakeDevFS,
   ) : super(
-        targetPlatform: .unsupported,
+        targetPlatform: const TargetPlatform(.unsupported, .unknown),
         buildInfo: buildInfo,
         generator: residentCompiler,
         developmentShaderCompiler: const FakeShaderCompiler(),
@@ -389,7 +389,7 @@ class FakeProjectFileInvalidator extends Fake implements ProjectFileInvalidator 
 class FakeDevice extends Fake implements Device {
   FakeDevice({
     String sdkNameAndVersion = 'Android',
-    TargetPlatform targetPlatform = TargetPlatform.android_arm,
+    TargetPlatform targetPlatform = const TargetPlatform(.android, .armv7),
     bool isLocalEmulator = false,
     this.supportsHotRestart = true,
     this.supportsScreenshot = true,
@@ -416,8 +416,9 @@ class FakeDevice extends Fake implements Device {
   bool supportsFlutterExit;
 
   @override
-  PlatformType get platformType =>
-      _targetPlatform == TargetPlatform.web_javascript ? PlatformType.web : PlatformType.android;
+  PlatformType get platformType => _targetPlatform == const TargetPlatform(.web, .unknown)
+      ? PlatformType.web
+      : PlatformType.android;
 
   @override
   Future<String> get sdkNameAndVersion async => _sdkNameAndVersion;

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -240,7 +240,7 @@ void main() {
         contains(
           Event.hotRunnerInfo(
             label: 'exception',
-            targetPlatform: TargetPlatform.android_arm.getName(),
+            targetPlatform: const TargetPlatform(.android, .armv7).getName(),
             sdkName: 'Android',
             emulator: false,
             fullRestart: false,
@@ -308,7 +308,7 @@ void main() {
         contains(
           Event.hotRunnerInfo(
             label: 'reload-barred',
-            targetPlatform: TargetPlatform.android_arm.getName(),
+            targetPlatform: const TargetPlatform(.android, .armv7).getName(),
             sdkName: 'Android',
             emulator: false,
             fullRestart: false,
@@ -361,7 +361,7 @@ void main() {
         contains(
           Event.hotRunnerInfo(
             label: 'exception',
-            targetPlatform: TargetPlatform.android_arm.getName(),
+            targetPlatform: const TargetPlatform(.android, .armv7).getName(),
             sdkName: 'Android',
             emulator: false,
             fullRestart: false,
@@ -579,7 +579,7 @@ void main() {
       final Event event = fakeAnalytics.sentEvents.first;
       expect(event.eventName.label, 'hot_runner_info');
       expect(event.eventData['label'], 'reload');
-      expect(event.eventData['targetPlatform'], TargetPlatform.android_arm.getName());
+      expect(event.eventData['targetPlatform'], const TargetPlatform(.android, .armv7).getName());
     }),
   );
 
@@ -725,7 +725,10 @@ void main() {
       expect(hotRunnerInfoEvents, hasLength(1));
       final Event newEvent = hotRunnerInfoEvents.first;
       expect(newEvent.eventData['label'], 'restart');
-      expect(newEvent.eventData['targetPlatform'], TargetPlatform.android_arm.getName());
+      expect(
+        newEvent.eventData['targetPlatform'],
+        const TargetPlatform(.android, .armv7).getName(),
+      );
     }),
   );
 
@@ -943,7 +946,7 @@ void main() {
         contains(
           Event.hotRunnerInfo(
             label: 'exception',
-            targetPlatform: TargetPlatform.android_arm.getName(),
+            targetPlatform: const TargetPlatform(.android, .armv7).getName(),
             sdkName: 'Android',
             emulator: false,
             fullRestart: true,
@@ -1310,7 +1313,7 @@ flutter:
     'ResidentRunner printHelpDetails hides v on web in profile mode',
     () => testbed.run(() async {
       final FlutterDevice flutterDevice = await FlutterDevice.create(
-        FakeDevice(targetPlatform: TargetPlatform.web_javascript),
+        FakeDevice(targetPlatform: const TargetPlatform(.web, .unknown)),
         target: 'lib/main.dart',
         buildInfo: BuildInfo.profile,
         platform: FakePlatform(),
@@ -1685,7 +1688,7 @@ flutter:
     'FlutterDevice uses dartdevc configuration when targeting web',
     () async {
       fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-      final device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
+      final device = FakeDevice(targetPlatform: const TargetPlatform(.web, .unknown));
       final residentCompiler =
           (await FlutterDevice.create(
                 device,
@@ -1736,7 +1739,7 @@ flutter:
     'FlutterDevice uses dartdevc configuration when targeting web with null-safety autodetected',
     () async {
       fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-      final device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
+      final device = FakeDevice(targetPlatform: const TargetPlatform(.web, .unknown));
 
       final residentCompiler =
           (await FlutterDevice.create(
@@ -2121,7 +2124,7 @@ flutter:
       final webFlutterDevice = FakeFlutterDevice()
         ..vmServiceHost = (() => fakeVmServiceHost)
         ..fakeDevFS = devFS
-        ..targetPlatform = TargetPlatform.web_javascript;
+        ..targetPlatform = const TargetPlatform(.web, .unknown);
       fakeVmServiceHost = FakeVmServiceHost(
         requests: <VmServiceExpectation>[
           listViews,
@@ -2234,14 +2237,17 @@ flutter:
   testUsingContext(
     'use the nativeAssetsYamlFile when provided',
     () => testbed.run(() async {
-      final device = FakeDevice(targetPlatform: TargetPlatform.darwin, sdkNameAndVersion: 'Macos');
+      final device = FakeDevice(
+        targetPlatform: const TargetPlatform(.macos, .x64),
+        sdkNameAndVersion: 'Macos',
+      );
       final residentCompiler = FakeResidentCompiler();
       final flutterDevice = FakeFlutterDevice()
         ..testUri = testUri
         ..vmServiceHost = (() => fakeVmServiceHost)
         ..device = device
         ..fakeDevFS = devFS
-        ..targetPlatform = TargetPlatform.darwin
+        ..targetPlatform = const TargetPlatform(.macos, .x64)
         ..generator = residentCompiler;
 
       fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[listViews, listViews]);
@@ -2329,7 +2335,7 @@ flutter:
     testUsingContext(
       'correctly caches Web Device compilation',
       () => testbed.run(() {
-        flutterDevice.targetPlatform = TargetPlatform.web_javascript;
+        flutterDevice.targetPlatform = const TargetPlatform(.web, .unknown);
         residentRunner.testCacheInitialDillCompilation();
 
         final String expectedPath = getDefaultCachedKernelPath(
@@ -2349,7 +2355,7 @@ flutter:
     testUsingContext(
       'correctly caches Fuchsia Device compilation',
       () => testbed.run(() {
-        flutterDevice.targetPlatform = TargetPlatform.fuchsia_arm64;
+        flutterDevice.targetPlatform = const TargetPlatform(.fuchsia, .arm64);
         residentRunner.testCacheInitialDillCompilation();
 
         final String expectedPath = getDefaultCachedKernelPath(
@@ -2369,7 +2375,7 @@ flutter:
     testUsingContext(
       'correctly caches Android Device compilation',
       () => testbed.run(() {
-        flutterDevice.targetPlatform = TargetPlatform.android_arm;
+        flutterDevice.targetPlatform = const TargetPlatform(.android, .armv7);
         residentRunner.testCacheInitialDillCompilation();
 
         final String expectedPath = getDefaultCachedKernelPath(

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -2508,7 +2508,7 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   Exception? reportError;
 
   @override
-  TargetPlatform get targetPlatform => TargetPlatform.web_javascript;
+  TargetPlatform get targetPlatform => const TargetPlatform(.web, .unknown);
 
   @override
   ResidentCompiler? generator;

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -3110,7 +3110,7 @@ class FakeDevice extends Fake implements Device {
     this.isConnected = true,
     this.connectionInterface = DeviceConnectionInterface.attached,
     this.platformType = PlatformType.android,
-    TargetPlatform deviceTargetPlatform = TargetPlatform.android,
+    TargetPlatform deviceTargetPlatform = const TargetPlatform(.android, .unknown),
   }) : id = deviceId ?? 'xxx',
        name = deviceName ?? 'test',
        _isSupported = deviceSupported,
@@ -3126,7 +3126,7 @@ class FakeDevice extends Fake implements Device {
     this.isConnected = true,
     this.connectionInterface = DeviceConnectionInterface.wireless,
     this.platformType = PlatformType.android,
-    TargetPlatform deviceTargetPlatform = TargetPlatform.android,
+    TargetPlatform deviceTargetPlatform = const TargetPlatform(.android, .unknown),
   }) : id = deviceId ?? 'xxx',
        name = deviceName ?? 'test',
        _isSupported = deviceSupported,
@@ -3142,7 +3142,7 @@ class FakeDevice extends Fake implements Device {
     this.isConnected = true,
     this.connectionInterface = DeviceConnectionInterface.attached,
     this.platformType = PlatformType.fuchsia,
-    TargetPlatform deviceTargetPlatform = TargetPlatform.fuchsia_arm64,
+    TargetPlatform deviceTargetPlatform = const TargetPlatform(.fuchsia, .arm64),
   }) : id = deviceId ?? 'xxx',
        name = deviceName ?? 'test',
        _isSupported = deviceSupported,
@@ -3204,7 +3204,7 @@ class FakeDevice extends Fake implements Device {
   Category? get category => Category.mobile;
 
   @override
-  Future<String> get targetPlatformDisplayName async => (await targetPlatform).getName();
+  Future<String> get targetPlatformDisplayName async => (await targetPlatform).devicePlatformName;
 }
 
 class FakeIOSDevice extends Fake implements IOSDevice {
@@ -3314,7 +3314,7 @@ class FakeIOSDevice extends Fake implements IOSDevice {
   Future<String> get targetPlatformDisplayName async => 'ios';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.tester;
+  Future<TargetPlatform> get targetPlatform async => const TargetPlatform(.tester, .unknown);
 }
 
 class FakeTerminal extends Fake implements AnsiTerminal {

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -1293,7 +1293,7 @@ void main() {
     final residentRunner = FakeResidentRunner(
       FlutterDevice(
         FakeDevice(),
-        targetPlatform: .unsupported,
+        targetPlatform: const TargetPlatform(.unsupported, .unknown),
         buildInfo: BuildInfo.debug,
         generator: FakeResidentCompiler(),
         developmentShaderCompiler: const FakeShaderCompiler(),
@@ -1674,7 +1674,9 @@ TerminalHandler setUpTerminalHandler(
     ),
     generator: FakeResidentCompiler(),
     developmentShaderCompiler: const FakeShaderCompiler(),
-    targetPlatform: web ? TargetPlatform.web_javascript : TargetPlatform.android_arm,
+    targetPlatform: web
+        ? const TargetPlatform(.web, .unknown)
+        : const TargetPlatform(.android, .armv7),
   );
   device.vmService = nullVmService ? null : FakeVmServiceHost(requests: requests).vmService;
   final residentRunner = FakeResidentRunner(device, testLogger, localFileSystem)

--- a/packages/flutter_tools/test/general.shard/test/web_test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/web_test_compiler_test.dart
@@ -37,8 +37,8 @@ void main() {
     final processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <Pattern>[
-          'Artifact.engineDartAotRuntime.TargetPlatform.web_javascript',
-          'Artifact.frontendServerSnapshotForEngineDartSdk.TargetPlatform.web_javascript',
+          'Artifact.engineDartAotRuntime.web-javascript',
+          'Artifact.frontendServerSnapshotForEngineDartSdk.web-javascript',
           '--sdk-root',
           'HostArtifact.flutterWebSdk/',
           '--incremental',
@@ -118,7 +118,7 @@ void main() {
     final processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <Pattern>[
-          'Artifact.engineDartBinary.TargetPlatform.web_javascript',
+          'Artifact.engineDartBinary.web-javascript',
           'compile',
           'wasm',
           '--packages=.dart_tool/package_config.json',

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -111,7 +111,7 @@ void main() {
       expect(await device.isLocalEmulator, isFalse);
       expect(device.name, 'Flutter test device');
       expect(device.portForwarder, isNot(isNull));
-      expect(await device.targetPlatform, TargetPlatform.tester);
+      expect(await device.targetPlatform, const TargetPlatform(.tester, .unknown));
 
       expect(await device.installApp(FakeApplicationPackage()), isTrue);
       expect(await device.isAppInstalled(FakeApplicationPackage()), isFalse);

--- a/packages/flutter_tools/test/general.shard/windows/build_windows_flavor_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/build_windows_flavor_test.dart
@@ -72,7 +72,7 @@ void main() {
 
   FakeCommand cmakeGenerationCommand({
     String? flavor,
-    TargetPlatform targetPlatform = TargetPlatform.windows_x64,
+    TargetPlatform targetPlatform = const TargetPlatform(.windows, .x64),
   }) {
     final String buildDir = flavor != null && flavor.isNotEmpty
         ? r'C:\build\windows\x64\' + flavor
@@ -93,10 +93,7 @@ void main() {
     );
   }
 
-  FakeCommand buildCommand(
-    String buildMode, {
-    String? flavor,
-  }) {
+  FakeCommand buildCommand(String buildMode, {String? flavor}) {
     final String buildDir = flavor != null && flavor.isNotEmpty
         ? r'C:\build\windows\x64\' + flavor
         : r'C:\build\windows\x64';
@@ -137,7 +134,7 @@ void main() {
       'returns legacy path when no flavor',
       () {
         expect(
-          getWindowsBuildDirectory(TargetPlatform.windows_x64),
+          getWindowsBuildDirectory(const TargetPlatform(.windows, .x64)),
           endsWith(fileSystem.path.join('windows', 'x64')),
         );
       },
@@ -151,7 +148,7 @@ void main() {
       'inserts flavor segment when flavor is set',
       () {
         expect(
-          getWindowsBuildDirectory(TargetPlatform.windows_x64, 'apple'),
+          getWindowsBuildDirectory(const TargetPlatform(.windows, .x64), 'apple'),
           endsWith(fileSystem.path.join('windows', 'x64', 'apple')),
         );
       },

--- a/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
@@ -24,7 +24,7 @@ void main() {
     final File dummyFile = MemoryFileSystem.test().file('dummy');
     final windowsApp = PrebuiltWindowsApp(executable: 'foo', applicationPackage: dummyFile);
 
-    expect(await windowsDevice.targetPlatform, TargetPlatform.windows_x64);
+    expect(await windowsDevice.targetPlatform, const TargetPlatform(.windows, .x64));
     expect(windowsDevice.name, 'Windows');
     expect(await windowsDevice.installApp(windowsApp), true);
     expect(await windowsDevice.uninstallApp(windowsApp), true);

--- a/packages/flutter_tools/test/integration.shard/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/integration.shard/shader_compiler_test.dart
@@ -32,9 +32,9 @@ void main() {
       outputPath: tmpDir.childFile('test_shader.frag.out').path,
       targetPlatform: targetSkslOnly
           // web_javascript compiles to sksl only.
-          ? TargetPlatform.web_javascript
+          ? const TargetPlatform(.web, .unknown)
           // tester compiles to sksl and runtime-stage-vulkan
-          : TargetPlatform.tester,
+          : const TargetPlatform(.tester, .unknown),
     );
   }
 
@@ -66,7 +66,7 @@ void main() {
     final bool compileResult = await shaderCompiler.compileShader(
       input: globals.fs.file(inkSparklePath),
       outputPath: inkSparkleOutputPath,
-      targetPlatform: TargetPlatform.tester,
+      targetPlatform: const TargetPlatform(.tester, .unknown),
     );
     final File resultFile = globals.fs.file(inkSparkleOutputPath);
 

--- a/packages/flutter_tools/test/integration.shard/web_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/integration.shard/web_plugin_registrant_test.dart
@@ -372,7 +372,7 @@ Future<void> _analyzeEntity(FileSystemEntity target) async {
   final ProcessResult exec = await Process.run(
     globals.artifacts!.getArtifactPath(
       Artifact.engineDartBinary,
-      platform: TargetPlatform.web_javascript,
+      platform: const TargetPlatform(.web, .unknown),
     ),
     args,
     workingDirectory: target is Directory ? target.path : target.dirname,
@@ -400,7 +400,7 @@ Future<void> _runFlutterSnapshot(List<String> flutterCommandArgs, Directory work
   final args = <String>[
     globals.artifacts!.getArtifactPath(
       Artifact.engineDartBinary,
-      platform: TargetPlatform.web_javascript,
+      platform: const TargetPlatform(.web, .unknown),
     ),
     flutterToolsSnapshotPath,
     ...flutterCommandArgs,

--- a/packages/flutter_tools/test/src/fake_devices.dart
+++ b/packages/flutter_tools/test/src/fake_devices.dart
@@ -37,7 +37,7 @@ List<FakeDeviceJsonData> fakeDevices = <FakeDeviceJsonData>[
   ),
   FakeDeviceJsonData(
     FakeDevice('webby', 'webby')
-      ..targetPlatform = Future<TargetPlatform>.value(TargetPlatform.web_javascript)
+      ..targetPlatform = Future<TargetPlatform>.value(const TargetPlatform(.web, .unknown))
       ..cpuArch = Future<CpuArch>.value(CpuArch.unknown)
       ..sdkNameAndVersion = Future<String>.value('Web SDK (1.2.4)'),
     <String, Object>{
@@ -90,7 +90,7 @@ List<FakeDeviceJsonData> fakeDevices = <FakeDeviceJsonData>[
         type: PlatformType.ios,
         connectionInterface: DeviceConnectionInterface.wireless,
       )
-      ..targetPlatform = Future<TargetPlatform>.value(TargetPlatform.ios)
+      ..targetPlatform = Future<TargetPlatform>.value(const TargetPlatform(.ios, .arm64))
       ..cpuArch = Future<CpuArch>.value(CpuArch.arm64)
       ..sdkNameAndVersion = Future<String>.value('iOS 16'),
     <String, Object>{
@@ -167,7 +167,9 @@ class FakeDevice extends Device {
   Future<void> dispose() async {}
 
   @override
-  Future<TargetPlatform> targetPlatform = Future<TargetPlatform>.value(TargetPlatform.android_arm);
+  Future<TargetPlatform> targetPlatform = Future<TargetPlatform>.value(
+    const TargetPlatform(.android, .armv7),
+  );
 
   @override
   Future<CpuArch> cpuArch = Future<CpuArch>.value(CpuArch.armv7);


### PR DESCRIPTION
This reverts commit ddb43a36077c7fa8b61ce2a1aa55e71d008ed480.

This is a reland for #189479 with additional fixes applied.

Convert enum TargetPlatform into a class with two fields: TargetPlatformType and CpuArch.