### PR TITLE
Windows: Propagate enabled accessibility state

### DIFF
--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -318,7 +318,7 @@ void AccessibilityBridge::SetRoleFromFlutterUpdate(ui::AXNodeData& node_data,
     node_data.role = ax::mojom::Role::kButton;
     return;
   }
-  if (flags->is_text_field && !flags->is_read_only) {
+  if (flags->is_text_field) {
     node_data.role = ax::mojom::Role::kTextField;
     return;
   }

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
@@ -356,6 +356,41 @@ TEST(AccessibilityBridgeTest, ReadOnlyTextFieldHasReadOnlyRestriction) {
             ax::mojom::Restriction::kReadOnly);
 }
 
+TEST(AccessibilityBridgeTest, ReadOnlyTextFieldHasTextFieldRole) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateTrue,
+      .is_text_field = true,
+      .is_read_only = true,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kTextField);
+}
+
+TEST(AccessibilityBridgeTest, EditableTextFieldHasTextFieldRole) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
+  auto flags = FlutterSemanticsFlags{
+      .is_enabled = FlutterTristate::kFlutterTristateTrue,
+      .is_text_field = true,
+      .is_read_only = false,
+  };
+  root.flags2 = &flags;
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kTextField);
+  EXPECT_TRUE(root_node->GetData().HasState(ax::mojom::State::kEditable));
+}
+
 // Ensure that checkboxes have their checked status set apropriately
 // Previously, only Radios could have this flag updated
 // Resulted in the issue seen at

--- a/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows.cc
@@ -103,6 +103,11 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
       DispatchWinAccessibilityEvent(win_delegate,
                                     ax::mojom::Event::kStateChanged);
       break;
+    case ui::AXEventGenerator::Event::ENABLED_CHANGED:
+    case ui::AXEventGenerator::Event::READONLY_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate,
+                                    ax::mojom::Event::kStateChanged);
+      break;
     case ui::AXEventGenerator::Event::ACCESS_KEY_CHANGED:
     case ui::AXEventGenerator::Event::ACTIVE_DESCENDANT_CHANGED:
     case ui::AXEventGenerator::Event::ATK_TEXT_OBJECT_ATTRIBUTE_CHANGED:
@@ -116,7 +121,6 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
     case ui::AXEventGenerator::Event::DESCRIPTION_CHANGED:
     case ui::AXEventGenerator::Event::DOCUMENT_TITLE_CHANGED:
     case ui::AXEventGenerator::Event::DROPEFFECT_CHANGED:
-    case ui::AXEventGenerator::Event::ENABLED_CHANGED:
     case ui::AXEventGenerator::Event::EXPANDED:
     case ui::AXEventGenerator::Event::FLOW_FROM_CHANGED:
     case ui::AXEventGenerator::Event::FLOW_TO_CHANGED:
@@ -142,7 +146,6 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
     case ui::AXEventGenerator::Event::PLACEHOLDER_CHANGED:
     case ui::AXEventGenerator::Event::PORTAL_ACTIVATED:
     case ui::AXEventGenerator::Event::POSITION_IN_SET_CHANGED:
-    case ui::AXEventGenerator::Event::READONLY_CHANGED:
     case ui::AXEventGenerator::Event::RELATED_NODE_CHANGED:
     case ui::AXEventGenerator::Event::REQUIRED_STATE_CHANGED:
     case ui::AXEventGenerator::Event::ROLE_CHANGED:

--- a/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -403,5 +403,35 @@ TEST(AccessibilityBridgeWindows, OnDocumentSelectionChanged) {
       ax::mojom::Event::kDocumentSelectionChanged, 2);
 }
 
