### PR TITLE
Fix an ANR in HCPP rotation due to platform <-> raster thread deadlock

### DIFF
--- a/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_2.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_2.cc
@@ -239,11 +239,12 @@ void AndroidExternalViewEmbedder2::PrepareFlutterView(
     double device_pixel_ratio) {
   Reset();
 
-  // The surface size changed. Therefore, destroy existing surfaces as
-  // the existing surfaces in the pool can't be recycled.
+  // The singular overlay surface is persistent, so it is resized in place by
+  // |SurfacePool::GetLayer| rather than destroyed and recreated here.
+  // Destroying it would block the raster thread on the platform thread, which
+  // deadlocks against |PlatformViewAndroid::NotifyChanged| when the platform
+  // thread is inside a layout traversal.
   if (frame_size_ != frame_size) {
-    DestroySurfaces();
-
     // This should not block to prevent deadlocks with
     // setViewportMetrics.
     task_runners_.GetPlatformTaskRunner()->PostTask(fml::MakeCopyable(

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_2.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_2.cc
@@ -241,9 +241,6 @@ void AndroidExternalViewEmbedder2::PrepareFlutterView(
 
   // The singular overlay surface is persistent, so it is resized in place by
   // |SurfacePool::GetLayer| rather than destroyed and recreated here.
-  // Destroying it would block the raster thread on the platform thread, which
-  // deadlocks against |PlatformViewAndroid::NotifyChanged| when the platform
-  // thread is inside a layout traversal.
   if (frame_size_ != frame_size) {
     // This should not block to prevent deadlocks with
     // setViewportMetrics.

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -11,6 +11,7 @@
 
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/surface.h"
+#include "flutter/fml/make_copyable.h"
 #include "flutter/fml/raster_thread_merger.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/thread.h"
@@ -18,6 +19,7 @@
 #include "flutter/shell/platform/android/jni/jni_mock.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
 #include "flutter/shell/platform/android/surface/android_surface_mock.h"
+#include "flutter/testing/post_task_sync.h"
 #include "flutter/testing/testing.h"
 
 #include "gmock/gmock.h"
@@ -1219,17 +1221,19 @@ TEST(AndroidExternalViewEmbedder2, FrameSizeChangeDoesNotDestroySurfaces) {
           [](const SurfaceFrame&) { return true; }, frame_size2))));
 
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [frame_size2, &surface_mock]() {
-        auto android_surface = std::make_unique<AndroidSurfaceMock>();
-        EXPECT_CALL(*android_surface, IsValid()).WillRepeatedly(Return(true));
-        EXPECT_CALL(*android_surface, SetNativeWindow(_, _))
-            .WillRepeatedly(Return(true));
-        EXPECT_CALL(*android_surface, CreateGPUSurface(_))
-            .WillOnce(Return(ByMove(std::move(surface_mock))));
-        EXPECT_CALL(*android_surface, OnScreenSurfaceResize(frame_size2))
-            .Times(1);
-        return android_surface;
-      });
+      fml::MakeCopyable(
+          [frame_size2, surface_mock = std::move(surface_mock)]() mutable {
+            auto android_surface = std::make_unique<AndroidSurfaceMock>();
+            EXPECT_CALL(*android_surface, IsValid())
+                .WillRepeatedly(Return(true));
+            EXPECT_CALL(*android_surface, SetNativeWindow(_, _))
+                .WillRepeatedly(Return(true));
+            EXPECT_CALL(*android_surface, CreateGPUSurface(_))
+                .WillOnce(Return(ByMove(std::move(surface_mock))));
+            EXPECT_CALL(*android_surface, OnScreenSurfaceResize(frame_size2))
+                .Times(1);
+            return android_surface;
+          }));
 
   fml::RefPtr<AndroidNativeWindow> window =
       fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
@@ -1269,14 +1273,12 @@ TEST(AndroidExternalViewEmbedder2, FrameSizeChangeDoesNotDestroySurfaces) {
       [](const SurfaceFrame& surface_frame) { return true; },
       /*frame_size=*/frame_size1);
 
-  fml::AutoResetWaitableEvent latch1;
-  fml::TaskRunner::RunNowOrPostTask(task_runners.GetRasterTaskRunner(), [&]() {
+  PostTaskSync(task_runners.GetRasterTaskRunner(), [&]() {
     embedder->SubmitFlutterView(kImplicitViewId, nullptr, nullptr,
                                 std::move(surface_frame1));
-    fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),
-                                      [&latch1]() { latch1.Signal(); });
   });
-  latch1.Wait();
+  // Drain the work that SubmitFlutterView posted to the platform thread.
+  PostTaskSync(task_runners.GetPlatformTaskRunner(), []() {});
 
   // Second frame with size 200x200 (simulating rotation/resize).
   // PrepareFlutterView should NOT destroy overlay surfaces.
@@ -1299,14 +1301,11 @@ TEST(AndroidExternalViewEmbedder2, FrameSizeChangeDoesNotDestroySurfaces) {
       [](const SurfaceFrame& surface_frame) { return true; },
       /*frame_size=*/frame_size2);
 
-  fml::AutoResetWaitableEvent latch2;
-  fml::TaskRunner::RunNowOrPostTask(task_runners.GetRasterTaskRunner(), [&]() {
+  PostTaskSync(task_runners.GetRasterTaskRunner(), [&]() {
     embedder->SubmitFlutterView(kImplicitViewId, nullptr, nullptr,
                                 std::move(surface_frame2));
-    fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),
-                                      [&latch2]() { latch2.Signal(); });
   });
-  latch2.Wait();
+  PostTaskSync(task_runners.GetPlatformTaskRunner(), []() {});
 
   EXPECT_CALL(*jni_mock, destroyOverlaySurface2()).Times(1);
   embedder->Teardown();
@@ -1345,8 +1344,8 @@ TEST(AndroidExternalViewEmbedder2, ResizeDoesNotBlockRasterOnPlatformThread) {
           [](const SurfaceFrame&, DlCanvas*) { return true; },
           [](const SurfaceFrame&) { return true; }, frame_size1))));
 
