### PR TITLE
Move Apple image generator creation off the UI thread

### DIFF
--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -8991,7 +8991,7 @@ abstract class ImageDescriptor {
   /// Creates an image descriptor from encoded data in a supported format.
   static Future<ImageDescriptor> encoded(ImmutableBuffer buffer) {
     final descriptor = _NativeImageDescriptor._();
-    return _futurize((_Callback<void> callback) {
+    return _futurizeWithError((_CallbackWithError<void> callback) {
       return descriptor._initEncoded(buffer, callback);
     }).then((_) => descriptor);
   }
@@ -9062,7 +9062,7 @@ base class _NativeImageDescriptor extends NativeFieldWrapperClass1 implements Im
   }
 
   @Native<Handle Function(Handle, Pointer<Void>, Handle)>(symbol: 'ImageDescriptor::initEncoded')
-  external String? _initEncoded(ImmutableBuffer buffer, _Callback<void> callback);
+  external String? _initEncoded(ImmutableBuffer buffer, _CallbackWithError<void> callback);
 
   @Native<Void Function(Handle, Handle, Int32, Int32, Int32, Int32)>(
     symbol: 'ImageDescriptor::initRaw',

--- a/engine/src/flutter/lib/ui/painting/image_descriptor.cc
+++ b/engine/src/flutter/lib/ui/painting/image_descriptor.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
+#include "flutter/fml/make_copyable.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/lib/ui/painting/multi_frame_codec.h"
 #include "flutter/lib/ui/painting/single_frame_codec.h"
@@ -113,21 +114,36 @@ Dart_Handle ImageDescriptor::initEncoded(Dart_Handle descriptor_handle,
         "https://github.com/flutter/flutter/issues.");
   }
 
-  auto generator =
-      registry->CreateCompatibleGenerator(immutable_buffer->data());
+  auto ui_task_runner = dart_state->GetTaskRunners().GetUITaskRunner();
+  auto descriptor_wrapper = std::make_unique<tonic::DartPersistentValue>(
+      dart_state, descriptor_handle);
+  auto callback =
+      std::make_unique<tonic::DartPersistentValue>(dart_state, callback_handle);
+  const sk_sp<SkData> buffer = immutable_buffer->data();
 
-  if (!generator) {
-    // No compatible image decoder was found.
-    return tonic::ToDart("Invalid image data");
-  }
+  registry->CreateCompatibleGeneratorAsync(
+      buffer, dart_state->GetConcurrentTaskRunner(), ui_task_runner,
+      fml::MakeCopyable([buffer,
+                         descriptor_wrapper = std::move(descriptor_wrapper),
+                         callback = std::move(callback)](
+                            std::shared_ptr<ImageGenerator> generator) mutable {
+        auto dart_state = callback->dart_state().lock();
+        if (!dart_state) {
+          return;
+        }
+        tonic::DartState::Scope scope(dart_state);
 
-  auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
-      immutable_buffer->data(), std::move(generator));
+        if (!generator) {
+          tonic::DartInvoke(callback->Get(),
+                            {Dart_Null(), tonic::ToDart("Invalid image data")});
+          return;
+        }
 
-  FML_DCHECK(descriptor);
-
-  descriptor->AssociateWithDartWrapper(descriptor_handle);
-  tonic::DartInvoke(callback_handle, {Dart_TypeVoid()});
+        auto descriptor =
+            fml::MakeRefCounted<ImageDescriptor>(buffer, std::move(generator));
+        descriptor->AssociateWithDartWrapper(descriptor_wrapper->Get());
+        tonic::DartInvoke(callback->Get(), {Dart_TypeVoid(), Dart_Null()});
+      }));
 
   return Dart_Null();
 }

--- a/engine/src/flutter/lib/ui/painting/image_generator_registry.cc
+++ b/engine/src/flutter/lib/ui/painting/image_generator_registry.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <utility>
+#include <vector>
 
 #include "flutter/lib/ui/painting/image_generator_registry.h"
 #include "third_party/skia/include/codec/SkBmpDecoder.h"
