### PR TITLE
[web] Ensure a device-width viewport meta in the built index.html

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/full_page_embedding_strategy.dart
@@ -75,7 +75,15 @@ class FullPageEmbeddingStrategy implements EmbeddingStrategy {
         // Filter out the meta tag that the engine placed on the page. This is
         // to avoid UI flicker during hot restart. Hot restart will clean up the
         // old meta tag synchronously with the first post-restart frame.
-        if (!viewportMeta.hasAttribute('flt-viewport')) {
+        //
+        // Also don't warn about an app-provided `width=device-width` viewport.
+        // That configuration is compatible with Flutter, and shipping it in the
+        // initial HTML is in fact required on iOS so the correct viewport (and
+        // devicePixelRatio) applies from the first layout rather than the 980px
+        // desktop fallback. See https://github.com/flutter/flutter/issues/129324
+        final String? content = viewportMeta.getAttribute('content');
+        final bool isCompatible = content != null && content.contains('width=device-width');
+        if (!viewportMeta.hasAttribute('flt-viewport') && !isCompatible) {
           printWarning(
             'Found an existing <meta name="viewport"> tag. Flutter Web uses its own viewport '
             'configuration for better compatibility with Flutter. This tag will be replaced.',

--- a/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/full_page_embedding_strategy_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/view_embedder/embedding_strategy/full_page_embedding_strategy_test.dart
@@ -59,7 +59,47 @@ void doTests() {
         isTrue,
         reason: 'Should install flutter viewport meta tag.',
       );
-      expect(warnings, hasLength(1), reason: 'Should print a warning to the user.');
+      expect(
+        warnings,
+        isEmpty,
+        reason:
+            'Should not warn about a width=device-width viewport, which is '
+            'compatible with Flutter and is what apps are expected to ship in '
+            'index.html. See https://github.com/flutter/flutter/issues/129324',
+      );
+
+      printWarning = oldPrintWarning;
+    });
+
+    test('Warns about (and replaces) an incompatible viewport meta', () {
+      final warnings = <String>[];
+      final void Function(String) oldPrintWarning = printWarning;
+      printWarning = (String message) {
+        warnings.add(message);
+      };
+
+      for (final DomElement meta in domDocument.head!.querySelectorAll('meta[name="viewport"]')) {
+        meta.remove();
+      }
+      domDocument.head!.append(
+        createDomHTMLMetaElement()
+          ..name = 'viewport'
+          // A fixed-width (non device-width) viewport is not compatible with
+          // Flutter and gets replaced, so the user should be warned.
+          ..content = 'width=1024',
+      );
+
+      // ignore: unused_local_variable
+      final strategy = FullPageEmbeddingStrategy();
+
+      final DomElement? flutterMeta = domDocument.querySelector('meta[name="viewport"]');
+      expect(flutterMeta, isNotNull);
+      expect(flutterMeta!.hasAttribute('flt-viewport'), isTrue);
+      expect(
+        warnings,
+        hasLength(1),
+        reason: 'Should warn that an incompatible viewport is replaced.',
+      );
       expect(warnings.single, contains(RegExp(r'Found an existing.*meta.*viewport')));
 
       printWarning = oldPrintWarning;

--- a/packages/flutter_tools/lib/src/web_template.dart
+++ b/packages/flutter_tools/lib/src/web_template.dart
@@ -18,6 +18,18 @@ const kStaticAssetsUrlPlaceholder = r'$FLUTTER_STATIC_ASSETS_URL';
 const _kServiceWorkerDeprecationNotice =
     "Flutter's service worker is deprecated and will be removed in a future Flutter release.";
 
+/// The viewport meta tag injected into an app's `index.html` when it declares
+/// none of its own.
+///
+/// A viewport meta must be present in the initial HTML: on iOS a missing
+/// viewport makes Safari use the 980px desktop fallback at first parse, which
+/// both mis-scales the semantics tree (via a fractional devicePixelRatio) and
+/// leaves the ~350ms click delay enabled, so an in-gesture focus never reaches
+/// the on-screen keyboard. A tag injected later by JavaScript is applied too
+/// late to change either. See https://github.com/flutter/flutter/issues/129324
+const _kDefaultViewportMeta =
+    '<meta name="viewport" content="width=device-width, initial-scale=1.0">';
+
 class WebTemplateWarning {
   WebTemplateWarning(this.warningText, this.lineNumber);
   final String warningText;
@@ -68,6 +80,29 @@ class WebTemplate {
     return stripLeadingSlash(stripTrailingSlash(baseHref));
   }
 
+  /// Returns [html] with [_kDefaultViewportMeta] inserted into its `<head>`
+  /// when the document does not already declare a `<meta name="viewport">`.
+  ///
+  /// Existing apps created before the viewport meta was added to the template
+  /// are fixed on their next rebuild without editing their `web/index.html`.
+  /// The developer's HTML is otherwise left byte-for-byte unchanged. See
+  /// https://github.com/flutter/flutter/issues/129324
+  @visibleForTesting
+  static String injectViewportMetaIfMissing(String html) {
+    final bool hasViewport = parse(html)
+        .querySelectorAll('meta')
+        .any((Element meta) => (meta.attributes['name'] ?? '').toLowerCase() == 'viewport');
+    if (hasViewport) {
+      return html;
+    }
+    final Match? headClose = RegExp('</head>', caseSensitive: false).firstMatch(html);
+    if (headClose == null) {
+      return html;
+    }
+    final int insertAt = headClose.start;
+    return '${html.substring(0, insertAt)}  $_kDefaultViewportMeta\n${html.substring(insertAt)}';
+  }
+
   List<WebTemplateWarning> getWarnings() {
     return <WebTemplateWarning>[
       ..._getWarningsForPattern(
@@ -112,6 +147,11 @@ class WebTemplate {
     Map<String, String> webDefines = const <String, String>{},
   }) {
     String newContent = _content;
+
+    // If the app's index.html declares no viewport meta, inject one so the
+    // correct devicePixelRatio and (on iOS) fast-click behavior apply from the
+    // initial parse. See https://github.com/flutter/flutter/issues/129324
+    newContent = injectViewportMetaIfMissing(newContent);
 
     if (newContent.contains(kBaseHrefPlaceholder)) {
       newContent = newContent.replaceAll(kBaseHrefPlaceholder, baseHref);

--- a/packages/flutter_tools/templates/app/web/index.html.tmpl
+++ b/packages/flutter_tools/templates/app/web/index.html.tmpl
@@ -18,6 +18,12 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <!-- The viewport must be in the initial HTML. On iOS, a viewport injected
+       later by JavaScript is applied too late: Safari uses the 980px desktop
+       fallback at first paint, which mis-scales the semantics tree and keeps
+       the tap delay that stops the on-screen keyboard from opening on a
+       TextField. See https://github.com/flutter/flutter/issues/129324 -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="{{description}}">
 
   <!-- iOS meta tags & icons -->

--- a/packages/flutter_tools/test/general.shard/web_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/web_template_test.dart
@@ -82,6 +82,7 @@ const htmlSampleInlineFlutterJsBootstrapOutput = '''
   <base href="/foo/222/">
   <meta charset="utf-8">
   <link rel="icon" type="image/png" href="favicon.png"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
   <div></div>
@@ -124,6 +125,7 @@ const htmlSampleFullFlutterBootstrapReplacementOutput = '''
   <base href="/foo/222/">
   <meta charset="utf-8">
   <link rel="icon" type="image/png" href="favicon.png"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
   <div></div>
@@ -193,6 +195,7 @@ String htmlSample2Replaced({required String baseHref, required String serviceWor
   <base href="$baseHref">
   <meta charset="utf-8">
   <link rel="icon" type="image/png" href="favicon.png"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
   <div></div>
@@ -263,6 +266,7 @@ String htmlSampleStaticAssetsUrlReplaced({required String staticAssetsUrl}) =>
   <base href="/">
   <meta charset="utf-8">
   <link rel="icon" type="image/png" href="favicon.png"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
   <div></div>
@@ -591,5 +595,74 @@ void main() {
     );
 
     expect(result, contains("const value = '';"));
+  });
+
+  group('viewport meta injection', () {
+    const noViewport = '''
+<!DOCTYPE html>
+<html>
+<head>
+  <title></title>
+  <meta charset="utf-8">
+</head>
+<body></body>
+</html>
+''';
+
+    test('injects a viewport meta when the document declares none', () {
+      final String result = WebTemplate.injectViewportMetaIfMissing(noViewport);
+      // Inserted inside <head>, immediately before </head>.
+      expect(
+        result,
+        contains(
+          '  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n</head>',
+        ),
+      );
+    });
+
+    test('does not inject when a viewport meta already exists', () {
+      const withViewport = '''
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width">
+</head>
+<body></body>
+</html>
+''';
+      expect(WebTemplate.injectViewportMetaIfMissing(withViewport), withViewport);
+    });
+
+    test('detects an existing viewport meta regardless of case and attribute order', () {
+      const withViewport = '''
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="width=device-width" NAME="Viewport">
+</head>
+<body></body>
+</html>
+''';
+      expect(WebTemplate.injectViewportMetaIfMissing(withViewport), withViewport);
+    });
+
+    test('leaves the document unchanged when there is no head', () {
+      const noHead = '<html><body></body></html>';
+      expect(WebTemplate.injectViewportMetaIfMissing(noHead), noHead);
+    });
+
+    test('withSubstitutions injects the viewport meta into a viewport-less app', () {
+      const indexHtml = WebTemplate(noViewport);
+      final String result = indexHtml.withSubstitutions(
+        baseHref: '/',
+        serviceWorkerVersion: null,
+        flutterJsFile: flutterJs,
+        logger: logger,
+      );
+      expect(
+        result,
+        contains('<meta name="viewport" content="width=device-width, initial-scale=1.0">'),
+      );
+    });
   });
 }


### PR DESCRIPTION
Addresses #129324

## Problem
On iOS, if an app's `index.html` has no viewport meta, Safari renders through its 980px desktop fallback at first parse. That mis-scales the semantics tree via a fractional devicePixelRatio and keeps the roughly 350ms tap delay active, so the synchronous focus that opens the on-screen keyboard fires outside the gesture and the keyboard never opens on a TextField. A viewport meta injected later by JavaScript is applied too late to change either.

## Fix
Ship a `width=device-width` viewport meta in the initial HTML. The `flutter create` web template now includes it, and `flutter build web` injects it into the built `index.html` when the app declares none, so existing apps are fixed on rebuild with no source change. The engine no longer warns when it finds this compatible viewport. `web_template_test` covers the injection and `full_page_embedding_strategy_test` covers the warning change.

## Demo
On an iPhone:
- Before: https://flutter-demo-50-before.web.app cannot type in the TextField.
- After: https://flutter-demo-50-after.web.app opens the keyboard and types. This after build has both this fix and the #190483 Fix A applied.

#129324 needs both halves. This PR removes the tap delay so focus is in-gesture, and #190483 keeps the `<input>` on-screen so the tap hits it. Verified on-device that the viewport meta alone does not fix typing without #190483.
