### PR TITLE
[Flutter GPU] Push constants for small per-draw uniform data

### DIFF
--- a/engine/src/flutter/impeller/compiler/reflector.cc
+++ b/engine/src/flutter/impeller/compiler/reflector.cc
@@ -595,6 +595,50 @@ std::shared_ptr<ShaderBundleData> Reflector::GenerateShaderBundleData() const {
     data->AddUniformStruct(uniform_struct);
   }
 
+  // A stage declares at most one push constant block, and always reads it from
+  // offset zero.
+  const auto push_constants =
+      compiler_->get_shader_resources().push_constant_buffers;
+  if (push_constants.size() > 1u) {
+    std::cerr << "Error: A shader may declare at most one push constant block."
+              << std::endl;
+    return nullptr;
+  }
+  for (const auto& push_constant : push_constants) {
+    ShaderBundleData::ShaderPushConstantBlock block;
+    block.name = push_constant.name;
+    block.ext_res_0 = compiler_.GetExtendedMSLResourceBinding(
+        CompilerBackend::ExtendedResourceIndex::kPrimary, push_constant.id);
+
+    const auto type = compiler_->get_type(push_constant.type_id);
+    if (type.basetype != spirv_cross::SPIRType::BaseType::Struct) {
+      std::cerr << "Error: Push constant block \"" << push_constant.name
+                << "\" is not a struct." << std::endl;
+      return nullptr;
+    }
+
+    size_t size_in_bytes = 0;
+    for (const auto& struct_member : ReadStructMembers(push_constant.type_id)) {
+      size_in_bytes += struct_member.byte_length;
+      if (StringStartsWith(struct_member.name, "_PADDING_")) {
+        continue;
+      }
+      ShaderBundleData::ShaderUniformStructField field;
+      field.name = struct_member.name;
+      field.type = struct_member.base_type;
+      field.offset_in_bytes = struct_member.offset;
+      field.element_size_in_bytes = struct_member.size;
+      field.total_size_in_bytes = struct_member.byte_length;
+      field.array_elements = struct_member.array_elements;
+      field.vec_size = struct_member.vec_size;
+      field.columns = struct_member.columns;
+      block.fields.push_back(field);
+    }
+    block.size_in_bytes = size_in_bytes;
+
+    data->SetPushConstantBlock(std::move(block));
+  }
+
   const auto sampled_images = compiler_->get_shader_resources().sampled_images;
   for (const auto& image : sampled_images) {
     ShaderBundleData::ShaderUniformTexture uniform_texture;

--- a/engine/src/flutter/impeller/compiler/shader_bundle_data.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_data.cc
@@ -30,6 +30,11 @@ void ShaderBundleData::AddUniformTexture(ShaderUniformTexture uniform_texture) {
   uniform_textures_.emplace_back(std::move(uniform_texture));
 }
 
+void ShaderBundleData::SetPushConstantBlock(
+    ShaderPushConstantBlock push_constants) {
+  push_constants_ = std::move(push_constants);
+}
+
 void ShaderBundleData::AddInputDescription(InputDescription input) {
   inputs_.emplace_back(std::move(input));
 }
@@ -208,6 +213,38 @@ ShaderBundleData::CreateFlatbuffer() const {
     desc->set = texture.set;
     desc->binding = texture.binding;
     shader_bundle->uniform_textures.emplace_back(std::move(desc));
+  }
+
+  if (push_constants_.has_value()) {
+    auto desc = std::make_unique<fb::shaderbundle::ShaderPushConstantBlockT>();
+    desc->name = push_constants_->name;
+    if (desc->name.empty()) {
+      VALIDATION_LOG << "Push constant block name cannot be empty.";
+      return nullptr;
+    }
+    desc->ext_res_0 = push_constants_->ext_res_0;
+    desc->size_in_bytes = push_constants_->size_in_bytes;
+
+    for (const auto& field : push_constants_->fields) {
+      auto field_desc =
+          std::make_unique<fb::shaderbundle::ShaderUniformStructFieldT>();
+      field_desc->name = field.name;
+      auto type = ToUniformType(field.type);
+      if (!type.has_value()) {
+        VALIDATION_LOG << " Invalid shader type " << field.type << ".";
+        return nullptr;
+      }
+      field_desc->type = type.value();
+      field_desc->offset_in_bytes = field.offset_in_bytes;
+      field_desc->element_size_in_bytes = field.element_size_in_bytes;
+      field_desc->total_size_in_bytes = field.total_size_in_bytes;
+      field_desc->array_elements = field.array_elements.value_or(0);
+      field_desc->vec_size = field.vec_size;
+      field_desc->columns = field.columns;
+      desc->fields.push_back(std::move(field_desc));
+    }
+
+    shader_bundle->push_constants = std::move(desc);
   }
 
   for (const auto& input : inputs_) {

--- a/engine/src/flutter/impeller/compiler/shader_bundle_data.h
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_data.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_COMPILER_SHADER_BUNDLE_DATA_H_
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "flutter/fml/mapping.h"
@@ -48,6 +49,13 @@ class ShaderBundleData {
     size_t binding = 0u;
   };
 
+  struct ShaderPushConstantBlock {
+    std::string name;
+    size_t ext_res_0 = 0u;
+    size_t size_in_bytes = 0u;
+    std::vector<ShaderUniformStructField> fields;
+  };
+
   ShaderBundleData(std::string entrypoint,
                    spv::ExecutionModel stage,
                    TargetPlatform target_platform);
@@ -57,6 +65,8 @@ class ShaderBundleData {
   void AddUniformStruct(ShaderUniformStruct uniform_struct);
 
   void AddUniformTexture(ShaderUniformTexture uniform_texture);
+
+  void SetPushConstantBlock(ShaderPushConstantBlock push_constants);
 
   void AddInputDescription(InputDescription input);
 
@@ -72,6 +82,7 @@ class ShaderBundleData {
   const TargetPlatform target_platform_;
   std::vector<ShaderUniformStruct> uniform_structs_;
   std::vector<ShaderUniformTexture> uniform_textures_;
+  std::optional<ShaderPushConstantBlock> push_constants_;
   std::vector<InputDescription> inputs_;
   std::shared_ptr<fml::Mapping> shader_;
   std::shared_ptr<fml::Mapping> sksl_;

--- a/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
@@ -219,6 +219,52 @@ TEST(ShaderBundleTest, GenerateShaderBundleFlatbufferProducesCorrectResult) {
   ASSERT_EQ(fragment->metal_desktop->inputs.size(), 0u);
 }
 
+TEST(ShaderBundleTest, GenerateShaderBundleFlatbufferReflectsPushConstants) {
+  std::string fixtures_path = flutter::testing::GetFixturesPath();
+  std::string config =
+      "{\"PushConstantsVertex\": {\"type\": \"vertex\", \"file\": \"" +
+      fixtures_path + "/flutter_gpu_push_constants.vert\"}}";
+
+  SourceOptions options;
+  options.target_platform = TargetPlatform::kRuntimeStageMetal;
+  options.source_language = SourceLanguage::kGLSL;
+
+  std::optional<fb::shaderbundle::ShaderBundleT> bundle =
+      GenerateShaderBundleFlatbuffer(config, options);
+  ASSERT_TRUE(bundle.has_value());
+
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+  const auto* vertex = FindByName(bundle->shaders, "PushConstantsVertex");
+  ASSERT_NE(vertex, nullptr);
+
+  // The block is reflected separately from the uniform structs.
+  EXPECT_EQ(vertex->metal_desktop->uniform_structs.size(), 0u);
+
+  const auto& block = vertex->metal_desktop->push_constants;
+  ASSERT_NE(block, nullptr);
+  // A push constant block reflects under its instance name, which is what the
+  // OpenGL ES backend has to match against.
+  EXPECT_STREQ(block->name.c_str(), "draw_info");
+  EXPECT_EQ(block->size_in_bytes, 80u);
+  ASSERT_EQ(block->fields.size(), 2u);
+
+  const auto& color = block->fields[0];
+  EXPECT_STREQ(color->name.c_str(), "color");
+  EXPECT_EQ(color->type, fb::shaderbundle::UniformDataType::kFloat);
+  EXPECT_EQ(color->offset_in_bytes, 0u);
+  EXPECT_EQ(color->element_size_in_bytes, 16u);
+  EXPECT_EQ(color->vec_size, 4u);
+  EXPECT_EQ(color->columns, 1u);
+
+  const auto& mvp = block->fields[1];
+  EXPECT_STREQ(mvp->name.c_str(), "mvp");
+  EXPECT_EQ(mvp->type, fb::shaderbundle::UniformDataType::kFloat);
+  EXPECT_EQ(mvp->offset_in_bytes, 16u);
+  EXPECT_EQ(mvp->element_size_in_bytes, 64u);
+  EXPECT_EQ(mvp->vec_size, 4u);
+  EXPECT_EQ(mvp->columns, 4u);
+}
+
 TEST(ShaderBundleTest,
      GenerateShaderBundleFlatbufferReportsSourceFilesAsDependencies) {
   std::string fixtures_path = flutter::testing::GetFixturesPath();

--- a/engine/src/flutter/impeller/core/shader_types.h
+++ b/engine/src/flutter/impeller/core/shader_types.h
@@ -159,6 +159,41 @@ struct ShaderUniformSlot {
   size_t binding;
 };
 
+/// @brief Metadata required to set a push constant block.
+///
+/// A pipeline has a single block of push constant memory. Both stages may
+/// declare a block against it, in which case they read the same bytes.
+struct ShaderPushConstantSlot {
+  /// @brief The name of the push constant block.
+  ///
+  /// The OpenGL ES backend, which has no push constants, matches this against
+  /// the plain uniforms the block was lowered to.
+  const char* name;
+
+  /// @brief `ext_res_0` is the Metal binding value.
+  size_t ext_res_0;
+
+  /// @brief The reflected size of the block, including alignment padding.
+  size_t size_in_bytes;
+};
+
+/// @brief The span of push constant memory a single shader stage reads.
+///
+/// Stages always read from offset zero, so two stages that both declare a
+/// block are aliases of each other rather than neighbours.
+struct PushConstantRange {
+  ShaderStage shader_stage;
+  uint32_t size;
+
+  constexpr size_t GetHash() const {
+    return fml::HashCombine(shader_stage, size);
+  }
+
+  constexpr bool operator==(const PushConstantRange& other) const {
+    return shader_stage == other.shader_stage && size == other.size;
+  }
+};
+
 /// @brief Metadata required to bind a combined texture and sampler.
 ///
 /// OpenGL binding requires the usage of the separate shader metadata struct.

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -153,6 +153,8 @@ test_fixtures("file_fixtures") {
     "embarcadero.jpg",
     "flutter_gpu_instanced.frag",
     "flutter_gpu_instanced.vert",
+    "flutter_gpu_push_constants.frag",
+    "flutter_gpu_push_constants.vert",
     "flutter_gpu_texture.frag",
     "flutter_gpu_texture.vert",
     "flutter_gpu_unlit.frag",
@@ -212,10 +214,12 @@ impellerc("flutter_gpu_shaders") {
     "flutter_gpu_unlit.vert",
     "flutter_gpu_texture.frag",
     "flutter_gpu_texture.vert",
+    "flutter_gpu_push_constants.frag",
+    "flutter_gpu_push_constants.vert",
   ]
 
   fixtures = rebase_path("//flutter/impeller/fixtures")
-  shader_bundle = "{\"InstancedFragment\": {\"type\": \"fragment\", \"file\": \"${fixtures}/flutter_gpu_instanced.frag\"}, \"InstancedVertex\": {\"type\": \"vertex\", \"file\": \"${fixtures}/flutter_gpu_instanced.vert\"}, \"UnlitFragment\": {\"type\": \"fragment\", \"file\": \"${fixtures}/flutter_gpu_unlit.frag\"}, \"UnlitVertex\": {\"type\": \"vertex\", \"file\": \"${fixtures}/flutter_gpu_unlit.vert\"}, \"TextureFragment\": {\"type\": \"fragment\", \"file\": \"${fixtures}/flutter_gpu_texture.frag\"}, \"TextureVertex\": {\"type\": \"vertex\", \"file\": \"${fixtures}/flutter_gpu_texture.vert\"}}"
+  shader_bundle = "{\"InstancedFragment\": {\"type\": \"fragment\", \"file\": \"${fixtures}/flutter_gpu_instanced.frag\"}, \"InstancedVertex\": {\"type\": \"vertex\", \"file\": \"${fixtures}/flutter_gpu_instanced.vert\"}, \"UnlitFragment\": {\"type\": \"fragment\", \"file\": \"${fixtures}/flutter_gpu_unlit.frag\"}, \"UnlitVertex\": {\"type\": \"vertex\", \"file\": \"${fixtures}/flutter_gpu_unlit.vert\"}, \"TextureFragment\": {\"type\": \"fragment\", \"file\": \"${fixtures}/flutter_gpu_texture.frag\"}, \"TextureVertex\": {\"type\": \"vertex\", \"file\": \"${fixtures}/flutter_gpu_texture.vert\"}, \"PushConstantsFragment\": {\"type\": \"fragment\", \"file\": \"${fixtures}/flutter_gpu_push_constants.frag\"}, \"PushConstantsVertex\": {\"type\": \"vertex\", \"file\": \"${fixtures}/flutter_gpu_push_constants.vert\"}}"
   shader_bundle_output = "playground.shaderbundle"
 }
 

--- a/engine/src/flutter/impeller/fixtures/dart_tests.dart
+++ b/engine/src/flutter/impeller/fixtures/dart_tests.dart
@@ -50,6 +50,35 @@ Future<void> canReflectUniformStructs() async {
   assert(colorOffset! == 64);
 }
 
+@pragma('vm:entry-point')
+Future<void> canReflectPushConstants() async {
+  final gpu.RenderPipeline pipeline = await createPushConstantsRenderPipeline();
+
+  assert(pipeline.vertexShader.pushConstantSizeInBytes == 80);
+  assert(pipeline.vertexShader.getPushConstantMemberOffsetInBytes('color') == 0);
+  assert(pipeline.vertexShader.getPushConstantMemberOffsetInBytes('mvp') == 16);
+  assert(pipeline.vertexShader.getPushConstantMemberOffsetInBytes('nope') == null);
+
+  // Both stages declare the same block, so both report it.
+  assert(pipeline.fragmentShader.pushConstantSizeInBytes == 80);
+
+  // A shader without a block reports null rather than zero.
+  final gpu.RenderPipeline unlit = await createUnlitRenderPipeline();
+  assert(unlit.vertexShader.pushConstantSizeInBytes == null);
+
+  assert(gpu.gpuContext.maxPushConstantSizeInBytes >= 80);
+}
+
+Future<gpu.RenderPipeline> createPushConstantsRenderPipeline() async {
+  final gpu.ShaderLibrary? library = await gpu.ShaderLibrary.fromAsset('playground');
+  assert(library != null);
+  final gpu.Shader? vertex = library!['PushConstantsVertex'];
+  assert(vertex != null);
+  final gpu.Shader? fragment = library['PushConstantsFragment'];
+  assert(fragment != null);
+  return gpu.gpuContext.createRenderPipeline(vertex!, fragment!);
+}
+
 Future<gpu.RenderPipeline> createUnlitRenderPipeline() async {
   final gpu.ShaderLibrary? library = await gpu.ShaderLibrary.fromAsset('playground');
   assert(library != null);
@@ -58,6 +87,47 @@ Future<gpu.RenderPipeline> createUnlitRenderPipeline() async {
   final gpu.Shader? fragment = library['UnlitFragment'];
   assert(fragment != null);
   return gpu.gpuContext.createRenderPipeline(vertex!, fragment!);
+}
+
+@pragma('vm:entry-point')
+Future<void> canDrawWithPushConstants(int width, int height) async {
+  final gpu.Texture renderTexture = gpu.gpuContext.createTexture(
+    gpu.StorageMode.devicePrivate,
+    width,
+    height,
+  );
+
+  final gpu.CommandBuffer commandBuffer = gpu.gpuContext.createCommandBuffer();
+  final renderTarget = gpu.RenderTarget.singleColor(gpu.ColorAttachment(texture: renderTexture));
+  final gpu.RenderPass encoder = commandBuffer.createRenderPass(renderTarget);
+
+  final gpu.RenderPipeline pipeline = await createPushConstantsRenderPipeline();
+  encoder.bindPipeline(pipeline);
+
+  final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
+  final gpu.BufferView vertices = transients.emplace(
+    float32(<double>[
+      -0.5, 0.5, //
+      0.0, -0.5, //
+      0.5, 0.5, //
+    ]),
+  );
+  encoder.bindVertexBuffer(vertices);
+
+  encoder.setPushConstants(
+    float32(<double>[
+      0, 1, 0, 1, // color
+      1, 0, 0, 0, // mvp
+      0, 1, 0, 0, // mvp
+      0, 0, 1, 0, // mvp
+      0, 0, 0, 1, // mvp
+    ]),
+  );
+  encoder.draw(3);
+
+  commandBuffer.submit();
+
+  setDisplayTexture(renderTexture);
 }
 
 ByteData float32(List<double> values) {

--- a/engine/src/flutter/impeller/fixtures/flutter_gpu_push_constants.frag
+++ b/engine/src/flutter/impeller/fixtures/flutter_gpu_push_constants.frag
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+layout(push_constant) uniform DrawInfo {
+  vec4 color;
+  mat4 mvp;
+}
+draw_info;
+
+in vec4 v_color;
+out vec4 frag_color;
+
+void main() {
+  frag_color = v_color * draw_info.color;
+}

--- a/engine/src/flutter/impeller/fixtures/flutter_gpu_push_constants.vert
+++ b/engine/src/flutter/impeller/fixtures/flutter_gpu_push_constants.vert
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Declared by both stages, which read the same 80 bytes. `color` comes first
+// so both stages agree on its offset.
+layout(push_constant) uniform DrawInfo {
+  vec4 color;  // offset 0 bytes, size 16 bytes
+  mat4 mvp;    // offset 16 bytes, size 64 bytes
+}
+draw_info;
+
+in vec2 position;
+out vec4 v_color;
+
+void main() {
+  v_color = draw_info.color;
+  gl_Position = draw_info.mvp * vec4(position, 0.0, 1.0);
+}

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -407,9 +407,23 @@ bool BufferBindingsGLES::BindUniformBufferV2(
     const BufferView& buffer,
     const ShaderMetadata* metadata,
     const DeviceBufferGLES& device_buffer_gles) {
-  const uint8_t* buffer_ptr =
-      device_buffer_gles.GetBufferData() + buffer.GetRange().offset;
+  return BindUniformMembers(
+      gl, metadata,
+      device_buffer_gles.GetBufferData() + buffer.GetRange().offset);
+}
 
+bool BufferBindingsGLES::BindPushConstants(const ProcTableGLES& gl,
+                                           const ShaderMetadata* metadata,
+                                           const uint8_t* data) {
+  // GLES has no push constants. The shader compiler lowers the block to plain
+  // uniforms named the same way a legacy uniform block's members are, so the
+  // per-member upload path is shared verbatim.
+  return BindUniformMembers(gl, metadata, data);
+}
+
+bool BufferBindingsGLES::BindUniformMembers(const ProcTableGLES& gl,
+                                            const ShaderMetadata* metadata,
+                                            const uint8_t* buffer_ptr) {
   if (metadata->members.empty()) {
     VALIDATION_LOG << "Uniform buffer had no members. This is currently "
                       "unsupported in the OpenGL ES backend. Use a uniform "

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -57,6 +57,12 @@ class BufferBindingsGLES {
                        Range texture_range,
                        Range buffer_range);
 
+  /// Upload a push constant block. `data` points at the block's bytes, which
+  /// the caller owns.
+  bool BindPushConstants(const ProcTableGLES& gl,
+                         const ShaderMetadata* metadata,
+                         const uint8_t* data);
+
   bool UnbindVertexAttributes(const ProcTableGLES& gl);
 
  private:
@@ -115,6 +121,12 @@ class BufferBindingsGLES {
                            const BufferView& buffer,
                            const ShaderMetadata* metadata,
                            const DeviceBufferGLES& device_buffer_gles);
+
+  /// Upload each member of `metadata` with the matching glUniform call,
+  /// reading from `buffer_ptr` at the member's reflected offset.
+  bool BindUniformMembers(const ProcTableGLES& gl,
+                          const ShaderMetadata* metadata,
+                          const uint8_t* buffer_ptr);
 
   std::optional<size_t> BindTextures(
       const ProcTableGLES& gl,

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -376,6 +376,10 @@ size_t CapabilitiesGLES::GetMinimumUniformAlignment() const {
   return 256;
 }
 
+size_t CapabilitiesGLES::GetMaxPushConstantSize() const {
+  return kDefaultMaxPushConstantSize;
+}
+
 bool CapabilitiesGLES::NeedsPartitionedHostBuffer() const {
 #ifdef FML_OS_EMSCRIPTEN
   // WebGL has special requirements here to keep indexes and other data

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
@@ -170,6 +170,9 @@ class CapabilitiesGLES final
   size_t GetMinimumUniformAlignment() const override;
 
   // |Capabilities|
+  size_t GetMaxPushConstantSize() const override;
+
+  // |Capabilities|
   bool NeedsPartitionedHostBuffer() const override;
 
  private:

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -241,6 +241,8 @@ static void EncodeViewport(const ProcTableGLES& gl,
     const std::vector<BufferView>& vertex_buffers,
     const std::vector<TextureAndSampler>& bound_textures,
     const std::vector<BufferResource>& bound_buffers,
+    const std::vector<PushConstantBinding>& push_constants,
+    const std::vector<uint8_t>& push_constant_data,
     const std::shared_ptr<GPUTracerGLES>& tracer,
     const std::shared_ptr<const Context>& impeller_context) {
   TRACE_EVENT0("impeller", "RenderPassGLES::EncodeCommandsInReactor");
@@ -518,6 +520,19 @@ static void EncodeViewport(const ProcTableGLES& gl,
             /*buffer_range=*/command.bound_buffers     //
             )) {
       return false;
+    }
+
+    //--------------------------------------------------------------------------
+    /// Bind push constant data.
+    ///
+    for (size_t i = 0; i < command.push_constants.length; i++) {
+      const PushConstantBinding& binding =
+          push_constants[command.push_constants.offset + i];
+      if (!vertex_desc_gles->BindPushConstants(
+              gl, &binding.metadata,
+              push_constant_data.data() + binding.data.offset)) {
+        return false;
+      }
     }
 
     //--------------------------------------------------------------------------
@@ -839,7 +854,9 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
             /*vertex_buffers=*/render_pass->vertex_buffers_,  //
             /*bound_textures=*/render_pass->bound_textures_,  //
             /*bound_buffers=*/render_pass->bound_buffers_,    //
-            /*tracer=*/tracer,                                //
+            /*push_constants=*/render_pass->push_constants_,  //
+            /*push_constant_data=*/render_pass->push_constant_data_,
+            /*tracer=*/tracer,  //
             /*impeller_context=*/render_pass->context_);
         FML_CHECK(result)
             << "Must be able to encode GL commands without error.";

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -90,6 +90,9 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       // Anisotropic filtering with a clamp in the range [1, 16] is supported
       // on all Metal devices.
       .SetMaxSamplerAnisotropy(16)
+      // `setBytes` copies inline up to 4 KB; past that Metal allocates a
+      // buffer anyway, which defeats the point.
+      .SetMaxPushConstantSize(kDefaultMaxPushConstantSize)
       .SetSupportsExtendedRangeFormats(
           DeviceSupportsExtendedRangeFormats(device))
       .SetSupportsTextureCompression(CompressedTextureFamily::kBC,

--- a/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.h
@@ -55,6 +55,15 @@ struct PassBindingsCacheMTL {
                  uint64_t offset,
                  id<MTLBuffer> buffer);
 
+  /// @brief Set inline bytes for the given shader stage and binding.
+  ///
+  /// The driver owns the copy, so there is nothing to compare against and the
+  /// call is always made. Any buffer cached at this index is forgotten.
+  bool SetBytes(ShaderStage stage,
+                uint64_t index,
+                const void* bytes,
+                size_t length);
+
   /// @brief Set the texture for the given stage and binding.
   ///
   /// If the same texture is already bound at the index for this stage, no

--- a/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.mm
@@ -78,6 +78,30 @@ bool PassBindingsCacheMTL::SetBuffer(ShaderStage stage,
   return false;
 }
 
+bool PassBindingsCacheMTL::SetBytes(ShaderStage stage,
+                                    uint64_t index,
+                                    const void* bytes,
+                                    size_t length) {
+  if (index == kOptimizedOutBinding) {
+    // See SetBuffer: a dead-code-eliminated block has no argument-table slot.
+    return true;
+  }
+  // Metal binds a driver-owned allocation at this index, so a buffer bound
+  // here earlier is no longer what the shader reads.
+  buffers_[stage][index] = {nullptr, 0u};
+  switch (stage) {
+    case ShaderStage::kVertex:
+      [encoder_ setVertexBytes:bytes length:length atIndex:index];
+      return true;
+    case ShaderStage::kFragment:
+      [encoder_ setFragmentBytes:bytes length:length atIndex:index];
+      return true;
+    default:
+      VALIDATION_LOG << "Cannot set bytes on an unknown shader stage.";
+      return false;
+  }
+}
+
 bool PassBindingsCacheMTL::SetTexture(ShaderStage stage,
                                       uint64_t index,
                                       id<MTLTexture> texture) {

--- a/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -89,6 +89,13 @@ class RenderPassMTL final : public RenderPass {
   bool SetIndexBuffer(BufferView index_buffer, IndexType index_type) override;
 
   // |RenderPass|
+  bool SetPushConstants(ShaderStage stage,
+                        const ShaderPushConstantSlot& slot,
+                        const ShaderMetadata* metadata,
+                        const uint8_t* data,
+                        size_t length) override;
+
+  // |RenderPass|
   fml::Status Draw() override;
 
   // |RenderPass|

--- a/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -323,6 +323,24 @@ bool RenderPassMTL::SetIndexBuffer(BufferView index_buffer,
 }
 
 // |RenderPass|
+bool RenderPassMTL::SetPushConstants(ShaderStage stage,
+                                     const ShaderPushConstantSlot& slot,
+                                     const ShaderMetadata* metadata,
+                                     const uint8_t* data,
+                                     size_t length) {
+  if (data == nullptr || length < slot.size_in_bytes) {
+    VALIDATION_LOG << "Push constant data is smaller than the block declared "
+                      "by the shader.";
+    return false;
+  }
+  // Metal has no push constants. `setBytes` is the equivalent small-data path:
+  // the driver copies the bytes into an allocation it owns and binds it at the
+  // block's argument table index.
+  return pass_bindings_.SetBytes(stage, slot.ext_res_0, data,
+                                 slot.size_in_bytes);
+}
+
+// |RenderPass|
 fml::Status RenderPassMTL::Draw() {
   if (!has_valid_pipeline_) {
     return fml::Status(fml::StatusCode::kCancelled, "Invalid pipeline.");

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -806,6 +806,10 @@ size_t CapabilitiesVK::GetMinimumStorageBufferAlignment() const {
   return minimum_storage_alignment_;
 }
 
+size_t CapabilitiesVK::GetMaxPushConstantSize() const {
+  return device_properties_.limits.maxPushConstantsSize;
+}
+
 bool CapabilitiesVK::NeedsPartitionedHostBuffer() const {
   return false;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -310,6 +310,9 @@ class CapabilitiesVK final : public Capabilities,
   size_t GetMinimumStorageBufferAlignment() const override;
 
   // |Capabilities|
+  size_t GetMaxPushConstantSize() const override;
+
+  // |Capabilities|
   bool NeedsPartitionedHostBuffer() const override;
 
   //----------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
@@ -5,6 +5,8 @@
 #include "impeller/renderer/backend/vulkan/pipeline_vk.h"
 
 #include <format>
+#include <optional>
+#include <vector>
 
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/status_or.h"
@@ -225,8 +227,28 @@ fml::StatusOr<vk::UniquePipelineLayout> MakePipelineLayout(
     const PipelineDescriptor& desc,
     const std::shared_ptr<DeviceHolderVK>& device_holder,
     const vk::DescriptorSetLayout& descs_layout) {
+  // Every stage reads its block from offset zero, so two stages that both
+  // declare one alias the same memory. Vulkan allows that; what it forbids is
+  // naming a stage in more than one range.
+  std::vector<vk::PushConstantRange> push_constant_ranges;
+  if (const auto& vertex_descriptor = desc.GetVertexDescriptor()) {
+    for (const auto& range : vertex_descriptor->GetPushConstantRanges()) {
+      std::optional<vk::ShaderStageFlagBits> stage =
+          ToVKShaderStageFlagBits(range.shader_stage);
+      if (!stage.has_value()) {
+        continue;
+      }
+      vk::PushConstantRange vk_range;
+      vk_range.setStageFlags(stage.value());
+      vk_range.setOffset(0u);
+      vk_range.setSize(range.size);
+      push_constant_ranges.push_back(vk_range);
+    }
+  }
+
   vk::PipelineLayoutCreateInfo pipeline_layout_info;
   pipeline_layout_info.setSetLayouts(descs_layout);
+  pipeline_layout_info.setPushConstantRanges(push_constant_ranges);
   auto pipeline_layout = device_holder->GetDevice().createPipelineLayoutUnique(
       pipeline_layout_info);
   if (pipeline_layout.result != vk::Result::eSuccess) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -499,6 +499,34 @@ bool RenderPassVK::SetIndexBuffer(BufferView index_buffer,
 }
 
 // |RenderPass|
+bool RenderPassVK::SetPushConstants(ShaderStage stage,
+                                    const ShaderPushConstantSlot& slot,
+                                    const ShaderMetadata* metadata,
+                                    const uint8_t* data,
+                                    size_t length) {
+  if (data == nullptr || length < slot.size_in_bytes) {
+    VALIDATION_LOG << "Push constant data is smaller than the block declared "
+                      "by the shader.";
+    return false;
+  }
+  // The push happens in `Draw`, once the pipeline layout the data has to be
+  // compatible with is known.
+  switch (stage) {
+    case ShaderStage::kVertex:
+      vertex_push_constants_.assign(data, data + slot.size_in_bytes);
+      return true;
+    case ShaderStage::kFragment:
+      fragment_push_constants_.assign(data, data + slot.size_in_bytes);
+      return true;
+    case ShaderStage::kUnknown:
+    case ShaderStage::kCompute:
+      VALIDATION_LOG << "Cannot set push constants on this shader stage.";
+      return false;
+  }
+  FML_UNREACHABLE();
+}
+
+// |RenderPass|
 fml::Status RenderPassVK::Draw() {
   if (!pipeline_) {
     return fml::Status(fml::StatusCode::kCancelled,
@@ -565,6 +593,34 @@ fml::Status RenderPassVK::Draw() {
       0,                                 // offset count
       nullptr                            // offsets
   );
+
+  // A push must be covered by a range this layout declares for the stage, so
+  // the pipeline is what decides which stages get one and how much.
+  if (const auto& vertex_descriptor =
+          pipeline_->GetDescriptor().GetVertexDescriptor()) {
+    for (const auto& range : vertex_descriptor->GetPushConstantRanges()) {
+      vk::ShaderStageFlagBits stage;
+      const std::vector<uint8_t>* data = nullptr;
+      switch (range.shader_stage) {
+        case ShaderStage::kVertex:
+          stage = vk::ShaderStageFlagBits::eVertex;
+          data = &vertex_push_constants_;
+          break;
+        case ShaderStage::kFragment:
+          stage = vk::ShaderStageFlagBits::eFragment;
+          data = &fragment_push_constants_;
+          break;
+        case ShaderStage::kUnknown:
+        case ShaderStage::kCompute:
+          continue;
+      }
+      if (data->size() < range.size) {
+        continue;
+      }
+      command_buffer_vk_.pushConstants(pipeline_layout, stage, 0u, range.size,
+                                       data->data());
+    }
+  }
 
   if (pipeline_uses_input_attachments_) {
     InsertBarrierForInputAttachmentRead(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -5,6 +5,9 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_RENDER_PASS_VK_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_RENDER_PASS_VK_H_
 
+#include <cstdint>
+#include <vector>
+
 #include "impeller/core/buffer_view.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/pipeline_vk.h"
@@ -51,6 +54,10 @@ class RenderPassVK final : public RenderPass {
   bool has_label_ = false;
   PipelineRef pipeline_ = PipelineRef(nullptr);
   bool pipeline_uses_input_attachments_ = false;
+  // Push constant state, kept across draws to match the persistence every
+  // backend gives it. Reused rather than reallocated per draw.
+  std::vector<uint8_t> vertex_push_constants_;
+  std::vector<uint8_t> fragment_push_constants_;
   std::shared_ptr<SamplerVK> immutable_sampler_;
 
   RenderPassVK(const std::shared_ptr<const Context>& context,
@@ -87,6 +94,13 @@ class RenderPassVK final : public RenderPass {
 
   // |RenderPass|
   bool SetIndexBuffer(BufferView index_buffer, IndexType index_type) override;
+
+  // |RenderPass|
+  bool SetPushConstants(ShaderStage stage,
+                        const ShaderPushConstantSlot& slot,
+                        const ShaderMetadata* metadata,
+                        const uint8_t* data,
+                        size_t length) override;
 
   // |RenderPass|
   fml::Status Draw() override;

--- a/engine/src/flutter/impeller/renderer/capabilities.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities.cc
@@ -136,6 +136,11 @@ class StandardCapabilities final : public Capabilities {
   }
 
   // |Capabilities|
+  size_t GetMaxPushConstantSize() const override {
+    return max_push_constant_size_;
+  }
+
+  // |Capabilities|
   bool NeedsPartitionedHostBuffer() const override {
     return needs_partitioned_host_buffer_;
   }
@@ -159,6 +164,7 @@ class StandardCapabilities final : public Capabilities {
                        ISize default_maximum_render_pass_attachment_size,
                        uint32_t max_sampler_anisotropy,
                        size_t minimum_uniform_alignment,
+                       size_t max_push_constant_size,
                        bool needs_partitioned_host_buffer,
                        bool supports_texture_compression_bc,
                        bool supports_texture_compression_etc2,
@@ -185,6 +191,7 @@ class StandardCapabilities final : public Capabilities {
             default_maximum_render_pass_attachment_size),
         max_sampler_anisotropy_(max_sampler_anisotropy),
         minimum_uniform_alignment_(minimum_uniform_alignment),
+        max_push_constant_size_(max_push_constant_size),
         supports_texture_compression_bc_(supports_texture_compression_bc),
         supports_texture_compression_etc2_(supports_texture_compression_etc2),
         supports_texture_compression_astc_(supports_texture_compression_astc),
@@ -212,6 +219,7 @@ class StandardCapabilities final : public Capabilities {
   ISize default_maximum_render_pass_attachment_size_ = ISize(1, 1);
   uint32_t max_sampler_anisotropy_ = 1;
   size_t minimum_uniform_alignment_ = 256;
+  size_t max_push_constant_size_ = 0u;
   bool supports_texture_compression_bc_ = false;
   bool supports_texture_compression_etc2_ = false;
   bool supports_texture_compression_astc_ = false;
@@ -350,6 +358,11 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetMinimumUniformAlignment(
   return *this;
 }
 
+CapabilitiesBuilder& CapabilitiesBuilder::SetMaxPushConstantSize(size_t value) {
+  max_push_constant_size_ = value;
+  return *this;
+}
+
 CapabilitiesBuilder& CapabilitiesBuilder::SetNeedsPartitionedHostBuffer(
     bool value) {
   needs_partitioned_host_buffer_ = value;
@@ -377,6 +390,7 @@ std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
       default_maximum_render_pass_attachment_size_.value_or(ISize{1, 1}),  //
       max_sampler_anisotropy_,                                             //
       minimum_uniform_alignment_,                                          //
+      max_push_constant_size_,                                             //
       needs_partitioned_host_buffer_,                                      //
       supports_texture_compression_bc_,                                    //
       supports_texture_compression_etc2_,                                  //

--- a/engine/src/flutter/impeller/renderer/capabilities.h
+++ b/engine/src/flutter/impeller/renderer/capabilities.h
@@ -11,6 +11,15 @@
 
 namespace impeller {
 
+/// @brief The push constant size reported by backends with no hardware ceiling
+///        worth reporting.
+///
+///        Metal copies anything up to 4 KB inline before it allocates a buffer
+///        anyway, and OpenGL ES lowers the block to plain uniforms bounded by
+///        the stage's uniform budget. Vulkan reports the device's own
+///        `maxPushConstantsSize` instead, whose guaranteed floor is 128 bytes.
+inline constexpr size_t kDefaultMaxPushConstantSize = 4096u;
+
 class Capabilities {
  public:
   virtual ~Capabilities();
@@ -157,6 +166,14 @@ class Capabilities {
   /// @brief The minimum alignment of uniform value offsets in bytes.
   virtual size_t GetMinimumUniformAlignment() const = 0;
 
+  /// @brief The maximum size in bytes of the push constant block a single
+  ///        shader stage can read.
+  ///
+  ///        Zero means the backend has no push constant path at all. The
+  ///        portable floor is small and varies by backend, so callers check
+  ///        this rather than assume a constant.
+  virtual size_t GetMaxPushConstantSize() const = 0;
+
   /// @brief The minimum alignment of storage buffer value offsets in bytes.
   virtual size_t GetMinimumStorageBufferAlignment() const;
 
@@ -218,6 +235,8 @@ class CapabilitiesBuilder {
 
   CapabilitiesBuilder& SetMinimumUniformAlignment(size_t value);
 
+  CapabilitiesBuilder& SetMaxPushConstantSize(size_t value);
+
   CapabilitiesBuilder& SetNeedsPartitionedHostBuffer(bool value);
 
   std::unique_ptr<Capabilities> Build();
@@ -247,6 +266,7 @@ class CapabilitiesBuilder {
       std::nullopt;
   uint32_t max_sampler_anisotropy_ = 1;
   size_t minimum_uniform_alignment_ = 256;
+  size_t max_push_constant_size_ = 0u;
 
   CapabilitiesBuilder(const CapabilitiesBuilder&) = delete;
 

--- a/engine/src/flutter/impeller/renderer/command.h
+++ b/engine/src/flutter/impeller/renderer/command.h
@@ -55,6 +55,19 @@ class Resource {
 using BufferResource = Resource<BufferView>;
 using TextureResource = Resource<std::shared_ptr<const Texture>>;
 
+/// @brief A push constant block and the bytes to fill it with.
+///
+/// Only backends that defer encoding to submit record these. The metadata is
+/// owned rather than borrowed because the shader it was reflected from can be
+/// collected before the pass is encoded.
+struct PushConstantBinding {
+  ShaderPushConstantSlot slot;
+  ShaderStage stage;
+  ShaderMetadata metadata;
+  /// The block's bytes within the render pass's push constant storage.
+  Range data;
+};
+
 /// @brief combines the texture, sampler and sampler slot information.
 struct TextureAndSampler {
   SampledImageSlot slot;
@@ -91,6 +104,10 @@ struct Command {
   /// stored.
   Range bound_buffers = Range{0, 0};
   Range bound_textures = Range{0, 0};
+
+  /// An offset into render pass storage where push constant blocks set for
+  /// this draw are stored.
+  Range push_constants = Range{0, 0};
 
   //----------------------------------------------------------------------------
   /// An offset and range of vertex buffers bound for this draw call.

--- a/engine/src/flutter/impeller/renderer/render_pass.cc
+++ b/engine/src/flutter/impeller/renderer/render_pass.cc
@@ -205,15 +205,44 @@ bool RenderPass::ValidateIndexBuffer(const BufferView& index_buffer,
   return true;
 }
 
+bool RenderPass::SetPushConstants(ShaderStage stage,
+                                  const ShaderPushConstantSlot& slot,
+                                  const ShaderMetadata* metadata,
+                                  const uint8_t* data,
+                                  size_t length) {
+  if (data == nullptr || length < slot.size_in_bytes) {
+    VALIDATION_LOG << "Push constant data is smaller than the block declared "
+                      "by the shader.";
+    return false;
+  }
+  if (!push_constants_start_.has_value()) {
+    push_constants_start_ = push_constants_.size();
+  }
+
+  Range range = {push_constant_data_.size(), slot.size_in_bytes};
+  push_constant_data_.insert(push_constant_data_.end(), data,
+                             data + slot.size_in_bytes);
+  push_constants_.push_back(PushConstantBinding{
+      .slot = slot,
+      .stage = stage,
+      .metadata = metadata ? *metadata : ShaderMetadata{},
+      .data = range,
+  });
+  pending_.push_constants.length++;
+  return true;
+}
+
 fml::Status RenderPass::Draw() {
   pending_.bound_buffers.offset = bound_buffers_start_.value_or(0u);
   pending_.bound_textures.offset = bound_textures_start_.value_or(0u);
   pending_.vertex_buffers.offset = vertex_buffers_start_.value_or(0u);
+  pending_.push_constants.offset = push_constants_start_.value_or(0u);
   auto result = AddCommand(std::move(pending_));
   pending_ = Command{};
   bound_textures_start_ = std::nullopt;
   bound_buffers_start_ = std::nullopt;
   vertex_buffers_start_ = std::nullopt;
+  push_constants_start_ = std::nullopt;
   if (result) {
     return fml::Status();
   }

--- a/engine/src/flutter/impeller/renderer/render_pass.h
+++ b/engine/src/flutter/impeller/renderer/render_pass.h
@@ -6,6 +6,8 @@
 #define FLUTTER_IMPELLER_RENDERER_RENDER_PASS_H_
 
 #include <cstddef>
+#include <cstdint>
+#include <vector>
 
 #include "fml/status.h"
 #include "impeller/core/formats.h"
@@ -168,6 +170,32 @@ class RenderPass : public ResourceBinder {
   ///
   virtual bool SetIndexBuffer(BufferView index_buffer, IndexType index_type);
 
+  //----------------------------------------------------------------------------
+  /// @brief      Set the data a pipeline's push constant block reads.
+  ///
+  ///             A pipeline has one block of push constant memory. A stage
+  ///             that declares a block always reads it from offset zero, so
+  ///             two stages declaring a block read the same bytes.
+  ///
+  ///             The value persists for the rest of the pass, or until it is
+  ///             set again.
+  ///
+  /// @param[in]  stage     The stage that declared the block.
+  /// @param[in]  slot      The reflected block.
+  /// @param[in]  metadata  The block's member layout. Required by backends
+  ///                       that lower push constants to plain uniforms.
+  /// @param[in]  data      The bytes to write. Must be at least
+  ///                       `slot.size_in_bytes` long.
+  /// @param[in]  length    The length of `data` in bytes.
+  ///
+  /// @return     Whether the data was recorded.
+  ///
+  virtual bool SetPushConstants(ShaderStage stage,
+                                const ShaderPushConstantSlot& slot,
+                                const ShaderMetadata* metadata,
+                                const uint8_t* data,
+                                size_t length);
+
   /// Record the currently pending command.
   virtual fml::Status Draw();
 
@@ -249,6 +277,8 @@ class RenderPass : public ResourceBinder {
   std::vector<BufferView> vertex_buffers_;
   std::vector<BufferResource> bound_buffers_;
   std::vector<TextureAndSampler> bound_textures_;
+  std::vector<PushConstantBinding> push_constants_;
+  std::vector<uint8_t> push_constant_data_;
   const Matrix orthographic_;
 
   //----------------------------------------------------------------------------
@@ -293,6 +323,7 @@ class RenderPass : public ResourceBinder {
   std::optional<size_t> bound_buffers_start_ = std::nullopt;
   std::optional<size_t> bound_textures_start_ = std::nullopt;
   std::optional<size_t> vertex_buffers_start_ = std::nullopt;
+  std::optional<size_t> push_constants_start_ = std::nullopt;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/renderer_dart_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_dart_unittests.cc
@@ -314,8 +314,16 @@ TEST_P(RendererDartTest, CanReflectUniformStructs) {
   ASSERT_TRUE(RunDartFunction("canReflectUniformStructs"));
 }
 
+TEST_P(RendererDartTest, CanReflectPushConstants) {
+  ASSERT_TRUE(RunDartFunction("canReflectPushConstants"));
+}
+
 TEST_P(RendererDartTest, CanCreateRenderPassAndSubmit) {
   ASSERT_TRUE(RenderDartToPlayground("canCreateRenderPassAndSubmit"));
+}
+
+TEST_P(RendererDartTest, CanDrawWithPushConstants) {
+  ASSERT_TRUE(RenderDartToPlayground("canDrawWithPushConstants"));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/vertex_descriptor.cc
+++ b/engine/src/flutter/impeller/renderer/vertex_descriptor.cc
@@ -43,6 +43,17 @@ void VertexDescriptor::RegisterDescriptorSetLayouts(
   }
 }
 
+void VertexDescriptor::RegisterPushConstantRange(ShaderStage stage,
+                                                 size_t size_in_bytes) {
+  if (size_in_bytes == 0u) {
+    return;
+  }
+  push_constant_ranges_.emplace_back(PushConstantRange{
+      .shader_stage = stage,
+      .size = static_cast<uint32_t>(size_in_bytes),
+  });
+}
+
 // |Comparable<VertexDescriptor>|
 size_t VertexDescriptor::GetHash() const {
   auto seed = fml::HashCombine();
@@ -52,12 +63,16 @@ size_t VertexDescriptor::GetHash() const {
   for (const auto& layout : layouts_) {
     fml::HashCombineSeed(seed, layout.GetHash());
   }
+  for (const auto& range : push_constant_ranges_) {
+    fml::HashCombineSeed(seed, range.GetHash());
+  }
   return seed;
 }
 
 // |Comparable<VertexDescriptor>|
 bool VertexDescriptor::IsEqual(const VertexDescriptor& other) const {
-  return inputs_ == other.inputs_ && layouts_ == other.layouts_;
+  return inputs_ == other.inputs_ && layouts_ == other.layouts_ &&
+         push_constant_ranges_ == other.push_constant_ranges_;
 }
 
 const std::vector<ShaderStageIOSlot>& VertexDescriptor::GetStageInputs() const {
@@ -72,6 +87,11 @@ const std::vector<ShaderStageBufferLayout>& VertexDescriptor::GetStageLayouts()
 const std::vector<DescriptorSetLayout>&
 VertexDescriptor::GetDescriptorSetLayouts() const {
   return desc_set_layouts_;
+}
+
+const std::vector<PushConstantRange>& VertexDescriptor::GetPushConstantRanges()
+    const {
+  return push_constant_ranges_;
 }
 
 bool VertexDescriptor::UsesInputAttachments() const {

--- a/engine/src/flutter/impeller/renderer/vertex_descriptor.h
+++ b/engine/src/flutter/impeller/renderer/vertex_descriptor.h
@@ -55,11 +55,20 @@ class VertexDescriptor final : public Comparable<VertexDescriptor> {
   void RegisterDescriptorSetLayouts(const DescriptorSetLayout desc_set_layout[],
                                     size_t count);
 
+  /// @brief Declare that `stage` reads `size_in_bytes` of push constant data.
+  ///
+  ///        Backends that need the pipeline layout to spell out its push
+  ///        constant usage (Vulkan) build it from these. A zero size registers
+  ///        nothing.
+  void RegisterPushConstantRange(ShaderStage stage, size_t size_in_bytes);
+
   const std::vector<ShaderStageIOSlot>& GetStageInputs() const;
 
   const std::vector<ShaderStageBufferLayout>& GetStageLayouts() const;
 
   const std::vector<DescriptorSetLayout>& GetDescriptorSetLayouts() const;
+
+  const std::vector<PushConstantRange>& GetPushConstantRanges() const;
 
   // |Comparable<VertexDescriptor>|
   std::size_t GetHash() const override;
@@ -73,6 +82,7 @@ class VertexDescriptor final : public Comparable<VertexDescriptor> {
   std::vector<ShaderStageIOSlot> inputs_;
   std::vector<ShaderStageBufferLayout> layouts_;
   std::vector<DescriptorSetLayout> desc_set_layouts_;
+  std::vector<PushConstantRange> push_constant_ranges_;
   bool uses_input_attachments_ = false;
 
   VertexDescriptor(const VertexDescriptor&) = delete;

--- a/engine/src/flutter/impeller/shader_bundle/shader_bundle.fbs
+++ b/engine/src/flutter/impeller/shader_bundle/shader_bundle.fbs
@@ -8,7 +8,7 @@ namespace impeller.fb.shaderbundle;
 // incremented any time there is a change to this file which changes the
 // resulting flat buffer format.
 enum ShaderBundleFormatVersion:uint32 {
-  kVersion = 2
+  kVersion = 3
 }
 
 enum ShaderStage:byte {
@@ -96,6 +96,15 @@ table ShaderUniformTexture {
   binding: uint64;
 }
 
+// A `layout(push_constant)` block. A stage declares at most one and always
+// reads it from offset zero, so it carries no set or binding.
+table ShaderPushConstantBlock {
+  name: string;
+  ext_res_0: uint64;
+  size_in_bytes: uint64; // Includes all alignment padding.
+  fields: [ShaderUniformStructField];
+}
+
 table BackendShader {
   stage: ShaderStage;
   entrypoint: string;
@@ -103,6 +112,7 @@ table BackendShader {
   uniform_structs: [ShaderUniformStruct];
   uniform_textures: [ShaderUniformTexture];
   shader: [ubyte];
+  push_constants: ShaderPushConstantBlock;
 }
 
 table Shader {

--- a/engine/src/flutter/lib/gpu/context.cc
+++ b/engine/src/flutter/lib/gpu/context.cc
@@ -135,6 +135,11 @@ extern int InternalFlutterGpu_Context_GetMinimumUniformByteAlignment(
   return wrapper->GetContext().GetCapabilities()->GetMinimumUniformAlignment();
 }
 
+extern int InternalFlutterGpu_Context_GetMaxPushConstantSize(
+    flutter::gpu::Context* wrapper) {
+  return wrapper->GetContext().GetCapabilities()->GetMaxPushConstantSize();
+}
+
 extern bool InternalFlutterGpu_Context_GetSupportsOffscreenMSAA(
     flutter::gpu::Context* wrapper) {
   return flutter::gpu::SupportsNormalOffscreenMSAA(wrapper->GetContext());

--- a/engine/src/flutter/lib/gpu/context.h
+++ b/engine/src/flutter/lib/gpu/context.h
@@ -79,6 +79,10 @@ extern int InternalFlutterGpu_Context_GetMinimumUniformByteAlignment(
     flutter::gpu::Context* wrapper);
 
 FLUTTER_GPU_EXPORT
+extern int InternalFlutterGpu_Context_GetMaxPushConstantSize(
+    flutter::gpu::Context* wrapper);
+
+FLUTTER_GPU_EXPORT
 extern bool InternalFlutterGpu_Context_GetSupportsOffscreenMSAA(
     flutter::gpu::Context* wrapper);
 

--- a/engine/src/flutter/lib/gpu/lib/src/context.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/context.dart
@@ -46,6 +46,16 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     return _getMinimumUniformByteAlignment();
   }
 
+  /// The maximum size in bytes of the push constant block a single shader
+  /// stage can read (see [RenderPass.setPushConstants]).
+  ///
+  /// This varies widely by backend and device, so branch on it rather than
+  /// assume a constant. A shader that declares a larger block fails at
+  /// [createRenderPipeline] rather than falling back to a uniform buffer.
+  int get maxPushConstantSizeInBytes {
+    return _getMaxPushConstantSize();
+  }
+
   /// Whether the backend supports multisample anti-aliasing for offscreen
   /// color and stencil attachments. A subset of OpenGLES-only devices do not
   /// support this functionality.
@@ -303,6 +313,11 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     symbol: 'InternalFlutterGpu_Context_GetMinimumUniformByteAlignment',
   )
   external int _getMinimumUniformByteAlignment();
+
+  @Native<Int Function(Pointer<Void>)>(
+    symbol: 'InternalFlutterGpu_Context_GetMaxPushConstantSize',
+  )
+  external int _getMaxPushConstantSize();
 
   @Native<Bool Function(Pointer<Void>)>(
     symbol: 'InternalFlutterGpu_Context_GetSupportsOffscreenMSAA',

--- a/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/render_pass.dart
@@ -541,6 +541,30 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     }
   }
 
+  /// Set the bytes read by the bound pipeline's `layout(push_constant)`
+  /// block.
+  ///
+  /// A pipeline has a single block of push constant memory. Both stages may
+  /// declare a block against it, in which case they read the same bytes, so
+  /// one call feeds both. Use [Shader.pushConstantSizeInBytes] and
+  /// [Shader.getPushConstantMemberOffsetInBytes] to lay [data] out.
+  ///
+  /// The value persists for the rest of the pass, or until it is set again or
+  /// [clearBindings] is called. [data] must be at least as long as the block
+  /// the shader declares, and no longer than
+  /// [GpuContext.maxPushConstantSizeInBytes].
+  void setPushConstants(ByteData data) {
+    if (data.lengthInBytes > gpuContext.maxPushConstantSizeInBytes) {
+      throw Exception(
+        "Push constant data is ${data.lengthInBytes} bytes, but this device "
+        "supports at most ${gpuContext.maxPushConstantSizeInBytes} bytes",
+      );
+    }
+    if (!_setPushConstants(data)) {
+      throw Exception("Failed to set push constants");
+    }
+  }
+
   void clearBindings() {
     _clearBindings();
     _boundVertexSlotsMask = 0;
@@ -863,6 +887,11 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     int heightAddressMode,
     int maxAnisotropy,
   );
+
+  @Native<Bool Function(Pointer<Void>, Handle)>(
+    symbol: 'InternalFlutterGpu_RenderPass_SetPushConstants',
+  )
+  external bool _setPushConstants(ByteData data);
 
   @Native<Void Function(Pointer<Void>)>(
     symbol: 'InternalFlutterGpu_RenderPass_ClearBindings',

--- a/engine/src/flutter/lib/gpu/lib/src/shader.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/shader.dart
@@ -81,6 +81,35 @@ base class Shader extends NativeFieldWrapperClass1 {
     return _uniformSlots[uniformName] ??= UniformSlot._(this, uniformName);
   }
 
+  /// The reflected size of this shader's `layout(push_constant)` block, or
+  /// null when it declares none.
+  ///
+  /// Set the block's contents with [RenderPass.setPushConstants].
+  int? get pushConstantSizeInBytes {
+    int size = _getPushConstantSize();
+    return size < 0 ? null : size;
+  }
+
+  /// The reflected offset of a named member of this shader's push constant
+  /// block.
+  ///
+  /// Returns null when the shader declares no push constant block, or when
+  /// the block has no member with the given name.
+  int? getPushConstantMemberOffsetInBytes(String memberName) {
+    int offset = _getPushConstantMemberOffset(memberName);
+    return offset < 0 ? null : offset;
+  }
+
+  @Native<Int Function(Pointer<Void>)>(
+    symbol: 'InternalFlutterGpu_Shader_GetPushConstantSize',
+  )
+  external int _getPushConstantSize();
+
+  @Native<Int Function(Pointer<Void>, Handle)>(
+    symbol: 'InternalFlutterGpu_Shader_GetPushConstantMemberOffset',
+  )
+  external int _getPushConstantMemberOffset(String memberName);
+
   @Native<Int Function(Pointer<Void>, Handle)>(
     symbol: 'InternalFlutterGpu_Shader_GetUniformStructSize',
   )

--- a/engine/src/flutter/lib/gpu/render_pass.cc
+++ b/engine/src/flutter/lib/gpu/render_pass.cc
@@ -24,6 +24,7 @@
 #include "impeller/renderer/pipeline_library.h"
 #include "lib/gpu/context.h"
 #include "lib/ui/ui_dart_state.h"
+#include "third_party/tonic/typed_data/dart_byte_data.h"
 #include "tonic/converter/dart_converter.h"
 
 namespace flutter {
@@ -152,7 +153,12 @@ void RenderPass::SetPolygonMode(impeller::PolygonMode mode) {
   pipeline_state_dirty_ = true;
 }
 
+void RenderPass::SetPushConstants(const uint8_t* data, size_t length) {
+  push_constant_data.assign(data, data + length);
+}
+
 void RenderPass::ClearBindings() {
+  push_constant_data.clear();
   vertex_uniform_bindings.clear();
   vertex_texture_bindings.clear();
   fragment_uniform_bindings.clear();
@@ -267,6 +273,33 @@ RenderPass::GetOrCreatePipeline() {
   return pipeline;
 }
 
+bool RenderPass::ReplayPushConstants() {
+  const flutter::gpu::Shader::PushConstantBinding* blocks[2] = {
+      render_pipeline_->GetVertexShader().GetPushConstantBlock(),
+      render_pipeline_->GetFragmentShader().GetPushConstantBlock(),
+  };
+  const impeller::ShaderStage stages[2] = {
+      impeller::ShaderStage::kVertex,
+      impeller::ShaderStage::kFragment,
+  };
+  for (size_t i = 0; i < 2; i++) {
+    if (blocks[i] == nullptr) {
+      continue;
+    }
+    if (push_constant_data.empty()) {
+      VALIDATION_LOG << "The bound pipeline declares a push constant block, "
+                        "but no push constants were set on the render pass.";
+      return false;
+    }
+    if (!render_pass_->SetPushConstants(
+            stages[i], blocks[i]->slot, &blocks[i]->metadata,
+            push_constant_data.data(), push_constant_data.size())) {
+      return false;
+    }
+  }
+  return true;
+}
+
 bool RenderPass::Draw(size_t element_count,
                       size_t instance_count,
                       bool indexed) {
@@ -317,6 +350,10 @@ bool RenderPass::Draw(size_t element_count,
         std::make_unique<impeller::ShaderMetadata>(
             *texture.texture.GetMetadata()),
         texture.texture.resource, texture.sampler);
+  }
+
+  if (!ReplayPushConstants()) {
+    return false;
   }
 
   render_pass_->SetVertexBuffer(vertex_buffers.data(), vertex_buffer_count);
@@ -647,6 +684,18 @@ bool InternalFlutterGpu_RenderPass_BindTextureIndexed(
       wrapper, shader, shader->GetUniformTextureAt(uniform_texture_index),
       texture, min_filter, mag_filter, mip_filter, width_address_mode,
       height_address_mode, max_anisotropy);
+}
+
+bool InternalFlutterGpu_RenderPass_SetPushConstants(
+    flutter::gpu::RenderPass* wrapper,
+    Dart_Handle data_handle) {
+  tonic::DartByteData data(data_handle);
+  if (data.data() == nullptr) {
+    return false;
+  }
+  wrapper->SetPushConstants(static_cast<const uint8_t*>(data.data()),
+                            data.length_in_bytes());
+  return true;
 }
 
 void InternalFlutterGpu_RenderPass_ClearBindings(

--- a/engine/src/flutter/lib/gpu/render_pass.h
+++ b/engine/src/flutter/lib/gpu/render_pass.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <vector>
 #include "flutter/lib/gpu/command_buffer.h"
 #include "flutter/lib/gpu/export.h"
 #include "flutter/lib/ui/dart_wrapper.h"
@@ -68,6 +69,10 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
 
   void ClearBindings();
 
+  /// Record the bytes the bound pipeline's push constant block reads. The
+  /// value persists until it is set again or [ClearBindings] is called.
+  void SetPushConstants(const uint8_t* data, size_t length);
+
   /// Append a draw to the underlying render pass. [element_count] is the
   /// vertex count for a non-indexed draw, or the index count when
   /// [indexed] is true. [instance_count] is the number of instances to draw.
@@ -111,11 +116,21 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
   impeller::BufferView index_buffer;
   impeller::IndexType index_buffer_type = impeller::IndexType::kNone;
 
+  // The push constant bytes replayed to every stage that declares a block.
+  // Both stages read the same memory, so there is one copy, not one per
+  // stage.
+  std::vector<uint8_t> push_constant_data;
+
   uint32_t stencil_reference = 0;
   std::optional<impeller::IRect32> scissor;
   std::optional<impeller::Viewport> viewport;
 
  private:
+  /// Push the recorded push constant data to every stage of the bound
+  /// pipeline that declares a block. Returns false when a stage declares one
+  /// and nothing was set.
+  bool ReplayPushConstants();
+
   /// Lookup an Impeller pipeline by building a descriptor based on the current
   /// command state, or return the memoized pipeline when that state is
   /// unchanged since the last draw. Returns null (after a validation log)
@@ -266,6 +281,11 @@ extern bool InternalFlutterGpu_RenderPass_BindTextureIndexed(
     int width_address_mode,
     int height_address_mode,
     int max_anisotropy);
+
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_RenderPass_SetPushConstants(
+    flutter::gpu::RenderPass* wrapper,
+    Dart_Handle data_handle);
 
 FLUTTER_GPU_EXPORT
 extern void InternalFlutterGpu_RenderPass_ClearBindings(

--- a/engine/src/flutter/lib/gpu/render_pipeline.cc
+++ b/engine/src/flutter/lib/gpu/render_pipeline.cc
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <span>
 #include <string_view>
+#include <utility>
 
 #include "flutter/lib/gpu/shader.h"
 #include "impeller/base/validation.h"
@@ -42,6 +43,17 @@ RenderPipeline::RenderPipeline(
   vertex_descriptor_->RegisterDescriptorSetLayouts(
       fragment_shader_->GetDescriptorSetLayouts().data(),
       fragment_shader_->GetDescriptorSetLayouts().size());
+
+  // Same reasoning: the pipeline layout has to spell out which stages read
+  // push constants, and the ranges accumulate.
+  if (const auto* block = vertex_shader_->GetPushConstantBlock()) {
+    vertex_descriptor_->RegisterPushConstantRange(
+        impeller::ShaderStage::kVertex, block->slot.size_in_bytes);
+  }
+  if (const auto* block = fragment_shader_->GetPushConstantBlock()) {
+    vertex_descriptor_->RegisterPushConstantRange(
+        impeller::ShaderStage::kFragment, block->slot.size_in_bytes);
+  }
 }
 
 bool RenderPipeline::BindToPipelineDescriptor(
@@ -72,6 +84,29 @@ bool RenderPipeline::BindToPipelineDescriptor(
 }
 
 RenderPipeline::~RenderPipeline() = default;
+
+std::string ValidatePushConstantSizes(Context& gpu_context,
+                                      const Shader& vertex_shader,
+                                      const Shader& fragment_shader) {
+  const size_t max_size =
+      gpu_context.GetContext().GetCapabilities()->GetMaxPushConstantSize();
+  const std::pair<const Shader*, const char*> stages[] = {
+      {&vertex_shader, "vertex"},
+      {&fragment_shader, "fragment"},
+  };
+  for (const auto& [shader, stage_name] : stages) {
+    const auto* block = shader->GetPushConstantBlock();
+    if (block == nullptr || block->slot.size_in_bytes <= max_size) {
+      continue;
+    }
+    return absl::StrCat("The ", stage_name, " shader declares a ",
+                        block->slot.size_in_bytes,
+                        " byte push constant block, but this device supports "
+                        "at most ",
+                        max_size, " bytes.");
+  }
+  return {};
+}
 
 const char* ValidateRenderPipelineShaderStages(const Shader& vertex_shader,
                                                const Shader& fragment_shader) {
@@ -334,6 +369,14 @@ Dart_Handle InternalFlutterGpu_RenderPipeline_Initialize(
           flutter::gpu::ValidateRenderPipelineShaderStages(*vertex_shader,
                                                            *fragment_shader)) {
     return tonic::ToDart(stage_error);
+  }
+
+  // Failing here rather than at draw time is deliberate: silently falling back
+  // to a uniform buffer would make an unsupported size invisible.
+  const std::string size_error = flutter::gpu::ValidatePushConstantSizes(
+      *gpu_context, *vertex_shader, *fragment_shader);
+  if (!size_error.empty()) {
+    return tonic::ToDart(size_error);
   }
 
   // Lazily register the shaders synchronously if they haven't been already.

--- a/engine/src/flutter/lib/gpu/render_pipeline.h
+++ b/engine/src/flutter/lib/gpu/render_pipeline.h
@@ -6,6 +6,7 @@
 #define FLUTTER_LIB_GPU_RENDER_PIPELINE_H_
 
 #include <memory>
+#include <string>
 
 #include "flutter/lib/gpu/context.h"
 #include "flutter/lib/gpu/export.h"
@@ -36,6 +37,10 @@ class RenderPipeline : public RefCountedDartWrappable<RenderPipeline> {
       impeller::ShaderLibrary& library,
       impeller::PipelineDescriptor& desc);
 
+  const Shader& GetVertexShader() const { return *vertex_shader_; }
+
+  const Shader& GetFragmentShader() const { return *fragment_shader_; }
+
  private:
   fml::RefPtr<flutter::gpu::Shader> vertex_shader_;
   fml::RefPtr<flutter::gpu::Shader> fragment_shader_;
@@ -60,6 +65,14 @@ class RenderPipeline : public RefCountedDartWrappable<RenderPipeline> {
 /// deep inside backend pipeline compilation with no useful signal).
 const char* ValidateRenderPipelineShaderStages(const Shader& vertex_shader,
                                                const Shader& fragment_shader);
+
+/// Checks that neither stage declares a push constant block larger than the
+/// device supports, returning an error message suitable for a Dart exception
+/// when one does, and an empty string otherwise. Reported at pipeline creation
+/// rather than emulated, so an unsupported size is never silently slow.
+std::string ValidatePushConstantSizes(Context& gpu_context,
+                                      const Shader& vertex_shader,
+                                      const Shader& fragment_shader);
 
 }  // namespace gpu
 }  // namespace flutter

--- a/engine/src/flutter/lib/gpu/render_pipeline_unittests.cc
+++ b/engine/src/flutter/lib/gpu/render_pipeline_unittests.cc
@@ -6,16 +6,33 @@
 
 #include "gtest/gtest.h"
 
+#include <optional>
+#include <utility>
+
 #include "flutter/lib/gpu/shader.h"
 
 namespace flutter::gpu {
 namespace {
 
-fml::RefPtr<Shader> MakeShader(impeller::ShaderStage stage) {
+fml::RefPtr<Shader> MakeShader(
+    impeller::ShaderStage stage,
+    std::optional<Shader::PushConstantBinding> push_constants = std::nullopt) {
   return Shader::Make("library", "Entrypoint", stage,
                       /*code_mapping=*/nullptr, /*inputs=*/{}, /*layouts=*/{},
                       /*uniform_structs=*/{}, /*uniform_textures=*/{},
-                      /*descriptor_set_layouts=*/{});
+                      /*descriptor_set_layouts=*/{}, std::move(push_constants));
+}
+
+Shader::PushConstantBinding MakePushConstantBlock(size_t size_in_bytes) {
+  return Shader::PushConstantBinding{
+      .slot =
+          impeller::ShaderPushConstantSlot{
+              .name = "DrawInfo",
+              .ext_res_0 = 0u,
+              .size_in_bytes = size_in_bytes,
+          },
+      .metadata = impeller::ShaderMetadata{.name = "DrawInfo", .members = {}},
+  };
 }
 
 // Pairing shaders of the wrong stages previously constructed a pipeline that
@@ -34,6 +51,20 @@ TEST(FlutterGpuRenderPipelineTest, ValidatesShaderStages) {
   const char* two_vertex = ValidateRenderPipelineShaderStages(*vertex, *vertex);
   ASSERT_NE(two_vertex, nullptr);
   EXPECT_NE(std::string(two_vertex).find("fragment"), std::string::npos);
+}
+
+// A shader reflects its push constant block independently of its uniform
+// structs, and the member lookup is scoped to that block.
+TEST(FlutterGpuRenderPipelineTest, ReflectsPushConstantBlock) {
+  auto without = MakeShader(impeller::ShaderStage::kVertex);
+  EXPECT_EQ(without->GetPushConstantBlock(), nullptr);
+
+  auto with = MakeShader(impeller::ShaderStage::kVertex,
+                         MakePushConstantBlock(/*size_in_bytes=*/80u));
+  const auto* block = with->GetPushConstantBlock();
+  ASSERT_NE(block, nullptr);
+  EXPECT_EQ(block->slot.size_in_bytes, 80u);
+  EXPECT_EQ(block->GetMemberMetadata("missing"), nullptr);
 }
 
 }  // namespace

--- a/engine/src/flutter/lib/gpu/shader.cc
+++ b/engine/src/flutter/lib/gpu/shader.cc
@@ -32,6 +32,19 @@ Shader::UniformBinding::GetMemberMetadata(const std::string& name) const {
   return &(*result);
 }
 
+const impeller::ShaderStructMemberMetadata*
+Shader::PushConstantBinding::GetMemberMetadata(const std::string& name) const {
+  auto result =
+      std::find_if(metadata.members.begin(), metadata.members.end(),
+                   [&name](const impeller::ShaderStructMemberMetadata& member) {
+                     return member.name == name;
+                   });
+  if (result == metadata.members.end()) {
+    return nullptr;
+  }
+  return &(*result);
+}
+
 IMPLEMENT_WRAPPERTYPEINFO(flutter_gpu, Shader);
 
 Shader::Shader() = default;
@@ -47,7 +60,8 @@ fml::RefPtr<Shader> Shader::Make(
     std::vector<impeller::ShaderStageBufferLayout> layouts,
     std::unordered_map<std::string, UniformBinding> uniform_structs,
     std::unordered_map<std::string, TextureBinding> uniform_textures,
-    std::vector<impeller::DescriptorSetLayout> descriptor_set_layouts) {
+    std::vector<impeller::DescriptorSetLayout> descriptor_set_layouts,
+    std::optional<PushConstantBinding> push_constants) {
   auto shader = fml::MakeRefCounted<Shader>();
   shader->library_id_ = std::move(library_id);
   shader->entrypoint_ = std::move(entrypoint);
@@ -58,6 +72,7 @@ fml::RefPtr<Shader> Shader::Make(
   shader->uniform_structs_ = std::move(uniform_structs);
   shader->uniform_textures_ = std::move(uniform_textures);
   shader->descriptor_set_layouts_ = std::move(descriptor_set_layouts);
+  shader->push_constants_ = std::move(push_constants);
   shader->RebuildBindingOrder();
   return shader;
 }
@@ -111,6 +126,7 @@ void Shader::ResetFrom(Shader& other) {
   uniform_structs_ = std::move(other.uniform_structs_);
   uniform_textures_ = std::move(other.uniform_textures_);
   descriptor_set_layouts_ = std::move(other.descriptor_set_layouts_);
+  push_constants_ = std::move(other.push_constants_);
   RebuildBindingOrder();
   if (code_changed) {
     is_dirty_ = true;
@@ -155,6 +171,10 @@ std::shared_ptr<impeller::VertexDescriptor> Shader::CreateVertexDescriptor()
   auto vertex_descriptor = std::make_shared<impeller::VertexDescriptor>();
   vertex_descriptor->SetStageInputs(inputs_, layouts_);
   return vertex_descriptor;
+}
+
+const Shader::PushConstantBinding* Shader::GetPushConstantBlock() const {
+  return push_constants_.has_value() ? &push_constants_.value() : nullptr;
 }
 
 const std::vector<impeller::ShaderStageIOSlot>& Shader::GetStageInputs() const {
@@ -296,6 +316,32 @@ int InternalFlutterGpu_Shader_GetUniformMemberOffset(
 
   auto member_name = tonic::StdStringFromDart(member_name_handle);
   const auto* member = uniform->GetMemberMetadata(member_name);
+  if (member == nullptr) {
+    return -1;
+  }
+
+  return member->offset;
+}
+
+int InternalFlutterGpu_Shader_GetPushConstantSize(
+    flutter::gpu::Shader* wrapper) {
+  const auto* block = wrapper->GetPushConstantBlock();
+  if (block == nullptr) {
+    return -1;
+  }
+  return block->slot.size_in_bytes;
+}
+
+int InternalFlutterGpu_Shader_GetPushConstantMemberOffset(
+    flutter::gpu::Shader* wrapper,
+    Dart_Handle member_name_handle) {
+  const auto* block = wrapper->GetPushConstantBlock();
+  if (block == nullptr) {
+    return -1;
+  }
+
+  auto member_name = tonic::StdStringFromDart(member_name_handle);
+  const auto* member = block->GetMemberMetadata(member_name);
   if (member == nullptr) {
     return -1;
   }

--- a/engine/src/flutter/lib/gpu/shader.h
+++ b/engine/src/flutter/lib/gpu/shader.h
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "flutter/lib/gpu/context.h"
@@ -39,6 +40,14 @@ class Shader : public RefCountedDartWrappable<Shader> {
     impeller::ShaderMetadata metadata;
   };
 
+  struct PushConstantBinding {
+    impeller::ShaderPushConstantSlot slot;
+    impeller::ShaderMetadata metadata;
+
+    const impeller::ShaderStructMemberMetadata* GetMemberMetadata(
+        const std::string& name) const;
+  };
+
   ~Shader() override;
 
   static fml::RefPtr<Shader> Make(
@@ -50,7 +59,8 @@ class Shader : public RefCountedDartWrappable<Shader> {
       std::vector<impeller::ShaderStageBufferLayout> layouts,
       std::unordered_map<std::string, UniformBinding> uniform_structs,
       std::unordered_map<std::string, TextureBinding> uniform_textures,
-      std::vector<impeller::DescriptorSetLayout> descriptor_set_layouts);
+      std::vector<impeller::DescriptorSetLayout> descriptor_set_layouts,
+      std::optional<PushConstantBinding> push_constants);
 
   std::shared_ptr<const impeller::ShaderFunction> GetFunctionFromLibrary(
       impeller::ShaderLibrary& library);
@@ -109,6 +119,10 @@ class Shader : public RefCountedDartWrappable<Shader> {
   /// The texture counterpart to `GetUniformStructAt`.
   const Shader::TextureBinding* GetUniformTextureAt(int index) const;
 
+  /// The push constant block this shader declares, or nullptr when it
+  /// declares none.
+  const Shader::PushConstantBinding* GetPushConstantBlock() const;
+
  private:
   Shader();
 
@@ -130,6 +144,7 @@ class Shader : public RefCountedDartWrappable<Shader> {
   std::vector<const UniformBinding*> uniform_struct_order_;
   std::vector<const TextureBinding*> uniform_texture_order_;
   std::vector<impeller::DescriptorSetLayout> descriptor_set_layouts_;
+  std::optional<PushConstantBinding> push_constants_;
   bool is_dirty_ = true;
 
   void RebuildBindingOrder();
@@ -165,6 +180,15 @@ FLUTTER_GPU_EXPORT
 extern int InternalFlutterGpu_Shader_GetUniformStructIndex(
     flutter::gpu::Shader* wrapper,
     Dart_Handle struct_name_handle);
+
+FLUTTER_GPU_EXPORT
+extern int InternalFlutterGpu_Shader_GetPushConstantSize(
+    flutter::gpu::Shader* wrapper);
+
+FLUTTER_GPU_EXPORT
+extern int InternalFlutterGpu_Shader_GetPushConstantMemberOffset(
+    flutter::gpu::Shader* wrapper,
+    Dart_Handle member_name_handle);
 
 FLUTTER_GPU_EXPORT
 extern int InternalFlutterGpu_Shader_GetUniformTextureIndex(

--- a/engine/src/flutter/lib/gpu/shader_library.cc
+++ b/engine/src/flutter/lib/gpu/shader_library.cc
@@ -326,6 +326,48 @@ static ShaderLibrary::ShaderMap ParseShaderBundle(
       }
     }
 
+    std::optional<Shader::PushConstantBinding> push_constants;
+    if (const auto* block = backend_shader->push_constants();
+        block != nullptr &&
+        block->ext_res_0() != impeller::kOptimizedOutBinding) {
+      std::vector<impeller::ShaderStructMemberMetadata> members;
+      if (block->fields() != nullptr) {
+        for (const auto& struct_member : *block->fields()) {
+          const impeller::ShaderType type =
+              FromUniformType(struct_member->type());
+          members.push_back(impeller::ShaderStructMemberMetadata{
+              .type = type,
+              .name = struct_member->name()->c_str(),
+              .offset = static_cast<size_t>(struct_member->offset_in_bytes()),
+              .size =
+                  static_cast<size_t>(struct_member->element_size_in_bytes()),
+              .byte_length =
+                  static_cast<size_t>(struct_member->total_size_in_bytes()),
+              .array_elements =
+                  struct_member->array_elements() == 0
+                      ? std::optional<size_t>(std::nullopt)
+                      : static_cast<size_t>(struct_member->array_elements()),
+              .float_type = impeller::DeriveShaderFloatType(
+                  type, static_cast<size_t>(struct_member->vec_size()),
+                  static_cast<size_t>(struct_member->columns())),
+          });
+        }
+      }
+      push_constants = Shader::PushConstantBinding{
+          .slot =
+              impeller::ShaderPushConstantSlot{
+                  .name = block->name()->c_str(),
+                  .ext_res_0 = static_cast<size_t>(block->ext_res_0()),
+                  .size_in_bytes = static_cast<size_t>(block->size_in_bytes()),
+              },
+          .metadata =
+              impeller::ShaderMetadata{
+                  .name = block->name()->c_str(),
+                  .members = members,
+              },
+      };
+    }
+
     std::vector<impeller::ShaderStageIOSlot> inputs;
     std::vector<impeller::ShaderStageBufferLayout> layouts;
     if (backend_shader->stage() ==
@@ -360,7 +402,8 @@ static ShaderLibrary::ShaderMap ParseShaderBundle(
         library_id, backend_shader->entrypoint()->str(),
         ToShaderStage(backend_shader->stage()), std::move(code_mapping),
         std::move(inputs), std::move(layouts), std::move(uniform_structs),
-        std::move(uniform_textures), std::move(descriptor_set_layouts));
+        std::move(uniform_textures), std::move(descriptor_set_layouts),
+        std::move(push_constants));
     shader_map[bundled_shader->name()->str()] = std::move(shader);
   }
 


### PR DESCRIPTION
Exposes `layout(push_constant)` blocks through Flutter GPU, so per-draw data that is usually a `mat4` and a few scalars no longer needs a `HostBuffer` emplace plus a full uniform bind. impellerc reflects the block into the shader bundle, and each backend uses its own small-data path: `vkCmdPushConstants` on Vulkan, `setVertexBytes`/`setFragmentBytes` on Metal, and the plain uniforms SPIRV-Cross lowers the block to on OpenGL ES.

The portable floor is small and inconsistent, so the limit is a capability (`gpuContext.maxPushConstantSizeInBytes`) rather than a constant, reporting the device's `maxPushConstantsSize` on Vulkan and 4 KB elsewhere. A shader that declares a block larger than the device allows fails at `createRenderPipeline` instead of silently falling back to a uniform buffer.

A pipeline has one block of push constant memory. Both stages may declare a block against it, in which case they read the same bytes and one `renderPass.setPushConstants(data)` feeds both. That follows the hardware: Vulkan's push constant pool is shared across stages, and a stage always reads its block from offset zero, so two stages that declare one are aliases rather than neighbours. Values persist for the rest of the pass, matching every backend and SDL_GPU.

This bumps the shader bundle format version, so bundles need rebuilding with the matching impellerc.

Fixes https://github.com/flutter/flutter/issues/190403

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
