### PR TITLE
[CP-stable] Detach LLDB and print stack trace on process stop (#188576)

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -566,8 +566,12 @@ class IOSDevice extends Device {
         app: package,
         usingCISystem: debuggingOptions.usingCISystem,
       );
+
+      // This completer is used to intercept when the app crashes after the app launches but
+      // before the Dart VM service is found.
+      final appTerminatedCompleter = Completer<Uri?>();
       if (deviceLogReader is SharedIOSDeviceLogReader) {
-        await _addLogInterceptors(deviceLogReader);
+        await _addLogInterceptors(deviceLogReader, appTerminatedCompleter);
       }
 
       if (debuggingOptions.debuggingEnabled) {
@@ -677,6 +681,7 @@ class IOSDevice extends Device {
           vmServiceDiscovery: vmServiceDiscovery,
           package: package,
           deviceLogReader: deviceLogReader,
+          appTerminatedCompleter: appTerminatedCompleter,
         );
       } else if (isWirelesslyConnected) {
         // Wait for the Dart VM url to be discovered via logs (from `ios-deploy`)
@@ -836,7 +841,10 @@ class IOSDevice extends Device {
     _logger.printError('');
   }
 
-  Future<void> _addLogInterceptors(SharedIOSDeviceLogReader deviceLogReader) async {
+  Future<void> _addLogInterceptors(
+    SharedIOSDeviceLogReader deviceLogReader,
+    Completer<Uri?> appTerminatedCompleter,
+  ) async {
     final String? uisceneWarning = globals.userMessages.uiSceneMigrationWarning;
     if (uisceneWarning != null) {
       final uisceneWarningInterceptor = LogInterceptor(
@@ -856,6 +864,18 @@ class IOSDevice extends Device {
     if (jitCrashInterceptor != null) {
       deviceLogReader.addLogInterceptor(jitCrashInterceptor);
     }
+
+    final appTerminatedInterceptor = LogInterceptor(
+      identifier: 'app_terminated',
+      pattern: RegExp('^App terminated due to signal'),
+      action: () {
+        if (!appTerminatedCompleter.isCompleted) {
+          appTerminatedCompleter.complete();
+        }
+      },
+      excludeFromStream: false,
+    );
+    deviceLogReader.addLogInterceptor(appTerminatedInterceptor);
   }
 
   /// Find the Dart VM url using ProtocolDiscovery (logs from `idevicesyslog`)
@@ -868,47 +888,8 @@ class IOSDevice extends Device {
     ProtocolDiscovery? vmServiceDiscovery,
     IOSApp? package,
     required DeviceLogReader deviceLogReader,
+    required Completer<Uri?> appTerminatedCompleter,
   }) async {
-    Timer? maxWaitForCI;
-    final cancelCompleter = Completer<Uri?>();
-
-    // When testing in CI, wait a max of 10 minutes for the Dart VM to be found.
-    // Afterwards, stop the app from running and upload DerivedData Logs to debug
-    // logs directory. CoreDevices are run through Xcode and launch logs are
-    // therefore found in DerivedData.
-    if (debuggingOptions.usingCISystem && debuggingOptions.debugLogsDirectoryPath != null) {
-      maxWaitForCI = Timer(const Duration(minutes: 10), () async {
-        _logger.printError('Failed to find Dart VM after 10 minutes.');
-        await _xcodeDebug.exit();
-        final String? homePath = _platform.environment['HOME'];
-        Directory? derivedData;
-        if (homePath != null) {
-          derivedData = _fileSystem.directory(
-            _fileSystem.path.join(homePath, 'Library', 'Developer', 'Xcode', 'DerivedData'),
-          );
-        }
-        if (derivedData != null && derivedData.existsSync()) {
-          final Directory debugLogsDirectory = _fileSystem.directory(
-            debuggingOptions.debugLogsDirectoryPath,
-          );
-          debugLogsDirectory.createSync(recursive: true);
-          for (final FileSystemEntity entity in derivedData.listSync()) {
-            if (entity is! Directory || !entity.childDirectory('Logs').existsSync()) {
-              continue;
-            }
-            final Directory logsToCopy = entity.childDirectory('Logs');
-            final Directory copyDestination = debugLogsDirectory
-                .childDirectory('DerivedDataLogs')
-                .childDirectory(entity.basename)
-                .childDirectory('Logs');
-            _logger.printTrace('Copying logs ${logsToCopy.path} to ${copyDestination.path}...');
-            copyDirectory(logsToCopy, copyDestination);
-          }
-        }
-        cancelCompleter.complete();
-      });
-    }
-
     final bool discoverVMUrlFromLogs = vmServiceDiscovery != null && !isWirelesslyConnected;
 
     // If mDNS fails, don't throw since url may still be findable through vmServiceDiscovery.
@@ -927,20 +908,26 @@ class IOSDevice extends Device {
       if (discoverVMUrlFromLogs) vmServiceDiscovery.uri,
     ];
 
-    Uri? localUri = await Future.any(<Future<Uri?>>[...discoveryOptions, cancelCompleter.future]);
+    Uri? localUri = await Future.any(<Future<Uri?>>[
+      ...discoveryOptions,
+      appTerminatedCompleter.future,
+    ]);
 
     // If the first future to return is null, wait for the other to complete
-    // unless canceled.
-    if (localUri == null && !cancelCompleter.isCompleted) {
+    // unless the app was terminated.
+    if (localUri == null && !appTerminatedCompleter.isCompleted) {
       final Future<List<Uri?>> allDiscoveryOptionsComplete = Future.wait(discoveryOptions);
-      await Future.any(<Future<Object?>>[allDiscoveryOptionsComplete, cancelCompleter.future]);
-      if (!cancelCompleter.isCompleted) {
-        // If it wasn't cancelled, that means one of the discovery options completed.
+      await Future.any(<Future<Object?>>[
+        allDiscoveryOptionsComplete,
+        appTerminatedCompleter.future,
+      ]);
+      if (!appTerminatedCompleter.isCompleted) {
+        // If it wasn't terminated, that means one of the discovery options completed.
         final List<Uri?> vmUrls = await allDiscoveryOptionsComplete;
         localUri = vmUrls.where((Uri? vmUrl) => vmUrl != null).firstOrNull;
       }
     }
-    maxWaitForCI?.cancel();
+
     if (deviceLogReader is SharedIOSDeviceLogReader) {
       deviceLogReader.removeLogInterceptorByIdentifier(kJITCrashLogInterceptorIdentifier);
     }

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -58,8 +58,21 @@ class LLDB {
   /// Example: Breakpoint 1: no locations (pending).
   static final _breakpointPattern = RegExp(r'Breakpoint (\d+)*:');
 
+  /// Pattern of lldb log when a stop hook is added.
+  ///
+  /// Example: Stop hook #1 added.
+  static final _stopHookAddedPattern = RegExp(r'Stop hook #\d+ added');
+
+  /// Pattern of lldb log when a stop hook is processed.
+  ///
+  /// Example: "- Hook 1 (thread backtrace all)"
+  static final _stopHookProcessedPattern = RegExp(r'- Hook \d+');
+
   /// A list of log patterns to ignore.
-  static final _ignorePatterns = <Pattern>[RegExp(r'\d+ location added to breakpoint \d+')];
+  static final _ignorePatterns = <Pattern>[
+    RegExp(r'\d+ location added to breakpoint \d+'),
+    _stopHookProcessedPattern,
+  ];
 
   /// Breakpoint script required for JIT on iOS.
   ///
@@ -122,6 +135,7 @@ return False
         await _setBreakpoint();
       }
       await _attachToAppProcess(appProcessId);
+      await _setupStopHooks();
       await _resumeProcess(mode);
       _isAttached = true;
     } on _LLDBError catch (e) {
@@ -204,6 +218,9 @@ return False
   bool exit() {
     final bool success = (_lldbProcess == null) || _lldbProcess!.kill();
     _lldbProcess = null;
+    if (_logCompleter != null) {
+      _logCompleter!.completeError(_LLDBError('LLDB process exited'));
+    }
     _logCompleter = null;
     _isAttached = false;
     return success;
@@ -265,6 +282,18 @@ return False
     ).then((value) => value, onError: _handleAsyncError);
 
     await _lldbProcess?.stdinWriteln('process continue');
+    await futureLog;
+  }
+
+  /// Adds a stop hook to print the backtrace of all threads and then detach the debugger from the
+  /// process once it stops, such as when it crashes.
+  ///
+  /// Without this, the debugger would remain attached to the process and the app will hang on crash.
+  Future<void> _setupStopHooks() async {
+    final Future<String> futureLog = _startWaitingForLog(
+      _stopHookAddedPattern,
+    ).then((value) => value, onError: _handleAsyncError);
+    await _lldbProcess?.stdinWriteln('target stop-hook add -o "thread backtrace all" -o "detach"');
     await futureLog;
   }
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -1415,7 +1415,7 @@ void main() {
           device.setLogReader(iosApp, deviceLogReader);
 
           unawaited(
-            mdnsDiscovery.completer.future.whenComplete(() {
+            mdnsDiscovery.discoveryStarted.future.whenComplete(() {
               // Start writing messages to the log reader.
               Timer.run(() {
                 deviceLogReader.addLine('Foo');
@@ -1444,13 +1444,18 @@ void main() {
         }, overrides: <Type, Generator>{MDnsVmServiceDiscovery: () => mdnsDiscovery});
       });
 
-      testUsingContext(
-        'IOSDevice.startApp fails to find Dart VM in CI',
-        () async {
+      group('IOSDevice.startApp fails to find Dart VM', () {
+        late FakeMDnsVmServiceDiscovery mdnsDiscovery;
+        late Completer<void> mdnsDiscoveryWaitToComplete;
+        setUp(() {
+          mdnsDiscoveryWaitToComplete = Completer<void>();
+          mdnsDiscovery = FakeMDnsVmServiceDiscovery(waitToReturn: mdnsDiscoveryWaitToComplete);
+        });
+
+        testUsingContext('when app terminates', () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
           final processManager = FakeProcessManager.empty();
 
-          const pathToFlutterLogs = '/path/to/flutter/logs';
           const pathToHome = '/path/to/home';
 
           final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
@@ -1486,37 +1491,28 @@ void main() {
             uncompressedBundle: bundleLocation,
             applicationPackage: bundleLocation,
           );
-          final deviceLogReader = FakeDeviceLogReader();
+          final deviceLogReader = FakeSharedIOSDeviceLogReader();
 
           device.portForwarder = const NoOpDevicePortForwarder();
           device.setLogReader(iosApp, deviceLogReader);
 
-          const projectLogsPath = 'Runner-project1/Logs/Launch/Runner.xcresults';
-          fileSystem
-              .directory('$pathToHome/Library/Developer/Xcode/DerivedData/$projectLogsPath')
-              .createSync(recursive: true);
-
           final completer = Completer<void>();
-          await FakeAsync().run((FakeAsync time) {
-            final Future<LaunchResult> futureLaunchResult = device.startApp(
-              iosApp,
-              prebuiltApplication: true,
-              debuggingOptions: DebuggingOptions.enabled(
-                BuildInfo.debug,
-                usingCISystem: true,
-                debugLogsDirectoryPath: pathToFlutterLogs,
-              ),
-              platformArgs: <String, dynamic>{},
-            );
+          final Future<LaunchResult> futureLaunchResult = device.startApp(
+            iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            platformArgs: <String, dynamic>{},
+          );
+          unawaited(
+            mdnsDiscovery.discoveryStarted.future.whenComplete(() {
+              deviceLogReader.addLine('App terminated due to signal 5');
+            }),
+          );
+
+          unawaited(
             futureLaunchResult.then((LaunchResult launchResult) {
               expect(launchResult.started, false);
               expect(launchResult.hasVmService, false);
-              expect(
-                fileSystem
-                    .directory('$pathToFlutterLogs/DerivedDataLogs/$projectLogsPath')
-                    .existsSync(),
-                true,
-              );
               expect(fakeAnalytics.sentEvents, [
                 Event.appleUsageEvent(
                   workflow: 'ios-physical-deployment',
@@ -1525,16 +1521,13 @@ void main() {
                 ),
               ]);
               completer.complete();
-            });
-            time.elapse(const Duration(minutes: 15));
-            time.flushMicrotasks();
-            return completer.future;
-          });
-        },
-        overrides: <Type, Generator>{
-          MDnsVmServiceDiscovery: () => FakeMDnsVmServiceDiscovery(returnsNull: true),
-        },
-      );
+              mdnsDiscoveryWaitToComplete.complete();
+            }),
+          );
+
+          await completer.future;
+        }, overrides: <Type, Generator>{MDnsVmServiceDiscovery: () => mdnsDiscovery});
+      });
 
       testUsingContext(
         'IOSDevice.startApp prints guided message when iOS 18.4 crashes due to JIT',
@@ -1747,11 +1740,14 @@ class FakeMDnsVmServiceDiscovery extends Fake implements MDnsVmServiceDiscovery 
   FakeMDnsVmServiceDiscovery({
     this.returnsNull = false,
     this.allowthrowOnMissingLocalNetworkPermissionsError = true,
+    this.waitToReturn,
   });
   bool returnsNull;
   bool allowthrowOnMissingLocalNetworkPermissionsError;
 
-  Completer<void> completer = Completer<void>();
+  Completer<void> discoveryStarted = Completer<void>();
+
+  Completer<void>? waitToReturn;
   @override
   Future<Uri?> getVMServiceUriForLaunch(
     String applicationId,
@@ -1763,7 +1759,8 @@ class FakeMDnsVmServiceDiscovery extends Fake implements MDnsVmServiceDiscovery 
     Duration timeout = Duration.zero,
     bool throwOnMissingLocalNetworkPermissionsError = true,
   }) async {
-    completer.complete();
+    discoveryStarted.complete();
+    await waitToReturn?.future;
     if (returnsNull) {
       return null;
     }

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -309,10 +309,7 @@ Target 0: (Runner) stopped.
 
     final processManager = FakeLLDBProcessManager([lldbCommand]);
     final processUtils = ProcessUtils(processManager: processManager, logger: logger);
-    final lldb = LLDB(
-      logger: logger,
-      processUtils: processUtils,
-    );
+    final lldb = LLDB(logger: logger, processUtils: processUtils);
     final expectedInputs = [
       'device select $deviceId',
       r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -59,11 +59,13 @@ void main() {
 
     final breakPointCompleter = Completer<List<int>>();
     final processAttachCompleter = Completer<List<int>>();
+    final setupStopHooksCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       breakPointCompleter.future,
       processAttachCompleter.future,
+      setupStopHooksCompleter.future,
       processResumedCompleted.future,
     ]);
 
@@ -87,12 +89,14 @@ void main() {
     const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
+    const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
     final expectedInputs = [
       'device select $deviceId',
       breakPointMatcher,
       'breakpoint command add --script-type python $breakpointId',
       'script lldb.debugger.SetAsync(False)',
       processAttachMatcher,
+      setupStopHooksMatcher,
       processResumedMatcher,
     ];
 
@@ -120,6 +124,9 @@ Target 0: (Runner) stopped.
 '''),
         );
       }
+      if (line == setupStopHooksMatcher) {
+        setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
+      }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));
       }
@@ -144,10 +151,12 @@ Target 0: (Runner) stopped.
     const appProcessId = 5678;
 
     final processAttachCompleter = Completer<List<int>>();
+    final setupStopHooksCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       processAttachCompleter.future,
+      setupStopHooksCompleter.future,
       processResumedCompleted.future,
     ]);
 
@@ -170,7 +179,13 @@ Target 0: (Runner) stopped.
 
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
-    final expectedInputs = ['device select $deviceId', processAttachMatcher, processResumedMatcher];
+    const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
+    final expectedInputs = [
+      'device select $deviceId',
+      processAttachMatcher,
+      setupStopHooksMatcher,
+      processResumedMatcher,
+    ];
 
     stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
       String line,
@@ -190,6 +205,9 @@ dyld`_dyld_start:
 Target 0: (Runner) stopped.
 '''),
         );
+      }
+      if (line == setupStopHooksMatcher) {
+        setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
       }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
@@ -291,15 +309,23 @@ Target 0: (Runner) stopped.
 
     final processManager = FakeLLDBProcessManager([lldbCommand]);
     final processUtils = ProcessUtils(processManager: processManager, logger: logger);
-    final lldb = LLDB(logger: logger, processUtils: processUtils);
-    final expectedInputs = ['device select $deviceId'];
+    final lldb = LLDB(
+      logger: logger,
+      processUtils: processUtils,
+    );
+    final expectedInputs = [
+      'device select $deviceId',
+      r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
+    ];
     const errorText = "error: 'device' is not a valid command.\n";
 
     stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
       String line,
     ) {
       expectedInputs.remove(line);
-      errorCompleter.complete(utf8.encode(errorText));
+      if (expectedInputs.isEmpty) {
+        errorCompleter.complete(utf8.encode(errorText));
+      }
     });
 
     final bool success = await lldb.attachAndStart(
@@ -372,12 +398,14 @@ Target 0: (Runner) stopped.
 
     final breakPointCompleter = Completer<List<int>>();
     final processAttachCompleter = Completer<List<int>>();
+    final setupStopHooksCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
     final logAfterAttachCompleter = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       breakPointCompleter.future,
       processAttachCompleter.future,
+      setupStopHooksCompleter.future,
       processResumedCompleted.future,
       logAfterAttachCompleter.future,
     ]);
@@ -402,12 +430,14 @@ Target 0: (Runner) stopped.
     const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
+    const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
     final expectedInputs = [
       'device select $deviceId',
       breakPointMatcher,
       'breakpoint command add --script-type python $breakpointId',
       'script lldb.debugger.SetAsync(False)',
       processAttachMatcher,
+      setupStopHooksMatcher,
       processResumedMatcher,
     ];
 
@@ -434,6 +464,9 @@ dyld`_dyld_start:
 Target 0: (Runner) stopped.
 '''),
         );
+      }
+      if (line == setupStopHooksMatcher) {
+        setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
       }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));


### PR DESCRIPTION
Impacted Users (Approximately who will hit this issue, ex. all Flutter devs, Windows developers, all end-customers, apps using X framework feature).

iOS developers debugging on iOS 17+ devices.

Impact Description (What is the impact? ex. visual jank on Samsung phones, app crash, cannot ship an iOS app. Does it impact development? ex. flutter doctor crashes when Android Studio is installed. Or shipping a production app? ex. the app crashes on launch).

[flutter/186366](https://github.com/flutter/flutter/issues/186366) When debugging an iOS app, if the app crashes, the Flutter CLI will hang. Tests that crash will hang.

Workaround (Is there a workaround for this issue?)

Manually kill the Flutter CLI

Risk (What is the risk level of this cherry-pick?)

Low

Test Coverage (Are you confident that your fix is well-tested by automated tests?)

Yes

Validation Steps (What are the steps to validate that this fix works?)

Debug an iOS app and force it to crash. Flutter CLI should stop and print stack trace