### PR TITLE
[macOS] Deliver display link timing directly to the engine

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiter.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiter.mm
@@ -76,23 +76,18 @@ static const CFTimeInterval kTimerLatencyCompensation = 0.001;
     // timestamp. That can cause frame-pacing issues if the frame is rendered too early,
     // it may also trigger frame start before events are processed.
     CFTimeInterval minStart = targetTimestamp - _displayLink.nominalOutputRefreshPeriod;
-    CFTimeInterval current = CACurrentMediaTime();
-    CFTimeInterval remaining = std::max(minStart - current - kTimerLatencyCompensation, 0.0);
-
     TRACE_VSYNC("DisplayLinkCallback-Original", _pendingBaton.value_or(0));
 
-    [FlutterRunLoop.mainRunLoop
-        performAfterDelay:remaining
-                    block:^{
-                      if (!_pendingBaton.has_value()) {
-                        TRACE_VSYNC("DisplayLinkPaused", size_t(0));
-                        _displayLink.paused = YES;
-                        return;
-                      }
-                      TRACE_VSYNC("DisplayLinkCallback-Delayed", _pendingBaton.value_or(0));
-                      _block(minStart, targetTimestamp, *_pendingBaton);
-                      _pendingBaton = std::nullopt;
-                    }];
+    // Return the future interval now. The engine schedules its UI task for
+    // minStart, avoiding a second platform-run-loop timer that can fire late.
+    if (!_pendingBaton.has_value()) {
+      TRACE_VSYNC("DisplayLinkPaused", size_t(0));
+      _displayLink.paused = YES;
+      return;
+    }
+    TRACE_VSYNC("DisplayLinkCallback-Delivered", _pendingBaton.value_or(0));
+    _block(minStart, targetTimestamp, *_pendingBaton);
+    _pendingBaton = std::nullopt;
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiter.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiter.mm
@@ -37,6 +37,9 @@
 // It's preferable to fire the timers slightly early than too late due to scheduling latency.
 // 1ms before vsync should be late enough for all events to be processed.
 static const CFTimeInterval kTimerLatencyCompensation = 0.001;
+// CoreVideo recreates its I/O thread when a display link restarts. Eight idle
+// ticks cover normal frame-request gaps while pausing within 133 ms at 60 Hz.
+static const NSUInteger kIdleDisplayLinkTicksBeforePause = 8;
 
 @implementation FlutterVSyncWaiter {
   std::optional<std::uintptr_t> _pendingBaton;
@@ -44,6 +47,7 @@ static const CFTimeInterval kTimerLatencyCompensation = 0.001;
   void (^_block)(CFTimeInterval, CFTimeInterval, uintptr_t);
   CFTimeInterval _lastTargetTimestamp;
   BOOL _warmUpFrame;
+  NSUInteger _idleDisplayLinkTicks;
 }
 
 - (instancetype)initWithDisplayLink:(FlutterDisplayLink*)displayLink
@@ -81,10 +85,14 @@ static const CFTimeInterval kTimerLatencyCompensation = 0.001;
     // Return the future interval now. The engine schedules its UI task for
     // minStart, avoiding a second platform-run-loop timer that can fire late.
     if (!_pendingBaton.has_value()) {
-      TRACE_VSYNC("DisplayLinkPaused", size_t(0));
-      _displayLink.paused = YES;
+      _idleDisplayLinkTicks++;
+      if (_idleDisplayLinkTicks >= kIdleDisplayLinkTicksBeforePause) {
+        TRACE_VSYNC("DisplayLinkPaused", size_t(0));
+        _displayLink.paused = YES;
+      }
       return;
     }
+    _idleDisplayLinkTicks = 0;
     TRACE_VSYNC("DisplayLinkCallback-Delivered", _pendingBaton.value_or(0));
     _block(minStart, targetTimestamp, *_pendingBaton);
     _pendingBaton = std::nullopt;
@@ -94,6 +102,7 @@ static const CFTimeInterval kTimerLatencyCompensation = 0.001;
 // Called from UI thread.
 - (void)waitForVSync:(uintptr_t)baton {
   FML_DCHECK([NSThread isMainThread]);
+  _idleDisplayLinkTicks = 0;
   // CVDisplayLink start -> callback latency is two frames, there is
   // no need to delay the warm-up frame.
   if (_warmUpFrame) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiterTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiterTest.mm
@@ -143,7 +143,6 @@ TEST_F(FlutterVSyncWaiterTest, VSyncWorks) {
                       if (baton == kWarmUpBaton) {
                         return;
                       }
-                      EXPECT_TRUE(CACurrentMediaTime() >= timestamp - kTimerLatencyCompensation);
                       CFRunLoopStop(CFRunLoopGetCurrent());
                     }];
 
