### PR TITLE
iOS: Serialise CADisplayLink access in VSyncClient tests

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VSyncClientTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VSyncClientTests.swift
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
 import Testing
 
 @testable import InternalFlutterSwift
@@ -17,6 +18,25 @@ extension TaskRunner {
       postTask {
         continuation.resume(returning: work())
       }
+    }
+  }
+}
+
+extension AsyncStream where Element: Sendable {
+  /// Returns the stream's next element, or `nil` if `timeout` elapses first.
+  fileprivate func next(timeout: TimeInterval) async -> Element? {
+    await withTaskGroup(of: Element?.self) { group in
+      group.addTask {
+        var iterator = self.makeAsyncIterator()
+        return await iterator.next()
+      }
+      group.addTask {
+        try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+        return nil
+      }
+      let result = await group.next() ?? nil
+      group.cancelAll()
+      return result
     }
   }
 }
@@ -207,8 +227,8 @@ struct VSyncClientTests {
       await threadTaskRunner.run { client.await() }
 
       // Wait for the display link to deliver its first vsync on the runner's thread.
-      var vsyncs = vsyncSignals.makeAsyncIterator()
-      _ = await vsyncs.next()
+      let vsync = await vsyncSignals.next(timeout: 1.0)
+      #expect(vsync != nil)
 
       client.invalidate()
     }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VSyncClientTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/VSyncClientTests.swift
@@ -6,6 +6,21 @@ import Testing
 
 @testable import InternalFlutterSwift
 
