### PR TITLE
[iOS] Fix touch passthrough when a native UIViewController is presented

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -267,6 +267,23 @@ FLUTTER_DARWIN_EXPORT
  */
 @property(nonatomic, getter=isAutoResizable) BOOL autoResizable;
 
+/**
+ * Controls whether this `FlutterViewController` ignores touches while a `UIViewController` is
+ * presented on top of it (via `presentedViewController`) or while it is being dismissed.
+ *
+ * When set to `YES` (the default), touches are dropped in either case, preventing them from
+ * reaching Flutter while a native view controller is covering the screen.
+ *
+ * This check does not consider whether the presented content actually covers the touched point:
+ * touches are dropped everywhere on screen while anything is presented. Some apps intentionally
+ * present a `UIViewController` that does not cover the entire screen and rely on Flutter
+ * continuing to receive touches while it is presented. Set this property to `NO` to restore
+ * that behavior.
+ *
+ * Default is `YES`.
+ */
+@property(nonatomic) BOOL shouldIgnoreTouchesWhenPresented;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1281,28 +1281,28 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
-  if (self.presentedViewController != nil) {
+  if (self.presentedViewController != nil || self.isBeingDismissed) {
     return;
   }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
-  if (self.presentedViewController != nil) {
+  if (self.presentedViewController != nil || self.isBeingDismissed) {
     return;
   }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
-  if (self.presentedViewController != nil) {
+  if (self.presentedViewController != nil || self.isBeingDismissed) {
     return;
   }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {
-  if (self.presentedViewController != nil) {
+  if (self.presentedViewController != nil || self.isBeingDismissed) {
     return;
   }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1281,18 +1281,30 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
+  if (self.presentedViewController != nil) {
+    return;
+  }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
+  if (self.presentedViewController != nil) {
+    return;
+  }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
+  if (self.presentedViewController != nil) {
+    return;
+  }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {
+  if (self.presentedViewController != nil) {
+    return;
+  }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -363,6 +363,7 @@ typedef struct MouseState {
   _initialized = YES;
   _orientationPreferences = UIInterfaceOrientationMaskAll;
   _statusBarStyle = UIStatusBarStyleDefault;
+  _shouldIgnoreTouchesWhenPresented = YES;
 
   _accessibilityFeatures = [[FlutterAccessibilityFeatures alloc] init];
   _displayLinkManager = FlutterDisplayLinkManager.shared;
@@ -1281,28 +1282,32 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
-  if (self.presentedViewController != nil || self.isBeingDismissed) {
+  if (self.shouldIgnoreTouchesWhenPresented &&
+      (self.presentedViewController != nil || self.isBeingDismissed)) {
     return;
   }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
-  if (self.presentedViewController != nil || self.isBeingDismissed) {
+  if (self.shouldIgnoreTouchesWhenPresented &&
+      (self.presentedViewController != nil || self.isBeingDismissed)) {
     return;
   }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
-  if (self.presentedViewController != nil || self.isBeingDismissed) {
+  if (self.shouldIgnoreTouchesWhenPresented &&
+      (self.presentedViewController != nil || self.isBeingDismissed)) {
     return;
   }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {
-  if (self.presentedViewController != nil || self.isBeingDismissed) {
+  if (self.shouldIgnoreTouchesWhenPresented &&
+      (self.presentedViewController != nil || self.isBeingDismissed)) {
     return;
   }
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -376,7 +376,6 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
 // Overrides dispatchTouches:pointerDataChangeOverride:event: with void* for the C++ pointer
 // parameter so ObjC selector dispatch matches without pulling in flutter::PointerData types.
-// Does not call super to avoid crashing on raw UITouch stubs in the loop body.
 @interface FlutterViewControllerDispatchTouchesSpy : FlutterViewController
 @property(nonatomic) BOOL touchesDispatched;
 @property(nonatomic, strong) UIViewController* stubbedPresentedViewController;
@@ -3134,7 +3133,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
       [self spyViewControllerWithPresentedViewController:[[UIViewController alloc] init]];
   UITouch* touch = [[UITouch alloc] init];
   touch.phase = UITouchPhaseBegan;
-  UIEvent* event = nil;  // nil via variable suppresses -Wnonnull; event is unused by the fix path
+  UIEvent* event = nil;
   [vc touchesBegan:[NSSet setWithObject:touch] withEvent:event];
   XCTAssertFalse(vc.touchesDispatched,
                  @"touchesBegan must not dispatch to Flutter when a native VC is presented");

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -376,6 +376,27 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
 @end
 
+// Captures the pointer data the view controller dispatches, so touch tests can assert on the
+// contents of the packet rather than only on the fact that dispatch happened.
+@interface FlutterEnginePointerDataRecorder : FlutterEnginePartialMock
+- (const std::vector<flutter::PointerData>&)dispatchedPointerData;
+@end
+
+@implementation FlutterEnginePointerDataRecorder {
+  std::vector<flutter::PointerData> _dispatchedPointerData;
+}
+
+- (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet {
+  for (size_t i = 0; i < packet->GetLength(); i++) {
+    _dispatchedPointerData.push_back(packet->GetPointerData(i));
+  }
+}
+
+- (const std::vector<flutter::PointerData>&)dispatchedPointerData {
+  return _dispatchedPointerData;
+}
+@end
+
 // Records whether dispatchTouches:pointerDataChangeOverride:event: was invoked, while still
 // calling super so the real dispatch pipeline (touch -> PointerDataPacket -> engine) is exercised.
 @interface FlutterViewControllerDispatchTouchesSpy : FlutterViewController
@@ -3175,52 +3196,93 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 // Positive-path controls for the tests above: verifies the guard only blocks dispatch when
-// something is actually presented / being dismissed, not unconditionally.
+// something is actually presented / being dismissed, not unconditionally, and that the pointer
+// data that reaches the engine describes the touch that was sent.
 
-- (FlutterViewControllerDispatchTouchesSpy*)spyViewControllerNotPresented {
-  return [[FlutterViewControllerDispatchTouchesSpy alloc] initWithEngine:self.mockEngine
+- (FlutterViewControllerDispatchTouchesSpy*)spyViewControllerWithEngine:(FlutterEngine*)engine {
+  return [[FlutterViewControllerDispatchTouchesSpy alloc] initWithEngine:engine
                                                                  nibName:nil
                                                                   bundle:nil];
 }
 
 - (void)testTouchesBeganDispatchedWhenNothingPresented {
-  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerNotPresented];
+  FlutterEnginePointerDataRecorder* engine = [[FlutterEnginePointerDataRecorder alloc] init];
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerWithEngine:engine];
   UITouch* touch = [[UITouch alloc] init];
   touch.phase = UITouchPhaseBegan;
   UIEvent* event = nil;
   [vc touchesBegan:[NSSet setWithObject:touch] withEvent:event];
   XCTAssertTrue(vc.touchesDispatched,
                 @"touchesBegan must dispatch to Flutter when nothing is presented");
+  const std::vector<flutter::PointerData>& dispatched = [engine dispatchedPointerData];
+  XCTAssertEqual(dispatched.size(), 1UL, @"touchesBegan must dispatch exactly one pointer data");
+  XCTAssertEqual(dispatched[0].device, reinterpret_cast<int64_t>(touch),
+                 @"the dispatched pointer data must describe the touch that was sent");
+  XCTAssertEqual(static_cast<int>(dispatched[0].change),
+                 static_cast<int>(flutter::PointerData::Change::kDown),
+                 @"UITouchPhaseBegan must dispatch a kDown change");
 }
 
 - (void)testTouchesMovedDispatchedWhenNothingPresented {
-  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerNotPresented];
+  FlutterEnginePointerDataRecorder* engine = [[FlutterEnginePointerDataRecorder alloc] init];
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerWithEngine:engine];
   UITouch* touch = [[UITouch alloc] init];
   touch.phase = UITouchPhaseMoved;
   UIEvent* event = nil;
   [vc touchesMoved:[NSSet setWithObject:touch] withEvent:event];
   XCTAssertTrue(vc.touchesDispatched,
                 @"touchesMoved must dispatch to Flutter when nothing is presented");
+  const std::vector<flutter::PointerData>& dispatched = [engine dispatchedPointerData];
+  XCTAssertEqual(dispatched.size(), 1UL, @"touchesMoved must dispatch exactly one pointer data");
+  XCTAssertEqual(dispatched[0].device, reinterpret_cast<int64_t>(touch),
+                 @"the dispatched pointer data must describe the touch that was sent");
+  XCTAssertEqual(static_cast<int>(dispatched[0].change),
+                 static_cast<int>(flutter::PointerData::Change::kMove),
+                 @"UITouchPhaseMoved must dispatch a kMove change");
 }
 
 - (void)testTouchesEndedDispatchedWhenNothingPresented {
-  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerNotPresented];
+  FlutterEnginePointerDataRecorder* engine = [[FlutterEnginePointerDataRecorder alloc] init];
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerWithEngine:engine];
   UITouch* touch = [[UITouch alloc] init];
   touch.phase = UITouchPhaseEnded;
   UIEvent* event = nil;
   [vc touchesEnded:[NSSet setWithObject:touch] withEvent:event];
   XCTAssertTrue(vc.touchesDispatched,
                 @"touchesEnded must dispatch to Flutter when nothing is presented");
+  const std::vector<flutter::PointerData>& dispatched = [engine dispatchedPointerData];
+  XCTAssertEqual(dispatched.size(), 2UL,
+                 @"touchesEnded must dispatch the pointer data followed by a remove");
+  XCTAssertEqual(dispatched[0].device, reinterpret_cast<int64_t>(touch),
+                 @"the dispatched pointer data must describe the touch that was sent");
+  XCTAssertEqual(static_cast<int>(dispatched[0].change),
+                 static_cast<int>(flutter::PointerData::Change::kUp),
+                 @"UITouchPhaseEnded must dispatch a kUp change");
+  XCTAssertEqual(static_cast<int>(dispatched[1].change),
+                 static_cast<int>(flutter::PointerData::Change::kRemove),
+                 @"UITouchPhaseEnded must be followed by a kRemove change");
 }
 
 - (void)testTouchesCancelledDispatchedWhenNothingPresented {
-  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerNotPresented];
+  FlutterEnginePointerDataRecorder* engine = [[FlutterEnginePointerDataRecorder alloc] init];
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerWithEngine:engine];
   UITouch* touch = [[UITouch alloc] init];
   touch.phase = UITouchPhaseCancelled;
   UIEvent* event = nil;
   [vc touchesCancelled:[NSSet setWithObject:touch] withEvent:event];
   XCTAssertTrue(vc.touchesDispatched,
                 @"touchesCancelled must dispatch to Flutter when nothing is presented");
+  const std::vector<flutter::PointerData>& dispatched = [engine dispatchedPointerData];
+  XCTAssertEqual(dispatched.size(), 2UL,
+                 @"touchesCancelled must dispatch the pointer data followed by a remove");
+  XCTAssertEqual(dispatched[0].device, reinterpret_cast<int64_t>(touch),
+                 @"the dispatched pointer data must describe the touch that was sent");
+  XCTAssertEqual(static_cast<int>(dispatched[0].change),
+                 static_cast<int>(flutter::PointerData::Change::kCancel),
+                 @"UITouchPhaseCancelled must dispatch a kCancel change");
+  XCTAssertEqual(static_cast<int>(dispatched[1].change),
+                 static_cast<int>(flutter::PointerData::Change::kRemove),
+                 @"UITouchPhaseCancelled must be followed by a kRemove change");
 }
 
 // Regression tests for the isBeingDismissed guard.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -374,18 +374,23 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
 @end
 
-// Spy subclass for testing touch dispatch blocking when a native VC is presented.
+// Spy subclass for testing touch dispatch blocking when a native VC is presented or when
+// FlutterViewController itself is being dismissed.
 // Overrides dispatchTouches:pointerDataChangeOverride:event: with void* for the C++ pointer
 // parameter so ObjC selector dispatch matches without pulling in flutter::PointerData types.
 // Does not call super to avoid crashing on raw UITouch stubs in the loop body.
 @interface FlutterViewControllerDispatchTouchesSpy : FlutterViewController
 @property(nonatomic) BOOL touchesDispatched;
 @property(nonatomic, strong) UIViewController* stubbedPresentedViewController;
+@property(nonatomic) BOOL stubbedIsBeingDismissed;
 @end
 
 @implementation FlutterViewControllerDispatchTouchesSpy
 - (UIViewController*)presentedViewController {
   return self.stubbedPresentedViewController;
+}
+- (BOOL)isBeingDismissed {
+  return self.stubbedIsBeingDismissed;
 }
 - (void)dispatchTouches:(NSSet*)touches
     pointerDataChangeOverride:(void*)overridden_change
@@ -3171,6 +3176,63 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [vc touchesCancelled:[NSSet setWithObject:touch] withEvent:event];
   XCTAssertFalse(vc.touchesDispatched,
                  @"touchesCancelled must not dispatch to Flutter when a native VC is presented");
+}
+
+// Regression tests for isBeingDismissed guard (companion to presentedViewController guard above).
+// Touches must not be dispatched to Flutter while FlutterViewController itself is being dismissed
+// (i.e. during its own disappearance animation).
+
+- (FlutterViewControllerDispatchTouchesSpy*)spyViewControllerBeingDismissed {
+  FlutterViewControllerDispatchTouchesSpy* vc =
+      [[FlutterViewControllerDispatchTouchesSpy alloc] initWithEngine:self.mockEngine
+                                                              nibName:nil
+                                                               bundle:nil];
+  vc.stubbedIsBeingDismissed = YES;
+  return vc;
+}
+
+- (void)testTouchesBeganNotDispatchedWhenFlutterVCIsBeingDismissed {
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerBeingDismissed];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseBegan;
+  UIEvent* event = nil;
+  [vc touchesBegan:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertFalse(vc.touchesDispatched,
+                 @"touchesBegan must not dispatch to Flutter while FlutterViewController is being "
+                 @"dismissed");
+}
+
+- (void)testTouchesMovedNotDispatchedWhenFlutterVCIsBeingDismissed {
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerBeingDismissed];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseMoved;
+  UIEvent* event = nil;
+  [vc touchesMoved:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertFalse(vc.touchesDispatched,
+                 @"touchesMoved must not dispatch to Flutter while FlutterViewController is being "
+                 @"dismissed");
+}
+
+- (void)testTouchesEndedNotDispatchedWhenFlutterVCIsBeingDismissed {
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerBeingDismissed];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseEnded;
+  UIEvent* event = nil;
+  [vc touchesEnded:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertFalse(vc.touchesDispatched,
+                 @"touchesEnded must not dispatch to Flutter while FlutterViewController is being "
+                 @"dismissed");
+}
+
+- (void)testTouchesCancelledNotDispatchedWhenFlutterVCIsBeingDismissed {
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerBeingDismissed];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseCancelled;
+  UIEvent* event = nil;
+  [vc touchesCancelled:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertFalse(vc.touchesDispatched,
+                 @"touchesCancelled must not dispatch to Flutter while FlutterViewController is "
+                 @"being dismissed");
 }
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -358,7 +358,9 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (void)sceneWillEnterForeground:(NSNotification*)notification API_AVAILABLE(ios(13.0));
 - (void)triggerTouchRateCorrectionIfNeeded:(NSSet*)touches;
 - (void)onAccessibilityStatusChanged:(NSNotification*)notification;
-- (void)dispatchTouches:(NSSet*)touches pointerDataChangeOverride:(void*)overridden_change event:(UIEvent*)event;
+- (void)dispatchTouches:(NSSet*)touches
+    pointerDataChangeOverride:(void*)overridden_change
+                        event:(UIEvent*)event;
 @end
 
 @interface FlutterViewControllerTest : XCTestCase
@@ -3118,8 +3120,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
 // Regression tests for https://github.com/flutter/flutter/issues/14720
 
-- (FlutterViewControllerDispatchTouchesSpy*)
-    spyViewControllerWithPresentedViewController:(UIViewController*)presentedVC {
+- (FlutterViewControllerDispatchTouchesSpy*)spyViewControllerWithPresentedViewController:
+    (UIViewController*)presentedVC {
   FlutterViewControllerDispatchTouchesSpy* vc =
       [[FlutterViewControllerDispatchTouchesSpy alloc] initWithEngine:self.mockEngine
                                                               nibName:nil

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -374,8 +374,6 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
 @end
 
-// Spy subclass for testing touch dispatch blocking when a native VC is presented or when
-// FlutterViewController itself is being dismissed.
 // Overrides dispatchTouches:pointerDataChangeOverride:event: with void* for the C++ pointer
 // parameter so ObjC selector dispatch matches without pulling in flutter::PointerData types.
 // Does not call super to avoid crashing on raw UITouch stubs in the loop body.
@@ -395,8 +393,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (void)dispatchTouches:(NSSet*)touches
     pointerDataChangeOverride:(void*)overridden_change
                         event:(UIEvent*)event {
-  // Record that dispatch was attempted; do not call super to avoid processing
-  // raw UITouch stubs that would crash in the loop body.
+  // Do not call super — raw UITouch stubs crash in the dispatch loop body.
   self.touchesDispatched = YES;
 }
 @end
@@ -3121,8 +3118,6 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 // Regression tests for https://github.com/flutter/flutter/issues/14720
-// Touches must not be dispatched to Flutter when a native UIViewController is
-// presented on top of FlutterViewController via presentViewController:animated:completion:.
 
 - (FlutterViewControllerDispatchTouchesSpy*)
     spyViewControllerWithPresentedViewController:(UIViewController*)presentedVC {
@@ -3178,9 +3173,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                  @"touchesCancelled must not dispatch to Flutter when a native VC is presented");
 }
 
-// Regression tests for isBeingDismissed guard (companion to presentedViewController guard above).
-// Touches must not be dispatched to Flutter while FlutterViewController itself is being dismissed
-// (i.e. during its own disappearance animation).
+// Regression tests for the isBeingDismissed guard.
 
 - (FlutterViewControllerDispatchTouchesSpy*)spyViewControllerBeingDismissed {
   FlutterViewControllerDispatchTouchesSpy* vc =

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -358,6 +358,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (void)sceneWillEnterForeground:(NSNotification*)notification API_AVAILABLE(ios(13.0));
 - (void)triggerTouchRateCorrectionIfNeeded:(NSSet*)touches;
 - (void)onAccessibilityStatusChanged:(NSNotification*)notification;
+- (void)dispatchTouches:(NSSet*)touches pointerDataChangeOverride:(void*)overridden_change event:(UIEvent*)event;
 @end
 
 @interface FlutterViewControllerTest : XCTestCase
@@ -371,6 +372,28 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
 @property(nonatomic, readwrite) UITouchPhase phase;
 
+@end
+
+// Spy subclass for testing touch dispatch blocking when a native VC is presented.
+// Overrides dispatchTouches:pointerDataChangeOverride:event: with void* for the C++ pointer
+// parameter so ObjC selector dispatch matches without pulling in flutter::PointerData types.
+// Does not call super to avoid crashing on raw UITouch stubs in the loop body.
+@interface FlutterViewControllerDispatchTouchesSpy : FlutterViewController
+@property(nonatomic) BOOL touchesDispatched;
+@property(nonatomic, strong) UIViewController* stubbedPresentedViewController;
+@end
+
+@implementation FlutterViewControllerDispatchTouchesSpy
+- (UIViewController*)presentedViewController {
+  return self.stubbedPresentedViewController;
+}
+- (void)dispatchTouches:(NSSet*)touches
+    pointerDataChangeOverride:(void*)overridden_change
+                        event:(UIEvent*)event {
+  // Record that dispatch was attempted; do not call super to avoid processing
+  // raw UITouch stubs that would crash in the loop body.
+  self.touchesDispatched = YES;
+}
 @end
 
 @implementation FlutterViewControllerTest
@@ -3090,6 +3113,64 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   XCTAssertNotNil(flutterViewController.engine);
   XCTAssertNotEqual(flutterViewController.engine, self.mockEngine);
   [appDelegate setMockLaunchEngine:nil];
+}
+
+// Regression tests for https://github.com/flutter/flutter/issues/14720
+// Touches must not be dispatched to Flutter when a native UIViewController is
+// presented on top of FlutterViewController via presentViewController:animated:completion:.
+
+- (FlutterViewControllerDispatchTouchesSpy*)
+    spyViewControllerWithPresentedViewController:(UIViewController*)presentedVC {
+  FlutterViewControllerDispatchTouchesSpy* vc =
+      [[FlutterViewControllerDispatchTouchesSpy alloc] initWithEngine:self.mockEngine
+                                                              nibName:nil
+                                                               bundle:nil];
+  vc.stubbedPresentedViewController = presentedVC;
+  return vc;
+}
+
+- (void)testTouchesBeganNotDispatchedWhenNativeVCPresented {
+  FlutterViewControllerDispatchTouchesSpy* vc =
+      [self spyViewControllerWithPresentedViewController:[[UIViewController alloc] init]];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseBegan;
+  UIEvent* event = nil;  // nil via variable suppresses -Wnonnull; event is unused by the fix path
+  [vc touchesBegan:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertFalse(vc.touchesDispatched,
+                 @"touchesBegan must not dispatch to Flutter when a native VC is presented");
+}
+
+- (void)testTouchesMovedNotDispatchedWhenNativeVCPresented {
+  FlutterViewControllerDispatchTouchesSpy* vc =
+      [self spyViewControllerWithPresentedViewController:[[UIViewController alloc] init]];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseMoved;
+  UIEvent* event = nil;
+  [vc touchesMoved:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertFalse(vc.touchesDispatched,
+                 @"touchesMoved must not dispatch to Flutter when a native VC is presented");
+}
+
+- (void)testTouchesEndedNotDispatchedWhenNativeVCPresented {
+  FlutterViewControllerDispatchTouchesSpy* vc =
+      [self spyViewControllerWithPresentedViewController:[[UIViewController alloc] init]];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseEnded;
+  UIEvent* event = nil;
+  [vc touchesEnded:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertFalse(vc.touchesDispatched,
+                 @"touchesEnded must not dispatch to Flutter when a native VC is presented");
+}
+
+- (void)testTouchesCancelledNotDispatchedWhenNativeVCPresented {
+  FlutterViewControllerDispatchTouchesSpy* vc =
+      [self spyViewControllerWithPresentedViewController:[[UIViewController alloc] init]];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseCancelled;
+  UIEvent* event = nil;
+  [vc touchesCancelled:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertFalse(vc.touchesDispatched,
+                 @"touchesCancelled must not dispatch to Flutter when a native VC is presented");
 }
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -359,7 +359,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (void)triggerTouchRateCorrectionIfNeeded:(NSSet*)touches;
 - (void)onAccessibilityStatusChanged:(NSNotification*)notification;
 - (void)dispatchTouches:(NSSet*)touches
-    pointerDataChangeOverride:(void*)overridden_change
+    pointerDataChangeOverride:(flutter::PointerData::Change*)overridden_change
                         event:(UIEvent*)event;
 @end
 
@@ -376,8 +376,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
 @end
 
-// Overrides dispatchTouches:pointerDataChangeOverride:event: with void* for the C++ pointer
-// parameter so ObjC selector dispatch matches without pulling in flutter::PointerData types.
+// Records whether dispatchTouches:pointerDataChangeOverride:event: was invoked, while still
+// calling super so the real dispatch pipeline (touch -> PointerDataPacket -> engine) is exercised.
 @interface FlutterViewControllerDispatchTouchesSpy : FlutterViewController
 @property(nonatomic) BOOL touchesDispatched;
 @property(nonatomic, strong) UIViewController* stubbedPresentedViewController;
@@ -392,9 +392,9 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   return self.stubbedIsBeingDismissed;
 }
 - (void)dispatchTouches:(NSSet*)touches
-    pointerDataChangeOverride:(void*)overridden_change
+    pointerDataChangeOverride:(flutter::PointerData::Change*)overridden_change
                         event:(UIEvent*)event {
-  // Do not call super — raw UITouch stubs crash in the dispatch loop body.
+  [super dispatchTouches:touches pointerDataChangeOverride:overridden_change event:event];
   self.touchesDispatched = YES;
 }
 @end
@@ -3172,6 +3172,55 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [vc touchesCancelled:[NSSet setWithObject:touch] withEvent:event];
   XCTAssertFalse(vc.touchesDispatched,
                  @"touchesCancelled must not dispatch to Flutter when a native VC is presented");
+}
+
+// Positive-path controls for the tests above: verifies the guard only blocks dispatch when
+// something is actually presented / being dismissed, not unconditionally.
+
+- (FlutterViewControllerDispatchTouchesSpy*)spyViewControllerNotPresented {
+  return [[FlutterViewControllerDispatchTouchesSpy alloc] initWithEngine:self.mockEngine
+                                                                 nibName:nil
+                                                                  bundle:nil];
+}
+
+- (void)testTouchesBeganDispatchedWhenNothingPresented {
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerNotPresented];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseBegan;
+  UIEvent* event = nil;
+  [vc touchesBegan:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertTrue(vc.touchesDispatched,
+                @"touchesBegan must dispatch to Flutter when nothing is presented");
+}
+
+- (void)testTouchesMovedDispatchedWhenNothingPresented {
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerNotPresented];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseMoved;
+  UIEvent* event = nil;
+  [vc touchesMoved:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertTrue(vc.touchesDispatched,
+                @"touchesMoved must dispatch to Flutter when nothing is presented");
+}
+
+- (void)testTouchesEndedDispatchedWhenNothingPresented {
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerNotPresented];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseEnded;
+  UIEvent* event = nil;
+  [vc touchesEnded:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertTrue(vc.touchesDispatched,
+                @"touchesEnded must dispatch to Flutter when nothing is presented");
+}
+
+- (void)testTouchesCancelledDispatchedWhenNothingPresented {
+  FlutterViewControllerDispatchTouchesSpy* vc = [self spyViewControllerNotPresented];
+  UITouch* touch = [[UITouch alloc] init];
+  touch.phase = UITouchPhaseCancelled;
+  UIEvent* event = nil;
+  [vc touchesCancelled:[NSSet setWithObject:touch] withEvent:event];
+  XCTAssertTrue(vc.touchesDispatched,
+                @"touchesCancelled must dispatch to Flutter when nothing is presented");
 }
 
 // Regression tests for the isBeingDismissed guard.


### PR DESCRIPTION
Fixed touch passthrough when a native `UIViewController` is presented on top of a `FlutterViewController`. Previously, `FlutterViewController` dispatched touches to Flutter even when a native `UIViewController` was presented via `presentViewController:` or while it was being dismissed, causing ghost interactions on the Flutter layer underneath.

Added a guard to all four touch methods (`touchesBegan:`, `touchesMoved:`, `touchesEnded:`, `touchesCancelled:`) that drops touches while `presentedViewController != nil` or `isBeingDismissed`. Also added a new `shouldIgnoreTouchesWhenPresented` property (default `YES`) so apps that intentionally present a `UIViewController` not covering the whole screen, and rely on Flutter continuing to receive touches while it's presented, can opt out of the new guard.

Fixes #14720
Related: #35784 (closed as a duplicate of #14720; same root cause)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
