### PR TITLE
Migrate the shell unit tests from legacy Dart native functions to FFI

### DIFF
--- a/engine/src/flutter/shell/common/animator_unittests.cc
+++ b/engine/src/flutter/shell/common/animator_unittests.cc
@@ -57,14 +57,12 @@ TEST_F(ShellTest, VSyncTargetTime) {
   int64_t target_time;
   fml::AutoResetWaitableEvent on_target_time_latch;
   auto nativeOnBeginFrame = [&on_target_time_latch,
-                             &target_time](Dart_NativeArguments args) {
-    Dart_Handle exception = nullptr;
-    target_time =
-        tonic::DartConverter<int64_t>::FromArguments(args, 0, exception);
+                             &target_time](int64_t microseconds) {
+    target_time = microseconds;
     on_target_time_latch.Signal();
   };
-  AddNativeCallback("NativeOnBeginFrame",
-                    CREATE_NATIVE_ENTRY(nativeOnBeginFrame));
+  AddFfiNativeCallback("NativeOnBeginFrame",
+                       CREATE_FFI_LAMBDA(nativeOnBeginFrame));
 
   // Create all te prerequisites for a shell.
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());

--- a/engine/src/flutter/shell/common/dart_native_benchmarks.cc
+++ b/engine/src/flutter/shell/common/dart_native_benchmarks.cc
@@ -35,10 +35,8 @@ BENCHMARK_F(DartNativeBenchmarks, TimeToFirstNativeMessageFromIsolateInNewVM)
     fml::AutoResetWaitableEvent latch;
     st.PauseTiming();
     ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-    AddNativeCallback("NotifyNative",
-                      CREATE_NATIVE_ENTRY(([&latch](Dart_NativeArguments args) {
-                        latch.Signal();
-                      })));
+    AddFfiNativeCallback("NotifyNative",
+                         CREATE_FFI_LAMBDA(([&latch]() { latch.Signal(); })));
 
     const auto settings = CreateSettingsForFixture();
     DartVMRef vm_ref = DartVMRef::Create(settings);
@@ -72,10 +70,8 @@ BENCHMARK_F(DartNativeBenchmarks, MultipleDartToNativeMessages)
     fml::CountDownLatch latch(1000);
     st.PauseTiming();
     ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-    AddNativeCallback("NotifyNative",
-                      CREATE_NATIVE_ENTRY(([&latch](Dart_NativeArguments args) {
-                        latch.CountDown();
-                      })));
+    AddFfiNativeCallback(
+        "NotifyNative", CREATE_FFI_LAMBDA(([&latch]() { latch.CountDown(); })));
 
     const auto settings = CreateSettingsForFixture();
     DartVMRef vm_ref = DartVMRef::Create(settings);

--- a/engine/src/flutter/shell/common/engine_animator_unittests.cc
+++ b/engine/src/flutter/shell/common/engine_animator_unittests.cc
@@ -303,7 +303,8 @@ TEST_F(EngineAnimatorTest, AnimatorAcceptsMultipleRenders) {
       });
 
   native_latch.Reset();
-  AddNativeCallback("NotifyNative", [](auto args) { native_latch.Signal(); });
+  AddFfiNativeCallback("NotifyNative",
+                       CREATE_FFI_LAMBDA([]() { native_latch.Signal(); }));
 
   std::unique_ptr<Animator> animator;
   PostSync(task_runners_.GetUITaskRunner(),
@@ -395,8 +396,7 @@ TEST_F(EngineAnimatorTest, IgnoresDuplicateRenders) {
   std::unique_ptr<EngineContext> engine_context;
 
   std::vector<std::shared_ptr<Layer>> benchmark_layers;
-  auto capture_root_layer = [&benchmark_layers](Dart_NativeArguments args) {
-    auto handle = Dart_GetNativeArgument(args, 0);
+  auto capture_root_layer = [&benchmark_layers](Dart_Handle handle) {
     intptr_t peer = 0;
     Dart_Handle result = Dart_GetNativeInstanceField(
         handle, tonic::DartWrappable::kPeerIndex, &peer);
@@ -438,8 +438,8 @@ TEST_F(EngineAnimatorTest, IgnoresDuplicateRenders) {
         });
       });
 
-  AddNativeCallback("CaptureRootLayer",
-                    CREATE_NATIVE_ENTRY(capture_root_layer));
+  AddFfiNativeCallback("CaptureRootLayer",
+                       CREATE_FFI_LAMBDA(capture_root_layer));
 
   std::unique_ptr<Animator> animator;
   PostSync(task_runners_.GetUITaskRunner(),
@@ -506,11 +506,11 @@ TEST_F(EngineAnimatorTest, AnimatorSubmitsImplicitViewBeforeDrawFrameEnds) {
 
   native_latch.Reset();
   // The native_latch is signaled at the end of handleDrawFrame.
-  AddNativeCallback("NotifyNative",
-                    CREATE_NATIVE_ENTRY([&rasterization_started](auto args) {
-                      EXPECT_EQ(rasterization_started, true);
-                      native_latch.Signal();
-                    }));
+  AddFfiNativeCallback("NotifyNative",
+                       CREATE_FFI_LAMBDA([&rasterization_started]() {
+                         EXPECT_EQ(rasterization_started, true);
+                         native_latch.Signal();
+                       }));
 
   engine_context = EngineContext::Create(delegate_, settings_, task_runners_,
                                          std::move(animator));

--- a/engine/src/flutter/shell/common/fixtures/shell_test.dart
+++ b/engine/src/flutter/shell/common/fixtures/shell_test.dart
@@ -6,6 +6,7 @@
 
 import 'dart:async';
 import 'dart:convert' show json, utf8;
+import 'dart:ffi';
 import 'dart:isolate';
 import 'dart:typed_data';
 import 'dart:ui';
@@ -23,11 +24,11 @@ void mainNotifyNative() {
   notifyNative();
 }
 
-@pragma('vm:external-name', 'NativeReportTimingsCallback')
+@Native<Void Function(Handle)>(symbol: 'NativeReportTimingsCallback')
 external void nativeReportTimingsCallback(List<int> timings);
-@pragma('vm:external-name', 'NativeOnBeginFrame')
+@Native<Void Function(Int64)>(symbol: 'NativeOnBeginFrame')
 external void nativeOnBeginFrame(int microseconds);
-@pragma('vm:external-name', 'NativeOnPointerDataPacket')
+@Native<Void Function(Handle)>(symbol: 'NativeOnPointerDataPacket')
 external void nativeOnPointerDataPacket(List<int> sequences);
 
 @pragma('vm:entry-point')
@@ -50,9 +51,9 @@ void onErrorB() {
   throw Exception('I should be coming from B');
 }
 
-@pragma('vm:external-name', 'NotifyErrorA')
+@Native<Void Function(Handle)>(symbol: 'NotifyErrorA')
 external void notifyErrorA(String message);
-@pragma('vm:external-name', 'NotifyErrorB')
+@Native<Void Function(Handle)>(symbol: 'NotifyErrorB')
 external void notifyErrorB(String message);
 
 @pragma('vm:entry-point')
@@ -120,7 +121,7 @@ void reportMetrics() {
   };
 }
 
-@pragma('vm:external-name', 'ReportMetrics')
+@Native<Void Function(Double, Double, Double)>(symbol: 'ReportMetrics')
 external void _reportMetrics(double devicePixelRatio, double width, double height);
 
 @pragma('vm:entry-point')
@@ -133,11 +134,11 @@ void fixturesAreFunctionalMain() {
   sayHiFromFixturesAreFunctionalMain();
 }
 
-@pragma('vm:external-name', 'SayHiFromFixturesAreFunctionalMain')
+@Native<Void Function()>(symbol: 'SayHiFromFixturesAreFunctionalMain')
 external void sayHiFromFixturesAreFunctionalMain();
 
 @pragma('vm:entry-point')
-@pragma('vm:external-name', 'NotifyNative')
+@Native<Void Function()>(symbol: 'NotifyNative')
 external void notifyNative();
 
 @pragma('vm:entry-point')
@@ -184,7 +185,7 @@ void testSkiaResourceCacheSendsResponse() {
   );
 }
 
-@pragma('vm:external-name', 'NotifyWidthHeight')
+@Native<Void Function(Int, Int)>(symbol: 'NotifyWidthHeight')
 external void notifyWidthHeight(int width, int height);
 
 @pragma('vm:entry-point')
@@ -215,7 +216,7 @@ void performanceModeImpactsNotifyIdle() {
   PlatformDispatcher.instance.requestDartPerformanceMode(DartPerformanceMode.balanced);
 }
 
-@pragma('vm:external-name', 'NotifyMessage')
+@Native<Void Function(Handle)>(symbol: 'NotifyMessage')
 external void notifyMessage(String string);
 
 @pragma('vm:entry-point')
@@ -229,10 +230,10 @@ void canRegisterImageDecoders() {
   );
 }
 
