### PR TITLE
Fixes popuntilwithresult drops results

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5716,7 +5716,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
         (_RouteEntry e) => _RouteEntry.isPresentPredicate(e) && e != candidate,
       );
 
-      if (next != null && !next.route.willHandlePopInternally && predicate(next.route)) {
+      if (next != null && !candidate.route.willHandlePopInternally && predicate(next.route)) {
         pop<T>(result);
       } else {
         pop();

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1348,47 +1348,46 @@ void main() {
       bool? firstReturnValue;
       bool? secondReturnValue;
 
+      Widget buildPage(String id, VoidCallback? onTap) {
+        return GestureDetector(
+          onTap: onTap,
+          behavior: HitTestBehavior.opaque,
+          child: Center(child: Text(id, textDirection: TextDirection.ltr)),
+        );
+      }
+
       await tester.pumpWidget(
-        MaterialApp(
+        TestWidgetsApp(
           initialRoute: '/',
           onGenerateRoute: (RouteSettings settings) {
             final String? routeName = settings.name;
 
             switch (routeName) {
               case '/':
-                return MaterialPageRoute<bool>(
-                  builder: (BuildContext context) => OnTapPage(
-                    id: '/',
-                    onTap: () async {
-                      ModalRoute.of(context)!.addLocalHistoryEntry(LocalHistoryEntry());
-                      firstReturnValue = await Navigator.pushNamed(context, '/A');
-                    },
-                  ),
+                return TestRoute<bool>(
                   settings: settings,
+                  builder: (BuildContext context) => buildPage('/', () async {
+                    ModalRoute.of(context)!.addLocalHistoryEntry(LocalHistoryEntry());
+                    firstReturnValue = await Navigator.pushNamed(context, '/A');
+                  }),
                 );
               case '/A':
-                return MaterialPageRoute<bool>(
-                  builder: (BuildContext context) => OnTapPage(
-                    id: 'A',
-                    onTap: () async {
-                      secondReturnValue = await Navigator.pushNamed(context, '/B');
-                    },
-                  ),
+                return TestRoute<bool>(
                   settings: settings,
+                  builder: (BuildContext context) => buildPage('A', () async {
+                    secondReturnValue = await Navigator.pushNamed(context, '/B');
+                  }),
                 );
               case '/B':
-                return MaterialPageRoute<bool>(
-                  builder: (BuildContext context) => OnTapPage(
-                    id: 'B',
-                    onTap: () async {
-                      Navigator.popUntilWithResult<bool>(
-                        context,
-                        (Route<dynamic> route) => route.isFirst,
-                        true,
-                      );
-                    },
-                  ),
+                return TestRoute<bool>(
                   settings: settings,
+                  builder: (BuildContext context) => buildPage('B', () async {
+                    Navigator.popUntilWithResult<bool>(
+                      context,
+                      (Route<dynamic> route) => route.isFirst,
+                      true,
+                    );
+                  }),
                 );
               default:
                 return null;

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1342,6 +1342,78 @@ void main() {
     expect(secondReturnValue, isNull);
   });
 
+  testWidgets(
+    'popUntilWithResult returns value to the last popped route when destination route has local history entries',
+    (WidgetTester tester) async {
+      bool? firstReturnValue;
+      bool? secondReturnValue;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          initialRoute: '/',
+          onGenerateRoute: (RouteSettings settings) {
+            final String? routeName = settings.name;
+
+            switch (routeName) {
+              case '/':
+                return MaterialPageRoute<bool>(
+                  builder: (BuildContext context) => OnTapPage(
+                    id: '/',
+                    onTap: () async {
+                      ModalRoute.of(context)!.addLocalHistoryEntry(LocalHistoryEntry());
+                      firstReturnValue = await Navigator.pushNamed(context, '/A');
+                    },
+                  ),
+                  settings: settings,
+                );
+              case '/A':
+                return MaterialPageRoute<bool>(
+                  builder: (BuildContext context) => OnTapPage(
+                    id: 'A',
+                    onTap: () async {
+                      secondReturnValue = await Navigator.pushNamed(context, '/B');
+                    },
+                  ),
+                  settings: settings,
+                );
+              case '/B':
+                return MaterialPageRoute<bool>(
+                  builder: (BuildContext context) => OnTapPage(
+                    id: 'B',
+                    onTap: () async {
+                      Navigator.popUntilWithResult<bool>(
+                        context,
+                        (Route<dynamic> route) => route.isFirst,
+                        true,
+                      );
+                    },
+                  ),
+                  settings: settings,
+                );
+              default:
+                return null;
+            }
+          },
+        ),
+      );
+      expect(find.text('/'), findsOneWidget);
+
+      await tester.tap(find.text('/'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('A'));
+      await tester.pumpAndSettle();
+      expect(find.text('B'), findsOneWidget);
+
+      await tester.tap(find.text('B'));
+      await tester.pumpAndSettle();
+      expect(find.text('/'), findsOneWidget);
+
+      expect(firstReturnValue, isTrue);
+      expect(secondReturnValue, isNull);
+    },
+  );
+
   testWidgets('pushAndRemoveUntil triggers secondaryAnimation', (WidgetTester tester) async {
     final routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => OnTapPage(
@@ -6265,84 +6337,82 @@ void main() {
     clear();
   });
 
-  testWidgets(
-    'Navigator focus restoration reports error to FlutterError',
-    (WidgetTester tester) async {
-      final errorDetails = <FlutterErrorDetails>[];
-      final FlutterExceptionHandler? oldHandler = FlutterError.onError;
-      FlutterError.onError = (FlutterErrorDetails details) {
-        errorDetails.add(details);
-      };
+  testWidgets('Navigator focus restoration reports error to FlutterError', (
+    WidgetTester tester,
+  ) async {
+    final errorDetails = <FlutterErrorDetails>[];
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      errorDetails.add(details);
+    };
 
-      try {
-        // Mock accessibility channel to throw error.
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<dynamic>(SystemChannels.accessibility, (
-              dynamic message,
-            ) async {
-              final map = message as Map<dynamic, dynamic>;
-              if (map['type'] == 'focus') {
-                throw Exception('Focus restoration failed');
-              }
-              return null;
-            });
+    try {
+      // Mock accessibility channel to throw error.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockDecodedMessageHandler<dynamic>(SystemChannels.accessibility, (
+            dynamic message,
+          ) async {
+            final map = message as Map<dynamic, dynamic>;
+            if (map['type'] == 'focus') {
+              throw Exception('Focus restoration failed');
+            }
+            return null;
+          });
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Builder(
-                builder: (BuildContext context) {
-                  return ElevatedButton(
-                    onPressed: () {
-                      Navigator.push(
-                        context,
-                        NoAnimationPageRoute(
-                          pageBuilder: (BuildContext context) => Scaffold(
-                            appBar: AppBar(title: const Text('Second Route')),
-                            body: ElevatedButton(
-                              onPressed: () => Navigator.pop(context),
-                              child: const Text('Pop'),
-                            ),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      NoAnimationPageRoute(
+                        pageBuilder: (BuildContext context) => Scaffold(
+                          appBar: AppBar(title: const Text('Second Route')),
+                          body: ElevatedButton(
+                            onPressed: () => Navigator.pop(context),
+                            child: const Text('Pop'),
                           ),
                         ),
-                      );
-                    },
-                    child: const Text('Push'),
-                  );
-                },
-              ),
+                      ),
+                    );
+                  },
+                  child: const Text('Push'),
+                );
+              },
             ),
           ),
-        );
+        ),
+      );
 
-        // Record the last focus in route entry.
-        ServicesBinding.instance.accessibilityFocus.value = 123;
-        await tester.pump();
+      // Record the last focus in route entry.
+      ServicesBinding.instance.accessibilityFocus.value = 123;
+      await tester.pump();
 
-        // Push second route.
-        await tester.tap(find.text('Push'));
-        await tester.pumpAndSettle();
+      // Push second route.
+      await tester.tap(find.text('Push'));
+      await tester.pumpAndSettle();
 
-        // Now we are on the second route.
-        // Pop it.
-        await tester.tap(find.text('Pop'));
-        await tester.pumpAndSettle();
+      // Now we are on the second route.
+      // Pop it.
+      await tester.tap(find.text('Pop'));
+      await tester.pumpAndSettle();
 
-        expect(errorDetails.length, 1);
-        expect(errorDetails[0].exception.toString(), contains('Focus restoration failed'));
-        expect(errorDetails[0].library, 'widgets library');
-        expect(
-          errorDetails[0].context.toString(),
-          contains('while restoring focus in the navigator'),
-        );
-      } finally {
-        FlutterError.onError = oldHandler;
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<dynamic>(SystemChannels.accessibility, null);
-      }
-    },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-  );
+      expect(errorDetails.length, 1);
+      expect(errorDetails[0].exception.toString(), contains('Focus restoration failed'));
+      expect(errorDetails[0].library, 'widgets library');
+      expect(
+        errorDetails[0].context.toString(),
+        contains('while restoring focus in the navigator'),
+      );
+    } finally {
+      FlutterError.onError = oldHandler;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockDecodedMessageHandler<dynamic>(SystemChannels.accessibility, null);
+    }
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
   testWidgets('Navigator.pop throws FlutterError when popped with mismatched type', (
     WidgetTester tester,


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

as title, it is a typo and should have checked current route's will handle pop internally

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
