### PR TITLE
[Flutter GPU] Reusable binding sets

### DIFF
--- a/engine/src/flutter/lib/gpu/BUILD.gn
+++ b/engine/src/flutter/lib/gpu/BUILD.gn
@@ -32,6 +32,8 @@ source_set("gpu") {
 
   if (!is_fuchsia) {
     sources = [
+      "binding_set.cc",
+      "binding_set.h",
       "command_buffer.cc",
       "command_buffer.h",
       "context.cc",
@@ -87,6 +89,7 @@ if (enable_unittests && !is_fuchsia) {
     testonly = true
 
     sources = [
+      "binding_set_unittests.cc",
       "command_buffer_unittests.cc",
       "render_pass_unittests.cc",
       "render_pipeline_unittests.cc",

--- a/engine/src/flutter/lib/gpu/binding_set.cc
+++ b/engine/src/flutter/lib/gpu/binding_set.cc
@@ -1,0 +1,161 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/gpu/binding_set.h"
+
+#include <utility>
+
+#include "flutter/lib/gpu/formats.h"
+#include "impeller/core/sampler_descriptor.h"
+#include "impeller/renderer/sampler_library.h"
+
+namespace flutter {
+namespace gpu {
+
+IMPLEMENT_WRAPPERTYPEINFO(flutter_gpu, BindingSet);
+
+BindingSet::BindingSet() = default;
+
+BindingSet::~BindingSet() = default;
+
+// Whether a shader stage can take resource bindings from a render pass.
+static bool IsRenderStage(impeller::ShaderStage stage) {
+  return stage == impeller::ShaderStage::kVertex ||
+         stage == impeller::ShaderStage::kFragment;
+}
+
+void BindingSet::RetainShader(Shader& shader) {
+  for (const auto& retained : shaders_) {
+    if (retained.get() == &shader) {
+      return;
+    }
+  }
+  shaders_.push_back(fml::RefPtr<Shader>(&shader));
+}
+
+bool BindingSet::AddUniform(
+    Shader& shader,
+    int uniform_struct_index,
+    const std::shared_ptr<const impeller::DeviceBuffer>& buffer,
+    size_t offset_in_bytes,
+    size_t length_in_bytes) {
+  if (!IsRenderStage(shader.GetShaderStage())) {
+    return false;
+  }
+  const Shader::UniformBinding* uniform_struct =
+      shader.GetUniformStructAt(uniform_struct_index);
+  if (!uniform_struct) {
+    return false;
+  }
+  if (!buffer || offset_in_bytes + length_in_bytes >
+                     buffer->GetDeviceBufferDescriptor().size) {
+    return false;
+  }
+
+  RetainShader(shader);
+  buffer_bindings_.push_back(BufferBinding{
+      .stage = shader.GetShaderStage(),
+      .slot = uniform_struct->slot,
+      .metadata = &uniform_struct->metadata,
+      .view = impeller::BufferView(
+          buffer, impeller::Range(offset_in_bytes, length_in_bytes)),
+  });
+  return true;
+}
+
+bool BindingSet::AddTexture(
+    Shader& shader,
+    int uniform_texture_index,
+    std::shared_ptr<const impeller::Texture> texture,
+    impeller::raw_ptr<const impeller::Sampler> sampler) {
+  if (!IsRenderStage(shader.GetShaderStage())) {
+    return false;
+  }
+  const Shader::TextureBinding* texture_binding =
+      shader.GetUniformTextureAt(uniform_texture_index);
+  if (!texture_binding) {
+    return false;
+  }
+  if (!texture || !sampler) {
+    return false;
+  }
+
+  RetainShader(shader);
+  texture_bindings_.push_back(TextureBinding{
+      .stage = shader.GetShaderStage(),
+      .slot = texture_binding->slot,
+      .metadata = &texture_binding->metadata,
+      .texture = std::move(texture),
+      // NOLINTNEXTLINE(performance-move-const-arg)
+      .sampler = std::move(sampler),
+  });
+  return true;
+}
+
+void BindingSet::Clear() {
+  buffer_bindings_.clear();
+  texture_bindings_.clear();
+  shaders_.clear();
+}
+
+const std::vector<BindingSet::BufferBinding>& BindingSet::GetBufferBindings()
+    const {
+  return buffer_bindings_;
+}
+
+const std::vector<BindingSet::TextureBinding>& BindingSet::GetTextureBindings()
+    const {
+  return texture_bindings_;
+}
+
+}  // namespace gpu
+}  // namespace flutter
+
+//----------------------------------------------------------------------------
+/// Exports
+///
+
+void InternalFlutterGpu_BindingSet_Initialize(Dart_Handle wrapper) {
+  auto res = fml::MakeRefCounted<flutter::gpu::BindingSet>();
+  res->AssociateWithDartWrapper(wrapper);
+}
+
+bool InternalFlutterGpu_BindingSet_AddUniform(
+    flutter::gpu::BindingSet* wrapper,
+    flutter::gpu::Shader* shader,
+    int uniform_struct_index,
+    flutter::gpu::DeviceBuffer* device_buffer,
+    int offset_in_bytes,
+    int length_in_bytes) {
+  if (offset_in_bytes < 0 || length_in_bytes < 0) {
+    return false;
+  }
+  return wrapper->AddUniform(*shader, uniform_struct_index,
+                             device_buffer->GetBuffer(), offset_in_bytes,
+                             length_in_bytes);
+}
+
+bool InternalFlutterGpu_BindingSet_AddTexture(flutter::gpu::BindingSet* wrapper,
+                                              flutter::gpu::Context* context,
+                                              flutter::gpu::Shader* shader,
+                                              int uniform_texture_index,
+                                              flutter::gpu::Texture* texture,
+                                              int min_filter,
+                                              int mag_filter,
+                                              int mip_filter,
+                                              int width_address_mode,
+                                              int height_address_mode,
+                                              int max_anisotropy) {
+  const impeller::SamplerDescriptor sampler_desc =
+      flutter::gpu::ToImpellerSamplerDescriptor(
+          min_filter, mag_filter, mip_filter, width_address_mode,
+          height_address_mode, max_anisotropy);
+  return wrapper->AddTexture(
+      *shader, uniform_texture_index, texture->GetTexture(),
+      context->GetContext().GetSamplerLibrary()->GetSampler(sampler_desc));
+}
+
+void InternalFlutterGpu_BindingSet_Clear(flutter::gpu::BindingSet* wrapper) {
+  wrapper->Clear();
+}

--- a/engine/src/flutter/lib/gpu/binding_set.h
+++ b/engine/src/flutter/lib/gpu/binding_set.h
@@ -50,6 +50,9 @@ class BindingSet : public RefCountedDartWrappable<BindingSet> {
     impeller::SampledImageSlot slot;
     const impeller::ShaderMetadata* metadata;
     std::shared_ptr<const impeller::Texture> texture;
+    /// Owned by the context's sampler library, which caches it for the
+    /// context's lifetime. The Dart wrapper holds the context that resolved
+    /// this binding, so the sampler outlives the set.
     impeller::raw_ptr<const impeller::Sampler> sampler;
   };
 

--- a/engine/src/flutter/lib/gpu/binding_set.h
+++ b/engine/src/flutter/lib/gpu/binding_set.h
@@ -1,0 +1,138 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_GPU_BINDING_SET_H_
+#define FLUTTER_LIB_GPU_BINDING_SET_H_
+
+#include <memory>
+#include <vector>
+
+#include "flutter/lib/gpu/context.h"
+#include "flutter/lib/gpu/device_buffer.h"
+#include "flutter/lib/gpu/export.h"
+#include "flutter/lib/gpu/shader.h"
+#include "flutter/lib/gpu/texture.h"
+#include "flutter/lib/ui/dart_wrapper.h"
+#include "fml/memory/ref_ptr.h"
+#include "impeller/core/buffer_view.h"
+#include "impeller/core/device_buffer.h"
+#include "impeller/core/raw_ptr.h"
+#include "impeller/core/sampler.h"
+#include "impeller/core/shader_types.h"
+#include "impeller/core/texture.h"
+
+namespace flutter {
+namespace gpu {
+
+/// A group of uniform and texture bindings, resolved against shader
+/// reflection once at creation and replayed by every draw that binds it.
+///
+/// Binding the set on a render pass costs one slot assignment no matter how
+/// many resources it holds, so a renderer that draws many nodes with the same
+/// material stops paying per-resource bind work per draw.
+class BindingSet : public RefCountedDartWrappable<BindingSet> {
+  DEFINE_WRAPPERTYPEINFO();
+  FML_FRIEND_MAKE_REF_COUNTED(BindingSet);
+
+ public:
+  struct BufferBinding {
+    impeller::ShaderStage stage;
+    impeller::ShaderUniformSlot slot;
+    /// Borrowed from the shader that declared the binding, which this set
+    /// keeps alive.
+    const impeller::ShaderMetadata* metadata;
+    impeller::BufferView view;
+  };
+
+  struct TextureBinding {
+    impeller::ShaderStage stage;
+    impeller::SampledImageSlot slot;
+    const impeller::ShaderMetadata* metadata;
+    std::shared_ptr<const impeller::Texture> texture;
+    impeller::raw_ptr<const impeller::Sampler> sampler;
+  };
+
+  BindingSet();
+
+  ~BindingSet() override;
+
+  /// Appends the uniform struct at `uniform_struct_index` in `shader`'s
+  /// binding order, viewing `length_in_bytes` of `buffer` starting at
+  /// `offset_in_bytes`. Returns false when the index names no struct, the
+  /// shader's stage takes no uniform bindings, or the view runs past the end
+  /// of the buffer.
+  bool AddUniform(Shader& shader,
+                  int uniform_struct_index,
+                  const std::shared_ptr<const impeller::DeviceBuffer>& buffer,
+                  size_t offset_in_bytes,
+                  size_t length_in_bytes);
+
+  /// The texture counterpart to `AddUniform`.
+  bool AddTexture(Shader& shader,
+                  int uniform_texture_index,
+                  std::shared_ptr<const impeller::Texture> texture,
+                  impeller::raw_ptr<const impeller::Sampler> sampler);
+
+  /// Drops every binding so the set can be repopulated. Used when a shader
+  /// reload replaces the reflection data the bindings resolved against.
+  void Clear();
+
+  const std::vector<BufferBinding>& GetBufferBindings() const;
+
+  const std::vector<TextureBinding>& GetTextureBindings() const;
+
+ private:
+  /// Keeps `shader` alive for this set's lifetime, since the bindings point
+  /// into reflection data the shader owns.
+  void RetainShader(Shader& shader);
+
+  std::vector<BufferBinding> buffer_bindings_;
+  std::vector<TextureBinding> texture_bindings_;
+  std::vector<fml::RefPtr<Shader>> shaders_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(BindingSet);
+};
+
+}  // namespace gpu
+}  // namespace flutter
+
+//----------------------------------------------------------------------------
+/// Exports
+///
+
+extern "C" {
+
+FLUTTER_GPU_EXPORT
+extern void InternalFlutterGpu_BindingSet_Initialize(Dart_Handle wrapper);
+
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_BindingSet_AddUniform(
+    flutter::gpu::BindingSet* wrapper,
+    flutter::gpu::Shader* shader,
+    int uniform_struct_index,
+    flutter::gpu::DeviceBuffer* device_buffer,
+    int offset_in_bytes,
+    int length_in_bytes);
+
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_BindingSet_AddTexture(
+    flutter::gpu::BindingSet* wrapper,
+    flutter::gpu::Context* context,
+    flutter::gpu::Shader* shader,
+    int uniform_texture_index,
+    flutter::gpu::Texture* texture,
+    int min_filter,
+    int mag_filter,
+    int mip_filter,
+    int width_address_mode,
+    int height_address_mode,
+    int max_anisotropy);
+
+FLUTTER_GPU_EXPORT
+extern void InternalFlutterGpu_BindingSet_Clear(
+    flutter::gpu::BindingSet* wrapper);
+
+}  // extern "C"
+
+#endif  // FLUTTER_LIB_GPU_BINDING_SET_H_

--- a/engine/src/flutter/lib/gpu/binding_set_unittests.cc
+++ b/engine/src/flutter/lib/gpu/binding_set_unittests.cc
@@ -1,0 +1,196 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/gpu/binding_set.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "gtest/gtest.h"
+
+#include "flutter/lib/gpu/shader.h"
+#include "impeller/core/device_buffer_descriptor.h"
+#include "impeller/core/sampler_descriptor.h"
+#include "impeller/core/texture_descriptor.h"
+#include "impeller/renderer/testing/mocks.h"
+
+namespace flutter::gpu {
+namespace {
+
+constexpr size_t kFrameInfoExtRes0 = 3;
+constexpr size_t kTextureIndex = 2;
+
+// A shader declaring one uniform struct ("FrameInfo") and one texture
+// ("tex"), which is all a binding set resolves against.
+fml::RefPtr<Shader> MakeShader(impeller::ShaderStage stage) {
+  std::unordered_map<std::string, Shader::UniformBinding> uniform_structs;
+  uniform_structs["FrameInfo"] = Shader::UniformBinding{
+      .slot =
+          impeller::ShaderUniformSlot{
+              .name = "FrameInfo",
+              .ext_res_0 = kFrameInfoExtRes0,
+              .set = 0,
+              .binding = 0,
+          },
+      .metadata = impeller::ShaderMetadata{.name = "FrameInfo", .members = {}},
+      .size_in_bytes = 64,
+  };
+
+  std::unordered_map<std::string, Shader::TextureBinding> uniform_textures;
+  Shader::TextureBinding texture_binding;
+  texture_binding.slot = impeller::SampledImageSlot{
+      .name = "tex",
+      .texture_index = kTextureIndex,
+      .set = 0,
+      .binding = 1,
+  };
+  texture_binding.metadata =
+      impeller::ShaderMetadata{.name = "tex", .members = {}};
+  uniform_textures["tex"] = texture_binding;
+
+  return Shader::Make("library", "Entrypoint", stage,
+                      /*code_mapping=*/nullptr, /*inputs=*/{}, /*layouts=*/{},
+                      std::move(uniform_structs), std::move(uniform_textures),
+                      /*descriptor_set_layouts=*/{});
+}
+
+std::shared_ptr<impeller::DeviceBuffer> MakeBuffer(size_t size) {
+  impeller::DeviceBufferDescriptor desc;
+  desc.size = size;
+  return std::make_shared<impeller::testing::MockDeviceBuffer>(desc);
+}
+
+std::shared_ptr<impeller::Texture> MakeTexture() {
+  impeller::TextureDescriptor desc;
+  desc.size = impeller::ISize{1, 1};
+  return std::make_shared<impeller::testing::MockTexture>(desc);
+}
+
+// A set resolves each entry against the shader's reflection data once, so the
+// slot and the borrowed metadata must both come from the shader's binding.
+TEST(FlutterGpuBindingSetTest, AddUniformResolvesTheShaderBinding) {
+  auto shader = MakeShader(impeller::ShaderStage::kVertex);
+  auto set = fml::MakeRefCounted<BindingSet>();
+  auto buffer = MakeBuffer(128);
+
+  EXPECT_TRUE(set->AddUniform(*shader, /*uniform_struct_index=*/0, buffer,
+                              /*offset_in_bytes=*/16,
+                              /*length_in_bytes=*/64));
+
+  ASSERT_EQ(set->GetBufferBindings().size(), 1u);
+  const BindingSet::BufferBinding& binding = set->GetBufferBindings()[0];
+  EXPECT_EQ(binding.stage, impeller::ShaderStage::kVertex);
+  EXPECT_EQ(binding.slot.ext_res_0, kFrameInfoExtRes0);
+  ASSERT_NE(binding.metadata, nullptr);
+  EXPECT_EQ(binding.metadata->name, "FrameInfo");
+  EXPECT_EQ(binding.view.GetRange().offset, 16u);
+  EXPECT_EQ(binding.view.GetRange().length, 64u);
+}
+
+// An index outside the shader's binding order names no uniform, so the entry
+// must be rejected rather than resolved to whatever is at that address.
+TEST(FlutterGpuBindingSetTest, AddUniformRejectsAnOutOfRangeIndex) {
+  auto shader = MakeShader(impeller::ShaderStage::kFragment);
+  auto set = fml::MakeRefCounted<BindingSet>();
+  auto buffer = MakeBuffer(128);
+
+  EXPECT_FALSE(set->AddUniform(*shader, /*uniform_struct_index=*/1, buffer,
+                               /*offset_in_bytes=*/0,
+                               /*length_in_bytes=*/64));
+  EXPECT_FALSE(set->AddUniform(*shader, /*uniform_struct_index=*/-1, buffer,
+                               /*offset_in_bytes=*/0,
+                               /*length_in_bytes=*/64));
+  EXPECT_TRUE(set->GetBufferBindings().empty());
+}
+
+// The set outlives the call that created it, so an out of bounds view would
+// only fail at draw time on a backend that bothers to check. Reject it here.
+TEST(FlutterGpuBindingSetTest, AddUniformRejectsAViewPastTheEndOfTheBuffer) {
+  auto shader = MakeShader(impeller::ShaderStage::kVertex);
+  auto set = fml::MakeRefCounted<BindingSet>();
+  auto buffer = MakeBuffer(64);
+
+  EXPECT_FALSE(set->AddUniform(*shader, /*uniform_struct_index=*/0, buffer,
+                               /*offset_in_bytes=*/32,
+                               /*length_in_bytes=*/64));
+  EXPECT_FALSE(set->AddUniform(*shader, /*uniform_struct_index=*/0,
+                               /*buffer=*/nullptr, /*offset_in_bytes=*/0,
+                               /*length_in_bytes=*/64));
+  EXPECT_TRUE(set->GetBufferBindings().empty());
+}
+
+// Only the vertex and fragment stages take bindings from a render pass.
+TEST(FlutterGpuBindingSetTest, AddRejectsNonRenderStages) {
+  auto shader = MakeShader(impeller::ShaderStage::kCompute);
+  auto set = fml::MakeRefCounted<BindingSet>();
+  auto buffer = MakeBuffer(128);
+
+  EXPECT_FALSE(set->AddUniform(*shader, /*uniform_struct_index=*/0, buffer,
+                               /*offset_in_bytes=*/0,
+                               /*length_in_bytes=*/64));
+  EXPECT_TRUE(set->GetBufferBindings().empty());
+}
+
+TEST(FlutterGpuBindingSetTest, AddTextureResolvesTheShaderBinding) {
+  auto shader = MakeShader(impeller::ShaderStage::kFragment);
+  auto set = fml::MakeRefCounted<BindingSet>();
+  auto texture = MakeTexture();
+  std::shared_ptr<const impeller::Sampler> sampler =
+      std::make_shared<impeller::testing::MockSampler>(
+          impeller::SamplerDescriptor{});
+
+  EXPECT_TRUE(
+      set->AddTexture(*shader, /*uniform_texture_index=*/0, texture,
+                      impeller::raw_ptr<const impeller::Sampler>(sampler)));
+
+  ASSERT_EQ(set->GetTextureBindings().size(), 1u);
+  const BindingSet::TextureBinding& binding = set->GetTextureBindings()[0];
+  EXPECT_EQ(binding.stage, impeller::ShaderStage::kFragment);
+  EXPECT_EQ(binding.slot.texture_index, kTextureIndex);
+  ASSERT_NE(binding.metadata, nullptr);
+  EXPECT_EQ(binding.metadata->name, "tex");
+  EXPECT_EQ(binding.texture, texture);
+}
+
+TEST(FlutterGpuBindingSetTest, AddTextureRejectsAnOutOfRangeIndex) {
+  auto shader = MakeShader(impeller::ShaderStage::kFragment);
+  auto set = fml::MakeRefCounted<BindingSet>();
+  auto texture = MakeTexture();
+  std::shared_ptr<const impeller::Sampler> sampler =
+      std::make_shared<impeller::testing::MockSampler>(
+          impeller::SamplerDescriptor{});
+
+  EXPECT_FALSE(
+      set->AddTexture(*shader, /*uniform_texture_index=*/1, texture,
+                      impeller::raw_ptr<const impeller::Sampler>(sampler)));
+  EXPECT_TRUE(set->GetTextureBindings().empty());
+}
+
+// A shader hot reload replaces the reflection data the bindings point into,
+// so the set has to be emptied before it is repopulated.
+TEST(FlutterGpuBindingSetTest, ClearDropsEveryBinding) {
+  auto shader = MakeShader(impeller::ShaderStage::kFragment);
+  auto set = fml::MakeRefCounted<BindingSet>();
+  auto buffer = MakeBuffer(128);
+  auto texture = MakeTexture();
+  std::shared_ptr<const impeller::Sampler> sampler =
+      std::make_shared<impeller::testing::MockSampler>(
+          impeller::SamplerDescriptor{});
+
+  ASSERT_TRUE(set->AddUniform(*shader, /*uniform_struct_index=*/0, buffer,
+                              /*offset_in_bytes=*/0, /*length_in_bytes=*/64));
+  ASSERT_TRUE(
+      set->AddTexture(*shader, /*uniform_texture_index=*/0, texture,
+                      impeller::raw_ptr<const impeller::Sampler>(sampler)));
+
+  set->Clear();
+
+  EXPECT_TRUE(set->GetBufferBindings().empty());
+  EXPECT_TRUE(set->GetTextureBindings().empty());
+}
+
+}  // namespace
+}  // namespace flutter::gpu

--- a/engine/src/flutter/lib/gpu/formats.h
+++ b/engine/src/flutter/lib/gpu/formats.h
@@ -5,8 +5,11 @@
 #ifndef FLUTTER_LIB_GPU_FORMATS_H_
 #define FLUTTER_LIB_GPU_FORMATS_H_
 
+#include <algorithm>
+
 #include "fml/logging.h"
 #include "impeller/core/formats.h"
+#include "impeller/core/sampler_descriptor.h"
 #include "impeller/core/shader_types.h"
 
 // ATTENTION! ATTENTION! ATTENTION!
@@ -477,6 +480,28 @@ constexpr impeller::SamplerAddressMode ToImpellerSamplerAddressMode(
 constexpr impeller::SamplerAddressMode ToImpellerSamplerAddressMode(int value) {
   return ToImpellerSamplerAddressMode(
       static_cast<FlutterGPUSamplerAddressMode>(value));
+}
+
+/// Builds a sampler descriptor from the enum indices and anisotropy clamp
+/// that `SamplerOptions` marshals across the Dart boundary.
+inline impeller::SamplerDescriptor ToImpellerSamplerDescriptor(
+    int min_filter,
+    int mag_filter,
+    int mip_filter,
+    int width_address_mode,
+    int height_address_mode,
+    int max_anisotropy) {
+  impeller::SamplerDescriptor desc;
+  desc.min_filter = ToImpellerMinMagFilter(min_filter);
+  desc.mag_filter = ToImpellerMinMagFilter(mag_filter);
+  desc.mip_filter = ToImpellerMipFilter(mip_filter);
+  desc.width_address_mode = ToImpellerSamplerAddressMode(width_address_mode);
+  desc.height_address_mode = ToImpellerSamplerAddressMode(height_address_mode);
+  // Backends clamp this to the device limit reported by
+  // Capabilities::GetMaxSamplerAnisotropy.
+  desc.max_anisotropy =
+      static_cast<uint8_t>(std::clamp(max_anisotropy, 1, 255));
+  return desc;
 }
 
 enum class FlutterGPUIndexType {

--- a/engine/src/flutter/lib/gpu/lib/gpu.dart
+++ b/engine/src/flutter/lib/gpu/lib/gpu.dart
@@ -30,6 +30,7 @@ import 'dart:ui' as ui;
 
 import 'package:vector_math/vector_math.dart' as vm;
 
+part 'src/binding_set.dart';
 part 'src/buffer.dart';
 part 'src/command_buffer.dart';
 part 'src/context.dart';

--- a/engine/src/flutter/lib/gpu/lib/src/binding_set.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/binding_set.dart
@@ -11,6 +11,7 @@ part of flutter_gpu;
 base class TextureBinding {
   const TextureBinding(this.texture, {this.sampler});
 
+  /// The texture to read.
   final Texture texture;
 
   /// The sampler to read [texture] with. Defaults to the same nearest

--- a/engine/src/flutter/lib/gpu/lib/src/binding_set.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/binding_set.dart
@@ -1,0 +1,168 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+part of flutter_gpu;
+
+/// A texture and the sampler configuration used to read it, for use in a
+/// [BindingSet].
+base class TextureBinding {
+  const TextureBinding(this.texture, {this.sampler});
+
+  final Texture texture;
+
+  /// The sampler to read [texture] with. Defaults to the same nearest
+  /// filtering and clamped addressing as [RenderPass.bindTexture] when null.
+  final SamplerOptions? sampler;
+}
+
+/// An immutable group of uniform and texture bindings, resolved against
+/// shader reflection once at creation and reusable across draws and passes.
+///
+/// Create one with [GpuContext.createBindingSet] and bind it with
+/// [RenderPass.bindSet]. Binding costs one slot assignment no matter how many
+/// resources the set holds, so a renderer that draws one material across many
+/// nodes stops paying per-resource bind work on every draw.
+///
+/// A set references its resources rather than copying them, so it stays valid
+/// for as long as the bound buffers and textures do. Data that changes from
+/// frame to frame produces a new [BufferView] each frame (see
+/// [HostBuffer.emplace]) and belongs in a per-draw [RenderPass.bindUniform]
+/// instead.
+base class BindingSet extends NativeFieldWrapperClass1 {
+  BindingSet._(
+    this._gpuContext,
+    Map<UniformSlot, BufferView> uniforms,
+    Map<UniformSlot, TextureBinding> textures,
+  ) : _uniforms = Map<UniformSlot, BufferView>.unmodifiable(uniforms),
+      _textures = Map<UniformSlot, TextureBinding>.unmodifiable(textures) {
+    _initialize();
+    _populate();
+  }
+
+  final GpuContext _gpuContext;
+  final Map<UniformSlot, BufferView> _uniforms;
+  final Map<UniformSlot, TextureBinding> _textures;
+
+  /// The shader reload epoch the native bindings were resolved against. A
+  /// reload replaces the reflection data they point at, so the set is
+  /// repopulated the next time it is bound.
+  int _epoch = -1;
+
+  /// Resolves every entry against shader reflection and hands it to the
+  /// native set. Throws for a name the shader does not declare, a buffer view
+  /// that runs past the end of its buffer, or an invalid sampler.
+  void _populate() {
+    for (final MapEntry<UniformSlot, BufferView> entry in _uniforms.entries) {
+      final UniformSlot slot = entry.key;
+      final int structIndex = slot._resolvedStructIndex;
+      if (structIndex < 0) {
+        throw Exception(
+          "Failed to bind uniform (no uniform struct named '${slot.uniformName}')",
+        );
+      }
+      final BufferView view = entry.value;
+      if (!_addUniform(
+        slot.shader,
+        structIndex,
+        view.buffer,
+        view.offsetInBytes,
+        view.lengthInBytes,
+      )) {
+        throw Exception("Failed to bind uniform '${slot.uniformName}'");
+      }
+    }
+
+    for (final MapEntry<UniformSlot, TextureBinding> entry
+        in _textures.entries) {
+      final UniformSlot slot = entry.key;
+      final int textureIndex = slot._resolvedTextureIndex;
+      if (textureIndex < 0) {
+        throw Exception(
+          "Failed to bind texture (no texture named '${slot.uniformName}')",
+        );
+      }
+      final TextureBinding binding = entry.value;
+      final SamplerOptions sampler = binding.sampler ?? SamplerOptions();
+      _validateBindableTexture(binding.texture);
+      sampler._validate();
+      if (!_addTexture(
+        _gpuContext,
+        slot.shader,
+        textureIndex,
+        binding.texture,
+        sampler.minFilter.index,
+        sampler.magFilter.index,
+        sampler.mipFilter.index,
+        sampler.widthAddressMode.index,
+        sampler.heightAddressMode.index,
+        sampler.maxAnisotropy,
+      )) {
+        throw Exception("Failed to bind texture '${slot.uniformName}'");
+      }
+    }
+
+    _epoch = _shaderReloadEpoch;
+  }
+
+  /// Re-resolves the set after a shader hot reload. Cheap no-op otherwise.
+  void _syncReloadEpoch() {
+    if (_epoch == _shaderReloadEpoch) {
+      return;
+    }
+    _clear();
+    _populate();
+  }
+
+  /// Wrap with native counterpart.
+  @Native<Void Function(Handle)>(
+    symbol: 'InternalFlutterGpu_BindingSet_Initialize',
+  )
+  external void _initialize();
+
+  @Native<
+    Bool Function(Pointer<Void>, Pointer<Void>, Int, Pointer<Void>, Int, Int)
+  >(symbol: 'InternalFlutterGpu_BindingSet_AddUniform')
+  external bool _addUniform(
+    Shader shader,
+    int uniformStructIndex,
+    DeviceBuffer buffer,
+    int offsetInBytes,
+    int lengthInBytes,
+  );
+
+  @Native<
+    Bool Function(
+      Pointer<Void>,
+      Pointer<Void>,
+      Pointer<Void>,
+      Int,
+      Pointer<Void>,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+    )
+  >(symbol: 'InternalFlutterGpu_BindingSet_AddTexture')
+  external bool _addTexture(
+    GpuContext gpuContext,
+    Shader shader,
+    int uniformTextureIndex,
+    Texture texture,
+    int minFilter,
+    int magFilter,
+    int mipFilter,
+    int widthAddressMode,
+    int heightAddressMode,
+    int maxAnisotropy,
+  );
+
+  @Native<Void Function(Pointer<Void>)>(
+    symbol: 'InternalFlutterGpu_BindingSet_Clear',
+  )
+  external void _clear();
+}

--- a/engine/src/flutter/lib/gpu/lib/src/context.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/context.dart
@@ -265,6 +265,33 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     return CommandBuffer._(this);
   }
 
+  /// Creates a reusable group of uniform and texture bindings.
+  ///
+  /// Every entry is resolved against its shader's reflection data here, so
+  /// binding the set later costs one slot assignment instead of per-resource
+  /// work on every draw. See [RenderPass.bindSet].
+  ///
+  /// The keys come from [Shader.getUniformSlot], so a single set may span the
+  /// vertex and fragment stages. Throws if a slot names a uniform the shader
+  /// does not declare, if a [BufferView] runs past the end of its buffer, or
+  /// if a [SamplerOptions] is invalid.
+  ///
+  /// ```dart
+  /// final gpu.BindingSet material = gpu.gpuContext.createBindingSet(
+  ///   uniforms: {vertex.getUniformSlot('FrameInfo'): frameInfo},
+  ///   textures: {
+  ///     fragment.getUniformSlot('base_color_texture'): gpu.TextureBinding(albedo),
+  ///   },
+  /// );
+  /// ```
+  BindingSet createBindingSet({
+    Map<UniformSlot, BufferView> uniforms = const <UniformSlot, BufferView>{},
+    Map<UniformSlot, TextureBinding> textures =
+        const <UniformSlot, TextureBinding>{},
+  }) {
+    return BindingSet._(this, uniforms, textures);
+  }
+
   RenderPipeline createRenderPipeline(
     Shader vertexShader,
     Shader fragmentShader, {

--- a/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
@@ -191,6 +191,34 @@ base class SamplerOptions {
   /// levels (via [Texture.overwrite] or by rendering into them) to get the
   /// full quality benefit.
   int maxAnisotropy;
+
+  void _validate() {
+    if (maxAnisotropy < 1) {
+      throw Exception("SamplerOptions.maxAnisotropy must be at least 1");
+    }
+    if (maxAnisotropy > 1 &&
+        (minFilter != MinMagFilter.linear ||
+            magFilter != MinMagFilter.linear ||
+            mipFilter != MipFilter.linear)) {
+      throw Exception(
+        "When SamplerOptions.maxAnisotropy is greater than 1, minFilter, "
+        "magFilter, and mipFilter must all be linear",
+      );
+    }
+  }
+}
+
+/// Textures the GPU only ever writes have no backing memory to sample, so
+/// they cannot be read by a shader.
+void _validateBindableTexture(Texture texture) {
+  assert(() {
+    if (texture.storageMode == StorageMode.deviceTransient) {
+      throw Exception(
+        "Textures with StorageMode.deviceTransient cannot be bound to a RenderPass",
+      );
+    }
+    return true;
+  }());
 }
 
 base class Scissor {
@@ -342,6 +370,11 @@ base class RenderPass extends NativeFieldWrapperClass1 {
   /// native side, which in turn matches `impeller::kMaxVertexBuffers`; keep
   /// them in sync.
   static const int _kMaxVertexBufferSlots = 16;
+
+  /// The number of binding set slots that can be bound to a single draw.
+  /// Matches `flutter::gpu::RenderPass::kMaxBindingSets` on the native side;
+  /// keep them in sync. See [bindSet].
+  static const int maxBindingSets = 4;
 
   /// Bitmask of slots that have been bound via [bindVertexBuffer] since the
   /// most recent [clearBindings] (or since this RenderPass was created).
@@ -497,27 +530,8 @@ base class RenderPass extends NativeFieldWrapperClass1 {
       sampler = SamplerOptions();
     }
 
-    assert(() {
-      if (texture.storageMode == StorageMode.deviceTransient) {
-        throw Exception(
-          "Textures with StorageMode.deviceTransient cannot be bound to a RenderPass",
-        );
-      }
-      return true;
-    }());
-
-    if (sampler.maxAnisotropy < 1) {
-      throw Exception("SamplerOptions.maxAnisotropy must be at least 1");
-    }
-    if (sampler.maxAnisotropy > 1 &&
-        (sampler.minFilter != MinMagFilter.linear ||
-            sampler.magFilter != MinMagFilter.linear ||
-            sampler.mipFilter != MipFilter.linear)) {
-      throw Exception(
-        "When SamplerOptions.maxAnisotropy is greater than 1, minFilter, "
-        "magFilter, and mipFilter must all be linear",
-      );
-    }
+    _validateBindableTexture(texture);
+    sampler._validate();
 
     int uniformTextureIndex = slot._resolvedTextureIndex;
     if (uniformTextureIndex < 0) {
@@ -539,6 +553,32 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     if (!success) {
       throw Exception("Failed to bind texture");
     }
+  }
+
+  /// Binds every resource in [bindingSet] for subsequent draws, replacing
+  /// whatever set was bound to [slot].
+  ///
+  /// This is O(1) regardless of how many resources the set holds, because the
+  /// set already resolved them against shader reflection when it was created.
+  ///
+  /// Set bindings are applied before individual [bindUniform] and
+  /// [bindTexture] calls, so an individual bind to the same shader binding
+  /// overrides the set's. Where two bound sets declare the same binding, the
+  /// higher slot wins. [clearBindings] empties every slot.
+  ///
+  /// [slot] must be in `[0, maxBindingSets)`.
+  void bindSet(BindingSet bindingSet, {int slot = 0}) {
+    if (slot < 0 || slot >= maxBindingSets) {
+      throw RangeError.range(
+        slot,
+        0,
+        maxBindingSets - 1,
+        'slot',
+        'bindSet slot must be in [0, $maxBindingSets)',
+      );
+    }
+    bindingSet._syncReloadEpoch();
+    _bindSet(bindingSet, slot);
   }
 
   void clearBindings() {
@@ -863,6 +903,11 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     int heightAddressMode,
     int maxAnisotropy,
   );
+
+  @Native<Void Function(Pointer<Void>, Pointer<Void>, Int)>(
+    symbol: 'InternalFlutterGpu_RenderPass_BindSet',
+  )
+  external void _bindSet(BindingSet bindingSet, int slot);
 
   @Native<Void Function(Pointer<Void>)>(
     symbol: 'InternalFlutterGpu_RenderPass_ClearBindings',

--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/lib/gpu/render_pass.h"
-#include <algorithm>
 #include <future>
 #include <memory>
 
@@ -152,11 +151,23 @@ void RenderPass::SetPolygonMode(impeller::PolygonMode mode) {
   pipeline_state_dirty_ = true;
 }
 
+void RenderPass::BindSet(size_t slot, fml::RefPtr<BindingSet> set) {
+  if (slot >= kMaxBindingSets) {
+    return;
+  }
+  // On debug this makes a difference, but not on release builds.
+  // NOLINTNEXTLINE(performance-move-const-arg)
+  binding_sets[slot] = std::move(set);
+}
+
 void RenderPass::ClearBindings() {
   vertex_uniform_bindings.clear();
   vertex_texture_bindings.clear();
   fragment_uniform_bindings.clear();
   fragment_texture_bindings.clear();
+  for (auto& set : binding_sets) {
+    set = nullptr;
+  }
   for (auto& buffer : vertex_buffers) {
     buffer = {};
   }
@@ -287,6 +298,25 @@ bool RenderPass::Draw(size_t element_count,
     return false;
   }
   render_pass_->SetPipeline(impeller::PipelineRef(pipeline));
+
+  // Binding sets are replayed first, so an individual bind that collides
+  // with a set member overrides it for this draw. Their metadata is borrowed
+  // from the shader rather than copied, so no allocation happens here.
+  for (const auto& set : binding_sets) {
+    if (!set) {
+      continue;
+    }
+    for (const auto& buffer : set->GetBufferBindings()) {
+      render_pass_->BindResource(buffer.stage,
+                                 impeller::DescriptorType::kUniformBuffer,
+                                 buffer.slot, buffer.metadata, buffer.view);
+    }
+    for (const auto& texture : set->GetTextureBindings()) {
+      render_pass_->BindResource(
+          texture.stage, impeller::DescriptorType::kSampledImage, texture.slot,
+          texture.metadata, texture.texture, texture.sampler);
+    }
+  }
 
   for (const auto& [_, buffer] : vertex_uniform_bindings) {
     render_pass_->BindDynamicResource(
@@ -577,18 +607,10 @@ static bool BindTextureBinding(
     return false;
   }
 
-  impeller::SamplerDescriptor sampler_desc;
-  sampler_desc.min_filter = flutter::gpu::ToImpellerMinMagFilter(min_filter);
-  sampler_desc.mag_filter = flutter::gpu::ToImpellerMinMagFilter(mag_filter);
-  sampler_desc.mip_filter = flutter::gpu::ToImpellerMipFilter(mip_filter);
-  sampler_desc.width_address_mode =
-      flutter::gpu::ToImpellerSamplerAddressMode(width_address_mode);
-  sampler_desc.height_address_mode =
-      flutter::gpu::ToImpellerSamplerAddressMode(height_address_mode);
-  // Backends clamp this to the device limit reported by
-  // Capabilities::GetMaxSamplerAnisotropy.
-  sampler_desc.max_anisotropy =
-      static_cast<uint8_t>(std::clamp(max_anisotropy, 1, 255));
+  const impeller::SamplerDescriptor sampler_desc =
+      flutter::gpu::ToImpellerSamplerDescriptor(
+          min_filter, mag_filter, mip_filter, width_address_mode,
+          height_address_mode, max_anisotropy);
   auto sampler =
       wrapper->GetContext()->GetSamplerLibrary()->GetSampler(sampler_desc);
 
@@ -647,6 +669,16 @@ bool InternalFlutterGpu_RenderPass_BindTextureIndexed(
       wrapper, shader, shader->GetUniformTextureAt(uniform_texture_index),
       texture, min_filter, mag_filter, mip_filter, width_address_mode,
       height_address_mode, max_anisotropy);
+}
+
+void InternalFlutterGpu_RenderPass_BindSet(
+    flutter::gpu::RenderPass* wrapper,
+    flutter::gpu::BindingSet* binding_set,
+    int slot) {
+  if (slot < 0) {
+    return;
+  }
+  wrapper->BindSet(slot, fml::RefPtr<flutter::gpu::BindingSet>(binding_set));
 }
 
 void InternalFlutterGpu_RenderPass_ClearBindings(

--- a/engine/src/flutter/lib/gpu/render_pass.h
+++ b/engine/src/flutter/lib/gpu/render_pass.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include "flutter/lib/gpu/binding_set.h"
 #include "flutter/lib/gpu/command_buffer.h"
 #include "flutter/lib/gpu/export.h"
 #include "flutter/lib/ui/dart_wrapper.h"
@@ -66,6 +67,14 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
   /// Set the polygon fill mode for subsequent draws.
   void SetPolygonMode(impeller::PolygonMode mode);
 
+  /// The number of binding set slots a pass can hold at once. Mirrors
+  /// `RenderPass.maxBindingSets` in `gpu/lib/src/render_pass.dart`.
+  static constexpr size_t kMaxBindingSets = 4;
+
+  /// Puts [set] in [slot], replacing whatever was there. Passing a null set
+  /// empties the slot. Out of range slots are ignored.
+  void BindSet(size_t slot, fml::RefPtr<BindingSet> set);
+
   void ClearBindings();
 
   /// Append a draw to the underlying render pass. [element_count] is the
@@ -97,6 +106,10 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
   TextureUniformMap vertex_texture_bindings;
   BufferUniformMap fragment_uniform_bindings;
   TextureUniformMap fragment_texture_bindings;
+
+  // Binding sets replayed by every draw, in slot order. Individual binds are
+  // replayed after these, so a bind that collides with a set member wins.
+  std::array<fml::RefPtr<BindingSet>, kMaxBindingSets> binding_sets;
 
   // Vertex buffers indexed by binding slot. Mirrors
   // `impeller::kMaxVertexBuffers`; Impeller's HAL caps vertex buffer
@@ -266,6 +279,12 @@ extern bool InternalFlutterGpu_RenderPass_BindTextureIndexed(
     int width_address_mode,
     int height_address_mode,
     int max_anisotropy);
+
+FLUTTER_GPU_EXPORT
+extern void InternalFlutterGpu_RenderPass_BindSet(
+    flutter::gpu::RenderPass* wrapper,
+    flutter::gpu::BindingSet* binding_set,
+    int slot);
 
 FLUTTER_GPU_EXPORT
 extern void InternalFlutterGpu_RenderPass_ClearBindings(

--- a/engine/src/flutter/lib/gpu/render_pass_unittests.cc
+++ b/engine/src/flutter/lib/gpu/render_pass_unittests.cc
@@ -6,6 +6,7 @@
 
 #include "gtest/gtest.h"
 
+#include "flutter/lib/gpu/binding_set.h"
 #include "flutter/lib/gpu/render_pipeline.h"
 #include "flutter/lib/gpu/shader.h"
 #include "fml/memory/ref_ptr.h"
@@ -108,6 +109,34 @@ TEST(FlutterGpuRenderPassTest, RedundantPipelineStateAssignmentsAreIgnored) {
   // A real change still dirties.
   render_pass->SetCullMode(impeller::CullMode::kFrontFace);
   EXPECT_TRUE(render_pass->IsPipelineStateDirtyForTesting());
+}
+
+// A set goes into a slot rather than onto a list, so rebinding it once per
+// draw (the expected usage) must not accumulate bindings on the pass.
+TEST(FlutterGpuRenderPassTest, BindSetReplacesTheSlotContents) {
+  auto render_pass = fml::MakeRefCounted<RenderPass>();
+  auto first = fml::MakeRefCounted<BindingSet>();
+  auto second = fml::MakeRefCounted<BindingSet>();
+
+  render_pass->BindSet(0, first);
+  render_pass->BindSet(0, first);
+  EXPECT_EQ(render_pass->binding_sets[0].get(), first.get());
+
+  render_pass->BindSet(0, second);
+  EXPECT_EQ(render_pass->binding_sets[0].get(), second.get());
+
+  render_pass->BindSet(1, first);
+  EXPECT_EQ(render_pass->binding_sets[0].get(), second.get());
+  EXPECT_EQ(render_pass->binding_sets[1].get(), first.get());
+
+  // An out of range slot is dropped rather than corrupting a valid one.
+  render_pass->BindSet(RenderPass::kMaxBindingSets, first);
+  EXPECT_EQ(render_pass->binding_sets[0].get(), second.get());
+
+  render_pass->ClearBindings();
+  for (const auto& set : render_pass->binding_sets) {
+    EXPECT_EQ(set.get(), nullptr);
+  }
 }
 
 }  // namespace

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -1592,7 +1592,7 @@ void main() async {
 
     // A fullscreen quad. Each vertex is position (vec3), texture_coords
     // (vec2), and a white color (vec4) so the sampled texel passes through.
-    final List<double> quad = <double>[
+    final quad = <double>[
       -1, -1, 0, 0, 0, 1, 1, 1, 1, //
       1, -1, 0, 1, 0, 1, 1, 1, 1, //
       1, 1, 0, 1, 1, 1, 1, 1, 1, //

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -1514,6 +1514,180 @@ void main() async {
     await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
+  // Renders the same green triangle as the non-indexed test, this time
+  // supplying the uniform through a reusable BindingSet instead of a per-draw
+  // bindUniform call.
+  test('Can render triangle with a BindingSet', () async {
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
+
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    state.renderPass.bindVertexBuffer(
+      transients.emplace(float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5])),
+    );
+
+    final gpu.BindingSet bindings = gpu.gpuContext.createBindingSet(
+      uniforms: <gpu.UniformSlot, gpu.BufferView>{
+        pipeline.vertexShader.getUniformSlot('VertInfo'): transients.emplace(
+          unlitUBO(Matrix4.identity(), Colors.lime),
+        ),
+      },
+    );
+    // Binding the same set repeatedly is the expected per-draw usage, and
+    // must leave exactly one binding in the slot.
+    state.renderPass.bindSet(bindings);
+    state.renderPass.bindSet(bindings);
+    state.renderPass.draw(3);
+    state.commandBuffer.submit();
+
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  // Set bindings are applied before individual binds, so a bindUniform to the
+  // same slot wins. The set paints the triangle red and the override paints it
+  // the green of the shared triangle golden.
+  test('Individual binds override a bound BindingSet', () async {
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
+
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    state.renderPass.bindVertexBuffer(
+      transients.emplace(float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5])),
+    );
+
+    final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+    state.renderPass.bindSet(
+      gpu.gpuContext.createBindingSet(
+        uniforms: <gpu.UniformSlot, gpu.BufferView>{
+          vertInfo: transients.emplace(unlitUBO(Matrix4.identity(), Vector4(1.0, 0.0, 0.0, 1.0))),
+        },
+      ),
+    );
+    state.renderPass.bindUniform(
+      vertInfo,
+      transients.emplace(unlitUBO(Matrix4.identity(), Colors.lime)),
+    );
+    state.renderPass.draw(3);
+    state.commandBuffer.submit();
+
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  // A texture and uniform bound through a set must reach the shader exactly
+  // like the per-draw binds they replace, on every backend.
+  test('BindingSet bindings render the same as per-draw binds', () async {
+    final gpu.Texture texture = gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 2, 2);
+    final magenta = Uint8List(2 * 2 * 4);
+    for (var i = 0; i < magenta.length; i += 4) {
+      magenta[i] = 0xFF;
+      magenta[i + 1] = 0x00;
+      magenta[i + 2] = 0xFF;
+      magenta[i + 3] = 0xFF;
+    }
+    texture.overwrite(magenta.buffer.asByteData());
+
+    // A fullscreen quad. Each vertex is position (vec3), texture_coords
+    // (vec2), and a white color (vec4) so the sampled texel passes through.
+    final List<double> quad = <double>[
+      -1, -1, 0, 0, 0, 1, 1, 1, 1, //
+      1, -1, 0, 1, 0, 1, 1, 1, 1, //
+      1, 1, 0, 1, 1, 1, 1, 1, 1, //
+      -1, -1, 0, 0, 0, 1, 1, 1, 1, //
+      1, 1, 0, 1, 1, 1, 1, 1, 1, //
+      -1, 1, 0, 0, 1, 1, 1, 1, 1, //
+    ];
+
+    Future<ByteData> renderQuad({required bool withBindingSet}) async {
+      final RenderPassState state = createSimpleRenderPass();
+      final gpu.RenderPipeline pipeline = await createTextureRenderPipeline();
+      state.renderPass.bindPipeline(pipeline);
+
+      final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+      state.renderPass.bindVertexBuffer(transients.emplace(float32(quad)));
+
+      final gpu.UniformSlot vertInfo = pipeline.vertexShader.getUniformSlot('VertInfo');
+      final gpu.UniformSlot tex = pipeline.fragmentShader.getUniformSlot('tex');
+      final gpu.BufferView mvp = transients.emplace(mvpUBO(Matrix4.identity()));
+      if (withBindingSet) {
+        state.renderPass.bindSet(
+          gpu.gpuContext.createBindingSet(
+            uniforms: <gpu.UniformSlot, gpu.BufferView>{vertInfo: mvp},
+            textures: <gpu.UniformSlot, gpu.TextureBinding>{tex: gpu.TextureBinding(texture)},
+          ),
+        );
+      } else {
+        state.renderPass.bindUniform(vertInfo, mvp);
+        state.renderPass.bindTexture(tex, texture);
+      }
+      state.renderPass.draw(6);
+      await submitAndWait(state.commandBuffer);
+      return readTextureBytes(state.renderTexture);
+    }
+
+    final ByteData perDraw = await renderQuad(withBindingSet: false);
+    final ByteData viaSet = await renderQuad(withBindingSet: true);
+    expect(viaSet.lengthInBytes, perDraw.lengthInBytes);
+    expect(
+      Uint8List.view(viaSet.buffer, viaSet.offsetInBytes, viaSet.lengthInBytes),
+      Uint8List.view(perDraw.buffer, perDraw.offsetInBytes, perDraw.lengthInBytes),
+    );
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  // A set validates its entries once at creation, so a name the shader does
+  // not declare must fail there rather than silently at draw time.
+  test('createBindingSet throws for an unknown uniform name', () async {
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BufferView view = transients.emplace(unlitUBO(Matrix4.identity(), Colors.lime));
+
+    try {
+      gpu.gpuContext.createBindingSet(
+        uniforms: <gpu.UniformSlot, gpu.BufferView>{
+          pipeline.vertexShader.getUniformSlot('DoesNotExist'): view,
+        },
+      );
+      fail('Exception not thrown for an unknown uniform name.');
+    } catch (e) {
+      expect(e.toString(), contains("no uniform struct named 'DoesNotExist'"));
+    }
+
+    try {
+      gpu.gpuContext.createBindingSet(
+        textures: <gpu.UniformSlot, gpu.TextureBinding>{
+          pipeline.fragmentShader.getUniformSlot('DoesNotExist'): gpu.TextureBinding(
+            gpu.gpuContext.createTexture(gpu.StorageMode.hostVisible, 1, 1),
+          ),
+        },
+      );
+      fail('Exception not thrown for an unknown texture name.');
+    } catch (e) {
+      expect(e.toString(), contains("no texture named 'DoesNotExist'"));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('bindSet throws RangeError for out-of-range slot', () async {
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BindingSet bindings = gpu.gpuContext.createBindingSet(
+      uniforms: <gpu.UniformSlot, gpu.BufferView>{
+        pipeline.vertexShader.getUniformSlot('VertInfo'): transients.emplace(
+          unlitUBO(Matrix4.identity(), Colors.lime),
+        ),
+      },
+    );
+
+    expect(() => state.renderPass.bindSet(bindings, slot: -1), throwsRangeError);
+    expect(
+      () => state.renderPass.bindSet(bindings, slot: gpu.RenderPass.maxBindingSets),
+      throwsRangeError,
+    );
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
   // Samples a texture whose mip chain was uploaded by hand with
   // Texture.overwrite(mipLevel:) rather than generated, exercising the
   // manually-mipped sampling path end to end through Flutter GPU. The quad is


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/190397.

`GpuContext.createBindingSet` resolves a group of uniform and texture bindings against shader reflection once, and `RenderPass.bindSet` puts that set in one of four slots. Binding a whole material is now one slot assignment instead of per-resource work on every draw, and the set's bindings are replayed with borrowed reflection metadata, so no per-binding allocation happens inside `Draw`.

Keys are `UniformSlot`s rather than names, so a single set can span the vertex and fragment stages. The existing `bindUniform` and `bindTexture` are unchanged and are applied after any bound sets, so an individual bind still overrides a set member for that draw.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
