### PR TITLE
Migrate platform_channel_swift example to material_ui

### DIFF
--- a/dev/bots/check_examples_cross_imports.dart
+++ b/dev/bots/check_examples_cross_imports.dart
@@ -585,7 +585,6 @@ class ExamplesCrossImportChecker {
     'examples/multiple_windows/lib/app/window_settings_dialog.dart',
     'examples/multiple_windows/lib/main.dart',
     'examples/multiple_windows/test/multiple_windows_test.dart',
-    'examples/platform_channel_swift/lib/main.dart',
     'examples/platform_view/lib/main.dart',
     'examples/splash/lib/main.dart',
     'examples/splash/test/splash_test.dart',

--- a/examples/platform_channel_swift/lib/main.dart
+++ b/examples/platform_channel_swift/lib/main.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 class PlatformChannel extends StatefulWidget {
   const PlatformChannel({super.key});

--- a/examples/platform_channel_swift/pubspec.yaml
+++ b/examples/platform_channel_swift/pubspec.yaml
@@ -8,6 +8,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
+  material_ui: ^0.0.2
 
 
 dev_dependencies:

--- a/examples/platform_channel_swift/pubspec.yaml
+++ b/examples/platform_channel_swift/pubspec.yaml
@@ -22,4 +22,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: f9g2jl
+# PUBSPEC CHECKSUM: kujv36


### PR DESCRIPTION
Migrates the `platform_channel_swift` example to import material_ui.

Related to https://github.com/flutter/flutter/issues/190093.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
