### PR TITLE
[AGP 9] Base the KGP warning on applied plugins, not build file text

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -83,6 +83,19 @@ object FlutterPluginUtils {
         "https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers#report-incompatible-kotlin-gradle-plugin-usage-to-plugin-authors"
 
     /**
+     * The Kotlin Gradle Plugin (KGP) id for Android.
+     */
+    internal const val KGP_PLUGIN_ID = "org.jetbrains.kotlin.android"
+
+    /**
+     * The legacy alias KGP registers for [KGP_PLUGIN_ID].
+     *
+     * Gradle resolves a plugin id to its implementation class, so as long as a KGP release publishes descriptors
+     * for both ids, querying either one reports a KGP applied under the other.
+     */
+    internal const val KGP_LEGACY_PLUGIN_ID = "kotlin-android"
+
+    /**
      * Matches the AGP application plugin declaration in Kotlin DSL (`build.gradle.kts`).
      * Targets `id("com.android.application")` or `alias(libs.plugins.android.application)`
      * within a `plugins { ... }` block.
@@ -104,6 +117,18 @@ object FlutterPluginUtils {
      * Matches the KGP declaration in Kotlin DSL (`build.gradle.kts`).
      * Targets `kotlin-android`, `org.jetbrains.kotlin.android`, or version catalog aliases
      * for Kotlin Android within a `plugins { ... }` block.
+     *
+     * Unlike [kgpRegexGroovy] this deliberately does not match the imperative
+     * `apply(plugin = "kotlin-android")` form, even though that is valid Kotlin DSL. A match here means
+     * "the subproject applies KGP itself", which suppresses the fallback in
+     * [detectApplyingKotlinGradlePlugin] that applies KGP on the subproject's behalf. Plugins commonly write
+     * that imperative call behind a guard such as `if (agpMajor < 9)`, which is false on AGP 9 while
+     * `android.builtInKotlin=false` still leaves Kotlin uncompiled, so honoring the text would suppress the
+     * fallback exactly when the subproject needs it and fail the build with
+     * `Extension of type 'KotlinAndroidProjectExtension' does not exist`.
+     *
+     * Under-matching is the safe direction here: the fallback re-applying KGP to a subproject that already has
+     * it is a no-op, and the report in [detectApplyingKotlinGradlePlugin] no longer depends on this regex.
      */
     internal val kgpRegexKotlin =
         """(?m)^[ \t]*plugins[ \t]*\{[^{}]*?(?<=[\n{])[ \t]*(?:id|alias)[ \t]*\(\s*(['"](?:kotlin-android|org\.jetbrains\.kotlin\.android)['"]|libs\.plugins\.(?:android|kotlin)\.android)\s*\)(?=[ \t]*(\n|${'$'}|\}))"""
@@ -566,9 +591,14 @@ object FlutterPluginUtils {
     @JvmStatic
     @JvmName("detectApplyingKotlinGradlePlugin")
     internal fun detectApplyingKotlinGradlePlugin(project: Project) {
-        val pluginsWithKGPAppliedList = mutableListOf<String>()
         val agpVersion = VersionFetcher.getAGPVersion(project)
-        var shouldLogForApp = false
+
+        // Android subprojects that the report may name, paired with the roles their build script declares.
+        val androidSubprojects = mutableListOf<Pair<Project, SubprojectPluginState>>()
+        // Subprojects this function applied KGP to. They apply KGP because Flutter asked them to, not because
+        // they are unmigrated, so naming them in the report would tell app developers to chase their own build.
+        val subprojectsFlutterAppliedKgpTo = mutableSetOf<String>()
+
         project.rootProject.subprojects {
             val pluginState = getSubprojectPluginState(this) ?: return@subprojects
 
@@ -577,7 +607,8 @@ object FlutterPluginUtils {
 
             if (!isBuiltInKotlinEnabled(project, agpVersion) && !pluginState.hasKgpPlugin) {
                 try {
-                    pluginManager.apply("kotlin-android")
+                    pluginManager.apply(KGP_LEGACY_PLUGIN_ID)
+                    subprojectsFlutterAppliedKgpTo.add(path)
                 } catch (_: Exception) {
                     logger.quiet(
                         """
@@ -589,18 +620,11 @@ object FlutterPluginUtils {
                 }
             }
 
-            // Apply AGP exists and Apply KGP also exists in build.gradle
-            if (pluginState.hasAppPlugin && pluginState.hasKgpPlugin) {
-                shouldLogForApp = true
-            }
-
-            if (pluginState.hasLibPlugin && pluginState.hasKgpPlugin) {
-                pluginsWithKGPAppliedList.add(name)
-            }
+            androidSubprojects.add(this to pluginState)
         }
 
-        // If no imperative apply KGP declarations were found, there is nothing to log.
-        if (!shouldLogForApp && pluginsWithKGPAppliedList.isEmpty()) {
+        // No Android subprojects means there is nothing that could apply KGP, so there is nothing to report.
+        if (androidSubprojects.isEmpty()) {
             return
         }
 
@@ -608,6 +632,24 @@ object FlutterPluginUtils {
             if (agpVersion == null || agpVersion.major < 9) {
                 return@projectsEvaluated
             }
+
+            // Whether a subproject applies KGP is decided here rather than from the earlier scan of its build
+            // script. A build script can declare KGP behind a conditional that never runs, and can apply it by
+            // routes no regex can see, so only the evaluated plugin container knows the answer.
+            var shouldLogForApp = false
+            val pluginsWithKGPAppliedList = mutableListOf<String>()
+            for ((subproject, pluginState) in androidSubprojects) {
+                if (subproject.path in subprojectsFlutterAppliedKgpTo) continue
+                if (!hasKotlinAndroidPluginApplied(subproject)) continue
+
+                if (pluginState.hasAppPlugin) {
+                    shouldLogForApp = true
+                }
+                if (pluginState.hasLibPlugin) {
+                    pluginsWithKGPAppliedList.add(subproject.name)
+                }
+            }
+
             if (shouldLogForApp) {
                 project.logger.error(
                     """
@@ -633,6 +675,17 @@ object FlutterPluginUtils {
             )
         }
     }
+
+    /**
+     * Whether [subproject] has the Kotlin Gradle Plugin applied, as opposed to merely declaring it.
+     *
+     * Only meaningful once [subproject] has been evaluated, which for the subprojects of a Flutter app means
+     * inside a `Gradle.projectsEvaluated` callback.
+     *
+     * Both ids are queried so that this keeps working for a KGP release that publishes only one of them.
+     */
+    internal fun hasKotlinAndroidPluginApplied(subproject: Project): Boolean =
+        subproject.pluginManager.hasPlugin(KGP_PLUGIN_ID) || subproject.pluginManager.hasPlugin(KGP_LEGACY_PLUGIN_ID)
 
     /**
      * Represents whether Kotlin Gradle Plugin, Android Gradle Plugin (for applications), and the

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
@@ -44,6 +44,7 @@ import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.process.ExecOperations
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
+import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -70,12 +71,24 @@ import kotlin.test.assertTrue
  *           For more details, see [Gradle Plugins Block Docs](https://docs.gradle.org/current/userguide/plugins_intermediate.html#sec:plugins_block).
  * @property imperativelyAppliedPlugins Plugins applied via the imperative `apply plugin:` statement.
  *           For more details, see [Gradle Old Plugin Application Docs](https://docs.gradle.org/current/userguide/plugins_intermediate.html#sec:old_plugin_application).
+ * @property dslType The DSL the build script is written in, which decides whether it is named
+ *           `build.gradle` or `build.gradle.kts` and which imperative spelling it uses.
+ * @property pluginIdsAppliedAtRuntimeOverride The plugin ids the subproject actually applies when Gradle evaluates
+ *           it, for build scripts whose text and runtime behavior disagree. `null` means every declared plugin is
+ *           applied, which is the common case. Set it to model a conditional declaration such as
+ *           `if (!builtInKotlinEnabled) { apply plugin: 'kotlin-android' }`, where the id appears in the text but
+ *           the guard skips it.
  */
 private data class SubprojectConfig(
     val name: String,
     val declarativelyAppliedPlugins: List<String> = emptyList(),
-    val imperativelyAppliedPlugins: List<String> = emptyList()
-)
+    val imperativelyAppliedPlugins: List<String> = emptyList(),
+    val dslType: FlutterPluginUtilsTest.DslType = FlutterPluginUtilsTest.DslType.GROOVY,
+    val pluginIdsAppliedAtRuntimeOverride: List<String>? = null
+) {
+    fun pluginIdsAppliedAtRuntime(): List<String> =
+        pluginIdsAppliedAtRuntimeOverride ?: (declarativelyAppliedPlugins + imperativelyAppliedPlugins)
+}
 
 private class TestEnvironment(
     val appProject: Project,
@@ -83,9 +96,14 @@ private class TestEnvironment(
     val subprojectsActionSlot: io.mockk.CapturingSlot<Action<Project>> = slot(),
     val projectsEvaluatedActionSlot: io.mockk.CapturingSlot<Action<Gradle>> = slot()
 ) {
-    val appPluginManager: PluginManager get() = appProject.pluginManager
-    val plugin1Manager: PluginManager get() = plugins[0].pluginManager
-    val plugin2Manager: PluginManager get() = plugins[1].pluginManager
+    // Resolved once up front. Reading one of these inside a `verify(exactly = 0) { ... }` block must not itself
+    // record a `getPluginManager()` call on the project mock, or the block fails on its own bookkeeping.
+    private val appManager: PluginManager = appProject.pluginManager
+    private val pluginManagers: List<PluginManager> = plugins.map { it.pluginManager }
+
+    val appPluginManager: PluginManager get() = appManager
+    val plugin1Manager: PluginManager get() = pluginManagers[0]
+    val plugin2Manager: PluginManager get() = pluginManagers[1]
 }
 
 class FlutterPluginUtilsTest {
@@ -753,9 +771,17 @@ class FlutterPluginUtilsTest {
                 }
             val imperativeBlock =
                 if (imperativelyAppliedPlugins.isNotEmpty()) {
-                    // Expected output of imperativeBlock if imperativelyAppliedPlugins contains ["kotlin-android"]:
-                    // apply plugin: 'kotlin-android'
-                    imperativelyAppliedPlugins.joinToString("\n") { "apply plugin: '$it'" } + "\n"
+                    // The imperative spelling differs per DSL, so it is derived from the build file extension.
+                    // Expected output if imperativelyAppliedPlugins contains ["kotlin-android"]:
+                    //   build.gradle      -> apply plugin: 'kotlin-android'
+                    //   build.gradle.kts  -> apply(plugin = "kotlin-android")
+                    val format: (String) -> String =
+                        if (extension == "kts") {
+                            { "apply(plugin = \"$it\")" }
+                        } else {
+                            { "apply plugin: '$it'" }
+                        }
+                    imperativelyAppliedPlugins.joinToString("\n", transform = format) + "\n"
                 } else {
                     ""
                 }
@@ -787,6 +813,36 @@ class FlutterPluginUtilsTest {
                 assertSingeLinePluginDetection(FlutterPluginUtils.kgpRegexGroovy, "kotlin-android", DslType.GROOVY)
                 assertSingeLinePluginDetection(FlutterPluginUtils.kgpRegexKotlin, "org.jetbrains.kotlin.android", DslType.KOTLIN)
                 assertSingeLinePluginDetection(FlutterPluginUtils.kgpRegexGroovy, "org.jetbrains.kotlin.android", DslType.GROOVY)
+            }
+
+            @Test
+            fun `KGP Kotlin DSL regex does not match imperative apply`() {
+                // Deliberate, and load bearing. A match tells detectApplyingKotlinGradlePlugin that the subproject
+                // applies KGP itself, which stops Flutter applying it on the subproject's behalf. Plugins put this
+                // call behind guards like `if (agpMajor < 9)` that are false on AGP 9, so honoring the text breaks
+                // `android.builtInKotlin=false` builds with "Extension of type 'KotlinAndroidProjectExtension'
+                // does not exist". Verified against device_info_plus 13.2.0 on AGP 9.1.
+                assertFalse(FlutterPluginUtils.kgpRegexKotlin.containsMatchIn("""apply(plugin = "kotlin-android")"""))
+                assertFalse(
+                    FlutterPluginUtils.kgpRegexKotlin.containsMatchIn("""apply(plugin = "org.jetbrains.kotlin.android")""")
+                )
+            }
+
+            @Test
+            fun `KGP Kotlin DSL regex does not match imperative apply nested in a conditional`() {
+                // The exact shape of device_info_plus 13.2.0's android/build.gradle.kts.
+                val guardedImperativeApply =
+                    """
+                    plugins {
+                        id("com.android.library")
+                    }
+
+                    if (agpMajor < 9) {
+                        apply(plugin = "org.jetbrains.kotlin.android")
+                    }
+                    """.trimIndent()
+                assertTrue(FlutterPluginUtils.libPluginRegexKotlin.containsMatchIn(guardedImperativeApply))
+                assertFalse(FlutterPluginUtils.kgpRegexKotlin.containsMatchIn(guardedImperativeApply))
             }
 
             @Test
@@ -1158,6 +1214,31 @@ class FlutterPluginUtilsTest {
             }
 
             @Test
+            fun `reports no KGP for a Kotlin DSL library that only applies it imperatively`(
+                @TempDir tempDir: Path
+            ) {
+                // So that detectApplyingKotlinGradlePlugin still applies KGP on this subproject's behalf when
+                // Built-in Kotlin is off. See the note on FlutterPluginUtils.kgpRegexKotlin.
+                val buildFile = tempDir.resolve("build.gradle.kts").toFile()
+                writeBuildFile(
+                    buildFile = buildFile,
+                    declarativelyAppliedPlugins = listOf("com.android.library"),
+                    imperativelyAppliedPlugins = listOf("org.jetbrains.kotlin.android")
+                )
+                val subproject = mockk<Project>()
+                every { subproject.buildFile } returns buildFile
+                every { subproject.projectDir } returns tempDir.toFile()
+                every { subproject.logger } returns mockk(relaxed = true)
+
+                val state = FlutterPluginUtils.getSubprojectPluginState(subproject)
+
+                assertNotNull(state)
+                assertFalse(state.hasAppPlugin)
+                assertFalse(state.hasKgpPlugin)
+                assertTrue(state.hasLibPlugin)
+            }
+
+            @Test
             fun `does not detect KGP or AGP in Kotlin DSL`(
                 @TempDir tempDir: Path
             ) {
@@ -1177,6 +1258,40 @@ class FlutterPluginUtilsTest {
                 assertFalse(state.hasAppPlugin)
                 assertFalse(state.hasKgpPlugin)
                 assertFalse(state.hasLibPlugin)
+            }
+        }
+
+        /**
+         * These exercise a real Gradle project rather than a mock, because the value of
+         * [FlutterPluginUtils.hasKotlinAndroidPluginApplied] rests entirely on how Gradle's plugin container answers
+         * once a subproject has been evaluated. A mocked `PluginManager` can only replay what it was told.
+         */
+        @Nested
+        inner class HasKotlinAndroidPluginAppliedTests {
+            @Test
+            fun `is false for an Android library that never applies KGP`() {
+                val project = ProjectBuilder.builder().build()
+                project.pluginManager.apply("com.android.library")
+
+                assertFalse(FlutterPluginUtils.hasKotlinAndroidPluginApplied(project))
+            }
+
+            @Test
+            fun `is true when KGP is applied under its legacy id`() {
+                val project = ProjectBuilder.builder().build()
+                project.pluginManager.apply("com.android.library")
+                project.pluginManager.apply(FlutterPluginUtils.KGP_LEGACY_PLUGIN_ID)
+
+                assertTrue(FlutterPluginUtils.hasKotlinAndroidPluginApplied(project))
+            }
+
+            @Test
+            fun `is true when KGP is applied under its modern id`() {
+                val project = ProjectBuilder.builder().build()
+                project.pluginManager.apply("com.android.library")
+                project.pluginManager.apply(FlutterPluginUtils.KGP_PLUGIN_ID)
+
+                assertTrue(FlutterPluginUtils.hasKotlinAndroidPluginApplied(project))
             }
         }
 
@@ -1324,20 +1439,30 @@ class FlutterPluginUtilsTest {
 
             private fun createSubproject(
                 tempDir: Path,
-                projectName: String,
-                declarativelyAppliedPlugins: List<String> = emptyList(),
-                imperativelyAppliedPlugins: List<String> = emptyList()
+                config: SubprojectConfig
             ): Project {
+                val projectName = config.name
                 val rootDir = tempDir.toFile()
                 every { rootProject.file("gradle.properties") } returns File(rootDir, "gradle.properties")
                 every { rootProject.projectDir } returns rootDir
 
                 val projectDir = tempDir.resolve(projectName).toFile().apply { mkdirs() }
-                val buildGradleFile = File(projectDir, "build.gradle")
-                writeBuildFile(buildGradleFile, declarativelyAppliedPlugins, imperativelyAppliedPlugins)
+                val buildFileName = if (config.dslType == DslType.KOTLIN) "build.gradle.kts" else "build.gradle"
+                val buildGradleFile = File(projectDir, buildFileName)
+                writeBuildFile(buildGradleFile, config.declarativelyAppliedPlugins, config.imperativelyAppliedPlugins)
+
+                // Model Gradle's plugin container rather than a blanket `false`: `hasPlugin` reports the ids the
+                // subproject actually ends up with, and `apply` adds to them the way `PluginManager.apply` does.
+                val appliedPluginIds = config.pluginIdsAppliedAtRuntime().toMutableSet()
                 val pluginManager = mockk<PluginManager>(relaxed = true)
+                every { pluginManager.hasPlugin(any()) } answers { firstArg<String>() in appliedPluginIds }
+                every { pluginManager.apply(any<String>()) } answers {
+                    appliedPluginIds += firstArg<String>()
+                }
+
                 val project = mockk<Project>()
                 every { project.name } returns projectName
+                every { project.path } returns ":$projectName"
                 every { project.projectDir } returns projectDir
                 every { project.buildFile } returns buildGradleFile
                 every { project.logger } returns mockLogger
@@ -1375,23 +1500,9 @@ class FlutterPluginUtilsTest {
                 }
                 every { VersionFetcher.getAGPVersion(any()) } returns agpVersion
 
-                val appProject =
-                    createSubproject(
-                        tempDir = tempDir,
-                        projectName = appConfig.name,
-                        declarativelyAppliedPlugins = appConfig.declarativelyAppliedPlugins,
-                        imperativelyAppliedPlugins = appConfig.imperativelyAppliedPlugins
-                    )
+                val appProject = createSubproject(tempDir = tempDir, config = appConfig)
 
-                val pluginProjects =
-                    pluginConfigs.map { config ->
-                        createSubproject(
-                            tempDir = tempDir,
-                            projectName = config.name,
-                            declarativelyAppliedPlugins = config.declarativelyAppliedPlugins,
-                            imperativelyAppliedPlugins = config.imperativelyAppliedPlugins
-                        )
-                    }
+                val pluginProjects = pluginConfigs.map { config -> createSubproject(tempDir = tempDir, config = config) }
 
                 val allProjects = setOf(appProject) + pluginProjects
                 every { rootProject.subprojects } returns allProjects
@@ -1463,6 +1574,69 @@ class FlutterPluginUtilsTest {
                     verify(exactly = 1) { rootProject.subprojects(any<Action<Project>>()) }
                     verify(exactly = 0) { testProject.appPluginManager.apply("kotlin-android") }
                     verify(exactly = 0) { testProject.plugin1Manager.apply("kotlin-android") }
+                }
+
+                @Test
+                fun `does not warn about a plugin whose KGP declaration is guarded and never applies`(
+                    @TempDir tempDir: Path
+                ) {
+                    val testProject =
+                        setupTest(
+                            tempDir = tempDir,
+                            agpVersion = templateAgpVersion,
+                            builtInKotlin = "true",
+                            appConfig = SubprojectConfig("app", declarativelyAppliedPlugins = listOf("com.android.application")),
+                            pluginConfigs =
+                                listOf(
+                                    SubprojectConfig(
+                                        "plugin",
+                                        imperativelyAppliedPlugins = listOf("com.android.library", "kotlin-android"),
+                                        // The plugin has migrated: its `apply plugin: 'kotlin-android'` sits behind a
+                                        // guard that Built-in Kotlin makes false, so KGP is never actually applied.
+                                        pluginIdsAppliedAtRuntimeOverride = listOf("com.android.library")
+                                    )
+                                )
+                        )
+
+                    executeDetectApplyingKotlinGradlePlugin(testProject)
+
+                    verify(exactly = 0) { mockLogger.error(any()) }
+                }
+
+                @Test
+                fun `warns about a plugin that applies KGP without declaring it in its build script`(
+                    @TempDir tempDir: Path
+                ) {
+                    val testProject =
+                        setupTest(
+                            tempDir = tempDir,
+                            agpVersion = templateAgpVersion,
+                            builtInKotlin = "true",
+                            appConfig = SubprojectConfig("app", declarativelyAppliedPlugins = listOf("com.android.application")),
+                            pluginConfigs =
+                                listOf(
+                                    SubprojectConfig(
+                                        "plugin",
+                                        declarativelyAppliedPlugins = listOf("com.android.library"),
+                                        // KGP arrives by a route no regex over this build script can see, such as a
+                                        // convention plugin or an `apply from:` of another script.
+                                        pluginIdsAppliedAtRuntimeOverride =
+                                            listOf("com.android.library", "org.jetbrains.kotlin.android")
+                                    )
+                                )
+                        )
+
+                    executeDetectApplyingKotlinGradlePlugin(testProject)
+
+                    verify {
+                        mockLogger.error(
+                            match {
+                                it.contains("WARNING: Your app uses the following plugins") &&
+                                    it.contains("plugin") &&
+                                    it.contains(BUILT_IN_KOTLIN_DOCS_FOR_PLUGINS)
+                            }
+                        )
+                    }
                 }
             }
 
@@ -1664,6 +1838,38 @@ class FlutterPluginUtilsTest {
                         verify(exactly = 0) { testProject.appPluginManager.apply("kotlin-android") }
                         verify(exactly = 0) { testProject.plugin1Manager.apply("kotlin-android") }
                         verify(exactly = 0) { testProject.plugin2Manager.apply("kotlin-android") }
+                    }
+
+                    @Test
+                    fun `applies KGP to a Kotlin DSL plugin whose imperative apply is skipped by its own guard`(
+                        @TempDir tempDir: Path
+                    ) {
+                        // device_info_plus 13.2.0: `plugins { id("com.android.library") }` plus
+                        // `if (agpMajor < 9) { apply(plugin = "org.jetbrains.kotlin.android") }`. On AGP 9 that guard
+                        // is false, so nothing applies KGP unless Flutter does. Reading the imperative line as a
+                        // declaration would strand the subproject without Kotlin support and fail the build.
+                        val testProject =
+                            setupTest(
+                                tempDir = tempDir,
+                                agpVersion = templateAgpVersion,
+                                builtInKotlin = "false",
+                                appConfig = SubprojectConfig("app", declarativelyAppliedPlugins = listOf("com.android.application")),
+                                pluginConfigs =
+                                    listOf(
+                                        SubprojectConfig(
+                                            "plugin",
+                                            declarativelyAppliedPlugins = listOf("com.android.library"),
+                                            imperativelyAppliedPlugins = listOf("org.jetbrains.kotlin.android"),
+                                            dslType = DslType.KOTLIN,
+                                            pluginIdsAppliedAtRuntimeOverride = listOf("com.android.library")
+                                        )
+                                    )
+                            )
+
+                        executeDetectApplyingKotlinGradlePlugin(testProject)
+
+                        val plugin1Manager = testProject.plugin1Manager
+                        verify(exactly = 1) { plugin1Manager.apply("kotlin-android") }
                     }
 
                     @Test


### PR DESCRIPTION
`detectApplyingKotlinGradlePlugin` decides which plugins to name in its Built-in Kotlin warning by regex-matching each subproject's build script for a KGP declaration. A textual match cannot see a conditional, so a plugin that guards its `apply plugin: 'kotlin-android'` behind a check on `android.builtInKotlin` is named even though it applied nothing.

That makes the warning unactionable, which the style guide's [Only log actionable messages to the console](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#only-log-actionable-messages-to-the-console) rule asks warnings not to be: the attached advice is "upgrade to a version that supports Built-in Kotlin", and for an already-migrated plugin no such version exists, so the only available response is to ignore the message. The list also never shrinks as plugins migrate, so it cannot be used to track progress through a migration.

This splits the function into two passes:

- The first pass still scans build scripts, but only to decide whether Flutter applies KGP on a subproject's behalf. That decision necessarily precedes evaluation, so it cannot use runtime state.
- The second pass, inside the existing `projectsEvaluated` callback, builds the report from `PluginManager.hasPlugin` — the only source that knows what a subproject actually applied.

Subprojects that Flutter itself applied KGP to are excluded from the report. Without that exclusion, `android.builtInKotlin=false` would name every plugin in the build, since Flutter applies KGP to all of them on that path.

Reporting from runtime state also catches plugins that apply KGP by a route no regex can see, such as a convention plugin or `apply from:`.

## Verification on a real build

`flutter create` app on AGP 9.1.0 / Kotlin 2.4.0 / Gradle 9.3.1, depending on `app_settings` 8.0.3, whose `android/build.gradle` guards KGP on `android.builtInKotlin`. `PROBE` lines come from a `projectsEvaluated` hook added to the app's `build.gradle.kts` to show what Gradle itself reports in the same phase the warning is emitted from.

With `android.builtInKotlin=true`, before:

```
WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): app_settings
PROBE app_settings: kgp=false legacyKgp=false
✓ Built build/app/outputs/flutter-apk/app-debug.apk
```

Flutter names the plugin; Gradle says it never applied KGP. After this change the warning is gone and the build still succeeds.

With `android.builtInKotlin=false` the output is unchanged from before the patch — `app_settings` is still named, because on that path it genuinely does apply KGP:

```
WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): app_settings
PROBE app_settings: kgp=true legacyKgp=true
✓ Built build/app/outputs/flutter-apk/app-debug.apk
```

## Note on `kgpRegexKotlin`

This also documents why `kgpRegexKotlin` deliberately does not match the imperative `apply(plugin = "...")` form, unlike `kgpRegexGroovy`. Matching it suppresses the fallback that applies KGP for a subproject whose own guard skipped it. Tried against `device_info_plus` 13.2.0, which guards on `if (agpMajor < 9)`: on AGP 9 with `android.builtInKotlin=false` the build fails with `Extension of type 'KotlinAndroidProjectExtension' does not exist`. Under-matching is the safe direction, and now that the report no longer depends on this regex, the only cost is a redundant no-op `apply`.

## Tests

Nine tests in total.

Three for the reporting change: a guarded declaration produces no warning, a plugin that applies KGP without declaring it does produce one, and a subproject whose guard skips its imperative apply still gets KGP applied by Flutter.

Three pin the `kgpRegexKotlin` behavior described above, so the imperative form is not "fixed" into matching without understanding the consequence. One of them uses the exact shape of `device_info_plus` 13.2.0's build script.

Three exercise a real Gradle project via `ProjectBuilder` rather than a mocked `PluginManager`, since the change rests on how Gradle's plugin container answers after evaluation.

The mocked `PluginManager` in the existing test harness previously answered `false` to every `hasPlugin` call; it now tracks the ids a subproject declares and the ones `apply` adds, so it models Gradle instead of contradicting it. Existing coverage for `android.builtInKotlin=false` is unchanged and still passes.

Full module suite: 191 tests, 0 failures. `ktlint` 1.5.0 clean against the repo baseline and editorconfig.

Fixes https://github.com/flutter/flutter/issues/189770

*Prepared with AI assistance (Claude); see the `Co-Authored-By` trailer on the commit.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
