### PR TITLE
Rebuild a semantics fragment when its sibling conflict changes

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -6545,9 +6545,13 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
   }
 
   void _marksConflictsInMergeGroup(List<_SemanticsFragment> mergeGroup, {bool isMergeUp = false}) {
+    final wasConflicting = <_RenderObjectSemantics>{};
     final hasSiblingConflict = <_SemanticsFragment>{};
     for (var i = 0; i < mergeGroup.length; i += 1) {
       final _SemanticsFragment fragment = mergeGroup[i];
+      if (fragment is _RenderObjectSemantics && fragment._hasSiblingConflict) {
+        wasConflicting.add(fragment);
+      }
       // Remove old value
       fragment.markSiblingConfigurationConflict(false);
       if (fragment.configToMergeUp == null) {
@@ -6565,8 +6569,18 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         }
       }
     }
+    // A sibling conflict feeds shouldFormSemanticsNode, so gaining or losing one
+    // changes whether the fragment produces a semantics node of its own. What it
+    // has cached is stale until it is rebuilt.
     for (final fragment in hasSiblingConflict) {
       fragment.markSiblingConfigurationConflict(true);
+      if (fragment is _RenderObjectSemantics && !wasConflicting.remove(fragment)) {
+        fragment.markNeedsBuild();
+      }
+    }
+    // Whatever is left in wasConflicting stopped conflicting in this pass.
+    for (final fragment in wasConflicting) {
+      fragment.markNeedsBuild();
     }
   }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3263,7 +3263,11 @@ class SemanticsNode with DiagnosticableTreeMixin {
     }
     if (_children != null) {
       for (final SemanticsNode child in _children!) {
-        child.attach(owner);
+        // The list of children may be stale and may contain nodes that have
+        // been assigned to a different parent.
+        if (child.parent == this) {
+          child.attach(owner);
+        }
       }
     }
   }

