### PR TITLE
[flutter_tools] [DAP] Extract and forward DevTools Deep Link URLs to DAP clients

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/error_formatter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/error_formatter.dart
@@ -12,18 +12,26 @@ typedef _OutputSender =
       int? variablesReference,
     });
 
-/// A formatter for improving the display of Flutter structured errors over DAP.
+/// Deserializes and formats a Flutter structured error.
 ///
-/// The formatter deserializes a `Flutter.Error` event and produces output
-/// similar to the `renderedErrorText` field, but may include ansi color codes
-/// to provide improved formatting (such as making stack frames from non-user
-/// code faint) if the client indicated support.
+/// Produces output similar to the `renderedErrorText` field, but may include
+/// ansi color codes to provide improved formatting (such as making stack frames
+/// from non-user code faint) if the client indicated support.
 ///
 /// Lines that look like stack frames will be marked so they can be parsed by
 /// the base adapter and attached as `Source`s to allow them to be clickable
 /// in the client.
+///
+/// If the error contains a `DevToolsDeepLinkProperty` node, its URL will be
+/// extracted into [devToolsDeepLinkUrl].
 class FlutterErrorFormatter {
   final batchedOutput = <_BatchedOutput>[];
+
+  /// The text of the ErrorSummary node, if exists.
+  String? errorSummary;
+
+  /// The url of any DevTools deep link node.
+  String? devToolsDeepLinkUrl;
 
   /// Formats a Flutter error.
   ///
@@ -89,6 +97,12 @@ class FlutterErrorFormatter {
   /// Writes [node] to the output using [indent], recursing unless [recursive]
   /// is `false`.
   void _writeNode(_ErrorNode node, {int indent = 0, bool recursive = true}) {
+    if (node.type == _DiagnosticsNodeType.ErrorSummary) {
+      errorSummary = node.description;
+    } else if (node.type == _DiagnosticsNodeType.DevToolsDeepLinkProperty) {
+      _parseDevToolsDeepLink(node);
+    }
+
     // Errors, summaries and lines starting "Exception:" are marked as errors so
     // they go to stderr instead of stdout (this may cause the client to colour
     // them like errors).
@@ -138,6 +152,15 @@ class FlutterErrorFormatter {
       );
     }
   }
+
+  /// Parse the DevTools deep link URL out of a
+  /// [_DiagnosticsNodeType.DevToolsDeepLinkProperty] node.
+  void _parseDevToolsDeepLink(_ErrorNode node) {
+    assert(node.type == _DiagnosticsNodeType.DevToolsDeepLinkProperty);
+    if (node.value case final url?) {
+      devToolsDeepLinkUrl = url;
+    }
+  }
 }
 
 /// A container for output to be sent to the client.
@@ -160,7 +183,7 @@ enum _DiagnosticsNodeLevel { error, summary }
 
 enum _DiagnosticsNodeStyle { flat }
 
