### PR TITLE
[tool][web] Intercept dart2wasm errors & append JS migration footers

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -592,11 +592,14 @@ class Dart2WasmTarget extends Dart2WebTarget {
     );
   }
 
+  static final RegExp _kLegacyImportErrorPattern = RegExp(
+    "(?:Dart library|The unavailable library) '(${kLegacyWebLibraries.join('|')})'|"
+    '(${kLegacyWebLibraries.join('|')}) unsupported',
+  );
+
   void _checkForLegacyWebImports(Environment environment, String stdout, String stderr) {
-    if (stdout.contains('dart:html') ||
-        stderr.contains('dart:html') ||
-        stdout.contains('package:js') ||
-        stderr.contains('package:js')) {
+    if (_kLegacyImportErrorPattern.hasMatch(stdout) ||
+        _kLegacyImportErrorPattern.hasMatch(stderr)) {
       environment.logger.printStatus(
         'Note: WebAssembly compilation failed due to legacy web imports.\n'
         'Migrate your project from dart:html and package:js to package:web and dart:js_interop.\n'

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -389,22 +389,13 @@ class Dart2WasmTarget extends Dart2WebTarget {
       processManager: environment.processManager,
     );
 
-    final RunResult runResult = await processUtils.run(throwOnError: false, compilationArgs);
+    final RunResult runResult = await processUtils.run(compilationArgs);
     if (compilerConfig.dryRun) {
       await _handleDryRunResult(environment, runResult);
     } else if (runResult.exitCode != 0) {
       environment.logger.printStatus(runResult.stdout);
       environment.logger.printError(runResult.stderr);
-      if (runResult.stdout.contains('dart:html') ||
-          runResult.stderr.contains('dart:html') ||
-          runResult.stdout.contains('package:js') ||
-          runResult.stderr.contains('package:js')) {
-        environment.logger.printStatus(
-          'Note: WebAssembly compilation failed due to legacy web imports.\n'
-          'Migrate your project from dart:html and package:js to package:web and dart:js_interop.\n'
-          '$kWasmErrorsMoreInfo',
-        );
-      }
+      _checkForLegacyWebImports(environment, runResult.stdout, runResult.stderr);
       throwToolExit('Failed to compile application for the Web.');
     }
     final File recordedUsesFile = environment.buildDir.childFile(
@@ -588,16 +579,7 @@ class Dart2WasmTarget extends Dart2WebTarget {
     }
     result ??= 'unknown';
 
-    if (stdout.contains('dart:html') ||
-        stderr.contains('dart:html') ||
-        stdout.contains('package:js') ||
-        stderr.contains('package:js')) {
-      environment.logger.printStatus(
-        'Note: WebAssembly compilation failed due to legacy web imports.\n'
-        'Migrate your project from dart:html and package:js to package:web and dart:js_interop.\n'
-        '$kWasmErrorsMoreInfo',
-      );
-    }
+    _checkForLegacyWebImports(environment, stdout, stderr);
 
     environment.logger.printWarning('Use --no-wasm-dry-run to disable these warnings.');
 
@@ -608,6 +590,19 @@ class Dart2WasmTarget extends Dart2WebTarget {
         findingsInfo: findingsInfo,
       ),
     );
+  }
+
+  void _checkForLegacyWebImports(Environment environment, String stdout, String stderr) {
+    if (stdout.contains('dart:html') ||
+        stderr.contains('dart:html') ||
+        stdout.contains('package:js') ||
+        stderr.contains('package:js')) {
+      environment.logger.printStatus(
+        'Note: WebAssembly compilation failed due to legacy web imports.\n'
+        'Migrate your project from dart:html and package:js to package:web and dart:js_interop.\n'
+        '$kWasmErrorsMoreInfo',
+      );
+    }
   }
 }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -27,6 +27,7 @@ import '../../web/bootstrap.dart';
 import '../../web/compile.dart';
 import '../../web/file_generators/flutter_service_worker_js.dart';
 import '../../web/file_generators/main_dart.dart' as main_dart;
+import '../../web/web_constants.dart';
 import '../../web_template.dart';
 import '../build_system.dart';
 import '../depfile.dart';
@@ -388,12 +389,23 @@ class Dart2WasmTarget extends Dart2WebTarget {
       processManager: environment.processManager,
     );
 
-    final RunResult runResult = await processUtils.run(
-      throwOnError: !compilerConfig.dryRun,
-      compilationArgs,
-    );
+    final RunResult runResult = await processUtils.run(throwOnError: false, compilationArgs);
     if (compilerConfig.dryRun) {
       await _handleDryRunResult(environment, runResult);
+    } else if (runResult.exitCode != 0) {
+      environment.logger.printStatus(runResult.stdout);
+      environment.logger.printError(runResult.stderr);
+      if (runResult.stdout.contains('dart:html') ||
+          runResult.stderr.contains('dart:html') ||
+          runResult.stdout.contains('package:js') ||
+          runResult.stderr.contains('package:js')) {
+        environment.logger.printStatus(
+          'Note: WebAssembly compilation failed due to legacy web imports.\n'
+          'Migrate your project from dart:html and package:js to package:web and dart:js_interop.\n'
+          '$kWasmErrorsMoreInfo',
+        );
+      }
+      throwToolExit('Failed to compile application for the Web.');
     }
     final File recordedUsesFile = environment.buildDir.childFile(
       LinkHooks.recordedUsesWasmFileName,
@@ -575,6 +587,17 @@ class Dart2WasmTarget extends Dart2WebTarget {
       });
     }
     result ??= 'unknown';
+
+    if (stdout.contains('dart:html') ||
+        stderr.contains('dart:html') ||
+        stdout.contains('package:js') ||
+        stderr.contains('package:js')) {
+      environment.logger.printStatus(
+        'Note: WebAssembly compilation failed due to legacy web imports.\n'
+        'Migrate your project from dart:html and package:js to package:web and dart:js_interop.\n'
+        '$kWasmErrorsMoreInfo',
+      );
+    }
 
     environment.logger.printWarning('Use --no-wasm-dry-run to disable these warnings.');
 

--- a/packages/flutter_tools/lib/src/web/web_constants.dart
+++ b/packages/flutter_tools/lib/src/web/web_constants.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-const kWasmMoreInfo = 'See https://flutter.dev/to/wasm for more information.';
+const String kWasmMoreInfo = 'See https://flutter.dev/to/wasm for more information.';
+const String kWasmErrorsMoreInfo =
+    'See https://flutter.dev/to/wasm-errors for diagnostic and migration guidance.';
 
 /// Headers required to run Wasm-compiled applications with multi-threading.
 ///

--- a/packages/flutter_tools/lib/src/web/web_constants.dart
+++ b/packages/flutter_tools/lib/src/web/web_constants.dart
@@ -6,6 +6,19 @@ const String kWasmMoreInfo = 'See https://flutter.dev/to/wasm for more informati
 const String kWasmErrorsMoreInfo =
     'See https://flutter.dev/to/wasm-errors for diagnostic and migration guidance.';
 
+/// Legacy web libraries unsupported in WebAssembly compilation.
+const Set<String> kLegacyWebLibraries = <String>{
+  'dart:html',
+  'dart:indexed_db',
+  'dart:js',
+  'dart:js_util',
+  'dart:svg',
+  'dart:web_audio',
+  'dart:web_gl',
+  'dart:web_sql',
+  'package:js',
+};
+
 /// Headers required to run Wasm-compiled applications with multi-threading.
 ///
 /// See https://developer.chrome.com/blog/coep-credentialless-origin-trial

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
@@ -173,6 +174,18 @@ package:foo/some/path.dart 6:1 - dart:html unsupported (0)
       );
       final Dart2WasmTarget target = createTarget();
       await target.build(environment);
