### PR TITLE
[Impeller] Compile shader bundles for a subset of backends

### DIFF
--- a/engine/src/flutter/impeller/compiler/shader_bundle.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.cc
@@ -196,42 +196,54 @@ GenerateShaderBackendFB(TargetPlatform target_platform,
   return result;
 }
 
+/// The field of `Shader` that holds the compiled shader for `platform`, or
+/// nullptr when the platform has no place in a shader bundle.
+static std::unique_ptr<fb::shaderbundle::BackendShaderT>* GetBackendShaderSlot(
+    TargetPlatform platform,
+    fb::shaderbundle::ShaderT& shader) {
+  switch (platform) {
+    case TargetPlatform::kMetalIOS:
+      return &shader.metal_ios;
+    case TargetPlatform::kMetalDesktop:
+      return &shader.metal_desktop;
+    case TargetPlatform::kOpenGLES:
+      return &shader.opengl_es;
+    case TargetPlatform::kOpenGLDesktop:
+      return &shader.opengl_desktop;
+    case TargetPlatform::kVulkan:
+      return &shader.vulkan;
+    case TargetPlatform::kSkSL:
+    case TargetPlatform::kRuntimeStageMetal:
+    case TargetPlatform::kRuntimeStageGLES:
+    case TargetPlatform::kRuntimeStageGLES3:
+    case TargetPlatform::kRuntimeStageVulkan:
+    case TargetPlatform::kUnknown:
+      return nullptr;
+  }
+  return nullptr;
+}
+
 static std::unique_ptr<fb::shaderbundle::ShaderT> GenerateShaderFB(
     SourceOptions options,
     const std::string& shader_name,
     const ShaderConfig& shader_config,
+    const std::vector<TargetPlatform>& target_platforms,
     std::set<std::string>* out_dependencies) {
   auto result = std::make_unique<fb::shaderbundle::ShaderT>();
   result->name = shader_name;
-  result->metal_ios =
-      GenerateShaderBackendFB(TargetPlatform::kMetalIOS, options, shader_name,
-                              shader_config, out_dependencies);
-  if (!result->metal_ios) {
-    return nullptr;
-  }
-  result->metal_desktop =
-      GenerateShaderBackendFB(TargetPlatform::kMetalDesktop, options,
-                              shader_name, shader_config, out_dependencies);
-  if (!result->metal_desktop) {
-    return nullptr;
-  }
-  result->opengl_es =
-      GenerateShaderBackendFB(TargetPlatform::kOpenGLES, options, shader_name,
-                              shader_config, out_dependencies);
-  if (!result->opengl_es) {
-    return nullptr;
-  }
-  result->opengl_desktop =
-      GenerateShaderBackendFB(TargetPlatform::kOpenGLDesktop, options,
-                              shader_name, shader_config, out_dependencies);
-  if (!result->opengl_desktop) {
-    return nullptr;
-  }
-  result->vulkan =
-      GenerateShaderBackendFB(TargetPlatform::kVulkan, options, shader_name,
-                              shader_config, out_dependencies);
-  if (!result->vulkan) {
-    return nullptr;
+  for (TargetPlatform platform : target_platforms) {
+    std::unique_ptr<fb::shaderbundle::BackendShaderT>* slot =
+        GetBackendShaderSlot(platform, *result);
+    if (!slot) {
+      std::cerr << "Target platform \"" << TargetPlatformToString(platform)
+                << "\" cannot be stored in a shader bundle." << std::endl;
+      return nullptr;
+    }
+    *slot = GenerateShaderBackendFB(platform, options, shader_name,
+                                    shader_config, out_dependencies);
+    if (!*slot) {
+      return nullptr;
+    }
   }
   return result;
 }
@@ -239,6 +251,7 @@ static std::unique_ptr<fb::shaderbundle::ShaderT> GenerateShaderFB(
 std::optional<fb::shaderbundle::ShaderBundleT> GenerateShaderBundleFlatbuffer(
     const std::string& bundle_config_json,
     const SourceOptions& options,
+    const std::vector<TargetPlatform>& target_platforms,
     std::set<std::string>* out_dependencies) {
   // --------------------------------------------------------------------------
   /// 1. Parse the bundle configuration.
@@ -260,7 +273,8 @@ std::optional<fb::shaderbundle::ShaderBundleT> GenerateShaderBundleFlatbuffer(
 
   for (const auto& [shader_name, shader_config] : bundle_config.value()) {
     std::unique_ptr<fb::shaderbundle::ShaderT> shader =
-        GenerateShaderFB(options, shader_name, shader_config, out_dependencies);
+        GenerateShaderFB(options, shader_name, shader_config, target_platforms,
+                         out_dependencies);
     if (!shader) {
       return std::nullopt;
     }
@@ -319,7 +333,7 @@ bool GenerateShaderBundle(Switches& switches) {
   const bool want_depfile = !switches.depfile_path.empty();
   auto shader_bundle = GenerateShaderBundleFlatbuffer(
       switches.shader_bundle, switches.CreateSourceOptions(),
-      want_depfile ? &dependencies : nullptr);
+      switches.PlatformsToBundle(), want_depfile ? &dependencies : nullptr);
   if (!shader_bundle.has_value()) {
     // Specific error messages are already handled by
     // GenerateShaderBundleFlatbuffer.

--- a/engine/src/flutter/impeller/compiler/shader_bundle.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.cc
@@ -200,18 +200,18 @@ GenerateShaderBackendFB(TargetPlatform target_platform,
 /// nullptr when the platform has no place in a shader bundle.
 static std::unique_ptr<fb::shaderbundle::BackendShaderT>* GetBackendShaderSlot(
     TargetPlatform platform,
-    fb::shaderbundle::ShaderT& shader) {
+    fb::shaderbundle::ShaderT* shader) {
   switch (platform) {
     case TargetPlatform::kMetalIOS:
-      return &shader.metal_ios;
+      return &shader->metal_ios;
     case TargetPlatform::kMetalDesktop:
-      return &shader.metal_desktop;
+      return &shader->metal_desktop;
     case TargetPlatform::kOpenGLES:
-      return &shader.opengl_es;
+      return &shader->opengl_es;
     case TargetPlatform::kOpenGLDesktop:
-      return &shader.opengl_desktop;
+      return &shader->opengl_desktop;
     case TargetPlatform::kVulkan:
-      return &shader.vulkan;
+      return &shader->vulkan;
     case TargetPlatform::kSkSL:
     case TargetPlatform::kRuntimeStageMetal:
     case TargetPlatform::kRuntimeStageGLES:
@@ -233,7 +233,7 @@ static std::unique_ptr<fb::shaderbundle::ShaderT> GenerateShaderFB(
   result->name = shader_name;
   for (TargetPlatform platform : target_platforms) {
     std::unique_ptr<fb::shaderbundle::BackendShaderT>* slot =
-        GetBackendShaderSlot(platform, *result);
+        GetBackendShaderSlot(platform, result.get());
     if (!slot) {
       std::cerr << "Target platform \"" << TargetPlatformToString(platform)
                 << "\" cannot be stored in a shader bundle." << std::endl;

--- a/engine/src/flutter/impeller/compiler/shader_bundle.h
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.h
@@ -42,6 +42,10 @@ std::optional<ShaderBundleConfig> ParseShaderBundleConfig(
 /// @note   Exposed only for testing purposes. Use `GenerateShaderBundle`
 ///         directly.
 ///
+/// @param  target_platforms  The backends to compile each shader for. Only
+///                           these entries are populated on the resulting
+///                           shaders; the rest are left absent.
+///
 /// @param  out_dependencies  Optional. When non-null, populated with the
 ///                           set of source files (including transitive
 ///                           `#include`s) that contributed to the
@@ -50,6 +54,7 @@ std::optional<ShaderBundleConfig> ParseShaderBundleConfig(
 std::optional<fb::shaderbundle::ShaderBundleT> GenerateShaderBundleFlatbuffer(
     const std::string& bundle_config_json,
     const SourceOptions& options,
+    const std::vector<TargetPlatform>& target_platforms,
     std::set<std::string>* out_dependencies = nullptr);
 
 /// @brief  Parses the JSON shader bundle configuration and invokes the

--- a/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
@@ -15,6 +15,18 @@ namespace impeller {
 namespace compiler {
 namespace testing {
 
+/// Every backend a shader bundle can hold, the default when no platform flag
+/// narrows the selection.
+static std::vector<TargetPlatform> AllBundlePlatforms() {
+  return {
+      TargetPlatform::kMetalIOS,       //
+      TargetPlatform::kMetalDesktop,   //
+      TargetPlatform::kOpenGLES,       //
+      TargetPlatform::kOpenGLDesktop,  //
+      TargetPlatform::kVulkan,         //
+  };
+}
+
 const std::string kUnlitFragmentBundleConfig =
     "\"UnlitFragment\": {\"type\": \"fragment\", \"file\": "
     "\"shaders/flutter_gpu_unlit.frag\"}";
@@ -142,7 +154,7 @@ TEST(ShaderBundleTest, GenerateShaderBundleFlatbufferProducesCorrectResult) {
   options.source_language = SourceLanguage::kGLSL;
 
   std::optional<fb::shaderbundle::ShaderBundleT> bundle =
-      GenerateShaderBundleFlatbuffer(config, options);
+      GenerateShaderBundleFlatbuffer(config, options, AllBundlePlatforms());
   ASSERT_TRUE(bundle.has_value());
 
   // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
@@ -236,7 +248,8 @@ TEST(ShaderBundleTest,
 
   std::set<std::string> dependencies;
   std::optional<fb::shaderbundle::ShaderBundleT> bundle =
-      GenerateShaderBundleFlatbuffer(config, options, &dependencies);
+      GenerateShaderBundleFlatbuffer(config, options, AllBundlePlatforms(),
+                                     &dependencies);
   ASSERT_TRUE(bundle.has_value());
 
   // Every primary source file referenced by the bundle config should
@@ -265,8 +278,8 @@ TEST(ShaderBundleTest,
   options.source_language = SourceLanguage::kGLSL;
 
   std::optional<fb::shaderbundle::ShaderBundleT> bundle =
-      GenerateShaderBundleFlatbuffer(config, options, /*out_dependencies=*/
-                                     nullptr);
+      GenerateShaderBundleFlatbuffer(config, options, AllBundlePlatforms(),
+                                     /*out_dependencies=*/nullptr);
   ASSERT_TRUE(bundle.has_value());
 }
 
@@ -344,8 +357,55 @@ TEST(ShaderBundleTest, InjectsTargetDefinesDuringCompilation) {
   options.source_language = SourceLanguage::kGLSL;
 
   std::optional<fb::shaderbundle::ShaderBundleT> bundle =
-      GenerateShaderBundleFlatbuffer(config, options);
+      GenerateShaderBundleFlatbuffer(config, options, AllBundlePlatforms());
   EXPECT_FALSE(bundle.has_value());
+}
+
+TEST(ShaderBundleTest, OmitsBackendsThatWereNotRequested) {
+  std::string fixtures_path = flutter::testing::GetFixturesPath();
+  std::string config = "{\"UnlitVertex\": {\"type\": \"vertex\", \"file\": \"" +
+                       fixtures_path + "/flutter_gpu_unlit.vert\"}}";
+
+  SourceOptions options;
+  options.target_platform = TargetPlatform::kRuntimeStageMetal;
+  options.source_language = SourceLanguage::kGLSL;
+
+  std::optional<fb::shaderbundle::ShaderBundleT> bundle =
+      GenerateShaderBundleFlatbuffer(
+          config, options,
+          {TargetPlatform::kMetalIOS, TargetPlatform::kVulkan});
+  ASSERT_TRUE(bundle.has_value());
+
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+  const auto* vertex = FindByName(bundle->shaders, "UnlitVertex");
+  ASSERT_NE(vertex, nullptr);
+
+  EXPECT_NE(vertex->metal_ios, nullptr);
+  EXPECT_NE(vertex->vulkan, nullptr);
+  EXPECT_EQ(vertex->metal_desktop, nullptr);
+  EXPECT_EQ(vertex->opengl_es, nullptr);
+  EXPECT_EQ(vertex->opengl_desktop, nullptr);
+
+  // The requested backends carry the same reflection they would in a full
+  // bundle.
+  EXPECT_STREQ(vertex->metal_ios->entrypoint.c_str(),
+               "flutter_gpu_unlit_vertex_main");
+  EXPECT_EQ(vertex->vulkan->stage, fb::shaderbundle::ShaderStage::kVertex);
+}
+
+TEST(ShaderBundleTest, FailsWhenATargetHasNoPlaceInTheBundle) {
+  std::string fixtures_path = flutter::testing::GetFixturesPath();
+  std::string config = "{\"UnlitVertex\": {\"type\": \"vertex\", \"file\": \"" +
+                       fixtures_path + "/flutter_gpu_unlit.vert\"}}";
+
+  SourceOptions options;
+  options.target_platform = TargetPlatform::kRuntimeStageMetal;
+  options.source_language = SourceLanguage::kGLSL;
+
+  // Runtime stages and SkSL have no field on the bundled `Shader` table.
+  EXPECT_FALSE(GenerateShaderBundleFlatbuffer(
+                   config, options, {TargetPlatform::kRuntimeStageVulkan})
+                   .has_value());
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/compiler/switches.cc
+++ b/engine/src/flutter/impeller/compiler/switches.cc
@@ -96,7 +96,9 @@ void Switches::PrintHelp(std::ostream& stream) {
   stream << optional_prefix
          << "--shader-bundle=<bundle_spec> (causes --sl "
             "file to be "
-            "emitted in Flutter GPU's shader bundle format)"
+            "emitted in Flutter GPU's shader bundle format. Platform flags "
+            "select which backends the bundle contains, and may be combined. "
+            "Defaults to every backend when none are given)"
          << std::endl;
   stream << optional_prefix << "--reflection-json=<reflection_json_file>"
          << std::endl;
@@ -142,6 +144,17 @@ static TargetPlatform TargetPlatformFromCommandLine(
     }
   }
   return target;
+}
+
+static std::vector<TargetPlatform> TargetPlatformsFromCommandLine(
+    const fml::CommandLine& command_line) {
+  std::vector<TargetPlatform> platforms;
+  for (const auto& platform : kKnownPlatforms) {
+    if (command_line.HasOption(platform.first)) {
+      platforms.push_back(platform.second);
+    }
+  }
+  return platforms;
 }
 
 static std::vector<TargetPlatform> RuntimeStagesFromCommandLine(
@@ -207,6 +220,7 @@ Switches::Switches(const fml::CommandLine& command_line)
           command_line.HasOption("require-framebuffer-fetch")),
       verbose(command_line.HasOption("verbose")),
       target_platform_(TargetPlatformFromCommandLine(command_line)),
+      target_platforms_(TargetPlatformsFromCommandLine(command_line)),
       runtime_stages_(RuntimeStagesFromCommandLine(command_line)) {
   auto language = ToLowerCase(
       command_line.GetOptionValueWithDefault("source-language", "glsl"));
@@ -314,6 +328,21 @@ std::vector<TargetPlatform> Switches::PlatformsToCompile() const {
     return runtime_stages_;
   }
   return {target_platform_};
+}
+
+std::vector<TargetPlatform> Switches::PlatformsToBundle() const {
+  if (target_platforms_.empty()) {
+    // Every backend the bundle format can hold. Keep in sync with the fields
+    // of the `Shader` table in shader_bundle.fbs.
+    return {
+        TargetPlatform::kMetalIOS,       //
+        TargetPlatform::kMetalDesktop,   //
+        TargetPlatform::kOpenGLES,       //
+        TargetPlatform::kOpenGLDesktop,  //
+        TargetPlatform::kVulkan,         //
+    };
+  }
+  return target_platforms_;
 }
 
 SourceOptions Switches::CreateSourceOptions() const {

--- a/engine/src/flutter/impeller/compiler/switches.h
+++ b/engine/src/flutter/impeller/compiler/switches.h
@@ -58,6 +58,11 @@ class Switches {
   /// A vector containing at least one valid platform.
   std::vector<TargetPlatform> PlatformsToCompile() const;
 
+  /// The backends to emit when compiling a shader bundle. Platform flags
+  /// select a subset and may be combined; every backend is emitted when none
+  /// are given.
+  std::vector<TargetPlatform> PlatformsToBundle() const;
+
   /// Creates source options from these switches. The returned options does not
   /// have a set TargetPlatform because that cannot be determined based purely
   /// on the switches. Clients must set a valid TargetPlatform on the returned
@@ -69,6 +74,9 @@ class Switches {
  private:
   // Use |SelectDefaultTargetPlatform|.
   TargetPlatform target_platform_ = TargetPlatform::kUnknown;
+  // Every platform flag given, in contrast to |target_platform_|, which is
+  // unknown when more than one was specified. Use |PlatformsToBundle|.
+  std::vector<TargetPlatform> target_platforms_;
   // Use |PlatformsToCompile|.
   std::vector<TargetPlatform> runtime_stages_;
 };

--- a/engine/src/flutter/impeller/compiler/switches_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/switches_unittests.cc
@@ -95,6 +95,49 @@ TEST(SwitchesTest, ShaderBundleModeValid) {
   ASSERT_EQ(switches.shader_bundle, "{}");
 }
 
+TEST(SwitchesTest, ShaderBundleTargetsEveryBackendByDefault) {
+  std::vector<const char*> options = {"--shader-bundle={}",
+                                      "--sl=test.shaderbundle"};
+
+  auto cl = fml::CommandLineFromIteratorsWithArgv0("impellerc", options.begin(),
+                                                   options.end());
+  Switches switches(cl);
+  ASSERT_TRUE(switches.AreValid(std::cout));
+  EXPECT_EQ(switches.PlatformsToBundle(),
+            (std::vector<TargetPlatform>{
+                TargetPlatform::kMetalIOS, TargetPlatform::kMetalDesktop,
+                TargetPlatform::kOpenGLES, TargetPlatform::kOpenGLDesktop,
+                TargetPlatform::kVulkan}));
+}
+
+TEST(SwitchesTest, ShaderBundleTargetsCanBeNarrowedToOneBackend) {
+  std::vector<const char*> options = {"--shader-bundle={}",
+                                      "--sl=test.shaderbundle", "--metal-ios"};
+
+  auto cl = fml::CommandLineFromIteratorsWithArgv0("impellerc", options.begin(),
+                                                   options.end());
+  Switches switches(cl);
+  ASSERT_TRUE(switches.AreValid(std::cout));
+  EXPECT_EQ(switches.PlatformsToBundle(),
+            (std::vector<TargetPlatform>{TargetPlatform::kMetalIOS}));
+}
+
+TEST(SwitchesTest, ShaderBundleTargetsCombineAcrossPlatformFlags) {
+  // More than one platform flag is an error for single shader compiles, but
+  // selects a set of backends for a bundle.
+  std::vector<const char*> options = {"--shader-bundle={}",
+                                      "--sl=test.shaderbundle", "--opengl-es",
+                                      "--vulkan"};
+
+  auto cl = fml::CommandLineFromIteratorsWithArgv0("impellerc", options.begin(),
+                                                   options.end());
+  Switches switches(cl);
+  ASSERT_TRUE(switches.AreValid(std::cout));
+  EXPECT_EQ(switches.PlatformsToBundle(),
+            (std::vector<TargetPlatform>{TargetPlatform::kOpenGLES,
+                                         TargetPlatform::kVulkan}));
+}
+
 TEST(SwitchesTest, EntryPointPrefixIsApplied) {
   Switches switches =
       MakeSwitchesDesktopGL({"--entry-point-prefix=my_prefix_"});


### PR DESCRIPTION
Platform flags now select which backends a `--shader-bundle` build compiles, and may be combined. A bundle still carries every backend when no platform flag is given, so existing invocations are unchanged. Requesting a target with no field on the bundled `Shader` table, like a runtime stage, is an error rather than a silent omission.

This needs no bundle format version bump. Each backend is already an optional table in the schema, and `ShaderLibrary` already handles an absent one.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
