### PR TITLE
iOS: Remove the synchronous first-frame wait

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -1534,13 +1534,6 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   [self.statusBarChannel invokeMethod:@"handleScrollToTop" arguments:nil];
 }
 
-- (void)waitForFirstFrameSync:(NSTimeInterval)timeout
-                     callback:(NS_NOESCAPE void (^_Nonnull)(BOOL didTimeout))callback {
-  fml::TimeDelta waitTime = fml::TimeDelta::FromMilliseconds(timeout * 1000);
-  fml::Status status = self.shell.WaitForFirstFrame(waitTime);
-  callback(status.code() == fml::StatusCode::kDeadlineExceeded);
-}
-
 - (void)waitForFirstFrame:(NSTimeInterval)timeout
                  callback:(void (^_Nonnull)(BOOL didTimeout))callback {
   dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -65,10 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)attachView;
 - (void)notifyLowMemory;
 
-/// Blocks until the first frame is presented or the timeout is exceeded, then invokes callback.
-- (void)waitForFirstFrameSync:(NSTimeInterval)timeout
-                     callback:(NS_NOESCAPE void (^)(BOOL didTimeout))callback;
-
 /// Asynchronously waits until the first frame is presented or the timeout is exceeded, then invokes
 /// callback.
 - (void)waitForFirstFrame:(NSTimeInterval)timeout callback:(void (^)(BOOL didTimeout))callback;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1393,27 +1393,12 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [self updateViewportMetricsIfNeeded];
 
   // There is no guarantee that UIKit will layout subviews when the application/scene is active.
-  // Creating the surface when inactive will cause GPU accesses from the background. Only wait for
-  // the first frame to render when the application/scene is actually active.
+  // Creating the surface when inactive will cause GPU accesses from the background, so only
+  // create the surface when the application/scene is actually active.
   // This must run after updateViewportMetrics so that the surface creation tasks are queued after
   // the viewport metrics update tasks.
   if (firstViewBoundsUpdate && self.stateIsActive && self.engine) {
     [self surfaceUpdated:YES];
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-    NSTimeInterval timeout = 0.2;
-#else
-    NSTimeInterval timeout = 0.1;
-#endif
-    [self.engine
-        waitForFirstFrameSync:timeout
-                     callback:^(BOOL didTimeout) {
-                       if (didTimeout) {
-                         [FlutterLogger logInfo:@"Timeout waiting for the first frame to render. "
-                                                 "This may happen in unoptimized builds. If this is"
-                                                 "a release build, you should load a less complex "
-                                                 "frame to avoid the timeout."];
-                       }
-                     }];
   }
 }
 


### PR DESCRIPTION
`-waitForFirstFrameSync:` is a no-op on iOS. The iOS embedder now only supports merged platform/UI thread task runners on the iOS main thread. `FlutterDartProject.mm` passes `require_merged_platform_ui_thread` to `SettingsFromCommandLine`, and flutter/flutter#190051 prevents the `mergeAfterLaunch` configuration (which was never implemented for iOS. Because of this, the thread calling this method at first layout is the thread responsible for producing the frame, and `Shell::WaitForFirstFrame` always ends up taking the `kFailedPrecondition` bailout without waiting.

This removes the method and its only call site in FlutterViewController's first layout.

This *was* the main-thread wait introduced in flutter/engine#9506 to avoid presenting a black first frame when transitioning into a FlutterViewController with a prewarmed engine (flutter/flutter#32937).

It has been dead code since the platform and UI threads merged. Maybe more intuitive evidence of this is that the main thread can't block waiting for a frame that it itself has to produce.

Because I'm paranoid, I tested locally on a physical device (since the original issue mentioned this doesn't repro on simulators) on both debug and release builds using https://github.com/cbracken/flutter_flashofblack just to be 100% sure this didn't sneak back in at some point during or after the thread merge. It still looks good to me.

No test changes: the wait and its call site had no coverage, and regardless the removed code has been dead code for a couple years.

Issue: https://github.com/flutter/flutter/issues/112232 (prework)

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