+
+      final BufferLogger logger = environment.logger as BufferLogger;
+      expect(
+        logger.statusText,
+        contains('Note: WebAssembly compilation failed due to legacy web imports.'),
+      );
+      expect(
+        logger.statusText,
+        contains(
+          'Migrate your project from dart:html and package:js to package:web and dart:js_interop.',
+        ),
+      );
 
       expect(fakeAnalytics.sentEvents, hasLength(1));
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
@@ -198,6 +198,64 @@ package:foo/some/path.dart 6:1 - dart:html unsupported (0)
   );
 
   test(
+    'dry run prints JS interop migration footer on dart:svg and dart:js_util unsupported findings',
+    () => testbed.run(() async {
+      processManager.addCommand(
+        FakeCommand(
+          command: commandArgs,
+          exitCode: 254,
+          stdout: '''
+Found incompatibilities with WebAssembly.
+
+package:foo/some/path.dart 6:1 - dart:svg unsupported (5)
+package:bar/some/path.dart 12:4 - dart:js_util unsupported (6)
+''',
+        ),
+      );
+      final Dart2WasmTarget target = createTarget();
+      await target.build(environment);
+
+      final logger = environment.logger as BufferLogger;
+      expect(
+        logger.statusText,
+        contains('Note: WebAssembly compilation failed due to legacy web imports.'),
+      );
+      expect(
+        logger.statusText,
+        contains(
+          'Migrate your project from dart:html and package:js to package:web and dart:js_interop.',
+        ),
+      );
+    }),
+  );
+
+  test(
+    'dry run does not print JS interop migration footer on non-web unsupported libraries like dart:ffi or incidental filenames',
+    () => testbed.run(() async {
+      processManager.addCommand(
+        FakeCommand(
+          command: commandArgs,
+          exitCode: 254,
+          stdout: '''
+Found incompatibilities with WebAssembly.
+
+package:fizz/some/path.dart 80:2 - dart:ffi unsupported (3)
+package:foo/some/my_dart_html_wrapper.dart 103:20 - dart:io unsupported (4)
+''',
+        ),
+      );
+      final Dart2WasmTarget target = createTarget();
+      await target.build(environment);
+
+      final logger = environment.logger as BufferLogger;
+      expect(
+        logger.statusText,
+        isNot(contains('Note: WebAssembly compilation failed due to legacy web imports.')),
+      );
+    }),
+  );
+
+  test(
     'dry run findings public packages',
     () => testbed.run(() async {
       processManager.addCommand(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
@@ -175,7 +175,7 @@ package:foo/some/path.dart 6:1 - dart:html unsupported (0)
       final Dart2WasmTarget target = createTarget();
       await target.build(environment);
 
-      final BufferLogger logger = environment.logger as BufferLogger;
+      final logger = environment.logger as BufferLogger;
       expect(
         logger.statusText,
         contains('Note: WebAssembly compilation failed due to legacy web imports.'),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -7,8 +7,8 @@ import 'dart:convert';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
@@ -1426,10 +1426,8 @@ _flutter.loader.load();
             '-DFLUTTER_WEB_USE_SKIA=false',
             '-DFLUTTER_WEB_USE_SKWASM=true',
             '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
-            '--extra-compiler-option=--depfile=' +
-                environment.buildDir.childFile('dart2wasm.d').absolute.path,
-            '--recorded-uses=' +
-                environment.buildDir.childFile('recorded_uses_wasm.json').absolute.path,
+            '--extra-compiler-option=--depfile=${environment.buildDir.childFile('dart2wasm.d').absolute.path}',
+            '--recorded-uses=${environment.buildDir.childFile('recorded_uses_wasm.json').absolute.path}',
             '--enable-experiment=record-use',
             '-O2',
             '--no-strip-wasm',
@@ -1455,11 +1453,11 @@ _flutter.loader.load();
           const NoOpAnalytics(),
         ).build(environment);
         fail('Expected exception');
-      } catch (e) {
+      } on Exception catch (e) {
         expect(e.toString(), contains('Failed to compile application for the Web.'));
       }
 
-      final BufferLogger logger = globals.logger as BufferLogger;
+      final logger = globals.logger as BufferLogger;
       expect(
         logger.statusText,
         contains('Note: WebAssembly compilation failed due to legacy web imports.'),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -1408,38 +1408,49 @@ _flutter.loader.load();
     }
   }
 
+  void addWasmCompilerErrorCommand(
+    FakeProcessManager processManager,
+    Environment environment,
+    String stderr,
+  ) {
+    processManager.addCommand(
+      FakeCommand(
+        command: <String>[
+          ..._kDart2WasmLinuxArgs,
+          '-Ddart.vm.profile=true',
+          '-Ddart.vm.product=false',
+          '--extra-compiler-option=--delete-tostring-package-uri=dart:ui',
+          '--extra-compiler-option=--delete-tostring-package-uri=package:flutter',
+          '--extra-compiler-option=--import-shared-memory',
+          '--extra-compiler-option=--shared-memory-max-pages=32768',
+          '-DFLUTTER_WEB_USE_SKIA=false',
+          '-DFLUTTER_WEB_USE_SKWASM=true',
+          '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
+          '--extra-compiler-option=--depfile=${environment.buildDir.childFile('dart2wasm.d').absolute.path}',
+          '--recorded-uses=${environment.buildDir.childFile('recorded_uses_wasm.json').absolute.path}',
+          '--enable-experiment=record-use',
+          '-O2',
+          '--no-strip-wasm',
+          '--no-source-maps',
+          '--no-minify',
+          '-o',
+          environment.buildDir.childFile('main.dart.wasm').absolute.path,
+          environment.buildDir.childFile('main.dart').absolute.path,
+        ],
+        exitCode: 254,
+        stderr: stderr,
+      ),
+    );
+  }
+
   test(
-    'Dart2WasmTarget prints JS interop migration footer on legacy import failures',
+    'Dart2WasmTarget prints JS interop migration footer on dart:html library import failure',
     () => testbed.run(() async {
       environment.defines[kBuildMode] = 'profile';
-
-      processManager.addCommand(
-        FakeCommand(
-          command: <String>[
-            ..._kDart2WasmLinuxArgs,
-            '-Ddart.vm.profile=true',
-            '-Ddart.vm.product=false',
-            '--extra-compiler-option=--delete-tostring-package-uri=dart:ui',
-            '--extra-compiler-option=--delete-tostring-package-uri=package:flutter',
-            '--extra-compiler-option=--import-shared-memory',
-            '--extra-compiler-option=--shared-memory-max-pages=32768',
-            '-DFLUTTER_WEB_USE_SKIA=false',
-            '-DFLUTTER_WEB_USE_SKWASM=true',
-            '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
-            '--extra-compiler-option=--depfile=${environment.buildDir.childFile('dart2wasm.d').absolute.path}',
-            '--recorded-uses=${environment.buildDir.childFile('recorded_uses_wasm.json').absolute.path}',
-            '--enable-experiment=record-use',
-            '-O2',
-            '--no-strip-wasm',
-            '--no-source-maps',
-            '--no-minify',
-            '-o',
-            environment.buildDir.childFile('main.dart.wasm').absolute.path,
-            environment.buildDir.childFile('main.dart').absolute.path,
-          ],
-          exitCode: 254,
-          stderr: 'Error: Cannot use dart:html from WebAssembly.',
-        ),
+      addWasmCompilerErrorCommand(
+        processManager,
+        environment,
+        "Error: Dart library 'dart:html' is not available on this platform.",
       );
 
       try {
@@ -1467,6 +1478,73 @@ _flutter.loader.load();
         contains(
           'Migrate your project from dart:html and package:js to package:web and dart:js_interop.',
         ),
+      );
+    }, overrides: <Type, Generator>{ProcessManager: () => processManager}),
+  );
+
+  test(
+    'Dart2WasmTarget prints JS interop migration footer on dart:svg and dart:js_util failures',
+    () => testbed.run(() async {
+      environment.defines[kBuildMode] = 'profile';
+      addWasmCompilerErrorCommand(
+        processManager,
+        environment,
+        "Context: The unavailable library 'dart:svg' is imported through these paths:\n"
+        "Error: Dart library 'dart:js_util' is not available on this platform.",
+      );
+
+      try {
+        await Dart2WasmTarget(
+          const WasmCompilerConfig(
+            optimizationLevel: 2,
+            stripWasm: false,
+            sourceMaps: false,
+            minify: false,
+          ),
+          const NoOpAnalytics(),
+        ).build(environment);
+        fail('Expected exception');
+      } on Exception catch (e) {
+        expect(e.toString(), contains('Failed to compile application for the Web.'));
+      }
+
+      final logger = globals.logger as BufferLogger;
+      expect(
+        logger.statusText,
+        contains('Note: WebAssembly compilation failed due to legacy web imports.'),
+      );
+    }, overrides: <Type, Generator>{ProcessManager: () => processManager}),
+  );
+
+  test(
+    'Dart2WasmTarget does not print JS interop migration footer on incidental mentions of dart:html in unrelated errors',
+    () => testbed.run(() async {
+      environment.defines[kBuildMode] = 'profile';
+      addWasmCompilerErrorCommand(
+        processManager,
+        environment,
+        "Error: Syntax error in file:///my_dart_html_test.dart at line 4: print('dart:html');",
+      );
+
+      try {
+        await Dart2WasmTarget(
+          const WasmCompilerConfig(
+            optimizationLevel: 2,
+            stripWasm: false,
+            sourceMaps: false,
+            minify: false,
+          ),
+          const NoOpAnalytics(),
+        ).build(environment);
+        fail('Expected exception');
+      } on Exception catch (e) {
+        expect(e.toString(), contains('Failed to compile application for the Web.'));
+      }
+
+      final logger = globals.logger as BufferLogger;
+      expect(
+        logger.statusText,
+        isNot(contains('Note: WebAssembly compilation failed due to legacy web imports.')),
       );
     }, overrides: <Type, Generator>{ProcessManager: () => processManager}),
   );

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -8,6 +8,7 @@ import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
@@ -1406,6 +1407,71 @@ _flutter.loader.load();
       }
     }
   }
