### PR TITLE
Disallow Swift symbols in `verify_exported.dart`

### DIFF
--- a/engine/src/flutter/testing/symbols/verify_exported.dart
+++ b/engine/src/flutter/testing/symbols/verify_exported.dart
@@ -13,14 +13,9 @@ import 'package:path/path.dart' as p;
 // Android binaries (libflutter.so) should only export one symbol "JNI_OnLoad"
 // of type "T".
 //
-// Ideally, iOS binaries (Flutter.framework/Flutter) should only export
-// Objective-C Symbols from the Flutter namespace, of type "(__DATA,__common)" or
-// "(__DATA,__objc_data)". However, to allow Swift symbols to be exported in
-// an Objective-C bridging header, they must be public or open. The framework
-// uses these types internally and never publishes these types in a public header.
-// Like `_InternalFlutter` Obj-C symbols, we allow `InternalFlutterSwift` and
-// `InternalFlutterSwiftCommon` symbols, as they are clearly marked as internal
-// in the name.
+// The iOS binaries (Flutter.framework/Flutter) should only export Objective-C
+// Symbols from the Flutter namespace, of type "(__DATA,__common)" or
+// "(__DATA,__objc_data)".
 
 /// Takes the path to the out directory as the first argument, and the path to
 /// the buildtools directory as the second argument.
@@ -106,50 +101,10 @@ int _checkIos(String outPath, String nmPath, Iterable<String> builds) {
       failures++;
       continue;
     }
-    final swiftEntries = <NmEntry>[];
-    final unexpectedEntries = <NmEntry>[];
-
-    for (final NmEntry entry in NmEntry.parse(nmResult.stdout as String)) {
-      if (entry.isCInternalSymbol || entry.isAllowedCSymbol || entry.isAllowedObjCSymbol) {
-        continue;
-      }
-      final bool isSwiftSymbol = switch (entry.type) {
-        '(__TEXT,__text)' ||
-        '(__TEXT,__const)' ||
-        '(__TEXT,__constg_swiftt)' ||
-        '(__DATA_CONST,__const)' ||
-        '(__DATA,__data)' ||
-        '(__DATA,__objc_data)' ||
-        '(__DATA,__common)' => entry.name.startsWith(r'_$s'),
-        _ => false,
-      };
-
-      if (isSwiftSymbol) {
-        swiftEntries.add(entry);
-      } else {
-        unexpectedEntries.add(entry);
-      }
-    }
-
-    final Map<String, String?>? symbolToModuleNameMap = _demangleSymbols(
-      swiftEntries.map((NmEntry entry) => entry.name),
+    final Iterable<NmEntry> unexpectedEntries = NmEntry.parse(nmResult.stdout as String).where(
+      (NmEntry entry) =>
+          !entry.isCInternalSymbol && !entry.isAllowedCSymbol && !entry.isAllowedObjCSymbol,
     );
-
-    if (symbolToModuleNameMap == null) {
-      print('ERROR: failed to execute "swift demangle"');
-      failures++;
-      return failures;
-    }
-
-    unexpectedEntries.addAll(
-      swiftEntries.where(
-        (NmEntry entry) => switch (symbolToModuleNameMap[entry.name]) {
-          'InternalFlutterSwiftCommon' || 'InternalFlutterSwift' => false,
-          _ => true,
-        },
-      ),
-    );
-
     if (unexpectedEntries.isNotEmpty) {
       print('ERROR: $libFlutter exports unexpected symbols:');
       print(
@@ -284,59 +239,4 @@ final class NmEntry {
 
   @override
   String toString() => '$name: $type';
-}
-
-final RegExp moduleLinePattern = RegExp(r'kind=Module, text="(.+)"');
-// Demangles the given `symbols` and maps each mangled name to its Swift module name.
-//
-// Returns null if the `swift demangle` command failed entirely.
-// Individual map values may be null if a symbol failed to demangle or did not belong to a Swift module.
-Map<String, String?>? _demangleSymbols(Iterable<String> symbols) {
-  if (symbols.isEmpty) {
-    return <String, String?>{};
-  }
-  final ProcessResult demangledResult = Process.runSync('swift', <String>[
-    'demangle',
-    '--tree-only',
-    ...symbols,
-  ]);
-  if (demangledResult.exitCode != 0) {
-    return null;
-  }
-
-  final symbolToModule = <String, String?>{};
-  final output = demangledResult.stdout as String;
-
-  String trim(String string) => string.trim();
-
-  for (final String symbolTree in output.split('Demangling for ').map(trim)) {
-    final List<String> lines = LineSplitter.split(symbolTree).toList();
-    if (lines.isEmpty) {
-      continue;
-    }
-    final String mangledName = lines.first;
-
-    // Parses the output from `swift demangle --tree-only` and extracts the module
-    // name of a single entry.
-    //
-    // Example `swift demangle --tree-only` output:
-    //
-    // Demangling for _$s26InternalFlutterSwiftCommon8LogLevelOSYAAMc
-    // kind=Global
-    //   kind=ProtocolConformanceDescriptor
-    //     kind=ProtocolConformance
-    //       kind=Type
-    //         kind=Enum
-    //           kind=Module, text="InternalFlutterSwiftCommon"
-    //           kind=Identifier, text="LogLevel"
-    //       kind=Type
-    //         kind=Protocol
-    //           kind=Module, text="Swift"
-    //           kind=Identifier, text="RawRepresentable"
-    //       kind=Module, text="InternalFlutterSwiftCommon"
-    final String? moduleName = moduleLinePattern.firstMatch(symbolTree)?.group(1);
-
-    symbolToModule[mangledName] = moduleName;
-  }
-  return symbolToModule;
 }


### PR DESCRIPTION
Swift symbols are no longer exported in non-debug builds. Update `verify_exported.dart` so no new symbols get accidentally exported.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
