### PR TITLE
Remove --disable-dev-shm-usage from Chrome launch args

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -704,7 +704,6 @@ window.\$dartLoader.loader.nextAttempt();
       completer.future,
       headless: !_config.pauseAfterLoad,
       logger: _logger,
-      webBrowserFlags: <String>[if (useWasm) '--disable-dev-shm-usage'],
     );
   }
 


### PR DESCRIPTION
Testing CI stability without --disable-dev-shm-usage flag.