### PR TITLE
Increase /dev/shm size to 2g and bypass --disable-dev-shm-usage for Linux web tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2024,6 +2024,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      shm_size: "2g"
       dependencies: >-
         [
           {"dependency": "chrome_and_driver", "version": "version:145.0.7632.117"},
@@ -2200,6 +2201,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 45
     properties:
+      shm_size: "2g"
       dependencies: >-
         [
           {"dependency": "chrome_and_driver", "version": "version:145.0.7632.117"},

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -704,7 +704,10 @@ window.\$dartLoader.loader.nextAttempt();
       completer.future,
       headless: !_config.pauseAfterLoad,
       logger: _logger,
-      webBrowserFlags: <String>[if (useWasm) '--disable-dev-shm-usage'],
+      webBrowserFlags: <String>[
+        if (useWasm && Platform.environment['FLUTTER_TEST_USE_SHM'] != 'true')
+          '--disable-dev-shm-usage',
+      ],
     );
   }
 

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -697,7 +697,7 @@ window.\$dartLoader.loader.nextAttempt();
 
     _logger.printStatus('>>> CHECK /dev/shm SIZE INSIDE FLUTTER_TOOLS TEST RUNNER:');
     try {
-      final ProcessResult res = Process.runSync('df', <String>['-h', '/dev/shm']);
+      final ProcessResult res = globals.processManager.runSync(<String>['df', '-h', '/dev/shm']);
       _logger.printStatus(res.stdout as String);
     } catch (e) {
       _logger.printStatus('Failed to run df: $e');
@@ -712,7 +712,7 @@ window.\$dartLoader.loader.nextAttempt();
       headless: !_config.pauseAfterLoad,
       logger: _logger,
       webBrowserFlags: <String>[
-        if (useWasm && Platform.environment['FLUTTER_TEST_USE_SHM'] != 'true')
+        if (useWasm && globals.platform.environment['FLUTTER_TEST_USE_SHM'] != 'true')
           '--disable-dev-shm-usage',
       ],
     );

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -695,6 +695,13 @@ window.\$dartLoader.loader.nextAttempt();
           },
         );
 
+    _logger.printStatus('>>> CHECK /dev/shm SIZE INSIDE FLUTTER_TOOLS TEST RUNNER:');
+    try {
+      final ProcessResult res = Process.runSync('df', <String>['-h', '/dev/shm']);
+      _logger.printStatus(res.stdout as String);
+    } catch (e) {
+      _logger.printStatus('Failed to run df: $e');
+    }
     _logger.printTrace('Serving tests at $hostUrl');
 
     return BrowserManager.start(

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -699,7 +699,7 @@ window.\$dartLoader.loader.nextAttempt();
     try {
       final ProcessResult res = globals.processManager.runSync(<String>['df', '-h', '/dev/shm']);
       _logger.printStatus(res.stdout as String);
-    } catch (e) {
+    } on Object catch (e) {
       _logger.printStatus('Failed to run df: $e');
     }
     _logger.printTrace('Serving tests at $hostUrl');


### PR DESCRIPTION
## Summary
This PR configures `shm_size: "2g"` on Linux web test targets in `.ci.yaml` and updates `flutter_tools` to bypass `--disable-dev-shm-usage` when `FLUTTER_TEST_USE_SHM == 'true'`.

## Context & Related Issues
- **Issue**: Multi-threaded Wasm/SkWasm web tests hit 64MB OOM crashes in Docker containers unless `--disable-dev-shm-usage` is passed. However, `--disable-dev-shm-usage` forces shared memory onto disk `/tmp`, creating heavy disk I/O bottlenecks and 15-minute test timeouts on LUCI runners.
- **Solution**: Increase `/dev/shm` size via recipe property (`shm_size: "2g"`) and restore fast memory-backed execution in Chrome.
- **Related Report**: [Chrome 145 Roll Post-Mortem](https://docs.google.com/document/d/1dLRsLGDyPZ2s9498Vxuv0gJha8LAC6QnxAq7Fwm-XBY)