### PR TITLE
tools: Support --host-arch option in flutter precache

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -147,6 +147,12 @@ abstract class OperatingSystemUtils {
   HostPlatform? hostPlatformOverride;
 
   /// Represents the platform of the host machine running the Flutter tool.
+  ///
+  /// The architecture may be overridden, in precedence order, by the
+  /// [hostPlatformOverride] property or the `FLUTTER_HOST_ARCH` environment
+  /// variable. When neither is set, the host platform is determined by
+  /// [defaultHostPlatform], which subclasses may override to probe the
+  /// hardware directly.
   HostPlatform get hostPlatform {
     if (hostPlatformOverride != null) {
       return hostPlatformOverride!;
@@ -169,6 +175,16 @@ abstract class OperatingSystemUtils {
         return HostPlatform.windows_x64;
       }
     }
+    return defaultHostPlatform;
+  }
+
+  /// The host platform detected when no architecture override is in effect.
+  ///
+  /// Defaults to the architecture the tool was compiled for. Subclasses may
+  /// override this to probe the underlying hardware (for example, to see
+  /// through Rosetta translation on macOS).
+  @protected
+  HostPlatform get defaultHostPlatform {
     return switch (_currentAbi) {
       Abi.macosX64 => HostPlatform.darwin_x64,
       Abi.macosArm64 => HostPlatform.darwin_arm64,
@@ -389,43 +405,30 @@ class _MacOSUtils extends _PosixUtils {
   HostPlatform? _hostPlatform;
 
   @override
-  HostPlatform get hostPlatform {
-    if (hostPlatformOverride != null) {
-      return hostPlatformOverride!;
-    }
+  HostPlatform get defaultHostPlatform {
     if (_hostPlatform == null) {
-      final String? overrideArch = _platform.environment['FLUTTER_HOST_ARCH'];
-      if (overrideArch == 'arm64') {
-        _hostPlatform = HostPlatform.darwin_arm64;
-      } else if (overrideArch == 'x64') {
-        _hostPlatform = HostPlatform.darwin_x64;
-      } else {
-        String? sysctlPath;
-        if (which('sysctl') == null) {
-          // Fallback to known install locations.
-          for (final path in <String>['/usr/sbin/sysctl', '/sbin/sysctl']) {
-            if (_fileSystem.isFileSync(path)) {
-              sysctlPath = path;
-            }
+      String? sysctlPath;
+      if (which('sysctl') == null) {
+        // Fallback to known install locations.
+        for (final path in <String>['/usr/sbin/sysctl', '/sbin/sysctl']) {
+          if (_fileSystem.isFileSync(path)) {
+            sysctlPath = path;
           }
-        } else {
-          sysctlPath = 'sysctl';
         }
+      } else {
+        sysctlPath = 'sysctl';
+      }
 
-        if (sysctlPath == null) {
-          throwToolExit('sysctl not found. Try adding it to your PATH environment variable.');
-        }
-        final RunResult arm64Check = _processUtils.runSync(<String>[
-          sysctlPath,
-          'hw.optional.arm64',
-        ]);
-        // On arm64 stdout is "sysctl hw.optional.arm64: 1"
-        // On x86 hw.optional.arm64 is unavailable and exits with 1.
-        if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
-          _hostPlatform = HostPlatform.darwin_arm64;
-        } else {
-          _hostPlatform = HostPlatform.darwin_x64;
-        }
+      if (sysctlPath == null) {
+        throwToolExit('sysctl not found. Try adding it to your PATH environment variable.');
+      }
+      final RunResult arm64Check = _processUtils.runSync(<String>[sysctlPath, 'hw.optional.arm64']);
+      // On arm64 stdout is "sysctl hw.optional.arm64: 1"
+      // On x86 hw.optional.arm64 is unavailable and exits with 1.
+      if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
+        _hostPlatform = HostPlatform.darwin_arm64;
+      } else {
+        _hostPlatform = HostPlatform.darwin_x64;
       }
     }
     return _hostPlatform!;

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -150,29 +150,21 @@ abstract class OperatingSystemUtils {
   ///
   /// The architecture may be overridden, in precedence order, by the
   /// [hostPlatformOverride] property or the `FLUTTER_HOST_ARCH` environment
-  /// variable. When neither is set, the host platform is determined by
-  /// [defaultHostPlatform], which subclasses may override to probe the
-  /// hardware directly.
+  /// variable. When neither is set, or the environment variable does not match
+  /// an architecture supported on the current OS, the host platform is
+  /// determined by [defaultHostPlatform], which subclasses may override to
+  /// probe the hardware directly.
   HostPlatform get hostPlatform {
-    if (hostPlatformOverride != null) {
-      return hostPlatformOverride!;
+    if (hostPlatformOverride case final HostPlatform override) {
+      return override;
     }
-    final String? overrideArch = _platform.environment['FLUTTER_HOST_ARCH'];
-    if (overrideArch == 'arm64') {
-      if (_platform.isMacOS) {
-        return HostPlatform.darwin_arm64;
-      } else if (_platform.isLinux) {
-        return HostPlatform.linux_arm64;
-      } else if (_platform.isWindows) {
-        return HostPlatform.windows_arm64;
-      }
-    } else if (overrideArch == 'x64') {
-      if (_platform.isMacOS) {
-        return HostPlatform.darwin_x64;
-      } else if (_platform.isLinux) {
-        return HostPlatform.linux_x64;
-      } else if (_platform.isWindows) {
-        return HostPlatform.windows_x64;
+    if (_platform.environment['FLUTTER_HOST_ARCH'] case final String overrideArch) {
+      final HostPlatform? overridePlatform = HostPlatform.fromOsAndArch(
+        _platform.operatingSystem,
+        overrideArch,
+      );
+      if (overridePlatform != null) {
+        return overridePlatform;
       }
     }
     return defaultHostPlatform;
@@ -652,6 +644,25 @@ enum HostPlatform {
 
   final String cliName;
   final String platformName;
+
+  /// Returns the host platform for the specified OS and architecture.
+  ///
+  /// [os] is an operating system name as returned by
+  /// [Platform.operatingSystem]. [arch] is an architecture name matching the
+  /// [platformName] of one of the values of this enum. Returns null if no match
+  /// is found.
+  static HostPlatform? fromOsAndArch(String os, String arch) {
+    return switch ((os, arch.toLowerCase())) {
+      ('macos', 'x64') => darwin_x64,
+      ('macos', 'arm64') => darwin_arm64,
+      ('linux', 'x64') => linux_x64,
+      ('linux', 'arm64') => linux_arm64,
+      ('linux', 'riscv64') => linux_riscv64,
+      ('windows', 'x64') => windows_x64,
+      ('windows', 'arm64') => windows_arm64,
+      _ => null,
+    };
+  }
 }
 
 // flutter_ignore: deprecation_syntax (see analyze.dart)

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -143,8 +143,32 @@ abstract class OperatingSystemUtils {
     return osNames[osName] ?? osName;
   }
 
+  /// Optional override for the host platform architecture.
+  HostPlatform? hostPlatformOverride;
+
   /// Represents the platform of the host machine running the Flutter tool.
   HostPlatform get hostPlatform {
+    if (hostPlatformOverride != null) {
+      return hostPlatformOverride!;
+    }
+    final String? overrideArch = _platform.environment['FLUTTER_HOST_ARCH'];
+    if (overrideArch == 'arm64') {
+      if (_platform.isMacOS) {
+        return HostPlatform.darwin_arm64;
+      } else if (_platform.isLinux) {
+        return HostPlatform.linux_arm64;
+      } else if (_platform.isWindows) {
+        return HostPlatform.windows_arm64;
+      }
+    } else if (overrideArch == 'x64') {
+      if (_platform.isMacOS) {
+        return HostPlatform.darwin_x64;
+      } else if (_platform.isLinux) {
+        return HostPlatform.linux_x64;
+      } else if (_platform.isWindows) {
+        return HostPlatform.windows_x64;
+      }
+    }
     return switch (_currentAbi) {
       Abi.macosX64 => HostPlatform.darwin_x64,
       Abi.macosArm64 => HostPlatform.darwin_arm64,
@@ -366,29 +390,42 @@ class _MacOSUtils extends _PosixUtils {
 
   @override
   HostPlatform get hostPlatform {
+    if (hostPlatformOverride != null) {
+      return hostPlatformOverride!;
+    }
     if (_hostPlatform == null) {
-      String? sysctlPath;
-      if (which('sysctl') == null) {
-        // Fallback to known install locations.
-        for (final path in <String>['/usr/sbin/sysctl', '/sbin/sysctl']) {
-          if (_fileSystem.isFileSync(path)) {
-            sysctlPath = path;
-          }
-        }
-      } else {
-        sysctlPath = 'sysctl';
-      }
-
-      if (sysctlPath == null) {
-        throwToolExit('sysctl not found. Try adding it to your PATH environment variable.');
-      }
-      final RunResult arm64Check = _processUtils.runSync(<String>[sysctlPath, 'hw.optional.arm64']);
-      // On arm64 stdout is "sysctl hw.optional.arm64: 1"
-      // On x86 hw.optional.arm64 is unavailable and exits with 1.
-      if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
+      final String? overrideArch = _platform.environment['FLUTTER_HOST_ARCH'];
+      if (overrideArch == 'arm64') {
         _hostPlatform = HostPlatform.darwin_arm64;
-      } else {
+      } else if (overrideArch == 'x64') {
         _hostPlatform = HostPlatform.darwin_x64;
+      } else {
+        String? sysctlPath;
+        if (which('sysctl') == null) {
+          // Fallback to known install locations.
+          for (final path in <String>['/usr/sbin/sysctl', '/sbin/sysctl']) {
+            if (_fileSystem.isFileSync(path)) {
+              sysctlPath = path;
+            }
+          }
+        } else {
+          sysctlPath = 'sysctl';
+        }
+
+        if (sysctlPath == null) {
+          throwToolExit('sysctl not found. Try adding it to your PATH environment variable.');
+        }
+        final RunResult arm64Check = _processUtils.runSync(<String>[
+          sysctlPath,
+          'hw.optional.arm64',
+        ]);
+        // On arm64 stdout is "sysctl hw.optional.arm64: 1"
+        // On x86 hw.optional.arm64 is unavailable and exits with 1.
+        if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
+          _hostPlatform = HostPlatform.darwin_arm64;
+        } else {
+          _hostPlatform = HostPlatform.darwin_x64;
+        }
       }
     }
     return _hostPlatform!;

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -217,6 +217,7 @@ class Cache {
   final Platform _platform;
   final FileSystem _fileSystem;
   final OperatingSystemUtils _osUtils;
+  OperatingSystemUtils get osUtils => _osUtils;
   final Directory? _rootOverride;
   final List<ArtifactSet> _artifacts;
   final Stdio? _stdio;

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -180,17 +180,15 @@ class PrecacheCommand extends FlutterCommand {
     }
     final String? hostArch = stringArg('host-arch');
     if (hostArch != null) {
-      final HostPlatform overridePlatform = switch ((hostArch, _platform.operatingSystem)) {
-        ('x64', 'macos') => HostPlatform.darwin_x64,
-        ('x64', 'linux') => HostPlatform.linux_x64,
-        ('x64', 'windows') => HostPlatform.windows_x64,
-        ('arm64', 'macos') => HostPlatform.darwin_arm64,
-        ('arm64', 'linux') => HostPlatform.linux_arm64,
-        ('arm64', 'windows') => HostPlatform.windows_arm64,
-        _ => throwToolExit(
+      final HostPlatform? overridePlatform = HostPlatform.fromOsAndArch(
+        _platform.operatingSystem,
+        hostArch,
+      );
+      if (overridePlatform == null) {
+        throwToolExit(
           'Unsupported host architecture "$hostArch" for OS "${_platform.operatingSystem}"',
-        ),
-      };
+        );
+      }
       _cache.osUtils.hostPlatformOverride = overridePlatform;
     }
     final Set<String> explicitlyEnabled = _explicitArtifactSelections();

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -4,9 +4,11 @@
 
 import '../base/common.dart';
 import '../base/logger.dart';
+import '../base/os.dart';
 import '../base/platform.dart';
 import '../cache.dart';
 import '../features.dart';
+import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 
 /// The flutter precache command allows downloading of cache artifacts without
@@ -18,10 +20,12 @@ class PrecacheCommand extends FlutterCommand {
     required Platform platform,
     required Logger logger,
     required FeatureFlags featureFlags,
+    OperatingSystemUtils? os,
   }) : _cache = cache,
        _platform = platform,
        _logger = logger,
-       _featureFlags = featureFlags {
+       _featureFlags = featureFlags,
+       _os = os ?? globals.os {
     argParser.addFlag(
       'all-platforms',
       abbr: 'a',
@@ -83,12 +87,19 @@ class PrecacheCommand extends FlutterCommand {
       help: 'Precache the unsigned macOS binaries when available.',
       hide: !verboseHelp,
     );
+    argParser.addOption(
+      'host-arch',
+      allowed: const <String>['x64', 'arm64'],
+      help: 'Override the architecture of host artifacts to precache.',
+      hide: !verboseHelp,
+    );
   }
 
   final Cache _cache;
   final Logger _logger;
   final Platform _platform;
   final FeatureFlags _featureFlags;
+  final OperatingSystemUtils _os;
 
   @override
   final name = 'precache';
@@ -170,6 +181,22 @@ class PrecacheCommand extends FlutterCommand {
     }
     if (boolArg('use-unsigned-mac-binaries')) {
       _cache.useUnsignedMacBinaries = true;
+    }
+    final String? hostArch = stringArg('host-arch');
+    if (hostArch != null) {
+      final HostPlatform overridePlatform = switch ((hostArch, _platform.operatingSystem)) {
+        ('x64', 'macos') => HostPlatform.darwin_x64,
+        ('x64', 'linux') => HostPlatform.linux_x64,
+        ('x64', 'windows') => HostPlatform.windows_x64,
+        ('arm64', 'macos') => HostPlatform.darwin_arm64,
+        ('arm64', 'linux') => HostPlatform.linux_arm64,
+        ('arm64', 'windows') => HostPlatform.windows_arm64,
+        _ => throwToolExit(
+          'Unsupported host architecture "$hostArch" for OS "${_platform.operatingSystem}"',
+        ),
+      };
+      _os.hostPlatformOverride = overridePlatform;
+      _cache.osUtils.hostPlatformOverride = overridePlatform;
     }
     final Set<String> explicitlyEnabled = _explicitArtifactSelections();
     _cache.platformOverrideArtifacts = explicitlyEnabled;

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -8,7 +8,6 @@ import '../base/os.dart';
 import '../base/platform.dart';
 import '../cache.dart';
 import '../features.dart';
-import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 
 /// The flutter precache command allows downloading of cache artifacts without
@@ -20,12 +19,10 @@ class PrecacheCommand extends FlutterCommand {
     required Platform platform,
     required Logger logger,
     required FeatureFlags featureFlags,
-    OperatingSystemUtils? os,
   }) : _cache = cache,
        _platform = platform,
        _logger = logger,
-       _featureFlags = featureFlags,
-       _os = os ?? globals.os {
+       _featureFlags = featureFlags {
     argParser.addFlag(
       'all-platforms',
       abbr: 'a',
@@ -99,7 +96,6 @@ class PrecacheCommand extends FlutterCommand {
   final Logger _logger;
   final Platform _platform;
   final FeatureFlags _featureFlags;
-  final OperatingSystemUtils _os;
 
   @override
   final name = 'precache';
@@ -195,7 +191,6 @@ class PrecacheCommand extends FlutterCommand {
           'Unsupported host architecture "$hostArch" for OS "${_platform.operatingSystem}"',
         ),
       };
-      _os.hostPlatformOverride = overridePlatform;
       _cache.osUtils.hostPlatformOverride = overridePlatform;
     }
     final Set<String> explicitlyEnabled = _explicitArtifactSelections();

--- a/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/precache.dart';
@@ -504,6 +505,21 @@ void main() {
       }),
     );
   });
+
+  testUsingContext('precache --host-arch overrides cache and os hostPlatformOverride', () async {
+    final os = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64);
+    final PrecacheCommand command = PrecacheCommand(
+      cache: cache,
+      logger: BufferLogger.test(),
+      featureFlags: TestFeatureFlags(),
+      platform: FakePlatform(operatingSystem: 'macos', environment: <String, String>{}),
+      os: os,
+    );
+    await createTestCommandRunner(command).run(const <String>['precache', '--host-arch=x64']);
+
+    expect(os.hostPlatformOverride, HostPlatform.darwin_x64);
+    expect(cache.osUtils.hostPlatformOverride, HostPlatform.darwin_x64);
+  });
 }
 
 class FakeCache extends Fake implements Cache {
@@ -540,4 +556,7 @@ class FakeCache extends Fake implements Cache {
 
   @override
   bool includeAllPlatforms = false;
+
+  @override
+  late final OperatingSystemUtils osUtils = FakeOperatingSystemUtils();
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
@@ -506,18 +506,15 @@ void main() {
     );
   });
 
-  testUsingContext('precache --host-arch overrides cache and os hostPlatformOverride', () async {
-    final os = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64);
-    final PrecacheCommand command = PrecacheCommand(
+  testUsingContext('precache --host-arch overrides cache hostPlatformOverride', () async {
+    final command = PrecacheCommand(
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(),
       platform: FakePlatform(operatingSystem: 'macos', environment: <String, String>{}),
-      os: os,
     );
     await createTestCommandRunner(command).run(const <String>['precache', '--host-arch=x64']);
 
-    expect(os.hostPlatformOverride, HostPlatform.darwin_x64);
     expect(cache.osUtils.hostPlatformOverride, HostPlatform.darwin_x64);
   });
 }

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -200,17 +200,13 @@ void main() {
 
     testWithoutContext('Linux x64 with FLUTTER_HOST_ARCH=arm64 override', () async {
       final OperatingSystemUtils utils = createOSUtils(
-        FakePlatform(
-          operatingSystem: 'linux',
-          environment: <String, String>{'FLUTTER_HOST_ARCH': 'arm64'},
-        ),
+        FakePlatform(environment: <String, String>{'FLUTTER_HOST_ARCH': 'arm64'}),
         currentAbi: Abi.linuxX64,
       );
       expect(utils.hostPlatform, HostPlatform.linux_arm64);
     });
 
     testWithoutContext('hostPlatformOverride property takes precedence', () async {
-      fakeProcessManager.addCommands(<FakeCommand>[kWhichSysctlCommand, kARMCheckCommand]);
       final OperatingSystemUtils utils = createOSUtils(
         FakePlatform(operatingSystem: 'macos'),
         currentAbi: Abi.macosArm64,

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -206,6 +206,22 @@ void main() {
       expect(utils.hostPlatform, HostPlatform.linux_arm64);
     });
 
+    testWithoutContext('FLUTTER_HOST_ARCH override is case-insensitive', () async {
+      final OperatingSystemUtils utils = createOSUtils(
+        FakePlatform(environment: <String, String>{'FLUTTER_HOST_ARCH': 'ARM64'}),
+        currentAbi: Abi.linuxX64,
+      );
+      expect(utils.hostPlatform, HostPlatform.linux_arm64);
+    });
+
+    testWithoutContext('unrecognized FLUTTER_HOST_ARCH override is ignored', () async {
+      final OperatingSystemUtils utils = createOSUtils(
+        FakePlatform(environment: <String, String>{'FLUTTER_HOST_ARCH': 'sparc'}),
+        currentAbi: Abi.linuxX64,
+      );
+      expect(utils.hostPlatform, HostPlatform.linux_x64);
+    });
+
     testWithoutContext('hostPlatformOverride property takes precedence', () async {
       final OperatingSystemUtils utils = createOSUtils(
         FakePlatform(operatingSystem: 'macos'),
@@ -460,6 +476,28 @@ void main() {
         expect(fs.file('cache/windows-x64-profile/poc_marker.txt').existsSync(), isFalse);
       },
     );
+  });
+
+  group('HostPlatform.fromOsAndArch', () {
+    testWithoutContext('maps supported OS and architecture combinations', () {
+      expect(HostPlatform.fromOsAndArch('macos', 'x64'), HostPlatform.darwin_x64);
+      expect(HostPlatform.fromOsAndArch('macos', 'arm64'), HostPlatform.darwin_arm64);
+      expect(HostPlatform.fromOsAndArch('linux', 'x64'), HostPlatform.linux_x64);
+      expect(HostPlatform.fromOsAndArch('linux', 'arm64'), HostPlatform.linux_arm64);
+      expect(HostPlatform.fromOsAndArch('linux', 'riscv64'), HostPlatform.linux_riscv64);
+      expect(HostPlatform.fromOsAndArch('windows', 'x64'), HostPlatform.windows_x64);
+      expect(HostPlatform.fromOsAndArch('windows', 'arm64'), HostPlatform.windows_arm64);
+    });
+
+    testWithoutContext('matches the architecture case-insensitively', () {
+      expect(HostPlatform.fromOsAndArch('macos', 'ARM64'), HostPlatform.darwin_arm64);
+    });
+
+    testWithoutContext('returns null for unsupported combinations', () {
+      expect(HostPlatform.fromOsAndArch('macos', 'riscv64'), isNull);
+      expect(HostPlatform.fromOsAndArch('fuchsia', 'x64'), isNull);
+      expect(HostPlatform.fromOsAndArch('linux', 'sparc'), isNull);
+    });
   });
 
   testWithoutContext('If unzip fails, include stderr in exception text', () {

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ffi' show Abi;
+
 import 'package:archive/archive.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -173,6 +174,49 @@ void main() {
         currentAbi: Abi.macosArm64,
       );
       expect(utils.hostPlatform, HostPlatform.darwin_arm64);
+    });
+
+    testWithoutContext('macOS ARM64 with FLUTTER_HOST_ARCH=x64 override', () async {
+      final OperatingSystemUtils utils = createOSUtils(
+        FakePlatform(
+          operatingSystem: 'macos',
+          environment: <String, String>{'FLUTTER_HOST_ARCH': 'x64'},
+        ),
+        currentAbi: Abi.macosArm64,
+      );
+      expect(utils.hostPlatform, HostPlatform.darwin_x64);
+    });
+
+    testWithoutContext('macOS x64 with FLUTTER_HOST_ARCH=arm64 override', () async {
+      final OperatingSystemUtils utils = createOSUtils(
+        FakePlatform(
+          operatingSystem: 'macos',
+          environment: <String, String>{'FLUTTER_HOST_ARCH': 'arm64'},
+        ),
+        currentAbi: Abi.macosX64,
+      );
+      expect(utils.hostPlatform, HostPlatform.darwin_arm64);
+    });
+
+    testWithoutContext('Linux x64 with FLUTTER_HOST_ARCH=arm64 override', () async {
+      final OperatingSystemUtils utils = createOSUtils(
+        FakePlatform(
+          operatingSystem: 'linux',
+          environment: <String, String>{'FLUTTER_HOST_ARCH': 'arm64'},
+        ),
+        currentAbi: Abi.linuxX64,
+      );
+      expect(utils.hostPlatform, HostPlatform.linux_arm64);
+    });
+
+    testWithoutContext('hostPlatformOverride property takes precedence', () async {
+      fakeProcessManager.addCommands(<FakeCommand>[kWhichSysctlCommand, kARMCheckCommand]);
+      final OperatingSystemUtils utils = createOSUtils(
+        FakePlatform(operatingSystem: 'macos'),
+        currentAbi: Abi.macosArm64,
+      );
+      utils.hostPlatformOverride = HostPlatform.darwin_x64;
+      expect(utils.hostPlatform, HostPlatform.darwin_x64);
     });
 
     testWithoutContext('unsupported throws', () async {

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -686,6 +686,9 @@ class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {
   void makeExecutable(File file) {}
 
   @override
+  HostPlatform? hostPlatformOverride;
+
+  @override
   HostPlatform hostPlatform = HostPlatform.linux_x64;
 
   @override


### PR DESCRIPTION
Adds a `--host-arch=<x64|arm64>` option to `flutter precache` and adds support for the `FLUTTER_HOST_ARCH` environment variable in `OperatingSystemUtils.hostPlatform`.

When specified, this overrides the default hardware detection check (`sysctl hw.optional.arm64` on macOS), and causes `flutter precache` to download host engine artifacts for the specified architecture instead.

This is required to allow arm64 macOS CI hosts to download and cache x64 host engine artifacts when cross-packaging x64 Flutter SDK release archives on an arm64 host in the `packaging/packaging` recipe in `packaging.py`.

See: https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/packaging/packaging.py

Issue: https://github.com/flutter/flutter/issues/189144

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
