### PR TITLE
[Flutter GPU] Indirect draw

### DIFF
--- a/engine/src/flutter/impeller/core/formats.h
+++ b/engine/src/flutter/impeller/core/formats.h
@@ -533,6 +533,34 @@ enum class IndexType : uint8_t {
   kNone,
 };
 
+/// The parameters of a non-indexed draw, as read from a buffer by the GPU.
+///
+/// The layout is identical on every backend (`VkDrawIndirectCommand`,
+/// `MTLDrawPrimitivesIndirectArguments`, and the GLES 3.1
+/// `DrawArraysIndirectCommand`), so a shader that writes these fields is
+/// portable as-is.
+struct DrawIndirectArgs {
+  uint32_t vertex_count = 0u;
+  uint32_t instance_count = 0u;
+  uint32_t first_vertex = 0u;
+  uint32_t first_instance = 0u;
+};
+static_assert(sizeof(DrawIndirectArgs) == 16u);
+
+/// The parameters of an indexed draw, as read from a buffer by the GPU.
+///
+/// Matches `VkDrawIndexedIndirectCommand`,
+/// `MTLDrawIndexedPrimitivesIndirectArguments`, and the GLES 3.1
+/// `DrawElementsIndirectCommand`.
+struct DrawIndexedIndirectArgs {
+  uint32_t index_count = 0u;
+  uint32_t instance_count = 0u;
+  uint32_t first_index = 0u;
+  int32_t base_vertex = 0;
+  uint32_t first_instance = 0u;
+};
+static_assert(sizeof(DrawIndexedIndirectArgs) == 20u);
+
 /// Decides how backend draws pixels based on input vertices.
 enum class PrimitiveType : uint8_t {
   /// Draws a triangle for each separate set of three vertices.

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -218,6 +218,12 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
                             gl.TexSubImage3D.IsAvailable() &&
                             gl.CompressedTexSubImage3D.IsAvailable();
 
+  // Indirect draw is core on OpenGL ES 3.1 and desktop GL 4.0. Gate on the
+  // resolved entry points rather than the version so a driver that reports the
+  // version without providing them is treated as unsupported.
+  supports_indirect_draw_ = gl.DrawArraysIndirect.IsAvailable() &&
+                            gl.DrawElementsIndirect.IsAvailable();
+
   // Anisotropic filtering is not part of any core GL or GLES version; it is
   // always gated on GL_EXT_texture_filter_anisotropic. The query and the
   // texture parameter are applied with core ES 2.0 entry points (GetFloatv
@@ -328,6 +334,10 @@ bool CapabilitiesGLES::IsANGLE() const {
 
 bool CapabilitiesGLES::SupportsPrimitiveRestart() const {
   return false;
+}
+
+bool CapabilitiesGLES::SupportsIndirectDraw() const {
+  return supports_indirect_draw_;
 }
 
 bool CapabilitiesGLES::Supports32BitPrimitiveIndices() const {

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
@@ -136,6 +136,9 @@ class CapabilitiesGLES final
   bool SupportsPrimitiveRestart() const override;
 
   // |Capabilities|
+  bool SupportsIndirectDraw() const override;
+
+  // |Capabilities|
   bool Supports32BitPrimitiveIndices() const override;
 
   // |Capabilities|
@@ -181,6 +184,7 @@ class CapabilitiesGLES final
   bool supports_32bit_primitive_indices_ = false;
   bool supports_texture_max_level_ = false;
   bool supports_texture_array_ = false;
+  bool supports_indirect_draw_ = false;
   bool is_angle_ = false;
   bool is_es_ = false;
   bool supports_texture_compression_bc_ = false;

--- a/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.cc
@@ -84,6 +84,8 @@ static GLenum ToTarget(DeviceBufferGLES::BindingType type) {
       return GL_ELEMENT_ARRAY_BUFFER;
     case DeviceBufferGLES::BindingType::kUniformBuffer:
       return GL_UNIFORM_BUFFER;
+    case DeviceBufferGLES::BindingType::kDrawIndirectBuffer:
+      return IMPELLER_GL_DRAW_INDIRECT_BUFFER;
   }
   FML_UNREACHABLE();
 }

--- a/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.h
@@ -36,6 +36,7 @@ class DeviceBufferGLES final
     kArrayBuffer,
     kElementArrayBuffer,
     kUniformBuffer,
+    kDrawIndirectBuffer,
   };
 
   [[nodiscard]] bool BindAndUploadDataIfNecessary(BindingType type) const;

--- a/engine/src/flutter/impeller/renderer/backend/gles/gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/gles.h
@@ -16,6 +16,10 @@
 #define IMPELLER_GL_TEXTURE_MAX_ANISOTROPY 0x84FE
 #define IMPELLER_GL_MAX_TEXTURE_MAX_ANISOTROPY 0x84FF
 
+// OpenGL ES 3.1 / desktop GL 4.0. Not in the ES 3.0 headers this backend
+// builds against.
+#define IMPELLER_GL_DRAW_INDIRECT_BUFFER 0x8F3F
+
 #define GL_GLEXT_PROTOTYPES
 #include "GLES2/gl2ext.h"
 // IWYU pragma: end_exports

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -141,6 +141,14 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
     FOR_EACH_IMPELLER_GLES3_PROC(IMPELLER_PROC);
   }
 
+  // Indirect draw is core on OpenGL ES 3.1 and on desktop GL 4.0. Resolution
+  // is still best-effort, so a driver that advertises the version without the
+  // entry points leaves the procs unavailable and SupportsIndirectDraw false.
+  if (description_->GetGlVersion().IsAtLeast(
+          description_->IsES() ? Version(3, 1) : Version(4))) {
+    FOR_EACH_IMPELLER_INDIRECT_DRAW_PROC(IMPELLER_PROC);
+  }
+
   // 2D array textures need the 3D texture entry points. They are core on
   // GL/GLES 3.0, exposed on desktop GL 2.x through GL_EXT_texture_array (which
   // uses the same entry-point names), and on OpenGL ES 2.0 through

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -258,6 +258,15 @@ void(glDepthRange)(GLdouble n, GLdouble f);
   PROC(ClearDepth);                               \
   PROC(DepthRange);
 
+// Indirect draw entry points. Core on OpenGL ES 3.1 and desktop GL 4.0, and
+// declared here because this backend builds against the ES 3.0 headers.
+void(glDrawArraysIndirect)(GLenum mode, const void* indirect);
+void(glDrawElementsIndirect)(GLenum mode, GLenum type, const void* indirect);
+
+#define FOR_EACH_IMPELLER_INDIRECT_DRAW_PROC(PROC) \
+  PROC(DrawArraysIndirect);                        \
+  PROC(DrawElementsIndirect);
+
 #define FOR_EACH_IMPELLER_GLES3_PROC(PROC) \
   PROC(FenceSync);                         \
   PROC(DeleteSync);                        \
@@ -330,6 +339,7 @@ class ProcTableGLES {
   FOR_EACH_IMPELLER_ES_ONLY_PROC(IMPELLER_PROC);
   FOR_EACH_IMPELLER_DESKTOP_ONLY_PROC(IMPELLER_PROC);
   FOR_EACH_IMPELLER_GLES3_PROC(IMPELLER_PROC);
+  FOR_EACH_IMPELLER_INDIRECT_DRAW_PROC(IMPELLER_PROC);
   FOR_EACH_IMPELLER_TEXTURE_ARRAY_PROC(IMPELLER_PROC);
   FOR_EACH_IMPELLER_EXT_PROC(IMPELLER_PROC);
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -586,7 +586,24 @@ static void EncodeViewport(const ProcTableGLES& gl,
       }
     };
 
