### PR TITLE
Prepare device support symbols

### DIFF
--- a/packages/flutter_tools/lib/src/ios/device_support.dart
+++ b/packages/flutter_tools/lib/src/ios/device_support.dart
@@ -7,6 +7,7 @@ import '../base/version.dart';
 import '../convert.dart';
 import '../macos/xcode.dart';
 
+/// A class to handle preparing the device support for iOS devices.
 class IOSDeviceSupport {
   IOSDeviceSupport({
     required Logger logger,
@@ -20,20 +21,35 @@ class IOSDeviceSupport {
   final ProcessUtils _processUtils;
   final Xcode? _xcode;
 
+  /// Calls `xcodebuild -prepareDeviceSupport` for the given [deviceId] and streams the logs when
+  /// copying is in progress.
+  ///
+  /// The command copies symbols from the iOS device to the host machine and stores them in
+  /// $HOME/Library/Developer/Xcode/iOS DeviceSupport. Without these symbols, debugging is
+  /// extremely slow.
   Future<void> prepareDeviceSupport(String deviceId) async {
     final Version? xcodeVersion = _xcode?.currentVersion;
     if (xcodeVersion == null || xcodeVersion < Version(16, 3, 0)) {
       // The prepareDeviceSupport command is only available on Xcode 16.3+
       return;
     }
-
-    final Process process = await _processUtils.start([
+    final command = [
       'xcrun',
       'xcodebuild',
       '-prepareDeviceSupport',
       '-destination',
       'id=$deviceId',
-    ]);
+    ];
+    final Process process = await _processUtils.start(command);
+
+    final timer = Timer(const Duration(seconds: 10), () {
+      _logger.printError(
+        'Xcode is taking longer than expected to start preparing Device Support symbols...\n'
+        'Connect your device via USB and try running this command manually:\n'
+        '  "${command.join(' ')}"',
+      );
+    });
+
     var printToTrace = true;
     final StreamSubscription<String> stdoutSubscription = process.stdout
         .transform(utf8.decoder)
@@ -44,6 +60,7 @@ class IOSDeviceSupport {
               'Copying Device Support symbols. This may take several minutes to complete...\n'
               'Please do not connect or disconnect your device until finished.',
             );
+            timer.cancel();
           }
           if (printToTrace) {
             _logger.printTrace(text);
@@ -54,6 +71,7 @@ class IOSDeviceSupport {
 
     final StreamSubscription<String> stderrSubscription = process.stderr
         .transform(utf8.decoder)
+        .transform(const LineSplitter())
         .listen((String line) {
           _logger.printError(line);
         });
@@ -71,6 +89,7 @@ class IOSDeviceSupport {
     }
 
     await process.exitCode.whenComplete(() async {
+      timer.cancel();
       await stdoutSubscription.cancel();
       await stderrSubscription.cancel();
     });

--- a/packages/flutter_tools/lib/src/ios/device_support.dart
+++ b/packages/flutter_tools/lib/src/ios/device_support.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:io';
 
@@ -40,58 +44,67 @@ class IOSDeviceSupport {
       '-destination',
       'id=$deviceId',
     ];
-    final Process process = await _processUtils.start(command);
+    try {
+      final Process process = await _processUtils.start(command);
 
-    final timer = Timer(const Duration(seconds: 10), () {
+      final timer = Timer(const Duration(seconds: 10), () {
+        _logger.printError(
+          'Xcode is taking longer than expected to start preparing Device Support symbols...\n'
+          'Connect your device via USB and try running this command manually:\n'
+          '  "${command.join(' ')}"',
+        );
+      });
+
+      var printToTrace = true;
+      final StreamSubscription<String> stdoutSubscription = process.stdout
+          .transform(utf8.decoder)
+          .listen((String text) {
+            if (text.contains('Copying')) {
+              printToTrace = false;
+              _logger.printStatus(
+                'Copying Device Support symbols. This may take several minutes to complete...\n'
+                'Please do not connect or disconnect your device until finished.',
+              );
+              timer.cancel();
+            }
+            if (printToTrace) {
+              _logger.printTrace(text);
+            } else {
+              _logger.printStatus(text, newline: false);
+            }
+          });
+
+      final StreamSubscription<String> stderrSubscription = process.stderr
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((String line) {
+            _logger.printError(line);
+          });
+
+      try {
+        // Wait for stdout and stderr to be fully processed
+        // because process.exitCode may complete first.
+        await Future.wait<void>(<Future<void>>[
+          stdoutSubscription.asFuture<void>(),
+          stderrSubscription.asFuture<void>(),
+        ]);
+        await process.exitCode.whenComplete(() async {
+          await stdoutSubscription.cancel();
+          await stderrSubscription.cancel();
+        });
+      } finally {
+        timer.cancel();
+      }
+
+      // Print an empty line so that next prints aren't inline with logs from here.
+      if (!printToTrace) {
+        _logger.printStatus('');
+      }
+    } on ProcessException catch (exception, stackTrace) {
       _logger.printError(
-        'Xcode is taking longer than expected to start preparing Device Support symbols...\n'
-        'Connect your device via USB and try running this command manually:\n'
-        '  "${command.join(' ')}"',
+        'Process exception running "xcodebuild -prepareDeviceSupport": $exception',
       );
-    });
-
-    var printToTrace = true;
-    final StreamSubscription<String> stdoutSubscription = process.stdout
-        .transform(utf8.decoder)
-        .listen((String text) {
-          if (text.contains('Copying')) {
-            printToTrace = false;
-            _logger.printStatus(
-              'Copying Device Support symbols. This may take several minutes to complete...\n'
-              'Please do not connect or disconnect your device until finished.',
-            );
-            timer.cancel();
-          }
-          if (printToTrace) {
-            _logger.printTrace(text);
-          } else {
-            _logger.printStatus(text, newline: false);
-          }
-        });
-
-    final StreamSubscription<String> stderrSubscription = process.stderr
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen((String line) {
-          _logger.printError(line);
-        });
-
-    // Wait for stdout and stderr to be fully processed
-    // because process.exitCode may complete first.
-    await Future.wait<void>(<Future<void>>[
-      stdoutSubscription.asFuture<void>(),
-      stderrSubscription.asFuture<void>(),
-    ]);
-
-    // Print an empty line so that next prints aren't inline with logs from here.
-    if (!printToTrace) {
-      _logger.printStatus('');
+      _logger.printTrace('$stackTrace');
     }
-
-    await process.exitCode.whenComplete(() async {
-      timer.cancel();
-      await stdoutSubscription.cancel();
-      await stderrSubscription.cancel();
-    });
   }
 }

--- a/packages/flutter_tools/lib/src/ios/device_support.dart
+++ b/packages/flutter_tools/lib/src/ios/device_support.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+import 'dart:io';
+
+import '../base/logger.dart';
+import '../base/process.dart';
+import '../base/version.dart';
+import '../convert.dart';
+import '../macos/xcode.dart';
+
+class IOSDeviceSupport {
+  IOSDeviceSupport({
+    required Logger logger,
+    required ProcessUtils processUtils,
+    required Xcode? xcode,
+  }) : _xcode = xcode,
+       _logger = logger,
+       _processUtils = processUtils;
+
+  final Logger _logger;
+  final ProcessUtils _processUtils;
+  final Xcode? _xcode;
+
+  Future<void> prepareDeviceSupport(String deviceId) async {
+    final Version? xcodeVersion = _xcode?.currentVersion;
+    if (xcodeVersion == null || xcodeVersion < Version(16, 3, 0)) {
+      // The prepareDeviceSupport command is only available on Xcode 16.3+
+      return;
+    }
+
+    final Process process = await _processUtils.start([
+      'xcrun',
+      'xcodebuild',
+      '-prepareDeviceSupport',
+      '-destination',
+      'id=$deviceId',
+    ]);
+    var printToTrace = true;
+    final StreamSubscription<String> stdoutSubscription = process.stdout
+        .transform(utf8.decoder)
+        .listen((String text) {
+          if (text.contains('Copying')) {
+            printToTrace = false;
+            _logger.printStatus(
+              'Copying Device Support symbols. This may take several minutes to complete...\n'
+              'Please do not connect or disconnect your device until finished.',
+            );
+          }
+          if (printToTrace) {
+            _logger.printTrace(text);
+          } else {
+            _logger.printStatus(text, newline: false);
+          }
+        });
+
+    final StreamSubscription<String> stderrSubscription = process.stderr
+        .transform(utf8.decoder)
+        .listen((String line) {
+          _logger.printError(line);
+        });
+
+    // Wait for stdout and stderr to be fully processed
+    // because process.exitCode may complete first.
+    await Future.wait<void>(<Future<void>>[
+      stdoutSubscription.asFuture<void>(),
+      stderrSubscription.asFuture<void>(),
+    ]);
+
+    // Print an empty line so that next prints aren't inline with logs from here.
+    if (!printToTrace) {
+      _logger.printStatus('');
+    }
+
+    await process.exitCode.whenComplete(() async {
+      await stdoutSubscription.cancel();
+      await stderrSubscription.cancel();
+    });
+  }
+}

--- a/packages/flutter_tools/lib/src/ios/device_support.dart
+++ b/packages/flutter_tools/lib/src/ios/device_support.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
+import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/version.dart';
@@ -88,10 +88,14 @@ class IOSDeviceSupport {
           stdoutSubscription.asFuture<void>(),
           stderrSubscription.asFuture<void>(),
         ]);
-        await process.exitCode.whenComplete(() async {
-          await stdoutSubscription.cancel();
-          await stderrSubscription.cancel();
-        });
+
+        unawaited(stdoutSubscription.cancel());
+        unawaited(stderrSubscription.cancel());
+
+        final int exitCode = await process.exitCode;
+        if (exitCode != 0) {
+          _logger.printError('xcodebuild -prepareDeviceSupport exited with code $exitCode');
+        }
       } finally {
         timer.cancel();
       }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -38,6 +38,7 @@ import '../protocol_discovery.dart';
 import '../vmservice.dart';
 import 'application_package.dart';
 import 'core_devices.dart';
+import 'device_support.dart';
 import 'ios_deploy.dart';
 import 'ios_workflow.dart';
 import 'iproxy.dart';
@@ -308,6 +309,7 @@ class IOSDevice extends Device {
   IOSDevice(
     super.id, {
     required FileSystem fileSystem,
+    required ProcessUtils processUtils,
     required this.name,
     required CpuArch cpuArch,
     required this.connectionInterface,
@@ -325,6 +327,7 @@ class IOSDevice extends Device {
     required IProxy iProxy,
     required super.logger,
     required Analytics analytics,
+    required Xcode? xcode,
   }) : _cpuArch = cpuArch,
        _sdkVersion = sdkVersion,
        _iosDeploy = iosDeploy,
@@ -332,8 +335,10 @@ class IOSDevice extends Device {
        _coreDeviceControl = coreDeviceControl,
        _coreDeviceLauncher = coreDeviceLauncher,
        _xcodeDebug = xcodeDebug,
+       _xcode = xcode,
        _iproxy = iProxy,
        _fileSystem = fileSystem,
+       _processUtils = processUtils,
        _logger = logger,
        _analytics = analytics,
        _platform = platform,
@@ -348,12 +353,14 @@ class IOSDevice extends Device {
   final IOSDeploy _iosDeploy;
   final Analytics _analytics;
   final FileSystem _fileSystem;
+  final ProcessUtils _processUtils;
   final Logger _logger;
   final Platform _platform;
   final IMobileDevice _iMobileDevice;
   final IOSCoreDeviceControl _coreDeviceControl;
   final IOSCoreDeviceLauncher _coreDeviceLauncher;
   final XcodeDebug _xcodeDebug;
+  final Xcode? _xcode;
   final IProxy _iproxy;
 
   Version? get sdkVersion {
@@ -1018,6 +1025,11 @@ class IOSDevice extends Device {
     );
   }
 
+  bool shouldAttachDebugger(DebuggingOptions debuggingOptions) {
+    return debuggingOptions.buildInfo.isDebug ||
+        (debuggingOptions.buildInfo.isProfile && (debuggingOptions.iosProfileDebugger ?? false));
+  }
+
   /// Uses either `devicectl` or Xcode automation to install, launch, and debug
   /// apps on physical iOS devices.
   ///
@@ -1069,6 +1081,15 @@ class IOSDevice extends Device {
 
     IOSDeploymentMethod? deploymentMethod;
 
+    final bool attachDebugger = shouldAttachDebugger(debuggingOptions);
+    if (attachDebugger) {
+      await IOSDeviceSupport(
+        logger: _logger,
+        processUtils: _processUtils,
+        xcode: _xcode,
+      ).prepareDeviceSupport(id);
+    }
+
     // Xcode 16 introduced a way to start and attach to a debugserver through LLDB.
     // However, it doesn't work reliably until Xcode 26.
     // Use LLDB if Xcode version is greater than 26 and the feature is enabled.
@@ -1083,11 +1104,7 @@ class IOSDevice extends Device {
         await deviceLogReader.listenToCoreDeviceLauncher(_coreDeviceLauncher);
       }
 
-      final bool shouldAttachDebugger =
-          debuggingOptions.buildInfo.isDebug ||
-          (debuggingOptions.buildInfo.isProfile && (debuggingOptions.iosProfileDebugger ?? false));
-
-      if (shouldAttachDebugger) {
+      if (attachDebugger) {
         final bool launchSuccess = await _coreDeviceLauncher.launchAppWithLLDBDebugger(
           deviceId: id,
           bundlePath: package.deviceBundlePath,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -570,6 +570,15 @@ class IOSDevice extends Device {
       return LaunchResult.failed();
     }
 
+    final bool shouldAttachDebugger = shouldAttachLLDBDebugger(debuggingOptions);
+    if (shouldAttachDebugger) {
+      await IOSDeviceSupport(
+        logger: _logger,
+        processUtils: _processUtils,
+        xcode: _xcode,
+      ).prepareDeviceSupport(id);
+    }
+
     // Step 3: Attempt to install the application on the device.
     final List<String> launchArguments = debuggingOptions.getIOSLaunchArguments(
       EnvironmentType.physical,
@@ -618,6 +627,7 @@ class IOSDevice extends Device {
           mainPath: mainPath,
           discoveryTimeout: discoveryTimeout,
           shutdownHooks: shutdownHooks ?? globals.shutdownHooks,
+          shouldAttachDebugger: shouldAttachDebugger,
         );
         installationResult = result ? 0 : 1;
         deploymentMethod = coreDeviceDeploymentMethod;
@@ -1025,7 +1035,11 @@ class IOSDevice extends Device {
     );
   }
 
-  bool shouldAttachDebugger(DebuggingOptions debuggingOptions) {
+  /// Whether the LLDB debugger should be attached.
+  ///
+  /// The LLDB debugger should only be attached in debug mode or if the user uses the
+  /// `--ios-profile-debugger` flag in profile mode.
+  bool shouldAttachLLDBDebugger(DebuggingOptions debuggingOptions) {
     return debuggingOptions.buildInfo.isDebug ||
         (debuggingOptions.buildInfo.isProfile && (debuggingOptions.iosProfileDebugger ?? false));
   }
@@ -1053,6 +1067,7 @@ class IOSDevice extends Device {
     required IOSApp package,
     required List<String> launchArguments,
     required String? mainPath,
+    required bool shouldAttachDebugger,
     required ShutdownHooks shutdownHooks,
     @visibleForTesting Duration? discoveryTimeout,
   }) async {
@@ -1081,15 +1096,6 @@ class IOSDevice extends Device {
 
     IOSDeploymentMethod? deploymentMethod;
 
-    final bool attachDebugger = shouldAttachDebugger(debuggingOptions);
-    if (attachDebugger) {
-      await IOSDeviceSupport(
-        logger: _logger,
-        processUtils: _processUtils,
-        xcode: _xcode,
-      ).prepareDeviceSupport(id);
-    }
-
     // Xcode 16 introduced a way to start and attach to a debugserver through LLDB.
     // However, it doesn't work reliably until Xcode 26.
     // Use LLDB if Xcode version is greater than 26 and the feature is enabled.
@@ -1104,7 +1110,7 @@ class IOSDevice extends Device {
         await deviceLogReader.listenToCoreDeviceLauncher(_coreDeviceLauncher);
       }
 
-      if (attachDebugger) {
+      if (shouldAttachDebugger) {
         final bool launchSuccess = await _coreDeviceLauncher.launchAppWithLLDBDebugger(
           deviceId: id,
           bundlePath: package.deviceBundlePath,

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -652,10 +652,12 @@ class XCDevice {
             xcodeProjectInterpreter: globals.xcodeProjectInterpreter!,
           ),
           xcodeDebug: _xcodeDebug,
+          xcode: _xcode,
           platform: globals.platform,
           devModeEnabled: devModeEnabled,
           isPaired: isPaired,
           isCoreDevice: coreDevice != null,
+          processUtils: _processUtils,
         );
       }
     }

--- a/packages/flutter_tools/test/general.shard/ios/device_support_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/device_support_test.dart
@@ -1,0 +1,250 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/base/version.dart';
+import 'package:flutter_tools/src/ios/device_support.dart';
+import 'package:flutter_tools/src/macos/xcode.dart';
+import 'package:test/fake.dart';
+
+import '../../src/common.dart';
+import '../../src/fake_process_manager.dart';
+
+void main() {
+  group('IOSDeviceSupport', () {
+    testWithoutContext('does nothing when Xcode is null', () async {
+      final processManager = FakeProcessManager.empty();
+      final logger = BufferLogger.test();
+      final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+      final deviceSupport = IOSDeviceSupport(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: null,
+      );
+
+      await deviceSupport.prepareDeviceSupport('id-123');
+
+      expect(processManager, hasNoRemainingExpectations);
+      expect(logger.statusText, isEmpty);
+      expect(logger.traceText, isEmpty);
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext('does nothing when Xcode version is less than 16.3.0', () async {
+      final processManager = FakeProcessManager.empty();
+      final logger = BufferLogger.test();
+      final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+      final deviceSupport = IOSDeviceSupport(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: FakeXcode(currentVersion: Version(16, 2, 0)),
+      );
+
+      await deviceSupport.prepareDeviceSupport('id-123');
+
+      expect(processManager, hasNoRemainingExpectations);
+      expect(logger.statusText, isEmpty);
+      expect(logger.traceText, isEmpty);
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext(
+      'runs prepareDeviceSupport and logs stdout to trace when Copying is not present',
+      () async {
+        final processManager = FakeProcessManager.empty();
+        final logger = BufferLogger.test();
+        final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'xcrun',
+              'xcodebuild',
+              '-prepareDeviceSupport',
+              '-destination',
+              'id=id-123',
+            ],
+            stdout: 'Preparing device support...',
+          ),
+        );
+
+        final deviceSupport = IOSDeviceSupport(
+          logger: logger,
+          processUtils: processUtils,
+          xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+        );
+
+        await deviceSupport.prepareDeviceSupport('id-123');
+
+        expect(processManager, hasNoRemainingExpectations);
+        expect(logger.traceText, contains('Preparing device support...'));
+        expect(logger.statusText, isEmpty);
+        expect(logger.errorText, isEmpty);
+      },
+    );
+
+    testWithoutContext('runs prepareDeviceSupport and logs Copying messages to status', () async {
+      final processManager = FakeProcessManager.empty();
+      final logger = BufferLogger.test();
+      final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'xcrun',
+            'xcodebuild',
+            '-prepareDeviceSupport',
+            '-destination',
+            'id=id-123',
+          ],
+          stdout: 'Copying symbols...',
+        ),
+      );
+
+      final deviceSupport = IOSDeviceSupport(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+      );
+
+      await deviceSupport.prepareDeviceSupport('id-123');
+
+      expect(processManager, hasNoRemainingExpectations);
+      expect(
+        logger.statusText,
+        contains(
+          'Copying Device Support symbols. This may take several minutes to complete...\n'
+          'Please do not connect or disconnect your device until finished.',
+        ),
+      );
+      expect(logger.statusText, contains('Copying symbols...'));
+      expect(logger.statusText, endsWith('\n'));
+      expect(
+        logger.traceText,
+        'executing: xcrun xcodebuild -prepareDeviceSupport -destination id=id-123\n',
+      );
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext('runs prepareDeviceSupport and logs stderr to error', () async {
+      final processManager = FakeProcessManager.empty();
+      final logger = BufferLogger.test();
+      final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'xcrun',
+            'xcodebuild',
+            '-prepareDeviceSupport',
+            '-destination',
+            'id=id-123',
+          ],
+          stderr: 'Error occurred',
+        ),
+      );
+
+      final deviceSupport = IOSDeviceSupport(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: FakeXcode(currentVersion: Version(17, 0, 0)),
+      );
+
+      await deviceSupport.prepareDeviceSupport('id-123');
+
+      expect(processManager, hasNoRemainingExpectations);
+      expect(logger.errorText, contains('Error occurred'));
+    });
+
+    testWithoutContext(
+      'prints error message when prepareDeviceSupport takes longer than 10 seconds',
+      () {
+        FakeAsync().run((fakeAsync) {
+          final processManager = FakeProcessManager.empty();
+          final logger = BufferLogger.test();
+          final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+          processManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'xcrun',
+                'xcodebuild',
+                '-prepareDeviceSupport',
+                '-destination',
+                'id=id-123',
+              ],
+              duration: Duration(seconds: 11),
+            ),
+          );
+
+          final deviceSupport = IOSDeviceSupport(
+            logger: logger,
+            processUtils: processUtils,
+            xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+          );
+
+          deviceSupport.prepareDeviceSupport('id-123');
+
+          fakeAsync.elapse(const Duration(seconds: 10));
+
+          expect(
+            logger.errorText,
+            contains(
+              'Xcode is taking longer than expected to start preparing Device Support symbols...\n'
+              'Connect your device via USB and try running this command manually:\n'
+              '  "xcrun xcodebuild -prepareDeviceSupport -destination id=id-123"',
+            ),
+          );
+
+          fakeAsync.elapse(const Duration(seconds: 1));
+        });
+      },
+    );
+
+    testWithoutContext('does not print error message if Copying is printed within 10 seconds', () {
+      FakeAsync().run((fakeAsync) {
+        final processManager = FakeProcessManager.empty();
+        final logger = BufferLogger.test();
+        final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'xcrun',
+              'xcodebuild',
+              '-prepareDeviceSupport',
+              '-destination',
+              'id=id-123',
+            ],
+            duration: Duration(seconds: 11),
+            stdout: 'Copying symbols...',
+          ),
+        );
+
+        final deviceSupport = IOSDeviceSupport(
+          logger: logger,
+          processUtils: processUtils,
+          xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+        );
+
+        deviceSupport.prepareDeviceSupport('id-123');
+
+        fakeAsync.elapse(const Duration(seconds: 11));
+
+        expect(logger.errorText, isEmpty);
+      });
+    });
+  });
+}
+
+class FakeXcode extends Fake implements Xcode {
+  FakeXcode({this.currentVersion});
+
+  @override
+  final Version? currentVersion;
+}

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -49,11 +50,13 @@ void main() {
     late IOSCoreDeviceControl coreDeviceControl;
     late IOSCoreDeviceLauncher coreDeviceLauncher;
     late XcodeDebug xcodeDebug;
+    late ProcessUtils processUtils;
 
     setUp(() {
       final artifacts = Artifacts.test();
       cache = Cache.test(processManager: FakeProcessManager.any());
       logger = BufferLogger.test();
+      processUtils = ProcessUtils(processManager: FakeProcessManager.any(), logger: logger);
       fileSystem = MemoryFileSystem.test();
       iosDeploy = IOSDeploy(
         artifacts: artifacts,
@@ -94,8 +97,54 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       );
       expect(await device.isSupported(), isTrue);
+    });
+
+    group('shouldAttachLLDBDebugger', () {
+      testWithoutContext('returns expected values for different BuildInfo and options', () {
+        final device = IOSDevice(
+          'device-123',
+          iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
+          fileSystem: fileSystem,
+          logger: logger,
+          platform: macPlatform,
+          iosDeploy: iosDeploy,
+          analytics: FakeAnalytics(),
+          iMobileDevice: iMobileDevice,
+          coreDeviceControl: coreDeviceControl,
+          coreDeviceLauncher: coreDeviceLauncher,
+          xcodeDebug: xcodeDebug,
+          name: 'iPhone 1',
+          sdkVersion: '13.3',
+          cpuArch: .arm64,
+          connectionInterface: DeviceConnectionInterface.attached,
+          isConnected: true,
+          isPaired: true,
+          devModeEnabled: true,
+          isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
+        );
+
+        expect(device.shouldAttachLLDBDebugger(DebuggingOptions.enabled(BuildInfo.debug)), isTrue);
+        expect(
+          device.shouldAttachLLDBDebugger(
+            DebuggingOptions.enabled(BuildInfo.profile, iosProfileDebugger: true),
+          ),
+          isTrue,
+        );
+        expect(device.shouldAttachLLDBDebugger(DebuggingOptions.enabled(BuildInfo.profile)), isFalse);
+        expect(
+          device.shouldAttachLLDBDebugger(
+            DebuggingOptions.enabled(BuildInfo.profile, iosProfileDebugger: false),
+          ),
+          isFalse,
+        );
+        expect(device.shouldAttachLLDBDebugger(DebuggingOptions.enabled(BuildInfo.release)), isFalse);
+      });
     });
 
     testWithoutContext('32-bit devices are unsupported', () async {
@@ -118,6 +167,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       );
       expect(await device.isSupported(), isFalse);
     });
@@ -144,6 +195,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         ).majorSdkVersion,
         1,
       );
@@ -168,6 +221,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         ).majorSdkVersion,
         13,
       );
