### PR TITLE
Fix a flake in ShellTest.SecondaryVsyncCallbackShouldBeCalledAfterVsyncCallback

### DIFF
--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -2313,23 +2313,35 @@ TEST_F(ShellTest, SecondaryVsyncCallbackShouldBeCalledAfterVsyncCallback) {
   // Wait for the application to attach the listener.
   latch.Wait();
 
+  auto vsync_task = [&]() {
+    shell->GetEngine()->ScheduleSecondaryVsyncCallback(0, [&]() {
+      if (!test_started) {
+        return;
+      }
+      EXPECT_TRUE(is_on_begin_frame_called);
+      EXPECT_FALSE(is_secondary_callback_called);
+      is_secondary_callback_called = true;
+      count_down_latch.CountDown();
+    });
+    shell->GetEngine()->ScheduleFrame();
+    test_started = true;
+  };
+
+  // Run the test task after a vsync occurs so that the
+  // ScheduleSecondaryVsyncCallback and ScheduleFrame calls will happen within
+  // the same vsync interval.
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetUITaskRunner(), [&]() {
-        shell->GetEngine()->ScheduleSecondaryVsyncCallback(0, [&]() {
-          if (!test_started) {
-            return;
-          }
-          EXPECT_TRUE(is_on_begin_frame_called);
-          EXPECT_FALSE(is_secondary_callback_called);
-          is_secondary_callback_called = true;
-          count_down_latch.CountDown();
-        });
-        shell->GetEngine()->ScheduleFrame();
-        test_started = true;
+        auto vsync_waiter = shell->GetEngine()->GetVsyncWaiter().lock();
+        ASSERT_TRUE(vsync_waiter);
+        vsync_waiter->AsyncWaitForVsync(
+            [&](auto frame_timings_recorder) { vsync_task(); });
       });
+
   count_down_latch.Wait();
   EXPECT_TRUE(is_on_begin_frame_called);
   EXPECT_TRUE(is_secondary_callback_called);
+
   DestroyShell(std::move(shell), task_runners);
 }
 

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -2333,7 +2333,6 @@ TEST_F(ShellTest, SecondaryVsyncCallbackShouldBeCalledAfterVsyncCallback) {
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetUITaskRunner(), [&]() {
         auto vsync_waiter = shell->GetEngine()->GetVsyncWaiter().lock();
-        ASSERT_TRUE(vsync_waiter);
         vsync_waiter->AsyncWaitForVsync(
             [&](auto frame_timings_recorder) { vsync_task(); });
       });

--- a/engine/src/flutter/shell/common/vsync_waiter.cc
+++ b/engine/src/flutter/shell/common/vsync_waiter.cc
@@ -94,7 +94,7 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
 
   {
     std::scoped_lock lock(callback_mutex_);
-    callback = std::move(callback_);
+    callback_.swap(callback);
     for (auto& pair : secondary_callbacks_) {
       secondary_callbacks.push_back(std::move(pair.second));
     }


### PR DESCRIPTION
That test calls the engine's ScheduleSecondaryVsyncCallback and ScheduleFrame APIs.  If a vsync occurs between the two calls, then the secondary callback will be executed at that vsync, but the frame will be scheduled at the next vsync.  That will cause a false negative in the test.

This PR changes the test to execute the API calls shortly after a vsync happens.  That should ensure that both calls happen during the same vsync interval.

This also fixes an issue where VsyncWaiter::FireCallback was not properly resetting the VsyncWaiter's callback.  The failure to reset the callback meant that a second call to AsyncWaitForVsync with a different callback would not actually take effect.

Fixes https://github.com/flutter/flutter/issues/190430