### PR TITLE
feat(flutter_test): add startHover and startHoverAt helper to WidgetTester

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -1188,6 +1188,74 @@ abstract class WidgetController {
     });
   }
 
+  /// Dispatch a hover sequence at the center of the given widget, assuming it is
+  /// exposed.
+  ///
+  /// The return value is a [TestGesture] object that can be used to continue the
+  /// hover (e.g. moving the pointer or pressing buttons).
+  ///
+  /// By default, the gesture kind is [PointerDeviceKind.mouse].
+  ///
+  /// The `buttons` argument specifies [PointerEvent.buttons] of the hover event.
+  /// It defaults to 0 (no buttons pressed), which is typical for hover gestures.
+  /// It can be set to non-zero values to simulate special scenarios, such as
+  /// hovering with stylus buttons pressed.
+  ///
+  /// See also:
+  ///
+  ///  * [press], which dispatches a pointer down sequence.
+  ///  * [startHoverAt], which starts a hover gesture at a specific location.
+  Future<TestGesture> startHover(
+    finders.FinderBase<Element> finder, {
+    int? pointer,
+    int buttons = 0,
+    bool warnIfMissed = true,
+    PointerDeviceKind kind = PointerDeviceKind.mouse,
+  }) {
+    final FlutterView? view = _maybeViewOf(finder);
+    return startHoverAt(
+      getCenter(finder, warnIfMissed: warnIfMissed, callee: 'startHover'),
+      pointer: pointer,
+      buttons: buttons,
+      kind: kind,
+      view: view,
+    );
+  }
+
+  /// Dispatch a hover sequence at the given location.
+  ///
+  /// The return value is a [TestGesture] object that can be used to continue the
+  /// hover (e.g. moving the pointer or pressing buttons).
+  ///
+  /// By default, the gesture kind is [PointerDeviceKind.mouse].
+  ///
+  /// The `buttons` argument specifies [PointerEvent.buttons] of the hover event.
+  /// It defaults to 0 (no buttons pressed), which is typical for hover gestures.
+  /// It can be set to non-zero values to simulate special scenarios, such as
+  /// hovering with stylus buttons pressed.
+  Future<TestGesture> startHoverAt(
+    Offset location, {
+    int? pointer,
+    int buttons = 0,
+    PointerDeviceKind kind = PointerDeviceKind.mouse,
+    FlutterView? view,
+  }) {
+    assert(
+      kind == PointerDeviceKind.mouse || kind == PointerDeviceKind.stylus,
+      'Only mouse and stylus pointers can generate hover events.',
+    );
+    return TestAsyncUtils.guard<TestGesture>(() async {
+      final TestGesture gesture = await createGesture(
+        pointer: pointer,
+        kind: kind,
+        buttons: buttons,
+      );
+      await gesture.addPointer(location: location, view: view);
+      await gesture.moveTo(location, view: view);
+      return gesture;
+    });
+  }
+
   /// Dispatch a pointer down / pointer up sequence (with a delay of
   /// [kLongPressTimeout] + [kPressTimeout] between the two events) at the
   /// center of the given widget, assuming it is exposed.

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -292,6 +292,7 @@ class TestPointer {
       pointer: pointer,
       position: newLocation,
       delta: delta,
+      buttons: _buttons,
     );
   }
 
@@ -512,19 +513,35 @@ class TestGesture {
   }
 
   /// In a test, send a pointer add event for this pointer.