+
+  test(
+    'Dart2WasmTarget prints JS interop migration footer on legacy import failures',
+    () => testbed.run(() async {
+      environment.defines[kBuildMode] = 'profile';
+
+      processManager.addCommand(
+        FakeCommand(
+          command: <String>[
+            ..._kDart2WasmLinuxArgs,
+            '-Ddart.vm.profile=true',
+            '-Ddart.vm.product=false',
+            '--extra-compiler-option=--delete-tostring-package-uri=dart:ui',
+            '--extra-compiler-option=--delete-tostring-package-uri=package:flutter',
+            '--extra-compiler-option=--import-shared-memory',
+            '--extra-compiler-option=--shared-memory-max-pages=32768',
+            '-DFLUTTER_WEB_USE_SKIA=false',
+            '-DFLUTTER_WEB_USE_SKWASM=true',
+            '-DFLUTTER_WEB_CANVASKIT_URL=https://www.gstatic.com/flutter-canvaskit/abcdefghijklmnopqrstuvwxyz/',
+            '--extra-compiler-option=--depfile=' +
+                environment.buildDir.childFile('dart2wasm.d').absolute.path,
+            '--recorded-uses=' +
+                environment.buildDir.childFile('recorded_uses_wasm.json').absolute.path,
+            '--enable-experiment=record-use',
+            '-O2',
+            '--no-strip-wasm',
+            '--no-source-maps',
+            '--no-minify',
+            '-o',
+            environment.buildDir.childFile('main.dart.wasm').absolute.path,
+            environment.buildDir.childFile('main.dart').absolute.path,
+          ],
+          exitCode: 254,
+          stderr: 'Error: Cannot use dart:html from WebAssembly.',
+        ),
+      );
+
+      try {
+        await Dart2WasmTarget(
+          const WasmCompilerConfig(
+            optimizationLevel: 2,
+            stripWasm: false,
+            sourceMaps: false,
+            minify: false,
+          ),
+          const NoOpAnalytics(),
+        ).build(environment);
+        fail('Expected exception');
+      } catch (e) {
+        expect(e.toString(), contains('Failed to compile application for the Web.'));
+      }
+
+      final BufferLogger logger = globals.logger as BufferLogger;
+      expect(
+        logger.statusText,
+        contains('Note: WebAssembly compilation failed due to legacy web imports.'),
+      );
+      expect(
+        logger.statusText,
+        contains(
+          'Migrate your project from dart:html and package:js to package:web and dart:js_interop.',
+        ),
+      );
+    }, overrides: <Type, Generator>{ProcessManager: () => processManager}),
+  );
 
   test('Dart2WasmTarget.buildFiles respects compilerConfig.sourceMaps and matches modules', () {
     final File wasmFile = environment.buildDir.childFile('main.dart.wasm')..createSync();


### PR DESCRIPTION
When compiling a web project with `--wasm` (or running a dry-run) that encounters incompatible legacy JS interop dependencies (`dart:html` or `package:js`), standard `--wasm` builds default to an uncaught `ProcessException` dumping an internal stack trace, while dry-runs lack actionable migration remediation.

This change:
* Invokes `ProcessUtils.run(throwOnError: false)` in `Dart2WasmTarget.build` to forward uncorrupted compiler stdout/stderr directly to the logger without throwing an unformatted `ProcessException`.
* Adds `kWasmErrorsMoreInfo` constant targeting https://flutter.dev/to/wasm-errors.
* Inspects standard compile failure and Wasm dry-run outputs for instances of `dart:html` or `package:js`, appending an educational migration footer when matched.
* Terminates fatal Wasm builds cleanly via `throwToolExit`, preventing internal tool stack trace spillage.

Fixes #190466