-@pragma('vm:external-name', 'NotifyLocalTime')
+@Native<Void Function(Handle)>(symbol: 'NotifyLocalTime')
 external void notifyLocalTime(String string);
 
-@pragma('vm:external-name', 'WaitFixture')
+@Native<Bool Function()>(symbol: 'WaitFixture')
 external bool waitFixture();
 
 // Return local date-time as a string, to an hour resolution.  So, "2020-07-23
@@ -258,10 +259,10 @@ void timezonesChange() {
   } while (waitFixture());
 }
 
-@pragma('vm:external-name', 'NotifyCanAccessResource')
+@Native<Void Function(Bool)>(symbol: 'NotifyCanAccessResource')
 external void notifyCanAccessResource(bool success);
 
-@pragma('vm:external-name', 'NotifySetAssetBundlePath')
+@Native<Void Function()>(symbol: 'NotifySetAssetBundlePath')
 external void notifySetAssetBundlePath();
 
 @pragma('vm:entry-point')
@@ -276,10 +277,10 @@ Future<void> canAccessResourceFromAssetDir() async {
   );
 }
 
-@pragma('vm:external-name', 'NotifyNativeWhenEngineRun')
+@Native<Void Function(Bool)>(symbol: 'NotifyNativeWhenEngineRun')
 external void notifyNativeWhenEngineRun(bool success);
 
-@pragma('vm:external-name', 'NotifyNativeWhenEngineSpawn')
+@Native<Void Function(Bool)>(symbol: 'NotifyNativeWhenEngineSpawn')
 external void notifyNativeWhenEngineSpawn(bool success);
 
 @pragma('vm:entry-point')
@@ -307,7 +308,7 @@ void frameCallback(Object? image, int durationMilliseconds, String decodeError) 
   }
 }
 
-@pragma('vm:external-name', 'NativeOnBeforeToImageSync')
+@Native<Void Function()>(symbol: 'NativeOnBeforeToImageSync')
 external void onBeforeToImageSync();
 
 @pragma('vm:entry-point')
@@ -373,7 +374,7 @@ Future<void> runCallback(IsolateParam param) async {
 }
 
 @pragma('vm:entry-point')
-@pragma('vm:external-name', 'NotifyNativeBool')
+@Native<Void Function(Bool)>(symbol: 'NotifyNativeBool')
 external void notifyNativeBool(bool value);
 
 @pragma('vm:entry-point')
@@ -419,7 +420,7 @@ Future<void> testThatAssetLoadingHappensOnWorkerThread() async {
   notifyNative();
 }
 