-  auto surface_factory =
-      std::make_shared<TestAndroidSurfaceFactory>([&surface_mock]() {
+  auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
+      fml::MakeCopyable([surface_mock = std::move(surface_mock)]() mutable {
         auto android_surface = std::make_unique<AndroidSurfaceMock>();
         EXPECT_CALL(*android_surface, IsValid()).WillRepeatedly(Return(true));
         EXPECT_CALL(*android_surface, SetNativeWindow(_, _))
@@ -1354,7 +1353,7 @@ TEST(AndroidExternalViewEmbedder2, ResizeDoesNotBlockRasterOnPlatformThread) {
         EXPECT_CALL(*android_surface, CreateGPUSurface(_))
             .WillOnce(Return(ByMove(std::move(surface_mock))));
         return android_surface;
-      });
+      }));
 
   fml::RefPtr<AndroidNativeWindow> window =
       fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
@@ -1394,14 +1393,11 @@ TEST(AndroidExternalViewEmbedder2, ResizeDoesNotBlockRasterOnPlatformThread) {
       [](const SurfaceFrame& surface_frame) { return true; },
       /*frame_size=*/frame_size1);
 
-  fml::AutoResetWaitableEvent frame_done;
-  fml::TaskRunner::RunNowOrPostTask(task_runners.GetRasterTaskRunner(), [&]() {
+  PostTaskSync(task_runners.GetRasterTaskRunner(), [&]() {
     embedder->SubmitFlutterView(kImplicitViewId, nullptr, nullptr,
                                 std::move(surface_frame));
-    fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),
-                                      [&frame_done]() { frame_done.Signal(); });
   });
-  frame_done.Wait();
+  PostTaskSync(task_runners.GetPlatformTaskRunner(), []() {});
 
   // Occupy the platform thread, standing in for a layout traversal.
   fml::AutoResetWaitableEvent platform_occupied;
