### PR TITLE
Fix ExpansionTile semantics with WidgetSpan titles

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -669,7 +669,9 @@ class _ExpansionTileState extends State<ExpansionTile> {
       return Semantics(
         // Live region used to announce state changes (e.g., "expanded" or "collapsed")
         // without taking focus.
-        // blockNode prevents this node from being part of the focus traversal.
+        // The container ensures the live region forms the node that blockNode
+        // removes from focus traversal.
+        container: true,
         label: semanticsHint,
         liveRegion: true,
         accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2232,6 +2232,47 @@ void main() {
     );
   });
   group('Semantics tests for android platform', () {
+    // Regression test for https://github.com/flutter/flutter/issues/188298.
+    testWidgets('ExpansionTile supports a nested WidgetSpan title', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Text.rich(
+              TextSpan(
+                children: <InlineSpan>[
+                  WidgetSpan(
+                    child: SizedBox(
+                      width: 400,
+                      child: ExpansionTile(
+                        title: Text.rich(
+                          TextSpan(
+                            children: <InlineSpan>[
+                              WidgetSpan(
+                                child: Text.rich(
+                                  TextSpan(
+                                    style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+                                    text: 'Header',
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        children: <Widget>[Text('These are the details.')],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      handle.dispose();
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));
+
     testWidgets(
       'Semantics liveregion updates when expansion state changes',
       (WidgetTester tester) async {


### PR DESCRIPTION
## Description

On Android, `ExpansionTile` used `AccessibilityFocusBlockType.blockNode` for its announcement live region without forcing that live region to form a semantics node. When an `ExpansionTile` was nested inside `Text.rich` and `WidgetSpan`, the blocked configuration could be merged through `RenderParagraph`'s generated configurations and trigger the `_IncompleteSemanticsFragment` conflict assertion.

Make the live region a semantics container so `blockNode` applies to the intended node. This matches the existing blocked-live-region pattern used by `CalendarDatePicker`.

Fixes https://github.com/flutter/flutter/issues/188298.

## Tests

- `flutter test --no-pub packages/flutter/test/material/expansion_tile_test.dart`
- `flutter analyze --no-pub packages/flutter/lib/src/material/expansion_tile.dart packages/flutter/test/material/expansion_tile_test.dart`

The author reviewed the AI-assisted changes. This remains a draft while the Material and Cupertino code freeze is active; the signed CLA check is also pending refresh.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