-    if (command.instance_count == 0u) {
+    // An indirect draw reads its counts and offsets out of a buffer, so it
+    // ignores the counts on the command entirely.
+    if (command.indirect_buffer) {
+      const auto& indirect_gles =
+          DeviceBufferGLES::Cast(*command.indirect_buffer.GetBuffer());
+      if (!indirect_gles.BindAndUploadDataIfNecessary(
+              DeviceBufferGLES::BindingType::kDrawIndirectBuffer)) {
+        return false;
+      }
+      const GLvoid* indirect_offset = reinterpret_cast<const GLvoid*>(
+          static_cast<uintptr_t>(command.indirect_buffer.GetRange().offset));
+      if (!is_indexed) {
+        gl.DrawArraysIndirect(mode, indirect_offset);
+      } else {
+        gl.DrawElementsIndirect(mode, ToIndexType(command.index_type),
+                                indirect_offset);
+      }
+    } else if (command.instance_count == 0u) {
       // A zero instance count draws nothing, matching the Metal and Vulkan
       // backends.
     } else if (emulate_instanced) {

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -236,13 +236,16 @@ class RenderPassGLESCommandTest : public ::testing::Test {
   // Builds a mock OpenGL ES context with a render pass and a minimal
   // pipeline. The [resolver] controls which GL entry points the backend can
   // see, which is how a caller selects the hardware or emulated instancing
-  // path.
+  // path. [version_string] controls which core entry points are resolved at
+  // all, which is how a caller reaches the ES 3.1 indirect draw path.
   static RenderPassGLESContext CreateRenderPassGLESContext(
-      ProcTableGLES::Resolver resolver = kMockResolverGLES) {
+      ProcTableGLES::Resolver resolver = kMockResolverGLES,
+      const char* version_string = "OpenGL ES 3.0") {
     std::unique_ptr<NiceMock<MockGLESImpl>> mock_gl_impl =
         std::make_unique<NiceMock<MockGLESImpl>>();
     testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = *mock_gl_impl;
-    std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gl_impl));
+    std::shared_ptr<MockGLES> mock_gl =
+        MockGLES::Init(std::move(mock_gl_impl), std::nullopt, version_string);
 
     std::shared_ptr<ContextGLES> context =
         CreateFakeGLESContext(std::move(resolver));
@@ -543,6 +546,140 @@ TEST_F(RenderPassGLESCommandTest, ZeroInstanceCountIssuesNoDraw) {
 
   EXPECT_TRUE(render_pass->EncodeCommands());
   EXPECT_TRUE(reactor->React());
+}
+
+namespace {
+// A device buffer big enough to hold either indirect argument layout.
+std::shared_ptr<DeviceBuffer> CreateIndirectArgsBuffer(
+    const std::shared_ptr<ContextGLES>& context) {
+  DeviceBufferDescriptor desc;
+  desc.size = sizeof(DrawIndexedIndirectArgs);
+  desc.storage_mode = StorageMode::kHostVisible;
+  return std::static_pointer_cast<Context>(context)
+      ->GetResourceAllocator()
+      ->CreateBuffer(desc);
+}
+}  // namespace
+
+// A non-indexed command with an indirect argument buffer issues
+// glDrawArraysIndirect and never the count-carrying entry points.
+TEST_F(RenderPassGLESCommandTest, IndirectArrayDraw) {
+  auto ctx = CreateRenderPassGLESContext(kMockResolverGLES, "OpenGL ES 3.1");
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  EXPECT_TRUE(ctx.context->GetCapabilities()->SupportsIndirectDraw());
+
+  auto args = CreateIndirectArgsBuffer(ctx.context);
+  ASSERT_TRUE(args);
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  ASSERT_TRUE(render_pass->SetIndirectBuffer(DeviceBuffer::AsBufferView(args)));
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, DrawArraysIndirect(/*mode=*/_,
+                                                   /*indirect=*/nullptr))
+      .Times(1);
+  EXPECT_CALL(mock_gl_impl_ref, DrawArrays(_, _, _)).Times(0);
+  EXPECT_CALL(mock_gl_impl_ref, DrawArraysInstanced(_, _, _, _)).Times(0);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+// The indexed counterpart issues glDrawElementsIndirect.
+TEST_F(RenderPassGLESCommandTest, IndirectElementsDraw) {
+  auto ctx = CreateRenderPassGLESContext(kMockResolverGLES, "OpenGL ES 3.1");
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  DeviceBufferDescriptor index_desc;
+  index_desc.size = 6 * sizeof(uint16_t);
+  index_desc.storage_mode = StorageMode::kHostVisible;
+  auto index_buffer = std::static_pointer_cast<Context>(ctx.context)
+                          ->GetResourceAllocator()
+                          ->CreateBuffer(index_desc);
+  ASSERT_TRUE(index_buffer);
+  auto args = CreateIndirectArgsBuffer(ctx.context);
+  ASSERT_TRUE(args);
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  ASSERT_TRUE(render_pass->SetIndexBuffer(
+      DeviceBuffer::AsBufferView(index_buffer), IndexType::k16bit));
+  ASSERT_TRUE(render_pass->SetIndirectBuffer(DeviceBuffer::AsBufferView(args)));
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, DrawElementsIndirect(/*mode=*/_, /*type=*/_,
+                                                     /*indirect=*/nullptr))
+      .Times(1);
+  EXPECT_CALL(mock_gl_impl_ref, DrawElements(_, _, _, _)).Times(0);
+  EXPECT_CALL(mock_gl_impl_ref, DrawElementsInstanced(_, _, _, _, _)).Times(0);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+// The counts live in the argument buffer, so a command that never set them
+// still records a draw. Without this, the zero-count no-op check would drop
+// every indirect draw.
+TEST_F(RenderPassGLESCommandTest, IndirectDrawIgnoresUnsetCounts) {
+  auto ctx = CreateRenderPassGLESContext(kMockResolverGLES, "OpenGL ES 3.1");
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  auto args = CreateIndirectArgsBuffer(ctx.context);
+  ASSERT_TRUE(args);
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  render_pass->SetElementCount(0);
+  render_pass->SetInstanceCount(0);
+  ASSERT_TRUE(render_pass->SetIndirectBuffer(DeviceBuffer::AsBufferView(args)));
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, DrawArraysIndirect(_, _)).Times(1);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+// An argument view whose offset is not 4 byte aligned is rejected before it
+// reaches the driver, which requires the alignment on every backend.
+TEST_F(RenderPassGLESCommandTest, IndirectDrawRejectsUnalignedOffset) {
+  auto ctx = CreateRenderPassGLESContext(kMockResolverGLES, "OpenGL ES 3.1");
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+
+  DeviceBufferDescriptor desc;
+  desc.size = sizeof(DrawIndexedIndirectArgs) + 2u;
+  desc.storage_mode = StorageMode::kHostVisible;
+  auto args = std::static_pointer_cast<Context>(ctx.context)
+                  ->GetResourceAllocator()
+                  ->CreateBuffer(desc);
+  ASSERT_TRUE(args);
+
+  EXPECT_FALSE(render_pass->SetIndirectBuffer(
+      BufferView(args, Range(2u, sizeof(DrawIndirectArgs)))));
+}
+
+// A context that advertises ES 3.1 but does not hand back the entry points
+// reports indirect draw as unsupported.
+TEST_F(RenderPassGLESCommandTest, IndirectDrawNeedsResolvedEntryPoints) {
+  auto ctx = CreateRenderPassGLESContext(kMockResolverGLESWithoutIndirectDraw,
+                                         "OpenGL ES 3.1");
+  EXPECT_FALSE(ctx.context->GetCapabilities()->SupportsIndirectDraw());
+}
+
+// Indirect draw is an ES 3.1 feature; an ES 3.0 context does not offer it.
+TEST_F(RenderPassGLESCommandTest, IndirectDrawUnsupportedOnES30) {
+  auto ctx = CreateRenderPassGLESContext(kMockResolverGLES, "OpenGL ES 3.0");
+  EXPECT_FALSE(ctx.context->GetCapabilities()->SupportsIndirectDraw());
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -452,6 +452,20 @@ void mockDrawElementsInstanced(GLenum mode,
 static_assert(CheckSameSignature<decltype(mockDrawElementsInstanced),  //
                                  decltype(glDrawElementsInstanced)>::value);
 
+void mockDrawArraysIndirect(GLenum mode, const void* indirect) {
+  CallMockMethod(&IMockGLESImpl::DrawArraysIndirect, mode, indirect);
+}
+
+static_assert(CheckSameSignature<decltype(mockDrawArraysIndirect),  //
+                                 decltype(glDrawArraysIndirect)>::value);
+
+void mockDrawElementsIndirect(GLenum mode, GLenum type, const void* indirect) {
+  CallMockMethod(&IMockGLESImpl::DrawElementsIndirect, mode, type, indirect);
+}
+
+static_assert(CheckSameSignature<decltype(mockDrawElementsIndirect),  //
+                                 decltype(glDrawElementsIndirect)>::value);
+
 void mockVertexAttribDivisor(GLuint index, GLuint divisor) {
   CallMockMethod(&IMockGLESImpl::VertexAttribDivisor, index, divisor);
 }
@@ -581,6 +595,10 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockDrawArraysInstanced);
   } else if (strcmp(name, "glDrawElementsInstanced") == 0) {
     return reinterpret_cast<void*>(mockDrawElementsInstanced);
+  } else if (strcmp(name, "glDrawArraysIndirect") == 0) {
+    return reinterpret_cast<void*>(mockDrawArraysIndirect);
+  } else if (strcmp(name, "glDrawElementsIndirect") == 0) {
+    return reinterpret_cast<void*>(mockDrawElementsIndirect);
   } else if (strcmp(name, "glVertexAttribDivisor") == 0) {
     return reinterpret_cast<void*>(mockVertexAttribDivisor);
   } else if (strcmp(name, "glBindBufferRange") == 0) {
@@ -609,6 +627,15 @@ const ProcTableGLES::Resolver kMockResolverGLESWithoutInstancing =
       strcmp(name, "glDrawElementsInstanced") == 0 ||
       strcmp(name, "glVertexAttribDivisorEXT") == 0 ||
       strcmp(name, "glVertexAttribDivisor") == 0) {
+    return nullptr;
+  }
+  return kMockResolverGLES(name);
+};
+
+const ProcTableGLES::Resolver kMockResolverGLESWithoutIndirectDraw =
+    [](const char* name) -> void* {
+  if (strcmp(name, "glDrawArraysIndirect") == 0 ||
+      strcmp(name, "glDrawElementsIndirect") == 0) {
     return nullptr;
   }
   return kMockResolverGLES(name);

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -21,6 +21,11 @@ extern const ProcTableGLES::Resolver kMockResolverGLES;
 /// instanced-draw emulation fallback.
 extern const ProcTableGLES::Resolver kMockResolverGLESWithoutInstancing;
 
+/// A resolver that behaves like |kMockResolverGLES| but hides the indirect
+/// draw entry points, so the OpenGL ES backend reports indirect draw as
+/// unsupported even on a context that advertises ES 3.1.
+extern const ProcTableGLES::Resolver kMockResolverGLESWithoutIndirectDraw;
+
 class IMockGLESImpl {
  public:
   virtual ~IMockGLESImpl() = default;
@@ -124,6 +129,10 @@ class IMockGLESImpl {
                                      GLenum type,
                                      const void* indices,
                                      GLsizei instancecount) {}
+  virtual void DrawArraysIndirect(GLenum mode, const void* indirect) {}
+  virtual void DrawElementsIndirect(GLenum mode,
+                                    GLenum type,
+                                    const void* indirect) {}
   virtual void VertexAttribDivisor(GLuint index, GLuint divisor) {}
   virtual void BindBufferRange(GLenum target,
                                GLuint index,
@@ -313,6 +322,14 @@ class MockGLESImpl : public IMockGLESImpl {
                GLenum type,
                const void* indices,
                GLsizei instancecount),
+              (override));
+  MOCK_METHOD(void,
+              DrawArraysIndirect,
+              (GLenum mode, const void* indirect),
+              (override));
+  MOCK_METHOD(void,
+              DrawElementsIndirect,
+              (GLenum mode, GLenum type, const void* indirect),
               (override));
   MOCK_METHOD(void,
               VertexAttribDivisor,

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -49,6 +49,14 @@ static bool DeviceSupportsExtendedRangeFormats(id<MTLDevice> device) {
   return [device supportsFamily:MTLGPUFamilyApple3];
 }
 
+// See "Indirect Draw Calls" in the Metal Feature Set Tables:
+// https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
+// Reading draw arguments out of a buffer needs Apple3 (A9) or the Mac family.
+static bool DeviceSupportsIndirectDraw(id<MTLDevice> device) {
+  return [device supportsFamily:MTLGPUFamilyApple3] ||
+         [device supportsFamily:MTLGPUFamilyMac2];
+}
+
 // See "Pixel Format Capabilities" in the Metal Feature Set Tables:
 // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
 // BC formats are available on the Mac family and on Apple7+ (A14/M1 and newer).
@@ -86,6 +94,7 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetSupportsDeviceTransientTextures(true)
       .SetDefaultGlyphAtlasFormat(PixelFormat::kA8UNormInt)
       .SetSupportsTriangleFan(false)
+      .SetSupportsIndirectDraw(DeviceSupportsIndirectDraw(device))
       .SetMaximumRenderPassAttachmentSize(DeviceMaxTextureSizeSupported(device))
       // Anisotropic filtering with a clamp in the range [1, 16] is supported
       // on all Metal devices.

--- a/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -41,6 +41,7 @@ class RenderPassMTL final : public RenderPass {
   bool has_valid_pipeline_ = false;
   bool has_label_ = false;
   BufferView index_buffer_ = {};
+  BufferView indirect_buffer_ = {};
   PrimitiveType primitive_type_ = {};
   MTLIndexType index_type_ = {};
 
@@ -87,6 +88,9 @@ class RenderPassMTL final : public RenderPass {
 
   // |RenderPass|
   bool SetIndexBuffer(BufferView index_buffer, IndexType index_type) override;
+
+  // |RenderPass|
+  bool SetIndirectBuffer(BufferView indirect_args) override;
 
   // |RenderPass|
   fml::Status Draw() override;

--- a/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -323,12 +323,40 @@ bool RenderPassMTL::SetIndexBuffer(BufferView index_buffer,
 }
 
 // |RenderPass|
+bool RenderPassMTL::SetIndirectBuffer(BufferView indirect_args) {
+  if (!ValidateIndirectBuffer(indirect_args)) {
+    return false;
+  }
+
+  indirect_buffer_ = std::move(indirect_args);
+  return true;
+}
+
+// |RenderPass|
 fml::Status RenderPassMTL::Draw() {
   if (!has_valid_pipeline_) {
     return fml::Status(fml::StatusCode::kCancelled, "Invalid pipeline.");
   }
 
-  if (!index_buffer_) {
+  if (indirect_buffer_) {
+    id<MTLBuffer> mtl_indirect_buffer =
+        DeviceBufferMTL::Cast(*indirect_buffer_.GetBuffer()).GetMTLBuffer();
+    NSUInteger indirect_offset = indirect_buffer_.GetRange().offset;
+    if (!index_buffer_) {
+      [encoder_ drawPrimitives:ToMTLPrimitiveType(primitive_type_)
+                indirectBuffer:mtl_indirect_buffer
+          indirectBufferOffset:indirect_offset];
+    } else {
+      [encoder_ drawIndexedPrimitives:ToMTLPrimitiveType(primitive_type_)
+                            indexType:index_type_
+                          indexBuffer:DeviceBufferMTL::Cast(
+                                          *index_buffer_.GetBuffer())
+                                          .GetMTLBuffer()
+                    indexBufferOffset:index_buffer_.GetRange().offset
+                       indirectBuffer:mtl_indirect_buffer
+                 indirectBufferOffset:indirect_offset];
+    }
+  } else if (!index_buffer_) {
     if (instance_count_ != 1u) {
       [encoder_ drawPrimitives:ToMTLPrimitiveType(primitive_type_)
                    vertexStart:base_vertex_
@@ -371,6 +399,7 @@ fml::Status RenderPassMTL::Draw() {
   base_vertex_ = 0u;
   instance_count_ = 1u;
   index_buffer_ = {};
+  indirect_buffer_ = {};
   has_valid_pipeline_ = false;
   has_label_ = false;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -64,6 +64,7 @@ static PoolVMA CreateBufferPool(VmaAllocator allocator) {
                       vk::BufferUsageFlagBits::eIndexBuffer |
                       vk::BufferUsageFlagBits::eUniformBuffer |
                       vk::BufferUsageFlagBits::eStorageBuffer |
+                      vk::BufferUsageFlagBits::eIndirectBuffer |
                       vk::BufferUsageFlagBits::eTransferSrc |
                       vk::BufferUsageFlagBits::eTransferDst;
   buffer_info.size = 1u;  // doesn't matter
@@ -561,6 +562,7 @@ std::shared_ptr<DeviceBuffer> AllocatorVK::OnCreateBuffer(
                       vk::BufferUsageFlagBits::eIndexBuffer |
                       vk::BufferUsageFlagBits::eUniformBuffer |
                       vk::BufferUsageFlagBits::eStorageBuffer |
+                      vk::BufferUsageFlagBits::eIndirectBuffer |
                       vk::BufferUsageFlagBits::eTransferSrc |
                       vk::BufferUsageFlagBits::eTransferDst;
   buffer_info.size = desc.size;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -545,6 +545,13 @@ bool CapabilitiesVK::Supports32BitPrimitiveIndices() const {
   return true;
 }
 
+bool CapabilitiesVK::SupportsIndirectDraw() const {
+  // vkCmdDrawIndirect and vkCmdDrawIndexedIndirect are core Vulkan 1.0 for a
+  // single draw. Only a draw count above one needs the multiDrawIndirect
+  // device feature.
+  return true;
+}
+
 bool CapabilitiesVK::SupportsManuallyMippedTextures() const {
   return true;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -270,6 +270,9 @@ class CapabilitiesVK final : public Capabilities,
   bool SupportsPrimitiveRestart() const override;
 
   // |Capabilities|
+  bool SupportsIndirectDraw() const override;
+
+  // |Capabilities|
   bool Supports32BitPrimitiveIndices() const override;
 
   // |Capabilities|

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -499,6 +499,25 @@ bool RenderPassVK::SetIndexBuffer(BufferView index_buffer,
 }
 
 // |RenderPass|
+bool RenderPassVK::SetIndirectBuffer(BufferView indirect_args) {
+  if (!ValidateIndirectBuffer(indirect_args)) {
+    return false;
+  }
+
+  std::shared_ptr<const DeviceBuffer> device_buffer =
+      indirect_args.TakeBuffer();
+  if (device_buffer && !command_buffer_->Track(device_buffer)) {
+    return false;
+  }
+
+  indirect_buffer_ =
+      DeviceBufferVK::Cast(*indirect_args.GetBuffer()).GetBuffer();
+  indirect_buffer_offset_ = indirect_args.GetRange().offset;
+  has_indirect_buffer_ = true;
+  return true;
+}
+
+// |RenderPass|
 fml::Status RenderPassVK::Draw() {
   if (!pipeline_) {
     return fml::Status(fml::StatusCode::kCancelled,
@@ -571,7 +590,27 @@ fml::Status RenderPassVK::Draw() {
         command_buffer_vk_, TextureVK::Cast(*color_image_vk_).GetImage());
   }
 
-  if (has_index_buffer_) {
+  if (has_indirect_buffer_) {
+    // A single draw. Multi-draw is gated behind the multiDrawIndirect device
+    // feature and has no Metal or GLES equivalent.
+    // TODO(bdero): Widen this to a draw count once every backend can express
+    // it, natively or by looping the encode.
+    if (has_index_buffer_) {
+      command_buffer_vk_.drawIndexedIndirect(
+          indirect_buffer_,                                       //
+          indirect_buffer_offset_,                                //
+          1u,                                                     // draw count
+          static_cast<uint32_t>(sizeof(DrawIndexedIndirectArgs))  // stride
+      );
+    } else {
+      command_buffer_vk_.drawIndirect(
+          indirect_buffer_,                                //
+          indirect_buffer_offset_,                         //
+          1u,                                              // draw count
+          static_cast<uint32_t>(sizeof(DrawIndirectArgs))  // stride
+      );
+    }
+  } else if (has_index_buffer_) {
     command_buffer_vk_.drawIndexed(element_count_,   // index count
                                    instance_count_,  // instance count
                                    0u,               // first index
@@ -593,6 +632,9 @@ fml::Status RenderPassVK::Draw() {
 #endif  // IMPELLER_DEBUG
   has_label_ = false;
   has_index_buffer_ = false;
+  has_indirect_buffer_ = false;
+  indirect_buffer_ = {};
+  indirect_buffer_offset_ = 0u;
   bound_image_offset_ = 0u;
   bound_buffer_offset_ = 0u;
   descriptor_write_offset_ = 0u;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -48,6 +48,9 @@ class RenderPassVK final : public RenderPass {
   size_t base_vertex_ = 0u;
   size_t element_count_ = 0u;
   bool has_index_buffer_ = false;
+  vk::Buffer indirect_buffer_ = {};
+  vk::DeviceSize indirect_buffer_offset_ = 0u;
+  bool has_indirect_buffer_ = false;
   bool has_label_ = false;
   PipelineRef pipeline_ = PipelineRef(nullptr);
   bool pipeline_uses_input_attachments_ = false;
@@ -87,6 +90,9 @@ class RenderPassVK final : public RenderPass {
 
   // |RenderPass|
   bool SetIndexBuffer(BufferView index_buffer, IndexType index_type) override;
+
+  // |RenderPass|
+  bool SetIndirectBuffer(BufferView indirect_args) override;
 
   // |RenderPass|
   fml::Status Draw() override;

--- a/engine/src/flutter/impeller/renderer/capabilities.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities.cc
@@ -63,6 +63,9 @@ class StandardCapabilities final : public Capabilities {
   bool SupportsTriangleFan() const override { return supports_triangle_fan_; }
 
   // |Capabilities|
+  bool SupportsIndirectDraw() const override { return supports_indirect_draw_; }
+
+  // |Capabilities|
   PixelFormat GetDefaultColorFormat() const override {
     return default_color_format_;
   }
@@ -151,6 +154,7 @@ class StandardCapabilities final : public Capabilities {
                        bool supports_decal_sampler_address_mode,
                        bool supports_device_transient_textures,
                        bool supports_triangle_fan,
+                       bool supports_indirect_draw,
                        bool supports_extended_range_formats,
                        PixelFormat default_color_format,
                        PixelFormat default_stencil_format,
@@ -175,6 +179,7 @@ class StandardCapabilities final : public Capabilities {
             supports_decal_sampler_address_mode),
         supports_device_transient_textures_(supports_device_transient_textures),
         supports_triangle_fan_(supports_triangle_fan),
+        supports_indirect_draw_(supports_indirect_draw),
         supports_extended_range_formats_(supports_extended_range_formats),
         needs_partitioned_host_buffer_(needs_partitioned_host_buffer),
         default_color_format_(default_color_format),
@@ -203,6 +208,7 @@ class StandardCapabilities final : public Capabilities {
   bool supports_decal_sampler_address_mode_ = false;
   bool supports_device_transient_textures_ = false;
   bool supports_triangle_fan_ = false;
+  bool supports_indirect_draw_ = false;
   bool supports_extended_range_formats_ = false;
   bool needs_partitioned_host_buffer_ = false;
   PixelFormat default_color_format_ = PixelFormat::kUnknown;
@@ -301,6 +307,11 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetDefaultGlyphAtlasFormat(
   return *this;
 }
 
+CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsIndirectDraw(bool value) {
+  supports_indirect_draw_ = value;
+  return *this;
+}
+
 CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsTriangleFan(bool value) {
   supports_triangle_fan_ = value;
   return *this;
@@ -369,6 +380,7 @@ std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
       supports_decal_sampler_address_mode_,                                //
       supports_device_transient_textures_,                                 //
       supports_triangle_fan_,                                              //
+      supports_indirect_draw_,                                             //
       supports_extended_range_formats_,                                    //
       default_color_format_.value_or(PixelFormat::kUnknown),               //
       default_stencil_format_.value_or(PixelFormat::kUnknown),             //

--- a/engine/src/flutter/impeller/renderer/capabilities.h
+++ b/engine/src/flutter/impeller/renderer/capabilities.h
@@ -89,6 +89,15 @@ class Capabilities {
   /// @brief Whether primitive restart is supported.
   virtual bool SupportsPrimitiveRestart() const = 0;
 
+  /// @brief Whether a draw can source its element, instance, and offset
+  ///        counts from a buffer the GPU wrote, via
+  ///        `RenderPass::SetIndirectBuffer`.
+  ///
+  ///        Core on Vulkan and available on every Metal device Impeller
+  ///        targets. On OpenGL ES it needs the ES 3.1 entry points (desktop
+  ///        GL 4.0), so it is false on older drivers.
+  virtual bool SupportsIndirectDraw() const = 0;
+
   /// @brief Whether 32-bit values are supported in index buffers used to draw
   ///        primitives.
   virtual bool Supports32BitPrimitiveIndices() const = 0;
@@ -212,6 +221,8 @@ class CapabilitiesBuilder {
 
   CapabilitiesBuilder& SetSupportsTriangleFan(bool value);
 
+  CapabilitiesBuilder& SetSupportsIndirectDraw(bool value);
+
   CapabilitiesBuilder& SetMaximumRenderPassAttachmentSize(ISize size);
 
   CapabilitiesBuilder& SetMaxSamplerAnisotropy(uint32_t value);
@@ -233,6 +244,7 @@ class CapabilitiesBuilder {
   bool supports_decal_sampler_address_mode_ = false;
   bool supports_device_transient_textures_ = false;
   bool supports_triangle_fan_ = false;
+  bool supports_indirect_draw_ = false;
   bool supports_extended_range_formats_ = false;
   bool needs_partitioned_host_buffer_ = false;
   bool supports_texture_compression_bc_ = false;

--- a/engine/src/flutter/impeller/renderer/capabilities_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities_unittests.cc
@@ -28,6 +28,7 @@ CAPABILITY_TEST(SupportsReadFromResolve, false);
 CAPABILITY_TEST(SupportsDecalSamplerAddressMode, false);
 CAPABILITY_TEST(SupportsDeviceTransientTextures, false);
 CAPABILITY_TEST(SupportsTriangleFan, false);
+CAPABILITY_TEST(SupportsIndirectDraw, false);
 CAPABILITY_TEST(SupportsExtendedRangeFormats, false);
 CAPABILITY_TEST(NeedsPartitionedHostBuffer, false);
 

--- a/engine/src/flutter/impeller/renderer/command.h
+++ b/engine/src/flutter/impeller/renderer/command.h
@@ -87,6 +87,14 @@ struct Command {
   /// The index buffer binding used by the vertex shader stage.
   BufferView index_buffer;
 
+  //----------------------------------------------------------------------------
+  /// When set, the GPU reads the draw parameters from this buffer and
+  /// `element_count`, `instance_count`, and `base_vertex` are ignored.
+  ///
+  /// The contents are `DrawIndirectArgs`, or `DrawIndexedIndirectArgs` when an
+  /// index buffer is bound. They are never validated.
+  BufferView indirect_buffer;
+
   /// An offset into render pass storage where bound buffers/texture metadata is
   /// stored.
   Range bound_buffers = Range{0, 0};

--- a/engine/src/flutter/impeller/renderer/render_pass.cc
+++ b/engine/src/flutter/impeller/renderer/render_pass.cc
@@ -65,7 +65,9 @@ bool RenderPass::AddCommand(Command&& command) {
     return false;
   }
 
-  if (command.element_count == 0u || command.instance_count == 0u) {
+  // An indirect draw carries no counts here; they live in the argument buffer.
+  if (!command.indirect_buffer &&
+      (command.element_count == 0u || command.instance_count == 0u)) {
     // Essentially a no-op. Don't record the command but this is not necessary
     // an error either.
     return true;
@@ -171,6 +173,15 @@ bool RenderPass::SetIndexBuffer(BufferView index_buffer, IndexType index_type) {
   return true;
 }
 
+bool RenderPass::SetIndirectBuffer(BufferView indirect_args) {
+  if (!ValidateIndirectBuffer(indirect_args)) {
+    return false;
+  }
+
+  pending_.indirect_buffer = std::move(indirect_args);
+  return true;
+}
+
 bool RenderPass::ValidateVertexBuffers(const BufferView vertex_buffers[],
                                        size_t vertex_buffer_count) {
   if (vertex_buffer_count > kMaxVertexBuffers) {
@@ -199,6 +210,30 @@ bool RenderPass::ValidateIndexBuffer(const BufferView& index_buffer,
 
   if (index_type != IndexType::kNone && !index_buffer) {
     VALIDATION_LOG << "Attempted to bind an invalid index buffer.";
+    return false;
+  }
+
+  return true;
+}
+
+bool RenderPass::ValidateIndirectBuffer(const BufferView& indirect_args) {
+  if (!indirect_args) {
+    VALIDATION_LOG << "Attempted to bind an invalid indirect argument buffer.";
+    return false;
+  }
+
+  // Every backend requires the argument offset to be 4 byte aligned.
+  if (indirect_args.GetRange().offset % 4u != 0u) {
+    VALIDATION_LOG << "The indirect argument buffer offset must be a multiple "
+                      "of 4 bytes.";
+    return false;
+  }
+
+  // The arguments themselves are not inspected, but a view too small to hold
+  // even the shorter of the two layouts is always a caller bug.
+  if (indirect_args.GetRange().length < sizeof(DrawIndirectArgs)) {
+    VALIDATION_LOG << "The indirect argument buffer is too small to hold draw "
+                      "arguments.";
     return false;
   }
 

--- a/engine/src/flutter/impeller/renderer/render_pass.h
+++ b/engine/src/flutter/impeller/renderer/render_pass.h
@@ -168,6 +168,26 @@ class RenderPass : public ResourceBinder {
   ///
   virtual bool SetIndexBuffer(BufferView index_buffer, IndexType index_type);
 
+  //----------------------------------------------------------------------------
+  /// @brief      Source the next draw's parameters from a buffer read by the
+  ///             GPU instead of from `SetElementCount`, `SetInstanceCount`,
+  ///             and `SetBaseVertex`.
+  ///
+  ///             The buffer holds one `DrawIndirectArgs`, or one
+  ///             `DrawIndexedIndirectArgs` when an index buffer is bound. Its
+  ///             contents are read at draw time and are never validated, the
+  ///             same as the contents of an index buffer.
+  ///
+  ///             Only usable when `Capabilities::SupportsIndirectDraw` is
+  ///             true. Like the rest of the per-draw state, this is cleared
+  ///             once `Draw` records the command.
+  ///
+  /// @param[in]  indirect_args  The buffer view holding the draw arguments.
+  ///
+  /// @return     Returns false if the buffer view is invalid.
+  ///
+  virtual bool SetIndirectBuffer(BufferView indirect_args);
+
   /// Record the currently pending command.
   virtual fml::Status Draw();
 
@@ -270,6 +290,8 @@ class RenderPass : public ResourceBinder {
 
   static bool ValidateIndexBuffer(const BufferView& index_buffer,
                                   IndexType index_type);
+
+  static bool ValidateIndirectBuffer(const BufferView& indirect_args);
 
   virtual void OnSetLabel(std::string_view label) = 0;
 

--- a/engine/src/flutter/impeller/renderer/testing/mocks.h
+++ b/engine/src/flutter/impeller/renderer/testing/mocks.h
@@ -250,6 +250,7 @@ class MockCapabilities : public Capabilities {
   MOCK_METHOD(bool, SupportsDeviceTransientTextures, (), (const, override));
   MOCK_METHOD(bool, SupportsTriangleFan, (), (const override));
   MOCK_METHOD(bool, SupportsPrimitiveRestart, (), (const override));
+  MOCK_METHOD(bool, SupportsIndirectDraw, (), (const override));
   MOCK_METHOD(bool, Supports32BitPrimitiveIndices, (), (const override));
   MOCK_METHOD(bool, SupportsManuallyMippedTextures, (), (const override));
   MOCK_METHOD(bool, SupportsExtendedRangeFormats, (), (const override));

--- a/engine/src/flutter/lib/gpu/context.cc
+++ b/engine/src/flutter/lib/gpu/context.cc
@@ -154,6 +154,11 @@ extern bool InternalFlutterGpu_Context_GetSupportsManuallyMippedTextures(
       ->SupportsManuallyMippedTextures();
 }
 
+extern bool InternalFlutterGpu_Context_GetSupportsIndirectDraw(
+    flutter::gpu::Context* wrapper) {
+  return wrapper->GetContext().GetCapabilities()->SupportsIndirectDraw();
+}
+
 extern int InternalFlutterGpu_Context_GetMaxSamplerAnisotropy(
     flutter::gpu::Context* wrapper) {
   return wrapper->GetContext().GetCapabilities()->GetMaxSamplerAnisotropy();

--- a/engine/src/flutter/lib/gpu/context.h
+++ b/engine/src/flutter/lib/gpu/context.h
@@ -91,6 +91,10 @@ extern bool InternalFlutterGpu_Context_GetSupportsManuallyMippedTextures(
     flutter::gpu::Context* wrapper);
 
 FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_Context_GetSupportsIndirectDraw(
+    flutter::gpu::Context* wrapper);
+
+FLUTTER_GPU_EXPORT
 extern int InternalFlutterGpu_Context_GetMaxSamplerAnisotropy(
     flutter::gpu::Context* wrapper);
 

--- a/engine/src/flutter/lib/gpu/lib/src/context.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/context.dart
@@ -78,6 +78,16 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     return _getSupportsManuallyMippedTextures();
   }
 
+  /// Whether a draw can read its vertex, index, and instance counts out of a
+  /// [DeviceBuffer] the GPU wrote, via [RenderPass.drawIndirect] and
+  /// [RenderPass.drawIndexedIndirect].
+  ///
+  /// True on Metal and Vulkan. On OpenGL ES it needs ES 3.1, so it is false on
+  /// older drivers. Check this before building a GPU culling or LOD pass.
+  bool get doesSupportIndirectDraw {
+    return _getSupportsIndirectDraw();
+  }
+
   /// The maximum anisotropy clamp supported by device samplers (see
   /// [SamplerOptions.maxAnisotropy]).
   ///
@@ -318,6 +328,11 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     symbol: 'InternalFlutterGpu_Context_GetSupportsManuallyMippedTextures',
   )
   external bool _getSupportsManuallyMippedTextures();
+
+  @Native<Bool Function(Pointer<Void>)>(
+    symbol: 'InternalFlutterGpu_Context_GetSupportsIndirectDraw',
+  )
+  external bool _getSupportsIndirectDraw();
 
   @Native<Int Function(Pointer<Void>)>(
     symbol: 'InternalFlutterGpu_Context_GetMaxSamplerAnisotropy',

--- a/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
@@ -343,6 +343,11 @@ base class RenderPass extends NativeFieldWrapperClass1 {
   /// them in sync.
   static const int _kMaxVertexBufferSlots = 16;
 
+  /// Byte sizes of the two indirect argument layouts. Match
+  /// `impeller::DrawIndirectArgs` and `impeller::DrawIndexedIndirectArgs`.
+  static const int _kDrawIndirectArgsSize = 16;
+  static const int _kDrawIndexedIndirectArgsSize = 20;
+
   /// Bitmask of slots that have been bound via [bindVertexBuffer] since the
   /// most recent [clearBindings] (or since this RenderPass was created).
   /// Bit `i` is set when slot `i` has been bound.
@@ -702,6 +707,87 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     }
   }
 
+  /// Appends a non-indexed draw whose parameters the GPU reads out of
+  /// [indirectArgs] instead of taking them from Dart.
+  ///
+  /// The view must hold at least 16 bytes and start at a 4 byte aligned
+  /// offset. Those bytes are four little-endian `uint32`s, in order,
+  /// `vertexCount`, `instanceCount`, `firstVertex`, `firstInstance`. That
+  /// layout is the same on every backend, so a compute shader that writes it
+  /// is portable as-is.
+  ///
+  /// The arguments are read by the GPU at draw time and are never validated,
+  /// the same as the contents of an index buffer. Writing them from a shader
+  /// is the point of this entry point; it is what makes GPU culling and
+  /// GPU-side LOD selection expressible without a round trip to the CPU.
+  ///
+  /// `firstInstance` must be 0 unless the device is known to support a
+  /// non-zero base instance. OpenGL ES 3.1 requires zero without
+  /// `GL_EXT_base_instance`.
+  ///
+  /// Throws a [StateError] when [GpuContext.doesSupportIndirectDraw] is false.
+  void drawIndirect(BufferView indirectArgs) {
+    _validateIndirectArgs(indirectArgs, _kDrawIndirectArgsSize);
+    _validateVertexBindings();
+    if (!_drawIndirect(
+      indirectArgs.buffer,
+      indirectArgs.offsetInBytes,
+      indirectArgs.lengthInBytes,
+    )) {
+      throw Exception("Failed to append drawIndirect");
+    }
+  }
+
+  /// Appends an indexed draw whose parameters the GPU reads out of
+  /// [indirectArgs] instead of taking them from Dart.
+  ///
+  /// Indices are read from the index buffer previously bound with
+  /// [bindIndexBuffer].
+  ///
+  /// The view must hold at least 20 bytes and start at a 4 byte aligned
+  /// offset. Those bytes are five little-endian 32-bit words, in order,
+  /// `indexCount`, `instanceCount`, `firstIndex`, `baseVertex` (signed), and
+  /// `firstInstance`. See [drawIndirect] for the rest of the contract.
+  ///
+  /// Throws a [StateError] when [GpuContext.doesSupportIndirectDraw] is false.
+  void drawIndexedIndirect(BufferView indirectArgs) {
+    _validateIndirectArgs(indirectArgs, _kDrawIndexedIndirectArgsSize);
+    _validateVertexBindings();
+    if (!_drawIndexedIndirect(
+      indirectArgs.buffer,
+      indirectArgs.offsetInBytes,
+      indirectArgs.lengthInBytes,
+    )) {
+      throw Exception("Failed to append drawIndexedIndirect");
+    }
+  }
+
+  /// Rejects argument views the backend cannot use before the draw is
+  /// recorded, so the failure names the problem instead of surfacing as a
+  /// generic append failure.
+  void _validateIndirectArgs(BufferView indirectArgs, int requiredSize) {
+    if (!gpuContext.doesSupportIndirectDraw) {
+      throw StateError(
+        'This device does not support indirect draws. Check '
+        'GpuContext.doesSupportIndirectDraw before calling.',
+      );
+    }
+    if (indirectArgs.offsetInBytes % 4 != 0) {
+      throw ArgumentError.value(
+        indirectArgs.offsetInBytes,
+        'indirectArgs.offsetInBytes',
+        'must be a multiple of 4',
+      );
+    }
+    if (indirectArgs.lengthInBytes < requiredSize) {
+      throw ArgumentError.value(
+        indirectArgs.lengthInBytes,
+        'indirectArgs.lengthInBytes',
+        'must be at least $requiredSize',
+      );
+    }
+  }
+
   /// Throws a [StateError] when the bound vertex buffer slots are sparse,
   /// naming the slots in `[0, highestBound]` that were left unbound.
   void _validateVertexBindings() {
@@ -949,4 +1035,22 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     symbol: 'InternalFlutterGpu_RenderPass_DrawIndexed',
   )
   external bool _drawIndexed(int indexCount, int instanceCount);
+
+  @Native<Bool Function(Pointer<Void>, Pointer<Void>, Int, Int)>(
+    symbol: 'InternalFlutterGpu_RenderPass_DrawIndirect',
+  )
+  external bool _drawIndirect(
+    DeviceBuffer indirectBuffer,
+    int offsetInBytes,
+    int lengthInBytes,
+  );
+
+  @Native<Bool Function(Pointer<Void>, Pointer<Void>, Int, Int)>(
+    symbol: 'InternalFlutterGpu_RenderPass_DrawIndexedIndirect',
+  )
+  external bool _drawIndexedIndirect(
+    DeviceBuffer indirectBuffer,
+    int offsetInBytes,
+    int lengthInBytes,
+  );
 }

--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -226,13 +226,7 @@ RenderPass::GetOrCreatePipeline() {
   return pipeline;
 }
 
-bool RenderPass::Draw(size_t element_count,
-                      size_t instance_count,
-                      bool indexed) {
-  if (element_count == 0u || instance_count == 0u) {
-    return true;
-  }
-
+bool RenderPass::BindStateForDraw(bool indexed) {
   if (indexed && index_buffer_type == impeller::IndexType::kNone) {
     // drawIndexed was called without an index buffer bound.
     return false;
@@ -285,8 +279,6 @@ bool RenderPass::Draw(size_t element_count,
     render_pass_->SetIndexBuffer(impeller::BufferView{},
                                  impeller::IndexType::kNone);
   }
-  render_pass_->SetElementCount(element_count);
-  render_pass_->SetInstanceCount(instance_count);
 
   render_pass_->SetStencilReference(stencil_reference);
 
@@ -298,9 +290,54 @@ bool RenderPass::Draw(size_t element_count,
     render_pass_->SetScissor(scissor.value());
   }
 
-  bool result = render_pass_->Draw().ok();
+  return true;
+}
 
-  return result;
+bool RenderPass::Draw(size_t element_count,
+                      size_t instance_count,
+                      bool indexed) {
+  if (element_count == 0u || instance_count == 0u) {
+    return true;
+  }
+
+  if (!BindStateForDraw(indexed)) {
+    return false;
+  }
+
+  render_pass_->SetElementCount(element_count);
+  render_pass_->SetInstanceCount(instance_count);
+
+  return render_pass_->Draw().ok();
+}
+
+bool RenderPass::DrawIndirect(const impeller::BufferView& indirect_args,
+                              bool indexed) {
+  // Checked before any state is pushed onto the underlying pass, so a
+  // rejected call leaves no half-recorded command behind. The argument values
+  // themselves are never inspected; a bad argument is the caller's bug, the
+  // same as a bad index.
+  if (!indirect_args || indirect_args.GetRange().offset % 4u != 0u) {
+    return false;
+  }
+  const size_t required_size = indexed
+                                   ? sizeof(impeller::DrawIndexedIndirectArgs)
+                                   : sizeof(impeller::DrawIndirectArgs);
+  if (indirect_args.GetRange().length < required_size) {
+    return false;
+  }
+  if (!GetContext()->GetCapabilities()->SupportsIndirectDraw()) {
+    return false;
+  }
+
+  if (!BindStateForDraw(indexed)) {
+    return false;
+  }
+
+  if (!render_pass_->SetIndirectBuffer(indirect_args)) {
+    return false;
+  }
+
+  return render_pass_->Draw().ok();
 }
 
 }  // namespace gpu
@@ -775,4 +812,37 @@ bool InternalFlutterGpu_RenderPass_DrawIndexed(
   // Guard the casts to size_t; a negative value would wrap.
   return index_count >= 0 && instance_count >= 0 &&
          wrapper->Draw(index_count, instance_count, /*indexed=*/true);
+}
+
+static bool DrawIndirect(flutter::gpu::RenderPass* wrapper,
+                         flutter::gpu::DeviceBuffer* indirect_buffer,
+                         int offset_in_bytes,
+                         int length_in_bytes,
+                         bool indexed) {
+  // Guard the casts to size_t; a negative value would wrap.
+  if (offset_in_bytes < 0 || length_in_bytes < 0) {
+    return false;
+  }
+  return wrapper->DrawIndirect(
+      impeller::BufferView(indirect_buffer->GetBuffer(),
+                           impeller::Range(offset_in_bytes, length_in_bytes)),
+      indexed);
+}
+
+bool InternalFlutterGpu_RenderPass_DrawIndirect(
+    flutter::gpu::RenderPass* wrapper,
+    flutter::gpu::DeviceBuffer* indirect_buffer,
+    int offset_in_bytes,
+    int length_in_bytes) {
+  return DrawIndirect(wrapper, indirect_buffer, offset_in_bytes,
+                      length_in_bytes, /*indexed=*/false);
+}
+
+bool InternalFlutterGpu_RenderPass_DrawIndexedIndirect(
+    flutter::gpu::RenderPass* wrapper,
+    flutter::gpu::DeviceBuffer* indirect_buffer,
+    int offset_in_bytes,
+    int length_in_bytes) {
+  return DrawIndirect(wrapper, indirect_buffer, offset_in_bytes,
+                      length_in_bytes, /*indexed=*/true);
 }

--- a/engine/src/flutter/lib/gpu/render_pass.h
+++ b/engine/src/flutter/lib/gpu/render_pass.h
@@ -61,6 +61,12 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
   /// [indexed] is true. [instance_count] is the number of instances to draw.
   bool Draw(size_t element_count, size_t instance_count, bool indexed);
 
+  /// Append a draw whose parameters the GPU reads out of [indirect_args].
+  /// The view holds a `DrawIndirectArgs`, or a `DrawIndexedIndirectArgs` when
+  /// [indexed] is true. Fails when the backend does not support indirect
+  /// draws or the view cannot hold the arguments.
+  bool DrawIndirect(const impeller::BufferView& indirect_args, bool indexed);
+
   /// Whether the next draw must rebuild its backend pipeline. Exposed for
   /// testing the memoization's dirty tracking.
   bool IsPipelineStateDirtyForTesting() const;
@@ -104,6 +110,12 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
   std::optional<impeller::Viewport> viewport;
 
  private:
+  /// Push the pipeline, bindings, buffers, and pass state for the pending
+  /// draw. Returns false when the pipeline could not be built or an indexed
+  /// draw was requested with no index buffer bound; nothing is recorded in
+  /// that case.
+  bool BindStateForDraw(bool indexed);
+
   /// Lookup an Impeller pipeline by building a descriptor based on the current
   /// command state, or return the memoized pipeline when that state is
   /// unchanged since the last draw. Returns null (after a validation log)
@@ -351,6 +363,20 @@ extern bool InternalFlutterGpu_RenderPass_DrawIndexed(
     flutter::gpu::RenderPass* wrapper,
     int index_count,
     int instance_count);
+
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_RenderPass_DrawIndirect(
+    flutter::gpu::RenderPass* wrapper,
+    flutter::gpu::DeviceBuffer* indirect_buffer,
+    int offset_in_bytes,
+    int length_in_bytes);
+
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_RenderPass_DrawIndexedIndirect(
+    flutter::gpu::RenderPass* wrapper,
+    flutter::gpu::DeviceBuffer* indirect_buffer,
+    int offset_in_bytes,
+    int length_in_bytes);
 
 }  // extern "C"
 

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -23,6 +23,10 @@ ByteData float32(List<double> values) {
   return Float32List.fromList(values).buffer.asByteData();
 }
 
+ByteData uint32(List<int> values) {
+  return Uint32List.fromList(values).buffer.asByteData();
+}
+
 ByteData unlitUBO(Matrix4 mvp, Vector4 color) {
   return float32(<double>[
     mvp[0], mvp[1], mvp[2], mvp[3], //
@@ -1620,6 +1624,142 @@ void main() async {
           (Exception e) => e.toString(),
           'message',
           contains('Failed to append drawIndexed'),
+        ),
+      ),
+    );
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('GpuContext.doesSupportIndirectDraw reports a bool', () async {
+    expect(gpu.gpuContext.doesSupportIndirectDraw, isA<bool>());
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  // Renders the same green triangle as the non-indexed test, with the vertex
+  // and instance counts read out of a buffer by the GPU instead of passed
+  // from Dart.
+  test('Can render triangle with drawIndirect', () async {
+    if (!gpu.gpuContext.doesSupportIndirectDraw) {
+      return;
+    }
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
+
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    state.renderPass.bindVertexBuffer(
+      transients.emplace(float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5])),
+    );
+    state.renderPass.bindUniform(
+      pipeline.vertexShader.getUniformSlot('VertInfo'),
+      transients.emplace(unlitUBO(Matrix4.identity(), Colors.lime)),
+    );
+
+    // vertexCount, instanceCount, firstVertex, firstInstance.
+    final gpu.BufferView args = transients.emplace(uint32(<int>[3, 1, 0, 0]));
+    state.renderPass.drawIndirect(args);
+    state.commandBuffer.submit();
+
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  // The indexed counterpart, walking a 3-entry index buffer with the counts
+  // supplied by the argument buffer.
+  test('Can render triangle with drawIndexedIndirect', () async {
+    if (!gpu.gpuContext.doesSupportIndirectDraw) {
+      return;
+    }
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
+
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    state.renderPass.bindVertexBuffer(
+      transients.emplace(float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5])),
+    );
+    state.renderPass.bindIndexBuffer(
+      transients.emplace(Uint16List.fromList(<int>[0, 1, 2]).buffer.asByteData()),
+      gpu.IndexType.int16,
+    );
+    state.renderPass.bindUniform(
+      pipeline.vertexShader.getUniformSlot('VertInfo'),
+      transients.emplace(unlitUBO(Matrix4.identity(), Colors.lime)),
+    );
+
+    // indexCount, instanceCount, firstIndex, baseVertex, firstInstance.
+    final gpu.BufferView args = transients.emplace(uint32(<int>[3, 1, 0, 0, 0]));
+    state.renderPass.drawIndexedIndirect(args);
+    state.commandBuffer.submit();
+
+    final ui.Image image = state.renderTexture.asImage();
+    await comparer.addGoldenImage(image, 'flutter_gpu_test_triangle.png');
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('drawIndirect throws when the argument buffer is too small', () async {
+    if (!gpu.gpuContext.doesSupportIndirectDraw) {
+      return;
+    }
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    final gpu.BufferView args = transients.emplace(uint32(<int>[3, 1, 0]));
+
+    expect(() => state.renderPass.drawIndirect(args), throwsArgumentError);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('drawIndexedIndirect throws when the argument buffer is too small', () async {
+    if (!gpu.gpuContext.doesSupportIndirectDraw) {
+      return;
+    }
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    // Enough for the non-indexed layout, one word short of the indexed one.
+    final gpu.BufferView args = transients.emplace(uint32(<int>[3, 1, 0, 0]));
+
+    expect(() => state.renderPass.drawIndexedIndirect(args), throwsArgumentError);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('drawIndirect throws when the argument offset is misaligned', () async {
+    if (!gpu.gpuContext.doesSupportIndirectDraw) {
+      return;
+    }
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.DeviceBuffer buffer = gpu.gpuContext.createDeviceBuffer(
+      gpu.StorageMode.hostVisible,
+      64,
+    );
+
+    expect(
+      () => state.renderPass.drawIndirect(
+        gpu.BufferView(buffer, offsetInBytes: 2, lengthInBytes: 32),
+      ),
+      throwsArgumentError,
+    );
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('drawIndexedIndirect throws when no index buffer is bound', () async {
+    if (!gpu.gpuContext.doesSupportIndirectDraw) {
+      return;
+    }
+    final RenderPassState state = createSimpleRenderPass();
+    final gpu.RenderPipeline pipeline = await createUnlitRenderPipeline();
+    state.renderPass.bindPipeline(pipeline);
+
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    state.renderPass.bindVertexBuffer(
+      transients.emplace(float32(<double>[-0.5, 0.5, 0.0, -0.5, 0.5, 0.5])),
+    );
+    state.renderPass.bindUniform(
+      pipeline.vertexShader.getUniformSlot('VertInfo'),
+      transients.emplace(unlitUBO(Matrix4.identity(), Colors.lime)),
+    );
+    final gpu.BufferView args = transients.emplace(uint32(<int>[3, 1, 0, 0, 0]));
+
+    expect(
+      () => state.renderPass.drawIndexedIndirect(args),
+      throwsA(
+        isA<Exception>().having(
+          (Exception e) => e.toString(),
+          'message',
+          contains('Failed to append drawIndexedIndirect'),
         ),
       ),
     );


### PR DESCRIPTION
Impeller had no way to express a draw whose parameters come from the GPU, so GPU culling, GPU-side LOD selection, and any GPU-driven submission required a round trip to the CPU. This adds indirect draw to the HAL and to Flutter GPU.

`RenderPass::SetIndirectBuffer` takes a buffer view holding the draw arguments; whether the draw is indexed still follows from whether an index buffer is bound. The argument layout is the standard one (four `uint32`s non-indexed, five words indexed), which is byte-identical across Vulkan, Metal, and GLES, so it is passed to each backend as-is with no abstraction. Vulkan uses `vkCmdDraw{,Indexed}Indirect` (and `eIndirectBuffer` was added to the blanket buffer usage), Metal uses the `indirectBuffer:` draw variants, and GLES uses the ES 3.1 `glDraw{Arrays,Elements}Indirect` entry points. `Capabilities::SupportsIndirectDraw` reports availability, which is always true on Vulkan and on the Metal devices Impeller targets and gated on ES 3.1 for GLES.

Flutter GPU exposes this as `RenderPass.drawIndirect` and `RenderPass.drawIndexedIndirect`, with `GpuContext.doesSupportIndirectDraw` to check first. The argument buffer's contents are never validated, matching an index buffer; writing them from a shader is the point. The view itself is checked for size and 4 byte offset alignment, which every backend requires.

This lands single-draw only. Multi-draw is native on Vulkan (behind the `multiDrawIndirect` feature) but has no Metal or GLES 3.1 equivalent, so it needs an encode-side loop; a draw count can be added later as an optional argument without breaking callers. Indirect count (`vkCmdDrawIndirectCount`) is Vulkan-only and also left for later.

Related to https://github.com/flutter/flutter/issues/190398.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