@@ -1432,10 +1428,7 @@ TEST(AndroidExternalViewEmbedder2, ResizeDoesNotBlockRasterOnPlatformThread) {
   EXPECT_FALSE(timed_out)
       << "PrepareFlutterView blocked the raster thread on the platform thread";
 
-  fml::AutoResetWaitableEvent drained;
-  fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),
-                                    [&drained]() { drained.Signal(); });
-  drained.Wait();
+  PostTaskSync(task_runners.GetPlatformTaskRunner(), []() {});
 
   EXPECT_CALL(*jni_mock, destroyOverlaySurface2()).Times(1);
   embedder->Teardown();

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -1188,5 +1188,130 @@ TEST(AndroidExternalViewEmbedder2,
   embedder.reset();
 }
 
+TEST(AndroidExternalViewEmbedder2, FrameSizeChangeDoesNotDestroySurfaces) {
+  auto jni_mock = std::make_shared<JNIMock>();
+  auto android_context =
+      std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
+  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+                         ThreadHost::Type::kPlatform | ThreadHost::Type::kIo |
+                             ThreadHost::Type::kUi | ThreadHost::Type::kRaster);
+  TaskRunners task_runners(
+      "test",
+      thread_host.platform_thread->GetTaskRunner(),  // platform
+      thread_host.raster_thread->GetTaskRunner(),    // raster
+      thread_host.ui_thread->GetTaskRunner(),        // ui
+      thread_host.io_thread->GetTaskRunner()         // io
+  );
+  const DlISize frame_size1(100, 100);
+  const DlISize frame_size2(200, 200);
+  SurfaceFrame::FramebufferInfo framebuffer_info;
+
+  auto surface_mock = std::make_unique<SurfaceMock>();
+  EXPECT_CALL(*surface_mock, AcquireFrame(frame_size1))
+      .WillOnce(Return(ByMove(std::make_unique<SurfaceFrame>(
+          SkSurfaces::Null(100, 100), framebuffer_info,
+          [](const SurfaceFrame&, DlCanvas*) { return true; },
+          [](const SurfaceFrame&) { return true; }, frame_size1))));
+  EXPECT_CALL(*surface_mock, AcquireFrame(frame_size2))
+      .WillOnce(Return(ByMove(std::make_unique<SurfaceFrame>(
+          SkSurfaces::Null(200, 200), framebuffer_info,
+          [](const SurfaceFrame&, DlCanvas*) { return true; },
+          [](const SurfaceFrame&) { return true; }, frame_size2))));
+
+  auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
+      [frame_size2, &surface_mock]() {
+        auto android_surface = std::make_unique<AndroidSurfaceMock>();
+        EXPECT_CALL(*android_surface, IsValid()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*android_surface, SetNativeWindow(_, _))
+            .WillRepeatedly(Return(true));
+        EXPECT_CALL(*android_surface, CreateGPUSurface(_))
+            .WillOnce(Return(ByMove(std::move(surface_mock))));
+        EXPECT_CALL(*android_surface, OnScreenSurfaceResize(frame_size2))
+            .Times(1);
+        return android_surface;
+      });
+
+  fml::RefPtr<AndroidNativeWindow> window =
+      fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
+  EXPECT_CALL(*jni_mock, createOverlaySurface2())
+      .Times(1)
+      .WillOnce(Return(
+          ByMove(std::make_unique<PlatformViewAndroidJNI::OverlayMetadata>(
+              0, window))));
+  EXPECT_CALL(*jni_mock, destroyOverlaySurface2()).Times(0);
+
+  auto embedder = std::make_unique<AndroidExternalViewEmbedder2>(
+      *android_context, jni_mock, surface_factory, task_runners);
+
+  const int64_t view_id = 42;
+  MutatorsStack mutators;
+  DlMatrix matrix = DlMatrix::MakeTranslation({0, 0});
+  DlPaint rect_paint;
+  rect_paint.setColor(DlColor::kCyan());
+  rect_paint.setDrawStyle(DlDrawStyle::kFill);
+
+  // First frame with size 100x100
+  embedder->PrepareFlutterView(frame_size1, 1.0);
+  embedder->PrerollCompositeEmbeddedView(
+      view_id,
+      std::make_unique<EmbeddedViewParams>(matrix, DlSize(50, 50), mutators));
+  auto canvas1 = embedder->CompositeEmbeddedView(view_id);
+  canvas1->DrawRect(DlRect::MakeXYWH(0, 0, 50, 50), rect_paint);
+
+  EXPECT_CALL(*jni_mock,
+              onDisplayPlatformView2(view_id, 0, 0, 50, 50, 50, 50, mutators));
+  EXPECT_CALL(*jni_mock, swapTransaction());
+  EXPECT_CALL(*jni_mock, onEndFrame2());
+
+  auto surface_frame1 = std::make_unique<SurfaceFrame>(
+      SkSurfaces::Null(100, 100), framebuffer_info,
+      [](const SurfaceFrame& surface_frame, DlCanvas* canvas) { return true; },
+      [](const SurfaceFrame& surface_frame) { return true; },
+      /*frame_size=*/frame_size1);
+
+  fml::AutoResetWaitableEvent latch1;
+  fml::TaskRunner::RunNowOrPostTask(task_runners.GetRasterTaskRunner(), [&]() {
+    embedder->SubmitFlutterView(kImplicitViewId, nullptr, nullptr,
+                                std::move(surface_frame1));
+    fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),
+                                      [&latch1]() { latch1.Signal(); });
+  });
+  latch1.Wait();
+
+  // Second frame with size 200x200 (simulating rotation/resize).
+  // PrepareFlutterView should NOT destroy overlay surfaces.
+  EXPECT_CALL(*jni_mock, MaybeResizeSurfaceView(200, 200));
+  embedder->PrepareFlutterView(frame_size2, 1.0);
+  embedder->PrerollCompositeEmbeddedView(
+      view_id,
+      std::make_unique<EmbeddedViewParams>(matrix, DlSize(100, 100), mutators));
+  auto canvas2 = embedder->CompositeEmbeddedView(view_id);
+  canvas2->DrawRect(DlRect::MakeXYWH(0, 0, 100, 100), rect_paint);
+
+  EXPECT_CALL(*jni_mock, onDisplayPlatformView2(view_id, 0, 0, 100, 100, 100,
+                                                100, mutators));
+  EXPECT_CALL(*jni_mock, swapTransaction());
+  EXPECT_CALL(*jni_mock, onEndFrame2());
+
+  auto surface_frame2 = std::make_unique<SurfaceFrame>(
+      SkSurfaces::Null(200, 200), framebuffer_info,
+      [](const SurfaceFrame& surface_frame, DlCanvas* canvas) { return true; },
+      [](const SurfaceFrame& surface_frame) { return true; },
+      /*frame_size=*/frame_size2);
+
+  fml::AutoResetWaitableEvent latch2;
+  fml::TaskRunner::RunNowOrPostTask(task_runners.GetRasterTaskRunner(), [&]() {
+    embedder->SubmitFlutterView(kImplicitViewId, nullptr, nullptr,
+                                std::move(surface_frame2));
+    fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),
+                                      [&latch2]() { latch2.Signal(); });
+  });
+  latch2.Wait();
+
+  EXPECT_CALL(*jni_mock, destroyOverlaySurface2()).Times(1);
+  embedder->Teardown();
+  embedder.reset();
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -1221,19 +1221,18 @@ TEST(AndroidExternalViewEmbedder2, FrameSizeChangeDoesNotDestroySurfaces) {
           [](const SurfaceFrame&) { return true; }, frame_size2))));
 
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      fml::MakeCopyable(
-          [frame_size2, surface_mock = std::move(surface_mock)]() mutable {
-            auto android_surface = std::make_unique<AndroidSurfaceMock>();
-            EXPECT_CALL(*android_surface, IsValid())
-                .WillRepeatedly(Return(true));
-            EXPECT_CALL(*android_surface, SetNativeWindow(_, _))
-                .WillRepeatedly(Return(true));
-            EXPECT_CALL(*android_surface, CreateGPUSurface(_))
-                .WillOnce(Return(ByMove(std::move(surface_mock))));
-            EXPECT_CALL(*android_surface, OnScreenSurfaceResize(frame_size2))
-                .Times(1);
-            return android_surface;
-          }));
+      fml::MakeCopyable([frame_size2,
+                         surface_mock = std::move(surface_mock)]() mutable {
+        auto android_surface = std::make_unique<AndroidSurfaceMock>();
+        EXPECT_CALL(*android_surface, IsValid()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*android_surface, SetNativeWindow(_, _))
+            .WillRepeatedly(Return(true));
+        EXPECT_CALL(*android_surface, CreateGPUSurface(_))
+            .WillOnce(Return(ByMove(std::move(surface_mock))));
+        EXPECT_CALL(*android_surface, OnScreenSurfaceResize(frame_size2))
+            .Times(1);
+        return android_surface;
+      }));
 
   fml::RefPtr<AndroidNativeWindow> window =
       fml::MakeRefCounted<AndroidNativeWindow>(nullptr);

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -1313,5 +1313,134 @@ TEST(AndroidExternalViewEmbedder2, FrameSizeChangeDoesNotDestroySurfaces) {
   embedder.reset();
 }
 
