### PR TITLE
[Flutter GPU] Timestamp queries for per-pass GPU timing

### DIFF
--- a/engine/src/flutter/impeller/renderer/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/BUILD.gn
@@ -77,6 +77,8 @@ impeller_component("renderer") {
     "surface.h",
     "texture_util.cc",
     "texture_util.h",
+    "timestamp_query_pool.cc",
+    "timestamp_query_pool.h",
     "vertex_buffer_builder.cc",
     "vertex_buffer_builder.h",
     "vertex_descriptor.cc",

--- a/engine/src/flutter/impeller/renderer/backend/gles/command_buffer_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/command_buffer_gles.cc
@@ -111,7 +111,16 @@ void CommandBufferGLES::OnWaitUntilScheduled() {
 
 // |CommandBuffer|
 std::shared_ptr<RenderPass> CommandBufferGLES::OnCreateRenderPass(
-    RenderTarget target) {
+    RenderTarget target,
+    const TimestampWrites& timestamp_writes) {
+  // TODO(bdero): Record timestamps on GLES. This needs `glQueryCounterEXT`
+  // added to the proc table, a `GL_TIMESTAMP_EXT` probe (the GLES flavor of
+  // `GL_EXT_disjoint_timer_query` may only implement `GL_TIME_ELAPSED_EXT`),
+  // and a `GL_GPU_DISJOINT_EXT` check feeding
+  // `TimestampQueryResults::disjoint`. Until then
+  // `Capabilities::SupportsTimestampQueries` reports false, so a pool can
+  // never reach this point.
+  // https://github.com/flutter/flutter/issues/190404
   if (!IsValid()) {
     return nullptr;
   }

--- a/engine/src/flutter/impeller/renderer/backend/gles/command_buffer_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/command_buffer_gles.h
@@ -42,7 +42,9 @@ class CommandBufferGLES final : public CommandBuffer {
   void OnWaitUntilScheduled() override;
 
   // |CommandBuffer|
-  std::shared_ptr<RenderPass> OnCreateRenderPass(RenderTarget target) override;
+  std::shared_ptr<RenderPass> OnCreateRenderPass(
+      RenderTarget target,
+      const TimestampWrites& timestamp_writes) override;
 
   // |CommandBuffer|
   std::shared_ptr<BlitPass> OnCreateBlitPass() override;

--- a/engine/src/flutter/impeller/renderer/backend/metal/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/metal/BUILD.gn
@@ -47,6 +47,8 @@ impeller_component("metal") {
     "swapchain_transients_mtl.h",
     "swapchain_transients_mtl.mm",
     "texture_mtl.h",
+    "timestamp_query_pool_mtl.h",
+    "timestamp_query_pool_mtl.mm",
     "texture_mtl.mm",
     "texture_wrapper_mtl.h",
     "texture_wrapper_mtl.mm",

--- a/engine/src/flutter/impeller/renderer/backend/metal/command_buffer_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/command_buffer_mtl.h
@@ -44,7 +44,9 @@ class CommandBufferMTL final : public CommandBuffer {
   void OnWaitUntilScheduled() override;
 
   // |CommandBuffer|
-  std::shared_ptr<RenderPass> OnCreateRenderPass(RenderTarget target) override;
+  std::shared_ptr<RenderPass> OnCreateRenderPass(
+      RenderTarget target,
+      const TimestampWrites& timestamp_writes) override;
 
   // |CommandBuffer|
   std::shared_ptr<BlitPass> OnCreateBlitPass() override;

--- a/engine/src/flutter/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -196,7 +196,8 @@ void CommandBufferMTL::OnWaitUntilCompleted() {}
 void CommandBufferMTL::OnWaitUntilScheduled() {}
 
 std::shared_ptr<RenderPass> CommandBufferMTL::OnCreateRenderPass(
-    RenderTarget target) {
+    RenderTarget target,
+    const TimestampWrites& timestamp_writes) {
   if (!buffer_) {
     return nullptr;
   }
@@ -206,7 +207,7 @@ std::shared_ptr<RenderPass> CommandBufferMTL::OnCreateRenderPass(
     return nullptr;
   }
   auto pass = std::shared_ptr<RenderPassMTL>(
-      new RenderPassMTL(context, target, buffer_));
+      new RenderPassMTL(context, target, buffer_, timestamp_writes));
   if (!pass->IsValid()) {
     return nullptr;
   }

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.h
@@ -119,6 +119,10 @@ class ContextMTL final : public Context,
   std::shared_ptr<CommandQueue> GetCommandQueue() const override;
 
   // |Context|
+  std::shared_ptr<TimestampQueryPool> CreateTimestampQueryPool(
+      size_t query_count) const override;
+
+  // |Context|
   const std::shared_ptr<const Capabilities>& GetCapabilities() const override;
 
   // |Context|

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/backend/metal/context_mtl.h"
+
 #include <Metal/Metal.h>
 
 #include <memory>
@@ -17,6 +18,7 @@
 #include "impeller/core/sampler_descriptor.h"
 #include "impeller/renderer/backend/metal/gpu_tracer_mtl.h"
 #include "impeller/renderer/backend/metal/sampler_library_mtl.h"
+#include "impeller/renderer/backend/metal/timestamp_query_pool_mtl.h"
 #include "impeller/renderer/capabilities.h"
 
 namespace impeller {
@@ -89,6 +91,7 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetMaximumRenderPassAttachmentSize(DeviceMaxTextureSizeSupported(device))
       .SetSupportsExtendedRangeFormats(
           DeviceSupportsExtendedRangeFormats(device))
+      .SetSupportsTimestampQueries(TimestampQueryPoolMTL::IsSupported(device))
       .SetSupportsTextureCompression(CompressedTextureFamily::kBC,
                                      DeviceSupportsTextureCompressionBC(device))
       .SetSupportsTextureCompression(
@@ -500,6 +503,12 @@ void ContextMTL::SyncSwitchObserver::OnSyncSwitchUpdate(bool new_is_disabled) {
 // |Context|
 std::shared_ptr<CommandQueue> ContextMTL::GetCommandQueue() const {
   return command_queue_ip_;
+}
+
+// |Context|
+std::shared_ptr<TimestampQueryPool> ContextMTL::CreateTimestampQueryPool(
+    size_t query_count) const {
+  return TimestampQueryPoolMTL::Create(device_, query_count);
 }
 
 // |Context|

--- a/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -46,7 +46,8 @@ class RenderPassMTL final : public RenderPass {
 
   RenderPassMTL(std::shared_ptr<const Context> context,
                 const RenderTarget& target,
-                id<MTLCommandBuffer> buffer);
+                id<MTLCommandBuffer> buffer,
+                const TimestampWrites& timestamp_writes);
 
   // |RenderPass|
   bool IsValid() const override;

--- a/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -19,6 +19,7 @@
 #include "impeller/renderer/backend/metal/pipeline_mtl.h"
 #include "impeller/renderer/backend/metal/sampler_mtl.h"
 #include "impeller/renderer/backend/metal/texture_mtl.h"
+#include "impeller/renderer/backend/metal/timestamp_query_pool_mtl.h"
 #include "impeller/renderer/command.h"
 #include "impeller/renderer/pipeline_descriptor.h"
 #include "impeller/renderer/pipeline_library.h"
@@ -107,7 +108,8 @@ static bool ConfigureStencilAttachment(
 }
 
 static MTLRenderPassDescriptor* ToMTLRenderPassDescriptor(
-    const RenderTarget& desc) {
+    const RenderTarget& desc,
+    const TimestampWrites& timestamp_writes) {
   auto result = [MTLRenderPassDescriptor renderPassDescriptor];
 
   bool configured_attachment = desc.IterateAllColorAttachments(
@@ -137,15 +139,22 @@ static MTLRenderPassDescriptor* ToMTLRenderPassDescriptor(
     return nil;
   }
 
+  if (timestamp_writes.pool) {
+    TimestampQueryPoolMTL::Cast(*timestamp_writes.pool)
+        .AttachTo(result, timestamp_writes.beginning_of_pass_write_index,
+                  timestamp_writes.end_of_pass_write_index);
+  }
+
   return result;
 }
 
 RenderPassMTL::RenderPassMTL(std::shared_ptr<const Context> context,
                              const RenderTarget& target,
-                             id<MTLCommandBuffer> buffer)
+                             id<MTLCommandBuffer> buffer,
+                             const TimestampWrites& timestamp_writes)
     : RenderPass(std::move(context), target),
       buffer_(buffer),
-      desc_(ToMTLRenderPassDescriptor(GetRenderTarget())) {
+      desc_(ToMTLRenderPassDescriptor(GetRenderTarget(), timestamp_writes)) {
   if (!buffer_ || !desc_ || !render_target_.IsValid()) {
     return;
   }

--- a/engine/src/flutter/impeller/renderer/backend/metal/timestamp_query_pool_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/timestamp_query_pool_mtl.h
@@ -1,0 +1,70 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_METAL_TIMESTAMP_QUERY_POOL_MTL_H_
+#define FLUTTER_IMPELLER_RENDERER_BACKEND_METAL_TIMESTAMP_QUERY_POOL_MTL_H_
+
+#include <Metal/Metal.h>
+
+#include <cstdint>
+#include <memory>
+
+#include "impeller/base/backend_cast.h"
+#include "impeller/renderer/timestamp_query_pool.h"
+
+namespace impeller {
+
+//------------------------------------------------------------------------------
+/// @brief      An `MTLCounterSampleBuffer` of timestamp counters.
+///
+///             Metal only samples counters at stage, draw, blit, and dispatch
+///             boundaries, so slots are attached to a pass descriptor rather
+///             than written by a free floating command.
+///
+///             Sampled values are GPU ticks, whose relationship to nanoseconds
+///             is not fixed. `sampleTimestamps:gpuTimestamp:` is read once at
+///             construction and again on resolve to derive the conversion.
+///
+class TimestampQueryPoolMTL final
+    : public TimestampQueryPool,
+      public BackendCast<TimestampQueryPoolMTL, TimestampQueryPool> {
+ public:
+  /// Whether [device] can sample timestamp counters at stage boundaries.
+  static bool IsSupported(id<MTLDevice> device);
+
+  static std::shared_ptr<TimestampQueryPoolMTL> Create(id<MTLDevice> device,
+                                                       size_t query_count);
+
+  // |TimestampQueryPool|
+  ~TimestampQueryPoolMTL() override;
+
+  // |TimestampQueryPool|
+  TimestampQueryResults Resolve() const override;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Attach this pool's sample buffer to [descriptor] so the GPU
+  ///             samples it at the pass's stage boundaries.
+  ///
+  void AttachTo(MTLRenderPassDescriptor* descriptor,
+                std::optional<size_t> beginning_of_pass_write_index,
+                std::optional<size_t> end_of_pass_write_index) const;
+
+ private:
+  // Held as an untyped `id` (an `id<MTLCounterSampleBuffer>`) because that
+  // protocol is newer than the minimum deployment target.
+  TimestampQueryPoolMTL(id<MTLDevice> device, id buffer, size_t query_count);
+
+  id<MTLDevice> device_ = nil;
+  id buffer_ = nil;
+  uint64_t base_cpu_timestamp_ = 0;
+  uint64_t base_gpu_timestamp_ = 0;
+
+  TimestampQueryPoolMTL(const TimestampQueryPoolMTL&) = delete;
+
+  TimestampQueryPoolMTL& operator=(const TimestampQueryPoolMTL&) = delete;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_RENDERER_BACKEND_METAL_TIMESTAMP_QUERY_POOL_MTL_H_

--- a/engine/src/flutter/impeller/renderer/backend/metal/timestamp_query_pool_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/timestamp_query_pool_mtl.mm
@@ -1,0 +1,140 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/metal/timestamp_query_pool_mtl.h"
+
+#include "impeller/base/validation.h"
+
+namespace impeller {
+
+API_AVAILABLE(ios(14.0), macos(11.0), tvos(14.0))
+static id<MTLCounterSet> FindTimestampCounterSet(id<MTLDevice> device) {
+  for (id<MTLCounterSet> counter_set in device.counterSets) {
+    if ([counter_set.name isEqualToString:MTLCommonCounterSetTimestamp]) {
+      return counter_set;
+    }
+  }
+  return nil;
+}
+
+bool TimestampQueryPoolMTL::IsSupported(id<MTLDevice> device) {
+  if (device == nil) {
+    return false;
+  }
+  if (@available(iOS 14.0, macOS 11.0, tvOS 14.0, *)) {
+    return
+        [device
+            supportsCounterSampling:MTLCounterSamplingPointAtStageBoundary] &&
+        FindTimestampCounterSet(device) != nil;
+  }
+  return false;
+}
+
+std::shared_ptr<TimestampQueryPoolMTL> TimestampQueryPoolMTL::Create(
+    id<MTLDevice> device,
+    size_t query_count) {
+  if (query_count == 0u || !IsSupported(device)) {
+    return nullptr;
+  }
+  if (@available(iOS 14.0, macOS 11.0, tvOS 14.0, *)) {
+    MTLCounterSampleBufferDescriptor* descriptor =
+        [[MTLCounterSampleBufferDescriptor alloc] init];
+    descriptor.counterSet = FindTimestampCounterSet(device);
+    descriptor.sampleCount = query_count;
+    descriptor.storageMode = MTLStorageModeShared;
+
+    NSError* error = nil;
+    id<MTLCounterSampleBuffer> buffer =
+        [device newCounterSampleBufferWithDescriptor:descriptor error:&error];
+    if (buffer == nil) {
+      VALIDATION_LOG << "Could not create timestamp counter sample buffer: "
+                     << (error != nil ? error.localizedDescription.UTF8String
+                                      : "unknown error");
+      return nullptr;
+    }
+    return std::shared_ptr<TimestampQueryPoolMTL>(
+        new TimestampQueryPoolMTL(device, buffer, query_count));
+  }
+  return nullptr;
+}
+
+TimestampQueryPoolMTL::TimestampQueryPoolMTL(id<MTLDevice> device,
+                                             id buffer,
+                                             size_t query_count)
+    : TimestampQueryPool(query_count), device_(device), buffer_(buffer) {
+  if (@available(iOS 14.0, macOS 11.0, tvOS 14.0, *)) {
+    MTLTimestamp cpu = 0;
+    MTLTimestamp gpu = 0;
+    [device_ sampleTimestamps:&cpu gpuTimestamp:&gpu];
+    base_cpu_timestamp_ = cpu;
+    base_gpu_timestamp_ = gpu;
+  }
+}
+
+TimestampQueryPoolMTL::~TimestampQueryPoolMTL() = default;
+
+void TimestampQueryPoolMTL::AttachTo(
+    MTLRenderPassDescriptor* descriptor,
+    std::optional<size_t> beginning_of_pass_write_index,
+    std::optional<size_t> end_of_pass_write_index) const {
+  if (@available(iOS 14.0, macOS 11.0, tvOS 14.0, *)) {
+    MTLRenderPassSampleBufferAttachmentDescriptor* attachment =
+        descriptor.sampleBufferAttachments[0];
+    attachment.sampleBuffer = buffer_;
+    // The vertex stage starts the pass and the fragment stage ends it, so
+    // these two points bracket the pass's execution on the GPU.
+    attachment.startOfVertexSampleIndex =
+        beginning_of_pass_write_index.value_or(MTLCounterDontSample);
+    attachment.endOfVertexSampleIndex = MTLCounterDontSample;
+    attachment.startOfFragmentSampleIndex = MTLCounterDontSample;
+    attachment.endOfFragmentSampleIndex =
+        end_of_pass_write_index.value_or(MTLCounterDontSample);
+  }
+}
+
+TimestampQueryResults TimestampQueryPoolMTL::Resolve() const {
+  TimestampQueryResults results;
+  results.timestamps.resize(query_count_);
+
+  if (@available(iOS 14.0, macOS 11.0, tvOS 14.0, *)) {
+    id<MTLCounterSampleBuffer> buffer = buffer_;
+    NSData* data = [buffer resolveCounterRange:NSMakeRange(0, query_count_)];
+    if (data == nil ||
+        data.length < query_count_ * sizeof(MTLCounterResultTimestamp)) {
+      return results;
+    }
+
+    // GPU ticks are not nanoseconds and the ratio is not fixed, so it is
+    // derived from two correlated samples. The CPU side of
+    // `sampleTimestamps:gpuTimestamp:` is already in nanoseconds.
+    MTLTimestamp cpu_now = 0;
+    MTLTimestamp gpu_now = 0;
+    [device_ sampleTimestamps:&cpu_now gpuTimestamp:&gpu_now];
+    double nanoseconds_per_tick = 1.0;
+    if (gpu_now > base_gpu_timestamp_ && cpu_now > base_cpu_timestamp_) {
+      nanoseconds_per_tick =
+          static_cast<double>(cpu_now - base_cpu_timestamp_) /
+          static_cast<double>(gpu_now - base_gpu_timestamp_);
+    }
+
+    const MTLCounterResultTimestamp* samples =
+        static_cast<const MTLCounterResultTimestamp*>(data.bytes);
+    for (size_t i = 0u; i < query_count_; i++) {
+      const MTLTimestamp sample = samples[i].timestamp;
+      if (sample == MTLCounterErrorValue || sample < base_gpu_timestamp_) {
+        continue;
+      }
+      // Rebased onto the CPU nanosecond clock so the origin stays put across
+      // resolves. Only differences between timestamps are meaningful.
+      results.timestamps[i] =
+          base_cpu_timestamp_ +
+          static_cast<uint64_t>(
+              static_cast<double>(sample - base_gpu_timestamp_) *
+              nanoseconds_per_tick);
+    }
+  }
+  return results;
+}
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/BUILD.gn
@@ -42,6 +42,7 @@ impeller_component("vulkan_unittests") {
     "test/mock_vulkan_unittests.cc",
     "test/sampler_library_vk_unittests.cc",
     "test/swapchain_unittests.cc",
+    "test/timestamp_query_pool_unittests.cc",
   ]
   deps = [
     ":mock_vulkan",
@@ -133,6 +134,8 @@ impeller_component("vulkan") {
     "texture_source_vk.h",
     "texture_vk.cc",
     "texture_vk.h",
+    "timestamp_query_pool_vk.cc",
+    "timestamp_query_pool_vk.h",
     "tracked_objects_vk.cc",
     "tracked_objects_vk.h",
     "vertex_descriptor_vk.cc",

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -783,6 +783,12 @@ bool CapabilitiesVK::NeedsPartitionedHostBuffer() const {
   return false;
 }
 
+bool CapabilitiesVK::SupportsTimestampQueries() const {
+  // A zero period means the device has no timestamp counter at all.
+  return device_properties_.limits.timestampComputeAndGraphics &&
+         device_properties_.limits.timestampPeriod > 0.f;
+}
+
 bool CapabilitiesVK::HasExtension(RequiredCommonDeviceExtensionVK ext) const {
   return required_common_device_extensions_.find(ext) !=
          required_common_device_extensions_.end();

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -303,6 +303,9 @@ class CapabilitiesVK final : public Capabilities,
   // |Capabilities|
   bool NeedsPartitionedHostBuffer() const override;
 
+  // |Capabilities|
+  bool SupportsTimestampQueries() const override;
+
   //----------------------------------------------------------------------------
   /// @return     If fixed-rate compression for non-onscreen surfaces is
   ///             supported.

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_buffer_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_buffer_vk.cc
@@ -53,15 +53,17 @@ void CommandBufferVK::OnWaitUntilCompleted() {}
 void CommandBufferVK::OnWaitUntilScheduled() {}
 
 std::shared_ptr<RenderPass> CommandBufferVK::OnCreateRenderPass(
-    RenderTarget target) {
+    RenderTarget target,
+    const TimestampWrites& timestamp_writes) {
   auto context = context_.lock();
   if (!context) {
     return nullptr;
   }
   auto pass =
-      std::shared_ptr<RenderPassVK>(new RenderPassVK(context,            //
-                                                     target,             //
-                                                     shared_from_this()  //
+      std::shared_ptr<RenderPassVK>(new RenderPassVK(context,             //
+                                                     target,              //
+                                                     shared_from_this(),  //
+                                                     timestamp_writes     //
                                                      ));
   if (!pass->IsValid()) {
     return nullptr;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/command_buffer_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/command_buffer_vk.h
@@ -108,7 +108,9 @@ class CommandBufferVK final
   void OnWaitUntilScheduled() override;
 
   // |CommandBuffer|
-  std::shared_ptr<RenderPass> OnCreateRenderPass(RenderTarget target) override;
+  std::shared_ptr<RenderPass> OnCreateRenderPass(
+      RenderTarget target,
+      const TimestampWrites& timestamp_writes) override;
 
   // |CommandBuffer|
   std::shared_ptr<BlitPass> OnCreateBlitPass() override;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -41,6 +41,7 @@
 #include "impeller/renderer/backend/vulkan/gpu_tracer_vk.h"
 #include "impeller/renderer/backend/vulkan/resource_manager_vk.h"
 #include "impeller/renderer/backend/vulkan/surface_context_vk.h"
+#include "impeller/renderer/backend/vulkan/timestamp_query_pool_vk.h"
 #include "impeller/renderer/backend/vulkan/yuv_conversion_library_vk.h"
 #include "impeller/renderer/capabilities.h"
 
@@ -650,6 +651,11 @@ std::shared_ptr<DescriptorPoolRecyclerVK> ContextVK::GetDescriptorPoolRecycler()
 
 std::shared_ptr<CommandQueue> ContextVK::GetCommandQueue() const {
   return command_queue_vk_;
+}
+
+std::shared_ptr<TimestampQueryPool> ContextVK::CreateTimestampQueryPool(
+    size_t query_count) const {
+  return TimestampQueryPoolVK::Create(*this, query_count);
 }
 
 bool ContextVK::EnqueueCommandBuffer(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.h
@@ -217,6 +217,10 @@ class ContextVK final : public Context,
 
   std::shared_ptr<CommandQueue> GetCommandQueue() const override;
 
+  // |Context|
+  std::shared_ptr<TimestampQueryPool> CreateTimestampQueryPool(
+      size_t query_count) const override;
+
   std::shared_ptr<GPUTracerVK> GetGPUTracer() const;
 
   void RecordFrameEndTime() const;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -147,8 +147,14 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
 
 RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
                            const RenderTarget& target,
-                           std::shared_ptr<CommandBufferVK> command_buffer)
+                           std::shared_ptr<CommandBufferVK> command_buffer,
+                           const TimestampWrites& timestamp_writes)
     : RenderPass(context, target), command_buffer_(std::move(command_buffer)) {
+  if (timestamp_writes.pool) {
+    timestamp_pool_ =
+        std::static_pointer_cast<TimestampQueryPoolVK>(timestamp_writes.pool);
+    end_of_pass_timestamp_index_ = timestamp_writes.end_of_pass_write_index;
+  }
   const ColorAttachment& color0 = render_target_.GetColorAttachment(0);
   color_image_vk_ = color0.texture;
   resolve_image_vk_ = color0.resolve_texture;
@@ -237,6 +243,14 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
       static_cast<uint32_t>(target_size.height);
   pass_info.setPClearValues(clears.data());
   pass_info.setClearValueCount(clear_count);
+
+  // Recorded outside the render pass instance, since resetting a query is not
+  // allowed inside one.
+  if (timestamp_pool_ && timestamp_writes.beginning_of_pass_write_index) {
+    timestamp_pool_->RecordTimestamp(
+        command_buffer_vk_, vk::PipelineStageFlagBits::eTopOfPipe,
+        timestamp_writes.beginning_of_pass_write_index.value());
+  }
 
   command_buffer_vk_.beginRenderPass(pass_info, vk::SubpassContents::eInline);
 
@@ -708,6 +722,11 @@ bool RenderPassVK::BindResource(ShaderStage stage,
 
 bool RenderPassVK::OnEncodeCommands(const Context& context) const {
   command_buffer_->GetCommandBuffer().endRenderPass();
+  if (timestamp_pool_ && end_of_pass_timestamp_index_) {
+    timestamp_pool_->RecordTimestamp(command_buffer_->GetCommandBuffer(),
+                                     vk::PipelineStageFlagBits::eBottomOfPipe,
+                                     end_of_pass_timestamp_index_.value());
+  }
   return true;
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -9,6 +9,7 @@
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/pipeline_vk.h"
 #include "impeller/renderer/backend/vulkan/shared_object_vk.h"
+#include "impeller/renderer/backend/vulkan/timestamp_query_pool_vk.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
@@ -35,6 +36,8 @@ class RenderPassVK final : public RenderPass {
   std::shared_ptr<Texture> color_image_vk_;
   std::shared_ptr<Texture> resolve_image_vk_;
   uint32_t current_stencil_ = 0;
+  std::shared_ptr<TimestampQueryPoolVK> timestamp_pool_;
+  std::optional<size_t> end_of_pass_timestamp_index_;
 
   // Per-command state.
   std::array<vk::DescriptorImageInfo, kMaxBindings> image_workspace_;
@@ -55,7 +58,8 @@ class RenderPassVK final : public RenderPass {
 
   RenderPassVK(const std::shared_ptr<const Context>& context,
                const RenderTarget& target,
-               std::shared_ptr<CommandBufferVK> command_buffer);
+               std::shared_ptr<CommandBufferVK> command_buffer,
+               const TimestampWrites& timestamp_writes);
 
   // |RenderPass|
   void SetPipeline(PipelineRef pipeline) override;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -237,6 +237,7 @@ void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
                                       VK_SAMPLE_COUNT_4_BIT);
   pProperties->limits.maxImageDimension2D = 4096;
   pProperties->limits.timestampPeriod = 1;
+  pProperties->limits.timestampComputeAndGraphics = VK_TRUE;
   if (GetMockVulkanState().physical_device_properties_callback) {
     GetMockVulkanState().physical_device_properties_callback(physicalDevice,
                                                              pProperties);
@@ -253,6 +254,7 @@ void vkGetPhysicalDeviceQueueFamilyProperties(
     pQueueFamilyProperties[0].queueCount = 3;
     pQueueFamilyProperties[0].queueFlags = static_cast<VkQueueFlags>(
         VK_QUEUE_TRANSFER_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT);
+    pQueueFamilyProperties[0].timestampValidBits = 64;
   }
 }
 
@@ -523,6 +525,24 @@ void vkCmdBindPipeline(VkCommandBuffer commandBuffer,
   MockCommandBuffer* mock_command_buffer =
       reinterpret_cast<MockCommandBuffer*>(commandBuffer);
   mock_command_buffer->called_functions_->push_back("vkCmdBindPipeline");
+}
+
+void vkCmdResetQueryPool(VkCommandBuffer commandBuffer,
+                         VkQueryPool queryPool,
+                         uint32_t firstQuery,
+                         uint32_t queryCount) {
+  MockCommandBuffer* mock_command_buffer =
+      reinterpret_cast<MockCommandBuffer*>(commandBuffer);
+  mock_command_buffer->called_functions_->push_back("vkCmdResetQueryPool");
+}
+
+void vkCmdWriteTimestamp(VkCommandBuffer commandBuffer,
+                         VkPipelineStageFlagBits pipelineStage,
+                         VkQueryPool queryPool,
+                         uint32_t query) {
+  MockCommandBuffer* mock_command_buffer =
+      reinterpret_cast<MockCommandBuffer*>(commandBuffer);
+  mock_command_buffer->called_functions_->push_back("vkCmdWriteTimestamp");
 }
 
 void vkCmdPipelineBarrier(VkCommandBuffer commandBuffer,
@@ -1004,6 +1024,10 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateDebugUtilsMessengerEXT);
   } else if (strcmp("vkSetDebugUtilsObjectNameEXT", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkSetDebugUtilsObjectNameEXT);
+  } else if (strcmp("vkCmdResetQueryPool", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkCmdResetQueryPool);
+  } else if (strcmp("vkCmdWriteTimestamp", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkCmdWriteTimestamp);
   } else if (strcmp("vkCreateQueryPool", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkCreateQueryPool);
   } else if (strcmp("vkDestroyQueryPool", pName) == 0) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/timestamp_query_pool_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/timestamp_query_pool_unittests.cc
@@ -1,0 +1,141 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <algorithm>
+#include <memory>
+
+#include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "gtest/gtest.h"
+#include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
+#include "impeller/renderer/backend/vulkan/timestamp_query_pool_vk.h"
+
+namespace impeller {
+namespace testing {
+
+static bool Called(const std::shared_ptr<std::vector<std::string>>& functions,
+                   const std::string& name) {
+  return std::find(functions->begin(), functions->end(), name) !=
+         functions->end();
+}
+
+TEST(TimestampQueryPoolVKTest, SupportedWhenTheDeviceReportsATimestampPeriod) {
+  auto const context = MockVulkanContextBuilder().Build();
+  EXPECT_TRUE(context->GetCapabilities()->SupportsTimestampQueries());
+  context->Shutdown();
+}
+
+TEST(TimestampQueryPoolVKTest, UnsupportedWithoutComputeAndGraphicsTimestamps) {
+  auto const context =
+      MockVulkanContextBuilder()
+          .SetPhysicalPropertiesCallback(
+              [](VkPhysicalDevice device, VkPhysicalDeviceProperties* props) {
+                props->limits.timestampComputeAndGraphics = VK_FALSE;
+              })
+          .Build();
+  EXPECT_FALSE(context->GetCapabilities()->SupportsTimestampQueries());
+  EXPECT_EQ(context->CreateTimestampQueryPool(2u), nullptr);
+  context->Shutdown();
+}
+
+TEST(TimestampQueryPoolVKTest, CreatesAPoolOfTheRequestedSize) {
+  auto const context = MockVulkanContextBuilder().Build();
+
+  EXPECT_EQ(context->CreateTimestampQueryPool(0u), nullptr);
+
+  std::shared_ptr<TimestampQueryPool> pool =
+      context->CreateTimestampQueryPool(4u);
+  ASSERT_NE(pool, nullptr);
+  EXPECT_EQ(pool->GetQueryCount(), 4u);
+
+  auto functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_TRUE(Called(functions, "vkCreateQueryPool"));
+
+  context->Shutdown();
+}
+
+TEST(TimestampQueryPoolVKTest, ResetsASlotBeforeWritingIt) {
+  auto const context = MockVulkanContextBuilder().Build();
+  std::shared_ptr<TimestampQueryPool> pool =
+      context->CreateTimestampQueryPool(2u);
+  ASSERT_NE(pool, nullptr);
+
+  std::shared_ptr<CommandBuffer> command_buffer =
+      context->CreateCommandBuffer();
+  TimestampQueryPoolVK::Cast(*pool).RecordTimestamp(
+      CommandBufferVK::Cast(*command_buffer).GetCommandBuffer(),
+      vk::PipelineStageFlagBits::eTopOfPipe, 0u);
+
+  auto functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_TRUE(Called(functions, "vkCmdResetQueryPool"));
+  EXPECT_TRUE(Called(functions, "vkCmdWriteTimestamp"));
+
+  context->Shutdown();
+}
+
+TEST(TimestampQueryPoolVKTest, OutOfRangeWritesAreDropped) {
+  auto const context = MockVulkanContextBuilder().Build();
+  std::shared_ptr<TimestampQueryPool> pool =
+      context->CreateTimestampQueryPool(2u);
+  ASSERT_NE(pool, nullptr);
+
+  std::shared_ptr<CommandBuffer> command_buffer =
+      context->CreateCommandBuffer();
+  TimestampQueryPoolVK::Cast(*pool).RecordTimestamp(
+      CommandBufferVK::Cast(*command_buffer).GetCommandBuffer(),
+      vk::PipelineStageFlagBits::eTopOfPipe, 2u);
+
+  auto functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_FALSE(Called(functions, "vkCmdWriteTimestamp"));
+
+  context->Shutdown();
+}
+
+TEST(TimestampQueryPoolVKTest, ResolveReportsAnEntryPerSlot) {
+  auto const context = MockVulkanContextBuilder().Build();
+  std::shared_ptr<TimestampQueryPool> pool =
+      context->CreateTimestampQueryPool(3u);
+  ASSERT_NE(pool, nullptr);
+
+  TimestampQueryResults results = pool->Resolve();
+  EXPECT_EQ(results.timestamps.size(), 3u);
+  EXPECT_FALSE(results.disjoint);
+  // The mock never marks a query as available, so nothing was written.
+  for (const std::optional<uint64_t>& timestamp : results.timestamps) {
+    EXPECT_FALSE(timestamp.has_value());
+  }
+
+  auto functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_TRUE(Called(functions, "vkGetQueryPoolResults"));
+
+  context->Shutdown();
+}
+
+TEST(TimestampQueryPoolVKTest, WritesAreValidatedAgainstThePoolSize) {
+  auto const context = MockVulkanContextBuilder().Build();
+  std::shared_ptr<TimestampQueryPool> pool =
+      context->CreateTimestampQueryPool(2u);
+  ASSERT_NE(pool, nullptr);
+
+  TimestampWrites writes;
+  EXPECT_FALSE(writes.HasWrites());
+  EXPECT_FALSE(writes.IsValid());
+
+  writes.pool = pool;
+  writes.beginning_of_pass_write_index = 0u;
+  writes.end_of_pass_write_index = 1u;
+  EXPECT_TRUE(writes.HasWrites());
+  EXPECT_TRUE(writes.IsValid());
+
+  writes.end_of_pass_write_index = 2u;
+  EXPECT_FALSE(writes.IsValid());
+
+  writes.end_of_pass_write_index = 0u;
+  EXPECT_FALSE(writes.IsValid());
+
+  context->Shutdown();
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/timestamp_query_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/timestamp_query_pool_vk.cc
@@ -1,0 +1,134 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/timestamp_query_pool_vk.h"
+
+#include <utility>
+#include <vector>
+
+#include "impeller/base/validation.h"
+#include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/renderer/backend/vulkan/queue_vk.h"
+
+namespace impeller {
+
+// Each slot is read back as a value followed by an availability word, which is
+// what `vk::QueryResultFlagBits::eWithAvailability` appends.
+static constexpr size_t kWordsPerQuery = 2u;
+
+std::shared_ptr<TimestampQueryPoolVK> TimestampQueryPoolVK::Create(
+    const ContextVK& context,
+    size_t query_count) {
+  if (query_count == 0u) {
+    return nullptr;
+  }
+  if (!context.GetCapabilities()->SupportsTimestampQueries()) {
+    return nullptr;
+  }
+  const std::shared_ptr<DeviceHolderVK> device_holder =
+      context.GetDeviceHolder();
+  if (!device_holder) {
+    return nullptr;
+  }
+
+  const vk::PhysicalDeviceLimits limits =
+      device_holder->GetPhysicalDevice().getProperties().limits;
+
+  vk::QueryPoolCreateInfo info;
+  info.queryCount = static_cast<uint32_t>(query_count);
+  info.queryType = vk::QueryType::eTimestamp;
+  auto [status, pool] = device_holder->GetDevice().createQueryPoolUnique(info);
+  if (status != vk::Result::eSuccess) {
+    VALIDATION_LOG << "Could not create timestamp query pool.";
+    return nullptr;
+  }
+
+  // Bits above `timestampValidBits` are undefined and have to be discarded. A
+  // queue that reports timestamp support always reports at least 36 valid bits.
+  const std::vector<vk::QueueFamilyProperties> families =
+      device_holder->GetPhysicalDevice().getQueueFamilyProperties();
+  const size_t family = context.GetGraphicsQueue()->GetIndex().family;
+  uint32_t valid_bits =
+      family < families.size() ? families[family].timestampValidBits : 0u;
+  if (valid_bits == 0u) {
+    VALIDATION_LOG << "The graphics queue does not support timestamps.";
+    return nullptr;
+  }
+  const uint64_t valid_bits_mask =
+      valid_bits >= 64u ? ~uint64_t{0} : ((uint64_t{1} << valid_bits) - 1u);
+
+  return std::shared_ptr<TimestampQueryPoolVK>(
+      new TimestampQueryPoolVK(device_holder, std::move(pool), query_count,
+                               limits.timestampPeriod, valid_bits_mask));
+}
+
+TimestampQueryPoolVK::TimestampQueryPoolVK(
+    std::weak_ptr<const DeviceHolderVK> device_holder,
+    vk::UniqueQueryPool pool,
+    size_t query_count,
+    float timestamp_period,
+    uint64_t valid_bits_mask)
+    : TimestampQueryPool(query_count),
+      device_holder_(std::move(device_holder)),
+      pool_(std::move(pool)),
+      timestamp_period_(timestamp_period),
+      valid_bits_mask_(valid_bits_mask) {}
+
+TimestampQueryPoolVK::~TimestampQueryPoolVK() = default;
+
+void TimestampQueryPoolVK::RecordTimestamp(const vk::CommandBuffer& buffer,
+                                           vk::PipelineStageFlagBits stage,
+                                           size_t index) const {
+  if (index >= query_count_) {
+    return;
+  }
+  // A query must be reset before it is written again, and the reset has to be
+  // ordered before the write in the same buffer. Resetting only this slot
+  // leaves the writes recorded by other passes in the pool untouched.
+  const uint32_t query = static_cast<uint32_t>(index);
+  buffer.resetQueryPool(pool_.get(), query, 1u);
+  buffer.writeTimestamp(stage, pool_.get(), query);
+}
+
+TimestampQueryResults TimestampQueryPoolVK::Resolve() const {
+  TimestampQueryResults results;
+  results.timestamps.resize(query_count_);
+
+  std::shared_ptr<const DeviceHolderVK> device_holder = device_holder_.lock();
+  if (!device_holder) {
+    return results;
+  }
+
+  std::vector<uint64_t> words(query_count_ * kWordsPerQuery, 0u);
+  // Deliberately no wait bit. Slots the GPU has not retired come back
+  // unavailable rather than stalling the caller, and the whole call reports
+  // `eNotReady` instead of failing.
+  const vk::Result status = device_holder->GetDevice().getQueryPoolResults(
+      pool_.get(),                                    //
+      0u,                                             //
+      static_cast<uint32_t>(query_count_),            //
+      words.size() * sizeof(uint64_t),                //
+      words.data(),                                   //
+      kWordsPerQuery * sizeof(uint64_t),              //
+      vk::QueryResultFlagBits::e64 |                  //
+          vk::QueryResultFlagBits::eWithAvailability  //
+  );
+  if (status != vk::Result::eSuccess && status != vk::Result::eNotReady) {
+    return results;
+  }
+
+  for (size_t i = 0u; i < query_count_; i++) {
+    if (words[i * kWordsPerQuery + 1u] == 0u) {
+      continue;
+    }
+    const uint64_t ticks = words[i * kWordsPerQuery] & valid_bits_mask_;
+    // Scaled as a double. Tick counts routinely exceed the 24 bit mantissa of
+    // the period's own float type.
+    results.timestamps[i] = static_cast<uint64_t>(
+        static_cast<double>(ticks) * static_cast<double>(timestamp_period_));
+  }
+  return results;
+}
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/timestamp_query_pool_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/timestamp_query_pool_vk.h
@@ -1,0 +1,70 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_TIMESTAMP_QUERY_POOL_VK_H_
+#define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_TIMESTAMP_QUERY_POOL_VK_H_
+
+#include <memory>
+
+#include "impeller/base/backend_cast.h"
+#include "impeller/renderer/backend/vulkan/device_holder_vk.h"
+#include "impeller/renderer/backend/vulkan/vk.h"
+#include "impeller/renderer/timestamp_query_pool.h"
+
+namespace impeller {
+
+class ContextVK;
+
+//------------------------------------------------------------------------------
+/// @brief      A `vk::QueryPool` of `vk::QueryType::eTimestamp` slots.
+///
+///             Raw query values are device tick counts. They are scaled by
+///             `VkPhysicalDeviceLimits::timestampPeriod` on readback, and
+///             masked to the queue's `timestampValidBits` first because the
+///             bits above that are undefined.
+///
+class TimestampQueryPoolVK final
+    : public TimestampQueryPool,
+      public BackendCast<TimestampQueryPoolVK, TimestampQueryPool> {
+ public:
+  static std::shared_ptr<TimestampQueryPoolVK> Create(const ContextVK& context,
+                                                      size_t query_count);
+
+  // |TimestampQueryPool|
+  ~TimestampQueryPoolVK() override;
+
+  // |TimestampQueryPool|
+  TimestampQueryResults Resolve() const override;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Reset [index] and record a timestamp into it once [stage] is
+  ///             reached.
+  ///
+  ///             Must be recorded outside of a render pass instance, since
+  ///             `vkCmdResetQueryPool` is not allowed inside one.
+  ///
+  void RecordTimestamp(const vk::CommandBuffer& buffer,
+                       vk::PipelineStageFlagBits stage,
+                       size_t index) const;
+
+ private:
+  TimestampQueryPoolVK(std::weak_ptr<const DeviceHolderVK> device_holder,
+                       vk::UniqueQueryPool pool,
+                       size_t query_count,
+                       float timestamp_period,
+                       uint64_t valid_bits_mask);
+
+  std::weak_ptr<const DeviceHolderVK> device_holder_;
+  vk::UniqueQueryPool pool_;
+  float timestamp_period_ = 1.0f;
+  uint64_t valid_bits_mask_ = ~uint64_t{0};
+
+  TimestampQueryPoolVK(const TimestampQueryPoolVK&) = delete;
+
+  TimestampQueryPoolVK& operator=(const TimestampQueryPoolVK&) = delete;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_TIMESTAMP_QUERY_POOL_VK_H_

--- a/engine/src/flutter/impeller/renderer/capabilities.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities.cc
@@ -15,6 +15,10 @@ size_t Capabilities::GetMinimumStorageBufferAlignment() const {
   return GetMinimumUniformAlignment();
 }
 
+bool Capabilities::SupportsTimestampQueries() const {
+  return false;
+}
+
 class StandardCapabilities final : public Capabilities {
  public:
   // |Capabilities|
@@ -129,6 +133,11 @@ class StandardCapabilities final : public Capabilities {
     return needs_partitioned_host_buffer_;
   }
 
+  // |Capabilities|
+  bool SupportsTimestampQueries() const override {
+    return supports_timestamp_queries_;
+  }
+
  private:
   StandardCapabilities(bool supports_offscreen_msaa,
                        bool supports_ssbo,
@@ -148,6 +157,7 @@ class StandardCapabilities final : public Capabilities {
                        ISize default_maximum_render_pass_attachment_size,
                        size_t minimum_uniform_alignment,
                        bool needs_partitioned_host_buffer,
+                       bool supports_timestamp_queries,
                        bool supports_texture_compression_bc,
                        bool supports_texture_compression_etc2,
                        bool supports_texture_compression_astc,
@@ -165,6 +175,7 @@ class StandardCapabilities final : public Capabilities {
         supports_triangle_fan_(supports_triangle_fan),
         supports_extended_range_formats_(supports_extended_range_formats),
         needs_partitioned_host_buffer_(needs_partitioned_host_buffer),
+        supports_timestamp_queries_(supports_timestamp_queries),
         default_color_format_(default_color_format),
         default_stencil_format_(default_stencil_format),
         default_depth_stencil_format_(default_depth_stencil_format),
@@ -192,6 +203,7 @@ class StandardCapabilities final : public Capabilities {
   bool supports_triangle_fan_ = false;
   bool supports_extended_range_formats_ = false;
   bool needs_partitioned_host_buffer_ = false;
+  bool supports_timestamp_queries_ = false;
   PixelFormat default_color_format_ = PixelFormat::kUnknown;
   PixelFormat default_stencil_format_ = PixelFormat::kUnknown;
   PixelFormat default_depth_stencil_format_ = PixelFormat::kUnknown;
@@ -336,6 +348,12 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetNeedsPartitionedHostBuffer(
   return *this;
 }
 
+CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsTimestampQueries(
+    bool value) {
+  supports_timestamp_queries_ = value;
+  return *this;
+}
+
 std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   return std::unique_ptr<StandardCapabilities>(new StandardCapabilities(   //
@@ -357,6 +375,7 @@ std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
       default_maximum_render_pass_attachment_size_.value_or(ISize{1, 1}),  //
       minimum_uniform_alignment_,                                          //
       needs_partitioned_host_buffer_,                                      //
+      supports_timestamp_queries_,                                         //
       supports_texture_compression_bc_,                                    //
       supports_texture_compression_etc2_,                                  //
       supports_texture_compression_astc_,                                  //

--- a/engine/src/flutter/impeller/renderer/capabilities.h
+++ b/engine/src/flutter/impeller/renderer/capabilities.h
@@ -144,6 +144,10 @@ class Capabilities {
   /// for indexes from other data.
   virtual bool NeedsPartitionedHostBuffer() const = 0;
 
+  /// @brief Whether the backend can write GPU timestamps at pass boundaries.
+  ///        When false, `Context::CreateTimestampQueryPool` returns nullptr.
+  virtual bool SupportsTimestampQueries() const;
+
  protected:
   Capabilities();
 
@@ -198,6 +202,8 @@ class CapabilitiesBuilder {
 
   CapabilitiesBuilder& SetNeedsPartitionedHostBuffer(bool value);
 
+  CapabilitiesBuilder& SetSupportsTimestampQueries(bool value);
+
   std::unique_ptr<Capabilities> Build();
 
  private:
@@ -213,6 +219,7 @@ class CapabilitiesBuilder {
   bool supports_triangle_fan_ = false;
   bool supports_extended_range_formats_ = false;
   bool needs_partitioned_host_buffer_ = false;
+  bool supports_timestamp_queries_ = false;
   bool supports_texture_compression_bc_ = false;
   bool supports_texture_compression_etc2_ = false;
   bool supports_texture_compression_astc_ = false;

--- a/engine/src/flutter/impeller/renderer/command_buffer.cc
+++ b/engine/src/flutter/impeller/renderer/command_buffer.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/command_buffer.h"
 
+#include "impeller/base/validation.h"
 #include "impeller/renderer/compute_pass.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
@@ -40,8 +41,13 @@ void CommandBuffer::WaitUntilScheduled() {
 }
 
 std::shared_ptr<RenderPass> CommandBuffer::CreateRenderPass(
-    const RenderTarget& render_target) {
-  auto pass = OnCreateRenderPass(render_target);
+    const RenderTarget& render_target,
+    const TimestampWrites& timestamp_writes) {
+  if (timestamp_writes.HasWrites() && !timestamp_writes.IsValid()) {
+    VALIDATION_LOG << "Invalid timestamp writes for render pass.";
+    return nullptr;
+  }
+  auto pass = OnCreateRenderPass(render_target, timestamp_writes);
   if (pass && pass->IsValid()) {
     pass->SetLabel("RenderPass");
     return pass;

--- a/engine/src/flutter/impeller/renderer/command_buffer.h
+++ b/engine/src/flutter/impeller/renderer/command_buffer.h
@@ -10,6 +10,7 @@
 
 #include "impeller/renderer/blit_pass.h"
 #include "impeller/renderer/compute_pass.h"
+#include "impeller/renderer/timestamp_query_pool.h"
 
 namespace impeller {
 
@@ -75,13 +76,18 @@ class CommandBuffer {
   //----------------------------------------------------------------------------
   /// @brief      Create a render pass to record render commands into.
   ///
-  /// @param[in]  render_target  The description of the render target this pass
-  ///                            will target.
+  /// @param[in]  render_target     The description of the render target this
+  ///                               pass will target.
+  /// @param[in]  timestamp_writes  The GPU timestamps to record at the
+  ///                               boundaries of this pass. Ignored by
+  ///                               backends that do not support timestamp
+  ///                               queries.
   ///
   /// @return     A valid render pass or null.
   ///
   std::shared_ptr<RenderPass> CreateRenderPass(
-      const RenderTarget& render_target);
+      const RenderTarget& render_target,
+      const TimestampWrites& timestamp_writes = {});
 
   //----------------------------------------------------------------------------
   /// @brief      Create a blit pass to record blit commands into.
@@ -103,7 +109,8 @@ class CommandBuffer {
   explicit CommandBuffer(std::weak_ptr<const Context> context);
 
   virtual std::shared_ptr<RenderPass> OnCreateRenderPass(
-      RenderTarget render_target) = 0;
+      RenderTarget render_target,
+      const TimestampWrites& timestamp_writes) = 0;
 
   virtual std::shared_ptr<BlitPass> OnCreateBlitPass() = 0;
 

--- a/engine/src/flutter/impeller/renderer/context.cc
+++ b/engine/src/flutter/impeller/renderer/context.cc
@@ -7,6 +7,8 @@
 #include <mutex>
 #include <utility>
 
+#include "impeller/renderer/timestamp_query_pool.h"
+
 namespace impeller {
 
 ImpellerContextFuture::ImpellerContextFuture(
@@ -53,6 +55,11 @@ bool Context::AddTrackingFence(const std::shared_ptr<Texture>& texture) const {
 
 bool Context::SubmitOnscreen(std::shared_ptr<CommandBuffer> cmd_buffer) {
   return EnqueueCommandBuffer(std::move(cmd_buffer));
+}
+
+std::shared_ptr<TimestampQueryPool> Context::CreateTimestampQueryPool(
+    size_t query_count) const {
+  return nullptr;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/context.h
+++ b/engine/src/flutter/impeller/renderer/context.h
@@ -27,6 +27,7 @@ namespace impeller {
 class ShaderLibrary;
 class CommandBuffer;
 class PipelineLibrary;
+class TimestampQueryPool;
 
 /// A wrapper for provided a deferred initialization of impeller to various
 /// engine subsystems.
@@ -187,6 +188,20 @@ class Context {
 
   /// @brief Return the graphics queue for submitting command buffers.
   virtual std::shared_ptr<CommandQueue> GetCommandQueue() const = 0;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Create a pool of [query_count] slots that passes can write GPU
+  ///             timestamps into.
+  ///
+  ///             Attach a pool to a pass with `TimestampWrites` when creating
+  ///             the pass, then read the slots back once the GPU has retired
+  ///             the command buffer.
+  ///
+  /// @return     A new pool, or nullptr if the backend cannot record
+  ///             timestamps. See `Capabilities::SupportsTimestampQueries`.
+  ///
+  virtual std::shared_ptr<TimestampQueryPool> CreateTimestampQueryPool(
+      size_t query_count) const;
 
   //----------------------------------------------------------------------------
   /// @brief      Force all pending asynchronous work to finish. This is

--- a/engine/src/flutter/impeller/renderer/testing/mocks.h
+++ b/engine/src/flutter/impeller/renderer/testing/mocks.h
@@ -157,7 +157,8 @@ class MockCommandBuffer : public CommandBuffer {
               (override));
   MOCK_METHOD(std::shared_ptr<RenderPass>,
               OnCreateRenderPass,
-              (RenderTarget render_target),
+              (RenderTarget render_target,
+               const TimestampWrites& timestamp_writes),
               (override));
 };
 

--- a/engine/src/flutter/impeller/renderer/timestamp_query_pool.cc
+++ b/engine/src/flutter/impeller/renderer/timestamp_query_pool.cc
@@ -1,0 +1,43 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/timestamp_query_pool.h"
+
+namespace impeller {
+
+TimestampQueryPool::TimestampQueryPool(size_t query_count)
+    : query_count_(query_count) {}
+
+TimestampQueryPool::~TimestampQueryPool() = default;
+
+size_t TimestampQueryPool::GetQueryCount() const {
+  return query_count_;
+}
+
+bool TimestampWrites::IsValid() const {
+  if (!pool) {
+    return false;
+  }
+  const size_t count = pool->GetQueryCount();
+  if (beginning_of_pass_write_index.has_value() &&
+      beginning_of_pass_write_index.value() >= count) {
+    return false;
+  }
+  if (end_of_pass_write_index.has_value() &&
+      end_of_pass_write_index.value() >= count) {
+    return false;
+  }
+  if (beginning_of_pass_write_index.has_value() &&
+      beginning_of_pass_write_index == end_of_pass_write_index) {
+    return false;
+  }
+  return true;
+}
+
+bool TimestampWrites::HasWrites() const {
+  return pool != nullptr && (beginning_of_pass_write_index.has_value() ||
+                             end_of_pass_write_index.has_value());
+}
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/timestamp_query_pool.h
+++ b/engine/src/flutter/impeller/renderer/timestamp_query_pool.h
@@ -1,0 +1,96 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_RENDERER_TIMESTAMP_QUERY_POOL_H_
+#define FLUTTER_IMPELLER_RENDERER_TIMESTAMP_QUERY_POOL_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace impeller {
+
+//------------------------------------------------------------------------------
+/// @brief      The timestamps read back from a `TimestampQueryPool`.
+///
+struct TimestampQueryResults {
+  /// Nanosecond timestamps indexed by query slot. An empty entry means the
+  /// slot was never written, or the GPU discarded its result.
+  ///
+  /// These are points on the GPU's own timeline, not durations. Subtracting
+  /// one from another is only meaningful when the GPU is known to have
+  /// executed the writes in the recorded order.
+  std::vector<std::optional<uint64_t>> timestamps;
+
+  /// Whether the GPU reported that its timer was interrupted while these
+  /// timestamps were recorded. Every timestamp in the set is unusable when
+  /// this is true.
+  bool disjoint = false;
+};
+
+//------------------------------------------------------------------------------
+/// @brief      A fixed set of slots that passes write GPU timestamps into.
+///
+///             Pools are created from a `Context` and attached to a pass with
+///             `TimestampWrites`. Results are only readable once the GPU has
+///             retired every command buffer that recorded writes into the
+///             pool.
+///
+class TimestampQueryPool {
+ public:
+  virtual ~TimestampQueryPool();
+
+  /// The number of slots in this pool.
+  size_t GetQueryCount() const;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Read back every slot in the pool.
+  ///
+  ///             Call this only after the GPU has retired the command buffers
+  ///             that recorded into the pool. Reading early leaves the
+  ///             not-yet-written slots empty instead of stalling.
+  ///
+  virtual TimestampQueryResults Resolve() const = 0;
+
+ protected:
+  explicit TimestampQueryPool(size_t query_count);
+
+  const size_t query_count_;
+
+ private:
+  TimestampQueryPool(const TimestampQueryPool&) = delete;
+
+  TimestampQueryPool& operator=(const TimestampQueryPool&) = delete;
+};
+
+//------------------------------------------------------------------------------
+/// @brief      The timestamps a pass writes at its own execution boundaries.
+///
+///             Writes are declared when the pass is created rather than
+///             recorded as free floating commands, because backends can only
+///             sample counters at stage boundaries.
+///
+struct TimestampWrites {
+  /// The pool the timestamps are written into. It must stay alive until the
+  /// GPU has retired the command buffer the pass was recorded into.
+  std::shared_ptr<TimestampQueryPool> pool;
+
+  /// The slot written when the GPU begins executing the pass.
+  std::optional<size_t> beginning_of_pass_write_index;
+
+  /// The slot written when the GPU finishes executing the pass.
+  std::optional<size_t> end_of_pass_write_index;
+
+  /// Whether a pool is present and every requested slot is in range.
+  bool IsValid() const;
+
+  /// Whether anything at all would be recorded.
+  bool HasWrites() const;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_RENDERER_TIMESTAMP_QUERY_POOL_H_

--- a/engine/src/flutter/lib/gpu/BUILD.gn
+++ b/engine/src/flutter/lib/gpu/BUILD.gn
@@ -52,6 +52,8 @@ source_set("gpu") {
       "shader_library.h",
       "texture.cc",
       "texture.h",
+      "timestamp_query_set.cc",
+      "timestamp_query_set.h",
     ]
   }
   deps = [

--- a/engine/src/flutter/lib/gpu/context.cc
+++ b/engine/src/flutter/lib/gpu/context.cc
@@ -140,6 +140,11 @@ extern bool InternalFlutterGpu_Context_GetSupportsOffscreenMSAA(
   return flutter::gpu::SupportsNormalOffscreenMSAA(wrapper->GetContext());
 }
 
+extern bool InternalFlutterGpu_Context_SupportsTimestampQueries(
+    flutter::gpu::Context* wrapper) {
+  return wrapper->GetContext().GetCapabilities()->SupportsTimestampQueries();
+}
+
 extern bool InternalFlutterGpu_Context_SupportsTextureCompression(
     flutter::gpu::Context* wrapper,
     int family) {

--- a/engine/src/flutter/lib/gpu/context.h
+++ b/engine/src/flutter/lib/gpu/context.h
@@ -83,6 +83,10 @@ extern bool InternalFlutterGpu_Context_GetSupportsOffscreenMSAA(
     flutter::gpu::Context* wrapper);
 
 FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_Context_SupportsTimestampQueries(
+    flutter::gpu::Context* wrapper);
+
+FLUTTER_GPU_EXPORT
 extern bool InternalFlutterGpu_Context_SupportsTextureCompression(
     flutter::gpu::Context* wrapper,
     int family);

--- a/engine/src/flutter/lib/gpu/lib/gpu.dart
+++ b/engine/src/flutter/lib/gpu/lib/gpu.dart
@@ -20,6 +20,7 @@
 ///  * [Flutter GPU documentation](https://github.com/flutter/flutter/blob/main/docs/engine/impeller/Flutter-GPU.md).
 library flutter_gpu;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:ffi';
@@ -40,4 +41,5 @@ part 'src/render_pass.dart';
 part 'src/render_pipeline.dart';
 part 'src/shader.dart';
 part 'src/shader_library.dart';
+part 'src/timestamp_query_set.dart';
 part 'src/vertex_layout.dart';

--- a/engine/src/flutter/lib/gpu/lib/src/command_buffer.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/command_buffer.dart
@@ -16,13 +16,59 @@ base class CommandBuffer extends NativeFieldWrapperClass1 {
     _initialize(_gpuContext);
   }
 
-  RenderPass createRenderPass(RenderTarget renderTarget) {
-    return RenderPass._(_gpuContext, this, renderTarget);
+  /// Query sets written by passes created from this command buffer, tracked so
+  /// their pending resolves can be completed once the GPU retires the work.
+  final List<TimestampQuerySet> _timestampQuerySets = <TimestampQuerySet>[];
+
+  /// Creates a render pass targeting [renderTarget].
+  ///
+  /// [timestampWrites] records GPU timestamps at the pass's execution
+  /// boundaries. Read them back with [TimestampQuerySet.resolve] after
+  /// [submit].
+  RenderPass createRenderPass(
+    RenderTarget renderTarget, {
+    TimestampWrites? timestampWrites,
+  }) {
+    final RenderPass pass = RenderPass._(
+      _gpuContext,
+      this,
+      renderTarget,
+      timestampWrites,
+    );
+    if (timestampWrites != null &&
+        !_timestampQuerySets.contains(timestampWrites.querySet)) {
+      _timestampQuerySets.add(timestampWrites.querySet);
+    }
+    return pass;
   }
 
   void submit({CompletionCallback? completionCallback}) {
-    String? error = _submit(completionCallback);
+    if (_timestampQuerySets.isEmpty) {
+      final String? error = _submit(completionCallback);
+      if (error != null) {
+        throw Exception(error);
+      }
+      return;
+    }
+
+    final List<TimestampQuerySet> querySets = List<TimestampQuerySet>.of(
+      _timestampQuerySets,
+    );
+    _timestampQuerySets.clear();
+    for (final TimestampQuerySet querySet in querySets) {
+      querySet._onSubmitted();
+    }
+    final String? error = _submit((bool success) {
+      for (final TimestampQuerySet querySet in querySets) {
+        querySet._onRetired();
+      }
+      completionCallback?.call(success);
+    });
     if (error != null) {
+      // Nothing was scheduled, so nothing will ever retire these.
+      for (final TimestampQuerySet querySet in querySets) {
+        querySet._onRetired();
+      }
       throw Exception(error);
     }
   }

--- a/engine/src/flutter/lib/gpu/lib/src/context.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/context.dart
@@ -58,6 +58,14 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     return _getSupportsOffscreenMSAA();
   }
 
+  /// Whether this device can write GPU timestamps at render pass boundaries.
+  ///
+  /// When false, [createTimestampQuerySet] throws. Timestamp queries are
+  /// currently implemented on the Metal and Vulkan backends.
+  bool get doesSupportTimestampQueries {
+    return _supportsTimestampQueries();
+  }
+
   /// Whether this device supports the given family of block-compressed
   /// texture formats. Hardware support is granted on a per-family basis.
   ///
@@ -214,6 +222,15 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     return result;
   }
 
+  /// Allocates a set of [count] slots that render passes can write GPU
+  /// timestamps into.
+  ///
+  /// Throws an exception if the backend does not support timestamp queries.
+  /// See [doesSupportTimestampQueries].
+  TimestampQuerySet createTimestampQuerySet({required int count}) {
+    return TimestampQuerySet._(this, count);
+  }
+
   /// Create a new command buffer that can be used to submit GPU commands.
   CommandBuffer createCommandBuffer() {
     return CommandBuffer._(this);
@@ -262,6 +279,11 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     symbol: 'InternalFlutterGpu_Context_GetSupportsOffscreenMSAA',
   )
   external bool _getSupportsOffscreenMSAA();
+
+  @Native<Bool Function(Pointer<Void>)>(
+    symbol: 'InternalFlutterGpu_Context_SupportsTimestampQueries',
+  )
+  external bool _supportsTimestampQueries();
 
   @Native<Bool Function(Pointer<Void>, Int)>(
     symbol: 'InternalFlutterGpu_Context_SupportsTextureCompression',

--- a/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
@@ -245,9 +245,11 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     GpuContext gpuContext,
     CommandBuffer commandBuffer,
     RenderTarget renderTarget,
+    TimestampWrites? timestampWrites,
   ) {
     assert(() {
       renderTarget._validate();
+      timestampWrites?._validate();
       return true;
     }());
 
@@ -285,7 +287,12 @@ base class RenderPass extends NativeFieldWrapperClass1 {
         throw Exception(error);
       }
     }
-    error = _begin(commandBuffer);
+    error = _begin(
+      commandBuffer,
+      timestampWrites?.querySet,
+      timestampWrites?.beginningOfPassWriteIndex ?? -1,
+      timestampWrites?.endOfPassWriteIndex ?? -1,
+    );
     if (error != null) {
       throw Exception(error);
     }
@@ -594,10 +601,15 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     Texture texture,
   );
 
-  @Native<Handle Function(Pointer<Void>, Pointer<Void>)>(
+  @Native<Handle Function(Pointer<Void>, Pointer<Void>, Handle, Int, Int)>(
     symbol: 'InternalFlutterGpu_RenderPass_Begin',
   )
-  external String? _begin(CommandBuffer commandBuffer);
+  external String? _begin(
+    CommandBuffer commandBuffer,
+    TimestampQuerySet? timestampQuerySet,
+    int beginningOfPassWriteIndex,
+    int endOfPassWriteIndex,
+  );
 
   @Native<Void Function(Pointer<Void>, Pointer<Void>)>(
     symbol: 'InternalFlutterGpu_RenderPass_BindPipeline',

--- a/engine/src/flutter/lib/gpu/lib/src/timestamp_query_set.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/timestamp_query_set.dart
@@ -1,0 +1,159 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+part of flutter_gpu;
+
+/// The timestamps read back from a [TimestampQuerySet].
+base class TimestampQueryResults {
+  const TimestampQueryResults(this.timestamps, this.disjoint);
+
+  /// Nanosecond timestamps indexed by query slot. A null entry means the slot
+  /// was never written, or the GPU discarded its result.
+  ///
+  /// These are points on the GPU's own timeline, not durations. Subtracting
+  /// one from another only measures a pass when the GPU actually executed the
+  /// two writes in the order they were recorded. Backends are free to
+  /// reorder or overlap work across passes, so treat a negative or
+  /// implausible difference as "not measurable this frame" rather than as an
+  /// error.
+  ///
+  /// The origin of the timeline is arbitrary and differs between backends and
+  /// between runs. Only differences are meaningful.
+  final List<int?> timestamps;
+
+  /// Whether the GPU reported that its timer was interrupted while these
+  /// timestamps were recorded. Every entry in [timestamps] is unusable when
+  /// this is true.
+  final bool disjoint;
+}
+
+/// A fixed set of slots that render passes can write GPU timestamps into.
+///
+/// Create one with [GpuContext.createTimestampQuerySet], attach it to a pass
+/// with [TimestampWrites], and read the slots back with [resolve] once the
+/// GPU has retired the work.
+base class TimestampQuerySet extends NativeFieldWrapperClass1 {
+  /// Creates a new TimestampQuerySet.
+  TimestampQuerySet._(GpuContext gpuContext, this.count) {
+    if (count < 1) {
+      throw ArgumentError.value(count, 'count', 'must be at least 1');
+    }
+    if (!_initialize(gpuContext, count)) {
+      throw Exception(
+        'TimestampQuerySet creation failed. Check '
+        'GpuContext.doesSupportTimestampQueries first.',
+      );
+    }
+  }
+
+  /// The number of slots in this set.
+  final int count;
+
+  /// Command buffers referencing this set that the GPU has not retired yet.
+  int _pendingSubmissions = 0;
+
+  final List<Completer<TimestampQueryResults>> _pendingResolves =
+      <Completer<TimestampQueryResults>>[];
+
+  /// Reads back every slot in this set.
+  ///
+  /// Completes once the GPU has retired every command buffer that was
+  /// submitted with a pass writing into this set. Results are never available
+  /// in the frame that recorded them, so this never blocks the frame; it just
+  /// completes later.
+  ///
+  /// When nothing is in flight, this completes with whatever the slots hold
+  /// right now, which is all nulls for a set that has never been submitted.
+  Future<TimestampQueryResults> resolve() {
+    if (_pendingSubmissions == 0) {
+      return Future<TimestampQueryResults>.value(_readBack());
+    }
+    final Completer<TimestampQueryResults> completer =
+        Completer<TimestampQueryResults>();
+    _pendingResolves.add(completer);
+    return completer.future;
+  }
+
+  void _onSubmitted() {
+    _pendingSubmissions++;
+  }
+
+  void _onRetired() {
+    if (_pendingSubmissions > 0) {
+      _pendingSubmissions--;
+    }
+    if (_pendingSubmissions > 0 || _pendingResolves.isEmpty) {
+      return;
+    }
+    final TimestampQueryResults results = _readBack();
+    final List<Completer<TimestampQueryResults>> completers =
+        List<Completer<TimestampQueryResults>>.of(_pendingResolves);
+    _pendingResolves.clear();
+    for (final Completer<TimestampQueryResults> completer in completers) {
+      completer.complete(results);
+    }
+  }
+
+  TimestampQueryResults _readBack() {
+    final Int64List raw = Int64List(count);
+    final bool disjoint = _resolve(raw);
+    return TimestampQueryResults(
+      List<int?>.unmodifiable(<int?>[
+        for (final int value in raw) value < 0 ? null : value,
+      ]),
+      disjoint,
+    );
+  }
+
+  @Native<Bool Function(Handle, Pointer<Void>, Int)>(
+    symbol: 'InternalFlutterGpu_TimestampQuerySet_Initialize',
+  )
+  external bool _initialize(GpuContext gpuContext, int queryCount);
+
+  @Native<Bool Function(Pointer<Void>, Handle)>(
+    symbol: 'InternalFlutterGpu_TimestampQuerySet_Resolve',
+  )
+  external bool _resolve(Int64List timestamps);
+}
+
+/// The timestamps a render pass writes at its own execution boundaries.
+///
+/// Writes are declared when the pass is created rather than recorded as free
+/// floating commands, because backends can only sample counters at stage
+/// boundaries.
+base class TimestampWrites {
+  TimestampWrites({
+    required this.querySet,
+    this.beginningOfPassWriteIndex,
+    this.endOfPassWriteIndex,
+  });
+
+  /// The set the timestamps are written into.
+  final TimestampQuerySet querySet;
+
+  /// The slot written when the GPU begins executing the pass.
+  final int? beginningOfPassWriteIndex;
+
+  /// The slot written when the GPU finishes executing the pass.
+  final int? endOfPassWriteIndex;
+
+  void _validate() {
+    _validateIndex(beginningOfPassWriteIndex, 'beginningOfPassWriteIndex');
+    _validateIndex(endOfPassWriteIndex, 'endOfPassWriteIndex');
+    if (beginningOfPassWriteIndex != null &&
+        beginningOfPassWriteIndex == endOfPassWriteIndex) {
+      throw ArgumentError(
+        'TimestampWrites cannot write both pass boundaries into the same slot',
+      );
+    }
+  }
+
+  void _validateIndex(int? index, String name) {
+    if (index != null && (index < 0 || index >= querySet.count)) {
+      throw RangeError.range(index, 0, querySet.count - 1, name);
+    }
+  }
+}

--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -9,6 +9,7 @@
 #include "flutter/lib/gpu/formats.h"
 #include "flutter/lib/gpu/render_pipeline.h"
 #include "flutter/lib/gpu/shader.h"
+#include "flutter/lib/gpu/timestamp_query_set.h"
 #include "fml/make_copyable.h"
 #include "fml/memory/ref_ptr.h"
 #include "impeller/core/buffer_view.h"
@@ -73,9 +74,10 @@ impeller::PipelineDescriptor& RenderPass::GetPipelineDescriptor() {
   return pipeline_descriptor_;
 }
 
-bool RenderPass::Begin(flutter::gpu::CommandBuffer& command_buffer) {
-  render_pass_ =
-      command_buffer.GetCommandBuffer()->CreateRenderPass(render_target_);
+bool RenderPass::Begin(flutter::gpu::CommandBuffer& command_buffer,
+                       const impeller::TimestampWrites& timestamp_writes) {
+  render_pass_ = command_buffer.GetCommandBuffer()->CreateRenderPass(
+      render_target_, timestamp_writes);
   if (!render_pass_) {
     return false;
   }
@@ -324,8 +326,25 @@ Dart_Handle InternalFlutterGpu_RenderPass_SetDepthStencilAttachment(
 
 Dart_Handle InternalFlutterGpu_RenderPass_Begin(
     flutter::gpu::RenderPass* wrapper,
-    flutter::gpu::CommandBuffer* command_buffer) {
-  if (!wrapper->Begin(*command_buffer)) {
+    flutter::gpu::CommandBuffer* command_buffer,
+    Dart_Handle timestamp_query_set_wrapper,
+    int beginning_of_pass_write_index,
+    int end_of_pass_write_index) {
+  impeller::TimestampWrites timestamp_writes;
+  if (!Dart_IsNull(timestamp_query_set_wrapper)) {
+    flutter::gpu::TimestampQuerySet* query_set =
+        tonic::DartConverter<flutter::gpu::TimestampQuerySet*>::FromDart(
+            timestamp_query_set_wrapper);
+    timestamp_writes.pool = query_set->GetPool();
+    if (beginning_of_pass_write_index >= 0) {
+      timestamp_writes.beginning_of_pass_write_index =
+          beginning_of_pass_write_index;
+    }
+    if (end_of_pass_write_index >= 0) {
+      timestamp_writes.end_of_pass_write_index = end_of_pass_write_index;
+    }
+  }
+  if (!wrapper->Begin(*command_buffer, timestamp_writes)) {
     return tonic::ToDart("Failed to begin RenderPass");
   }
   return Dart_Null();

--- a/engine/src/flutter/lib/gpu/render_pass.h
+++ b/engine/src/flutter/lib/gpu/render_pass.h
@@ -18,6 +18,7 @@
 #include "impeller/renderer/command.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
+#include "impeller/renderer/timestamp_query_pool.h"
 #include "lib/gpu/device_buffer.h"
 #include "lib/gpu/render_pipeline.h"
 #include "lib/gpu/texture.h"
@@ -50,7 +51,8 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
 
   impeller::PipelineDescriptor& GetPipelineDescriptor();
 
-  bool Begin(flutter::gpu::CommandBuffer& command_buffer);
+  bool Begin(flutter::gpu::CommandBuffer& command_buffer,
+             const impeller::TimestampWrites& timestamp_writes);
 
   void SetPipeline(fml::RefPtr<RenderPipeline> pipeline);
 
@@ -159,7 +161,10 @@ extern Dart_Handle InternalFlutterGpu_RenderPass_SetDepthStencilAttachment(
 FLUTTER_GPU_EXPORT
 extern Dart_Handle InternalFlutterGpu_RenderPass_Begin(
     flutter::gpu::RenderPass* wrapper,
-    flutter::gpu::CommandBuffer* command_buffer);
+    flutter::gpu::CommandBuffer* command_buffer,
+    Dart_Handle timestamp_query_set_wrapper,
+    int beginning_of_pass_write_index,
+    int end_of_pass_write_index);
 
 FLUTTER_GPU_EXPORT
 extern void InternalFlutterGpu_RenderPass_BindPipeline(

--- a/engine/src/flutter/lib/gpu/timestamp_query_set.cc
+++ b/engine/src/flutter/lib/gpu/timestamp_query_set.cc
@@ -1,0 +1,77 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/gpu/timestamp_query_set.h"
+
+#include <utility>
+
+#include "dart_api.h"
+#include "fml/memory/ref_ptr.h"
+
+namespace flutter {
+namespace gpu {
+
+IMPLEMENT_WRAPPERTYPEINFO(flutter_gpu, TimestampQuerySet);
+
+TimestampQuerySet::TimestampQuerySet(
+    std::shared_ptr<impeller::TimestampQueryPool> pool)
+    : pool_(std::move(pool)) {}
+
+TimestampQuerySet::~TimestampQuerySet() = default;
+
+const std::shared_ptr<impeller::TimestampQueryPool>&
+TimestampQuerySet::GetPool() const {
+  return pool_;
+}
+
+}  // namespace gpu
+}  // namespace flutter
+
+//----------------------------------------------------------------------------
+/// Exports
+///
+
+bool InternalFlutterGpu_TimestampQuerySet_Initialize(
+    Dart_Handle wrapper,
+    flutter::gpu::Context* context,
+    int query_count) {
+  if (query_count <= 0) {
+    return false;
+  }
+  std::shared_ptr<impeller::TimestampQueryPool> pool =
+      context->GetContext().CreateTimestampQueryPool(query_count);
+  if (!pool) {
+    return false;
+  }
+  auto res =
+      fml::MakeRefCounted<flutter::gpu::TimestampQuerySet>(std::move(pool));
+  res->AssociateWithDartWrapper(wrapper);
+  return true;
+}
+
+bool InternalFlutterGpu_TimestampQuerySet_Resolve(
+    flutter::gpu::TimestampQuerySet* wrapper,
+    Dart_Handle timestamps) {
+  const impeller::TimestampQueryResults results = wrapper->GetPool()->Resolve();
+
+  Dart_TypedData_Type type = Dart_TypedData_kInvalid;
+  void* data = nullptr;
+  intptr_t length = 0;
+  if (Dart_IsError(
+          Dart_TypedDataAcquireData(timestamps, &type, &data, &length))) {
+    return results.disjoint;
+  }
+  if (type == Dart_TypedData_kInt64 && data != nullptr) {
+    int64_t* out = static_cast<int64_t*>(data);
+    for (intptr_t i = 0; i < length; i++) {
+      out[i] = (static_cast<size_t>(i) < results.timestamps.size() &&
+                results.timestamps[i].has_value())
+                   ? static_cast<int64_t>(results.timestamps[i].value())
+                   : -1;
+    }
+  }
+  Dart_TypedDataReleaseData(timestamps);
+
+  return results.disjoint;
+}

--- a/engine/src/flutter/lib/gpu/timestamp_query_set.h
+++ b/engine/src/flutter/lib/gpu/timestamp_query_set.h
@@ -1,0 +1,61 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_GPU_TIMESTAMP_QUERY_SET_H_
+#define FLUTTER_LIB_GPU_TIMESTAMP_QUERY_SET_H_
+
+#include <memory>
+
+#include "flutter/lib/gpu/context.h"
+#include "flutter/lib/gpu/export.h"
+#include "flutter/lib/ui/dart_wrapper.h"
+#include "impeller/renderer/timestamp_query_pool.h"
+
+namespace flutter {
+namespace gpu {
+
+class TimestampQuerySet : public RefCountedDartWrappable<TimestampQuerySet> {
+  DEFINE_WRAPPERTYPEINFO();
+  FML_FRIEND_MAKE_REF_COUNTED(TimestampQuerySet);
+
+ public:
+  explicit TimestampQuerySet(
+      std::shared_ptr<impeller::TimestampQueryPool> pool);
+
+  ~TimestampQuerySet() override;
+
+  const std::shared_ptr<impeller::TimestampQueryPool>& GetPool() const;
+
+ private:
+  std::shared_ptr<impeller::TimestampQueryPool> pool_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(TimestampQuerySet);
+};
+
+}  // namespace gpu
+}  // namespace flutter
+
+//----------------------------------------------------------------------------
+/// Exports
+///
+
+extern "C" {
+
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_TimestampQuerySet_Initialize(
+    Dart_Handle wrapper,
+    flutter::gpu::Context* context,
+    int query_count);
+
+/// Fills [timestamps], an `Int64List` sized to the query count, with
+/// nanosecond timestamps. Slots the GPU has not written are set to -1.
+/// Returns whether the GPU reported a timing disjoint.
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_TimestampQuerySet_Resolve(
+    flutter::gpu::TimestampQuerySet* wrapper,
+    Dart_Handle timestamps);
+
+}  // extern "C"
+
+#endif  // FLUTTER_LIB_GPU_TIMESTAMP_QUERY_SET_H_

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -1632,4 +1632,94 @@ void main() async {
     final ui.Image image = state.renderTexture.asImage();
     await comparer.addGoldenImage(image, 'flutter_gpu_test_viewport.png');
   }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('TimestampQuerySet validates its slot indices', () async {
+    if (!gpu.gpuContext.doesSupportTimestampQueries) {
+      return;
+    }
+    final gpu.TimestampQuerySet querySet = gpu.gpuContext.createTimestampQuerySet(count: 2);
+    expect(querySet.count, 2);
+
+    expect(() => gpu.gpuContext.createTimestampQuerySet(count: 0), throwsArgumentError);
+
+    final gpu.TimestampQueryResults results = await querySet.resolve();
+    expect(results.timestamps.length, 2);
+    expect(results.timestamps, everyElement(isNull));
+
+    final gpu.Texture renderTexture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.devicePrivate,
+      100,
+      100,
+    );
+    final gpu.CommandBuffer commandBuffer = gpu.gpuContext.createCommandBuffer();
+    final gpu.RenderTarget renderTarget = gpu.RenderTarget.singleColor(
+      gpu.ColorAttachment(texture: renderTexture),
+    );
+    expect(
+      () => commandBuffer.createRenderPass(
+        renderTarget,
+        timestampWrites: gpu.TimestampWrites(querySet: querySet, beginningOfPassWriteIndex: 5),
+      ),
+      throwsRangeError,
+    );
+    expect(
+      () => commandBuffer.createRenderPass(
+        renderTarget,
+        timestampWrites: gpu.TimestampWrites(
+          querySet: querySet,
+          beginningOfPassWriteIndex: 0,
+          endOfPassWriteIndex: 0,
+        ),
+      ),
+      throwsArgumentError,
+    );
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('Can resolve GPU timestamps written by a render pass', () async {
+    if (!gpu.gpuContext.doesSupportTimestampQueries) {
+      return;
+    }
+    final gpu.TimestampQuerySet querySet = gpu.gpuContext.createTimestampQuerySet(count: 2);
+
+    final gpu.Texture renderTexture = gpu.gpuContext.createTexture(
+      gpu.StorageMode.devicePrivate,
+      100,
+      100,
+    );
+    final gpu.CommandBuffer commandBuffer = gpu.gpuContext.createCommandBuffer();
+    final gpu.RenderPass renderPass = commandBuffer.createRenderPass(
+      gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: renderTexture)),
+      timestampWrites: gpu.TimestampWrites(
+        querySet: querySet,
+        beginningOfPassWriteIndex: 0,
+        endOfPassWriteIndex: 1,
+      ),
+    );
+
+    final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
+    renderPass.bindPipeline(pipeline);
+    final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+    renderPass.bindVertexBuffer(
+      transients.emplace(float32(<double>[-0.5, -0.5, 0, 0.5, 0.5, -0.5])),
+    );
+    renderPass.bindUniform(
+      pipeline.vertexShader.getUniformSlot('VertInfo'),
+      transients.emplace(unlitUBO(Matrix4.identity(), Vector4(0, 1, 0, 1))),
+    );
+    renderPass.draw(3);
+    commandBuffer.submit();
+
+    final gpu.TimestampQueryResults results = await querySet.resolve();
+    expect(results.timestamps.length, 2);
+    if (results.disjoint) {
+      return;
+    }
+    // A backend is free to drop a query, so ordering is only checked when both
+    // slots actually landed.
+    final int? beginning = results.timestamps[0];
+    final int? end = results.timestamps[1];
+    if (beginning != null && end != null) {
+      expect(end, greaterThanOrEqualTo(beginning));
+    }
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
 }


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/190404.

Adds GPU timestamp queries so a Flutter GPU app can attribute GPU time to an individual pass instead of only seeing whole frame time. `TimestampQueryPool` is a new Impeller HAL object created from a `Context`, and `TimestampWrites` attaches slots to a pass when the pass is created (the WebGPU `timestampWrites` shape), which keeps the backend mapping simple and matches the fact that counters can only be sampled at stage boundaries. Vulkan records `vkCmdWriteTimestamp` around the render pass and scales raw ticks by `timestampPeriod`, masked to the queue's `timestampValidBits`. Metal attaches an `MTLCounterSampleBuffer` to the pass descriptor and derives ticks-to-nanoseconds from two correlated `sampleTimestamps:gpuTimestamp:` reads. Timestamps are reported at hardware resolution, without the 100us quantization the web imposes for timing-attack reasons.

GLES reports the capability as unsupported for now and carries a TODO. `GL_EXT_disjoint_timer_query` on GLES is not guaranteed to implement `glQueryCounterEXT`, and a disjoint event silently invalidates already-recorded results, so it needs its own proc-table work and a `GL_GPU_DISJOINT_EXT` path feeding `TimestampQueryResults::disjoint`.

The Dart surface is `gpuContext.createTimestampQuerySet(count:)`, a `timestampWrites` argument on `createRenderPass`, and `TimestampQuerySet.resolve()`, which is async and completes once the GPU has retired the submitting command buffer rather than stalling the frame.

```dart
final timestamps = gpu.gpuContext.createTimestampQuerySet(count: 2);
final pass = commandBuffer.createRenderPass(
  renderTarget,
  timestampWrites: gpu.TimestampWrites(
    querySet: timestamps,
    beginningOfPassWriteIndex: 0,
    endOfPassWriteIndex: 1,
  ),
);
// ...
commandBuffer.submit();
final results = await timestamps.resolve();
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
