### PR TITLE
iOS: Eliminate the Impeller/Skia backend selection params

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/ios_context.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_context.h
@@ -47,14 +47,11 @@ class IOSContext {
   ///
   /// @param[in]  api       A client rendering API supported by the
   ///                       engine/platform.
-  /// @param[in]  backend   A client rendering backend supported by the
-  ///                       engine/platform.
   ///
   /// @return     A valid context on success. `nullptr` on failure.
   ///
   static std::unique_ptr<IOSContext> Create(
       IOSRenderingAPI api,
-      IOSRenderingBackend backend,
       const std::shared_ptr<const fml::SyncSwitch>& is_gpu_disabled_sync_switch,
       const Settings& settings);
 
@@ -63,13 +60,6 @@ class IOSContext {
   ///             which this object was created.
   ///
   virtual ~IOSContext();
-
-  //----------------------------------------------------------------------------
-  /// @brief      Get the rendering backend used by this context.
-  ///
-  /// @return     The rendering backend.
-  ///
-  virtual IOSRenderingBackend GetBackend() const;
 
   //----------------------------------------------------------------------------
   /// @brief      Creates an external texture proxy of the appropriate client

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_context.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_context.mm
@@ -22,7 +22,6 @@ IOSContext::~IOSContext() = default;
 
 std::unique_ptr<IOSContext> IOSContext::Create(
     IOSRenderingAPI api,
-    IOSRenderingBackend backend,
     const std::shared_ptr<const fml::SyncSwitch>& is_gpu_disabled_sync_switch,
     const Settings& settings) {
   switch (api) {
@@ -34,23 +33,10 @@ std::unique_ptr<IOSContext> IOSContext::Create(
                                    "this."];
       return std::make_unique<IOSContextNoop>();
     case IOSRenderingAPI::kMetal:
-      switch (backend) {
-        case IOSRenderingBackend::kSkia:
-          [FlutterLogger logFatal:@"Impeller opt-out unavailable."];
-          return nullptr;
-        case IOSRenderingBackend::kImpeller:
-          return std::make_unique<IOSContextMetalImpeller>(settings, is_gpu_disabled_sync_switch);
-      }
-    default:
-      break;
+      return std::make_unique<IOSContextMetalImpeller>(settings, is_gpu_disabled_sync_switch);
   }
   FML_CHECK(false);
   return nullptr;
-}
-
-IOSRenderingBackend IOSContext::GetBackend() const {
-  // Overridden by Impeller subclasses.
-  return IOSRenderingBackend::kSkia;
 }
 
 std::shared_ptr<impeller::Context> IOSContext::GetImpellerContext() const {

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_context_metal_impeller.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_context_metal_impeller.h
@@ -26,8 +26,6 @@ class IOSContextMetalImpeller final : public IOSContext {
 
   ~IOSContextMetalImpeller();
 
-  IOSRenderingBackend GetBackend() const override;
-
  private:
   FlutterDarwinContextMetalImpeller* darwin_context_metal_impeller_;
   std::shared_ptr<impeller::AiksContext> aiks_context_;

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_context_metal_impeller.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_context_metal_impeller.mm
@@ -34,10 +34,6 @@ IOSContextMetalImpeller::IOSContextMetalImpeller(
 
 IOSContextMetalImpeller::~IOSContextMetalImpeller() = default;
 
-IOSRenderingBackend IOSContextMetalImpeller::GetBackend() const {
-  return IOSRenderingBackend::kImpeller;
-}
-
 // |IOSContext|
 std::shared_ptr<impeller::Context> IOSContextMetalImpeller::GetImpellerContext() const {
   return darwin_context_metal_impeller_.context;

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_context_noop.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_context_noop.h
@@ -21,8 +21,6 @@ class IOSContextNoop final : public IOSContext {
   std::unique_ptr<Texture> CreateExternalTexture(int64_t texture_id,
                                                  NSObject<FlutterTexture>* texture) override;
 
-  IOSRenderingBackend GetBackend() const override;
-
  private:
   IOSContextNoop(const IOSContextNoop&) = delete;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_context_noop.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_context_noop.mm
@@ -16,11 +16,6 @@ IOSContextNoop::IOSContextNoop() = default;
 IOSContextNoop::~IOSContextNoop() = default;
 
 // |IOSContext|
-IOSRenderingBackend IOSContextNoop::GetBackend() const {
-  return IOSRenderingBackend::kImpeller;
-}
-
-// |IOSContext|
 std::unique_ptr<Texture> IOSContextNoop::CreateExternalTexture(int64_t texture_id,
                                                                NSObject<FlutterTexture>* texture) {
   // Don't use FML for logging as it will contain engine specific details. This is a user facing

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_context_noop_unittests.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_context_noop_unittests.mm
@@ -18,7 +18,7 @@ FLUTTER_ASSERT_ARC
 - (void)testCreateNoop {
   flutter::IOSContextNoop noop;
 
-  XCTAssertTrue(noop.GetBackend() == flutter::IOSRenderingBackend::kImpeller);
+  XCTAssertTrue(noop.GetImpellerContext() == nullptr);
 }
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_surface.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_surface.mm
@@ -22,16 +22,10 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(std::shared_ptr<IOSContext> conte
 
   if (@available(iOS METAL_IOS_VERSION_BASELINE, *)) {
     if ([layer isKindOfClass:[CAMetalLayer class]]) {
-      switch (context->GetBackend()) {
-        case IOSRenderingBackend::kSkia:
-          [FlutterLogger logFatal:@"Impeller opt-out unavailable."];
-          return nullptr;
-        case IOSRenderingBackend::kImpeller:
-          return std::make_unique<IOSSurfaceMetalImpeller>(
-              static_cast<CAMetalLayer*>(layer),  // Metal layer
-              std::move(context)                  // context
-          );
-      }
+      return std::make_unique<IOSSurfaceMetalImpeller>(
+          static_cast<CAMetalLayer*>(layer),  // Metal layer
+          std::move(context)                  // context
+      );
     }
   }
   return std::make_unique<IOSSurfaceNoop>(std::move(context));

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios.mm
@@ -38,9 +38,6 @@ PlatformViewIOS::PlatformViewIOS(
     const std::shared_ptr<const fml::SyncSwitch>& is_gpu_disabled_sync_switch)
     : PlatformViewIOS(delegate,
                       IOSContext::Create(rendering_api,
-                                         delegate.OnPlatformViewGetSettings().enable_impeller
-                                             ? IOSRenderingBackend::kImpeller
-                                             : IOSRenderingBackend::kSkia,
                                          is_gpu_disabled_sync_switch,
                                          delegate.OnPlatformViewGetSettings()),
                       platform_views_controller,

--- a/engine/src/flutter/shell/platform/darwin/ios/rendering_api_selection.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/rendering_api_selection.h
@@ -16,11 +16,6 @@ enum class IOSRenderingAPI {
   kMetal,
 };
 
-enum class IOSRenderingBackend {
-  kSkia,
-  kImpeller,
-};
-
 IOSRenderingAPI GetRenderingAPIForProcess();
 
 Class GetCoreAnimationLayerClassForRenderingAPI(IOSRenderingAPI rendering_api);


### PR DESCRIPTION
iOS has been Impeller for a while now. Skia is gone. There are still a few remnants like `IOSRenderingBackend` enum and `IOSContext::GetBackend()` that offer the illusion of a choice, when in fact every Skia arm leads to an abort(). The base `GetBackend()` still returned a `kSkia` value that can no longer be constructed. This removes the remaining dead code.

We still need to keep the cross-platform bits around: the `enable_impeller` setting itself stays. iOS simply stops consulting it here.

The `IOSContextNoop` unit test used to assert on `GetBackend`, but we removed that; it now asserts the noop context has no Impeller context, which is equivalent.

Issue: https://github.com/flutter/flutter/issues/190041
Issue: https://github.com/flutter/flutter/issues/112232

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
