### PR TITLE
[Flutter GPU] Ignore redundant render pass state assignments

### DIFF
--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -105,10 +105,51 @@ bool RenderPass::Begin(flutter::gpu::CommandBuffer& command_buffer) {
 }
 
 void RenderPass::SetPipeline(fml::RefPtr<RenderPipeline> pipeline) {
+  if (render_pipeline_.get() == pipeline.get()) {
+    return;
+  }
   pipeline_state_dirty_ = true;
   // On debug this makes a difference, but not on release builds.
   // NOLINTNEXTLINE(performance-move-const-arg)
   render_pipeline_ = std::move(pipeline);
+}
+
+// The setters below assign through the pipeline descriptor directly rather
+// than through GetPipelineDescriptor, which would dirty the state
+// unconditionally. Callers re-send the same fixed-function state ahead of
+// most draws, and dirtying on a redundant assignment would rebuild the
+// pipeline for every one of them.
+
+void RenderPass::SetCullMode(impeller::CullMode mode) {
+  if (pipeline_descriptor_.GetCullMode() == mode) {
+    return;
+  }
+  pipeline_descriptor_.SetCullMode(mode);
+  pipeline_state_dirty_ = true;
+}
+
+void RenderPass::SetWindingOrder(impeller::WindingOrder order) {
+  if (pipeline_descriptor_.GetWindingOrder() == order) {
+    return;
+  }
+  pipeline_descriptor_.SetWindingOrder(order);
+  pipeline_state_dirty_ = true;
+}
+
+void RenderPass::SetPrimitiveType(impeller::PrimitiveType type) {
+  if (pipeline_descriptor_.GetPrimitiveType() == type) {
+    return;
+  }
+  pipeline_descriptor_.SetPrimitiveType(type);
+  pipeline_state_dirty_ = true;
+}
+
+void RenderPass::SetPolygonMode(impeller::PolygonMode mode) {
+  if (pipeline_descriptor_.GetPolygonMode() == mode) {
+    return;
+  }
+  pipeline_descriptor_.SetPolygonMode(mode);
+  pipeline_state_dirty_ = true;
 }
 
 void RenderPass::ClearBindings() {
@@ -728,36 +769,26 @@ void InternalFlutterGpu_RenderPass_SetStencilConfig(
 void InternalFlutterGpu_RenderPass_SetCullMode(
     flutter::gpu::RenderPass* wrapper,
     int cull_mode) {
-  impeller::PipelineDescriptor& pipeline_descriptor =
-      wrapper->GetPipelineDescriptor();
-  pipeline_descriptor.SetCullMode(flutter::gpu::ToImpellerCullMode(cull_mode));
+  wrapper->SetCullMode(flutter::gpu::ToImpellerCullMode(cull_mode));
 }
 
 void InternalFlutterGpu_RenderPass_SetPrimitiveType(
     flutter::gpu::RenderPass* wrapper,
     int primitive_type) {
-  impeller::PipelineDescriptor& pipeline_descriptor =
-      wrapper->GetPipelineDescriptor();
-  pipeline_descriptor.SetPrimitiveType(
+  wrapper->SetPrimitiveType(
       flutter::gpu::ToImpellerPrimitiveType(primitive_type));
 }
 
 void InternalFlutterGpu_RenderPass_SetWindingOrder(
     flutter::gpu::RenderPass* wrapper,
     int winding_order) {
-  impeller::PipelineDescriptor& pipeline_descriptor =
-      wrapper->GetPipelineDescriptor();
-  pipeline_descriptor.SetWindingOrder(
-      flutter::gpu::ToImpellerWindingOrder(winding_order));
+  wrapper->SetWindingOrder(flutter::gpu::ToImpellerWindingOrder(winding_order));
 }
 
 void InternalFlutterGpu_RenderPass_SetPolygonMode(
     flutter::gpu::RenderPass* wrapper,
     int polygon_mode) {
-  impeller::PipelineDescriptor& pipeline_descriptor =
-      wrapper->GetPipelineDescriptor();
-  pipeline_descriptor.SetPolygonMode(
-      flutter::gpu::ToImpellerPolygonMode(polygon_mode));
+  wrapper->SetPolygonMode(flutter::gpu::ToImpellerPolygonMode(polygon_mode));
 }
 
 bool InternalFlutterGpu_RenderPass_Draw(flutter::gpu::RenderPass* wrapper,

--- a/engine/src/flutter/lib/gpu/render_pass.h
+++ b/engine/src/flutter/lib/gpu/render_pass.h
@@ -54,6 +54,18 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
 
   void SetPipeline(fml::RefPtr<RenderPipeline> pipeline);
 
+  /// Set the face culling mode for subsequent draws.
+  void SetCullMode(impeller::CullMode mode);
+
+  /// Set the front-face winding order for subsequent draws.
+  void SetWindingOrder(impeller::WindingOrder order);
+
+  /// Set the primitive topology for subsequent draws.
+  void SetPrimitiveType(impeller::PrimitiveType type);
+
+  /// Set the polygon fill mode for subsequent draws.
+  void SetPolygonMode(impeller::PolygonMode mode);
+
   void ClearBindings();
 
   /// Append a draw to the underlying render pass. [element_count] is the

--- a/engine/src/flutter/lib/gpu/render_pass_unittests.cc
+++ b/engine/src/flutter/lib/gpu/render_pass_unittests.cc
@@ -6,10 +6,26 @@
 
 #include "gtest/gtest.h"
 
+#include "flutter/lib/gpu/render_pipeline.h"
+#include "flutter/lib/gpu/shader.h"
 #include "fml/memory/ref_ptr.h"
 
 namespace flutter::gpu {
 namespace {
+
+fml::RefPtr<Shader> MakeShader(impeller::ShaderStage stage) {
+  return Shader::Make("library", "Entrypoint", stage,
+                      /*code_mapping=*/nullptr, /*inputs=*/{}, /*layouts=*/{},
+                      /*uniform_structs=*/{}, /*uniform_textures=*/{},
+                      /*descriptor_set_layouts=*/{});
+}
+
+fml::RefPtr<RenderPipeline> MakeRenderPipeline() {
+  auto vertex = MakeShader(impeller::ShaderStage::kVertex);
+  auto fragment = MakeShader(impeller::ShaderStage::kFragment);
+  return fml::MakeRefCounted<RenderPipeline>(vertex, fragment,
+                                             vertex->CreateVertexDescriptor());
+}
 
 // Regression test for https://github.com/flutter/flutter/issues/188712:
 // SetDepthWriteEnable must honor its argument. It previously ignored the
@@ -48,7 +64,49 @@ TEST(FlutterGpuRenderPassTest, PipelineStateMutationsMarkStateDirty) {
   EXPECT_TRUE(render_pass->IsPipelineStateDirtyForTesting());
 
   render_pass->ClearPipelineStateDirtyForTesting();
-  render_pass->SetPipeline(nullptr);
+  render_pass->SetCullMode(impeller::CullMode::kBackFace);
+  EXPECT_TRUE(render_pass->IsPipelineStateDirtyForTesting());
+
+  render_pass->ClearPipelineStateDirtyForTesting();
+  render_pass->SetWindingOrder(impeller::WindingOrder::kCounterClockwise);
+  EXPECT_TRUE(render_pass->IsPipelineStateDirtyForTesting());
+
+  render_pass->ClearPipelineStateDirtyForTesting();
+  render_pass->SetPrimitiveType(impeller::PrimitiveType::kTriangleStrip);
+  EXPECT_TRUE(render_pass->IsPipelineStateDirtyForTesting());
+
+  render_pass->ClearPipelineStateDirtyForTesting();
+  render_pass->SetPolygonMode(impeller::PolygonMode::kLine);
+  EXPECT_TRUE(render_pass->IsPipelineStateDirtyForTesting());
+
+  render_pass->ClearPipelineStateDirtyForTesting();
+  render_pass->SetPipeline(MakeRenderPipeline());
+  EXPECT_TRUE(render_pass->IsPipelineStateDirtyForTesting());
+}
+
+// Callers re-send the same fixed-function state and rebind the same pipeline
+// ahead of most draws. Dirtying on those redundant assignments would rebuild
+// the pipeline for every draw and leave the memoization doing nothing.
+TEST(FlutterGpuRenderPassTest, RedundantPipelineStateAssignmentsAreIgnored) {
+  auto render_pass = fml::MakeRefCounted<RenderPass>();
+  auto pipeline = MakeRenderPipeline();
+
+  render_pass->SetCullMode(impeller::CullMode::kBackFace);
+  render_pass->SetWindingOrder(impeller::WindingOrder::kCounterClockwise);
+  render_pass->SetPrimitiveType(impeller::PrimitiveType::kTriangleStrip);
+  render_pass->SetPolygonMode(impeller::PolygonMode::kLine);
+  render_pass->SetPipeline(pipeline);
+
+  render_pass->ClearPipelineStateDirtyForTesting();
+  render_pass->SetCullMode(impeller::CullMode::kBackFace);
+  render_pass->SetWindingOrder(impeller::WindingOrder::kCounterClockwise);
+  render_pass->SetPrimitiveType(impeller::PrimitiveType::kTriangleStrip);
+  render_pass->SetPolygonMode(impeller::PolygonMode::kLine);
+  render_pass->SetPipeline(pipeline);
+  EXPECT_FALSE(render_pass->IsPipelineStateDirtyForTesting());
+
+  // A real change still dirties.
+  render_pass->SetCullMode(impeller::CullMode::kFrontFace);
   EXPECT_TRUE(render_pass->IsPipelineStateDirtyForTesting());
 }
 


### PR DESCRIPTION
Related to #189899.

`RenderPass` memoizes its built pipeline behind a dirty flag, but the fixed-function setters all assign through `GetPipelineDescriptor`, which dirties unconditionally. Callers re-send the same cull mode, winding order, primitive type, and polygon mode ahead of most draws, and rebind the same pipeline, so the memo was being invalidated on nearly every draw. These setters now compare before assigning and leave the state clean when nothing changed.