--- a/packages/flutter/test/widgets/overlay_portal_test.dart
+++ b/packages/flutter/test/widgets/overlay_portal_test.dart
@@ -3242,6 +3242,72 @@ void main() {
         ),
       );
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/187198.
+    //
+    // Showing and hiding an overlay child moves a SemanticsNode between the
+    // anchor's semantics parent and the overlay portal's node. The node it is
+    // taken from keeps a stale entry in its child list, and re-attaching that
+    // node used to re-attach the stale child along with it, leaving a
+    // SemanticsNode that was attached but had no parent.
+    testWidgets('toggling an overlay child does not leave a parentless attached semantics node', (
+      WidgetTester tester,
+    ) async {
+      final semantics = SemanticsTester(tester);
+      final controller = OverlayPortalController();
+      final siblingController = OverlayPortalController();
+
+      late final OverlayEntry entry;
+      addTearDown(() {
+        entry.remove();
+        entry.dispose();
+      });
+
+      // A second anchor is required: the node that goes stale belongs to the
+      // sibling, not to the portal being toggled.
+      final Widget sibling = OverlayPortal.overlayChildLayoutBuilder(
+        controller: siblingController,
+        overlayChildBuilder: (BuildContext context, OverlayChildLayoutInfo info) =>
+            const SizedBox.shrink(),
+        child: Semantics(explicitChildNodes: true, child: const Text('sibling')),
+      );
+
+      Widget portal = OverlayPortal.overlayChildLayoutBuilder(
+        controller: controller,
+        overlayChildBuilder: (BuildContext context, OverlayChildLayoutInfo info) =>
+            const Align(alignment: Alignment.topLeft, child: Text('overlay child')),
+        child: Semantics(explicitChildNodes: true, child: const Text('anchor')),
+      );
+      portal = Overlay.wrap(child: ExcludeSemantics(child: portal));
+      portal = SizedBox(width: 200, height: 100, child: portal);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              entry = OverlayEntry(
+                builder: (BuildContext context) =>
+                    Semantics(container: true, child: Column(children: <Widget>[sibling, portal])),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      // The corruption only becomes observable on the second round trip.
+      for (var i = 0; i < 2; i += 1) {
+        controller.show();
+        await tester.pumpAndSettle();
+        expect(find.text('overlay child'), findsOneWidget);
+
+        controller.hide();
+        await tester.pumpAndSettle();
+        expect(find.text('overlay child'), findsNothing);
+      }
+
+      semantics.dispose();
+    });
   });
 
   testWidgets(

--- a/packages/flutter/test/widgets/overlay_portal_test.dart
+++ b/packages/flutter/test/widgets/overlay_portal_test.dart
@@ -3242,6 +3242,66 @@ void main() {
         ),
       );
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/189902 and
+    // https://github.com/flutter/flutter/issues/187198.
+    //
+    // Showing an overlay child gives the anchor next to it a sibling conflict,
+    // and hiding it takes that conflict away again. The conflict feeds
+    // shouldFormSemanticsNode, so the fragment stops producing a node of its
+    // own while keeping the one it cached. Its children are taken by an
+    // ancestor while it is out of the tree, and it used to be handed back in
+    // still holding them, leaving a SemanticsNode that was attached but had no
+    // parent.
+    testWidgets('toggling an overlay child does not leave a parentless attached semantics node', (
+      WidgetTester tester,
+    ) async {
+      final controller = OverlayPortalController();
+      final siblingController = OverlayPortalController();
+
+      // A second anchor is required: the fragment whose conflict changes is the
+      // sibling's, not the one belonging to the portal being toggled.
+      final Widget sibling = OverlayPortal.overlayChildLayoutBuilder(
+        controller: siblingController,
+        overlayChildBuilder: (BuildContext context, OverlayChildLayoutInfo info) =>
+            const SizedBox.shrink(),
+        child: Semantics(explicitChildNodes: true, child: const Text('sibling')),
+      );
+
+      Widget portal = OverlayPortal.overlayChildLayoutBuilder(
+        controller: controller,
+        overlayChildBuilder: (BuildContext context, OverlayChildLayoutInfo info) =>
+            const Align(alignment: Alignment.topLeft, child: Text('overlay child')),
+        child: Semantics(explicitChildNodes: true, child: const Text('anchor')),
+      );
+      portal = Overlay.wrap(child: ExcludeSemantics(child: portal));
+      portal = SizedBox(width: 200, height: 100, child: portal);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) =>
+                    Semantics(container: true, child: Column(children: <Widget>[sibling, portal])),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      // The corruption only becomes observable on the second round trip.
+      for (var i = 0; i < 2; i += 1) {
+        controller.show();
+        await tester.pumpAndSettle();
+        expect(find.text('overlay child'), findsOneWidget);
+
+        controller.hide();
+        await tester.pumpAndSettle();
+        expect(find.text('overlay child'), findsNothing);
+      }
+    });
   });
 
   testWidgets(


### PR DESCRIPTION
`shouldFormSemanticsNode` ends in `return parentData!.explicitChildNodes || _hasSiblingConflict;`. When the parent data half changes, `_didUpdateParentData` calls `markNeedsBuild`, because whether a fragment forms a node may have changed. When the sibling conflict half changes, nothing does. `markSiblingConfigurationConflict` just assigns the flag and returns.

That gap is enough to corrupt the semantics tree. A fragment that stops forming its own node keeps `built == true` and keeps its `cachedSemanticsNode`. While it is out of the tree an ancestor can take its children back, and its child list is never refreshed because `_buildSemantics` short circuits on `built`. When the fragment forms a node again it is handed straight back into the tree still holding children that now belong to somebody else, and attaching it attaches them too. The result is a `SemanticsNode` that is attached but has no parent, which is what trips `assert(!child.attached)` in `_replaceChildren`.

There are three earlier branches in `shouldFormSemanticsNode` (`isSemanticBoundary`, `isRoot`, `contributesToSemanticsTree`). I went looking for the same gap in those and could not find one, because everything that feeds them goes through `markNeedsUpdate`, which nulls parent data on its way up and so ends at `markNeedsBuild` anyway. I would not swear to that the way I would to the paragraph above, so if you know of a path I am not seeing, I would rather hear it now.

Outside debug builds this looks worse than an assertion. The orphan still passes the `node.attached` check used when building `childrenInTraversalOrder`, so its id goes to the engine as a child that is not reachable, which is the shape of the `Failed to update ui::AXTree, error: N will not be in the tree and is not the new root` that @davidhicks980 reported in #187198. I should be clear that this part is me reading the code and not something I measured. I could not find a way to drive VoiceOver from a test, so I have not confirmed that the release mode failure is this and only this.

OverlayPortal runs into this reliably because showing an overlay child creates and removes a sibling conflict for the anchors around it, so node formation flips back and forth while the traversal graft moves nodes between subtrees.

The change marks the fragment as needing a build when its sibling conflict flag actually changes across a pass. It has to be a before and after comparison rather than a check inside `markSiblingConfigurationConflict`, because `_marksConflictsInMergeGroup` deliberately resets every fragment to false first and that reset is load bearing: `configToMergeUp` reads `shouldFormSemanticsNode`, so leaving the previous pass's flag in place while recomputing changes the result. The snapshot is taken in the existing loop just before the reset, and the comparison rides along with the loop that marks the conflicts, so there is no extra pass over `mergeGroup`. Both directions are marked, because losing a conflict changes node formation just as much as gaining one.

This runs during the parent data phase of `flushSemantics`, before the build loop, so the fragment is rebuilt in the same flush.

### Why not repair the child list instead

The first version of this PR fixed the stale child list at the point of the theft, and guarded `attach` the way `detach` already is. Both work, and the test passes with either. @chunhtai pointed out that the fragment should have known its children were taken and marked itself, which turned out to be right, so this version drops both in favour of fixing the invalidation. Happy to add the `attach` guard back as hardening if you want it, since `detach` is still the only one of the ten methods in `semantics.dart` that walk `_children` that checks whether the child is still its own, but it is a separate concern from this bug.

While I was checking that number I found I had got it wrong earlier. I said eight places here and on #187198. It is ten, and the two I missed, `_redepthChildren` and `_updateChildrenMergeFlags`, both assert on `child.owner`, so a stale entry can trip there as well.

I did earlier report that invalidating was not possible because `markNeedsBuild`, `RenderObject.markNeedsSemanticsUpdate` and the `flushSemantics` exit assert all reject being dirtied during the flush. That was true of invalidating at the moment of the theft, which is in the middle of the build phase. Invalidating at the moment the decision changes is a different place and does not have that problem.

### Test

The regression test goes in the existing `Semantics` group in `overlay_portal_test.dart`. It needs two portal anchors before it will fail, because the fragment whose conflict changes belongs to the sibling anchor rather than the one being toggled. Taking the sibling out makes it pass on unpatched master. It fails on master with `'!child.attached': is not true` and passes with this change.

One thing worth flagging: the test has no semantics expectations of its own, so its only failure mode is that framework assertion. Happy to add some if you would rather it pinned the resulting tree down.

`test/semantics`, `test/rendering`, `test/widgets` and `test/material` come out at 16171 passing with nothing failing.

Fixes https://github.com/flutter/flutter/issues/189902

One request on that: @madenvel reported a `computeChildGeometry` assertion variant in a comment on that issue, and closing it through this PR would bury that report. Could that be split into its own issue? I have not been able to reproduce it, it is described as Linux and AT-SPI, and I do not know whether this change covers it. I said earlier that I expected it to survive any fix in this area, but that was about the two patches this version replaced, and the reasoning does not carry over. Rebuilding the fragment refreshes its geometry too, so it is genuinely an open question now rather than a no.

Partially addresses https://github.com/flutter/flutter/issues/187198. The assertions reported there go away, and I would expect the AXTree failure to as well for the reason above, though I have not verified that on a device. The menu item positioning problem also reported there is separate and this does not touch it.

For the record, #182604 turned out not to be the same defect, even though it sits downstream of the same refactor. It was fixed by #192139 on the engine side, where `setChildrenInHitTestOrder` was overwriting the traversal parent that `OverlayPortal` had set. I had said on the two issues above that all three came down to one thing, which was wrong.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
