### PR TITLE
fix(tool): remove redundant --enable-experiment=record-use flag

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -198,10 +198,7 @@ class Dart2JSTarget extends Dart2WebTarget {
       else if (buildMode == BuildMode.release)
         '-Ddart.vm.product=true',
       for (final String dartDefine in computeDartDefines(environment)) '-D$dartDefine',
-      if (featureFlags.isRecordUseEnabled) ...<String>[
-        '--write-resources',
-        '--enable-experiment=record-use',
-      ],
+      if (featureFlags.isRecordUseEnabled) '--write-resources',
     ];
 
     // NOTE: most args should be populated in [toSharedCommandOptions].
@@ -373,10 +370,8 @@ class Dart2WasmTarget extends Dart2WebTarget {
       ...decodeCommaSeparated(environment.defines, kExtraFrontEndOptions),
       for (final String dartDefine in dartDefines) '-D$dartDefine',
       '--extra-compiler-option=--depfile=${depFile.path}',
-      if (featureFlags.isRecordUseEnabled) ...<String>[
+      if (featureFlags.isRecordUseEnabled)
         '--recorded-uses=${environment.buildDir.childFile(LinkHooks.recordedUsesWasmFileName).path}',
-        '--enable-experiment=record-use',
-      ],
       ...compilerConfig.toCommandOptions(buildMode),
       '-o',
       outputWasmFile.path,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
@@ -97,7 +97,6 @@ name: my_app
           '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
           '--extra-compiler-option=--depfile=${environment.buildDir.childFile('dart2wasm.d').path}',
           '--recorded-uses=${environment.buildDir.childFile('recorded_uses_wasm.json').path}',
-          '--enable-experiment=record-use',
           '-O0',
           '--no-strip-wasm',
           '--no-minify',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -40,7 +40,6 @@ const _kStandardFlutterWebDefines = <String>[
   '-DFLUTTER_WEB_USE_SKWASM=false',
   '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
   '--write-resources',
-  '--enable-experiment=record-use',
 ];
 
 const _kDart2WasmLinuxArgs = <String>[
@@ -1366,7 +1365,6 @@ _flutter.loader.load();
                           '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
                           '--extra-compiler-option=--depfile=${depFile.absolute.path}',
                           '--recorded-uses=${environment.buildDir.childFile('recorded_uses_wasm.json').absolute.path}',
-                          '--enable-experiment=record-use',
                           '-O$expectedLevel',
                           if (strip && buildMode == 'release')
                             '--strip-wasm'


### PR DESCRIPTION
When compiling web targets (dart2js and dart2wasm) or running dry runs with the record-use feature flag enabled, flutter_tools explicitly passed --enable-experiment=record-use to the compiler. Since record-use is enabled by default in recent Dart SDKs, passing this flag caused warning spam during standard compilation and dry runs.

* Remove --enable-experiment=record-use from Dart2JSTarget and Dart2WasmTarget in web.dart.
* Remove expected flag from test commands in web_test.dart and web_dry_run_test.dart.

Fixes #190465
