### PR TITLE
iOS,macOS: add tsan and ubsan support for Swift

### DIFF
--- a/engine/src/build/config/compiler/BUILD.gn
+++ b/engine/src/build/config/compiler/BUILD.gn
@@ -143,6 +143,11 @@ config("compiler") {
     if (is_asan) {
       cflags += [ "-fsanitize=address" ]
       ldflags += [ "-fsanitize=address" ]
+
+      # ASan is deliberately not added to swiftflags.
+      # The Swift frontend emits an ASan version-mismatch guard
+      # (__asan_version_mismatch_check_apple_clang_*) that the engine's clang
+      # ASan runtime doesn't provide, so instrumenting Swift fails to link.
     }
     if (is_hwasan && is_android && current_cpu == "arm64") {
       cflags += [ "-fsanitize=hwaddress" ]
@@ -155,6 +160,7 @@ config("compiler") {
     if (is_tsan) {
       cflags += [ "-fsanitize=thread" ]
       ldflags += [ "-fsanitize=thread" ]
+      swiftflags += [ "-sanitize=thread" ]
     }
     if (is_msan) {
       cflags += [ "-fsanitize=memory" ]
@@ -163,6 +169,10 @@ config("compiler") {
     if (is_ubsan) {
       cflags += [ "-fsanitize=undefined" ]
       ldflags += [ "-fsanitize=undefined" ]
+
+      # UBSan is deliberately not added to swiftflags. The Swift compiler
+      # accepts -sanitize=undefined but emits no UBSan instrumentation for Swift
+      # code.
     }
 
     if (use_custom_libcxx) {
@@ -435,9 +445,9 @@ config("compiler") {
     # to say that it does. Define them here instead.
     defines += [ "HAVE_SYS_UIO_H" ]
 
-    # When Android requires new flags consider also editing the flags in
-    # the following locations.
-    # Framework plugin_ffi template: packages/flutter_tools/templates/plugin_ffi/src.tmpl/CMakeLists.txt.tmpl
+    # When Android requires new flags consider also editing the flags in the
+    # following locations. Framework plugin_ffi template:
+    # packages/flutter_tools/templates/plugin_ffi/src.tmpl/CMakeLists.txt.tmpl
     # Example PR: https://github.com/flutter/flutter/pull/155508
     # Dart Lang JNI package: pkgs/jni/src/CMakeLists.txt
     # Example PR: https://github.com/dart-lang/native/pull/1615
@@ -1023,7 +1033,8 @@ config("optimize") {
   }
 
   lto_flags = []
-  if (enable_lto && (is_linux || is_ios || is_mac || is_android || is_fuchsia || is_wasm)) {
+  if (enable_lto &&
+      (is_linux || is_ios || is_mac || is_android || is_fuchsia || is_wasm)) {
     lto_flags += [ "-flto" ]
   }
 


### PR DESCRIPTION
Previously asan/tsan/ubsan builds applied only to C[++]/Obj-C[++] builds but not Swift since the flags were never wired up. This adds support for TSan (`-fsanitize=thread`) and UBSan (`-fsanitize=undefined`) for Swift.

ASan is intentionally excluded. Swift is compiled with the Apple toolchain, while C/C++ and the link step use the Fuchsia clang from CIPD, and the two ship different ASan runtimes. Apple's swift-frontend stamps each instrumented module with a version-mismatch guard that the linked Fuchsia runtime doesn't provide, so Swift + ASan fails to link with an undefined symbol:

    Swift objects reference:  ___asan_version_mismatch_check_apple_clang_2100
    Fuchsia asan runtime has: ___asan_version_mismatch_check_v8

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
