### PR TITLE
[Flutter GPU] Bind shader metadata by pointer instead of copying it per draw

### DIFF
--- a/engine/src/flutter/lib/gpu/command_buffer.cc
+++ b/engine/src/flutter/lib/gpu/command_buffer.cc
@@ -5,6 +5,7 @@
 #include "flutter/lib/gpu/command_buffer.h"
 
 #include "dart_api.h"
+#include "flutter/lib/gpu/render_pass.h"
 #include "fml/make_copyable.h"
 #include "impeller/core/buffer_view.h"
 #include "impeller/renderer/command_buffer.h"
@@ -40,10 +41,12 @@ std::shared_ptr<impeller::CommandBuffer> CommandBuffer::GetCommandBuffer() {
 }
 
 void CommandBuffer::AddRenderPass(
-    std::shared_ptr<impeller::RenderPass> render_pass) {
+    std::shared_ptr<impeller::RenderPass> render_pass,
+    fml::RefPtr<RenderPass> owner) {
   Encodable encodable;
   encodable.render_pass = std::move(render_pass);
   encodables_.push_back(std::move(encodable));
+  retained_render_passes_.push_back(std::move(owner));
 }
 
 std::shared_ptr<impeller::BlitPass> CommandBuffer::GetOrCreateBlitPass() {

--- a/engine/src/flutter/lib/gpu/command_buffer.cc
+++ b/engine/src/flutter/lib/gpu/command_buffer.cc
@@ -146,7 +146,11 @@ bool CommandBuffer::Submit(
   }
 
   // For the GLES backend, command queue submission just flushes the reactor,
-  // which needs to happen on the raster thread.
+  // which needs to happen on the raster thread. Encoding then outlives this
+  // call, so `retained_render_passes_` keeps holding the metadata the encode
+  // reads. It stays on the command buffer instead of moving into the task
+  // because dropping the last reference to a Dart wrappable off the UI thread
+  // enters the isolate from the raster thread.
   if (context_->GetBackendType() == impeller::Context::BackendType::kOpenGLES) {
     auto dart_state = flutter::UIDartState::Current();
     auto& task_runners = dart_state->GetTaskRunners();
@@ -180,6 +184,10 @@ bool CommandBuffer::Submit(
       return false;
     }
   }
+  // Encoding is the last read of the borrowed shader metadata, so the passes
+  // owning it can be released now rather than waiting for this command buffer
+  // to be collected.
+  retained_render_passes_.clear();
 
   auto status = context_->GetCommandQueue()->Submit(
       {command_buffer_}, combined_completion_callback);

--- a/engine/src/flutter/lib/gpu/command_buffer.h
+++ b/engine/src/flutter/lib/gpu/command_buffer.h
@@ -23,6 +23,8 @@
 namespace flutter {
 namespace gpu {
 
+class RenderPass;
+
 class CommandBuffer : public RefCountedDartWrappable<CommandBuffer> {
   DEFINE_WRAPPERTYPEINFO();
   FML_FRIEND_MAKE_REF_COUNTED(CommandBuffer);
@@ -33,7 +35,11 @@ class CommandBuffer : public RefCountedDartWrappable<CommandBuffer> {
 
   std::shared_ptr<impeller::CommandBuffer> GetCommandBuffer();
 
-  void AddRenderPass(std::shared_ptr<impeller::RenderPass> render_pass);
+  /// Queues [render_pass] for encoding at submit. [owner] is the wrapper that
+  /// records into it, retained until then because its bindings point at
+  /// shader reflection data that encoding reads.
+  void AddRenderPass(std::shared_ptr<impeller::RenderPass> render_pass,
+                     fml::RefPtr<RenderPass> owner);
 
   bool AddCompletionCallback(
       impeller::CommandBuffer::CompletionCallback completion_callback);
@@ -76,6 +82,7 @@ class CommandBuffer : public RefCountedDartWrappable<CommandBuffer> {
   std::shared_ptr<impeller::BlitPass> GetOrCreateBlitPass();
 
   std::vector<Encodable> encodables_;
+  std::vector<fml::RefPtr<RenderPass>> retained_render_passes_;
   std::vector<impeller::CommandBuffer::CompletionCallback>
       completion_callbacks_;
   bool submitted_ = false;

--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -100,8 +100,17 @@ bool RenderPass::Begin(flutter::gpu::CommandBuffer& command_buffer) {
   if (!render_pass_) {
     return false;
   }
-  command_buffer.AddRenderPass(render_pass_);
+  command_buffer.AddRenderPass(render_pass_, fml::RefPtr<RenderPass>(this));
   return true;
+}
+
+void RenderPass::RetainShader(Shader* shader) {
+  for (const fml::RefPtr<Shader>& retained : retained_shaders_) {
+    if (retained.get() == shader) {
+      return;
+    }
+  }
+  retained_shaders_.push_back(fml::RefPtr<Shader>(shader));
 }
 
 void RenderPass::SetPipeline(fml::RefPtr<RenderPipeline> pipeline) {
@@ -288,35 +297,32 @@ bool RenderPass::Draw(size_t element_count,
   }
   render_pass_->SetPipeline(impeller::PipelineRef(pipeline));
 
-  for (const auto& [_, buffer] : vertex_uniform_bindings) {
-    render_pass_->BindDynamicResource(
-        impeller::ShaderStage::kVertex,
-        impeller::DescriptorType::kUniformBuffer, buffer.slot,
-        std::make_unique<impeller::ShaderMetadata>(*buffer.view.GetMetadata()),
-        buffer.view.resource);
+  // Metadata is bound by pointer, not copied. It lives on the shader the
+  // binding came from, which `RetainShader` keeps alive, and the pass wrapper
+  // itself is retained by the command buffer until the commands encode.
+  for (const BufferAndUniformSlot& buffer : vertex_uniform_bindings) {
+    render_pass_->BindResource(impeller::ShaderStage::kVertex,
+                               impeller::DescriptorType::kUniformBuffer,
+                               buffer.slot, buffer.view.GetMetadata(),
+                               buffer.view.resource);
   }
-  for (const auto& [_, texture] : vertex_texture_bindings) {
-    render_pass_->BindDynamicResource(
-        impeller::ShaderStage::kVertex, impeller::DescriptorType::kSampledImage,
-        texture.slot,
-        std::make_unique<impeller::ShaderMetadata>(
-            *texture.texture.GetMetadata()),
-        texture.texture.resource, texture.sampler);
+  for (const TextureAndSamplerSlot& texture : vertex_texture_bindings) {
+    render_pass_->BindResource(impeller::ShaderStage::kVertex,
+                               impeller::DescriptorType::kSampledImage,
+                               texture.slot, texture.texture.GetMetadata(),
+                               texture.texture.resource, texture.sampler);
   }
-  for (const auto& [_, buffer] : fragment_uniform_bindings) {
-    render_pass_->BindDynamicResource(
-        impeller::ShaderStage::kFragment,
-        impeller::DescriptorType::kUniformBuffer, buffer.slot,
-        std::make_unique<impeller::ShaderMetadata>(*buffer.view.GetMetadata()),
-        buffer.view.resource);
+  for (const BufferAndUniformSlot& buffer : fragment_uniform_bindings) {
+    render_pass_->BindResource(impeller::ShaderStage::kFragment,
+                               impeller::DescriptorType::kUniformBuffer,
+                               buffer.slot, buffer.view.GetMetadata(),
+                               buffer.view.resource);
   }
-  for (const auto& [_, texture] : fragment_texture_bindings) {
-    render_pass_->BindDynamicResource(
-        impeller::ShaderStage::kFragment,
-        impeller::DescriptorType::kSampledImage, texture.slot,
-        std::make_unique<impeller::ShaderMetadata>(
-            *texture.texture.GetMetadata()),
-        texture.texture.resource, texture.sampler);
+  for (const TextureAndSamplerSlot& texture : fragment_texture_bindings) {
+    render_pass_->BindResource(impeller::ShaderStage::kFragment,
+                               impeller::DescriptorType::kSampledImage,
+                               texture.slot, texture.texture.GetMetadata(),
+                               texture.texture.resource, texture.sampler);
   }
 
   render_pass_->SetVertexBuffer(vertex_buffers.data(), vertex_buffer_count);
@@ -496,6 +502,31 @@ void InternalFlutterGpu_RenderPass_BindIndexBufferDevice(
                   length_in_bytes, index_type);
 }
 
+namespace {
+
+// Typical shaders stay well inside this, so a bound pass stops reallocating
+// after its first draw.
+constexpr size_t kInitialBindingCapacity = 8;
+
+/// The entry [list] holds for [binding], appended if this is the first bind
+/// for it. Rebinding overwrites in place, so the order draws replay bindings
+/// in is the order they were first bound.
+template <typename List, typename Key>
+typename List::value_type& GetOrAppendBinding(List& list, const Key* binding) {
+  for (typename List::value_type& entry : list) {
+    if (entry.binding == binding) {
+      return entry;
+    }
+  }
+  if (list.empty()) {
+    list.reserve(kInitialBindingCapacity);
+  }
+  list.push_back(typename List::value_type{.binding = binding});
+  return list.back();
+}
+
+}  // namespace
+
 static bool BindUniformStruct(
     flutter::gpu::RenderPass* wrapper,
     flutter::gpu::Shader* shader,
@@ -507,13 +538,13 @@ static bool BindUniformStruct(
     return false;
   }
 
-  flutter::gpu::RenderPass::BufferUniformMap* uniform_map = nullptr;
+  flutter::gpu::RenderPass::BufferUniformList* uniform_list = nullptr;
   switch (shader->GetShaderStage()) {
     case impeller::ShaderStage::kVertex:
-      uniform_map = &wrapper->vertex_uniform_bindings;
+      uniform_list = &wrapper->vertex_uniform_bindings;
       break;
     case impeller::ShaderStage::kFragment:
-      uniform_map = &wrapper->fragment_uniform_bindings;
+      uniform_list = &wrapper->fragment_uniform_bindings;
       break;
     case impeller::ShaderStage::kUnknown:
     case impeller::ShaderStage::kCompute:
@@ -525,15 +556,13 @@ static bool BindUniformStruct(
     return false;
   }
 
-  uniform_map->insert_or_assign(
-      uniform_struct,
-      flutter::gpu::RenderPass::BufferAndUniformSlot{
-          .slot = uniform_struct->slot,
-          .view = impeller::BufferResource{
-              &uniform_struct->metadata,
-              impeller::BufferView(
-                  buffer, impeller::Range(offset_in_bytes, length_in_bytes)),
-          }});
+  wrapper->RetainShader(shader);
+  auto& entry = GetOrAppendBinding(*uniform_list, uniform_struct);
+  entry.slot = uniform_struct->slot;
+  entry.view = impeller::BufferResource(
+      &uniform_struct->metadata,
+      impeller::BufferView(buffer,
+                           impeller::Range(offset_in_bytes, length_in_bytes)));
   return true;
 }
 
@@ -592,25 +621,25 @@ static bool BindTextureBinding(
   auto sampler =
       wrapper->GetContext()->GetSamplerLibrary()->GetSampler(sampler_desc);
 
-  flutter::gpu::RenderPass::TextureUniformMap* uniform_map = nullptr;
+  flutter::gpu::RenderPass::TextureUniformList* uniform_list = nullptr;
   switch (shader->GetShaderStage()) {
     case impeller::ShaderStage::kVertex:
-      uniform_map = &wrapper->vertex_texture_bindings;
+      uniform_list = &wrapper->vertex_texture_bindings;
       break;
     case impeller::ShaderStage::kFragment:
-      uniform_map = &wrapper->fragment_texture_bindings;
+      uniform_list = &wrapper->fragment_texture_bindings;
       break;
     case impeller::ShaderStage::kUnknown:
     case impeller::ShaderStage::kCompute:
       return false;
   }
-  uniform_map->insert_or_assign(
-      texture_binding,
-      impeller::TextureAndSampler{
-          .slot = texture_binding->slot,
-          .texture = {&texture_binding->metadata, texture->GetTexture()},
-          .sampler = sampler,
-      });
+
+  wrapper->RetainShader(shader);
+  auto& entry = GetOrAppendBinding(*uniform_list, texture_binding);
+  entry.slot = texture_binding->slot;
+  entry.texture = impeller::TextureResource(&texture_binding->metadata,
+                                            texture->GetTexture());
+  entry.sampler = sampler;
   return true;
 }
 

--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -105,7 +105,7 @@ bool RenderPass::Begin(flutter::gpu::CommandBuffer& command_buffer) {
 }
 
 void RenderPass::RetainShader(Shader* shader) {
-  for (const fml::RefPtr<Shader>& retained : retained_shaders_) {
+  for (const auto& retained : retained_shaders_) {
     if (retained.get() == shader) {
       return;
     }
@@ -513,7 +513,7 @@ constexpr size_t kInitialBindingCapacity = 8;
 /// in is the order they were first bound.
 template <typename List, typename Key>
 typename List::value_type& GetOrAppendBinding(List& list, const Key* binding) {
-  for (typename List::value_type& entry : list) {
+  for (auto& entry : list) {
     if (entry.binding == binding) {
       return entry;
     }
@@ -521,7 +521,7 @@ typename List::value_type& GetOrAppendBinding(List& list, const Key* binding) {
   if (list.empty()) {
     list.reserve(kInitialBindingCapacity);
   }
-  list.push_back(typename List::value_type{.binding = binding});
+  list.push_back({.binding = binding});
   return list.back();
 }
 

--- a/engine/src/flutter/lib/gpu/render_pass.h
+++ b/engine/src/flutter/lib/gpu/render_pass.h
@@ -9,11 +9,14 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <vector>
 #include "flutter/lib/gpu/command_buffer.h"
 #include "flutter/lib/gpu/export.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "fml/memory/ref_ptr.h"
 #include "impeller/core/formats.h"
+#include "impeller/core/raw_ptr.h"
+#include "impeller/core/sampler.h"
 #include "impeller/core/shader_types.h"
 #include "impeller/renderer/command.h"
 #include "impeller/renderer/render_pass.h"
@@ -81,22 +84,37 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
   /// can observe which mutations re-dirty it.
   void ClearPipelineStateDirtyForTesting();
 
+  /// Keeps [shader] alive until this pass is destroyed. Bindings borrow the
+  /// `impeller::ShaderMetadata` stored on the shader instead of copying it,
+  /// and the backend reads that metadata when the command buffer encodes,
+  /// which is after the last draw.
+  void RetainShader(Shader* shader);
+
   struct BufferAndUniformSlot {
-    impeller::ShaderUniformSlot slot;
+    /// The shader binding this entry was recorded for. Rebinding the same
+    /// uniform overwrites the entry rather than appending another.
+    const flutter::gpu::Shader::UniformBinding* binding = nullptr;
+    impeller::ShaderUniformSlot slot = {};
     impeller::BufferResource view;
   };
 
-  using BufferUniformMap =
-      std::unordered_map<const flutter::gpu::Shader::UniformBinding*,
-                         BufferAndUniformSlot>;
-  using TextureUniformMap =
-      std::unordered_map<const flutter::gpu::Shader::TextureBinding*,
-                         impeller::TextureAndSampler>;
+  struct TextureAndSamplerSlot {
+    const flutter::gpu::Shader::TextureBinding* binding = nullptr;
+    impeller::SampledImageSlot slot = {};
+    impeller::TextureResource texture;
+    impeller::raw_ptr<const impeller::Sampler> sampler;
+  };
 
-  BufferUniformMap vertex_uniform_bindings;
-  TextureUniformMap vertex_texture_bindings;
-  BufferUniformMap fragment_uniform_bindings;
-  TextureUniformMap fragment_texture_bindings;
+  // Bindings are replayed in full on every draw, and a draw binds well under
+  // 16 of them, so these are flat lists scanned linearly rather than hash
+  // maps. Draws see them in the order they were first bound.
+  using BufferUniformList = std::vector<BufferAndUniformSlot>;
+  using TextureUniformList = std::vector<TextureAndSamplerSlot>;
+
+  BufferUniformList vertex_uniform_bindings;
+  TextureUniformList vertex_texture_bindings;
+  BufferUniformList fragment_uniform_bindings;
+  TextureUniformList fragment_texture_bindings;
 
   // Vertex buffers indexed by binding slot. Mirrors
   // `impeller::kMaxVertexBuffers`; Impeller's HAL caps vertex buffer
@@ -141,6 +159,11 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
 
   impeller::RenderTarget render_target_;
   std::shared_ptr<impeller::RenderPass> render_pass_;
+
+  // Shaders whose reflection metadata the recorded bindings point at. Held
+  // for the whole pass, not just until `ClearBindings`, because draws
+  // recorded before a rebind still reference it.
+  std::vector<fml::RefPtr<Shader>> retained_shaders_;
 
   // Command encoding state.
   fml::RefPtr<RenderPipeline> render_pipeline_;

--- a/engine/src/flutter/lib/gpu/render_pass_unittests.cc
+++ b/engine/src/flutter/lib/gpu/render_pass_unittests.cc
@@ -26,6 +26,7 @@ namespace flutter::gpu {
 namespace {
 
 using ::impeller::testing::MockCommandBuffer;
+using ::impeller::testing::MockCommandQueue;
 using ::impeller::testing::MockDeviceBuffer;
 using ::impeller::testing::MockImpellerContext;
 using ::impeller::testing::MockRenderPass;
@@ -257,6 +258,37 @@ TEST(FlutterGpuRenderPassTest, CommandBufferRetainsTheRecordingPass) {
 
   EXPECT_TRUE(render_pass->Begin(command_buffer));
   EXPECT_FALSE(render_pass->HasOneRef());
+}
+
+// Command buffers are collected by the Dart GC, so holding the pass past the
+// encode would keep it and its shaders alive for an unbounded stretch.
+TEST(FlutterGpuRenderPassTest, SubmitReleasesTheRecordingPass) {
+  auto context = std::make_shared<MockImpellerContext>();
+  auto command_queue = std::make_shared<MockCommandQueue>();
+  auto impeller_command_buffer = std::make_shared<MockCommandBuffer>(context);
+  auto impeller_render_pass =
+      std::make_shared<MockRenderPass>(context, impeller::RenderTarget());
+  EXPECT_CALL(*impeller_render_pass, IsValid).WillRepeatedly(Return(true));
+  EXPECT_CALL(*impeller_render_pass, OnSetLabel(_)).Times(AnyNumber());
+  EXPECT_CALL(*impeller_render_pass, OnEncodeCommands(_))
+      .WillOnce(Return(true));
+  EXPECT_CALL(*impeller_command_buffer, OnCreateRenderPass(_))
+      .WillOnce(Return(impeller_render_pass));
+  // Not GLES, so the encode happens inside `Submit` instead of being posted to
+  // the raster thread.
+  EXPECT_CALL(*context, GetBackendType)
+      .WillRepeatedly(Return(impeller::Context::BackendType::kMetal));
+  EXPECT_CALL(*context, GetCommandQueue).WillRepeatedly(Return(command_queue));
+  EXPECT_CALL(*command_queue, Submit).WillOnce(Return(fml::Status()));
+
+  CommandBuffer command_buffer(context, impeller_command_buffer);
+  auto render_pass = fml::MakeRefCounted<RenderPass>();
+
+  EXPECT_TRUE(render_pass->Begin(command_buffer));
+  EXPECT_FALSE(render_pass->HasOneRef());
+
+  EXPECT_TRUE(command_buffer.Submit());
+  EXPECT_TRUE(render_pass->HasOneRef());
 }
 
 }  // namespace

--- a/engine/src/flutter/lib/gpu/render_pass_unittests.cc
+++ b/engine/src/flutter/lib/gpu/render_pass_unittests.cc
@@ -4,14 +4,34 @@
 
 #include "flutter/lib/gpu/render_pass.h"
 
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "flutter/lib/gpu/command_buffer.h"
+#include "flutter/lib/gpu/device_buffer.h"
 #include "flutter/lib/gpu/render_pipeline.h"
 #include "flutter/lib/gpu/shader.h"
 #include "fml/memory/ref_ptr.h"
+#include "impeller/core/device_buffer_descriptor.h"
+#include "impeller/core/shader_types.h"
+#include "impeller/renderer/render_target.h"
+#include "impeller/renderer/testing/mocks.h"
 
 namespace flutter::gpu {
 namespace {
+
+using ::impeller::testing::MockCommandBuffer;
+using ::impeller::testing::MockDeviceBuffer;
+using ::impeller::testing::MockImpellerContext;
+using ::impeller::testing::MockRenderPass;
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::Return;
 
 fml::RefPtr<Shader> MakeShader(impeller::ShaderStage stage) {
   return Shader::Make("library", "Entrypoint", stage,
@@ -25,6 +45,38 @@ fml::RefPtr<RenderPipeline> MakeRenderPipeline() {
   auto fragment = MakeShader(impeller::ShaderStage::kFragment);
   return fml::MakeRefCounted<RenderPipeline>(vertex, fragment,
                                              vertex->CreateVertexDescriptor());
+}
+
+// A vertex-stage shader carrying two uniform structs. Enough to exercise the
+// binding lists without a GPU context.
+fml::RefPtr<Shader> MakeVertexShader() {
+  std::unordered_map<std::string, Shader::UniformBinding> uniform_structs;
+  uniform_structs.emplace(
+      "FrameInfo",
+      Shader::UniformBinding{
+          .slot = {.name = "FrameInfo", .ext_res_0 = 0, .set = 0, .binding = 0},
+          .metadata = {.name = "FrameInfo"},
+          .size_in_bytes = 64,
+      });
+  uniform_structs.emplace(
+      "JointInfo",
+      Shader::UniformBinding{
+          .slot = {.name = "JointInfo", .ext_res_0 = 1, .set = 0, .binding = 1},
+          .metadata = {.name = "JointInfo"},
+          .size_in_bytes = 64,
+      });
+  return Shader::Make("test_library", "vertex_main",
+                      impeller::ShaderStage::kVertex, /*code_mapping=*/nullptr,
+                      /*inputs=*/{}, /*layouts=*/{}, std::move(uniform_structs),
+                      /*uniform_textures=*/{},
+                      /*descriptor_set_layouts=*/{});
+}
+
+fml::RefPtr<DeviceBuffer> MakeDeviceBuffer(size_t size_in_bytes) {
+  impeller::DeviceBufferDescriptor desc;
+  desc.size = size_in_bytes;
+  return fml::MakeRefCounted<DeviceBuffer>(
+      std::make_shared<MockDeviceBuffer>(desc));
 }
 
 // Regression test for https://github.com/flutter/flutter/issues/188712:
@@ -108,6 +160,103 @@ TEST(FlutterGpuRenderPassTest, RedundantPipelineStateAssignmentsAreIgnored) {
   // A real change still dirties.
   render_pass->SetCullMode(impeller::CullMode::kFrontFace);
   EXPECT_TRUE(render_pass->IsPipelineStateDirtyForTesting());
+}
+
+// Draws bind the shader's own reflection metadata. Copying it per binding
+// meant every draw allocated once for each bound uniform and texture.
+TEST(FlutterGpuRenderPassTest, UniformBindingsBorrowShaderMetadata) {
+  auto shader = MakeVertexShader();
+  auto buffer = MakeDeviceBuffer(256);
+  auto render_pass = fml::MakeRefCounted<RenderPass>();
+
+  const int index = shader->GetUniformStructIndex("FrameInfo");
+  ASSERT_GE(index, 0);
+  EXPECT_TRUE(InternalFlutterGpu_RenderPass_BindUniformDeviceIndexed(
+      render_pass.get(), shader.get(), index, buffer.get(),
+      /*offset_in_bytes=*/0, /*length_in_bytes=*/64));
+
+  ASSERT_EQ(render_pass->vertex_uniform_bindings.size(), 1u);
+  const RenderPass::BufferAndUniformSlot& entry =
+      render_pass->vertex_uniform_bindings[0];
+  const Shader::UniformBinding* uniform = shader->GetUniformStruct("FrameInfo");
+  EXPECT_EQ(entry.binding, uniform);
+  EXPECT_EQ(entry.view.GetMetadata(), &uniform->metadata);
+}
+
+// A rebind must overwrite the existing entry instead of appending a second
+// one, otherwise a pass that rebinds the same uniform per draw would grow its
+// binding list without bound.
+TEST(FlutterGpuRenderPassTest, RebindingAUniformOverwritesItInPlace) {
+  auto shader = MakeVertexShader();
+  auto buffer = MakeDeviceBuffer(256);
+  auto render_pass = fml::MakeRefCounted<RenderPass>();
+
+  const int frame_info = shader->GetUniformStructIndex("FrameInfo");
+  const int joint_info = shader->GetUniformStructIndex("JointInfo");
+  ASSERT_GE(frame_info, 0);
+  ASSERT_GE(joint_info, 0);
+
+  EXPECT_TRUE(InternalFlutterGpu_RenderPass_BindUniformDeviceIndexed(
+      render_pass.get(), shader.get(), frame_info, buffer.get(), 0, 64));
+  EXPECT_TRUE(InternalFlutterGpu_RenderPass_BindUniformDeviceIndexed(
+      render_pass.get(), shader.get(), joint_info, buffer.get(), 64, 64));
+  EXPECT_TRUE(InternalFlutterGpu_RenderPass_BindUniformDeviceIndexed(
+      render_pass.get(), shader.get(), frame_info, buffer.get(), 128, 64));
+
+  ASSERT_EQ(render_pass->vertex_uniform_bindings.size(), 2u);
+  EXPECT_EQ(render_pass->vertex_uniform_bindings[0].binding,
+            shader->GetUniformStruct("FrameInfo"));
+  EXPECT_EQ(render_pass->vertex_uniform_bindings[1].binding,
+            shader->GetUniformStruct("JointInfo"));
+  EXPECT_EQ(
+      render_pass->vertex_uniform_bindings[0].view.resource.GetRange().offset,
+      128u);
+}
+
+// Bindings point at metadata owned by the shader, so the pass has to keep
+// that shader alive. Clearing bindings must not release it either; draws
+// already recorded still reference the metadata.
+TEST(FlutterGpuRenderPassTest, BindingRetainsTheShaderOwningTheMetadata) {
+  auto shader = MakeVertexShader();
+  auto buffer = MakeDeviceBuffer(256);
+  const int index = shader->GetUniformStructIndex("FrameInfo");
+  ASSERT_GE(index, 0);
+
+  {
+    auto render_pass = fml::MakeRefCounted<RenderPass>();
+    EXPECT_TRUE(shader->HasOneRef());
+
+    EXPECT_TRUE(InternalFlutterGpu_RenderPass_BindUniformDeviceIndexed(
+        render_pass.get(), shader.get(), index, buffer.get(), 0, 64));
+    EXPECT_FALSE(shader->HasOneRef());
+
+    render_pass->ClearBindings();
+    EXPECT_TRUE(render_pass->vertex_uniform_bindings.empty());
+    EXPECT_FALSE(shader->HasOneRef());
+  }
+
+  EXPECT_TRUE(shader->HasOneRef());
+}
+
+// Encoding happens at submit, after the last draw, and reads the borrowed
+// metadata. The command buffer therefore has to keep the pass wrapper the
+// bindings live on alive.
+TEST(FlutterGpuRenderPassTest, CommandBufferRetainsTheRecordingPass) {
+  auto context = std::make_shared<MockImpellerContext>();
+  auto impeller_command_buffer = std::make_shared<MockCommandBuffer>(context);
+  auto impeller_render_pass =
+      std::make_shared<MockRenderPass>(context, impeller::RenderTarget());
+  EXPECT_CALL(*impeller_render_pass, IsValid).WillRepeatedly(Return(true));
+  EXPECT_CALL(*impeller_render_pass, OnSetLabel(_)).Times(AnyNumber());
+  EXPECT_CALL(*impeller_command_buffer, OnCreateRenderPass(_))
+      .WillOnce(Return(impeller_render_pass));
+
+  CommandBuffer command_buffer(context, impeller_command_buffer);
+  auto render_pass = fml::MakeRefCounted<RenderPass>();
+  EXPECT_TRUE(render_pass->HasOneRef());
+
+  EXPECT_TRUE(render_pass->Begin(command_buffer));
+  EXPECT_FALSE(render_pass->HasOneRef());
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/190396.

`RenderPass::Draw` replayed every binding through `BindDynamicResource`, which takes ownership of its metadata, so each bound uniform and texture allocated a `ShaderMetadata` copy inside the draw call. A draw with 3 uniform binds and 8 texture binds allocated 11 times, all copies of reflection data that never changes between draws. The source is already a borrowed `const ShaderMetadata*`, so this binds it directly through the `BindResource` overloads instead.

The four pointer-keyed binding maps become flat lists, scanned linearly and replayed in the order they were first bound. Because the bindings now borrow rather than own, the command buffer retains the pass wrapper and the pass retains the shaders whose reflection data it points at, so the metadata stays valid through encoding at submit.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