-enum _DiagnosticsNodeType { DiagnosticsBlock }
+enum _DiagnosticsNodeType { ErrorSummary, DevToolsDeepLinkProperty, DiagnosticsBlock }
 
 class _ErrorData extends _ErrorNode {
   _ErrorData(super.data);
@@ -182,6 +205,7 @@ class _ErrorNode {
   bool get showName => data['showName'] != false;
   _DiagnosticsNodeStyle? get style => asEnum('style', _DiagnosticsNodeStyle.values);
   _DiagnosticsNodeType? get type => asEnum('type', _DiagnosticsNodeType.values);
+  String? get value => asString('value');
 
   String? asString(String field) {
     final Object? value = data[field];

--- a/packages/flutter_tools/lib/src/debug_adapters/error_formatter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/error_formatter.dart
@@ -98,7 +98,9 @@ class FlutterErrorFormatter {
   /// is `false`.
   void _writeNode(_ErrorNode node, {int indent = 0, bool recursive = true}) {
     if (node.type == _DiagnosticsNodeType.ErrorSummary) {
-      errorSummary = node.description;
+      // Probably there is only one error summary, but keep the first
+      // (outer-most) if not.
+      errorSummary ??= node.description;
     } else if (node.type == _DiagnosticsNodeType.DevToolsDeepLinkProperty) {
       _parseDevToolsDeepLink(node);
     }
@@ -158,7 +160,9 @@ class FlutterErrorFormatter {
   void _parseDevToolsDeepLink(_ErrorNode node) {
     assert(node.type == _DiagnosticsNodeType.DevToolsDeepLinkProperty);
     if (node.value case final url?) {
-      devToolsDeepLinkUrl = url;
+      // Probably there is only one deep link, but keep the first
+      // (outer-most) if not.
+      devToolsDeepLinkUrl ??= url;
     }
   }
 }

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -228,9 +228,22 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
       return;
     }
 
-    FlutterErrorFormatter()
+    final formatter = FlutterErrorFormatter()
       ..formatError(errorData)
       ..sendOutput(sendOutput);
+
+    // Forward any DevTools deep-links in a 'dart.flutter.devToolsDeepLink'
+    // event.
+    final String? errorSummary = formatter.errorSummary;
+    final String? deepLinkUrl = formatter.devToolsDeepLinkUrl;
+    if (errorSummary != null && deepLinkUrl != null) {
+      // This event is interpreted by IDEs extensions like like Dart-Code and
+      // should not be changed in breaking ways without coordination.
+      sendEvent(
+        RawEventBody({'summary': errorSummary, 'deepLinkUrl': deepLinkUrl}),
+        eventType: 'dart.flutter.devToolsDeepLink',
+      );
+    }
   }
 
   /// Called by [launchRequest] to request that we actually start the app to be run/debugged.

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -234,9 +234,10 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
 
     // Forward any DevTools deep-links in a 'dart.flutter.devToolsDeepLink'
     // event.
-    final String? errorSummary = formatter.errorSummary;
-    final String? deepLinkUrl = formatter.devToolsDeepLinkUrl;
-    if (errorSummary != null && deepLinkUrl != null) {
+    if ((formatter.errorSummary, formatter.devToolsDeepLinkUrl) case (
+      final errorSummary?,
+      final deepLinkUrl?,
+    )) {
       // This event is interpreted by IDEs extensions like like Dart-Code and
       // should not be changed in breaking ways without coordination.
       sendEvent(

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -234,14 +234,11 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
 
     // Forward any DevTools deep-links in a 'dart.flutter.devToolsDeepLink'
     // event.
-    if ((formatter.errorSummary, formatter.devToolsDeepLinkUrl) case (
-      final errorSummary?,
-      final deepLinkUrl?,
-    )) {
+    if (formatter case FlutterErrorFormatter(:final errorSummary?, :final devToolsDeepLinkUrl?)) {
       // This event is interpreted by IDEs extensions like like Dart-Code and
       // should not be changed in breaking ways without coordination.
       sendEvent(
-        RawEventBody({'summary': errorSummary, 'deepLinkUrl': deepLinkUrl}),
+        RawEventBody({'summary': errorSummary, 'deepLinkUrl': devToolsDeepLinkUrl}),
         eventType: 'dart.flutter.devToolsDeepLink',
       );
     }

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/debug_adapters/flutter_adapter_args.dart';
 import 'package:flutter_tools/src/globals.dart' as globals show fs, platform;
 import 'package:test/fake.dart';
 import 'package:test/test.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' as vm;
 
 import 'mocks.dart';
 
@@ -601,6 +601,56 @@ void main() {
           'params': <String, Object?>{'warning': 'This is a test warning'},
         });
       });
+
+      test('forward inspector deep links as dart.flutter.devToolsDeepLink events', () async {
+        final adapter = FakeFlutterDebugAdapter(
+          fileSystem: MemoryFileSystem.test(style: fsStyle),
+          platform: platform,
+        );
+
+        // Simulate startup.
+        final args = FlutterLaunchRequestArguments(cwd: '.', program: 'foo.dart');
+        final responseCompleter = Completer<void>();
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
+
+        // Start listening for the forwarded event (don't await it yet, it won't
+        // be triggered until the call below).
+        final Future<Map<String, Object?>> forwardedEvent = adapter.dapToClientMessages.firstWhere(
+          (Map<String, Object?> data) => data['event'] == 'dart.flutter.devToolsDeepLink',
+        );
+
+        // Simulate Flutter asking for a URL to be launched.
+        await adapter.handleExtensionEvent(
+          vm.Event(
+            kind: vm.EventKind.kExtension,
+            extensionKind: 'Flutter.Error',
+            extensionData: vm.ExtensionData.parse({
+              'properties': <Map<String, Object?>>[
+                {
+                  'type': 'ErrorSummary',
+                  'description': 'An overflow occurred',
+                  'properties': <Map<String, Object?>>[
+                    <String, Object?>{
+                      'type': 'DevToolsDeepLinkProperty',
+                      'description': 'Click to open the inspector',
+                      'value': 'http://127.0.0.1:9100/inspector?uri=x&inspectorRef=y',
+                    },
+                  ],
+                },
+              ],
+            }),
+          ),
+        );
+
+        // Wait for the forwarded event.
+        final Map<String, Object?> message = await forwardedEvent;
+        // Ensure the body of the event matches the original event sent by Flutter.
+        expect(message['body'], <String, Object?>{
+          'summary': 'An overflow occurred',
+          'deepLinkUrl': 'http://127.0.0.1:9100/inspector?uri=x&inspectorRef=y',
+        });
+      });
     });
 
     group('handles reverse requests', () {
@@ -952,7 +1002,7 @@ stderr "════════════════════════
   });
 }
 
-class _FakeVm extends Fake implements VM {
+class _FakeVm extends Fake implements vm.VM {
   _FakeVm({this.pid = 1});
 
   @override

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -907,6 +907,47 @@ stdout "The relevant error-causing widget was:\n    MyWidget:file:///path/to/wid
 stderr "════════════════════════════════════════════════════════════════════════════════\n"
 ''');
       });
+
+      test('extracts the error summary', () {
+        final formatter = FlutterErrorFormatter()
+          ..formatError(<String, Object?>{
+            'type': 'NotErrorSummary',
+            'description': 'xxx',
+            'properties': <Map<String, Object?>>[
+              <String, Object>{'description': 'yyy'},
+              <String, Object?>{
+                'type': 'ErrorSummary',
+                'description': 'my error summary',
+                'children': <Map<String, Object>>[
+                  <String, Object>{'type': 'NotErrorSummary2', 'description': 'zzz'},
+                ],
+              },
+            ],
+          });
+
+        expect(formatter.errorSummary, 'my error summary');
+      });
+
+      test('extracts a DevTools Deep Link', () {
+        final formatter = FlutterErrorFormatter()
+          ..formatError(<String, Object?>{
+            'type': 'NotErrorSummary',
+            'description': 'xxx',
+            'properties': <Map<String, Object?>>[
+              <String, Object>{'description': 'yyy'},
+              <String, Object?>{
+                'type': 'DevToolsDeepLinkProperty',
+                'description': 'Click to open the inspector',
+                'value': 'http://127.0.0.1:9100/inspector?uri=x&inspectorRef=y',
+              },
+            ],
+          });
+
+        expect(
+          formatter.devToolsDeepLinkUrl,
+          'http://127.0.0.1:9100/inspector?uri=x&inspectorRef=y',
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
This is functionality from the legacy DAPs that was missed when migrating to the SDK. Some kinds of errors (such as Overflow errors) includes nodes to deep-link into DevTools. By forwarding these to the IDE, instead of just a text link the IDE can show a toast notification with a button to open the embedded version of DevTools.

This is part of the work to fix https://github.com/Dart-Code/Dart-Code/issues/6134. There are some additional fixes required elsewhere, but once those are resolved, this will result in a notification like this:

<img width="533" height="226" alt="image" src="https://github.com/user-attachments/assets/8989a67f-3ac2-4d87-b583-f56704ca8872" />

Clicked "Inspect Widget" will open the embedded Inspector on the correct widget.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