@@ -192,6 +247,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         ).majorSdkVersion,
         10,
       );
@@ -216,6 +273,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         ).majorSdkVersion,
         0,
       );
@@ -240,6 +299,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         ).majorSdkVersion,
         0,
       );
@@ -266,6 +327,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       var expectedVersion = Version(13, 3, 1, text: '13.3.1');
       expect(sdkVersion, isNotNull);
@@ -292,6 +355,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       expectedVersion = Version(13, 3, 1, text: '13.3.1 (20ADBC)');
       expect(sdkVersion, isNotNull);
@@ -318,6 +383,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       expectedVersion = Version(16, 4, 1, text: '16.4.1(a) (20ADBC)');
       expect(sdkVersion, isNotNull);
@@ -344,6 +411,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       expectedVersion = Version(0, 0, 0, text: '0');
       expect(sdkVersion, isNotNull);
@@ -369,6 +438,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       expect(sdkVersion, isNull);
 
@@ -392,6 +463,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       expect(sdkVersion, isNull);
     });
@@ -417,6 +490,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       );
 
       expect(await device.sdkNameAndVersion, 'iOS 13.3 17C54');
@@ -443,6 +518,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       );
 
       expect(device.supportsRuntimeMode(BuildMode.debug), true);
@@ -476,6 +553,8 @@ void main() {
               isPaired: true,
               devModeEnabled: true,
               isCoreDevice: false,
+              processUtils: processUtils,
+              xcode: null,
             );
           }, throwsAssertionError);
         },
