### PR TITLE
iOS: Migrate the unit test host app to UIScene

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
@@ -197,6 +197,8 @@ FLUTTER_ASSERT_ARC
   XCTNSNotificationExpectation* expectation = [[XCTNSNotificationExpectation alloc]
       initWithName:UIApplicationDidEnterBackgroundNotification];
   FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
+  id mockApplication = OCMClassMock([FlutterSharedApplication class]);
+  OCMStub([mockApplication hasSceneDelegate]).andReturn(NO);
   id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
   [delegate addDelegate:plugin];
   [[NSNotificationCenter defaultCenter]
@@ -246,6 +248,8 @@ FLUTTER_ASSERT_ARC
       initWithName:UIApplicationWillEnterForegroundNotification];
 
   FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
+  id mockApplication = OCMClassMock([FlutterSharedApplication class]);
+  OCMStub([mockApplication hasSceneDelegate]).andReturn(NO);
   id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
   [delegate addDelegate:plugin];
   [[NSNotificationCenter defaultCenter]
@@ -294,6 +298,8 @@ FLUTTER_ASSERT_ARC
       [[XCTNSNotificationExpectation alloc] initWithName:UIApplicationWillResignActiveNotification];
 
   FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
+  id mockApplication = OCMClassMock([FlutterSharedApplication class]);
+  OCMStub([mockApplication hasSceneDelegate]).andReturn(NO);
   id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
   [delegate addDelegate:plugin];
   [[NSNotificationCenter defaultCenter]
@@ -342,6 +348,8 @@ FLUTTER_ASSERT_ARC
       [[XCTNSNotificationExpectation alloc] initWithName:UIApplicationDidBecomeActiveNotification];
 
   FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
+  id mockApplication = OCMClassMock([FlutterSharedApplication class]);
+  OCMStub([mockApplication hasSceneDelegate]).andReturn(NO);
   id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
   [delegate addDelegate:plugin];
   [[NSNotificationCenter defaultCenter]

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -2310,7 +2310,11 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [engine runWithEntrypoint:nil];
   FlutterViewController* flutterViewController =
       [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
-  UIWindow* window = [[UIWindow alloc] init];
+  // The window must be attached to the connected scene to have a screen, without which the
+  // viewport metrics stay empty and the surface is never updated.
+  UIWindow* window = [[UIWindow alloc]
+      initWithWindowScene:(UIWindowScene*)
+                              UIApplication.sharedApplication.connectedScenes.anyObject];
   [window addSubview:flutterViewController.view];
   flutterViewController.view.bounds = CGRectMake(0, 0, 100, 100);
   [flutterViewController viewDidLayoutSubviews];
@@ -2348,7 +2352,11 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [engine runWithEntrypoint:nil];
   FlutterViewController* flutterViewController =
       [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
-  UIWindow* window = [[UIWindow alloc] init];
+  // The window must be attached to the connected scene to have a screen, without which the
+  // viewport metrics stay empty and the surface is never updated.
+  UIWindow* window = [[UIWindow alloc]
+      initWithWindowScene:(UIWindowScene*)
+                              UIApplication.sharedApplication.connectedScenes.anyObject];
   [window addSubview:flutterViewController.view];
   flutterViewController.view.bounds = CGRectMake(0, 0, 100, 100);
   [flutterViewController viewDidLayoutSubviews];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -2312,9 +2312,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
       [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
   // The window must be attached to the connected scene to have a screen, without which the
   // viewport metrics stay empty and the surface is never updated.
-  UIWindow* window = [[UIWindow alloc]
-      initWithWindowScene:(UIWindowScene*)
-                              UIApplication.sharedApplication.connectedScenes.anyObject];
+  UIWindowScene* windowScene =
+      (UIWindowScene*)UIApplication.sharedApplication.connectedScenes.anyObject;
+  XCTAssertNotNil(windowScene, @"The host app must have a connected scene for test");
+  UIWindow* window = [[UIWindow alloc] initWithWindowScene:windowScene];
   [window addSubview:flutterViewController.view];
   flutterViewController.view.bounds = CGRectMake(0, 0, 100, 100);
   [flutterViewController viewDidLayoutSubviews];
@@ -2354,9 +2355,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
       [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
   // The window must be attached to the connected scene to have a screen, without which the
   // viewport metrics stay empty and the surface is never updated.
-  UIWindow* window = [[UIWindow alloc]
-      initWithWindowScene:(UIWindowScene*)
-                              UIApplication.sharedApplication.connectedScenes.anyObject];
+  UIWindowScene* windowScene =
+      (UIWindowScene*)UIApplication.sharedApplication.connectedScenes.anyObject;
+  XCTAssertNotNil(windowScene, @"The host app must have a connected scene for test");
+  UIWindow* window = [[UIWindow alloc] initWithWindowScene:windowScene];
   [window addSubview:flutterViewController.view];
   flutterViewController.view.bounds = CGRectMake(0, 0, 100, 100);
   [flutterViewController viewDidLayoutSubviews];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
@@ -225,8 +225,12 @@ FLUTTER_ASSERT_ARC
   FlutterView* view = [[FlutterView alloc] initWithDelegate:delegate
                                                      opaque:NO
                                             enableWideGamut:enableWideGamut];
-  // Add to a real window so layoutSubviews has access to screen.
-  UIWindow* window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  // Add to a real window so layoutSubviews has access to screen. The host app uses the UIScene
+  // life cycle, so the window only has a screen once it is attached to the connected scene.
+  UIWindow* window = [[UIWindow alloc]
+      initWithWindowScene:(UIWindowScene*)
+                              UIApplication.sharedApplication.connectedScenes.anyObject];
+  window.frame = CGRectMake(0, 0, 100, 100);
   [window addSubview:view];
   view.frame = window.bounds;
   [view layoutSubviews];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
@@ -227,9 +227,10 @@ FLUTTER_ASSERT_ARC
                                             enableWideGamut:enableWideGamut];
   // Add to a real window so layoutSubviews has access to screen. The host app uses the UIScene
   // life cycle, so the window only has a screen once it is attached to the connected scene.
-  UIWindow* window = [[UIWindow alloc]
-      initWithWindowScene:(UIWindowScene*)
-                              UIApplication.sharedApplication.connectedScenes.anyObject];
+  UIWindowScene* windowScene =
+      (UIWindowScene*)UIApplication.sharedApplication.connectedScenes.anyObject;
+  XCTAssertNotNil(windowScene, @"The host app must have a connected scene for test");
+  UIWindow* window = [[UIWindow alloc] initWithWindowScene:windowScene];
   window.frame = CGRectMake(0, 0, 100, 100);
   [window addSubview:view];
   view.frame = window.bounds;

--- a/engine/src/flutter/testing/ios/IosUnitTests/App/Info.plist
+++ b/engine/src/flutter/testing/ios/IosUnitTests/App/Info.plist
@@ -20,6 +20,27 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/engine/src/flutter/testing/ios/IosUnitTests/App/SceneDelegate.h
+++ b/engine/src/flutter/testing/ios/IosUnitTests/App/SceneDelegate.h
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_TESTING_IOS_IOSUNITTESTS_APP_SCENEDELEGATE_H_
+#define FLUTTER_TESTING_IOS_IOSUNITTESTS_APP_SCENEDELEGATE_H_
+
+#import <UIKit/UIKit.h>
+
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property(nonatomic, strong, nullable) UIWindow* window;
+
+@end
+
+#endif  // FLUTTER_TESTING_IOS_IOSUNITTESTS_APP_SCENEDELEGATE_H_

--- a/engine/src/flutter/testing/ios/IosUnitTests/App/SceneDelegate.m
+++ b/engine/src/flutter/testing/ios/IosUnitTests/App/SceneDelegate.m
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "SceneDelegate.h"
+
+@implementation SceneDelegate
+
+// The window is created from the Main storyboard and attached to the scene by UIKit.
+
+@end

--- a/engine/src/flutter/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/engine/src/flutter/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0D6AB6BE22BB05E200EEE540 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0D6AB6BD22BB05E200EEE540 /* Assets.xcassets */; };
 		0D6AB6C122BB05E200EEE540 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0D6AB6BF22BB05E200EEE540 /* LaunchScreen.storyboard */; };
 		0D6AB6C422BB05E200EEE540 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D6AB6C322BB05E200EEE540 /* main.m */; };
+		0D5CE1A22E4A000100AA0003 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D5CE1A12E4A000100AA0002 /* SceneDelegate.m */; };
 		F7521D7826BB68BC005F15C5 /* libios_test_flutter.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = F7521D7226BB671E005F15C5 /* libios_test_flutter.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F7521D7926BB68BC005F15C5 /* libocmock_shared.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = F7521D7526BB673E005F15C5 /* libocmock_shared.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F77E081926FA9CE6003E6E4C /* Flutter.framework in Embed Libraries */ = {isa = PBXBuildFile; fileRef = F77E081726FA9CE6003E6E4C /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -61,6 +62,8 @@
 		0D6AB6B122BB05E100EEE540 /* IosUnitTests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IosUnitTests.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D6AB6B422BB05E100EEE540 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		0D6AB6B522BB05E100EEE540 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		0D5CE1A02E4A000100AA0001 /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
+		0D5CE1A12E4A000100AA0002 /* SceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
 		0D6AB6B722BB05E100EEE540 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		0D6AB6B822BB05E100EEE540 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		0D6AB6BB22BB05E100EEE540 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -164,6 +167,8 @@
 			children = (
 				0D6AB6B422BB05E100EEE540 /* AppDelegate.h */,
 				0D6AB6B522BB05E100EEE540 /* AppDelegate.m */,
+				0D5CE1A02E4A000100AA0001 /* SceneDelegate.h */,
+				0D5CE1A12E4A000100AA0002 /* SceneDelegate.m */,
 				0D6AB6B722BB05E100EEE540 /* ViewController.h */,
 				0D6AB6B822BB05E100EEE540 /* ViewController.m */,
 				0D6AB6BA22BB05E100EEE540 /* Main.storyboard */,
@@ -302,6 +307,7 @@
 				0D6AB6B922BB05E100EEE540 /* ViewController.m in Sources */,
 				0D6AB6C422BB05E200EEE540 /* main.m in Sources */,
 				0D6AB6B622BB05E100EEE540 /* AppDelegate.m in Sources */,
+				0D5CE1A22E4A000100AA0003 /* SceneDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Apps that haven't adopted the UIScene life cycle will not launch on iOS
27. The `IosUnitTests` host app was still using the pre-scene `UIApplicationMain` plus `UIMainStoryboardFile` setup, and failed with

    "Early unexpected exit ... The test runner crashed before establishing connection"

when run with on an iOS 27 simulator.

This adds a `UIApplicationSceneManifest` to the host app's `Info.plist` and a `SceneDelegate`.

Migrating to scenes changes a couple things the tests were relying on. `FlutterSharedApplication.hasSceneDelegate` now returns `YES` in the host app, which suppresses forwarding of app lifecycle notifications to plugins. The `FlutterPluginAppLifeCycleDelegate` tests covering the pre-migration case stub this back out to `NO`.

`[[UIWindow alloc] init]` no longer picks up a window scene so the window no longer has a screen. There were a few tests that need a screen, which now build their window with `initWithWindowScene:` instead. Without this we trip an `FML_DCHECK(self.screen)` in `FlutterView isWideGamutSupported]`. I'll send a followup to handle this more gracefully.

Issue: https://github.com/flutter/flutter/issues/188336

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