+// Regression test for the HCPP rotation ANR.
+//
+// The platform thread is unavailable while it is inside
+// ViewRootImpl.performTraversals dispatching surfaceChanged, so a frame resize
+// on the raster thread must not block waiting on it. Rather than reproduce both
+// halves of the deadlock, this occupies the platform thread directly and
+// asserts the raster thread still makes progress.
+TEST(AndroidExternalViewEmbedder2, ResizeDoesNotBlockRasterOnPlatformThread) {
+  auto jni_mock = std::make_shared<JNIMock>();
+  auto android_context =
+      std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
+  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+                         ThreadHost::Type::kPlatform | ThreadHost::Type::kIo |
+                             ThreadHost::Type::kUi | ThreadHost::Type::kRaster);
+  TaskRunners task_runners(
+      "test",
+      thread_host.platform_thread->GetTaskRunner(),  // platform
+      thread_host.raster_thread->GetTaskRunner(),    // raster
+      thread_host.ui_thread->GetTaskRunner(),        // ui
+      thread_host.io_thread->GetTaskRunner()         // io
+  );
+  const DlISize frame_size1(100, 100);
+  const DlISize frame_size2(200, 200);
+  SurfaceFrame::FramebufferInfo framebuffer_info;
+
+  auto surface_mock = std::make_unique<SurfaceMock>();
+  EXPECT_CALL(*surface_mock, AcquireFrame(frame_size1))
+      .WillOnce(Return(ByMove(std::make_unique<SurfaceFrame>(
+          SkSurfaces::Null(100, 100), framebuffer_info,
+          [](const SurfaceFrame&, DlCanvas*) { return true; },
+          [](const SurfaceFrame&) { return true; }, frame_size1))));
+
+  auto surface_factory =
+      std::make_shared<TestAndroidSurfaceFactory>([&surface_mock]() {
+        auto android_surface = std::make_unique<AndroidSurfaceMock>();
+        EXPECT_CALL(*android_surface, IsValid()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*android_surface, SetNativeWindow(_, _))
+            .WillRepeatedly(Return(true));
+        EXPECT_CALL(*android_surface, CreateGPUSurface(_))
+            .WillOnce(Return(ByMove(std::move(surface_mock))));
+        return android_surface;
+      });
+
+  fml::RefPtr<AndroidNativeWindow> window =
+      fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
+  EXPECT_CALL(*jni_mock, createOverlaySurface2())
+      .Times(1)
+      .WillOnce(Return(
+          ByMove(std::make_unique<PlatformViewAndroidJNI::OverlayMetadata>(
+              0, window))));
+
+  auto embedder = std::make_unique<AndroidExternalViewEmbedder2>(
+      *android_context, jni_mock, surface_factory, task_runners);
+
+  const int64_t view_id = 42;
+  MutatorsStack mutators;
+  DlMatrix matrix = DlMatrix::MakeTranslation({0, 0});
+  DlPaint rect_paint;
+  rect_paint.setColor(DlColor::kCyan());
+  rect_paint.setDrawStyle(DlDrawStyle::kFill);
+
+  // Run one frame so the overlay layer exists. Without a layer, DestroySurfaces
+  // early-returns and there is nothing to deadlock on.
+  embedder->PrepareFlutterView(frame_size1, 1.0);
+  embedder->PrerollCompositeEmbeddedView(
+      view_id,
+      std::make_unique<EmbeddedViewParams>(matrix, DlSize(50, 50), mutators));
+  auto canvas = embedder->CompositeEmbeddedView(view_id);
+  canvas->DrawRect(DlRect::MakeXYWH(0, 0, 50, 50), rect_paint);
+
+  EXPECT_CALL(*jni_mock,
+              onDisplayPlatformView2(view_id, 0, 0, 50, 50, 50, 50, mutators));
+  EXPECT_CALL(*jni_mock, swapTransaction());
+  EXPECT_CALL(*jni_mock, onEndFrame2());
+
+  auto surface_frame = std::make_unique<SurfaceFrame>(
+      SkSurfaces::Null(100, 100), framebuffer_info,
+      [](const SurfaceFrame& surface_frame, DlCanvas* canvas) { return true; },
+      [](const SurfaceFrame& surface_frame) { return true; },
+      /*frame_size=*/frame_size1);
+
+  fml::AutoResetWaitableEvent frame_done;
+  fml::TaskRunner::RunNowOrPostTask(task_runners.GetRasterTaskRunner(), [&]() {
+    embedder->SubmitFlutterView(kImplicitViewId, nullptr, nullptr,
+                                std::move(surface_frame));
+    fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),
+                                      [&frame_done]() { frame_done.Signal(); });
+  });
+  frame_done.Wait();
+
+  // Occupy the platform thread, standing in for a layout traversal.
+  fml::AutoResetWaitableEvent platform_occupied;
+  fml::AutoResetWaitableEvent release_platform;
+  task_runners.GetPlatformTaskRunner()->PostTask([&]() {
+    platform_occupied.Signal();
+    release_platform.Wait();
+  });
+  platform_occupied.Wait();
+
+  EXPECT_CALL(*jni_mock, MaybeResizeSurfaceView(200, 200));
+
+  // The resize must complete without the platform thread running anything.
+  fml::AutoResetWaitableEvent resize_done;
+  task_runners.GetRasterTaskRunner()->PostTask([&]() {
+    embedder->PrepareFlutterView(frame_size2, 1.0);
+    resize_done.Signal();
+  });
+  const bool timed_out =
+      resize_done.WaitWithTimeout(fml::TimeDelta::FromSeconds(10));
+
+  // Release the platform thread before asserting so that a regression fails
+  // this test instead of hanging the suite.
+  release_platform.Signal();
+  if (timed_out) {
+    resize_done.Wait();
+  }
+  EXPECT_FALSE(timed_out)
+      << "PrepareFlutterView blocked the raster thread on the platform thread";
+
+  fml::AutoResetWaitableEvent drained;
+  fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),
+                                    [&drained]() { drained.Signal(); });
+  drained.Wait();
+
+  EXPECT_CALL(*jni_mock, destroyOverlaySurface2()).Times(1);
+  embedder->Teardown();
+  embedder.reset();
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool.cc
@@ -28,9 +28,18 @@ std::shared_ptr<OverlayLayer> SurfacePool::GetLayer(
     const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade,
     const std::shared_ptr<AndroidSurfaceFactory>& surface_factory) {
   std::lock_guard lock(mutex_);
-  // Destroy current layers in the pool if the frame size has changed.
   if (requested_frame_size_ != current_frame_size_) {
-    DestroyLayersLocked(jni_facade);
+    if (use_new_surface_methods_) {
+      // The overlay surface is persistent, so resize it in place. Nothing else
+      // resizes the swapchain: |Surface::AcquireFrame| ignores the size it is
+      // handed.
+      for (const auto& layer : layers_) {
+        layer->android_surface->OnScreenSurfaceResize(requested_frame_size_);
+      }
+    } else {
+      // Destroy current layers in the pool if the frame size has changed.
+      DestroyLayersLocked(jni_facade);
+    }
   }
   intptr_t gr_context_key = reinterpret_cast<intptr_t>(gr_context);
   // Allocate a new surface if there isn't one available.

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool.cc
@@ -33,7 +33,7 @@ std::shared_ptr<OverlayLayer> SurfacePool::GetLayer(
       // The overlay surface is persistent, so resize it in place. Nothing else
       // resizes the swapchain: |Surface::AcquireFrame| ignores the size it is
       // handed.
-      for (const auto& layer : layers_) {
+      for (const std::shared_ptr<OverlayLayer>& layer : layers_) {
         layer->android_surface->OnScreenSurfaceResize(requested_frame_size_);
       }
     } else {

--- a/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
@@ -304,7 +304,7 @@ TEST(SurfacePool, DestroyLayersFrameSizeChanged) {
   ASSERT_TRUE(pool->HasLayers());
 }
 
-TEST(SurfacePool, DestroyLayersFrameSizeChangedNew) {
+TEST(SurfacePool, DoesNotDestroyLayersFrameSizeChangedNew) {
   auto pool = std::make_unique<SurfacePool>(/*use_new_surface_methods=*/true);
   auto jni_mock = std::make_shared<JNIMock>();
 
@@ -320,6 +320,9 @@ TEST(SurfacePool, DestroyLayersFrameSizeChangedNew) {
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
         EXPECT_CALL(*android_surface_mock, SetNativeWindow(window, _));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
+        EXPECT_CALL(*android_surface_mock,
+                    OnScreenSurfaceResize(DlISize(20, 20)))
+            .Times(1);
         return android_surface_mock;
       });
   pool->SetFrameSize(DlISize(10, 10));
@@ -332,21 +335,20 @@ TEST(SurfacePool, DestroyLayersFrameSizeChangedNew) {
 
   ASSERT_FALSE(pool->HasLayers());
 
-  pool->GetLayer(gr_context.get(), *android_context, jni_mock, surface_factory);
+  auto layer_1 = pool->GetLayer(gr_context.get(), *android_context, jni_mock,
+                                surface_factory);
 
   ASSERT_TRUE(pool->HasLayers());
+  ASSERT_NE(nullptr, layer_1);
 
+  pool->RecycleLayers();
   pool->SetFrameSize(DlISize(20, 20));
-  EXPECT_CALL(*jni_mock, destroyOverlaySurface2()).Times(1);
-  EXPECT_CALL(*jni_mock, createOverlaySurface2())
-      .Times(1)
-      .WillOnce(Return(
-          ByMove(std::make_unique<PlatformViewAndroidJNI::OverlayMetadata>(
-              1, window))));
-  pool->GetLayer(gr_context.get(), *android_context, jni_mock, surface_factory);
+  auto layer_2 = pool->GetLayer(gr_context.get(), *android_context, jni_mock,
+                                surface_factory);
 
   ASSERT_TRUE(pool->GetUnusedLayers().empty());
   ASSERT_TRUE(pool->HasLayers());
+  ASSERT_EQ(layer_1, layer_2);
 }
 
 }  // namespace testing


### PR DESCRIPTION
Fixes a deadlock where we are waiting here
https://github.com/flutter/flutter/blob/master/engine/src/flutter/shell/platform/android/platform_view_android.cc#L247
and at the same time here
https://github.com/flutter/flutter/blob/master/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder_2.cc#L292

by removing the call to `DestroySurfaces()` - we shouldn't be destroying in hcpp in the first place. I'm pretty sure this was an error in copying it from 
https://github.com/flutter/flutter/blob/master/engine/src/flutter/shell/platform/android/external_view_embedder/external_view_embedder.cc#L226
in the first place, and it shouldn't have been included.