### PR TITLE
[cp-beta] [macOS] Resume app lifecycle on becomeActive to avoid frozen UI after occlusion

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -1654,11 +1654,18 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
  */
 - (void)handleWillBecomeActive:(NSNotification*)notification {
   _active = YES;
-  if (!_visible) {
-    [self setApplicationState:flutter::AppLifecycleState::kHidden];
-  } else {
-    [self setApplicationState:flutter::AppLifecycleState::kResumed];
+  // occlusionState can latch stale on an occlusion->visible transition (same-screen
+  // Cmd-Tab / Mission Control), so `_visible` is unreliable here. Resume from
+  // NSWindow.isVisible instead — NO for a minimized window, so it won't resume hidden.
+  // https://github.com/flutter/flutter/issues/155977
+  for (NSWindow* window in [NSApplication sharedApplication].windows) {
+    if (window.isVisible) {
+      _visible = YES;
+      break;
+    }
   }
+  [self setApplicationState:_visible ? flutter::AppLifecycleState::kResumed
+                                     : flutter::AppLifecycleState::kHidden];
 }
 
 /**
@@ -1675,8 +1682,8 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 }
 
 /**
- * Called when the |FlutterAppDelegate| gets the applicationDidUnhide
- * notification.
+ * Called when the application's occlusion state changes
+ * (NSApplicationDidChangeOcclusionStateNotification).
  */
 - (void)handleDidChangeOcclusionState:(NSNotification*)notification {
   NSApplicationOcclusionState occlusionState = [[NSApplication sharedApplication] occlusionState];

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -1199,6 +1199,16 @@ TEST_F(FlutterEngineTest, HandleLifecycleStates) API_AVAILABLE(macos(10.9)) {
         [invocation setReturnValue:&visibility];
       });
 
+  // handleWillBecomeActive derives visibility from the windows (not from the
+  // occlusion state, which can latch stale), so provide a window whose visibility
+  // we can toggle independently.
+  __block BOOL windowVisible = YES;
+  id mockWindow = OCMClassMock([NSWindow class]);
+  OCMStub([mockWindow isVisible]).andDo(^(NSInvocation* invocation) {
+    [invocation setReturnValue:&windowVisible];
+  });
+  OCMStub([mockApplication windows]).andReturn(@[ mockWindow ]);
+
   NSNotification* willBecomeActive =
       [[NSNotification alloc] initWithName:NSApplicationWillBecomeActiveNotification
                                     object:nil
@@ -1227,12 +1237,30 @@ TEST_F(FlutterEngineTest, HandleLifecycleStates) API_AVAILABLE(macos(10.9)) {
   [engineMock handleDidChangeOcclusionState:didChangeOcclusionState];
   EXPECT_EQ(sentState, flutter::AppLifecycleState::kHidden);
 
+  // Becoming active with an on-screen window resumes even though occlusionState still
+  // reads not-visible (the stale-latch case). Regression test for #155977.
+  [engineMock handleWillBecomeActive:willBecomeActive];
+  EXPECT_EQ(sentState, flutter::AppLifecycleState::kResumed);
+
+  // The app is now active and considered visible, so resigning active makes it
+  // inactive (not hidden) until a real occlusion notification hides it.
+  [engineMock handleWillResignActive:willResignActive];
+  EXPECT_EQ(sentState, flutter::AppLifecycleState::kInactive);
+
+  // Occlusion stays authoritative after a becomeActive resume: a genuine
+  // not-visible occlusion notification still hides the app.
+  visibility = 0;
+  [engineMock handleDidChangeOcclusionState:didChangeOcclusionState];
+  EXPECT_EQ(sentState, flutter::AppLifecycleState::kHidden);
+
+  // Becoming active while no window is visible (e.g. activated with all windows
+  // minimized, which does not deminiaturize) must not resume: visibility is
+  // derived from the windows, not from the activation itself.
+  windowVisible = NO;
   [engineMock handleWillBecomeActive:willBecomeActive];
   EXPECT_EQ(sentState, flutter::AppLifecycleState::kHidden);
 
-  [engineMock handleWillResignActive:willResignActive];
-  EXPECT_EQ(sentState, flutter::AppLifecycleState::kHidden);
-
+  [mockWindow stopMocking];
   [mockApplication stopMocking];
 }
 


### PR DESCRIPTION
### Issue Link:
https://github.com/flutter/flutter/issues/155977

### Impacted Users:
All macOS desktop end-users and developers of Flutter apps on macOS. The issue reproduces reliably and frequently on macOS desktop apps launched via Finder/LaunchServices when returning to an occluded app on the same screen (e.g. via Cmd-Tab, Mission Control, or clicking away and back).

### Impact Description:
TL;DR: This issue can cause macOS desktop apps to visibly lock up.

When a Flutter macOS desktop app is occluded and then brought back to the foreground on the same screen (e.g. via Cmd-Tab or Mission Control), macOS does not reliably deliver an
`NSApplicationDidChangeOcclusionState` (visible=YES) notification.

Because `_visible` was driven solely by occlusion notifications, returning to the foreground caused `applicationWillBecomeActive` to read a stale `_visible = NO` and resend `AppLifecycleState.hidden` to the engine. Consequently, the framework stays in the `hidden` lifecycle state: animations are muted, frame scheduling is gated off, and no vsyncs are requested, leaving the UI completely frozen and unresponsive even though the window is frontmost and active.

This is a showstopper bug for shipping production macOS Flutter apps.

### Changelog Description:
[flutter/155977] When returning to an occluded macOS desktop app via Cmd-Tab or Mission Control [on macOS], the UI no longer freezes due to missed occlusion notifications.

### Workaround:
Yes. When the app is frozen after returning via Cmd-Tab or Mission Control, clicking the application's Dock icon will bring it back to life (triggering a WindowServer-driven occlusion state update that recovers rendering).

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

This patch adds an additional means of updating its `_visible` state from `NO` to `YES` during `handleWillBecomeActive:`, this then triggers frames to start pumping. This does NOT add any additional means to transition the `_visible` state from `YES` to `NO`.

It's simple, properly tested and doesn't introduce any additional bugs.

It's worth noting that this doesn't reasolve ALL bugs in the code; there's still a small bug in the code:

In the case where `_visible` is `YES` and the user minimises the window (which @bdero mentions fires no occlusion notification) and then cmd-tabs back, `handleWillBecomeActive` would result in `kResumed` even though the window is still down in the dock and not on-screen (because the loop find no visible window but leaves the stale `_visible` = `YES` untouched.

This is intentionally NOT fixed in this patch; which addresses only the high priority visual lock up. The impact of the remaining issue is much, much smaller.

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
1. Build and launch a Flutter macOS desktop app via Finder or `open` (LaunchServices GUI launch) on macOS.
2. Open another application window so that the Flutter app is occluded.
3. Switch away from the Flutter app and then return to it on the same screen multiple times using Cmd-Tab or Mission Control.
4. Verify that upon returning to the frontmost Flutter app, the UI remains responsive, animations continue to play, and new frames render without freezing.
5. Verify that activating the app via Cmd-Tab while all its windows are minimized does not improperly resume rendering.
6. Run the macOS engine unit tests (`FlutterEngineTest`) to verify all lifecycle tests in `HandleLifecycleStates` pass.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
