### PR TITLE
tests: add --ios-runtime param

### DIFF
--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -1335,7 +1335,7 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
       action='store',
       default=None,
       help='The iOS simulator runtime to run tests on '
-           '(example: "com.apple.CoreSimulator.SimRuntime.iOS-26-5")'
+      '(example: "com.apple.CoreSimulator.SimRuntime.iOS-26-5")'
   )
   parser.add_argument(
       '--verbose-dart-snapshot',

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -880,9 +880,7 @@ def run_objc_tests(
   ]
   if ios_runtime is not None:
     create_simulator.append(ios_runtime)
-  simulator_id = subprocess.check_output(
-      create_simulator, text=True
-  ).strip()
+  simulator_id = subprocess.check_output(create_simulator, text=True).strip()
 
   try:
     ios_unit_test_dir = os.path.join(BUILDROOT_DIR, 'flutter', 'testing', 'ios', 'IosUnitTests')

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -856,7 +856,9 @@ def run_android_tests(
 
 
 def run_objc_tests(
-    ios_variant: str = 'ios_debug_sim_unopt', test_filter: typing.Optional[str] = None
+    ios_variant: str = 'ios_debug_sim_unopt',
+    test_filter: typing.Optional[str] = None,
+    ios_runtime: typing.Optional[str] = None,
 ) -> None:
   """Runs Objective-C XCTest unit tests for the iOS embedding"""
   assert_expected_xcode_version()
@@ -875,7 +877,11 @@ def run_objc_tests(
       'create '
       f'{new_simulator_name} com.apple.CoreSimulator.SimDeviceType.iPhone-11'
   ]
-  run_cmd(create_simulator, shell=True)
+  if ios_runtime is not None:
+    create_simulator[0] = create_simulator[0] + f' {ios_runtime}'
+  simulator_id = subprocess.check_output(
+      create_simulator, shell=True, text=True
+  ).strip()
 
   try:
     ios_unit_test_dir = os.path.join(BUILDROOT_DIR, 'flutter', 'testing', 'ios', 'IosUnitTests')
@@ -892,7 +898,7 @@ def run_objc_tests(
           '-sdk iphonesimulator '
           '-scheme IosUnitTests '
           '-resultBundlePath ' + result_bundle_path + ' '
-          '-destination name=' + new_simulator_name + ' '
+          f'-destination id={simulator_id} '
           'test '
           'FLUTTER_ENGINE=' + ios_variant
       ]
@@ -1325,6 +1331,13 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
       help='The engine build variant to run objective-c tests for'
   )
   parser.add_argument(
+      '--ios-runtime',
+      dest='ios_runtime',
+      action='store',
+      default=None,
+      help='The iOS simulator runtime to run objective-c tests for (example: "com.apple.CoreSimulator.SimRuntime.iOS-26-5")'
+  )
+  parser.add_argument(
       '--verbose-dart-snapshot',
       dest='verbose_dart_snapshot',
       action='store_true',
@@ -1490,7 +1503,7 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
 
   if 'objc' in types:
     assert is_mac(), 'iOS embedding tests can only be run on macOS.'
-    run_objc_tests(args.ios_variant, args.objc_filter)
+    run_objc_tests(args.ios_variant, args.objc_filter, args.ios_runtime)
 
   # https://github.com/flutter/flutter/issues/36300
   if 'benchmarks' in types and not is_windows():

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -1334,7 +1334,8 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
       dest='ios_runtime',
       action='store',
       default=None,
-      help='The iOS simulator runtime to run objective-c tests for (example: "com.apple.CoreSimulator.SimRuntime.iOS-26-5")'
+      help='The iOS simulator runtime to run tests on '
+           '(example: "com.apple.CoreSimulator.SimRuntime.iOS-26-5")'
   )
   parser.add_argument(
       '--verbose-dart-snapshot',

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -872,15 +872,16 @@ def run_objc_tests(
   delete_simulator(new_simulator_name)
 
   create_simulator = [
-      'xcrun '
-      'simctl '
-      'create '
-      f'{new_simulator_name} com.apple.CoreSimulator.SimDeviceType.iPhone-11'
+      'xcrun',
+      'simctl',
+      'create',
+      new_simulator_name,
+      'com.apple.CoreSimulator.SimDeviceType.iPhone-11',
   ]
   if ios_runtime is not None:
-    create_simulator[0] = create_simulator[0] + f' {ios_runtime}'
+    create_simulator.append(ios_runtime)
   simulator_id = subprocess.check_output(
-      create_simulator, shell=True, text=True
+      create_simulator, text=True
   ).strip()
 
   try:


### PR DESCRIPTION
By default, when creating the simulator to run iOS unit tests, we use the newest installed runtime, even if it's a beta release of iOS. During the annual window between WWDC and the final release, we may want to test using either current stable or the beta OS version.

This adds an --ios-runtime param. By default, the code behaves as it does today, selecting the newest installed runtime. If you want to override, you can specify the simulator runtime to use explicitly, such as:

    --ios-runtime com.apple.CoreSimulator.SimRuntime.iOS-26-5

the returend simulator UUID is then passed to xcodebuild.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
