### PR TITLE
tools: Support FLUTTER_HOST_ARCH in update_dart_sdk scripts

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -49,10 +49,16 @@ if ($engineRealm) {
 
 # It's important to use the native Dart SDK as the default target architecture
 # for Flutter Windows builds depend on the Dart executable's architecture.
+# FLUTTER_HOST_ARCH can be set as an override to force download for the specified architecture.
+# PROCESSOR_ARCHITECTURE is a standard Windows env var indicating host CPU architecture.
 $dartZipNameX64 = "dart-sdk-windows-x64.zip"
 $dartZipNameArm64 = "dart-sdk-windows-arm64.zip"
 $dartZipName = $dartZipNameX64
-if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+if ($env:FLUTTER_HOST_ARCH -eq "arm64") {
+    $dartZipName = $dartZipNameArm64
+} elseif ($env:FLUTTER_HOST_ARCH -eq "x64") {
+    $dartZipName = $dartZipNameX64
+} elseif ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
     $dartSdkArm64Url = "$dartSdkBaseUrl/flutter_infra_release/flutter/$engineVersion/$dartZipNameArm64"
     Try {
         Invoke-WebRequest -Uri $dartSdkArm64Url -UseBasicParsing -Method Head | Out-Null

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -61,8 +61,11 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != "$(< "$ENGINE_STAMP")" ]; 
     exit 1
   }
 
-  # `uname -m` may be running in Rosetta mode, instead query sysctl
-  if [ "$OS" = 'Darwin' ]; then
+  if [ -n "$FLUTTER_HOST_ARCH" ]; then
+    # FLUTTER_HOST_ARCH can be set to override the host architecture detection.
+    ARCH="$FLUTTER_HOST_ARCH"
+  elif [ "$OS" = 'Darwin' ]; then
+    # `uname -m` may be running in Rosetta mode, instead query sysctl
     # Allow non-zero exit so we can do control flow
     set +e
     # -n means only print value, not key


### PR DESCRIPTION
Adds support for overriding the host CPU architecture via a `FLUTTER_HOST_ARCH` environment variable when pre-caching binaries. Updates `update_dart_sdk.sh` and `update_dart_sdk.ps1`, to make use of this to pull down the specified Dart SDK.

This is required to allow arm64 macOS CI hosts to download and cache the x64 Dart SDK when cross-packaging x64 Flutter SDK release archives in the `packaging/packaging` recipe in `packaging.py`.

See: https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/packaging/packaging.py

This is pre-factoring prior to updating the tool's precache code.

No test changes since by default, this behaves exactly as today and this is "tested" by the build itself on CI. The followup that updates the tool's precache code will exercise this and add tests for it.

Issue: https://github.com/flutter/flutter/issues/189144

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
