### PR TITLE
Revert "Reduce the number of gtest-parallel workers when running Impeller tests on Mac Minis used by CI (#189813)"

### DIFF
--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -164,12 +164,6 @@ def is_aarm64() -> bool:
   return aarm64
 
 
-def mac_hardware_model() -> str:
-  assert is_mac()
-  output = subprocess.check_output(['sysctl', '-n', 'hw.model'])
-  return output.decode('utf-8').strip()
-
-
 def is_linux() -> bool:
   return sys_platform.startswith('linux')
 
@@ -574,13 +568,7 @@ def run_cc_tests(
       )
     extra_env = metal_validation_env()
     extra_env.update(vulkan_validation_env(build_dir))
-    if mac_hardware_model() == 'Macmini9,1':
-      # For the Mac Minis used on CI, limit the number of Impeller test cases run in parallel
-      # in order to reduce the risk of resource exhaustion errors.
-      workers_flag = ['--workers=%d' % (os.cpu_count() - 2)]
-    else:
-      workers_flag = []
-    mac_impeller_unittests_flags = repeat_flags + workers_flag + [
+    mac_impeller_unittests_flags = repeat_flags + [
         '--gtest_filter=-*OpenGLES:*OpenGLESSDF',  # These are covered in the golden tests.
         '--',
         '--enable_vulkan_validation',


### PR DESCRIPTION
This reverts commit 285bf671f395d4e4a3e1592e50826cd30fafdd3e.

This was an experiment that tried to reduce the frequency of flakes when running Impeller OpenGLESSDF rendering tests.  It is obsolete now that these tests were disabled by https://github.com/flutter/flutter/pull/190469