### PR TITLE
Migrate example image_list to material_ui

### DIFF
--- a/dev/bots/check_examples_cross_imports.dart
+++ b/dev/bots/check_examples_cross_imports.dart
@@ -569,7 +569,6 @@ class ExamplesCrossImportChecker {
     'examples/api/test/widgets/inherited_notifier/inherited_notifier.0_test.dart',
     'examples/api/test/widgets/text_magnifier/text_magnifier.0_test.dart',
     'examples/flutter_view/lib/main.dart',
-    'examples/image_list/lib/main.dart',
     'examples/multiple_windows/lib/app/main_window.dart',
     'examples/multiple_windows/lib/app/tooltip_button.dart',
     'examples/multiple_windows/lib/app/tooltip_window_edit_dialog.dart',

--- a/examples/image_list/lib/main.dart
+++ b/examples/image_list/lib/main.dart
@@ -5,8 +5,9 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
-import 'package:flutter/material.dart';
+
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// An example that sets up local http server for serving single
 /// image, creates single flutter widget with five copies of requested

--- a/examples/image_list/pubspec.yaml
+++ b/examples/image_list/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
 
 
+  material_ui: ^0.0.2
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/examples/image_list/pubspec.yaml
+++ b/examples/image_list/pubspec.yaml
@@ -38,4 +38,4 @@ flutter:
   assets:
    - images/coast.jpg
 
-# PUBSPEC CHECKSUM: 60tfp7
+# PUBSPEC CHECKSUM: oescuq


### PR DESCRIPTION
Migrates the image_list example to material_ui.

Part of https://github.com/flutter/flutter/issues/190093.