### PR TITLE
[flutter/flutter] Migrate multiple_windows example to material_ui

### DIFF
--- a/examples/multiple_windows/lib/app/dialog_window_content.dart
+++ b/examples/multiple_windows/lib/app/dialog_window_content.dart
@@ -5,8 +5,8 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'models.dart';
 

--- a/examples/multiple_windows/lib/app/dialog_window_edit_dialog.dart
+++ b/examples/multiple_windows/lib/app/dialog_window_edit_dialog.dart
@@ -5,8 +5,8 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
+import 'package:material_ui/material_ui.dart';
 
 void showDialogWindowEditDialog({
   required BuildContext context,

--- a/examples/multiple_windows/lib/app/main_window.dart
+++ b/examples/multiple_windows/lib/app/main_window.dart
@@ -5,8 +5,8 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'dialog_window_content.dart';
 import 'dialog_window_edit_dialog.dart';
@@ -105,10 +105,7 @@ class _WindowsTable extends StatelessWidget {
 
   void _showWindowEditDialog(BaseWindowController controller, BuildContext context) {
     return switch (controller) {
-      final WindowController regular => showWindowEditDialog(
-        context: context,
-        controller: regular,
-      ),
+      final WindowController regular => showWindowEditDialog(context: context, controller: regular),
       final DialogWindowController dialog => showDialogWindowEditDialog(
         context: context,
         controller: dialog,

--- a/examples/multiple_windows/lib/app/popup_button.dart
+++ b/examples/multiple_windows/lib/app/popup_button.dart
@@ -5,8 +5,8 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'element_position_tracker.dart';
 import 'models.dart';

--- a/examples/multiple_windows/lib/app/popup_window_content.dart
+++ b/examples/multiple_windows/lib/app/popup_window_content.dart
@@ -5,8 +5,8 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
+import 'package:material_ui/material_ui.dart';
 
 class PopupWindowContent extends StatefulWidget {
   /// Creates a popup window widget.

--- a/examples/multiple_windows/lib/app/popup_window_edit_dialog.dart
+++ b/examples/multiple_windows/lib/app/popup_window_edit_dialog.dart
@@ -5,9 +5,9 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
 import 'package:flutter/src/widgets/_window_positioner.dart';
+import 'package:material_ui/material_ui.dart';
 import 'models.dart';
 
 void showPopupWindowEditDialog({

--- a/examples/multiple_windows/lib/app/rotated_wire_cube.dart
+++ b/examples/multiple_windows/lib/app/rotated_wire_cube.dart
@@ -4,7 +4,7 @@
 
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 class RotatedWireCube extends StatefulWidget {

--- a/examples/multiple_windows/lib/app/tooltip_button.dart
+++ b/examples/multiple_windows/lib/app/tooltip_button.dart
@@ -5,8 +5,8 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'element_position_tracker.dart';
 import 'models.dart';

--- a/examples/multiple_windows/lib/app/tooltip_window_content.dart
+++ b/examples/multiple_windows/lib/app/tooltip_window_content.dart
@@ -7,8 +7,8 @@
 
 import 'dart:io' show Platform;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
+import 'package:material_ui/material_ui.dart';
 
 class TooltipWindowContent extends StatelessWidget {
   /// Creates a tooltip window widget.

--- a/examples/multiple_windows/lib/app/tooltip_window_edit_dialog.dart
+++ b/examples/multiple_windows/lib/app/tooltip_window_edit_dialog.dart
@@ -5,9 +5,9 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
 import 'package:flutter/src/widgets/_window_positioner.dart';
+import 'package:material_ui/material_ui.dart';
 import 'models.dart';
 
 void showTooltipWindowEditDialog({

--- a/examples/multiple_windows/lib/app/window_content.dart
+++ b/examples/multiple_windows/lib/app/window_content.dart
@@ -7,8 +7,8 @@
 
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'dialog_window_content.dart';
 import 'models.dart';

--- a/examples/multiple_windows/lib/app/window_edit_dialog.dart
+++ b/examples/multiple_windows/lib/app/window_edit_dialog.dart
@@ -5,8 +5,8 @@
 // ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: implementation_imports
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
+import 'package:material_ui/material_ui.dart';
 
 void showWindowEditDialog({
   required BuildContext context,

--- a/examples/multiple_windows/lib/app/window_settings_dialog.dart
+++ b/examples/multiple_windows/lib/app/window_settings_dialog.dart
@@ -4,9 +4,9 @@
 
 // ignore_for_file: invalid_use_of_internal_member
 
-import 'package:flutter/material.dart';
 // ignore: implementation_imports
 import 'package:flutter/src/widgets/_window_positioner.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'models.dart';
 

--- a/examples/multiple_windows/lib/main.dart
+++ b/examples/multiple_windows/lib/main.dart
@@ -7,9 +7,9 @@
 
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/src/widgets/_window.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'app/main_window.dart';
 import 'app/models.dart';

--- a/examples/multiple_windows/pubspec.yaml
+++ b/examples/multiple_windows/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  material_ui: ^0.0.2
   vector_math: ^2.2.0
 
 dev_dependencies:

--- a/examples/multiple_windows/pubspec.yaml
+++ b/examples/multiple_windows/pubspec.yaml
@@ -17,4 +17,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: dpf2lg
+# PUBSPEC CHECKSUM: mej66b

--- a/examples/multiple_windows/test/multiple_windows_test.dart
+++ b/examples/multiple_windows/test/multiple_windows_test.dart
@@ -4,9 +4,9 @@
 
 // ignore_for_file: invalid_use_of_internal_member
 
-import 'package:flutter/material.dart';
 import 'package:flutter/src/foundation/_features.dart' show isWindowingEnabled;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 // ignore: avoid_relative_lib_imports
 import '../lib/main.dart' as multiple_windows;


### PR DESCRIPTION
Migrates the multiple_windows example to material_ui.

Part of https://github.com/flutter/flutter/issues/190093.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
