### PR TITLE
iOS: Switch logging from syslog to os_log

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/Logger.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/Logger.swift
@@ -4,6 +4,7 @@
 
 import Darwin
 import Foundation
+import os
 
 /// The level of logging severity.
 ///
@@ -76,7 +77,7 @@ import Foundation
     #if os(iOS)
       // On iOS, the user has no access to stdout.
       // Output can be read from the log by the user or the `flutter` tool.
-      self.init(outputWriter: SyslogOutputWriter(), logLevel: .info)
+      self.init(outputWriter: OSLogOutputWriter(), logLevel: .info)
     #elseif os(macOS)
       // On macOS, both the user and the tool read from stdout.
       self.init(outputWriter: StdoutOutputWriter(), logLevel: .info)
@@ -182,11 +183,34 @@ public protocol OutputWriter: Sendable {
   func writeLine(level: LogLevel, _ message: String)
 }
 
-final class SyslogOutputWriter: OutputWriter, Sendable {
+private extension LogLevel {
+  /// The `OSLogType` used to emit a message at this level via `os_log`.
+  ///
+  /// `OSLogType` is not a strict severity ladder like `LogLevel`. It's a small set of categories
+  /// with differing persistence and display behavior. Each level therefore maps to the type with
+  /// the closest semantics rather than a matching severity.
+  ///
+  /// - `.info` is buffered in memory and not written to persistent store by default.
+  /// - `.warning` is written to persistent store.
+  /// - `.error` is logged with error metadata and is written to persistent store.
+  /// - `.important` is used by Dart `print` output, so is written to persistent store.
+  /// - `.fatal` is logged with fault metadata and is written to persistent store.
+  var osLogType: OSLogType {
+    switch self {
+    case .info: return .info
+    case .warning: return .default
+    case .error: return .error
+    case .important: return .default
+    case .fatal: return .fault
+    }
+  }
+}
+
+final class OSLogOutputWriter: OutputWriter, Sendable {
+  private let osLog = OSLog(subsystem: "io.flutter.flutter", category: "flutter")
+
   func writeLine(level: LogLevel, _ message: String) {
-    // TODO(cbracken): replace this with os_log-based approach.
-    // https://github.com/flutter/flutter/issues/44030
-    message.withCString { vsyslog(LOG_ALERT, "%s", getVaList([$0])) }
+    os_log("%{public}@", log: osLog, type: level.osLogType, message)
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTests.swift
@@ -7,7 +7,10 @@ import InternalFlutterSwiftCommon
 import Testing
 import test_utils_swift
 
-@Suite struct LoggerTests {
+// Several tests mutate shared `Logger` singleton properties (`outputWriter`, `logLevel`).
+// Even though those mutations are all lock-guarded and thread-safe, we serialize the tests to keep
+// them from racing each other.
+@Suite(.serialized) struct LoggerTests {
 
   @Test func testInitialization() {
     let writer = StringOutputWriter()
@@ -134,5 +137,11 @@ import test_utils_swift
     // After concurrent mutations and logging, Logger should remain in a valid state without data
     // races or crashes.
     #expect(Logger.logLevel == .info || Logger.logLevel == .warning)
+  }
+
+  @Test func testDefaultInitialization() {
+    let logger = Logger()
+    #expect(logger.logLevel == .info)
+    logger.log(level: .info, "Test default logger")
   }
 }


### PR DESCRIPTION
Previously, `Logger` on iOS defaulted to syslog which used C string interop and didn't record severity.

Because `Settings::log_message_callback` is wired to use `Logger`, this migrates all iOS logging to `os_log`: both iOS embedder logging AND core engine (FML-based) logging, which includes Dart print statements in Flutter apps since those rely on the core engine log callback too.

Manually tested using:
* debug mode iOS simulator
* debug mode iOS physical device
* release mode iOS physical device

This change does not affect macOS logging which previous used logging to stdout and still uses logging to stdout, but out of paranoia, since it also uses FlutterLogger, I manually tested using:
* debug mode macOS app
* release mode macOS app

A followup patch will expose the logging subsystem via a `tag` parameter in `Logger`'s API so we don't need to do manual concatentation in the `log_message_callback`.

Fixes https://github.com/flutter/flutter/issues/44030 (fingers crossed)

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
