### PR TITLE
[ci] Add experimental branch agp-gradle-api-flutter to enabled_branches

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -14,7 +14,7 @@
 enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
-  - agp-gradle-api-flutter
+  - agp-gradle-api-[a-z]*
 
 platform_properties:
   staging_build_linux:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -14,6 +14,7 @@
 enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
+  - agp-gradle-api-flutter
 
 platform_properties:
   staging_build_linux:

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -9,6 +9,7 @@ enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
   - fuchsia_f\d+[a-z]*
+  - agp-gradle-api-flutter
 
 platform_properties:
   linux:

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -9,7 +9,7 @@ enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
   - fuchsia_f\d+[a-z]*
-  - agp-gradle-api-flutter
+  - agp-gradle-api-[a-z]*
 
 platform_properties:
   linux:


### PR DESCRIPTION
I need https://flutter-dashboard.appspot.com/#/build?repo=flutter&branch=agp-gradle-api-flutter to populate to ensure that post submits work with my pr stack https://github.com/flutter/flutter/pull/189918 that tries to migrate flutter to newdsl apis. 

The regex is so I don't have to do another one of these prs if I need to push another branch to validate a sub pr. 

Googlers can see some historical attempts to do this in go/flutter-cherrypicks-for-master-ios

- @reidbaker 
---
Agent authored description 
Enables Cocoon CI commit indexing and build dashboard test scheduling for the experimental branch `agp-gradle-api-flutter`.