+extension TaskRunner {
+  /// Runs `work` on this runner's thread and returns its result once complete.
+  ///
+  /// `VSyncClient` owns its `CADisplayLink` on the runner's thread. To prevent races, all
+  /// interactions with it to happen via this call, and are dispatched to the owning thread, never
+  /// invoked directly from the test thread.
+  fileprivate func run<T>(_ work: @escaping () -> T) async -> T {
+    await withCheckedContinuation { continuation in
+      postTask {
+        continuation.resume(returning: work())
+      }
+    }
+  }
+}
+
 struct VSyncClientTests {
   let threadTaskRunner = TaskRunnerTestHelper.makeTaskRunner(withLabel: "VSyncClientTest")
 
@@ -27,7 +42,7 @@ struct VSyncClientTests {
   /// This test passes a newly created, paused `CADisplayLink` (whose properties both evaluate to
   /// 0.0) and asserts that the client intercepts the invalid state and synthesizes a safe, positive
   /// next-frame target timestamp based on the display's maximum refresh rate.
-  @Test func realDisplayLinkVsyncTimestampsCorrect() throws {
+  @Test func realDisplayLinkVsyncTimestampsCorrect() async throws {
     var callbackStartTime: CFTimeInterval = -1
     var callbackTargetTime: CFTimeInterval = -1
     let vsyncClient = VSyncClient(
@@ -40,7 +55,7 @@ struct VSyncClientTests {
     }
     let link = try #require(vsyncClient.displayLink)
 
-    vsyncClient.onDisplayLink(link)
+    await threadTaskRunner.run { vsyncClient.onDisplayLink(link) }
 
     // Since the display link is paused and has not delivered a frame yet, both timestamp and
     // targetTimestamp are 0.0. Verify the client synthesizes a valid target timestamp using the max
@@ -49,7 +64,7 @@ struct VSyncClientTests {
     #expect(abs((callbackTargetTime - callbackStartTime) - 1.0 / 60.0) <= 0.0001)
   }
 
-  @Test func vsyncClientPreventsZeroRefreshRateDivision() throws {
+  @Test func vsyncClientPreventsZeroRefreshRateDivision() async throws {
     var callbackStartTime: CFTimeInterval = -1
     var callbackTargetTime: CFTimeInterval = -1
     // Initialize with maxRefreshRate = 0.0 to simulate uninitialized/zero max refresh rate.
@@ -63,7 +78,7 @@ struct VSyncClientTests {
     }
     let link = try #require(vsyncClient.displayLink)
 
-    vsyncClient.onDisplayLink(link)
+    await threadTaskRunner.run { vsyncClient.onDisplayLink(link) }
 
     #expect(callbackStartTime > 0.0)
     // Should fallback to effectiveRefreshRate of 60.0.
@@ -84,7 +99,7 @@ struct VSyncClientTests {
     #expect(vsyncClient.refreshRate == 60.0)
   }
 
-  @Test func setAllowPauseAfterVsyncCorrect() throws {
+  @Test func setAllowPauseAfterVsyncCorrect() async throws {
     let vsyncClient = VSyncClient(
       taskRunner: threadTaskRunner,
       isVariableRefreshRateEnabled: false,
@@ -92,18 +107,24 @@ struct VSyncClientTests {
     ) { _, _ in }
     let link = try #require(vsyncClient.displayLink)
 
-    vsyncClient.allowPauseAfterVsync = false
-    vsyncClient.await()
-    vsyncClient.onDisplayLink(link)
-    #expect(link.isPaused == false)
+    let pausedWhenDisallowed = await threadTaskRunner.run { () -> Bool in
+      vsyncClient.allowPauseAfterVsync = false
+      vsyncClient.await()
+      vsyncClient.onDisplayLink(link)
+      return link.isPaused
+    }
+    #expect(pausedWhenDisallowed == false)
 
-    vsyncClient.allowPauseAfterVsync = true
-    vsyncClient.await()
-    vsyncClient.onDisplayLink(link)
-    #expect(link.isPaused)
+    let pausedWhenAllowed = await threadTaskRunner.run { () -> Bool in
+      vsyncClient.allowPauseAfterVsync = true
+      vsyncClient.await()
+      vsyncClient.onDisplayLink(link)
+      return link.isPaused
+    }
+    #expect(pausedWhenAllowed)
   }
 
-  @Test func setCorrectVariableRefreshRates() throws {
+  @Test func setCorrectVariableRefreshRates() async throws {
     let maxFrameRate: Double = 120.0
     let vsyncClient = VSyncClient(
       taskRunner: threadTaskRunner,
@@ -113,15 +134,19 @@ struct VSyncClientTests {
     let link = try #require(vsyncClient.displayLink)
 
     if #available(iOS 15.0, *) {
-      #expect(abs(Double(link.preferredFrameRateRange.maximum) - maxFrameRate) <= 0.1)
-      #expect(abs(Double(link.preferredFrameRateRange.preferred ?? 0) - maxFrameRate) <= 0.1)
-      #expect(abs(Double(link.preferredFrameRateRange.minimum) - maxFrameRate / 2) <= 0.1)
+      let range = await threadTaskRunner.run { link.preferredFrameRateRange }
+      #expect(abs(Double(range.maximum) - maxFrameRate) <= 0.1)
+      #expect(abs(Double(range.preferred ?? 0) - maxFrameRate) <= 0.1)
+      #expect(abs(Double(range.minimum) - maxFrameRate / 2) <= 0.1)
     } else {
-      #expect(abs(Double(link.preferredFramesPerSecond) - maxFrameRate) <= 0.1)
+      let framesPerSecond = await threadTaskRunner.run { link.preferredFramesPerSecond }
+      #expect(abs(Double(framesPerSecond) - maxFrameRate) <= 0.1)
     }
   }
 
-  @Test func doNotSetVariableRefreshRatesIfCADisableMinimumFrameDurationOnPhoneIsNotOn() throws {
+  @Test func doNotSetVariableRefreshRatesIfCADisableMinimumFrameDurationOnPhoneIsNotOn()
+    async throws
+  {
     let maxFrameRate: Double = 120.0
     let vsyncClient = VSyncClient(
       taskRunner: threadTaskRunner,
@@ -131,15 +156,17 @@ struct VSyncClientTests {
     let link = try #require(vsyncClient.displayLink)
 
     if #available(iOS 15.0, *) {
-      #expect(abs(Double(link.preferredFrameRateRange.maximum)) <= 0.1)
-      #expect(abs(Double(link.preferredFrameRateRange.preferred ?? 0)) <= 0.1)
-      #expect(abs(Double(link.preferredFrameRateRange.minimum)) <= 0.1)
+      let range = await threadTaskRunner.run { link.preferredFrameRateRange }
+      #expect(abs(Double(range.maximum)) <= 0.1)
+      #expect(abs(Double(range.preferred ?? 0)) <= 0.1)
+      #expect(abs(Double(range.minimum)) <= 0.1)
     } else {
-      #expect(abs(Double(link.preferredFramesPerSecond)) <= 0.1)
+      let framesPerSecond = await threadTaskRunner.run { link.preferredFramesPerSecond }
+      #expect(abs(Double(framesPerSecond)) <= 0.1)
     }
   }
 
-  @Test func awaitAndPauseWillWorkCorrectly() throws {
+  @Test func awaitAndPauseWillWorkCorrectly() async throws {
     let vsyncClient = VSyncClient(
       taskRunner: threadTaskRunner,
       isVariableRefreshRateEnabled: false,
@@ -147,49 +174,56 @@ struct VSyncClientTests {
     ) { _, _ in }
     let link = try #require(vsyncClient.displayLink)
 
-    #expect(link.isPaused)
-    vsyncClient.await()
-    #expect(link.isPaused == false)
-    vsyncClient.pause()
-    #expect(link.isPaused)
+    let (initiallyPaused, pausedAfterAwait, pausedAfterPause) = await threadTaskRunner.run {
+      () -> (Bool, Bool, Bool) in
+      let initiallyPaused = link.isPaused
+      vsyncClient.await()
+      let pausedAfterAwait = link.isPaused
+      vsyncClient.pause()
+      let pausedAfterPause = link.isPaused
+      return (initiallyPaused, pausedAfterAwait, pausedAfterPause)
+    }
+
+    #expect(initiallyPaused)
+    #expect(pausedAfterAwait == false)
+    #expect(pausedAfterPause)
   }
 
-  @Test func releasesLinkOnInvalidation() {
+  @Test func releasesLinkOnInvalidation() async {
     weak var weakClient: VSyncClient?
+    let (vsyncSignals, vsyncContinuation) = AsyncStream.makeStream(of: Void.self)
 
-    autoreleasepool {
-      let vsyncSignal = DispatchSemaphore(value: 0)
+    // Scope the VSyncClient to a nested function so it is released on return.
+    func awaitFirstVsyncThenInvalidate() async {
       let client = VSyncClient(
         taskRunner: threadTaskRunner,
         isVariableRefreshRateEnabled: false,
         maxRefreshRate: 60.0
       ) { _, _ in
-        vsyncSignal.signal()
+        vsyncContinuation.yield()
       }
       weakClient = client
 
-      threadTaskRunner.postTask {
-        client.await()
-      }
+      await threadTaskRunner.run { client.await() }
 
-      #expect(vsyncSignal.wait(timeout: .now() + 1.0) == .success)
+      // Wait for the display link to deliver its first vsync on the runner's thread.
+      var vsyncs = vsyncSignals.makeAsyncIterator()
+      _ = await vsyncs.next()
 
       client.invalidate()
     }
+    await awaitFirstVsyncThenInvalidate()
 
-    let backgroundThreadFlushed = DispatchSemaphore(value: 0)
-    threadTaskRunner.postTask {
-      backgroundThreadFlushed.signal()
-    }
-
-    #expect(backgroundThreadFlushed.wait(timeout: .now() + 1.0) == .success)
+    // Flush the task queue to ensure the invalidate() dispatched to the runner on dealloc has run.
+    await threadTaskRunner.run {}
     #expect(weakClient == nil)
   }
 
-  @Test func deallocatesWithoutExplicitInvalidation() {
+  @Test func deallocatesWithoutExplicitInvalidation() async {
     weak var weakClient: VSyncClient?
 
-    autoreleasepool {
+    // Scope the VSyncClient to a nested function so it is released on return.
+    func create() {
       let client = VSyncClient(
         taskRunner: threadTaskRunner,
         isVariableRefreshRateEnabled: false,
@@ -197,7 +231,11 @@ struct VSyncClientTests {
       ) { _, _ in }
       weakClient = client
     }
+    create()
 
+    // Flush the task queue to run the registration task dispatched in init. That task holds only a
+    // weak reference to the client, so the client can dealloc.
+    await threadTaskRunner.run {}
     #expect(weakClient == nil)
   }
 
@@ -205,24 +243,23 @@ struct VSyncClientTests {
   /// the display server has taken ownership of the link. On iOS 27+, QuartzCore holds a
   /// `_CADisplayLinkAssertion` on registered links; a never-unpaused link may therefore
   /// outlive `VSyncClient` itself, which is expected.
-  @Test func deallocatesAfterRegistrationCompletes() {
+  @Test func deallocatesAfterRegistrationCompletes() async {
     weak var weakClient: VSyncClient?
 
-    autoreleasepool {
+    // Scope the VSyncClient to a nested function so it is released on return.
+    func createAndAwaitRegistration() async {
       let client = VSyncClient(
         taskRunner: threadTaskRunner,
         isVariableRefreshRateEnabled: false,
         maxRefreshRate: 60.0
       ) { _, _ in }
-
       weakClient = client
 
-      // Registration is dispatched to the task runner in init. Post a barrier task after it
-      // so we know registration has completed before deinit fires.
-      let registered = DispatchSemaphore(value: 0)
-      threadTaskRunner.postTask { registered.signal() }
-      #expect(registered.wait(timeout: .now() + 1.0) == .success)
+      // Flush the task queue to run the registration dispatched in init. This ensures registration
+      // has completed before the strong reference is released.
+      await threadTaskRunner.run {}
     }
+    await createAndAwaitRegistration()
 
     #expect(weakClient == nil)
   }


### PR DESCRIPTION
VSyncClientTests were reaching into the client's CADisplayLink from the test thread, reading properties like isPaused, calling onDisplayLink directly, inspecting the frame rate range, etc. However, VSyncClient registration, vsync callbacks, and invalidation run on the dedicated worker thread it was handed as a task runner. CADisplayLink is not thread-safe, so this was an unsynchronised data race between the code running on the test thread and the code running on the worker.

VSyncClient is built around the assumption that its display link is only ever referenced on its task runner's thread. Right now tests violate that invariant. While this isn't actively buggy at the moment, it's not safe to write the tests this way.

This forces every interaction with the CADsiaplyLink through a new run() helper that dispatches onto the runner and returns the result. Test assertions remain on the test thread. I've moved the object-lifetime tests off the autoreleasepool and onto the sam async model. We also migrate to AsyncStream for the vsync signal and a run {} barrier for registration/flushing. It scopes the client's only strong reference to a nested func so we release deterministically on return. It also means we get rid of the blocking code altogether.

Issue: https://github.com/flutter/flutter/issues/181684
Issue: https://github.com/flutter/flutter/issues/112232

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
