### PR TITLE
Refactor `flutter_view` example to not use `material`

### DIFF
--- a/dev/bots/check_examples_cross_imports.dart
+++ b/dev/bots/check_examples_cross_imports.dart
@@ -585,7 +585,6 @@ class ExamplesCrossImportChecker {
     'packages/flutter/examples/api/test/widgets/scrollbar/raw_scrollbar.1_test.dart',
     'packages/flutter/examples/api/test/widgets/inherited_notifier/inherited_notifier.0_test.dart',
     'packages/flutter/examples/api/test/widgets/text_magnifier/text_magnifier.0_test.dart',
-    'examples/flutter_view/lib/main.dart',
     'examples/texture/lib/main.dart',
   };
 
@@ -1000,8 +999,7 @@ sealed class _ExamplesLibrary implements CrossImportCheckedLibrary {
               relativePath.startsWith('packages/flutter/examples/api/test/widgets') =>
         _ApiExampleLibrary(relativePath),
       _
-          when relativePath.startsWith('examples/flutter_view') ||
-              relativePath.startsWith('examples/hello_world') ||
+          when relativePath.startsWith('examples/hello_world') ||
               relativePath.startsWith('examples/image_list') ||
               relativePath.startsWith('examples/layers') ||
               relativePath.startsWith('examples/multiple_windows') ||

--- a/dev/bots/check_examples_cross_imports.dart
+++ b/dev/bots/check_examples_cross_imports.dart
@@ -999,7 +999,8 @@ sealed class _ExamplesLibrary implements CrossImportCheckedLibrary {
               relativePath.startsWith('packages/flutter/examples/api/test/widgets') =>
         _ApiExampleLibrary(relativePath),
       _
-          when relativePath.startsWith('examples/hello_world') ||
+          when relativePath.startsWith('examples/flutter_view') ||
+              relativePath.startsWith('examples/hello_world') ||
               relativePath.startsWith('examples/image_list') ||
               relativePath.startsWith('examples/layers') ||
               relativePath.startsWith('examples/multiple_windows') ||

--- a/examples/flutter_view/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_view/ios/Runner.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2DE332E71E55C6D800393FD5 /* MainViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DE332E61E55C6D800393FD5 /* MainViewController.m */; };
 		3B3967051E83383D004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967041E83383D004F5970 /* AppFrameworkInfo.plist */; };
 		978B8F6F1D3862AE00F588F7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */; };
+		A1B2C3D4E5F6000100000001 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000100000003 /* SceneDelegate.m */; };
 		97C146F31CF9000F007C117D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 97C146F21CF9000F007C117D /* main.m */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -41,6 +42,8 @@
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		A1B2C3D4E5F6000100000002 /* SceneDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
+		A1B2C3D4E5F6000100000003 /* SceneDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -96,6 +99,8 @@
 				2DD8945E1E5B87AF0010574F /* ic_add.png */,
 				7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */,
 				7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */,
+				A1B2C3D4E5F6000100000002 /* SceneDelegate.h */,
+				A1B2C3D4E5F6000100000003 /* SceneDelegate.m */,
 				2DE332E81E55C6F100393FD5 /* MainViewController.h */,
 				2DE332E61E55C6D800393FD5 /* MainViewController.m */,
 				2D4B11261E55A15A00FF14DB /* NativeViewController.m */,
@@ -228,6 +233,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				978B8F6F1D3862AE00F588F7 /* AppDelegate.m in Sources */,
+				A1B2C3D4E5F6000100000001 /* SceneDelegate.m in Sources */,
 				97C146F31CF9000F007C117D /* main.m in Sources */,
 				2D4B11271E55A15A00FF14DB /* NativeViewController.m in Sources */,
 				2DE332E71E55C6D800393FD5 /* MainViewController.m in Sources */,

--- a/examples/flutter_view/ios/Runner/AppDelegate.m
+++ b/examples/flutter_view/ios/Runner/AppDelegate.m
@@ -12,4 +12,13 @@
   return YES;
 }
 
