### PR TITLE
iOS,macOS: make Logger thread-safe, conform to Sendable

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/Logger.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/Logger.swift
@@ -9,7 +9,7 @@ import Foundation
 ///
 /// These levels are used by `Logger` to determine if a message should be output.
 /// They are ordered by increasing severity.
-@objc(FlutterLogLevel) public enum LogLevel: Int {
+@objc(FlutterLogLevel) public enum LogLevel: Int, Sendable {
   /// Informational messages that are helpful for tracing application flow.
   case info
 
@@ -38,14 +38,38 @@ import Foundation
 /// Logger.logLevel = .warning  // Only show warnings and above
 /// Logger.logError("Failed to load asset: \(assetKey)")
 /// ```
-@objc(FlutterLogger) public final class Logger: NSObject {
-  private static var shared = Logger()
-  private let outputWriter: OutputWriter
-  public let logLevel: LogLevel
+@objc(FlutterLogger) public final class Logger: NSObject, @unchecked Sendable {
+  private static let shared = Logger()
+  private let lock = NSLock()
+  private var _outputWriter: OutputWriter
+  private var _logLevel: LogLevel
+
+  public var outputWriter: OutputWriter {
+    get {
+      return lock.withLock { _outputWriter }
+    }
+    set {
+      lock.withLock {
+        _outputWriter = newValue
+      }
+    }
+  }
+
+  public var logLevel: LogLevel {
+    get {
+      return lock.withLock { _logLevel }
+    }
+    set {
+      lock.withLock {
+        _logLevel = newValue
+      }
+    }
+  }
 
   public init(outputWriter: OutputWriter, logLevel: LogLevel) {
-    self.outputWriter = outputWriter
-    self.logLevel = logLevel
+    self._outputWriter = outputWriter
+    self._logLevel = logLevel
+    super.init()
   }
 
   public override convenience init() {
@@ -60,8 +84,19 @@ import Foundation
   }
 
   public func log(level: LogLevel, _ message: @autoclosure () -> String) {
-    if level.rawValue >= logLevel.rawValue {
-      outputWriter.writeLine(level: level, message())
+    guard level.rawValue >= logLevel.rawValue else { return }
+
+    // Evaluate outside the lock keep lock time minimal and to guard against the possibility of
+    // someone accidentally calling the Logger from within the autoclosure.
+    let line = message()
+    lock.withLock {
+      _outputWriter.writeLine(level: level, line)
+    }
+  }
+
+  public func logDirect(_ message: String) {
+    lock.withLock {
+      _outputWriter.writeLine(level: .important, message)
     }
   }
 }
@@ -70,13 +105,13 @@ extension Logger {
   /// Sets the minimum log level.
   @objc public static var outputWriter: OutputWriter {
     get { return shared.outputWriter }
-    set(newValue) { shared = Logger(outputWriter: newValue, logLevel: shared.logLevel) }
+    set(newValue) { shared.outputWriter = newValue }
   }
 
   /// Sets the minimum log level.
   @objc public static var logLevel: LogLevel {
     get { return shared.logLevel }
-    set(newValue) { shared = Logger(outputWriter: shared.outputWriter, logLevel: newValue) }
+    set(newValue) { shared.logLevel = newValue }
   }
 
   /// Logs a message at `LogLevel.info`.
@@ -138,16 +173,16 @@ extension Logger {
 
   /// Logs a message unconditionally.
   @objc public static func logDirect(_ message: String) {
-    shared.outputWriter.writeLine(level: .important, message)
+    shared.logDirect(message)
   }
 }
 
 @objc(FlutterOutputWriter)
-public protocol OutputWriter {
+public protocol OutputWriter: Sendable {
   func writeLine(level: LogLevel, _ message: String)
 }
 
-final class SyslogOutputWriter: OutputWriter {
+final class SyslogOutputWriter: OutputWriter, Sendable {
   func writeLine(level: LogLevel, _ message: String) {
     // TODO(cbracken): replace this with os_log-based approach.
     // https://github.com/flutter/flutter/issues/44030
@@ -155,7 +190,7 @@ final class SyslogOutputWriter: OutputWriter {
   }
 }
 
-final class StdoutOutputWriter: OutputWriter {
+final class StdoutOutputWriter: OutputWriter, Sendable {
   func writeLine(level: LogLevel, _ message: String) {
     fputs(message, stdout)
     fputs("\n", stdout)

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTestUtils.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTestUtils.swift
@@ -7,7 +7,7 @@ import InternalFlutterSwiftCommon
 
 /// An `OutputWriter` that stores the most recently logged output in a string.
 @objc(FlutterStringOutputWriter)
-public final class StringOutputWriter: NSObject, OutputWriter {
+public final class StringOutputWriter: NSObject, OutputWriter, @unchecked Sendable {
   @objc public var didLog = false
   public var lastLevel: LogLevel!
   @objc public var lastLine: String!

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTests.swift
@@ -105,4 +105,34 @@ import test_utils_swift
     #expect(!wasEvaluated)
   }
 
+  // Hammers the shared `Logger` from concurrent tasks so that unsynchronised access to mutable
+  // state is caught under TSan.
+  @Test func testConcurrentLoggingAndLevelMutation() async {
+    let writer = StringOutputWriter()
+    let oldWriter = Logger.outputWriter
+    let oldLevel = Logger.logLevel
+    defer {
+      Logger.outputWriter = oldWriter
+      Logger.logLevel = oldLevel
+    }
+    Logger.outputWriter = writer
+    Logger.logLevel = .info
+
+    await withTaskGroup(of: Void.self) { group in
+      for i in 0..<100 {
+        group.addTask {
+          if i % 2 == 0 {
+            Logger.logLevel = .warning
+          } else {
+            Logger.logLevel = .info
+          }
+          Logger.logInfo("Message \(i)")
+        }
+      }
+    }
+
+    // After concurrent mutations and logging, Logger should remain in a valid state without data
+    // races or crashes.
+    #expect(Logger.logLevel == .info || Logger.logLevel == .warning)
+  }
 }


### PR DESCRIPTION
Previously, `Logger.shared` was a mutable static variable, and updating `Logger.logLevel` or `Logger.outputWriter` replaced the entire singleton instance without any synchronisation. This could cause data races when logging from multiple threads, and prevented `Logger` from conforming to `Sendable` under strict Swift concurrency.

We now make `shared` an immutable constant and guard its mutable `logLevel` and `outputWriter` state behind a lock.

The caller-supplied message autoclosure is evaluated outside the lock, both to keep the lock scope minimal and to avoid deadlocking should the closure re-enter `Logger` since the lock is not reentrant.

Issue: https://github.com/flutter/flutter/issues/44030

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
