### PR TITLE
[iOS] Reduce Metal scheduling waits for platform views

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/metal/surface_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/surface_mtl.h
@@ -63,7 +63,9 @@ class SurfaceMTL final : public Surface {
 
   /// Mark this surface as presenting with a transaction.
   ///
-  /// If true, [Present] will block on the scheduling of a command buffer.
+  /// If true, [Present] synchronizes command buffer scheduling before the
+  /// drawable is presented in the current transaction. Intermediate drawables
+  /// may be deferred until the frame boundary.
   void PresentWithTransaction(bool present_with_transaction) {
     present_with_transaction_ = present_with_transaction;
   }

--- a/engine/src/flutter/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/surface_mtl.mm
@@ -4,6 +4,8 @@
 
 #include "impeller/renderer/backend/metal/surface_mtl.h"
 
+#include <QuartzCore/CATransaction.h>
+
 #include "flutter/fml/trace_event.h"
 #include "flutter/impeller/renderer/command_buffer.h"
 #include "impeller/base/validation.h"
@@ -22,6 +24,9 @@ static_assert(__has_feature(objc_arc), "ARC must be enabled.");
 @end
 
 namespace impeller {
+
+static NSString* const kPendingTransactionDrawablesKey =
+    @"io.flutter.impeller.pendingTransactionDrawables";
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunguarded-availability-new"
@@ -286,12 +291,27 @@ bool SurfaceMTL::Present() const {
     constexpr bool alwaysWaitForScheduling = false;
 #endif  // defined(FML_OS_IOS_SIMULATOR) && defined(FML_ARCH_CPU_X86_64)
 
-    // If the threads have been merged, or there is a pending frame capture,
-    // then block on cmd buffer scheduling to ensure that the
-    // transaction/capture work correctly.
-    if (present_with_transaction_ || [[NSThread currentThread] isMainThread] ||
-        [[MTLCaptureManager sharedCaptureManager] isCapturing] ||
-        alwaysWaitForScheduling) {
+    const bool can_defer_transaction_presentation =
+        present_with_transaction_ && !frame_boundary_ &&
+        !alwaysWaitForScheduling &&
+        ![[MTLCaptureManager sharedCaptureManager] isCapturing];
+    if (can_defer_transaction_presentation) {
+      // Surfaces in a frame share a command queue. Retain intermediate
+      // drawables in the current transaction until the final command buffer
+      // has been scheduled.
+      [command_buffer commit];
+      NSMutableArray<id<MTLDrawable>>* pending_drawables =
+          [CATransaction valueForKey:kPendingTransactionDrawablesKey];
+      if (!pending_drawables) {
+        pending_drawables = [[NSMutableArray alloc] init];
+        [CATransaction setValue:pending_drawables
+                         forKey:kPendingTransactionDrawablesKey];
+      }
+      [pending_drawables addObject:drawable_];
+    } else if (present_with_transaction_ ||
+               [[NSThread currentThread] isMainThread] ||
+               alwaysWaitForScheduling ||
+               [[MTLCaptureManager sharedCaptureManager] isCapturing]) {
       TRACE_EVENT0("flutter", "waitUntilScheduled");
       [command_buffer commit];
 #if defined(FML_OS_IOS_SIMULATOR) && defined(FML_ARCH_CPU_X86_64)
@@ -299,6 +319,14 @@ bool SurfaceMTL::Present() const {
 #else
       [command_buffer waitUntilScheduled];
 #endif  // defined(FML_OS_IOS_SIMULATOR) && defined(FML_ARCH_CPU_X86_64)
+      if (present_with_transaction_) {
+        NSArray<id<MTLDrawable>>* pending_drawables =
+            [CATransaction valueForKey:kPendingTransactionDrawablesKey];
+        [CATransaction setValue:nil forKey:kPendingTransactionDrawablesKey];
+        for (id<MTLDrawable> drawable in pending_drawables) {
+          [drawable present];
+        }
+      }
       [drawable_ present];
     } else {
       // The drawable may come from a FlutterMetalLayer, so it can't be

--- a/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller.mm
@@ -173,6 +173,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
           return false;
         }
         surface->PresentWithTransaction(surface_frame.submit_info().present_with_transaction);
+        surface->SetFrameBoundary(surface_frame.submit_info().frame_boundary);
 
         if (clip_rect && clip_rect->IsEmpty()) {
           if (!surface->PreparePresent()) {
@@ -183,7 +184,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
         }
 
         impeller::Rect cull_rect = impeller::Rect::Make(surface->coverage());
-        surface->SetFrameBoundary(surface_frame.submit_info().frame_boundary);
 
         const bool reset_host_buffer = surface_frame.submit_info().frame_boundary;
         auto render_result = impeller::RenderToTarget(aiks_context->GetContentContext(),       //

--- a/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller_unittests.mm
+++ b/engine/src/flutter/shell/gpu/gpu_surface_metal_impeller_unittests.mm
@@ -5,6 +5,9 @@
 #include <Foundation/Foundation.h>
 #include <QuartzCore/QuartzCore.h>
 
+#include <atomic>
+
+#include "flutter/fml/trace_event.h"
 #include "flutter/shell/gpu/gpu_surface_metal_impeller.h"
 #include "gtest/gtest.h"
 #include "impeller/display_list/aiks_context.h"
@@ -12,7 +15,71 @@
 #include "impeller/entity/mtl/framebuffer_blend_shaders.h"
 #include "impeller/entity/mtl/modern_shaders.h"
 #include "impeller/renderer/backend/metal/context_mtl.h"
+#include "impeller/renderer/backend/metal/surface_mtl.h"
+#include "impeller/renderer/backend/metal/swapchain_transients_mtl.h"
 #include "impeller/typographer/typographer_context.h"
+
+// A drawable that records presentation without requiring a window.
+@interface TestCAMetalDrawable : NSObject <CAMetalDrawable>
+
+- (instancetype)initWithDevice:(id<MTLDevice>)device;
+
+@property(nonatomic) NSUInteger presentCount;
+
+@end
+
+@implementation TestCAMetalDrawable {
+  id<MTLTexture> _texture;
+  CAMetalLayer* _layer;
+}
+
+- (instancetype)initWithDevice:(id<MTLDevice>)device {
+  self = [super init];
+  if (self) {
+    _texture = [device
+        newTextureWithDescriptor:[MTLTextureDescriptor
+                                     texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+                                                                  width:100
+                                                                 height:100
+                                                              mipmapped:NO]];
+    _layer = [[CAMetalLayer alloc] init];
+    _layer.device = device;
+  }
+  return self;
+}
+
+- (id<MTLTexture>)texture {
+  return _texture;
+}
+
+- (CAMetalLayer*)layer {
+  return _layer;
+}
+
+- (void)present {
+  self.presentCount++;
+}
+
+- (void)presentAtTime:(CFTimeInterval)presentationTime {
+  [self present];
+}
+
+- (void)presentAfterMinimumDuration:(CFTimeInterval)duration {
+  [self present];
+}
+
+- (void)addPresentedHandler:(MTLDrawablePresentedHandler)block {
+}
+
+- (CFTimeInterval)presentedTime {
+  return 0;
+}
+
+- (NSUInteger)drawableID {
+  return 0;
+}
+
+@end
 
 namespace flutter {
 namespace testing {
@@ -56,6 +123,68 @@ static std::shared_ptr<impeller::ContextMTL> CreateImpellerContext() {
   auto sync_switch = std::make_shared<fml::SyncSwitch>(false);
   return impeller::ContextMTL::Create(impeller::Flags{}, shader_mappings, sync_switch,
                                       "Impeller Library");
+}
+
+#if FLUTTER_TIMELINE_ENABLED
+static std::atomic_int g_wait_until_scheduled_count = 0;
+
+static void CountWaitUntilScheduledEvents(const char*,
+                                          int64_t,
+                                          int64_t,
+                                          intptr_t,
+                                          const int64_t*,
+                                          Dart_Timeline_Event_Type type,
+                                          intptr_t,
+                                          const char**,
+                                          const char**) {
+  if (type == Dart_Timeline_Event_Begin) {
+    g_wait_until_scheduled_count++;
+  }
+}
+#endif  // FLUTTER_TIMELINE_ENABLED
+
+TEST(SurfaceMTL, DefersTransactionPresentationUntilFrameBoundary) {
+  auto context = CreateImpellerContext();
+#ifdef IMPELLER_DEBUG
+  context->GetCaptureManager()->StartCapture();
+#endif  // IMPELLER_DEBUG
+  auto previous_transaction_drawable =
+      [[TestCAMetalDrawable alloc] initWithDevice:context->GetMTLDevice()];
+  auto overlay_drawable = [[TestCAMetalDrawable alloc] initWithDevice:context->GetMTLDevice()];
+  auto background_drawable = [[TestCAMetalDrawable alloc] initWithDevice:context->GetMTLDevice()];
+  auto make_surface = [&context](TestCAMetalDrawable* drawable) {
+    auto transients =
+        std::make_shared<impeller::SwapchainTransientsMTL>(context->GetResourceAllocator());
+    return impeller::SurfaceMTL::MakeFromMetalLayerDrawable(context, drawable, transients);
+  };
+  auto previous_transaction_surface = make_surface(previous_transaction_drawable);
+  auto overlay_surface = make_surface(overlay_drawable);
+  auto background_surface = make_surface(background_drawable);
+  ASSERT_TRUE(previous_transaction_surface);
+  ASSERT_TRUE(overlay_surface);
+  ASSERT_TRUE(background_surface);
+  previous_transaction_surface->PresentWithTransaction(true);
+  previous_transaction_surface->SetFrameBoundary(false);
+  overlay_surface->PresentWithTransaction(true);
+  overlay_surface->SetFrameBoundary(false);
+  background_surface->PresentWithTransaction(true);
+  background_surface->SetFrameBoundary(true);
+
+  // A transaction without a frame boundary must not leak its pending drawable
+  // into the next transaction.
+  [CATransaction begin];
+  EXPECT_TRUE(previous_transaction_surface->Present());
+  EXPECT_EQ(previous_transaction_drawable.presentCount, 0u);
+  [CATransaction commit];
+
+  [CATransaction begin];
+  EXPECT_TRUE(overlay_surface->Present());
+  EXPECT_EQ(overlay_drawable.presentCount, 0u);
+  EXPECT_TRUE(background_surface->Present());
+  EXPECT_EQ(previous_transaction_drawable.presentCount, 0u);
+  EXPECT_EQ(overlay_drawable.presentCount, 1u);
+  EXPECT_EQ(background_drawable.presentCount, 1u);
+  [CATransaction commit];
 }
 
 TEST(GPUSurfaceMetalImpeller, InvalidImpellerContextCreatesCausesSurfaceToBeInvalid) {
@@ -127,6 +256,53 @@ TEST(GPUSurfaceMetalImpeller, ResetHostBufferBasedOnFrameBoundary) {
   ASSERT_TRUE(frame->Submit());
   EXPECT_EQ(data_host_buffer.GetStateForTest().current_frame, 1u);
 }
+
+#if FLUTTER_TIMELINE_ENABLED
+TEST(GPUSurfaceMetalImpeller, WaitsForSchedulingOnlyAtFrameBoundaryWithTransaction) {
+  auto overlay_delegate = std::make_shared<TestGPUSurfaceMetalDelegate>();
+  overlay_delegate->SetDevice();
+  auto background_delegate = std::make_shared<TestGPUSurfaceMetalDelegate>();
+  background_delegate->SetDevice();
+
+  auto aiks_context = std::make_shared<impeller::AiksContext>(CreateImpellerContext(), nullptr);
+  std::unique_ptr<Surface> overlay_surface =
+      std::make_unique<GPUSurfaceMetalImpeller>(overlay_delegate.get(), aiks_context);
+  std::unique_ptr<Surface> background_surface =
+      std::make_unique<GPUSurfaceMetalImpeller>(background_delegate.get(), aiks_context);
+
+  auto overlay_frame = overlay_surface->AcquireFrame(DlISize(100, 100));
+  auto background_frame = background_surface->AcquireFrame(DlISize(100, 100));
+  ASSERT_TRUE(overlay_frame);
+  ASSERT_TRUE(background_frame);
+  overlay_frame->set_submit_info({.frame_boundary = false, .present_with_transaction = true});
+  // Exercise the early return used when the final surface has no damage.
+  background_frame->set_submit_info({
+      .buffer_damage = DlIRect(),
+      .frame_boundary = true,
+      .present_with_transaction = true,
+  });
+
+  ASSERT_FALSE(fml::tracing::TraceHasTimelineEventHandler());
+  g_wait_until_scheduled_count = 0;
+  fml::tracing::TraceSetAllowlist({"waitUntilScheduled"});
+  fml::tracing::TraceSetTimelineEventHandler(CountWaitUntilScheduledEvents);
+
+  [CATransaction begin];
+  const bool overlay_submitted = overlay_frame->Submit();
+  const int waits_after_overlay = g_wait_until_scheduled_count.load();
+  const bool background_submitted = background_frame->Submit();
+  [CATransaction commit];
+  const int total_waits = g_wait_until_scheduled_count.load();
+
+  fml::tracing::TraceSetTimelineEventHandler(nullptr);
+  fml::tracing::TraceSetAllowlist({});
+
+  EXPECT_TRUE(overlay_submitted);
+  EXPECT_TRUE(background_submitted);
+  EXPECT_EQ(waits_after_overlay, 0);
+  EXPECT_EQ(total_waits, 1);
+}
+#endif  // FLUTTER_TIMELINE_ENABLED
 
 #ifdef IMPELLER_DEBUG
 TEST(GPUSurfaceMetalImpeller, CreatesImpellerCaptureScope) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/143198

When Flutter composites native iOS platform views, such as maps, web views, or ads, it may render several Flutter overlay surfaces plus the background surface in one `CATransaction`. Each surface currently blocks the platform thread in `waitUntilScheduled`, so frames with several overlays repeat the same scheduling wait several times before the transaction can be committed.

The solution is to commit intermediate Metal waiter command buffers without blocking and retain their drawables in the current `CATransaction`. At the frame boundary, wait once for the final command buffer; because every surface uses the same ordered Metal command queue, this also guarantees that all earlier command buffers have been scheduled. Then present all retained drawables while the transaction is still open. This preserves the required commit, schedule, then present ordering while removing redundant platform-thread waits.

## Performance

Measured with the existing `dev/benchmarks/platform_views_layout` scrolling benchmark in profile mode with Impeller Metal on a USB-connected iPad (A16) running iPadOS 26.5.2.

| Metric | Before | After | Difference |
| --- | ---: | ---: | ---: |
| `waitUntilScheduled` calls per frame | 4.71 | 1.01 | -78.6% |
| Accumulated scheduling wait per frame | 0.298 ms | 0.126 ms | -0.172 ms / -57.7% |
| `PlatformViewsController::PerformSubmit` | 2.232 ms | 2.153 ms | -0.079 ms / -3.5% |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.