### PR TITLE
[ci] Add experimental branch experimental/agp-gradle-api to enabled_branches

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -14,6 +14,7 @@
 enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
+  - experimental/agp-gradle-api
 
 platform_properties:
   staging_build_linux:

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -9,6 +9,7 @@ enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
   - fuchsia_f\d+[a-z]*
+  - experimental/agp-gradle-api
 
 platform_properties:
   linux:


### PR DESCRIPTION
Enables Cocoon CI commit indexing and build dashboard test scheduling for the experimental branch `experimental/agp-gradle-api`.