-  Future<void> addPointer({Duration timeStamp = Duration.zero, Offset? location}) {
+  Future<void> addPointer({
+    Duration timeStamp = Duration.zero,
+    Offset? location,
+    FlutterView? view,
+  }) {
     return TestAsyncUtils.guard<void>(() {
       return _dispatcher(
-        _pointer.addPointer(timeStamp: timeStamp, location: location ?? _pointer.location),
+        _pointer.addPointer(
+          timeStamp: timeStamp,
+          location: location ?? _pointer.location,
+          view: view,
+        ),
       );
     });
   }
 
   /// In a test, send a pointer remove event for this pointer.
-  Future<void> removePointer({Duration timeStamp = Duration.zero, Offset? location}) {
+  Future<void> removePointer({
+    Duration timeStamp = Duration.zero,
+    Offset? location,
+    FlutterView? view,
+  }) {
     return TestAsyncUtils.guard<void>(() {
       return _dispatcher(
-        _pointer.removePointer(timeStamp: timeStamp, location: location ?? _pointer.location),
+        _pointer.removePointer(
+          timeStamp: timeStamp,
+          location: location ?? _pointer.location,
+          view: view,
+        ),
       );
     });
   }

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -214,6 +214,149 @@ void main() {
     expect(logs, equals(<String>['down $b']));
   });
 
+  testWidgets('WidgetTester.startHover and startHoverAt must respect buttons and kinds', (
+    WidgetTester tester,
+  ) async {
+    final logs = <String>[];
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Listener(
+          onPointerHover: (PointerHoverEvent event) =>
+              logs.add('hover ${event.buttons} ${event.kind.name}'),
+          child: const Text('test'),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.startHover(
+      find.text('test'),
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pump();
+    expect(logs, equals(<String>['hover $kSecondaryMouseButton mouse']));
+    logs.clear();
+
+    await gesture.removePointer();
+    await tester.pump();
+
+    final TestGesture gestureAt = await tester.startHoverAt(
+      tester.getCenter(find.text('test')),
+      buttons: kPrimaryMouseButton,
+      kind: PointerDeviceKind.stylus,
+    );
+    await tester.pump();
+    expect(logs, equals(<String>['hover $kPrimaryMouseButton stylus']));
+
+    await gestureAt.removePointer();
+    await tester.pump();
+  });
+
+  testWidgets('WidgetTester.startHover and startHoverAt default values', (
+    WidgetTester tester,
+  ) async {
+    final logs = <String>[];
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Listener(
+          onPointerHover: (PointerHoverEvent event) =>
+              logs.add('hover ${event.buttons} ${event.kind.name}'),
+          child: const Text('test'),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.startHover(find.text('test'));
+    await tester.pump();
+    expect(logs, equals(<String>['hover 0 mouse']));
+    await gesture.removePointer();
+  });
+
+  testWidgets('WidgetTester.startHoverAt throws assertion error for invalid PointerDeviceKind', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const Directionality(textDirection: TextDirection.ltr, child: Text('test')),
+    );
+
+    expect(
+      () => tester.startHoverAt(Offset.zero, kind: PointerDeviceKind.touch),
+      throwsA(
+        isA<AssertionError>().having(
+          (AssertionError e) => e.message,
+          'message',
+          'Only mouse and stylus pointers can generate hover events.',
+        ),
+      ),
+    );
+
+    expect(
+      () => tester.startHoverAt(Offset.zero, kind: PointerDeviceKind.trackpad),
+      throwsA(
+        isA<AssertionError>().having(
+          (AssertionError e) => e.message,
+          'message',
+          'Only mouse and stylus pointers can generate hover events.',
+        ),
+      ),
+    );
+  });
+
+  testWidgets(
+    'WidgetTester.startHover integrates with MouseRegion and interleaves with move/moveTo',
+    (WidgetTester tester) async {
+      final logs = <String>[];
+
+      await tester.pumpWidget(
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 100.0,
+            height: 100.0,
+            child: MouseRegion(
+              onEnter: (PointerEnterEvent event) => logs.add('enter'),
+              onHover: (PointerHoverEvent event) =>
+                  logs.add('hover (${event.position.dx}, ${event.position.dy})'),
+              onExit: (PointerExitEvent event) => logs.add('exit'),
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      // Hover at the center of the MouseRegion (50.0, 50.0)
+      final TestGesture gesture = await tester.startHoverAt(const Offset(50.0, 50.0));
+      await tester.pump();
+      expect(logs, equals(<String>['enter', 'hover (50.0, 50.0)']));
+      logs.clear();
+
+      // Move within the MouseRegion
+      await gesture.moveTo(const Offset(60.0, 60.0));
+      await tester.pump();
+      expect(logs, equals(<String>['hover (60.0, 60.0)']));
+      logs.clear();
+
+      // Move outside the MouseRegion
+      await gesture.moveTo(const Offset(150.0, 150.0));
+      await tester.pump();
+      expect(logs, equals(<String>['exit']));
+      logs.clear();
+
+      // Move back inside the MouseRegion
+      await gesture.moveTo(const Offset(30.0, 30.0));
+      await tester.pump();
+      expect(logs, equals(<String>['enter', 'hover (30.0, 30.0)']));
+      logs.clear();
+
+      await gesture.removePointer();
+      await tester.pump();
+      expect(logs, equals(<String>['exit']));
+    },
+  );
+
   testWidgets('WidgetTester.longPress must respect buttons', (WidgetTester tester) async {
     final logs = <String>[];
 


### PR DESCRIPTION
Addresses #102754 by adding startHover and startHoverAt helpers to WidgetTester to simplify hover gesture simulation in tests. Also fixes TestPointer.hover to pass down _buttons.