### PR TITLE
iOS,macOS: Use @autoclosure in Logger

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/Logger.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/Logger.swift
@@ -59,9 +59,9 @@ import Foundation
     #endif
   }
 
-  public func log(level: LogLevel, _ message: String) {
+  public func log(level: LogLevel, _ message: @autoclosure () -> String) {
     if level.rawValue >= logLevel.rawValue {
-      outputWriter.writeLine(level: level, message)
+      outputWriter.writeLine(level: level, message())
     }
   }
 }
@@ -80,34 +80,65 @@ extension Logger {
   }
 
   /// Logs a message at `LogLevel.info`.
-  @objc public static func logInfo(_ message: String) {
+  @objc(logInfo:) public static func objcLogInfo(_ message: String) {
     shared.log(level: .info, message)
   }
 
+  /// Logs a message at `LogLevel.info`.
+  public static func logInfo(_ message: @autoclosure () -> String) {
+    shared.log(level: .info, message())
+  }
+
   /// Logs a message at `LogLevel.important`.
-  @objc public static func logImportant(_ message: String) {
+  @objc(logImportant:) public static func objcLogImportant(_ message: String) {
     shared.log(level: .important, message)
   }
 
+  /// Logs a message at `LogLevel.important`.
+  public static func logImportant(_ message: @autoclosure () -> String) {
+    shared.log(level: .important, message())
+  }
+
   /// Logs a message at `LogLevel.warning`.
-  @objc public static func logWarning(_ message: String) {
+  @objc(logWarning:) public static func objcLogWarning(_ message: String) {
     shared.log(level: .warning, message)
   }
 
+  /// Logs a message at `LogLevel.warning`.
+  public static func logWarning(_ message: @autoclosure () -> String) {
+    shared.log(level: .warning, message())
+  }
+
   /// Logs a message at `LogLevel.error`.
-  @objc public static func logError(_ message: String) {
+  @objc(logError:) public static func objcLogError(_ message: String) {
     shared.log(level: .error, message)
   }
 
+  /// Logs a message at `LogLevel.error`.
+  public static func logError(_ message: @autoclosure () -> String) {
+    shared.log(level: .error, message())
+  }
+
   /// Logs a message at `LogLevel.fatal` and immediately terminates the application.
-  @objc public static func logFatal(_ message: String) {
+  @objc(logFatal:) public static func objcLogFatal(_ message: String) {
     shared.log(level: .fatal, message)
     abort()
   }
 
+  /// Logs a message at `LogLevel.fatal` and immediately terminates the application.
+  public static func logFatal(_ message: @autoclosure () -> String) {
+    shared.log(level: .fatal, message())
+    abort()
+  }
+
   /// Logs a message unconditionally.
-  @objc public static func logDirect(_ message: String) {
+  @objc(logDirect:) public static func objcLogDirect(_ message: String) {
     shared.outputWriter.writeLine(level: .important, message)
+  }
+
+  /// Logs a message unconditionally.
+  public static func logDirect(_ message: @autoclosure () -> String) {
+    shared.outputWriter.writeLine(level: .important, message())
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/Logger.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/Logger.swift
@@ -80,6 +80,7 @@ extension Logger {
   }
 
   /// Logs a message at `LogLevel.info`.
+  @available(swift, obsoleted: 1.0)
   @objc(logInfo:) public static func objcLogInfo(_ message: String) {
     shared.log(level: .info, message)
   }
@@ -90,6 +91,7 @@ extension Logger {
   }
 
   /// Logs a message at `LogLevel.important`.
+  @available(swift, obsoleted: 1.0)
   @objc(logImportant:) public static func objcLogImportant(_ message: String) {
     shared.log(level: .important, message)
   }
@@ -100,6 +102,7 @@ extension Logger {
   }
 
   /// Logs a message at `LogLevel.warning`.
+  @available(swift, obsoleted: 1.0)
   @objc(logWarning:) public static func objcLogWarning(_ message: String) {
     shared.log(level: .warning, message)
   }
@@ -110,6 +113,7 @@ extension Logger {
   }
 
   /// Logs a message at `LogLevel.error`.
+  @available(swift, obsoleted: 1.0)
   @objc(logError:) public static func objcLogError(_ message: String) {
     shared.log(level: .error, message)
   }
@@ -120,6 +124,7 @@ extension Logger {
   }
 
   /// Logs a message at `LogLevel.fatal` and immediately terminates the application.
+  @available(swift, obsoleted: 1.0)
   @objc(logFatal:) public static func objcLogFatal(_ message: String) {
     shared.log(level: .fatal, message)
     abort()
@@ -132,13 +137,8 @@ extension Logger {
   }
 
   /// Logs a message unconditionally.
-  @objc(logDirect:) public static func objcLogDirect(_ message: String) {
+  @objc public static func logDirect(_ message: String) {
     shared.outputWriter.writeLine(level: .important, message)
-  }
-
-  /// Logs a message unconditionally.
-  public static func logDirect(_ message: @autoclosure () -> String) {
-    shared.outputWriter.writeLine(level: .important, message())
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTests.swift
@@ -3,9 +3,8 @@
 // found in the LICENSE file.
 
 import Foundation
-import Testing
-
 import InternalFlutterSwiftCommon
+import Testing
 import test_utils_swift
 
 @Suite struct LoggerTests {
@@ -53,6 +52,57 @@ import test_utils_swift
     #expect(writer.didLog)
     #expect(writer.lastLevel == .important)
     #expect(writer.lastLine == "Hello world")
+  }
+
+  @Test func testAutoclosureDoesNotEvaluateMessageBelowLogLevel() {
+    let writer = StringOutputWriter()
+    let logger = Logger(outputWriter: writer, logLevel: .warning)
+    var wasEvaluated = false
+
+    logger.log(
+      level: .info,
+      {
+        wasEvaluated = true
+        return "Hello world"
+      }())
+    #expect(!writer.didLog)
+    #expect(!wasEvaluated)
+  }
+
+  @Test func testAutoclosureEvaluatesMessageAtOrAboveLogLevel() {
+    let writer = StringOutputWriter()
+    let logger = Logger(outputWriter: writer, logLevel: .info)
+    var wasEvaluated = false
+
+    logger.log(
+      level: .info,
+      {
+        wasEvaluated = true
+        return "Hello world"
+      }())
+    #expect(writer.didLog)
+    #expect(wasEvaluated)
+  }
+
+  @Test func testStaticLogInfoDoesNotEvaluateMessageBelowLogLevel() {
+    let writer = StringOutputWriter()
+    let oldWriter = Logger.outputWriter
+    let oldLevel = Logger.logLevel
+    defer {
+      Logger.outputWriter = oldWriter
+      Logger.logLevel = oldLevel
+    }
+    Logger.outputWriter = writer
+    Logger.logLevel = .warning
+    var wasEvaluated = false
+
+    Logger.logInfo(
+      {
+        wasEvaluated = true
+        return "Hello world"
+      }())
+    #expect(!writer.didLog)
+    #expect(!wasEvaluated)
   }
 
 }


### PR DESCRIPTION
This updates `Logger` to use `@autoclosure` for its log message parameter, which enables lazy evaluation *after* checking the log level, similar to our `fml::Logger` macros in C++. Messages that are expensive to construct, e.g. "Semantics tree: \(expensiveFunction())".

Adds `objc@` wrappers taking string arguments to ensure this remains backwards compatible with the previous Obj-C API.

Issue: https://github.com/flutter/flutter/issues/44030

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
