### PR TITLE
[Impeller] Expand the vertex attribute formats and gate them by backend capability

### DIFF
--- a/engine/src/flutter/impeller/core/shader_types.h
+++ b/engine/src/flutter/impeller/core/shader_types.h
@@ -292,7 +292,7 @@ struct ShaderStageIOSlot {
   constexpr size_t GetHash() const {
     return fml::HashCombine(
         name, location, set, binding, type, bit_width, vec_size, columns,
-        offset, relaxed_precision,
+        offset, relaxed_precision, vertex_format.has_value(),
         vertex_format.value_or(VertexAttributeFormat::kInvalid));
   }
 

--- a/engine/src/flutter/impeller/core/shader_types.h
+++ b/engine/src/flutter/impeller/core/shader_types.h
@@ -180,10 +180,22 @@ struct SampledImageSlot {
 ///         bit width, and component count.
 ///
 ///         Each backend maps these values to its own native vertex format, so
-///         this is the shared vocabulary for vertex inputs. The values are
-///         currently derived from a reflected `ShaderStageIOSlot` (see
-///         `ShaderStageIOSlot::GetVertexAttributeFormat`), so only the kinds
-///         that reflection produces are reachable.
+///         this is the shared vocabulary for vertex inputs. Formats whose
+///         scalar kind matches a shader input type are derived from a
+///         reflected `ShaderStageIOSlot` (see
+///         `ShaderStageIOSlot::GetVertexAttributeFormat`). The normalized and
+///         packed formats have no shader-side spelling, since the shader
+///         always sees floats, so they are requested through
+///         `ShaderStageIOSlot::vertex_format`.
+///
+///         Normalized and packed formats deliberately omit their 3-component
+///         variants. They have no D3D11 equivalent, so they are unavailable
+///         through ANGLE.
+///
+/// TODO(https://github.com/flutter/flutter/issues/186309): Add the 64-bit
+/// float formats. They are Vulkan-only among the backends here (Metal has no
+/// double vertex format) and need a shader toolchain that can carry doubles
+/// through to the target language.
 enum class VertexAttributeFormat {
   /// Not a valid vertex attribute (a matrix input, an unsupported scalar kind,
   /// or a component count outside 1 to 4).
@@ -209,6 +221,18 @@ enum class VertexAttributeFormat {
   kUInt8x3,
   kUInt8x4,
 
+  kSNorm8,
+  kSNorm8x2,
+  kSNorm8x4,
+
+  kUNorm8,
+  kUNorm8x2,
+  kUNorm8x4,
+
+  /// Four unsigned normalized bytes stored in blue, green, red, alpha order.
+  /// This is the packed byte layout of a `Color` on the host.
+  kUNorm8x4BGRA,
+
   kSInt16,
   kSInt16x2,
   kSInt16x3,
@@ -219,6 +243,14 @@ enum class VertexAttributeFormat {
   kUInt16x3,
   kUInt16x4,
 
+  kSNorm16,
+  kSNorm16x2,
+  kSNorm16x4,
+
+  kUNorm16,
+  kUNorm16x2,
+  kUNorm16x4,
+
   kSInt32,
   kSInt32x2,
   kSInt32x3,
@@ -228,6 +260,11 @@ enum class VertexAttributeFormat {
   kUInt32x2,
   kUInt32x3,
   kUInt32x4,
+
+  /// Four unsigned normalized components packed into 32 bits, with 10 bits
+  /// each for red, green, and blue and 2 bits for alpha. Alpha occupies the
+  /// most significant bits.
+  kUNorm10_10_10_2,
 };
 
 struct ShaderStageIOSlot {
@@ -242,32 +279,49 @@ struct ShaderStageIOSlot {
   size_t offset;
   bool relaxed_precision;
 
+  /// @brief  The format of the attribute as it is stored in the vertex buffer,
+  ///         when that differs from the format implied by the shader's
+  ///         declared input type.
+  ///
+  ///         Normalized and packed formats are only reachable this way. The
+  ///         shader declares a float input and the hardware converts on read,
+  ///         so reflection alone cannot tell the two apart. Unset means the
+  ///         format is derived from `type`, `bit_width`, and `vec_size`.
+  std::optional<VertexAttributeFormat> vertex_format = std::nullopt;
+
   constexpr size_t GetHash() const {
-    return fml::HashCombine(name, location, set, binding, type, bit_width,
-                            vec_size, columns, offset, relaxed_precision);
+    return fml::HashCombine(
+        name, location, set, binding, type, bit_width, vec_size, columns,
+        offset, relaxed_precision,
+        vertex_format.value_or(VertexAttributeFormat::kInvalid));
   }
 
   constexpr bool operator==(const ShaderStageIOSlot& other) const {
-    return name == other.name &&                         //
-           location == other.location &&                 //
-           set == other.set &&                           //
-           binding == other.binding &&                   //
-           type == other.type &&                         //
-           bit_width == other.bit_width &&               //
-           vec_size == other.vec_size &&                 //
-           columns == other.columns &&                   //
-           offset == other.offset &&                     //
-           relaxed_precision == other.relaxed_precision  //
+    return name == other.name &&                            //
+           location == other.location &&                    //
+           set == other.set &&                              //
+           binding == other.binding &&                      //
+           type == other.type &&                            //
+           bit_width == other.bit_width &&                  //
+           vec_size == other.vec_size &&                    //
+           columns == other.columns &&                      //
+           offset == other.offset &&                        //
+           relaxed_precision == other.relaxed_precision &&  //
+           vertex_format == other.vertex_format             //
         ;
   }
 
-  /// @brief  Derives the flat vertex attribute format from this slot's scalar
+  /// @brief  The flat vertex attribute format for this slot, either the
+  ///         explicit `vertex_format` or one derived from the slot's scalar
   ///         type, bit width, and component count.
   ///
   ///         Returns `kInvalid` for matrices, component counts outside 1 to 4,
   ///         mismatched bit widths, and scalar kinds that are not valid vertex
   ///         inputs (boolean, 64-bit integers, and doubles).
   constexpr VertexAttributeFormat GetVertexAttributeFormat() const {
+    if (vertex_format.has_value()) {
+      return vertex_format.value();
+    }
     if (columns != 1u || vec_size < 1u || vec_size > 4u) {
       return VertexAttributeFormat::kInvalid;
     }

--- a/engine/src/flutter/impeller/core/shader_types_unittests.cc
+++ b/engine/src/flutter/impeller/core/shader_types_unittests.cc
@@ -91,6 +91,22 @@ TEST(ShaderTypesTest, VertexAttributeFormatRejectsBadBitWidth) {
       VertexAttributeFormat::kInvalid);
 }
 
+TEST(ShaderTypesTest, VertexAttributeFormatUsesExplicitFormat) {
+  // Normalized formats have no shader-side spelling; the shader declares a
+  // float input and the explicit format says how the bytes are stored.
+  ShaderStageIOSlot slot = MakeSlot(ShaderType::kFloat, 32u, 4u);
+  slot.vertex_format = VertexAttributeFormat::kUNorm8x4;
+  EXPECT_EQ(slot.GetVertexAttributeFormat(), VertexAttributeFormat::kUNorm8x4);
+}
+
+TEST(ShaderTypesTest, VertexAttributeFormatIsPartOfSlotIdentity) {
+  ShaderStageIOSlot derived = MakeSlot(ShaderType::kFloat, 32u, 4u);
+  ShaderStageIOSlot explicit_format = derived;
+  explicit_format.vertex_format = VertexAttributeFormat::kUNorm8x4;
+  EXPECT_FALSE(derived == explicit_format);
+  EXPECT_NE(derived.GetHash(), explicit_format.GetHash());
+}
+
 TEST(ShaderTypesTest, VertexAttributeFormatRejectsUnsupportedScalarKinds) {
   EXPECT_EQ(MakeSlot(ShaderType::kBoolean, 8u, 1u).GetVertexAttributeFormat(),
             VertexAttributeFormat::kInvalid);

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -47,17 +47,20 @@ bool BufferBindingsGLES::RegisterVertexStageInput(
       }
       VertexAttribPointer attrib;
       attrib.index = input.location;
-      // Component counts must be 1, 2, 3 or 4. Do that validation now.
-      if (input.vec_size < 1u || input.vec_size > 4u) {
+      // The component count, GL type, and normalization all come from the
+      // attribute format, which also rejects component counts outside 1 to 4.
+      std::optional<VertexAttribGLES> format =
+          ToVertexAttribGLES(input.GetVertexAttributeFormat(),
+                             gl.GetCapabilities()->GetVertexFormatSupport());
+      if (!format.has_value()) {
+        VALIDATION_LOG << "Vertex attribute '" << input.name
+                       << "' has a format this device cannot read.";
         return false;
       }
-      attrib.size = input.vec_size;
-      auto type = ToVertexAttribType(input.GetVertexAttributeFormat());
-      if (!type.has_value()) {
-        return false;
-      }
-      attrib.type = type.value();
-      attrib.normalized = GL_FALSE;
+      attrib.size = format->size;
+      attrib.type = format->type;
+      attrib.normalized = format->normalized;
+      attrib.integer = format->integer;
       attrib.offset = input.offset;
       attrib.stride = layout.stride;
       attrib.vertex_attrib_divisor =
@@ -238,14 +241,26 @@ bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
     if (array.vertex_attrib_divisor != 0u) {
       attribute_offset += instance * static_cast<size_t>(array.stride);
     }
-    gl.VertexAttribPointer(array.index,       // index
-                           array.size,        // size (must be 1, 2, 3, or 4)
-                           array.type,        // type
-                           array.normalized,  // normalized
-                           array.stride,      // stride
-                           reinterpret_cast<const GLvoid*>(
-                               static_cast<uintptr_t>(attribute_offset))  // ptr
-    );
+    const auto* pointer = reinterpret_cast<const GLvoid*>(
+        static_cast<uintptr_t>(attribute_offset));
+    if (array.integer) {
+      // Integer inputs take the unconverted path. There is no normalization
+      // argument, since the value reaches the shader as-is.
+      gl.VertexAttribIPointer(array.index,   // index
+                              array.size,    // size
+                              array.type,    // type
+                              array.stride,  // stride
+                              pointer        // ptr
+      );
+    } else {
+      gl.VertexAttribPointer(array.index,       // index
+                             array.size,        // size
+                             array.type,        // type
+                             array.normalized,  // normalized
+                             array.stride,      // stride
+                             pointer            // ptr
+      );
+    }
     // Set the instancing divisor when the driver supports it. It is core
     // on ES 3.0+ and comes from GL_EXT_instanced_arrays on ES 2.0. When
     // unavailable, only per-vertex (divisor 0) bindings are possible,

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -67,17 +67,21 @@ class BufferBindingsGLES {
   FML_FRIEND_TEST(testing::BufferBindingsGLESTest,
                   BindUniformFailsWithoutFloatType);
   //----------------------------------------------------------------------------
-  /// @brief      The arguments to glVertexAttribPointer.
+  /// @brief      The arguments to glVertexAttribPointer, or to
+  ///             glVertexAttribIPointer when `integer` is set.
   ///
   struct VertexAttribPointer {
     GLuint index = 0u;
     GLint size = 4;
     GLenum type = GL_FLOAT;
-    GLenum normalized = GL_FALSE;
+    GLboolean normalized = GL_FALSE;
     GLsizei stride = 0u;
     GLsizei offset = 0u;
     // glVertexAttribDivisor value: 0 advances per vertex, 1 per instance.
     GLuint vertex_attrib_divisor = 0u;
+    // Integer-typed inputs must be bound with glVertexAttribIPointer, which
+    // delivers the value unconverted.
+    bool integer = false;
   };
   std::vector<std::vector<VertexAttribPointer>> vertex_attrib_arrays_;
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -20,27 +20,88 @@ const GLint kBlockDataSize = 16;
 
 using ::testing::_;
 
-TEST(BufferBindingsGLESTest, ToVertexAttribTypeSupportedFormats) {
-  EXPECT_EQ(ToVertexAttribType(VertexAttributeFormat::kFloat32x3),
-            std::optional<GLenum>(GL_FLOAT));
-  EXPECT_EQ(ToVertexAttribType(VertexAttributeFormat::kSInt8x4),
-            std::optional<GLenum>(GL_BYTE));
-  EXPECT_EQ(ToVertexAttribType(VertexAttributeFormat::kUInt8),
-            std::optional<GLenum>(GL_UNSIGNED_BYTE));
-  EXPECT_EQ(ToVertexAttribType(VertexAttributeFormat::kSInt16x2),
-            std::optional<GLenum>(GL_SHORT));
-  EXPECT_EQ(ToVertexAttribType(VertexAttributeFormat::kUInt16),
-            std::optional<GLenum>(GL_UNSIGNED_SHORT));
+namespace {
+// A context that supports every format tier.
+constexpr VertexFormatSupportGLES kFullVertexFormatSupport = {
+    .half_float_type = GL_HALF_FLOAT,
+    .integer = true,
+    .packed_2_10_10_10 = true,
+    .bgra = true,
+};
+}  // namespace
+
+TEST(BufferBindingsGLESTest, ToVertexAttribGLESFloats) {
+  auto attrib = ToVertexAttribGLES(VertexAttributeFormat::kFloat32x3,
+                                   kFullVertexFormatSupport);
+  ASSERT_TRUE(attrib.has_value());
+  EXPECT_EQ(attrib->size, 3);
+  EXPECT_EQ(attrib->type, static_cast<GLenum>(GL_FLOAT));
+  EXPECT_EQ(attrib->normalized, GL_FALSE);
+  EXPECT_FALSE(attrib->integer);
 }
 
-TEST(BufferBindingsGLESTest, ToVertexAttribTypeRejectsUnsupportedFormats) {
-  // Half-float and 32-bit integer vertex attributes are not available on the
-  // GLES 2.0 floor.
-  EXPECT_FALSE(ToVertexAttribType(VertexAttributeFormat::kFloat16).has_value());
-  EXPECT_FALSE(ToVertexAttribType(VertexAttributeFormat::kSInt32).has_value());
+TEST(BufferBindingsGLESTest, ToVertexAttribGLESNormalized) {
+  auto attrib = ToVertexAttribGLES(VertexAttributeFormat::kUNorm8x4,
+                                   kFullVertexFormatSupport);
+  ASSERT_TRUE(attrib.has_value());
+  EXPECT_EQ(attrib->size, 4);
+  EXPECT_EQ(attrib->type, static_cast<GLenum>(GL_UNSIGNED_BYTE));
+  EXPECT_EQ(attrib->normalized, GL_TRUE);
+  EXPECT_FALSE(attrib->integer);
+}
+
+TEST(BufferBindingsGLESTest, ToVertexAttribGLESIntegersTakeTheIPointerPath) {
+  auto attrib = ToVertexAttribGLES(VertexAttributeFormat::kUInt32x2,
+                                   kFullVertexFormatSupport);
+  ASSERT_TRUE(attrib.has_value());
+  EXPECT_EQ(attrib->size, 2);
+  EXPECT_EQ(attrib->type, static_cast<GLenum>(GL_UNSIGNED_INT));
+  EXPECT_EQ(attrib->normalized, GL_FALSE);
+  EXPECT_TRUE(attrib->integer);
+}
+
+TEST(BufferBindingsGLESTest, ToVertexAttribGLESPackedFormats) {
+  auto bgra = ToVertexAttribGLES(VertexAttributeFormat::kUNorm8x4BGRA,
+                                 kFullVertexFormatSupport);
+  ASSERT_TRUE(bgra.has_value());
+  // Byte ordering is expressed by passing GL_BGRA_EXT as the component count.
+  EXPECT_EQ(bgra->size, GL_BGRA_EXT);
+  EXPECT_EQ(bgra->type, static_cast<GLenum>(GL_UNSIGNED_BYTE));
+  EXPECT_EQ(bgra->normalized, GL_TRUE);
+
+  auto packed = ToVertexAttribGLES(VertexAttributeFormat::kUNorm10_10_10_2,
+                                   kFullVertexFormatSupport);
+  ASSERT_TRUE(packed.has_value());
+  EXPECT_EQ(packed->size, 4);
+  EXPECT_EQ(packed->type, static_cast<GLenum>(GL_UNSIGNED_INT_2_10_10_10_REV));
+  EXPECT_EQ(packed->normalized, GL_TRUE);
+}
+
+TEST(BufferBindingsGLESTest, ToVertexAttribGLESHonorsTheHalfFloatEnum) {
+  VertexFormatSupportGLES support = kFullVertexFormatSupport;
+  support.half_float_type = GL_HALF_FLOAT_OES;
+  auto attrib = ToVertexAttribGLES(VertexAttributeFormat::kFloat16x2, support);
+  ASSERT_TRUE(attrib.has_value());
+  EXPECT_EQ(attrib->type, static_cast<GLenum>(GL_HALF_FLOAT_OES));
+}
+
+TEST(BufferBindingsGLESTest, ToVertexAttribGLESRejectsUnsupportedFormats) {
+  // The OpenGL ES 2.0 floor: normalized and 32-bit float formats only.
+  constexpr VertexFormatSupportGLES kFloor = {};
+  EXPECT_TRUE(
+      ToVertexAttribGLES(VertexAttributeFormat::kUNorm8x4, kFloor).has_value());
   EXPECT_FALSE(
-      ToVertexAttribType(VertexAttributeFormat::kUInt32x4).has_value());
-  EXPECT_FALSE(ToVertexAttribType(VertexAttributeFormat::kInvalid).has_value());
+      ToVertexAttribGLES(VertexAttributeFormat::kFloat16, kFloor).has_value());
+  EXPECT_FALSE(
+      ToVertexAttribGLES(VertexAttributeFormat::kSInt32, kFloor).has_value());
+  EXPECT_FALSE(ToVertexAttribGLES(VertexAttributeFormat::kUNorm8x4BGRA, kFloor)
+                   .has_value());
+  EXPECT_FALSE(
+      ToVertexAttribGLES(VertexAttributeFormat::kUNorm10_10_10_2, kFloor)
+          .has_value());
+  EXPECT_FALSE(ToVertexAttribGLES(VertexAttributeFormat::kInvalid,
+                                  kFullVertexFormatSupport)
+                   .has_value());
 }
 
 TEST(BufferBindingsGLESTest, BindUniformData) {
@@ -267,6 +328,112 @@ TEST(BufferBindingsGLESTest, BindVertexAttributesSetsInstanceRateDivisor) {
   EXPECT_TRUE(bindings.BindVertexAttributes(mock_gl->GetProcTable(),
                                             /*binding=*/1, /*vertex_offset=*/0,
                                             /*instance=*/0));
+}
+
+// A normalized attribute reaches glVertexAttribPointer with the normalized
+// flag set, so the hardware converts the stored bytes to floats on read.
+TEST(BufferBindingsGLESTest, BindVertexAttributesNormalizesPackedColors) {
+  auto mock_gles_impl = std::make_unique<::testing::NiceMock<MockGLESImpl>>();
+  EXPECT_CALL(*mock_gles_impl, VertexAttribPointer(/*index=*/0, /*size=*/4,
+                                                   GL_UNSIGNED_BYTE, GL_TRUE,
+                                                   /*stride=*/4, _))
+      .Times(1);
+  EXPECT_CALL(*mock_gles_impl, VertexAttribIPointer(_, _, _, _, _)).Times(0);
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+
+  BufferBindingsGLES bindings;
+  // The shader declares a vec4; only the explicit format says the buffer holds
+  // four normalized bytes.
+  ShaderStageIOSlot input = {
+      .name = "color",
+      .location = 0,
+      .set = 0,
+      .binding = 0,
+      .type = ShaderType::kFloat,
+      .bit_width = sizeof(float) * 8,
+      .vec_size = 4,
+      .columns = 1,
+      .offset = 0,
+      .vertex_format = VertexAttributeFormat::kUNorm8x4,
+  };
+  std::vector<ShaderStageIOSlot> inputs = {input};
+  std::vector<ShaderStageBufferLayout> layouts = {
+      ShaderStageBufferLayout{
+          .stride = 4, .binding = 0, .input_rate = VertexInputRate::kVertex},
+  };
+
+  ASSERT_TRUE(bindings.RegisterVertexStageInput(mock_gl->GetProcTable(), inputs,
+                                                layouts));
+  EXPECT_TRUE(bindings.BindVertexAttributes(mock_gl->GetProcTable(),
+                                            /*binding=*/0, /*vertex_offset=*/0,
+                                            /*instance=*/0));
+}
+
+// An integer-typed input must go through glVertexAttribIPointer, which hands
+// the value to the shader unconverted.
+TEST(BufferBindingsGLESTest, BindVertexAttributesUsesIPointerForIntegers) {
+  auto mock_gles_impl = std::make_unique<::testing::NiceMock<MockGLESImpl>>();
+  EXPECT_CALL(*mock_gles_impl,
+              VertexAttribIPointer(/*index=*/0, /*size=*/1, GL_UNSIGNED_INT,
+                                   /*stride=*/4, _))
+      .Times(1);
+  EXPECT_CALL(*mock_gles_impl, VertexAttribPointer(_, _, _, _, _, _)).Times(0);
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+
+  BufferBindingsGLES bindings;
+  ShaderStageIOSlot input = {
+      .name = "packed_color",
+      .location = 0,
+      .set = 0,
+      .binding = 0,
+      .type = ShaderType::kUnsignedInt,
+      .bit_width = 32,
+      .vec_size = 1,
+      .columns = 1,
+      .offset = 0,
+  };
+  std::vector<ShaderStageIOSlot> inputs = {input};
+  std::vector<ShaderStageBufferLayout> layouts = {
+      ShaderStageBufferLayout{
+          .stride = 4, .binding = 0, .input_rate = VertexInputRate::kVertex},
+  };
+
+  ASSERT_TRUE(bindings.RegisterVertexStageInput(mock_gl->GetProcTable(), inputs,
+                                                layouts));
+  EXPECT_TRUE(bindings.BindVertexAttributes(mock_gl->GetProcTable(),
+                                            /*binding=*/0, /*vertex_offset=*/0,
+                                            /*instance=*/0));
+}
+
+// Registering a pipeline whose vertex layout the device cannot read fails at
+// pipeline creation rather than at draw time.
+TEST(BufferBindingsGLESTest, RegisterVertexStageInputRejectsUnusableFormat) {
+  auto mock_gles_impl = std::make_unique<::testing::NiceMock<MockGLESImpl>>();
+  std::shared_ptr<MockGLES> mock_gl =
+      MockGLES::Init(std::move(mock_gles_impl),
+                     std::vector<const char*>{"GL_KHR_debug"}, "OpenGL ES 2.0");
+
+  BufferBindingsGLES bindings;
+  ShaderStageIOSlot input = {
+      .name = "packed_normal",
+      .location = 0,
+      .set = 0,
+      .binding = 0,
+      .type = ShaderType::kFloat,
+      .bit_width = sizeof(float) * 8,
+      .vec_size = 4,
+      .columns = 1,
+      .offset = 0,
+      .vertex_format = VertexAttributeFormat::kUNorm10_10_10_2,
+  };
+  std::vector<ShaderStageIOSlot> inputs = {input};
+  std::vector<ShaderStageBufferLayout> layouts = {
+      ShaderStageBufferLayout{
+          .stride = 4, .binding = 0, .input_rate = VertexInputRate::kVertex},
+  };
+
+  EXPECT_FALSE(bindings.RegisterVertexStageInput(mock_gl->GetProcTable(),
+                                                 inputs, layouts));
 }
 
 namespace {

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -61,6 +61,24 @@ static const constexpr char* kAppleTextureMaxLevelExt =
 static const constexpr char* kTextureFilterAnisotropicExt =
     "GL_EXT_texture_filter_anisotropic";
 
+// https://registry.khronos.org/OpenGL/extensions/OES/OES_vertex_half_float.txt
+static const constexpr char* kVertexHalfFloatOesExt =
+    "GL_OES_vertex_half_float";
+// https://registry.khronos.org/OpenGL/extensions/ARB/ARB_half_float_vertex.txt
+static const constexpr char* kHalfFloatVertexArbExt =
+    "GL_ARB_half_float_vertex";
+
+// https://registry.khronos.org/OpenGL/extensions/ARB/ARB_vertex_type_2_10_10_10_rev.txt
+static const constexpr char* kVertexType2101010RevArbExt =
+    "GL_ARB_vertex_type_2_10_10_10_rev";
+
+// Both are desktop GL extensions. There is no OpenGL ES equivalent.
+// https://registry.khronos.org/OpenGL/extensions/ARB/ARB_vertex_array_bgra.txt
+static const constexpr char* kVertexArrayBgraArbExt =
+    "GL_ARB_vertex_array_bgra";
+// https://registry.khronos.org/OpenGL/extensions/EXT/EXT_vertex_array_bgra.txt
+static const constexpr char* kVertexArrayBgraExt = "GL_EXT_vertex_array_bgra";
+
 CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   {
     GLint value = 0;
@@ -218,6 +236,44 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
                             gl.TexSubImage3D.IsAvailable() &&
                             gl.CompressedTexSubImage3D.IsAvailable();
 
+  const bool supports_gl3 = desc->GetGlVersion().IsAtLeast(Version{3, 0, 0});
+
+  // Half-float vertex attributes are core on GL/GLES 3.0. Below that they come
+  // from GL_OES_vertex_half_float on ES and GL_ARB_half_float_vertex on
+  // desktop GL, which describe the same layout under a different enum value.
+  if (supports_gl3 ||
+      (!desc->IsES() && desc->HasExtension(kHalfFloatVertexArbExt))) {
+    vertex_format_support_.half_float_type = GL_HALF_FLOAT;
+  } else if (desc->IsES() && desc->HasExtension(kVertexHalfFloatOesExt)) {
+    vertex_format_support_.half_float_type = GL_HALF_FLOAT_OES;
+  }
+
+  // Integer vertex inputs are bound with glVertexAttribIPointer, which is core
+  // on GL/GLES 3.0 and has no fallback below it (GLSL ES 1.00 has no integer
+  // vertex inputs at all). Gate on the resolved proc rather than the version so
+  // a context that reports 3.0 but does not provide the entry point is treated
+  // as unsupported.
+  vertex_format_support_.integer = gl.VertexAttribIPointer.IsAvailable();
+
+  // The 2/10/10/10 packed vertex type is core on OpenGL ES 3.0 and desktop GL
+  // 3.3. The OpenGL ES 2.0 GL_OES_vertex_type_10_10_10_2 extension is
+  // deliberately not accepted here: it places the 2-bit component at the
+  // opposite end of the word, so its data is not interchangeable with
+  // GL_UNSIGNED_INT_2_10_10_10_REV.
+  vertex_format_support_.packed_2_10_10_10 =
+      (desc->IsES() && supports_gl3) ||
+      (!desc->IsES() && desc->GetGlVersion().IsAtLeast(Version{3, 3, 0})) ||
+      desc->HasExtension(kVertexType2101010RevArbExt);
+
+  // Blue/green/red/alpha byte ordering is expressed by passing GL_BGRA as the
+  // attribute size, which is core on desktop GL 3.2 and otherwise comes from
+  // an extension. OpenGL ES has no equivalent at any version, so callers there
+  // have to reorder the bytes or swizzle in the shader.
+  vertex_format_support_.bgra =
+      !desc->IsES() && (desc->GetGlVersion().IsAtLeast(Version{3, 2, 0}) ||
+                        desc->HasExtension(kVertexArrayBgraArbExt) ||
+                        desc->HasExtension(kVertexArrayBgraExt));
+
   // Anisotropic filtering is not part of any core GL or GLES version; it is
   // always gated on GL_EXT_texture_filter_anisotropic. The query and the
   // texture parameter are applied with core ES 2.0 entry points (GetFloatv
@@ -251,6 +307,16 @@ bool CapabilitiesGLES::SupportsTextureMaxLevel() const {
 
 bool CapabilitiesGLES::SupportsTextureArray() const {
   return supports_texture_array_;
+}
+
+const VertexFormatSupportGLES& CapabilitiesGLES::GetVertexFormatSupport()
+    const {
+  return vertex_format_support_;
+}
+
+bool CapabilitiesGLES::SupportsVertexFormat(
+    VertexAttributeFormat format) const {
+  return ToVertexAttribGLES(format, vertex_format_support_).has_value();
 }
 
 size_t CapabilitiesGLES::GetMaxTextureUnits(ShaderStage stage) const {

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
@@ -11,6 +11,7 @@
 #include "impeller/core/formats.h"
 #include "impeller/core/shader_types.h"
 #include "impeller/geometry/size.h"
+#include "impeller/renderer/backend/gles/formats_gles.h"
 #include "impeller/renderer/capabilities.h"
 
 namespace impeller {
@@ -98,6 +99,14 @@ class CapabilitiesGLES final
   ///        or GL_NV_texture_array (OpenGL ES 2.0). When absent, callers must
   ///        fall back to a texture atlas.
   bool SupportsTextureArray() const;
+
+  /// @brief Which vertex attribute formats beyond the OpenGL ES 2.0 floor this
+  ///        context can consume, used to translate a `VertexAttributeFormat`
+  ///        into its `glVertexAttribPointer` arguments.
+  const VertexFormatSupportGLES& GetVertexFormatSupport() const;
+
+  // |Capabilities|
+  bool SupportsVertexFormat(VertexAttributeFormat format) const override;
 
   // |Capabilities|
   bool SupportsOffscreenMSAA() const override;
@@ -189,6 +198,7 @@ class CapabilitiesGLES final
   bool supports_texture_compression_astc_hdr_ = false;
   uint32_t max_sampler_anisotropy_ = 1;
   PixelFormat default_glyph_atlas_format_ = PixelFormat::kUnknown;
+  VertexFormatSupportGLES vertex_format_support_;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.h
@@ -137,51 +137,177 @@ constexpr GLenum ToBlendOperation(BlendOperation op) {
   FML_UNREACHABLE();
 }
 
-/// Returns the GL scalar type for a vertex attribute, or `std::nullopt` when
-/// the format cannot be consumed as a vertex attribute on this backend. The
-/// component count is supplied separately to `glVertexAttribPointer`, so only
-/// the scalar kind matters here. Half-float and 32-bit integer attributes are
-/// not available on the GLES 2.0 floor.
-constexpr std::optional<GLenum> ToVertexAttribType(VertexAttributeFormat type) {
-  switch (type) {
-    case VertexAttributeFormat::kSInt8:
-    case VertexAttributeFormat::kSInt8x2:
-    case VertexAttributeFormat::kSInt8x3:
-    case VertexAttributeFormat::kSInt8x4:
-      return GL_BYTE;
-    case VertexAttributeFormat::kUInt8:
-    case VertexAttributeFormat::kUInt8x2:
-    case VertexAttributeFormat::kUInt8x3:
-    case VertexAttributeFormat::kUInt8x4:
-      return GL_UNSIGNED_BYTE;
-    case VertexAttributeFormat::kSInt16:
-    case VertexAttributeFormat::kSInt16x2:
-    case VertexAttributeFormat::kSInt16x3:
-    case VertexAttributeFormat::kSInt16x4:
-      return GL_SHORT;
-    case VertexAttributeFormat::kUInt16:
-    case VertexAttributeFormat::kUInt16x2:
-    case VertexAttributeFormat::kUInt16x3:
-    case VertexAttributeFormat::kUInt16x4:
-      return GL_UNSIGNED_SHORT;
+/// Which of the vertex attribute formats beyond the GLES 2.0 floor the current
+/// context can consume. Computed once by `CapabilitiesGLES` and consulted when
+/// translating a `VertexAttributeFormat`.
+struct VertexFormatSupportGLES {
+  /// The GL type to bind half-float attributes with, or `GL_NONE` when they
+  /// are unavailable. Core GLES 3.0 spells this `GL_HALF_FLOAT`; the GLES 2.0
+  /// extension spells the same layout `GL_HALF_FLOAT_OES`.
+  GLenum half_float_type = GL_NONE;
+
+  /// Whether `glVertexAttribIPointer` is available, which every integer-typed
+  /// vertex input needs. GLES 3.0 only, since GLSL ES 1.00 has no integer
+  /// vertex inputs.
+  bool integer = false;
+
+  /// Whether `GL_UNSIGNED_INT_2_10_10_10_REV` is accepted as a vertex type.
+  bool packed_2_10_10_10 = false;
+
+  /// Whether `GL_BGRA_EXT` is accepted as a vertex attribute size, which is
+  /// how blue/green/red/alpha byte ordering is expressed.
+  bool bgra = false;
+};
+
+/// How a vertex attribute is described to `glVertexAttribPointer` or, when
+/// `integer` is set, to `glVertexAttribIPointer`.
+struct VertexAttribGLES {
+  /// The component count, or `GL_BGRA_EXT` for the swizzled byte format.
+  GLint size = 0;
+  GLenum type = GL_NONE;
+  GLboolean normalized = GL_FALSE;
+  bool integer = false;
+};
+
+/// Returns how to bind a vertex attribute of the given format, or
+/// `std::nullopt` when the current context cannot consume it.
+constexpr std::optional<VertexAttribGLES> ToVertexAttribGLES(
+    VertexAttributeFormat format,
+    const VertexFormatSupportGLES& support) {
+  auto floating = [](GLint size, GLenum type) {
+    return VertexAttribGLES{.size = size, .type = type};
+  };
+  auto normalized = [](GLint size, GLenum type) {
+    return VertexAttribGLES{.size = size, .type = type, .normalized = GL_TRUE};
+  };
+  auto integer = [&support](GLint size,
+                            GLenum type) -> std::optional<VertexAttribGLES> {
+    if (!support.integer) {
+      return std::nullopt;
+    }
+    return VertexAttribGLES{.size = size, .type = type, .integer = true};
+  };
+  auto half = [&support](GLint size) -> std::optional<VertexAttribGLES> {
+    if (support.half_float_type == GL_NONE) {
+      return std::nullopt;
+    }
+    return VertexAttribGLES{.size = size, .type = support.half_float_type};
+  };
+
+  switch (format) {
     case VertexAttributeFormat::kFloat32:
+      return floating(1, GL_FLOAT);
     case VertexAttributeFormat::kFloat32x2:
+      return floating(2, GL_FLOAT);
     case VertexAttributeFormat::kFloat32x3:
+      return floating(3, GL_FLOAT);
     case VertexAttributeFormat::kFloat32x4:
-      return GL_FLOAT;
-    case VertexAttributeFormat::kInvalid:
+      return floating(4, GL_FLOAT);
+
     case VertexAttributeFormat::kFloat16:
+      return half(1);
     case VertexAttributeFormat::kFloat16x2:
+      return half(2);
     case VertexAttributeFormat::kFloat16x3:
+      return half(3);
     case VertexAttributeFormat::kFloat16x4:
+      return half(4);
+
+    case VertexAttributeFormat::kSInt8:
+      return integer(1, GL_BYTE);
+    case VertexAttributeFormat::kSInt8x2:
+      return integer(2, GL_BYTE);
+    case VertexAttributeFormat::kSInt8x3:
+      return integer(3, GL_BYTE);
+    case VertexAttributeFormat::kSInt8x4:
+      return integer(4, GL_BYTE);
+
+    case VertexAttributeFormat::kUInt8:
+      return integer(1, GL_UNSIGNED_BYTE);
+    case VertexAttributeFormat::kUInt8x2:
+      return integer(2, GL_UNSIGNED_BYTE);
+    case VertexAttributeFormat::kUInt8x3:
+      return integer(3, GL_UNSIGNED_BYTE);
+    case VertexAttributeFormat::kUInt8x4:
+      return integer(4, GL_UNSIGNED_BYTE);
+
+    case VertexAttributeFormat::kSNorm8:
+      return normalized(1, GL_BYTE);
+    case VertexAttributeFormat::kSNorm8x2:
+      return normalized(2, GL_BYTE);
+    case VertexAttributeFormat::kSNorm8x4:
+      return normalized(4, GL_BYTE);
+
+    case VertexAttributeFormat::kUNorm8:
+      return normalized(1, GL_UNSIGNED_BYTE);
+    case VertexAttributeFormat::kUNorm8x2:
+      return normalized(2, GL_UNSIGNED_BYTE);
+    case VertexAttributeFormat::kUNorm8x4:
+      return normalized(4, GL_UNSIGNED_BYTE);
+
+    case VertexAttributeFormat::kUNorm8x4BGRA:
+      if (!support.bgra) {
+        return std::nullopt;
+      }
+      return normalized(GL_BGRA_EXT, GL_UNSIGNED_BYTE);
+
+    case VertexAttributeFormat::kSInt16:
+      return integer(1, GL_SHORT);
+    case VertexAttributeFormat::kSInt16x2:
+      return integer(2, GL_SHORT);
+    case VertexAttributeFormat::kSInt16x3:
+      return integer(3, GL_SHORT);
+    case VertexAttributeFormat::kSInt16x4:
+      return integer(4, GL_SHORT);
+
+    case VertexAttributeFormat::kUInt16:
+      return integer(1, GL_UNSIGNED_SHORT);
+    case VertexAttributeFormat::kUInt16x2:
+      return integer(2, GL_UNSIGNED_SHORT);
+    case VertexAttributeFormat::kUInt16x3:
+      return integer(3, GL_UNSIGNED_SHORT);
+    case VertexAttributeFormat::kUInt16x4:
+      return integer(4, GL_UNSIGNED_SHORT);
+
+    case VertexAttributeFormat::kSNorm16:
+      return normalized(1, GL_SHORT);
+    case VertexAttributeFormat::kSNorm16x2:
+      return normalized(2, GL_SHORT);
+    case VertexAttributeFormat::kSNorm16x4:
+      return normalized(4, GL_SHORT);
+
+    case VertexAttributeFormat::kUNorm16:
+      return normalized(1, GL_UNSIGNED_SHORT);
+    case VertexAttributeFormat::kUNorm16x2:
+      return normalized(2, GL_UNSIGNED_SHORT);
+    case VertexAttributeFormat::kUNorm16x4:
+      return normalized(4, GL_UNSIGNED_SHORT);
+
     case VertexAttributeFormat::kSInt32:
+      return integer(1, GL_INT);
     case VertexAttributeFormat::kSInt32x2:
+      return integer(2, GL_INT);
     case VertexAttributeFormat::kSInt32x3:
+      return integer(3, GL_INT);
     case VertexAttributeFormat::kSInt32x4:
+      return integer(4, GL_INT);
+
     case VertexAttributeFormat::kUInt32:
+      return integer(1, GL_UNSIGNED_INT);
     case VertexAttributeFormat::kUInt32x2:
+      return integer(2, GL_UNSIGNED_INT);
     case VertexAttributeFormat::kUInt32x3:
+      return integer(3, GL_UNSIGNED_INT);
     case VertexAttributeFormat::kUInt32x4:
+      return integer(4, GL_UNSIGNED_INT);
+
+    case VertexAttributeFormat::kUNorm10_10_10_2:
+      if (!support.packed_2_10_10_10) {
+        return std::nullopt;
+      }
+      return normalized(4, GL_UNSIGNED_INT_2_10_10_10_REV);
+
+    case VertexAttributeFormat::kInvalid:
       return std::nullopt;
   }
   FML_UNREACHABLE();

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -269,7 +269,8 @@ void(glDepthRange)(GLdouble n, GLdouble f);
   PROC(WaitSync);                          \
   PROC(RenderbufferStorageMultisample);    \
   PROC(BlitFramebuffer);                   \
-  PROC(InvalidateFramebuffer);
+  PROC(InvalidateFramebuffer);             \
+  PROC(VertexAttribIPointer);
 
 // 3D texture entry points, used by 2D array textures. These are core on
 // GL/GLES 3.0 and also reachable below it: desktop GL 2.x exposes these exact

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/capabilities_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/capabilities_unittests.cc
@@ -127,5 +127,83 @@ TEST(CapabilitiesGLES, SupportsTextureArrayViaEXTExtension) {
   EXPECT_TRUE(capabilities->SupportsTextureArray());
 }
 
+TEST(CapabilitiesGLES, VertexFormatsOnTheES2Floor) {
+  // Normalized 8 and 16-bit attributes only need glVertexAttribPointer with a
+  // normalized flag, which is core all the way down to OpenGL ES 2.0.
+  auto const extensions = std::vector<const char*>{"GL_KHR_debug"};
+  auto mock_gles = MockGLES::Init(extensions, "OpenGL ES 2.0");
+  auto capabilities = mock_gles->GetProcTable().GetCapabilities();
+
+  EXPECT_TRUE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kFloat32x4));
+  EXPECT_TRUE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kUNorm8x4));
+  EXPECT_TRUE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kSNorm8x2));
+  EXPECT_TRUE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kUNorm16x4));
+  EXPECT_TRUE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kSNorm16));
+
+  // Everything above the floor needs a newer context or an extension.
+  EXPECT_FALSE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kFloat16x2));
+  EXPECT_FALSE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kUInt8x4));
+  EXPECT_FALSE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kSInt32));
+  EXPECT_FALSE(capabilities->SupportsVertexFormat(
+      VertexAttributeFormat::kUNorm10_10_10_2));
+  EXPECT_FALSE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kUNorm8x4BGRA));
+  EXPECT_FALSE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kInvalid));
+}
+
+TEST(CapabilitiesGLES, VertexFormatsOnES3) {
+  // Half-float, integer, and packed 2/10/10/10 attributes are all core on
+  // OpenGL ES 3.0.
+  auto mock_gles = MockGLES::Init(std::nullopt, "OpenGL ES 3.0");
+  auto capabilities = mock_gles->GetProcTable().GetCapabilities();
+
+  EXPECT_TRUE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kFloat16x2));
+  EXPECT_TRUE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kUInt8x4));
+  EXPECT_TRUE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kSInt32));
+  EXPECT_TRUE(capabilities->SupportsVertexFormat(
+      VertexAttributeFormat::kUNorm10_10_10_2));
+
+  // The byte-swizzled format stays extension-gated on ES.
+  EXPECT_FALSE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kUNorm8x4BGRA));
+}
+
+TEST(CapabilitiesGLES, VertexHalfFloatViaOESExtensionOnES2) {
+  auto const extensions = std::vector<const char*>{
+      "GL_KHR_debug",              //
+      "GL_OES_vertex_half_float",  //
+  };
+  auto mock_gles = MockGLES::Init(extensions, "OpenGL ES 2.0");
+  auto capabilities = mock_gles->GetProcTable().GetCapabilities();
+
+  EXPECT_TRUE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kFloat16x4));
+  // The extension spells the same layout with a different enum value.
+  EXPECT_EQ(capabilities->GetVertexFormatSupport().half_float_type,
+            static_cast<GLenum>(GL_HALF_FLOAT_OES));
+}
+
+TEST(CapabilitiesGLES, VertexBgraOnDesktopGL) {
+  // GL_BGRA as an attribute size is core on desktop GL 3.2 and has no OpenGL
+  // ES counterpart at any version.
+  auto mock_gles = MockGLES::Init(std::nullopt, "3.3");
+  auto capabilities = mock_gles->GetProcTable().GetCapabilities();
+
+  EXPECT_TRUE(
+      capabilities->SupportsVertexFormat(VertexAttributeFormat::kUNorm8x4BGRA));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -459,6 +459,31 @@ void mockVertexAttribDivisor(GLuint index, GLuint divisor) {
 static_assert(CheckSameSignature<decltype(mockVertexAttribDivisor),  //
                                  decltype(glVertexAttribDivisor)>::value);
 
+void mockVertexAttribPointer(GLuint index,
+                             GLint size,
+                             GLenum type,
+                             GLboolean normalized,
+                             GLsizei stride,
+                             const void* pointer) {
+  CallMockMethod(&IMockGLESImpl::VertexAttribPointer, index, size, type,
+                 normalized, stride, pointer);
+}
+
+static_assert(CheckSameSignature<decltype(mockVertexAttribPointer),  //
+                                 decltype(glVertexAttribPointer)>::value);
+
+void mockVertexAttribIPointer(GLuint index,
+                              GLint size,
+                              GLenum type,
+                              GLsizei stride,
+                              const void* pointer) {
+  CallMockMethod(&IMockGLESImpl::VertexAttribIPointer, index, size, type,
+                 stride, pointer);
+}
+
+static_assert(CheckSameSignature<decltype(mockVertexAttribIPointer),  //
+                                 decltype(glVertexAttribIPointer)>::value);
+
 // static
 std::shared_ptr<MockGLES> MockGLES::Init(
     std::unique_ptr<MockGLESImpl> impl,
@@ -583,6 +608,10 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockDrawElementsInstanced);
   } else if (strcmp(name, "glVertexAttribDivisor") == 0) {
     return reinterpret_cast<void*>(mockVertexAttribDivisor);
+  } else if (strcmp(name, "glVertexAttribPointer") == 0) {
+    return reinterpret_cast<void*>(mockVertexAttribPointer);
+  } else if (strcmp(name, "glVertexAttribIPointer") == 0) {
+    return reinterpret_cast<void*>(mockVertexAttribIPointer);
   } else if (strcmp(name, "glBindBufferRange") == 0) {
     return reinterpret_cast<void*>(mockBindBufferRange);
   } else if (strcmp(name, "glGetProgramiv") == 0) {

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -125,6 +125,17 @@ class IMockGLESImpl {
                                      const void* indices,
                                      GLsizei instancecount) {}
   virtual void VertexAttribDivisor(GLuint index, GLuint divisor) {}
+  virtual void VertexAttribPointer(GLuint index,
+                                   GLint size,
+                                   GLenum type,
+                                   GLboolean normalized,
+                                   GLsizei stride,
+                                   const void* pointer) {}
+  virtual void VertexAttribIPointer(GLuint index,
+                                    GLint size,
+                                    GLenum type,
+                                    GLsizei stride,
+                                    const void* pointer) {}
   virtual void BindBufferRange(GLenum target,
                                GLuint index,
                                GLuint buffer,
@@ -346,6 +357,23 @@ class MockGLESImpl : public IMockGLESImpl {
   MOCK_METHOD(GLuint,
               GetUniformBlockIndex,
               (GLuint program, const GLchar* uniformBlockName),
+              (override));
+  MOCK_METHOD(void,
+              VertexAttribPointer,
+              (GLuint index,
+               GLint size,
+               GLenum type,
+               GLboolean normalized,
+               GLsizei stride,
+               const void* pointer),
+              (override));
+  MOCK_METHOD(void,
+              VertexAttribIPointer,
+              (GLuint index,
+               GLint size,
+               GLenum type,
+               GLsizei stride,
+               const void* pointer),
               (override));
 };
 

--- a/engine/src/flutter/impeller/renderer/backend/metal/vertex_descriptor_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/vertex_descriptor_mtl.mm
@@ -47,6 +47,20 @@ static MTLVertexFormat ReadStageInputFormat(const ShaderStageIOSlot& input) {
       return MTLVertexFormatUChar3;
     case VertexAttributeFormat::kUInt8x4:
       return MTLVertexFormatUChar4;
+    case VertexAttributeFormat::kSNorm8:
+      return MTLVertexFormatCharNormalized;
+    case VertexAttributeFormat::kSNorm8x2:
+      return MTLVertexFormatChar2Normalized;
+    case VertexAttributeFormat::kSNorm8x4:
+      return MTLVertexFormatChar4Normalized;
+    case VertexAttributeFormat::kUNorm8:
+      return MTLVertexFormatUCharNormalized;
+    case VertexAttributeFormat::kUNorm8x2:
+      return MTLVertexFormatUChar2Normalized;
+    case VertexAttributeFormat::kUNorm8x4:
+      return MTLVertexFormatUChar4Normalized;
+    case VertexAttributeFormat::kUNorm8x4BGRA:
+      return MTLVertexFormatUChar4Normalized_BGRA;
     case VertexAttributeFormat::kSInt16:
       return MTLVertexFormatShort;
     case VertexAttributeFormat::kSInt16x2:
@@ -63,6 +77,18 @@ static MTLVertexFormat ReadStageInputFormat(const ShaderStageIOSlot& input) {
       return MTLVertexFormatUShort3;
     case VertexAttributeFormat::kUInt16x4:
       return MTLVertexFormatUShort4;
+    case VertexAttributeFormat::kSNorm16:
+      return MTLVertexFormatShortNormalized;
+    case VertexAttributeFormat::kSNorm16x2:
+      return MTLVertexFormatShort2Normalized;
+    case VertexAttributeFormat::kSNorm16x4:
+      return MTLVertexFormatShort4Normalized;
+    case VertexAttributeFormat::kUNorm16:
+      return MTLVertexFormatUShortNormalized;
+    case VertexAttributeFormat::kUNorm16x2:
+      return MTLVertexFormatUShort2Normalized;
+    case VertexAttributeFormat::kUNorm16x4:
+      return MTLVertexFormatUShort4Normalized;
     case VertexAttributeFormat::kSInt32:
       return MTLVertexFormatInt;
     case VertexAttributeFormat::kSInt32x2:
@@ -79,6 +105,8 @@ static MTLVertexFormat ReadStageInputFormat(const ShaderStageIOSlot& input) {
       return MTLVertexFormatUInt3;
     case VertexAttributeFormat::kUInt32x4:
       return MTLVertexFormatUInt4;
+    case VertexAttributeFormat::kUNorm10_10_10_2:
+      return MTLVertexFormatUInt1010102Normalized;
     case VertexAttributeFormat::kInvalid:
       return MTLVertexFormatInvalid;
   }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -9,6 +9,7 @@
 
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
+#include "impeller/renderer/backend/vulkan/vertex_descriptor_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 #include "impeller/renderer/backend/vulkan/workarounds_vk.h"
 
@@ -914,6 +915,17 @@ bool CapabilitiesVK::SupportsExtendedRangeFormats() const {
 
 bool CapabilitiesVK::SupportsFramebufferRenderMipmap() const {
   return true;
+}
+
+bool CapabilitiesVK::SupportsVertexFormat(VertexAttributeFormat format) const {
+  const vk::Format vk_format = ToVertexDescriptorFormat(format);
+  if (vk_format == vk::Format::eUndefined || !physical_device_) {
+    return false;
+  }
+  // Most vertex formats are mandatory in Vulkan, but a few (notably the
+  // blue/green/red/alpha byte ordering) are not, so ask the device.
+  return !!(physical_device_.getFormatProperties(vk_format).bufferFeatures &
+            vk::FormatFeatureFlagBits::eVertexBuffer);
 }
 
 bool CapabilitiesVK::SupportsTextureCompression(

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -286,6 +286,9 @@ class CapabilitiesVK final : public Capabilities,
   bool SupportsFramebufferRenderMipmap() const override;
 
   // |Capabilities|
+  bool SupportsVertexFormat(VertexAttributeFormat format) const override;
+
+  // |Capabilities|
   PixelFormat GetDefaultColorFormat() const override;
 
   // |Capabilities|

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -226,6 +226,41 @@ TEST(CapabilitiesVKTest, ReportsBlockCompressedTextureSupport) {
       CompressedTextureFamily::kBC));
 }
 
+// Vertex formats are gated on the device's per-format buffer features, since
+// not every format Impeller can describe is mandatory in Vulkan.
+TEST(CapabilitiesVKTest, ReportsVertexFormatSupport) {
+  const std::shared_ptr<ContextVK> context =
+      MockVulkanContextBuilder()
+          .SetPhysicalDeviceFormatPropertiesCallback(
+              [](VkPhysicalDevice physicalDevice, VkFormat format,
+                 VkFormatProperties* pFormatProperties) {
+                if (format == VK_FORMAT_R8G8B8A8_UNORM) {
+                  pFormatProperties->optimalTilingFeatures =
+                      static_cast<VkFormatFeatureFlags>(
+                          vk::FormatFeatureFlagBits::eColorAttachment);
+                  pFormatProperties->bufferFeatures =
+                      static_cast<VkFormatFeatureFlags>(
+                          vk::FormatFeatureFlagBits::eVertexBuffer);
+                } else if (format == VK_FORMAT_D24_UNORM_S8_UINT) {
+                  pFormatProperties->optimalTilingFeatures =
+                      static_cast<VkFormatFeatureFlags>(
+                          vk::FormatFeatureFlagBits::eDepthStencilAttachment);
+                }
+              })
+          .Build();
+  ASSERT_NE(context, nullptr);
+  const CapabilitiesVK* capabilities_vk =
+      reinterpret_cast<const CapabilitiesVK*>(context->GetCapabilities().get());
+
+  EXPECT_TRUE(
+      capabilities_vk->SupportsVertexFormat(VertexAttributeFormat::kUNorm8x4));
+  // The device does not advertise the byte-swizzled format.
+  EXPECT_FALSE(capabilities_vk->SupportsVertexFormat(
+      VertexAttributeFormat::kUNorm8x4BGRA));
+  EXPECT_FALSE(
+      capabilities_vk->SupportsVertexFormat(VertexAttributeFormat::kInvalid));
+}
+
 // Impeller's 2D renderer relies on hardware support for a combined
 // depth-stencil format (widely supported). So fail initialization if a suitable
 // one couldn't be found. That way we have an opportunity to fallback to

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/vertex_descriptor_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/vertex_descriptor_vk.cc
@@ -9,7 +9,11 @@
 namespace impeller {
 
 vk::Format ToVertexDescriptorFormat(const ShaderStageIOSlot& input) {
-  switch (input.GetVertexAttributeFormat()) {
+  return ToVertexDescriptorFormat(input.GetVertexAttributeFormat());
+}
+
+vk::Format ToVertexDescriptorFormat(VertexAttributeFormat format) {
+  switch (format) {
     case VertexAttributeFormat::kFloat32:
       return vk::Format::eR32Sfloat;
     case VertexAttributeFormat::kFloat32x2:
@@ -42,6 +46,20 @@ vk::Format ToVertexDescriptorFormat(const ShaderStageIOSlot& input) {
       return vk::Format::eR8G8B8Uint;
     case VertexAttributeFormat::kUInt8x4:
       return vk::Format::eR8G8B8A8Uint;
+    case VertexAttributeFormat::kSNorm8:
+      return vk::Format::eR8Snorm;
+    case VertexAttributeFormat::kSNorm8x2:
+      return vk::Format::eR8G8Snorm;
+    case VertexAttributeFormat::kSNorm8x4:
+      return vk::Format::eR8G8B8A8Snorm;
+    case VertexAttributeFormat::kUNorm8:
+      return vk::Format::eR8Unorm;
+    case VertexAttributeFormat::kUNorm8x2:
+      return vk::Format::eR8G8Unorm;
+    case VertexAttributeFormat::kUNorm8x4:
+      return vk::Format::eR8G8B8A8Unorm;
+    case VertexAttributeFormat::kUNorm8x4BGRA:
+      return vk::Format::eB8G8R8A8Unorm;
     case VertexAttributeFormat::kSInt16:
       return vk::Format::eR16Sint;
     case VertexAttributeFormat::kSInt16x2:
@@ -58,6 +76,18 @@ vk::Format ToVertexDescriptorFormat(const ShaderStageIOSlot& input) {
       return vk::Format::eR16G16B16Uint;
     case VertexAttributeFormat::kUInt16x4:
       return vk::Format::eR16G16B16A16Uint;
+    case VertexAttributeFormat::kSNorm16:
+      return vk::Format::eR16Snorm;
+    case VertexAttributeFormat::kSNorm16x2:
+      return vk::Format::eR16G16Snorm;
+    case VertexAttributeFormat::kSNorm16x4:
+      return vk::Format::eR16G16B16A16Snorm;
+    case VertexAttributeFormat::kUNorm16:
+      return vk::Format::eR16Unorm;
+    case VertexAttributeFormat::kUNorm16x2:
+      return vk::Format::eR16G16Unorm;
+    case VertexAttributeFormat::kUNorm16x4:
+      return vk::Format::eR16G16B16A16Unorm;
     case VertexAttributeFormat::kSInt32:
       return vk::Format::eR32Sint;
     case VertexAttributeFormat::kSInt32x2:
@@ -74,6 +104,8 @@ vk::Format ToVertexDescriptorFormat(const ShaderStageIOSlot& input) {
       return vk::Format::eR32G32B32Uint;
     case VertexAttributeFormat::kUInt32x4:
       return vk::Format::eR32G32B32A32Uint;
+    case VertexAttributeFormat::kUNorm10_10_10_2:
+      return vk::Format::eA2B10G10R10UnormPack32;
     case VertexAttributeFormat::kInvalid:
       return vk::Format::eUndefined;
   }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/vertex_descriptor_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/vertex_descriptor_vk.h
@@ -10,6 +10,8 @@
 
 namespace impeller {
 
+vk::Format ToVertexDescriptorFormat(VertexAttributeFormat format);
+
 vk::Format ToVertexDescriptorFormat(const ShaderStageIOSlot& input);
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/capabilities.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities.cc
@@ -110,6 +110,13 @@ class StandardCapabilities final : public Capabilities {
   bool SupportsFramebufferRenderMipmap() const override { return true; }
 
   // |Capabilities|
+  bool SupportsVertexFormat(VertexAttributeFormat format) const override {
+    // Metal is the only backend built on these capabilities, and every format
+    // in the enum has an MTLVertexFormat equivalent.
+    return format != VertexAttributeFormat::kInvalid;
+  }
+
+  // |Capabilities|
   bool SupportsTextureCompression(
       CompressedTextureFamily family) const override {
     switch (family) {

--- a/engine/src/flutter/impeller/renderer/capabilities.h
+++ b/engine/src/flutter/impeller/renderer/capabilities.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "impeller/core/formats.h"
+#include "impeller/core/shader_types.h"
 
 namespace impeller {
 
@@ -146,6 +147,12 @@ class Capabilities {
   ///        always supported. Metal and Vulkan support this; the GLES backend
   ///        does not yet, so it returns false there.
   virtual bool SupportsFramebufferRenderMipmap() const = 0;
+
+  /// @brief Whether the given vertex attribute format can be read by a
+  ///        pipeline on this device. Only the GLES backend constrains the set,
+  ///        since it targets an OpenGL ES 2.0 floor; callers that use anything
+  ///        beyond 32-bit floats must check this before building a pipeline.
+  virtual bool SupportsVertexFormat(VertexAttributeFormat format) const = 0;
 
   /// @brief The maximum anisotropy clamp supported by device samplers.
   ///

--- a/engine/src/flutter/impeller/renderer/testing/mocks.h
+++ b/engine/src/flutter/impeller/renderer/testing/mocks.h
@@ -258,6 +258,10 @@ class MockCapabilities : public Capabilities {
               SupportsTextureCompression,
               (CompressedTextureFamily),
               (const override));
+  MOCK_METHOD(bool,
+              SupportsVertexFormat,
+              (VertexAttributeFormat),
+              (const override));
   MOCK_METHOD(PixelFormat, GetDefaultColorFormat, (), (const, override));
   MOCK_METHOD(PixelFormat, GetDefaultStencilFormat, (), (const, override));
   MOCK_METHOD(PixelFormat, GetDefaultDepthStencilFormat, (), (const, override));


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/issues/186309.

Adds the normalized, byte-swizzled, and packed 2/10/10/10 vertex attribute formats to the HAL and finishes the OpenGL ES binding path for them. Attributes now take their normalized flag from the format, integer-typed inputs go through `glVertexAttribIPointer` instead of being rejected outright, and half-float inputs bind with whichever enum the context spells them.

Also adds `Capabilities::SupportsVertexFormat`, since OpenGL ES is the one backend that cannot read every format. It derives the answer from the GL version and extensions, Vulkan asks the device for the format's buffer features, and Metal reads all of them. A pipeline whose vertex layout the device cannot read now fails at creation with a message naming the attribute.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