+#pragma mark - UISceneSession lifecycle
+
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options {
+  return [[UISceneConfiguration alloc] initWithName:@"Default Configuration" sessionRole:connectingSceneSession.role];
+}
+
+- (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions {
+}
+
 @end

--- a/examples/flutter_view/ios/Runner/Info.plist
+++ b/examples/flutter_view/ios/Runner/Info.plist
@@ -43,5 +43,24 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/examples/flutter_view/ios/Runner/SceneDelegate.h
+++ b/examples/flutter_view/ios/Runner/SceneDelegate.h
@@ -1,0 +1,11 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <UIKit/UIKit.h>
+
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow * window;
+
+@end

--- a/examples/flutter_view/ios/Runner/SceneDelegate.m
+++ b/examples/flutter_view/ios/Runner/SceneDelegate.m
@@ -1,0 +1,28 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "SceneDelegate.h"
+
+@implementation SceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
+  // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+}
+
+- (void)sceneDidDisconnect:(UIScene *)scene {
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene {
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene {
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene {
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene {
+}
+
+@end

--- a/examples/flutter_view/lib/main.dart
+++ b/examples/flutter_view/lib/main.dart
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'package:flutter/material.dart';
+
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 
 void main() {
   runApp(const FlutterView());
@@ -15,9 +16,22 @@ class FlutterView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return WidgetsApp(
       title: 'Flutter View',
-      theme: ThemeData(primarySwatch: Colors.grey),
+      color: const Color(0xFF9E9E9E),
+      pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) {
+        return PageRouteBuilder<T>(
+          settings: settings,
+          pageBuilder:
+              (
+                BuildContext context,
+                Animation<double> animation,
+                Animation<double> secondaryAnimation,
+              ) {
+                return builder(context);
+              },
+        );
+      },
       home: const MyHomePage(),
     );
   }
@@ -60,32 +74,67 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+    return ColoredBox(
+      color: const Color(0xFFFFFFFF),
+      child: Stack(
         children: <Widget>[
-          Expanded(
-            child: Center(
-              child: Text(
-                'Platform button tapped $_counter time${_counter == 1 ? '' : 's'}.',
-                style: const TextStyle(fontSize: 17.0),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Expanded(
+                child: Center(
+                  child: Text(
+                    'Platform button tapped $_counter time${_counter == 1 ? '' : 's'}.',
+                    style: const TextStyle(
+                      color: Color(0xFF000000),
+                      fontSize: 17.0,
+                      decoration: TextDecoration.none,
+                    ),
+                  ),
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.only(bottom: 15.0, left: 5.0),
+                child: Row(
+                  children: <Widget>[
+                    Image.asset('assets/flutter-mark-square-64.png', scale: 1.5),
+                    const Text(
+                      'Flutter',
+                      style: TextStyle(
+                        color: Color(0xFF000000),
+                        fontSize: 30.0,
+                        decoration: TextDecoration.none,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          Positioned(
+            bottom: 16.0,
+            right: 16.0,
+            child: GestureDetector(
+              onTap: _sendFlutterIncrement,
+              child: Container(
+                width: 56.0,
+                height: 56.0,
+                decoration: const BoxDecoration(color: Color(0xFF2196F3), shape: BoxShape.circle),
+                child: const Center(
+                  child: Text(
+                    '+',
+                    style: TextStyle(
+                      color: Color(0xFFFFFFFF),
+                      fontSize: 28.0,
+                      fontWeight: FontWeight.bold,
+                      decoration: TextDecoration.none,
+                    ),
+                  ),
+                ),
               ),
             ),
           ),
-          Container(
-            padding: const EdgeInsets.only(bottom: 15.0, left: 5.0),
-            child: Row(
-              children: <Widget>[
-                Image.asset('assets/flutter-mark-square-64.png', scale: 1.5),
-                const Text('Flutter', style: TextStyle(fontSize: 30.0)),
-              ],
-            ),
-          ),
         ],
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _sendFlutterIncrement,
-        child: const Icon(Icons.add),
       ),
     );
   }

--- a/examples/flutter_view/lib/main.dart
+++ b/examples/flutter_view/lib/main.dart
@@ -119,7 +119,7 @@ class _MyHomePageState extends State<MyHomePage> {
           Positioned(
             bottom: 16.0,
             right: 16.0,
-            child: _FloatingActionButton(
+            child: _Button(
               onPressed: _sendFlutterIncrement,
               icon: const Text(
                 '+',
@@ -138,8 +138,8 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 }
 
-class _FloatingActionButton extends StatelessWidget {
-  const _FloatingActionButton({required this.onPressed, required this.icon});
+class _Button extends StatelessWidget {
+  const _Button({required this.onPressed, required this.icon});
 
   final VoidCallback onPressed;
   final Widget icon;

--- a/examples/flutter_view/lib/main.dart
+++ b/examples/flutter_view/lib/main.dart
@@ -24,6 +24,7 @@ class FlutterView extends StatelessWidget {
     return WidgetsApp(
       title: 'Flutter View',
       color: _grey,
+      textStyle: const TextStyle(color: _black, decoration: TextDecoration.none),
       pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) {
         return PageRouteBuilder<T>(
           settings: settings,
@@ -90,11 +91,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: Center(
                   child: Text(
                     'Platform button tapped $_counter time${_counter == 1 ? '' : 's'}.',
-                    style: const TextStyle(
-                      color: _black,
-                      fontSize: 17.0,
-                      decoration: TextDecoration.none,
-                    ),
+                    style: const TextStyle(fontSize: 17.0),
                   ),
                 ),
               ),
@@ -103,14 +100,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: Row(
                   children: <Widget>[
                     Image.asset('assets/flutter-mark-square-64.png', scale: 1.5),
-                    const Text(
-                      'Flutter',
-                      style: TextStyle(
-                        color: _black,
-                        fontSize: 30.0,
-                        decoration: TextDecoration.none,
-                      ),
-                    ),
+                    const Text('Flutter', style: TextStyle(fontSize: 30.0)),
                   ],
                 ),
               ),
@@ -119,16 +109,11 @@ class _MyHomePageState extends State<MyHomePage> {
           Positioned(
             bottom: 16.0,
             right: 16.0,
-            child: _Button(
+            child: Button(
               onPressed: _sendFlutterIncrement,
               icon: const Text(
                 '+',
-                style: TextStyle(
-                  color: _white,
-                  fontSize: 28.0,
-                  fontWeight: FontWeight.bold,
-                  decoration: TextDecoration.none,
-                ),
+                style: TextStyle(color: _white, fontSize: 28.0, fontWeight: FontWeight.bold),
               ),
             ),
           ),
@@ -138,8 +123,8 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 }
 
-class _Button extends StatelessWidget {
-  const _Button({required this.onPressed, required this.icon});
+class Button extends StatelessWidget {
+  const Button({super.key, required this.onPressed, required this.icon});
 
   final VoidCallback onPressed;
   final Widget icon;

--- a/examples/flutter_view/lib/main.dart
+++ b/examples/flutter_view/lib/main.dart
@@ -124,7 +124,7 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 
 class _Button extends StatelessWidget {
-  const _Button({super.key, required this.onPressed, required this.icon});
+  const _Button({required this.onPressed, required this.icon});
 
   final VoidCallback onPressed;
   final Widget icon;

--- a/examples/flutter_view/lib/main.dart
+++ b/examples/flutter_view/lib/main.dart
@@ -109,7 +109,7 @@ class _MyHomePageState extends State<MyHomePage> {
           Positioned(
             bottom: 16.0,
             right: 16.0,
-            child: Button(
+            child: _Button(
               onPressed: _sendFlutterIncrement,
               icon: const Text(
                 '+',
@@ -123,8 +123,8 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 }
 
-class Button extends StatelessWidget {
-  const Button({super.key, required this.onPressed, required this.icon});
+class _Button extends StatelessWidget {
+  const _Button({super.key, required this.onPressed, required this.icon});
 
   final VoidCallback onPressed;
   final Widget icon;

--- a/examples/flutter_view/lib/main.dart
+++ b/examples/flutter_view/lib/main.dart
@@ -7,6 +7,11 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+const Color _grey = Color(0xFF9E9E9E);
+const Color _white = Color(0xFFFFFFFF);
+const Color _black = Color(0xFF000000);
+const Color _blue = Color(0xFF2196F3);
+
 void main() {
   runApp(const FlutterView());
 }
@@ -18,7 +23,7 @@ class FlutterView extends StatelessWidget {
   Widget build(BuildContext context) {
     return WidgetsApp(
       title: 'Flutter View',
-      color: const Color(0xFF9E9E9E),
+      color: _grey,
       pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) {
         return PageRouteBuilder<T>(
           settings: settings,
@@ -75,7 +80,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return ColoredBox(
-      color: const Color(0xFFFFFFFF),
+      color: _white,
       child: Stack(
         children: <Widget>[
           Column(
@@ -86,7 +91,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   child: Text(
                     'Platform button tapped $_counter time${_counter == 1 ? '' : 's'}.',
                     style: const TextStyle(
-                      color: Color(0xFF000000),
+                      color: _black,
                       fontSize: 17.0,
                       decoration: TextDecoration.none,
                     ),
@@ -101,7 +106,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     const Text(
                       'Flutter',
                       style: TextStyle(
-                        color: Color(0xFF000000),
+                        color: _black,
                         fontSize: 30.0,
                         decoration: TextDecoration.none,
                       ),
@@ -114,27 +119,40 @@ class _MyHomePageState extends State<MyHomePage> {
           Positioned(
             bottom: 16.0,
             right: 16.0,
-            child: GestureDetector(
-              onTap: _sendFlutterIncrement,
-              child: Container(
-                width: 56.0,
-                height: 56.0,
-                decoration: const BoxDecoration(color: Color(0xFF2196F3), shape: BoxShape.circle),
-                child: const Center(
-                  child: Text(
-                    '+',
-                    style: TextStyle(
-                      color: Color(0xFFFFFFFF),
-                      fontSize: 28.0,
-                      fontWeight: FontWeight.bold,
-                      decoration: TextDecoration.none,
-                    ),
-                  ),
+            child: _FloatingActionButton(
+              onPressed: _sendFlutterIncrement,
+              icon: const Text(
+                '+',
+                style: TextStyle(
+                  color: _white,
+                  fontSize: 28.0,
+                  fontWeight: FontWeight.bold,
+                  decoration: TextDecoration.none,
                 ),
               ),
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _FloatingActionButton extends StatelessWidget {
+  const _FloatingActionButton({required this.onPressed, required this.icon});
+
+  final VoidCallback onPressed;
+  final Widget icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onPressed,
+      child: Container(
+        width: 56.0,
+        height: 56.0,
+        decoration: const BoxDecoration(color: _blue, shape: BoxShape.circle),
+        child: Center(child: icon),
       ),
     );
   }

--- a/examples/flutter_view/pubspec.yaml
+++ b/examples/flutter_view/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
 
 
 flutter:
-  uses-material-design: true
   assets:
     - assets/flutter-mark-square-64.png
 


### PR DESCRIPTION
This PR refactors the `flutter_view` example to not use `material`. 

It also migrates the iOS app to utilize the UIScene lifecycle. Without the migration the app refused to run, and showed the error below.

```
failure in void _UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption(void)_block_invoke (UIApplication_RuntimeIssues.m:106) : Application
  failed to launch: UIScene life cycle is required for apps built with this SDK. See "Transitioning to the UIKit scene-based life cycle" in the UIKit
  documentation for more information on migration.
```

## Android:

https://github.com/user-attachments/assets/6b137881-2fbc-4756-8846-d57ec978e9c1

## iOS:

https://github.com/user-attachments/assets/abde493c-2b24-4f3e-8e91-e19f80fc9e56

Part of #190305


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.