@@ -567,6 +646,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         );
         logReader1 = createLogReader(device, appPackage1, process1);
         logReader2 = createLogReader(device, appPackage2, process2);
@@ -642,6 +723,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: ProcessUtils(processManager: fakeProcessManager, logger: logger),
+        xcode: null,
       );
 
       device2 = IOSDevice(
@@ -664,6 +747,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: ProcessUtils(processManager: fakeProcessManager, logger: logger),
+        xcode: null,
       );
     });
 
@@ -994,6 +1079,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: ProcessUtils(processManager: fakeProcessManager, logger: logger),
+        xcode: null,
       );
     });
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/application_package.dart';
@@ -363,6 +364,8 @@ IOSDevice setUpIOSDevice({
     '1234',
     name: 'iPhone 1',
     logger: logger,
+    processUtils: ProcessUtils(processManager: processManager, logger: logger),
+    xcode: null,
     fileSystem: fileSystem ?? MemoryFileSystem.test(),
     sdkVersion: '13.3',
     cpuArch: .arm64,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/core_devices.dart';
@@ -100,6 +101,8 @@ IOSDevice setUpIOSDevice(FileSystem fileSystem) {
     'test',
     fileSystem: fileSystem,
     logger: logger,
+    processUtils: ProcessUtils(processManager: processManager, logger: logger),
+    xcode: null,
     iosDeploy: IOSDeploy(
       platform: platform,
       logger: logger,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -1481,6 +1481,11 @@ IOSDevice setUpIOSDevice({
     sdkVersion: sdkVersion,
     fileSystem: fileSystem ?? MemoryFileSystem.test(),
     platform: macPlatform,
+    processUtils: ProcessUtils(
+      processManager: processManager ?? FakeProcessManager.any(),
+      logger: logger,
+    ),
+    xcode: null,
     iProxy: IProxy.test(logger: logger, processManager: processManager ?? FakeProcessManager.any()),
     logger: logger,
     iosDeploy: IOSDeploy(

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -908,6 +908,72 @@ void main() {
         },
       );
 
+      testUsingContext(
+        'calls prepareDeviceSupport when Xcode version is >= 16.3',
+        () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final processManager = FakeProcessManager.empty();
+          processManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'xcrun',
+                'xcodebuild',
+                '-prepareDeviceSupport',
+                '-destination',
+                'id=123',
+              ],
+            ),
+          );
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
+          final fakeLauncher = FakeIOSCoreDeviceLauncher();
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            isCoreDevice: true,
+            coreDeviceLauncher: fakeLauncher,
+            analytics: fakeAnalytics,
+            xcode: FakeXcode(currentVersion: Version(26, 0, 0)),
+          );
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final DeviceLogReader deviceLogReader = IOSDeviceLogReader.test(
+            iMobileDevice: FakeIMobileDevice(),
+            xcode: FakeXcode(currentVersion: Version(26, 0, 0)),
+            isCoreDevice: true,
+          );
+
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
+
+          // Start writing messages to the log reader.
+          Timer(const Duration(milliseconds: 50), () {
+            fakeLauncher.coreDeviceLogForwarder.addLog('Foo');
+            fakeLauncher.coreDeviceLogForwarder.addLog(
+              'The Dart VM service is listening on http://127.0.0.1:456',
+            );
+          });
+
+          final LaunchResult launchResult = await device.startApp(
+            iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            platformArgs: <String, dynamic>{},
+          );
+
+          expect(launchResult.started, true);
+          expect(processManager, hasNoRemainingExpectations);
+        },
+        overrides: {
+          Xcode: () => FakeXcode(currentVersion: Version(26, 0, 0)),
+          Analytics: () => FakeAnalytics(),
+        },
+      );
+
       testUsingContext('uses Xcode if LLDB fails', () async {
         final FileSystem fileSystem = MemoryFileSystem.test();
         final processManager = FakeProcessManager.empty();
@@ -1860,6 +1926,72 @@ void main() {
       );
 
       testUsingContext(
+        'calls prepareDeviceSupport when iosProfileDebugger is true and Xcode version is >= 16.3',
+        () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final processManager = FakeProcessManager.empty();
+          processManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'xcrun',
+                'xcodebuild',
+                '-prepareDeviceSupport',
+                '-destination',
+                'id=123',
+              ],
+            ),
+          );
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
+          final fakeLauncher = FakeIOSCoreDeviceLauncher();
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            isCoreDevice: true,
+            coreDeviceLauncher: fakeLauncher,
+            analytics: fakeAnalytics,
+            xcode: FakeXcode(currentVersion: Version(26, 0, 0)),
+          );
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final DeviceLogReader deviceLogReader = IOSDeviceLogReader.test(
+            iMobileDevice: FakeIMobileDevice(),
+            xcode: FakeXcode(currentVersion: Version(26, 0, 0)),
+            isCoreDevice: true,
+          );
+
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
+
+          // Start writing messages to the log reader.
+          Timer(const Duration(milliseconds: 50), () {
+            fakeLauncher.coreDeviceLogForwarder.addLog('Foo');
+            fakeLauncher.coreDeviceLogForwarder.addLog(
+              'The Dart VM service is listening on http://127.0.0.1:456',
+            );
+          });
+
+          final LaunchResult launchResult = await device.startApp(
+            iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, iosProfileDebugger: true),
+            platformArgs: <String, dynamic>{},
+          );
+
+          expect(launchResult.started, true);
+          expect(processManager, hasNoRemainingExpectations);
+        },
+        overrides: {
+          Xcode: () => FakeXcode(currentVersion: Version(26, 0, 0)),
+          Analytics: () => FakeAnalytics(),
+        },
+      );
+
+      testUsingContext(
         'uses Xcode if less than Xcode 26',
         () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
@@ -1945,6 +2077,7 @@ IOSDevice setUpIOSDevice({
   Analytics? analytics,
   FakeXcodeDebug? xcodeDebug,
   FakePlatform? platform,
+  Xcode? xcode,
 }) {
   final artifacts = Artifacts.test();
   final FakePlatform macPlatform =
@@ -1962,6 +2095,11 @@ IOSDevice setUpIOSDevice({
     sdkVersion: sdkVersion,
     fileSystem: fileSystem ?? MemoryFileSystem.test(),
     platform: macPlatform,
+    processUtils: ProcessUtils(
+      processManager: processManager ?? FakeProcessManager.any(),
+      logger: logger,
+    ),
+    xcode: xcode,
     iProxy: IProxy.test(logger: logger, processManager: processManager ?? FakeProcessManager.any()),
     logger: logger,
     iosDeploy:


### PR DESCRIPTION
When debugging for iOS devices, Device Support symbols are required to be copied from the iOS device to the host. Previously the only way to trigger this was to open Xcode. We recently discovered there's now a command that automates this.

This PR adds a command that calls `xcodebuild -prepareDeviceSupport` before installing/launching the app so that Device Support symbols are verified to be installed.

Toward https://github.com/flutter/flutter/issues/189284.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