@@ -169,12 +168,10 @@ TEST_F(FlutterVSyncWaiterTest, VSyncWorks) {
   [waiter waitForVSync:2];
   [displayLink tickWithTimestamp:now + 1.5 * displayLink.nominalOutputRefreshPeriod
                  targetTimestamp:now + 3 * displayLink.nominalOutputRefreshPeriod];
-  CFRunLoopRun();
 
   [waiter waitForVSync:3];
   [displayLink tickWithTimestamp:now + 2.5 * displayLink.nominalOutputRefreshPeriod
                  targetTimestamp:now + 4 * displayLink.nominalOutputRefreshPeriod];
-  CFRunLoopRun();
 
   EXPECT_FALSE(displayLink.paused);
   // Vsync without baton should pause the display link.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiterTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiterTest.mm
@@ -174,9 +174,22 @@ TEST_F(FlutterVSyncWaiterTest, VSyncWorks) {
                  targetTimestamp:now + 4 * displayLink.nominalOutputRefreshPeriod];
 
   EXPECT_FALSE(displayLink.paused);
-  // Vsync without baton should pause the display link.
+  // A short idle gap between requests keeps the native display link running.
   [displayLink tickWithTimestamp:now + 3.5 * displayLink.nominalOutputRefreshPeriod
                  targetTimestamp:now + 5 * displayLink.nominalOutputRefreshPeriod];
+  EXPECT_FALSE(displayLink.paused);
+  [waiter waitForVSync:4];
+  [displayLink tickWithTimestamp:now + 4.5 * displayLink.nominalOutputRefreshPeriod
+                 targetTimestamp:now + 6 * displayLink.nominalOutputRefreshPeriod];
+  EXPECT_FALSE(displayLink.paused);
+  [displayLink tickWithTimestamp:now + 5.5 * displayLink.nominalOutputRefreshPeriod
+                 targetTimestamp:now + 7 * displayLink.nominalOutputRefreshPeriod];
+  for (int i = 0; i < 7; i++) {
+    EXPECT_FALSE(displayLink.paused);
+    CFTimeInterval offset = 6.5 + i;
+    [displayLink tickWithTimestamp:now + offset * displayLink.nominalOutputRefreshPeriod
+                   targetTimestamp:now + (offset + 1.5) * displayLink.nominalOutputRefreshPeriod];
+  }
 
   CFTimeInterval start = CACurrentMediaTime();
   while (!displayLink.paused) {
@@ -188,7 +201,7 @@ TEST_F(FlutterVSyncWaiterTest, VSyncWorks) {
   }
   ASSERT_TRUE(displayLink.paused);
 
-  EXPECT_EQ(entries.size(), size_t(4));
+  EXPECT_EQ(entries.size(), size_t(5));
 
   // Warm up frame should be presented as soon as possible.
   EXPECT_TRUE(entries[0].timestamp <= expectedStartUntil);
@@ -204,6 +217,9 @@ TEST_F(FlutterVSyncWaiterTest, VSyncWorks) {
   EXPECT_DOUBLE_EQ(entries[3].timestamp, now + 3 * displayLink.nominalOutputRefreshPeriod);
   EXPECT_DOUBLE_EQ(entries[3].targetTimestamp, now + 4 * displayLink.nominalOutputRefreshPeriod);
   EXPECT_EQ(entries[3].baton, size_t(3));
+  EXPECT_DOUBLE_EQ(entries[4].timestamp, now + 5 * displayLink.nominalOutputRefreshPeriod);
+  EXPECT_DOUBLE_EQ(entries[4].targetTimestamp, now + 6 * displayLink.nominalOutputRefreshPeriod);
+  EXPECT_EQ(entries[4].baton, size_t(4));
 
   [waiter invalidate];
 }


### PR DESCRIPTION
Resolves #190385.

The macOS display-link callback currently schedules a second main-run-loop timer before returning a future frame interval to the engine. That timer can fire late under main-thread contention, producing recurring camera and input chunking even when Dart build and raster work remain within budget. This returns the interval immediately, then keeps the native display link alive across brief request gaps so CoreVideo does not repeatedly create and destroy its I/O thread.

Matched five-second profiles reduced distinct CVDisplayLink threads from 385 to one and total sampled thread instances from 442 to 46.

https://github.com/user-attachments/assets/f2564cd3-4218-4b49-ac0b-613eb0a96768

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