@@ -43,6 +44,102 @@ void RegisterSkiaCodecs() {
 }  // namespace
 
 namespace flutter {
+namespace {
+
+struct AsyncImageGeneratorFactory {
+  ImageGeneratorFactory callback;
+  ImageGeneratorFactoryExecution execution;
+};
+
+void LogNoImageDecoders() {
+  FML_LOG(WARNING)
+      << "There are currently no image decoders installed. If you're writing "
+         "your own platform embedding, you can register new image decoders "
+         "via `ImageGeneratorRegistry::AddFactory` on the "
+         "`ImageGeneratorRegistry` provided by the engine. Otherwise, please "
+         "file a bug on https://github.com/flutter/flutter/issues.";
+}
+
+// Resolves an ordered snapshot of factories while returning to the callback
+// task runner after invoking a factory concurrently.
+class AsyncImageGeneratorResolver
+    : public std::enable_shared_from_this<AsyncImageGeneratorResolver> {
+ public:
+  static void Resolve(
+      std::vector<AsyncImageGeneratorFactory> factories,
+      sk_sp<SkData> buffer,
+      std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
+      fml::RefPtr<fml::TaskRunner> callback_task_runner,
+      std::function<void(std::shared_ptr<ImageGenerator>)> callback) {
+    auto resolver = std::shared_ptr<AsyncImageGeneratorResolver>(
+        new AsyncImageGeneratorResolver(std::move(factories), std::move(buffer),
+                                        std::move(concurrent_task_runner),
+                                        std::move(callback_task_runner),
+                                        std::move(callback)));
+    resolver->ResolveFrom(0u);
+  }
+
+ private:
+  AsyncImageGeneratorResolver(
+      std::vector<AsyncImageGeneratorFactory> factories,
+      sk_sp<SkData> buffer,
+      std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
+      fml::RefPtr<fml::TaskRunner> callback_task_runner,
+      std::function<void(std::shared_ptr<ImageGenerator>)> callback)
+      : factories_(std::move(factories)),
+        buffer_(std::move(buffer)),
+        concurrent_task_runner_(std::move(concurrent_task_runner)),
+        callback_task_runner_(std::move(callback_task_runner)),
+        callback_(std::move(callback)) {}
+
+  void ResolveFrom(size_t index) {
+    while (index < factories_.size()) {
+      const AsyncImageGeneratorFactory& factory = factories_[index];
+      if (factory.execution ==
+          ImageGeneratorFactoryExecution::kConcurrentTaskRunner) {
+        auto self = shared_from_this();
+        concurrent_task_runner_->PostTask([self, index]() {
+          std::shared_ptr<ImageGenerator> result =
+              self->factories_[index].callback(self->buffer_);
+          self->callback_task_runner_->PostTask(
+              [self, index, result = std::move(result)]() mutable {
+                if (result) {
+                  self->Complete(std::move(result));
+                } else {
+                  self->ResolveFrom(index + 1u);
+                }
+              });
+        });
+        return;
+      }
+
+      std::shared_ptr<ImageGenerator> result = factory.callback(buffer_);
+      if (result) {
+        Complete(std::move(result));
+        return;
+      }
+      index++;
+    }
+    Complete(nullptr);
+  }
+
+  void Complete(std::shared_ptr<ImageGenerator> generator) {
+    auto callback = std::move(callback_);
+    callback_task_runner_->PostTask(
+        [callback = std::move(callback),
+         generator = std::move(generator)]() mutable {
+          callback(std::move(generator));
+        });
+  }
+
+  const std::vector<AsyncImageGeneratorFactory> factories_;
+  const sk_sp<SkData> buffer_;
+  const std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner_;
+  const fml::RefPtr<fml::TaskRunner> callback_task_runner_;
+  std::function<void(std::shared_ptr<ImageGenerator>)> callback_;
+};
+
+}  // namespace
 
 ImageGeneratorRegistry::ImageGeneratorRegistry() : weak_factory_(this) {
   AddFactory(
@@ -61,6 +158,9 @@ ImageGeneratorRegistry::ImageGeneratorRegistry() : weak_factory_(this) {
 
   // todo(bdero): https://github.com/flutter/flutter/issues/82603
 #ifdef FML_OS_MACOSX
+  // SkImageGeneratorCG copies the complete ImageIO property dictionary while
+  // constructing a generator. Images with rich metadata can make that
+  // operation too expensive for the UI thread.
   AddFactory(
       [](sk_sp<SkData> buffer) {
         auto generator =
@@ -68,7 +168,7 @@ ImageGeneratorRegistry::ImageGeneratorRegistry() : weak_factory_(this) {
         return BuiltinSkiaImageGenerator::MakeFromGenerator(
             std::move(generator));
       },
-      0);
+      0, ImageGeneratorFactoryExecution::kConcurrentTaskRunner);
 #elif FML_OS_WIN
   AddFactory(
       [](sk_sp<SkData> buffer) {
@@ -82,20 +182,18 @@ ImageGeneratorRegistry::ImageGeneratorRegistry() : weak_factory_(this) {
 
 ImageGeneratorRegistry::~ImageGeneratorRegistry() = default;
 
-void ImageGeneratorRegistry::AddFactory(ImageGeneratorFactory factory,
-                                        int32_t priority) {
-  image_generator_factories_.insert({std::move(factory), priority, ++nonce_});
+void ImageGeneratorRegistry::AddFactory(
+    ImageGeneratorFactory factory,
+    int32_t priority,
+    ImageGeneratorFactoryExecution execution) {
+  image_generator_factories_.insert(
+      {std::move(factory), priority, ++nonce_, execution});
 }
 
 std::shared_ptr<ImageGenerator>
 ImageGeneratorRegistry::CreateCompatibleGenerator(const sk_sp<SkData>& buffer) {
-  if (!image_generator_factories_.size()) {
-    FML_LOG(WARNING)
-        << "There are currently no image decoders installed. If you're writing "
-           "your own platform embedding, you can register new image decoders "
-           "via `ImageGeneratorRegistry::AddFactory` on the "
-           "`ImageGeneratorRegistry` provided by the engine. Otherwise, please "
-           "file a bug on https://github.com/flutter/flutter/issues.";
+  if (image_generator_factories_.empty()) {
+    LogNoImageDecoders();
   }
 
   for (auto& factory : image_generator_factories_) {
@@ -105,6 +203,28 @@ ImageGeneratorRegistry::CreateCompatibleGenerator(const sk_sp<SkData>& buffer) {
     }
   }
   return nullptr;
+}
+
+void ImageGeneratorRegistry::CreateCompatibleGeneratorAsync(
+    const sk_sp<SkData>& buffer,
+    const std::shared_ptr<fml::ConcurrentTaskRunner>& concurrent_task_runner,
+    const fml::RefPtr<fml::TaskRunner>& callback_task_runner,
+    std::function<void(std::shared_ptr<ImageGenerator>)> callback) {
+  FML_DCHECK(callback_task_runner->RunsTasksOnCurrentThread());
+
+  if (image_generator_factories_.empty()) {
+    LogNoImageDecoders();
+  }
+
+  std::vector<AsyncImageGeneratorFactory> factories;
+  factories.reserve(image_generator_factories_.size());
+  for (const auto& factory : image_generator_factories_) {
+    factories.push_back({factory.callback, factory.execution});
+  }
+
+  AsyncImageGeneratorResolver::Resolve(
+      std::move(factories), buffer, concurrent_task_runner,
+      callback_task_runner, std::move(callback));
 }
 
 fml::TaskRunnerAffineWeakPtr<ImageGeneratorRegistry>

--- a/engine/src/flutter/lib/ui/painting/image_generator_registry.h
+++ b/engine/src/flutter/lib/ui/painting/image_generator_registry.h
@@ -6,10 +6,13 @@
 #define FLUTTER_LIB_UI_PAINTING_IMAGE_GENERATOR_REGISTRY_H_
 
 #include <functional>
+#include <memory>
 #include <set>
 
+#include "flutter/fml/concurrent_message_loop.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/memory/weak_ptr.h"
+#include "flutter/fml/task_runner.h"
 #include "flutter/lib/ui/painting/image_generator.h"
 
 namespace flutter {
@@ -20,6 +23,17 @@ namespace flutter {
 ///         data.
 using ImageGeneratorFactory =
     std::function<std::shared_ptr<ImageGenerator>(sk_sp<SkData> buffer)>;
+
+/// @brief  Controls where an image generator factory is invoked when resolving
+///         a generator asynchronously.
+enum class ImageGeneratorFactoryExecution {
+  /// Invoke the factory on the callback task runner used to resolve the
+  /// registry.
+  kCallbackTaskRunner,
+
+  /// Invoke the factory on the engine's concurrent task runner.
+  kConcurrentTaskRunner,
+};
 
 /// @brief Keeps a priority-ordered registry of image generator builders to be
 ///        used when decoding images. This object must be created, accessed, and
@@ -41,15 +55,22 @@ class ImageGeneratorRegistry {
   ///                       over the builtin decoders. When multiple decoders
   ///                       are added with the same priority, those which are
   ///                       added earlier take precedent.
-  /// @see        `CreateCompatibleGenerator`
-  void AddFactory(ImageGeneratorFactory factory, int32_t priority);
+  /// @param[in]  execution  Where the factory is invoked when using
+  ///                        `CreateCompatibleGeneratorAsync`. This setting is
+  ///                        ignored by `CreateCompatibleGenerator`.
+  /// @see        `CreateCompatibleGenerator`, `CreateCompatibleGeneratorAsync`
+  void AddFactory(ImageGeneratorFactory factory,
+                  int32_t priority,
+                  ImageGeneratorFactoryExecution execution =
+                      ImageGeneratorFactoryExecution::kCallbackTaskRunner);
 
   /// @brief      Walks the list of image generator builders in descending
   ///             priority order until a compatible `ImageGenerator` is able to
-  ///             be built. This method is safe to perform on the UI thread, as
-  ///             checking for `ImageGenerator` compatibility is expected to be
-  ///             a lightweight operation. The returned `ImageGenerator` can
-  ///             then be used to fully decode the image on e.g. the IO thread.
+  ///             be built. This method invokes every factory synchronously on
+  ///             the calling thread, regardless of its execution setting. Use
+  ///             `CreateCompatibleGeneratorAsync` when calling from the UI
+  ///             thread. The returned `ImageGenerator` can then be used to
+  ///             fully decode the image on e.g. the IO thread.
   /// @param[in]  buffer  The raw encoded image data.
   /// @return     An `ImageGenerator` that is compatible with the input buffer.
   ///             If no compatible `ImageGenerator` type was found, then
@@ -57,6 +78,24 @@ class ImageGeneratorRegistry {
   /// @see        `ImageGenerator`
   std::shared_ptr<ImageGenerator> CreateCompatibleGenerator(
       const sk_sp<SkData>& buffer);
+
+  /// @brief      Asynchronously walks the list of image generator factories in
+  ///             priority order. Factories registered for concurrent execution
+  ///             are invoked on `concurrent_task_runner`; all other factories
+  ///             are invoked on `callback_task_runner`. This method must be
+  ///             called from `callback_task_runner`, where the registry is
+  ///             accessed. The callback is always posted to that runner.
+  /// @param[in]  buffer                  The raw encoded image data.
+  /// @param[in]  concurrent_task_runner  Runner for factories that may perform
+  ///                                     expensive compatibility checks.
+  /// @param[in]  callback_task_runner    Runner on which `callback` is invoked.
+  /// @param[in]  callback                Receives a compatible generator, or
+  ///                                     `nullptr` if none was found.
+  void CreateCompatibleGeneratorAsync(
+      const sk_sp<SkData>& buffer,
+      const std::shared_ptr<fml::ConcurrentTaskRunner>& concurrent_task_runner,
+      const fml::RefPtr<fml::TaskRunner>& callback_task_runner,
+      std::function<void(std::shared_ptr<ImageGenerator>)> callback);
 
   fml::TaskRunnerAffineWeakPtr<ImageGeneratorRegistry> GetWeakPtr() const;
 
@@ -67,6 +106,8 @@ class ImageGeneratorRegistry {
     int32_t priority = 0;
     // Used as a fallback priority comparison when equal.
     size_t ascending_nonce = 0;
+    ImageGeneratorFactoryExecution execution =
+        ImageGeneratorFactoryExecution::kCallbackTaskRunner;
   };
 
   struct Compare {

--- a/engine/src/flutter/lib/ui/painting/image_generator_registry_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_generator_registry_unittests.cc
@@ -4,7 +4,12 @@
 
 #include "flutter/lib/ui/painting/image_generator_registry.h"
 
+#include <thread>
+#include <vector>
+
+#include "flutter/fml/concurrent_message_loop.h"
 #include "flutter/fml/mapping.h"
+#include "flutter/fml/message_loop.h"
 #include "flutter/shell/common/shell_test.h"
 #include "flutter/testing/testing.h"
 
@@ -148,6 +153,74 @@ TEST_F(ShellTest, ImageGeneratorsWithSamePriorityCascadeChronologically) {
   // won't.
   auto result = registry.CreateCompatibleGenerator(SkData::MakeEmpty());
   ASSERT_EQ(result->GetInfo().width(), 1337);
+}
+
+TEST_F(ShellTest, AsyncResolutionPreservesOrderAcrossTaskRunners) {
+  ImageGeneratorRegistry registry;
+  const std::thread::id callback_thread = std::this_thread::get_id();
+  std::vector<std::thread::id> factory_threads;
+  std::thread::id result_callback_thread;
+  bool callback_called = false;
+
+  // Alternate between the callback and concurrent task runners. The first
+  // concurrent factory rejects the data; the second accepts it and stops the
+  // search before the final factory.
+  registry.AddFactory(
+      [&](const sk_sp<SkData>&) {
+        factory_threads.push_back(std::this_thread::get_id());
+        return nullptr;
+      },
+      100);
+  registry.AddFactory(
+      [&](const sk_sp<SkData>&) {
+        factory_threads.push_back(std::this_thread::get_id());
+        return nullptr;
+      },
+      99, ImageGeneratorFactoryExecution::kConcurrentTaskRunner);
+  registry.AddFactory(
+      [&](const sk_sp<SkData>&) {
+        factory_threads.push_back(std::this_thread::get_id());
+        return nullptr;
+      },
+      98);
+  registry.AddFactory(
+      [&](const sk_sp<SkData>&) {
+        factory_threads.push_back(std::this_thread::get_id());
+        return std::make_unique<FakeImageGenerator>(7331);
+      },
+      97, ImageGeneratorFactoryExecution::kConcurrentTaskRunner);
+  registry.AddFactory(
+      [&](const sk_sp<SkData>&) {
+        factory_threads.push_back(std::this_thread::get_id());
+        return std::make_unique<FakeImageGenerator>(1337);
+      },
+      96);
+
+  auto concurrent_loop = fml::ConcurrentMessageLoop::Create(1u);
+  auto ui_task_runner = GetCurrentTaskRunner();
+  registry.CreateCompatibleGeneratorAsync(
+      SkData::MakeEmpty(), concurrent_loop->GetTaskRunner(), ui_task_runner,
+      [&](const std::shared_ptr<ImageGenerator>& result) {
+        callback_called = true;
+        result_callback_thread = std::this_thread::get_id();
+        if (result) {
+          EXPECT_EQ(result->GetInfo().width(), 7331);
+        } else {
+          ADD_FAILURE() << "Expected an image generator";
+        }
+        fml::MessageLoop::GetCurrent().Terminate();
+      });
+
+  EXPECT_FALSE(callback_called);
+  fml::MessageLoop::GetCurrent().Run();
+
+  EXPECT_TRUE(callback_called);
+  ASSERT_EQ(factory_threads.size(), 4u);
+  EXPECT_EQ(factory_threads[0], callback_thread);
+  EXPECT_NE(factory_threads[1], callback_thread);
+  EXPECT_EQ(factory_threads[2], callback_thread);
+  EXPECT_NE(factory_threads[3], callback_thread);
+  EXPECT_EQ(result_callback_thread, callback_thread);
 }
 
 }  // namespace testing


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/177328

While reproducing the mentioned issue, I found that the expensive part is not the later pixel decode, which already runs off the UI thread, but the initial decoder selection. `ImageDescriptor.encoded` synchronously asks the registered image-generator factories, in priority order, whether they understand the bytes. On Apple platforms, the final ImageIO factory constructs `SkImageGeneratorCG`, which copies the complete image-property dictionary through `CGImageSourceCopyPropertiesAtIndex`. For HEIC images with rich EXIF/TIFF metadata this can take tens of milliseconds, so loading several images while scrolling blocks the UI isolate and visibly stalls the animation.

This PR adds an asynchronous ordered lookup to `ImageGeneratorRegistry`. Factories keep their existing callback-task-runner behavior by default, which preserves custom/embedder factory thread affinity, and only the Apple ImageIO fallback opts into the engine's concurrent task runner. Lookup order and short-circuiting remain unchanged, and the result is always delivered back on the callback task runner. `ImageDescriptor.encoded` uses this path and forwards a failed lookup through its `Future`. The synchronous registry API remains available for existing callers.

## Performance

In profile/AOT benchmarks on an iPad (A16) running iPadOS 26.5.2, I used the exact HEIC file and 1,200-image `ListView` from the issue and automatically scrolled from the beginning to the end in one second. I counted frames over 16.67 ms as janky, discarded one warm-up launch, and measured five fresh process launches for each engine so Flutter's image cache was reset between runs. Both variants used the same profile, LTO, and Impeller build settings; only the engine sources differed.

| Engine | Janky frames across five runs | Median worst frame | Worst-frame range |
| --- | ---: | ---: | ---: |
| Before | 7 | 67.98 ms | 32.99–76.57 ms |
| After | 0 | 8.25 ms | 7.77–8.38 ms |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.