### PR TITLE
[Impeller] Dispatch make-current lifecycle event only on success

### DIFF
--- a/engine/src/flutter/impeller/toolkit/egl/context.cc
+++ b/engine/src/flutter/impeller/toolkit/egl/context.cc
@@ -53,8 +53,9 @@ bool Context::MakeCurrent(const Surface& surface) const {
                                                 ) == EGL_TRUE;
   if (!result) {
     IMPELLER_LOG_EGL_ERROR;
+  } else {
+    DispatchLifecyleEvent(LifecycleEvent::kDidMakeCurrent);
   }
-  DispatchLifecyleEvent(LifecycleEvent::kDidMakeCurrent);
   return result;
 }
 

--- a/engine/src/flutter/shell/platform/android/android_context_gl_impeller_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_gl_impeller_unittests.cc
@@ -3,6 +3,13 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/android/android_context_gl_impeller.h"
+
+#include <atomic>
+#include <thread>
+
+#include "flutter/fml/synchronization/waitable_event.h"
+#include "flutter/impeller/toolkit/egl/context.h"
+#include "flutter/impeller/toolkit/egl/surface.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -134,6 +141,55 @@ TEST_F(AndroidContextGLImpellerTest, FallbackForEmulator) {
   auto context = std::make_unique<AndroidContextGLImpeller>(std::move(display),
                                                             true, nullptr);
   ASSERT_TRUE(context);
+}
+
+TEST_F(AndroidContextGLImpellerTest,
+       FailedMakeCurrentDoesNotDispatchDidMakeCurrent) {
+  impeller::egl::Display display;
+  ASSERT_TRUE(display.IsValid());
+
+  std::atomic<int> did_make_current_count{0};
+  auto config = display.ChooseConfig(ConfigDescriptor());
+  ASSERT_NE(config, nullptr);
+  auto context = display.CreateContext(*config, nullptr);
+  ASSERT_NE(context, nullptr);
+  auto surface = display.CreatePixelBufferSurface(*config, 1u, 1u);
+  ASSERT_NE(surface, nullptr);
+
+  ASSERT_TRUE(
+      context
+          ->AddLifecycleListener([&did_make_current_count](auto event) {
+            if (event ==
+                impeller::egl::Context::LifecycleEvent::kDidMakeCurrent) {
+              did_make_current_count++;
+            }
+          })
+          .has_value());
+
+  fml::AutoResetWaitableEvent context_is_current;
+  fml::AutoResetWaitableEvent allow_context_clear;
+  bool worker_made_current = false;
+  bool worker_cleared_current = false;
+  std::thread worker([&] {
+    // Holding the context current here makes the main-thread bind below fail
+    // with EGL_BAD_ACCESS.
+    worker_made_current = context->MakeCurrent(*surface);
+    context_is_current.Signal();
+    allow_context_clear.Wait();
+    if (worker_made_current) {
+      worker_cleared_current = context->ClearCurrent();
+    }
+  });
+
+  context_is_current.Wait();
+  const bool main_made_current = context->MakeCurrent(*surface);
+  allow_context_clear.Signal();
+  worker.join();
+
+  EXPECT_TRUE(worker_made_current);
+  EXPECT_FALSE(main_made_current);
+  EXPECT_TRUE(worker_cleared_current);
+  EXPECT_EQ(did_make_current_count.load(), 1);
 }
 
 }  // namespace testing


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/190640

When Android Impeller uses OpenGLES, `Context::MakeCurrent` currently dispatches `kDidMakeCurrent` to its lifecycle listeners even when the underlying `eglMakeCurrent` call fails. `AndroidContextGLImpeller` interprets that event as permission to run GLES reactor work on the current thread, so queued image resize blits can execute without a current OpenGL context and reach the fatal incomplete-framebuffer check seen in the issue.

The solution is to dispatch `kDidMakeCurrent` only after `eglMakeCurrent` succeeds while preserving the existing error logging and return value. This restores the lifecycle contract at the point where Impeller has the authoritative EGL result. A regression test uses EGL's cross-thread context ownership rule to make a second `MakeCurrent` call fail with `EGL_BAD_ACCESS` and verifies that only the successful bind emits the lifecycle event.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.