### PR TITLE
a11y: Map disabled/read-only semantics to AX node restriction

### DIFF
--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -373,6 +373,11 @@ void AccessibilityBridge::SetStateFromFlutterUpdate(ui::AXNodeData& node_data,
   if (flags->is_text_field && !flags->is_read_only) {
     node_data.AddState(ax::mojom::State::kEditable);
   }
+  if (flags->is_enabled == FlutterTristate::kFlutterTristateFalse) {
+    node_data.SetRestriction(ax::mojom::Restriction::kDisabled);
+  } else if (flags->is_read_only) {
+    node_data.SetRestriction(ax::mojom::Restriction::kReadOnly);
+  }
   if (node_data.role == ax::mojom::Role::kStaticText &&
       (actions & kHasScrollingAction) == 0 && node.value.empty() &&
       node.label.empty() && node.hint.empty()) {

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
@@ -302,6 +302,60 @@ TEST(AccessibilityBridgeTest, SliderHasSliderRole) {
   EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kSlider);
 }
 
+TEST(AccessibilityBridgeTest, DisabledButtonHasDisabledRestriction) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateFalse,
+      .is_button = true,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kButton);
+  EXPECT_EQ(root_node->GetData().GetRestriction(),
+            ax::mojom::Restriction::kDisabled);
+}
+
+TEST(AccessibilityBridgeTest, EnabledButtonHasNoRestriction) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateTrue,
+      .is_button = true,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kButton);
+  EXPECT_EQ(root_node->GetData().GetRestriction(),
+            ax::mojom::Restriction::kNone);
+}
+
+TEST(AccessibilityBridgeTest, ReadOnlyTextFieldHasReadOnlyRestriction) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateTrue,
+      .is_text_field = true,
+      .is_read_only = true,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().GetRestriction(),
+            ax::mojom::Restriction::kReadOnly);
+}
+
 // Ensure that checkboxes have their checked status set apropriately
 // Previously, only Radios could have this flag updated
 // Resulted in the issue seen at

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -320,6 +320,85 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   EXPECT_EQ([native_text_field.stringValue isEqualToString:@"textfield"], YES);
 }
 
+// A disabled (but otherwise editable) text field must be exposed as static text
+// rather than a `FlutterTextField`. This exercises the `!IsReadOnlyOrDisabled()`
+// guard in `Init`: the `GetData()` override rewrites the role to `kStaticText`,
+// but the node retains its `kEditableRoot` attribute, so `GetData().IsTextField()`
+// still returns true. The restriction check is what keeps a disabled field from
+// being instantiated as an editable `FlutterTextField`.
+TEST(FlutterPlatformNodeDelegateMac, DisabledTextFieldDoesNotUseFlutterTextField) {
+  FlutterViewController* viewController = CreateTestViewController();
+  FlutterEngine* engine = viewController.engine;
+  [viewController loadView];
+
+  // Creates a NSWindow so that the native accessibility element has a hosting view.
+  NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
+                                                 styleMask:NSBorderlessWindowMask
+                                                   backing:NSBackingStoreBuffered
+                                                     defer:NO];
+  window.contentView = viewController.view;
+  engine.semanticsEnabled = YES;
+
+  auto bridge = viewController.accessibilityBridge.lock();
+  // Initialize ax node data.
+  FlutterSemanticsNode2 root = {};
+  FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
+  // A text field that is editable (not read-only) but disabled.
+  FlutterSemanticsFlags child_flags =
+      FlutterSemanticsFlags{.is_enabled = FlutterTristate::kFlutterTristateFalse,
+                            .is_text_field = true,
+                            .is_read_only = false};
+  root.id = 0;
+  root.flags2 = &flags;
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
+  root.actions = static_cast<FlutterSemanticsAction>(0);
+  root.label = "root";
+  root.hint = "";
+  root.value = "";
+  root.increased_value = "";
+  root.decreased_value = "";
+  root.tooltip = "";
+  root.child_count = 1;
+  int32_t children[] = {1};
+  root.children_in_traversal_order = children;
+  root.custom_accessibility_actions_count = 0;
+  root.identifier = "";
+  root.rect = {0, 0, 100, 100};  // LTRB
+  root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+
+  FlutterSemanticsNode2 child1 = {};
+  child1.id = 1;
+  child1.flags2 = &child_flags;
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
+  child1.actions = static_cast<FlutterSemanticsAction>(0);
+  child1.label = "";
+  child1.hint = "";
+  child1.value = "disabled textfield";
+  child1.increased_value = "";
+  child1.decreased_value = "";
+  child1.tooltip = "";
+  child1.text_selection_base = -1;
+  child1.text_selection_extent = -1;
+  child1.child_count = 0;
+  child1.custom_accessibility_actions_count = 0;
+  child1.identifier = "";
+  child1.rect = {0, 0, 50, 50};  // LTRB
+  child1.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
+
+  bridge->CommitUpdates();
+
+  auto child_platform_node_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
+  // The disabled text field must not be backed by a `FlutterTextField`.
+  id native_accessibility = child_platform_node_delegate->GetNativeViewAccessible();
+  EXPECT_FALSE([native_accessibility isKindOfClass:[FlutterTextField class]]);
+  EXPECT_TRUE(
+      [[native_accessibility accessibilityRole] isEqualToString:NSAccessibilityStaticTextRole]);
+
+  [engine shutDownEngine];
+}
+
 TEST(FlutterPlatformNodeDelegateMac, ChangingFlagsUpdatesNativeViewAccessible) {
   FlutterViewController* viewController = CreateTestViewController();
   FlutterEngine* engine = viewController.engine;


### PR DESCRIPTION
This is a partial re-land of
https://github.com/flutter/flutter/pull/184501, which just lands the common bridge code and tests as well as a macOS test for behaviour landed in landed in https://github.com/flutter/flutter/pull/190330.

This sets AXNodeData::SetRestriction() from the Flutter semantics flags: kDisabled when is_enabled is false, and kReadOnly for read-only text fields. Previously the restriction was never populated, so disabled and read-only nodes were indistinguishable from editable/enabled ones at the platform layer.

We also add a macOS regression test that checks that a disabled, editable text field is exposed as static text rather than a FlutterTextField.

This guards the !GetData().IsReadOnlyOrDisabled() check in FlutterPlatformNodeDelegateMac::Init. The GetData() override rewrites a disabled field's role to kStaticText but leaves kEditableRoot set, so IsTextField() stays true and the restriction check is what prevents an editable FlutterTextField from being created. I've added this in response to a bad comment by the Gemini review bot to ensure that this doesn't regress.

Issue: https://github.com/flutter/flutter/issues/184559

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
