### PR TITLE
[Impeller] Fold HLSL textures and samplers into combined image samplers

### DIFF
--- a/engine/src/flutter/impeller/compiler/compiler_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_unittests.cc
@@ -249,6 +249,12 @@ TEST_P(CompilerTest, CanCompileHLSLWithMultipleStages) {
                                    SourceLanguage::kHLSL, "FragmentShader"));
 }
 
+TEST_P(CompilerTest, CanCompileHLSLWithSampledTexture) {
+  ASSERT_TRUE(CanCompileAndReflect("sampled_texture.hlsl",
+                                   SourceType::kFragmentShader,
+                                   SourceLanguage::kHLSL, "FragmentShader"));
+}
+
 TEST_P(CompilerTest, CanCompileComputeShader) {
   ASSERT_TRUE(CanCompileAndReflect("sample.comp", SourceType::kComputeShader,
                                    SourceLanguage::kGLSL, "main"));

--- a/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
@@ -348,6 +348,42 @@ TEST(ShaderBundleTest, InjectsTargetDefinesDuringCompilation) {
   EXPECT_FALSE(bundle.has_value());
 }
 
+TEST(ShaderBundleTest, GeneratesCombinedImageSamplersForHLSL) {
+  // HLSL declares the texture and the sampler separately, so the bundle can
+  // only record a binding if the two are folded together. The texture's name
+  // is the one that survives.
+  std::string fixtures_path = flutter::testing::GetFixturesPath();
+  std::string config =
+      "{\"Sampled\": {\"type\": \"fragment\", \"language\": \"hlsl\", "
+      "\"entry_point\": \"FragmentShader\", \"file\": \"" +
+      fixtures_path + "/sampled_texture.hlsl\"}}";
+
+  SourceOptions options;
+  options.target_platform = TargetPlatform::kRuntimeStageMetal;
+  options.source_language = SourceLanguage::kHLSL;
+
+  std::optional<fb::shaderbundle::ShaderBundleT> bundle =
+      GenerateShaderBundleFlatbuffer(config, options);
+  ASSERT_TRUE(bundle.has_value());
+
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+  const auto* sampled = FindByName(bundle->shaders, "Sampled");
+  ASSERT_NE(sampled, nullptr);
+
+  const std::vector<const fb::shaderbundle::BackendShaderT*> backends = {
+      sampled->metal_ios.get(),       //
+      sampled->metal_desktop.get(),   //
+      sampled->opengl_es.get(),       //
+      sampled->opengl_desktop.get(),  //
+      sampled->vulkan.get(),          //
+  };
+  for (const auto* backend : backends) {
+    ASSERT_NE(backend, nullptr);
+    ASSERT_EQ(backend->uniform_textures.size(), 1u);
+    EXPECT_STREQ(backend->uniform_textures[0]->name.c_str(), "tex");
+  }
+}
+
 }  // namespace testing
 }  // namespace compiler
 }  // namespace impeller

--- a/engine/src/flutter/impeller/compiler/spirv_compiler.cc
+++ b/engine/src/flutter/impeller/compiler/spirv_compiler.cc
@@ -285,6 +285,14 @@ shaderc::CompileOptions SPIRVCompilerOptions::BuildShadercOptions() const {
   options.SetAutoMapLocations(true);
   options.SetPreserveBindings(true);
 
+  // HLSL declares textures and samplers separately. Every backend here binds
+  // combined image samplers, so fold them together in the front end.
+  if (source_langauge.has_value() &&
+      source_langauge.value() ==
+          shaderc_source_language::shaderc_source_language_hlsl) {
+    options.SetAutoSampledTextures(true);
+  }
+
   options.SetOptimizationLevel(optimization_level);
 
   if (generate_debug_info) {

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -171,6 +171,7 @@ test_fixtures("file_fixtures") {
     "sample_with_binding.vert",
     "sample_with_positioned_uniforms.frag",
     "sample_with_uniforms.frag",
+    "sampled_texture.hlsl",
     "simple.vert.hlsl",
     "sa%m#ple.vert",
     "stage1.comp",

--- a/engine/src/flutter/impeller/fixtures/sampled_texture.hlsl
+++ b/engine/src/flutter/impeller/fixtures/sampled_texture.hlsl
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+Texture2D tex;
+SamplerState tex_sampler;
+
+float4 FragmentShader(float2 v_texture_coords : TEXCOORD0,
+                      float4 v_color : TEXCOORD1) : SV_TARGET {
+  return v_color * tex.Sample(tex_sampler, v_texture_coords);
+}


### PR DESCRIPTION
impellerc accepts `--source-language=hlsl`, and shader bundle manifests accept a per-entry `"language": "hlsl"`, but any HLSL shader that samples a texture aborts the compiler. HLSL declares a texture and its sampler as separate objects, while every backend impellerc targets binds combined image samplers, so spirv-cross has no mapping when it reaches the sample instruction and calls `FML_CHECK`.

```
There was a compiler error: Cannot find mapping for combined sampler,
was build_combined_image_samplers() used before compile() was called?
Frame 1: spirv_cross::CompilerGLSL::to_combined_image_sampler()
```

The GLSL and MSL backends both hit this, so it takes down four of the five backends a shader bundle compiles, and it is a `SIGABRT` with a backtrace rather than a diagnostic. The legacy `sampler2D` and `tex2D` form is not a workaround; it fails earlier in spirv-opt.

Rather than combining in the spirv-cross backends, this turns on shaderc's texture and sampler upgrade for HLSL, so glslang emits combined image samplers in the front end. That way the SPIR-V is already correct for every backend including the raw blob the Vulkan backend passes through, and the reflected binding keeps the texture variable's name. GLSL is unaffected.

Existing HLSL coverage is two fixtures with no uniforms, no textures, and no stage pair that has to link, which is why this went unnoticed. Added a fragment fixture that samples a texture, a `CompilerTest` case (parameterized over all five target platforms, and it reproduces the abort without the fix), and a shader bundle test asserting every backend records the binding under the texture's name.

No tracking issue exists for this yet.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