+TEST(AccessibilityBridgeWindows, OnAccessibilityEnabledChanged) {
+  auto engine = GetTestEngine();
+  FlutterWindowsViewSpy view{
+      engine.get(), std::make_unique<NiceMock<MockWindowBindingHandler>>()};
+  EngineModifier modifier{engine.get()};
+  modifier.SetImplicitView(&view);
+  view.OnUpdateSemanticsEnabled(true);
+
+  auto bridge = GetAccessibilityBridgeSpy(view);
+  PopulateAXTree(bridge);
+
+  bridge->ResetRecords();
+  bridge->OnAccessibilityEvent({AXNodeFromID(bridge, 1),
+                                {ui::AXEventGenerator::Event::ENABLED_CHANGED,
+                                 ax::mojom::EventFrom::kNone,
+                                 {}}});
+
+  // Should dispatch an MSAA state change event. The UIA property change for
+  // UIA_IsEnabledPropertyId is now raised internally by AXPlatformNodeWin
+  // when it processes the kStateChanged event.
+  ASSERT_EQ(bridge->dispatched_events().size(), 1u);
+  EXPECT_EQ(bridge->dispatched_events()[0].event_type,
+            ax::mojom::Event::kStateChanged);
+}
+
+TEST(AccessibilityBridgeWindows, OnAccessibilityReadOnlyChanged) {
+  ExpectWinEventFromAXEvent(1, ui::AXEventGenerator::Event::READONLY_CHANGED,
+                            ax::mojom::Event::kStateChanged);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -404,28 +404,8 @@ TEST(AccessibilityBridgeWindows, OnDocumentSelectionChanged) {
 }
 
 TEST(AccessibilityBridgeWindows, OnAccessibilityEnabledChanged) {
-  auto engine = GetTestEngine();
-  FlutterWindowsViewSpy view{
-      engine.get(), std::make_unique<NiceMock<MockWindowBindingHandler>>()};
-  EngineModifier modifier{engine.get()};
-  modifier.SetImplicitView(&view);
-  view.OnUpdateSemanticsEnabled(true);
-
-  auto bridge = GetAccessibilityBridgeSpy(view);
-  PopulateAXTree(bridge);
-
-  bridge->ResetRecords();
-  bridge->OnAccessibilityEvent({AXNodeFromID(bridge, 1),
-                                {ui::AXEventGenerator::Event::ENABLED_CHANGED,
-                                 ax::mojom::EventFrom::kNone,
-                                 {}}});
-
-  // Should dispatch an MSAA state change event. The UIA property change for
-  // UIA_IsEnabledPropertyId is now raised internally by AXPlatformNodeWin
-  // when it processes the kStateChanged event.
-  ASSERT_EQ(bridge->dispatched_events().size(), 1u);
-  EXPECT_EQ(bridge->dispatched_events()[0].event_type,
-            ax::mojom::Event::kStateChanged);
+  ExpectWinEventFromAXEvent(1, ui::AXEventGenerator::Event::ENABLED_CHANGED,
+                            ax::mojom::Event::kStateChanged);
 }
 
 TEST(AccessibilityBridgeWindows, OnAccessibilityReadOnlyChanged) {

--- a/engine/src/flutter/third_party/accessibility/ax/platform/ax_platform_node_win.cc
+++ b/engine/src/flutter/third_party/accessibility/ax/platform/ax_platform_node_win.cc
@@ -2599,7 +2599,8 @@ IFACEMETHODIMP AXPlatformNodeWin::QueryService(REFGUID guidService,
                                                void** object) {
   COM_OBJECT_VALIDATE_1_ARG(object);
 
-  if (guidService == IID_IAccessible || (guidService == IID_IAccessibleEx && delegate_->IsIAccessibleExEnabled())) {
+  if (guidService == IID_IAccessible || (guidService == IID_IAccessibleEx &&
+                                         delegate_->IsIAccessibleExEnabled())) {
     return QueryInterface(riid, object);
   }
 
@@ -5313,6 +5314,8 @@ std::optional<PROPERTYID> AXPlatformNodeWin::MojoEventToUIAProperty(
         return UIA_ToggleToggleStatePropertyId;
       }
       return std::nullopt;
+    case ax::mojom::Event::kStateChanged:
+      return UIA_IsEnabledPropertyId;
     default:
       return std::nullopt;
   }


### PR DESCRIPTION
Relands #184501, which was reverted in #186492 because mapping read-only text fields to Role::kTextField caused the macOS embedder to instantiate a FlutterTextPlatformNode for them, producing detached accessibility elements and test crashes.

The underlying macOS issue is now fixed by #190330 and #190353. This relands the remaining bits of #184501. In the common bits of the bridge, read-only text fields now map to `Role::kTextField`. In the Windows implementation `ENABLED_CHANGED` and `READONLY_CHANGED` are dispatched as MSAA `kStateChanged` events and `AXPlatformNodeWin` now raises the corresponding `UIA_IsEnabledPropertyId` change.

Fixes: #184559


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
