### PR TITLE
Update Widgets Localizations from Translation Console

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/generated_widgets_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_widgets_localizations.dart
@@ -1354,6 +1354,29 @@ class WidgetsLocalizationEsEc extends WidgetsLocalizationEs {
   String get radioButtonUnselectedLabel => 'Sin seleccionar';
 }
 
+/// The translations for Spanish Castilian, as used in Spain (`es_ES`).
+class WidgetsLocalizationEsEs extends WidgetsLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Spain.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalWidgetsLocalizations].
+  const WidgetsLocalizationEsEs();
+
+  @override
+  String get reorderItemToStart => 'Mover al inicio';
+
+  @override
+  String get searchResultsFound => 'Se encontraron resultados de la búsqueda';
+
+  @override
+  String get noResultsFound => 'No se encontraron resultados';
+
+  @override
+  String get lookUpButtonLabel => 'Consultar';
+
+  @override
+  String get radioButtonUnselectedLabel => 'Sin seleccionar';
+}
+
 /// The translations for Spanish Castilian, as used in Guatemala (`es_GT`).
 class WidgetsLocalizationEsGt extends WidgetsLocalizationEs {
   /// Create an instance of the translation bundle for Spanish Castilian, as used in Guatemala.
@@ -5539,7 +5562,7 @@ final Set<String> kWidgetsSupportedLanguages = HashSet<String>.from(const <Strin
 ///  * `de` - German (plus one country variation)
 ///  * `el` - Modern Greek
 ///  * `en` - English (plus 8 country variations)
-///  * `es` - Spanish Castilian (plus 20 country variations)
+///  * `es` - Spanish Castilian (plus 21 country variations)
 ///  * `et` - Estonian
 ///  * `eu` - Basque
 ///  * `fa` - Persian
@@ -5688,6 +5711,8 @@ GlobalWidgetsLocalizations? getWidgetsTranslation(
           return const WidgetsLocalizationEsDo();
         case 'EC':
           return const WidgetsLocalizationEsEc();
+        case 'ES':
+          return const WidgetsLocalizationEsEs();
         case 'GT':
           return const WidgetsLocalizationEsGt();
         case 'HN':

--- a/packages/flutter_localizations/lib/src/l10n/widgets_es_ES.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_es_ES.arb
@@ -1,0 +1,18 @@
+{
+  "reorderItemToStart": "Mover al inicio",
+  "reorderItemToEnd": "Mover al final",
+  "reorderItemUp": "Mover hacia arriba",
+  "reorderItemDown": "Mover hacia abajo",
+  "reorderItemLeft": "Mover hacia la izquierda",
+  "reorderItemRight": "Mover hacia la derecha",
+  "searchResultsFound": "Se encontraron resultados de la búsqueda",
+  "noResultsFound": "No se encontraron resultados",
+  "copyButtonLabel": "Copiar",
+  "cutButtonLabel": "Cortar",
+  "lookUpButtonLabel": "Consultar",
+  "searchWebButtonLabel": "Buscar en la Web",
+  "shareButtonLabel": "Compartir",
+  "pasteButtonLabel": "Pegar",
+  "selectAllButtonLabel": "Seleccionar todo",
+  "radioButtonUnselectedLabel": "Sin seleccionar"
+}


### PR DESCRIPTION
This PR is to update localizations in widgets layer from translation console. It doesn't fetch material and cupertino localziations because they have been decoupled from core flutter and will be updated in material_ui and cupertino_ui.

Fixes https://github.com/flutter/flutter/issues/190408

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