-@pragma('vm:external-name', 'NativeReportViewIdsCallback')
+@Native<Void Function(Bool, Handle)>(symbol: 'NativeReportViewIdsCallback')
 external void nativeReportViewIdsCallback(bool hasImplicitView, List<int> viewIds);
 
 List<int> getCurrentViewIds() {
@@ -468,7 +469,7 @@ List<int> getCurrentViewWidths() {
   return result;
 }
 
-@pragma('vm:external-name', 'NativeReportViewWidthsCallback')
+@Native<Void Function(Handle)>(symbol: 'NativeReportViewWidthsCallback')
 external void nativeReportViewWidthsCallback(List<int> viewWidthPacket);
 
 // This entrypoint reports the list of views and their widths using
@@ -513,7 +514,7 @@ void renderViewsInFrameAndOutOfFrame() {
   PlatformDispatcher.instance.scheduleFrame();
 }
 
-@pragma('vm:external-name', 'CaptureRootLayer')
+@Native<Void Function(Handle)>(symbol: 'CaptureRootLayer')
 external void _captureRootLayer(SceneBuilder sceneBuilder);
 
 @pragma('vm:entry-point')
@@ -634,7 +635,7 @@ void testSendViewFocusEvent() {
   notifyNative();
 }
 
-@pragma('vm:external-name', 'ReportEngineId')
+@Native<Void Function(Handle)>(symbol: 'ReportEngineId')
 external void _reportEngineId(int? identifier);
 
 @pragma('vm:entry-point')

--- a/engine/src/flutter/shell/common/input_events_unittests.cc
+++ b/engine/src/flutter/shell/common/input_events_unittests.cc
@@ -329,7 +329,6 @@ TEST_F(ShellTest, CanCorrectlyPipePointerPacket) {
   std::vector<int64_t> result_sequence;
   auto nativeOnPointerDataPacket = [&reportLatch,
                                     &result_sequence](Dart_Handle sequences) {
-    Dart_Handle exception = nullptr;
     result_sequence =
         tonic::DartConverter<std::vector<int64_t>>::FromDart(sequences);
     reportLatch.Signal();
@@ -394,7 +393,6 @@ TEST_F(ShellTest, CanCorrectlySynthesizePointerPacket) {
   std::vector<int64_t> result_sequence;
   auto nativeOnPointerDataPacket = [&reportLatch,
                                     &result_sequence](Dart_Handle sequences) {
-    Dart_Handle exception = nullptr;
     result_sequence =
         tonic::DartConverter<std::vector<int64_t>>::FromDart(sequences);
     reportLatch.Signal();

--- a/engine/src/flutter/shell/common/input_events_unittests.cc
+++ b/engine/src/flutter/shell/common/input_events_unittests.cc
@@ -79,7 +79,7 @@ static void TestSimulatedInputEvents(
   int frame_drawn = 0;
   auto nativeOnPointerDataPacket = [&events_consumed_at_frame,
                                     &will_draw_new_frame, &events_consumed,
-                                    &frame_drawn](Dart_NativeArguments args) {
+                                    &frame_drawn](Dart_Handle sequences) {
     events_consumed += 1;
     if (will_draw_new_frame) {
       frame_drawn += 1;
@@ -89,8 +89,8 @@ static void TestSimulatedInputEvents(
       events_consumed_at_frame.back() = events_consumed;
     }
   };
-  fixture->AddNativeCallback("NativeOnPointerDataPacket",
-                             CREATE_NATIVE_ENTRY(nativeOnPointerDataPacket));
+  fixture->AddFfiNativeCallback("NativeOnPointerDataPacket",
+                                CREATE_FFI_LAMBDA(nativeOnPointerDataPacket));
 
   ASSERT_TRUE(configuration.IsValid());
   fixture->RunEngine(shell.get(), std::move(configuration));
@@ -327,16 +327,16 @@ TEST_F(ShellTest, CanCorrectlyPipePointerPacket) {
   // Sets up native handler.
   fml::AutoResetWaitableEvent reportLatch;
   std::vector<int64_t> result_sequence;
-  auto nativeOnPointerDataPacket = [&reportLatch, &result_sequence](
-                                       Dart_NativeArguments args) {
+  auto nativeOnPointerDataPacket = [&reportLatch,
+                                    &result_sequence](Dart_Handle sequences) {
     Dart_Handle exception = nullptr;
-    result_sequence = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-        args, 0, exception);
+    result_sequence =
+        tonic::DartConverter<std::vector<int64_t>>::FromDart(sequences);
     reportLatch.Signal();
   };
   // Starts engine.
-  AddNativeCallback("NativeOnPointerDataPacket",
-                    CREATE_NATIVE_ENTRY(nativeOnPointerDataPacket));
+  AddFfiNativeCallback("NativeOnPointerDataPacket",
+                       CREATE_FFI_LAMBDA(nativeOnPointerDataPacket));
   ASSERT_TRUE(configuration.IsValid());
   RunEngine(shell.get(), std::move(configuration));
   // Starts test.
@@ -392,16 +392,16 @@ TEST_F(ShellTest, CanCorrectlySynthesizePointerPacket) {
   // Sets up native handler.
   fml::AutoResetWaitableEvent reportLatch;
   std::vector<int64_t> result_sequence;
-  auto nativeOnPointerDataPacket = [&reportLatch, &result_sequence](
-                                       Dart_NativeArguments args) {
+  auto nativeOnPointerDataPacket = [&reportLatch,
+                                    &result_sequence](Dart_Handle sequences) {
     Dart_Handle exception = nullptr;
-    result_sequence = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-        args, 0, exception);
+    result_sequence =
+        tonic::DartConverter<std::vector<int64_t>>::FromDart(sequences);
     reportLatch.Signal();
   };
   // Starts engine.
-  AddNativeCallback("NativeOnPointerDataPacket",
-                    CREATE_NATIVE_ENTRY(nativeOnPointerDataPacket));
+  AddFfiNativeCallback("NativeOnPointerDataPacket",
+                       CREATE_FFI_LAMBDA(nativeOnPointerDataPacket));
   ASSERT_TRUE(configuration.IsValid());
   RunEngine(shell.get(), std::move(configuration));
   // Starts test.

--- a/engine/src/flutter/shell/common/shell_fuchsia_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_fuchsia_unittests.cc
@@ -173,22 +173,21 @@ TEST_F(FuchsiaShellTest, LocaltimesVaryOnTimezoneChanges) {
   // there.
   fml::AutoResetWaitableEvent latch;
   std::string dart_isolate_time_str;
-  AddNativeCallback("NotifyLocalTime", CREATE_NATIVE_ENTRY([&](auto args) {
-                      dart_isolate_time_str =
-                          tonic::DartConverter<std::string>::FromDart(
-                              Dart_GetNativeArgument(args, 0));
-                      latch.Signal();
-                    }));
+  AddFfiNativeCallback(
+      "NotifyLocalTime", CREATE_FFI_LAMBDA([&](Dart_Handle string_handle) {
+        dart_isolate_time_str =
+            tonic::DartConverter<std::string>::FromDart(string_handle);
+        latch.Signal();
+      }));
 
   // As long as this is set, the isolate will keep rerunning its only task.
   bool continue_fixture = true;
   fml::AutoResetWaitableEvent fixture_latch;
-  AddNativeCallback("WaitFixture", CREATE_NATIVE_ENTRY([&](auto args) {
-                      // Wait for the test fixture to advance.
-                      fixture_latch.Wait();
-                      tonic::DartConverter<bool>::SetReturnValue(
-                          args, continue_fixture);
-                    }));
+  AddFfiNativeCallback("WaitFixture", CREATE_FFI_LAMBDA([&]() {
+                         // Wait for the test fixture to advance.
+                         fixture_latch.Wait();
+                         return continue_fixture;
+                       }));
 
   auto settings = CreateSettingsForFixture();
   auto configuration = RunConfiguration::InferFromSettings(settings);

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -3976,17 +3976,17 @@ TEST_F(ShellTest, SpawnWorksWithOnError) {
 
   AddFfiNativeCallback(
       "NotifyErrorA", CREATE_FFI_LAMBDA([&](Dart_Handle string_handle) {
-        const char* c_str;
-        Dart_StringToCString(string_handle, &c_str);
-        EXPECT_STREQ(c_str, "Exception: I should be coming from A");
+        const auto message =
+            tonic::DartConverter<std::string>::FromDart(string_handle);
+        EXPECT_EQ(message, "Exception: I should be coming from A");
         latch.CountDown();
       }));
 
   AddFfiNativeCallback(
       "NotifyErrorB", CREATE_FFI_LAMBDA([&](Dart_Handle string_handle) {
-        const char* c_str;
-        Dart_StringToCString(string_handle, &c_str);
-        EXPECT_STREQ(c_str, "Exception: I should be coming from B");
+        const auto message =
+            tonic::DartConverter<std::string>::FromDart(string_handle);
+        EXPECT_EQ(message, "Exception: I should be coming from B");
         latch.CountDown();
       }));
 

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -592,9 +592,9 @@ TEST_F(ShellTest, FixturesAreFunctional) {
   configuration.SetEntrypoint("fixturesAreFunctionalMain");
 
   fml::AutoResetWaitableEvent main_latch;
-  AddNativeCallback(
+  AddFfiNativeCallback(
       "SayHiFromFixturesAreFunctionalMain",
-      CREATE_NATIVE_ENTRY([&main_latch](auto args) { main_latch.Signal(); }));
+      CREATE_FFI_LAMBDA([&main_latch]() { main_latch.Signal(); }));
 
   RunEngine(shell.get(), std::move(configuration));
   main_latch.Wait();
@@ -682,9 +682,8 @@ TEST_F(ShellTest, SecondaryIsolateBindingsAreSetupViaShellSettings) {
   configuration.SetEntrypoint("testCanLaunchSecondaryIsolate");
 
   fml::CountDownLatch latch(2);
-  AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&latch](auto args) {
-                      latch.CountDown();
-                    }));
+  AddFfiNativeCallback("NotifyNative",
+                       CREATE_FFI_LAMBDA([&latch]() { latch.CountDown(); }));
 
   RunEngine(shell.get(), std::move(configuration));
 
@@ -708,8 +707,8 @@ TEST_F(ShellTest, LastEntrypoint) {
 
   fml::AutoResetWaitableEvent main_latch;
   std::string last_entry_point;
-  AddNativeCallback(
-      "SayHiFromFixturesAreFunctionalMain", CREATE_NATIVE_ENTRY([&](auto args) {
+  AddFfiNativeCallback(
+      "SayHiFromFixturesAreFunctionalMain", CREATE_FFI_LAMBDA([&]() {
         last_entry_point = shell->GetEngine()->GetLastEntrypoint();
         main_latch.Signal();
       }));
@@ -737,8 +736,8 @@ TEST_F(ShellTest, LastEntrypointArgs) {
 
   fml::AutoResetWaitableEvent main_latch;
   std::vector<std::string> last_entry_point_args;
-  AddNativeCallback(
-      "SayHiFromFixturesAreFunctionalMain", CREATE_NATIVE_ENTRY([&](auto args) {
+  AddFfiNativeCallback(
+      "SayHiFromFixturesAreFunctionalMain", CREATE_FFI_LAMBDA([&]() {
         last_entry_point_args = shell->GetEngine()->GetLastEntrypointArgs();
         main_latch.Signal();
       }));
@@ -879,16 +878,14 @@ TEST_F(ShellTest, ReportTimingsIsCalled) {
   configuration.SetEntrypoint("reportTimingsMain");
   fml::AutoResetWaitableEvent reportLatch;
   std::vector<int64_t> timestamps;
-  auto nativeTimingCallback = [&reportLatch,
-                               &timestamps](Dart_NativeArguments args) {
-    Dart_Handle exception = nullptr;
+  auto nativeTimingCallback = [&reportLatch, &timestamps](Dart_Handle timings) {
     ASSERT_EQ(timestamps.size(), 0ul);
-    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-        args, 0, exception);
+    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromDart(timings);
     reportLatch.Signal();
   };
-  AddNativeCallback("NativeReportTimingsCallback",
-                    CREATE_NATIVE_ENTRY(nativeTimingCallback));
+  AddFfiNativeCallback("NativeReportTimingsCallback",
+                       CREATE_FFI_LAMBDA(nativeTimingCallback));
+
   RunEngine(shell.get(), std::move(configuration));
 
   // Pump many frames so we can trigger the report quickly instead of waiting
@@ -952,13 +949,11 @@ TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
   configuration.SetEntrypoint("onBeginFrameMain");
 
   int64_t frame_target_time;
-  auto nativeOnBeginFrame = [&frame_target_time](Dart_NativeArguments args) {
-    Dart_Handle exception = nullptr;
-    frame_target_time =
-        tonic::DartConverter<int64_t>::FromArguments(args, 0, exception);
+  auto nativeOnBeginFrame = [&frame_target_time](int64_t microseconds) {
+    frame_target_time = microseconds;
   };
-  AddNativeCallback("NativeOnBeginFrame",
-                    CREATE_NATIVE_ENTRY(nativeOnBeginFrame));
+  AddFfiNativeCallback("NativeOnBeginFrame",
+                       CREATE_FFI_LAMBDA(nativeOnBeginFrame));
 
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
@@ -1647,16 +1642,13 @@ TEST_F(ShellTest, ReportTimingsIsCalledImmediatelyAfterTheFirstFrame) {
   configuration.SetEntrypoint("reportTimingsMain");
   fml::AutoResetWaitableEvent reportLatch;
   std::vector<int64_t> timestamps;
-  auto nativeTimingCallback = [&reportLatch,
-                               &timestamps](Dart_NativeArguments args) {
-    Dart_Handle exception = nullptr;
+  auto nativeTimingCallback = [&reportLatch, &timestamps](Dart_Handle timings) {
     ASSERT_EQ(timestamps.size(), 0ul);
-    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-        args, 0, exception);
+    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromDart(timings);
     reportLatch.Signal();
   };
-  AddNativeCallback("NativeReportTimingsCallback",
-                    CREATE_NATIVE_ENTRY(nativeTimingCallback));
+  AddFfiNativeCallback("NativeReportTimingsCallback",
+                       CREATE_FFI_LAMBDA(nativeTimingCallback));
   ASSERT_TRUE(configuration.IsValid());
   RunEngine(shell.get(), std::move(configuration));
 
@@ -2091,9 +2083,8 @@ TEST_F(ShellTest, SetResourceCacheSizeNotifiesDart) {
             static_cast<size_t>(3840000U));
 
   fml::AutoResetWaitableEvent latch;
-  AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&latch](auto args) {
-                      latch.Signal();
-                    }));
+  AddFfiNativeCallback("NotifyNative",
+                       CREATE_FFI_LAMBDA([&latch]() { latch.Signal(); }));
 
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
@@ -2121,16 +2112,12 @@ TEST_F(ShellTest, CanCreateImagefromDecompressedBytes) {
   configuration.SetEntrypoint("canCreateImageFromDecompressedData");
 
   fml::AutoResetWaitableEvent latch;
-  AddNativeCallback("NotifyWidthHeight",
-                    CREATE_NATIVE_ENTRY([&latch](auto args) {
-                      auto width = tonic::DartConverter<int>::FromDart(
-                          Dart_GetNativeArgument(args, 0));
-                      auto height = tonic::DartConverter<int>::FromDart(
-                          Dart_GetNativeArgument(args, 1));
-                      ASSERT_EQ(width, 10);
-                      ASSERT_EQ(height, 10);
-                      latch.Signal();
-                    }));
+  AddFfiNativeCallback("NotifyWidthHeight",
+                       CREATE_FFI_LAMBDA([&latch](int width, int height) {
+                         ASSERT_EQ(width, 10);
+                         ASSERT_EQ(height, 10);
+                         latch.Signal();
+                       }));
 
   RunEngine(shell.get(), std::move(configuration));
 
@@ -2226,14 +2213,13 @@ TEST_F(ShellTest, IsolateCanAccessPersistentIsolateData) {
   );
 
   fml::AutoResetWaitableEvent message_latch;
-  AddNativeCallback("NotifyMessage",
-                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      const auto message_from_dart =
-                          tonic::DartConverter<std::string>::FromDart(
-                              Dart_GetNativeArgument(args, 0));
-                      ASSERT_EQ(message, message_from_dart);
-                      message_latch.Signal();
-                    }));
+  AddFfiNativeCallback(
+      "NotifyMessage", CREATE_FFI_LAMBDA([&](Dart_Handle message_handle) {
+        const auto message_from_dart =
+            tonic::DartConverter<std::string>::FromDart(message_handle);
+        ASSERT_EQ(message, message_from_dart);
+        message_latch.Signal();
+      }));
 
   std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
 
@@ -2254,14 +2240,12 @@ TEST_F(ShellTest, CanScheduleFrameFromPlatform) {
   Settings settings = CreateSettingsForFixture();
   TaskRunners task_runners = GetTaskRunnersForFixture();
   fml::AutoResetWaitableEvent latch;
-  AddNativeCallback(
-      "NotifyNative",
-      CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { latch.Signal(); }));
+  AddFfiNativeCallback("NotifyNative",
+                       CREATE_FFI_LAMBDA([&]() { latch.Signal(); }));
   fml::AutoResetWaitableEvent check_latch;
-  AddNativeCallback("NativeOnBeginFrame",
-                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      check_latch.Signal();
-                    }));
+  AddFfiNativeCallback(
+      "NativeOnBeginFrame",
+      CREATE_FFI_LAMBDA([&](int64_t microseconds) { check_latch.Signal(); }));
   std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
   ASSERT_TRUE(shell->IsSetup());
 
@@ -2286,20 +2270,19 @@ TEST_F(ShellTest, SecondaryVsyncCallbackShouldBeCalledAfterVsyncCallback) {
   Settings settings = CreateSettingsForFixture();
   TaskRunners task_runners = GetTaskRunnersForFixture();
   fml::AutoResetWaitableEvent latch;
-  AddNativeCallback(
-      "NotifyNative",
-      CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { latch.Signal(); }));
+  AddFfiNativeCallback("NotifyNative",
+                       CREATE_FFI_LAMBDA([&]() { latch.Signal(); }));
   fml::CountDownLatch count_down_latch(2);
-  AddNativeCallback("NativeOnBeginFrame",
-                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      if (!test_started) {
-                        return;
-                      }
-                      EXPECT_FALSE(is_on_begin_frame_called);
-                      EXPECT_FALSE(is_secondary_callback_called);
-                      is_on_begin_frame_called = true;
-                      count_down_latch.CountDown();
-                    }));
+  AddFfiNativeCallback("NativeOnBeginFrame",
+                       CREATE_FFI_LAMBDA([&](int64_t microseconds) {
+                         if (!test_started) {
+                           return;
+                         }
+                         EXPECT_FALSE(is_on_begin_frame_called);
+                         EXPECT_FALSE(is_secondary_callback_called);
+                         is_on_begin_frame_called = true;
+                         count_down_latch.CountDown();
+                       }));
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
       .task_runners = task_runners,
@@ -2417,12 +2400,12 @@ TEST_F(ShellTest, LocaltimesMatch) {
 
   // See fixtures/shell_test.dart, the callback NotifyLocalTime is declared
   // there.
-  AddNativeCallback("NotifyLocalTime", CREATE_NATIVE_ENTRY([&](auto args) {
-                      dart_isolate_time_str =
-                          tonic::DartConverter<std::string>::FromDart(
-                              Dart_GetNativeArgument(args, 0));
-                      latch.Signal();
-                    }));
+  AddFfiNativeCallback(
+      "NotifyLocalTime", CREATE_FFI_LAMBDA([&](Dart_Handle string_handle) {
+        dart_isolate_time_str =
+            tonic::DartConverter<std::string>::FromDart(string_handle);
+        latch.Signal();
+      }));
 
   auto settings = CreateSettingsForFixture();
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -2492,15 +2475,12 @@ class SinglePixelImageGenerator : public ImageGenerator {
 
 TEST_F(ShellTest, CanRegisterImageDecoders) {
   fml::AutoResetWaitableEvent latch;
-  AddNativeCallback("NotifyWidthHeight", CREATE_NATIVE_ENTRY([&](auto args) {
-                      auto width = tonic::DartConverter<int>::FromDart(
-                          Dart_GetNativeArgument(args, 0));
-                      auto height = tonic::DartConverter<int>::FromDart(
-                          Dart_GetNativeArgument(args, 1));
-                      ASSERT_EQ(width, 1);
-                      ASSERT_EQ(height, 1);
-                      latch.Signal();
-                    }));
+  AddFfiNativeCallback("NotifyWidthHeight",
+                       CREATE_FFI_LAMBDA([&](int width, int height) {
+                         ASSERT_EQ(width, 1);
+                         ASSERT_EQ(height, 1);
+                         latch.Signal();
+                       }));
 
   auto settings = CreateSettingsForFixture();
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -2905,22 +2885,14 @@ TEST_F(ShellTest, IgnoresInvalidMetrics) {
   double last_device_pixel_ratio;
   double last_width;
   double last_height;
-  auto native_report_device_pixel_ratio = [&](Dart_NativeArguments args) {
-    auto dpr_handle = Dart_GetNativeArgument(args, 0);
-    ASSERT_TRUE(Dart_IsDouble(dpr_handle));
-    Dart_DoubleValue(dpr_handle, &last_device_pixel_ratio);
+  auto native_report_device_pixel_ratio = [&](double device_pixel_ratio,
+                                              double width, double height) {
+    last_device_pixel_ratio = device_pixel_ratio;
+    last_width = width;
+    last_height = height;
     ASSERT_FALSE(last_device_pixel_ratio == 0.0);
-
-    auto width_handle = Dart_GetNativeArgument(args, 1);
-    ASSERT_TRUE(Dart_IsDouble(width_handle));
-    Dart_DoubleValue(width_handle, &last_width);
     ASSERT_FALSE(last_width == 0.0);
-
-    auto height_handle = Dart_GetNativeArgument(args, 2);
-    ASSERT_TRUE(Dart_IsDouble(height_handle));
-    Dart_DoubleValue(height_handle, &last_height);
     ASSERT_FALSE(last_height == 0.0);
-
     latch.Signal();
   };
 
@@ -2929,8 +2901,8 @@ TEST_F(ShellTest, IgnoresInvalidMetrics) {
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
 
-  AddNativeCallback("ReportMetrics",
-                    CREATE_NATIVE_ENTRY(native_report_device_pixel_ratio));
+  AddFfiNativeCallback("ReportMetrics",
+                       CREATE_FFI_LAMBDA(native_report_device_pixel_ratio));
 
   std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
 
@@ -2981,11 +2953,10 @@ TEST_F(ShellTest, IgnoresMetricsUpdateToInvalidView) {
   fml::AutoResetWaitableEvent latch;
   double last_device_pixel_ratio;
   // This callback will be called whenever any view's metrics change.
-  auto native_report_device_pixel_ratio = [&](Dart_NativeArguments args) {
+  auto native_report_device_pixel_ratio = [&](double device_pixel_ratio,
+                                              double width, double height) {
     // The correct call will have a DPR of 3.
-    auto dpr_handle = Dart_GetNativeArgument(args, 0);
-    ASSERT_TRUE(Dart_IsDouble(dpr_handle));
-    Dart_DoubleValue(dpr_handle, &last_device_pixel_ratio);
+    last_device_pixel_ratio = device_pixel_ratio;
     ASSERT_TRUE(last_device_pixel_ratio > 2.5);
 
     latch.Signal();
@@ -2996,8 +2967,8 @@ TEST_F(ShellTest, IgnoresMetricsUpdateToInvalidView) {
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
 
-  AddNativeCallback("ReportMetrics",
-                    CREATE_NATIVE_ENTRY(native_report_device_pixel_ratio));
+  AddFfiNativeCallback("ReportMetrics",
+                       CREATE_FFI_LAMBDA(native_report_device_pixel_ratio));
 
   std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
 
@@ -3037,32 +3008,29 @@ TEST_F(ShellTest, OnServiceProtocolSetAssetBundlePathWorks) {
   // Callback used to signal whether the resource was loaded successfully.
   bool can_access_resource = false;
   auto native_can_access_resource = [&can_access_resource,
-                                     &latch](Dart_NativeArguments args) {
-    Dart_Handle exception = nullptr;
-    can_access_resource =
-        tonic::DartConverter<bool>::FromArguments(args, 0, exception);
+                                     &latch](bool success) {
+    can_access_resource = success;
     latch.Signal();
   };
-  AddNativeCallback("NotifyCanAccessResource",
-                    CREATE_NATIVE_ENTRY(native_can_access_resource));
+  AddFfiNativeCallback("NotifyCanAccessResource",
+                       CREATE_FFI_LAMBDA(native_can_access_resource));
 
   // Callback used to delay the asset load until after the service
   // protocol method has finished.
-  auto native_notify_set_asset_bundle_path =
-      [&shell](Dart_NativeArguments args) {
-        // Update the asset directory to a bonus path.
-        ServiceProtocol::Handler::ServiceProtocolMap params;
-        params["assetDirectory"] = "assetDirectory";
-        rapidjson::Document document;
-        OnServiceProtocol(shell.get(), ServiceProtocolEnum::kSetAssetBundlePath,
-                          shell->GetTaskRunners().GetUITaskRunner(), params,
-                          &document);
-        rapidjson::StringBuffer buffer;
-        rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-        document.Accept(writer);
-      };
-  AddNativeCallback("NotifySetAssetBundlePath",
-                    CREATE_NATIVE_ENTRY(native_notify_set_asset_bundle_path));
+  auto native_notify_set_asset_bundle_path = [&shell]() {
+    // Update the asset directory to a bonus path.
+    ServiceProtocol::Handler::ServiceProtocolMap params;
+    params["assetDirectory"] = "assetDirectory";
+    rapidjson::Document document;
+    OnServiceProtocol(shell.get(), ServiceProtocolEnum::kSetAssetBundlePath,
+                      shell->GetTaskRunners().GetUITaskRunner(), params,
+                      &document);
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    document.Accept(writer);
+  };
+  AddFfiNativeCallback("NotifySetAssetBundlePath",
+                       CREATE_FFI_LAMBDA(native_notify_set_asset_bundle_path));
 
   RunEngine(shell.get(), std::move(configuration));
 
@@ -3243,19 +3211,18 @@ TEST_F(ShellTest, Spawn) {
   fml::AutoResetWaitableEvent main_latch;
   std::string last_entry_point;
   // Fulfill native function for the first Shell's entrypoint.
-  AddNativeCallback(
-      "SayHiFromFixturesAreFunctionalMain", CREATE_NATIVE_ENTRY([&](auto args) {
+  AddFfiNativeCallback(
+      "SayHiFromFixturesAreFunctionalMain", CREATE_FFI_LAMBDA([&]() {
         last_entry_point = shell->GetEngine()->GetLastEntrypoint();
         main_latch.Signal();
       }));
   // Fulfill native function for the second Shell's entrypoint.
   fml::CountDownLatch second_latch(2);
-  AddNativeCallback(
+  AddFfiNativeCallback(
       // The Dart native function names aren't very consistent but this is
       // just the native function name of the second vm entrypoint in the
       // fixture.
-      "NotifyNative",
-      CREATE_NATIVE_ENTRY([&](auto args) { second_latch.CountDown(); }));
+      "NotifyNative", CREATE_FFI_LAMBDA([&]() { second_latch.CountDown(); }));
 
   RunEngine(shell.get(), std::move(configuration));
   main_latch.Wait();
@@ -3349,25 +3316,21 @@ TEST_F(ShellTest, SpawnWithDartEntrypointArgs) {
   fml::AutoResetWaitableEvent main_latch;
   std::string last_entry_point;
   // Fulfill native function for the first Shell's entrypoint.
-  AddNativeCallback("NotifyNativeWhenEngineRun",
-                    CREATE_NATIVE_ENTRY(([&](Dart_NativeArguments args) {
-                      ASSERT_TRUE(tonic::DartConverter<bool>::FromDart(
-                          Dart_GetNativeArgument(args, 0)));
-                      last_entry_point =
-                          shell->GetEngine()->GetLastEntrypoint();
-                      main_latch.Signal();
-                    })));
+  AddFfiNativeCallback(
+      "NotifyNativeWhenEngineRun", CREATE_FFI_LAMBDA(([&](bool success) {
+        ASSERT_TRUE(success);
+        last_entry_point = shell->GetEngine()->GetLastEntrypoint();
+        main_latch.Signal();
+      })));
 
   fml::AutoResetWaitableEvent second_latch;
   // Fulfill native function for the second Shell's entrypoint.
-  AddNativeCallback("NotifyNativeWhenEngineSpawn",
-                    CREATE_NATIVE_ENTRY(([&](Dart_NativeArguments args) {
-                      ASSERT_TRUE(tonic::DartConverter<bool>::FromDart(
-                          Dart_GetNativeArgument(args, 0)));
-                      last_entry_point =
-                          shell->GetEngine()->GetLastEntrypoint();
-                      second_latch.Signal();
-                    })));
+  AddFfiNativeCallback(
+      "NotifyNativeWhenEngineSpawn", CREATE_FFI_LAMBDA(([&](bool success) {
+        ASSERT_TRUE(success);
+        last_entry_point = shell->GetEngine()->GetLastEntrypoint();
+        second_latch.Signal();
+      })));
 
   RunEngine(shell.get(), std::move(configuration));
   main_latch.Wait();
@@ -3919,10 +3882,10 @@ TEST_F(ShellTest, UIWorkAfterOnPlatformViewDestroyed) {
 
   fml::AutoResetWaitableEvent latch;
   fml::AutoResetWaitableEvent notify_native_latch;
-  AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&](auto args) {
-                      notify_native_latch.Signal();
-                      latch.Wait();
-                    }));
+  AddFfiNativeCallback("NotifyNative", CREATE_FFI_LAMBDA([&]() {
+                         notify_native_latch.Signal();
+                         latch.Wait();
+                       }));
 
   RunEngine(shell.get(), std::move(configuration));
   // Wait to make sure we get called back from Dart and thus have latched
@@ -4011,18 +3974,16 @@ TEST_F(ShellTest, SpawnWorksWithOnError) {
 
   fml::CountDownLatch latch(2);
 
-  AddNativeCallback(
-      "NotifyErrorA", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-        auto string_handle = Dart_GetNativeArgument(args, 0);
+  AddFfiNativeCallback(
+      "NotifyErrorA", CREATE_FFI_LAMBDA([&](Dart_Handle string_handle) {
         const char* c_str;
         Dart_StringToCString(string_handle, &c_str);
         EXPECT_STREQ(c_str, "Exception: I should be coming from A");
         latch.CountDown();
       }));
 
-  AddNativeCallback(
-      "NotifyErrorB", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-        auto string_handle = Dart_GetNativeArgument(args, 0);
+  AddFfiNativeCallback(
+      "NotifyErrorB", CREATE_FFI_LAMBDA([&](Dart_Handle string_handle) {
         const char* c_str;
         Dart_StringToCString(string_handle, &c_str);
         EXPECT_STREQ(c_str, "Exception: I should be coming from B");
@@ -4071,8 +4032,8 @@ TEST_F(ShellTest, ImmutableBufferLoadsAssetOnBackgroundThread) {
   std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
 
   fml::CountDownLatch latch(1);
-  AddNativeCallback("NotifyNative",
-                    CREATE_NATIVE_ENTRY([&](auto args) { latch.CountDown(); }));
+  AddFfiNativeCallback("NotifyNative",
+                       CREATE_FFI_LAMBDA([&]() { latch.CountDown(); }));
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -4109,18 +4070,17 @@ TEST_F(ShellTest, PictureToImageSync) {
       }),
   });
 
-  AddNativeCallback("NativeOnBeforeToImageSync",
-                    CREATE_NATIVE_ENTRY([&](auto args) {
-                      // nop
-                    }));
+  AddFfiNativeCallback("NativeOnBeforeToImageSync", CREATE_FFI_LAMBDA([&]() {
+                         // nop
+                       }));
 
   fml::CountDownLatch latch(2);
-  AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&](auto args) {
-                      // Teardown and set up rasterizer again.
-                      PlatformViewNotifyDestroyed(shell.get());
-                      PlatformViewNotifyCreated(shell.get());
-                      latch.CountDown();
-                    }));
+  AddFfiNativeCallback("NotifyNative", CREATE_FFI_LAMBDA([&]() {
+                         // Teardown and set up rasterizer again.
+                         PlatformViewNotifyDestroyed(shell.get());
+                         PlatformViewNotifyCreated(shell.get());
+                         latch.CountDown();
+                       }));
 
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
@@ -4152,18 +4112,17 @@ TEST_F(ShellTest, PictureToImageSyncImpellerNoSurface) {
       }),
   });
 
-  AddNativeCallback("NativeOnBeforeToImageSync",
-                    CREATE_NATIVE_ENTRY([&](auto args) {
-                      // nop
-                    }));
+  AddFfiNativeCallback("NativeOnBeforeToImageSync", CREATE_FFI_LAMBDA([&]() {
+                         // nop
+                       }));
 
   fml::CountDownLatch latch(2);
-  AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&](auto args) {
-                      // Teardown and set up rasterizer again.
-                      PlatformViewNotifyDestroyed(shell.get());
-                      PlatformViewNotifyCreated(shell.get());
-                      latch.CountDown();
-                    }));
+  AddFfiNativeCallback("NotifyNative", CREATE_FFI_LAMBDA([&]() {
+                         // Teardown and set up rasterizer again.
+                         PlatformViewNotifyDestroyed(shell.get());
+                         PlatformViewNotifyCreated(shell.get());
+                         latch.CountDown();
+                       }));
 
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
@@ -4204,21 +4163,21 @@ TEST_F(ShellTest, PictureToImageSyncWithTrampledContext) {
       }),
   });
 
-  AddNativeCallback(
-      "NativeOnBeforeToImageSync", CREATE_NATIVE_ENTRY([&](auto args) {
-        // Trample the GL context. If the rasterizer fails
-        // to make the right one current again, test will
-        // fail.
-        ::eglMakeCurrent(::eglGetCurrentDisplay(), NULL, NULL, NULL);
-      }));
+  AddFfiNativeCallback("NativeOnBeforeToImageSync", CREATE_FFI_LAMBDA([&]() {
+                         // Trample the GL context. If the rasterizer fails
+                         // to make the right one current again, test will
+                         // fail.
+                         ::eglMakeCurrent(::eglGetCurrentDisplay(), NULL, NULL,
+                                          NULL);
+                       }));
 
   fml::CountDownLatch latch(2);
-  AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&](auto args) {
-                      // Teardown and set up rasterizer again.
-                      PlatformViewNotifyDestroyed(shell.get());
-                      PlatformViewNotifyCreated(shell.get());
-                      latch.CountDown();
-                    }));
+  AddFfiNativeCallback("NotifyNative", CREATE_FFI_LAMBDA([&]() {
+                         // Teardown and set up rasterizer again.
+                         PlatformViewNotifyDestroyed(shell.get());
+                         PlatformViewNotifyCreated(shell.get());
+                         latch.CountDown();
+                       }));
 
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
@@ -4241,12 +4200,10 @@ TEST_F(ShellTest, PluginUtilitiesCallbackHandleErrorHandling) {
 
   fml::AutoResetWaitableEvent latch;
   bool test_passed;
-  AddNativeCallback("NotifyNativeBool", CREATE_NATIVE_ENTRY([&](auto args) {
-                      Dart_Handle exception = nullptr;
-                      test_passed = tonic::DartConverter<bool>::FromArguments(
-                          args, 0, exception);
-                      latch.Signal();
-                    }));
+  AddFfiNativeCallback("NotifyNativeBool", CREATE_FFI_LAMBDA([&](bool value) {
+                         test_passed = value;
+                         latch.Signal();
+                       }));
 
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
@@ -4328,11 +4285,8 @@ TEST_F(ShellTest, NotifyIdleNotCalledInLatencyMode) {
   // succeed. After the first `NotifyNativeBool` we expect to be in latency
   // mode, where we expect idle notifications to fail.
   fml::CountDownLatch latch(2);
-  AddNativeCallback(
-      "NotifyNativeBool", CREATE_NATIVE_ENTRY([&](auto args) {
-        Dart_Handle exception = nullptr;
-        bool is_in_latency_mode =
-            tonic::DartConverter<bool>::FromArguments(args, 0, exception);
+  AddFfiNativeCallback(
+      "NotifyNativeBool", CREATE_FFI_LAMBDA([&](bool is_in_latency_mode) {
         auto runtime_controller = const_cast<RuntimeController*>(
             shell->GetEngine()->GetRuntimeController());
         bool success =
@@ -4443,12 +4397,11 @@ TEST_F(ShellTest, SemanticsActionsFlushMessageLoop) {
 
   RunEngine(shell.get(), std::move(configuration));
   fml::CountDownLatch latch(1);
-  AddNativeCallback(
+  AddFfiNativeCallback(
       // The Dart native function names aren't very consistent but this is
       // just the native function name of the second vm entrypoint in the
       // fixture.
-      "NotifyNative",
-      CREATE_NATIVE_ENTRY([&](auto args) { latch.CountDown(); }));
+      "NotifyNative", CREATE_FFI_LAMBDA([&]() { latch.CountDown(); }));
 
   task_runners.GetPlatformTaskRunner()->PostTask([&] {
     SendSemanticsAction(shell.get(), 456, 0, SemanticsAction::kTap,
@@ -4477,12 +4430,11 @@ TEST_F(ShellTest, PointerPacketFlushMessageLoop) {
 
   RunEngine(shell.get(), std::move(configuration));
   fml::CountDownLatch latch(1);
-  AddNativeCallback(
+  AddFfiNativeCallback(
       // The Dart native function names aren't very consistent but this is
       // just the native function name of the second vm entrypoint in the
       // fixture.
-      "NotifyNative",
-      CREATE_NATIVE_ENTRY([&](auto args) { latch.CountDown(); }));
+      "NotifyNative", CREATE_FFI_LAMBDA([&]() { latch.CountDown(); }));
 
   DispatchFakePointerData(shell.get(), 23);
   latch.Wait();
@@ -4509,11 +4461,11 @@ TEST_F(ShellTest, DISABLED_PointerPacketsAreDispatchedWithTask) {
   RunEngine(shell.get(), std::move(configuration));
   fml::CountDownLatch latch(1);
   bool did_invoke_callback = false;
-  AddNativeCallback(
+  AddFfiNativeCallback(
       // The Dart native function names aren't very consistent but this is
       // just the native function name of the second vm entrypoint in the
       // fixture.
-      "NotifyNative", CREATE_NATIVE_ENTRY([&](auto args) {
+      "NotifyNative", CREATE_FFI_LAMBDA([&]() {
         did_invoke_callback = true;
         latch.CountDown();
       }));
@@ -4546,21 +4498,6 @@ TEST_F(ShellTest, DiesIfSoftwareRenderingAndImpellerAreEnabledDeathTest) {
 #endif  // OS_FUCHSIA
 }
 
-// Parse the arguments of NativeReportViewIdsCallback and
-// store them in hasImplicitView and viewIds.
-static void ParseViewIdsCallback(const Dart_NativeArguments& args,
-                                 bool* hasImplicitView,
-                                 std::vector<int64_t>* viewIds) {
-  Dart_Handle exception = nullptr;
-  viewIds->clear();
-  *hasImplicitView =
-      tonic::DartConverter<bool>::FromArguments(args, 0, exception);
-  ASSERT_EQ(exception, nullptr);
-  *viewIds = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-      args, 1, exception);
-  ASSERT_EQ(exception, nullptr);
-}
-
 TEST_F(ShellTest, ShellStartsWithImplicitView) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
@@ -4573,13 +4510,15 @@ TEST_F(ShellTest, ShellStartsWithImplicitView) {
   bool hasImplicitView;
   std::vector<int64_t> viewIds;
   fml::AutoResetWaitableEvent reportLatch;
-  auto nativeViewIdsCallback = [&reportLatch, &hasImplicitView,
-                                &viewIds](Dart_NativeArguments args) {
-    ParseViewIdsCallback(args, &hasImplicitView, &viewIds);
+  auto nativeViewIdsCallback = [&reportLatch, &hasImplicitView, &viewIds](
+                                   bool has_implicit_view,
+                                   Dart_Handle view_ids) {
+    hasImplicitView = has_implicit_view;
+    viewIds = tonic::DartConverter<std::vector<int64_t>>::FromDart(view_ids);
     reportLatch.Signal();
   };
-  AddNativeCallback("NativeReportViewIdsCallback",
-                    CREATE_NATIVE_ENTRY(nativeViewIdsCallback));
+  AddFfiNativeCallback("NativeReportViewIdsCallback",
+                       CREATE_FFI_LAMBDA(nativeViewIdsCallback));
 
   PlatformViewNotifyCreated(shell.get());
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -4613,13 +4552,15 @@ TEST_F(ShellTest, ShellCanAddViewOrRemoveView) {
   bool hasImplicitView;
   std::vector<int64_t> viewIds;
   fml::AutoResetWaitableEvent reportLatch;
-  auto nativeViewIdsCallback = [&reportLatch, &hasImplicitView,
-                                &viewIds](Dart_NativeArguments args) {
-    ParseViewIdsCallback(args, &hasImplicitView, &viewIds);
+  auto nativeViewIdsCallback = [&reportLatch, &hasImplicitView, &viewIds](
+                                   bool has_implicit_view,
+                                   Dart_Handle view_ids) {
+    hasImplicitView = has_implicit_view;
+    viewIds = tonic::DartConverter<std::vector<int64_t>>::FromDart(view_ids);
     reportLatch.Signal();
   };
-  AddNativeCallback("NativeReportViewIdsCallback",
-                    CREATE_NATIVE_ENTRY(nativeViewIdsCallback));
+  AddFfiNativeCallback("NativeReportViewIdsCallback",
+                       CREATE_FFI_LAMBDA(nativeViewIdsCallback));
 
   PlatformViewNotifyCreated(shell.get());
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -4680,11 +4621,13 @@ TEST_F(ShellTest, ShellCannotAddDuplicateViewId) {
   bool has_implicit_view;
   std::vector<int64_t> view_ids;
   fml::AutoResetWaitableEvent report_latch;
-  AddNativeCallback("NativeReportViewIdsCallback",
-                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      ParseViewIdsCallback(args, &has_implicit_view, &view_ids);
-                      report_latch.Signal();
-                    }));
+  AddFfiNativeCallback(
+      "NativeReportViewIdsCallback",
+      CREATE_FFI_LAMBDA([&](bool has_implicit, Dart_Handle ids) {
+        has_implicit_view = has_implicit;
+        view_ids = tonic::DartConverter<std::vector<int64_t>>::FromDart(ids);
+        report_latch.Signal();
+      }));
 
   PlatformViewNotifyCreated(shell.get());
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -4747,11 +4690,13 @@ TEST_F(ShellTest, ShellCannotRemoveNonexistentId) {
   bool has_implicit_view;
   std::vector<int64_t> view_ids;
   fml::AutoResetWaitableEvent report_latch;
-  AddNativeCallback("NativeReportViewIdsCallback",
-                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      ParseViewIdsCallback(args, &has_implicit_view, &view_ids);
-                      report_latch.Signal();
-                    }));
+  AddFfiNativeCallback(
+      "NativeReportViewIdsCallback",
+      CREATE_FFI_LAMBDA([&](bool has_implicit, Dart_Handle ids) {
+        has_implicit_view = has_implicit;
+        view_ids = tonic::DartConverter<std::vector<int64_t>>::FromDart(ids);
+        report_latch.Signal();
+      }));
 
   PlatformViewNotifyCreated(shell.get());
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -4781,14 +4726,11 @@ TEST_F(ShellTest, ShellCannotRemoveNonexistentId) {
 
 // Parse the arguments of NativeReportViewWidthsCallback and
 // store them in viewWidths.
-static void ParseViewWidthsCallback(const Dart_NativeArguments& args,
+static void ParseViewWidthsCallback(Dart_Handle view_width_packet,
                                     std::map<int64_t, int64_t>* viewWidths) {
-  Dart_Handle exception = nullptr;
   viewWidths->clear();
   std::vector<int64_t> viewWidthPacket =
-      tonic::DartConverter<std::vector<int64_t>>::FromArguments(args, 0,
-                                                                exception);
-  ASSERT_EQ(exception, nullptr);
+      tonic::DartConverter<std::vector<int64_t>>::FromDart(view_width_packet);
   ASSERT_EQ(viewWidthPacket.size() % 2, 0ul);
   for (size_t packetIndex = 0; packetIndex < viewWidthPacket.size();
        packetIndex += 2) {
@@ -4827,15 +4769,15 @@ TEST_F(ShellTest, ShellFlushesPlatformStatesByMain) {
   bool first_report = true;
   std::map<int64_t, int64_t> viewWidths;
   fml::AutoResetWaitableEvent reportLatch;
-  auto nativeViewWidthsCallback = [&reportLatch, &viewWidths,
-                                   &first_report](Dart_NativeArguments args) {
+  auto nativeViewWidthsCallback = [&reportLatch, &viewWidths, &first_report](
+                                      Dart_Handle view_width_packet) {
     EXPECT_TRUE(first_report);
     first_report = false;
-    ParseViewWidthsCallback(args, &viewWidths);
+    ParseViewWidthsCallback(view_width_packet, &viewWidths);
     reportLatch.Signal();
   };
-  AddNativeCallback("NativeReportViewWidthsCallback",
-                    CREATE_NATIVE_ENTRY(nativeViewWidthsCallback));
+  AddFfiNativeCallback("NativeReportViewWidthsCallback",
+                       CREATE_FFI_LAMBDA(nativeViewWidthsCallback));
 
   PlatformViewNotifyCreated(shell.get());
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -4881,13 +4823,14 @@ TEST_F(ShellTest, CanRemoveViewBeforeLaunchingIsolate) {
   bool first_report = true;
   std::map<int64_t, int64_t> view_widths;
   fml::AutoResetWaitableEvent report_latch;
-  AddNativeCallback("NativeReportViewWidthsCallback",
-                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      EXPECT_TRUE(first_report);
-                      first_report = false;
-                      ParseViewWidthsCallback(args, &view_widths);
-                      report_latch.Signal();
-                    }));
+  AddFfiNativeCallback("NativeReportViewWidthsCallback",
+                       CREATE_FFI_LAMBDA([&](Dart_Handle view_width_packet) {
+                         EXPECT_TRUE(first_report);
+                         first_report = false;
+                         ParseViewWidthsCallback(view_width_packet,
+                                                 &view_widths);
+                         report_latch.Signal();
+                       }));
 
   PlatformViewNotifyCreated(shell.get());
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -4935,13 +4878,14 @@ TEST_F(ShellTest, IgnoresBadAddViewsBeforeLaunchingIsolate) {
   bool first_report = true;
   std::map<int64_t, int64_t> view_widths;
   fml::AutoResetWaitableEvent report_latch;
-  AddNativeCallback("NativeReportViewWidthsCallback",
-                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      EXPECT_TRUE(first_report);
-                      first_report = false;
-                      ParseViewWidthsCallback(args, &view_widths);
-                      report_latch.Signal();
-                    }));
+  AddFfiNativeCallback("NativeReportViewWidthsCallback",
+                       CREATE_FFI_LAMBDA([&](Dart_Handle view_width_packet) {
+                         EXPECT_TRUE(first_report);
+                         first_report = false;
+                         ParseViewWidthsCallback(view_width_packet,
+                                                 &view_widths);
+                         report_latch.Signal();
+                       }));
 
   PlatformViewNotifyCreated(shell.get());
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -4986,18 +4930,16 @@ TEST_F(ShellTest, SendViewFocusEvent) {
   fml::AutoResetWaitableEvent latch;
   std::string last_event;
 
-  AddNativeCallback(
-      "NotifyNative",
-      CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { latch.Signal(); }));
+  AddFfiNativeCallback("NotifyNative",
+                       CREATE_FFI_LAMBDA([&]() { latch.Signal(); }));
 
-  AddNativeCallback("NotifyMessage",
-                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-                      const auto message_from_dart =
-                          tonic::DartConverter<std::string>::FromDart(
-                              Dart_GetNativeArgument(args, 0));
-                      last_event = message_from_dart;
-                      latch.Signal();
-                    }));
+  AddFfiNativeCallback(
+      "NotifyMessage", CREATE_FFI_LAMBDA([&](Dart_Handle message) {
+        const auto message_from_dart =
+            tonic::DartConverter<std::string>::FromDart(message);
+        last_event = message_from_dart;
+        latch.Signal();
+      }));
   fml::AutoResetWaitableEvent check_latch;
 
   std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
@@ -5036,9 +4978,8 @@ TEST_F(ShellTest, ProvidesEngineId) {
 
   std::optional<int> reported_handle = std::nullopt;
 
-  AddNativeCallback(
-      "ReportEngineId", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-        Dart_Handle arg = Dart_GetNativeArgument(args, 0);
+  AddFfiNativeCallback(
+      "ReportEngineId", CREATE_FFI_LAMBDA([&](Dart_Handle arg) {
         if (Dart_IsNull(arg)) {
           reported_handle = std::nullopt;
         } else {
@@ -5077,9 +5018,8 @@ TEST_F(ShellTest, ProvidesNullEngineId) {
 
   std::optional<int> reported_handle = std::nullopt;
 
-  AddNativeCallback(
-      "ReportEngineId", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
-        Dart_Handle arg = Dart_GetNativeArgument(args, 0);
+  AddFfiNativeCallback(
+      "ReportEngineId", CREATE_FFI_LAMBDA([&](Dart_Handle arg) {
         if (Dart_IsNull(arg)) {
           reported_handle = std::nullopt;
         } else {
@@ -5122,8 +5062,8 @@ TEST_F(ShellTest, MergeUIAndPlatformThreadsAfterLaunch) {
       task_runners.GetPlatformTaskRunner()->GetTaskQueueId()));
 
   fml::AutoResetWaitableEvent latch;
-  AddNativeCallback(
-      "NotifyNative", CREATE_NATIVE_ENTRY([&](auto args) {
+  AddFfiNativeCallback(
+      "NotifyNative", CREATE_FFI_LAMBDA([&]() {
         ASSERT_TRUE(
             task_runners.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
         latch.Signal();

--- a/engine/src/flutter/testing/test_dart_native_resolver.h
+++ b/engine/src/flutter/testing/test_dart_native_resolver.h
@@ -24,6 +24,12 @@
     return entrypoint;                                                      \
   })()
 
+/// A macro that converts a lambda into a function pointer that can be called
+/// through Dart FFI.
+///
+/// Note: The lambda is stored in a global static variable. To avoid memory
+/// leaks and teardown crashes, the lambda should only capture variables by
+/// reference.
 #define CREATE_FFI_LAMBDA(lambda)                                       \
   ([&]() {                                                              \
     using FfiWrapper = ::flutter::testing::FfiLambda<decltype(lambda)>; \
@@ -69,16 +75,12 @@ struct FfiLambdaFunction {};
 /// Wraps a lambda in a function pointer that can be called through Dart FFI.
 template <typename ReturnType, typename ClassType, typename... Args>
 struct FfiLambdaFunction<ReturnType (ClassType::*)(Args...) const> {
-  static std::function<ReturnType(Args...)> function;
+  inline static std::function<ReturnType(Args...)> function;
 
   static ReturnType FfiFunction(Args... args) {
     return function(std::forward<Args>(args)...);
   }
 };
-
-template <typename ReturnType, typename ClassType, typename... Args>
-std::function<ReturnType(Args...)>
-    FfiLambdaFunction<ReturnType (ClassType::*)(Args...) const>::function;
 
 template <typename LambdaType>
 using FfiLambda = FfiLambdaFunction<decltype(&LambdaType::operator())>;

--- a/engine/src/flutter/testing/test_dart_native_resolver.h
+++ b/engine/src/flutter/testing/test_dart_native_resolver.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "flutter/fml/macros.h"
 #include "third_party/dart/runtime/include/dart_api.h"
@@ -21,6 +22,13 @@
     };                                                                      \
     closure = (native_entry);                                               \
     return entrypoint;                                                      \
+  })()
+
+#define CREATE_FFI_LAMBDA(lambda)                                       \
+  ([&]() {                                                              \
+    using FfiWrapper = ::flutter::testing::FfiLambda<decltype(lambda)>; \
+    FfiWrapper::function = (lambda);                                    \
+    return reinterpret_cast<void*>(FfiWrapper::FfiFunction);            \
   })()
 
 namespace flutter::testing {
@@ -54,6 +62,26 @@ class TestDartNativeResolver
 
   FML_DISALLOW_COPY_AND_ASSIGN(TestDartNativeResolver);
 };
+
+template <typename T>
+struct FfiLambdaFunction {};
+
+/// Wraps a lambda in a function pointer that can be called through Dart FFI.
+template <typename ReturnType, typename ClassType, typename... Args>
+struct FfiLambdaFunction<ReturnType (ClassType::*)(Args...) const> {
+  static std::function<ReturnType(Args...)> function;
+
+  static ReturnType FfiFunction(Args... args) {
+    return function(std::forward<Args>(args)...);
+  }
+};
+
+template <typename ReturnType, typename ClassType, typename... Args>
+std::function<ReturnType(Args...)>
+    FfiLambdaFunction<ReturnType (ClassType::*)(Args...) const>::function;
+
+template <typename LambdaType>
+using FfiLambda = FfiLambdaFunction<decltype(&LambdaType::operator())>;
 
 }  // namespace flutter::testing
 


### PR DESCRIPTION
This adds a CREATE_FFI_LAMBDA macro that can be used to register a lambda as a Dart FFI function (similar to how CREATE_NATIVE_ENTRY works for the old native function API).

The native functions also had to be ported from the Dart_NativeArguments API to FFI-style function signatures.

See https://github.com/flutter/flutter/issues/190154