### PR TITLE
[Impeller] Preserve grayscale images as Gray8 textures

### DIFF
--- a/engine/src/flutter/impeller/core/allocator_unittests.cc
+++ b/engine/src/flutter/impeller/core/allocator_unittests.cc
@@ -191,6 +191,7 @@ TEST(AllocatorTest, CompressedFormatBlockMath) {
   EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kASTC8x8HDR), 16u);
   // Uncompressed falls back to bytes-per-pixel.
   EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kR8G8B8A8UNormInt), 4u);
+  EXPECT_EQ(BytesPerBlockForPixelFormat(PixelFormat::kGray8UNormInt), 1u);
 }
 
 TEST(AllocatorTest, CompressedFormatRegionByteSizes) {

--- a/engine/src/flutter/impeller/core/formats.h
+++ b/engine/src/flutter/impeller/core/formats.h
@@ -99,6 +99,8 @@ constexpr const char* StorageModeToString(StorageMode mode) {
 enum class PixelFormat : uint8_t {
   kUnknown,
   kA8UNormInt,
+  /// One normalized luminance channel that samples as `(r, r, r, 1)`.
+  kGray8UNormInt,
   kR8UNormInt,
   kR8G8UNormInt,
   kR8G8B8A8UNormInt,
@@ -295,6 +297,8 @@ constexpr const char* PixelFormatToString(PixelFormat format) {
       return "Unknown";
     case PixelFormat::kA8UNormInt:
       return "A8UNormInt";
+    case PixelFormat::kGray8UNormInt:
+      return "Gray8UNormInt";
     case PixelFormat::kR8UNormInt:
       return "R8UNormInt";
     case PixelFormat::kR8G8UNormInt:
@@ -653,6 +657,7 @@ constexpr size_t BytesPerPixelForPixelFormat(PixelFormat format) {
     case PixelFormat::kUnknown:
       return 0u;
     case PixelFormat::kA8UNormInt:
+    case PixelFormat::kGray8UNormInt:
     case PixelFormat::kR8UNormInt:
     case PixelFormat::kS8UInt:
       return 1u;

--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -5,6 +5,7 @@
 #include "impeller/renderer/backend/gles/blit_command_gles.h"
 
 #include <algorithm>
+#include <vector>
 
 #include "flutter/fml/closure.h"
 #include "impeller/base/validation.h"
@@ -16,6 +17,8 @@
 #include "impeller/renderer/backend/gles/texture_gles.h"
 
 namespace impeller {
+
+constexpr size_t kGray8ReadbackChunkBytes = 4u * 1024u * 1024u;
 
 BlitEncodeGLES::~BlitEncodeGLES() = default;
 
@@ -313,6 +316,38 @@ bool BlitCopyTextureToBufferCommandGLES::Encode(
       return false;
     }
     read_fbo = read.value();
+  }
+
+  if (source_format == PixelFormat::kGray8UNormInt) {
+    DeviceBufferGLES::Cast(*destination)
+        .UpdateBufferData([&gl, this](uint8_t* data, size_t) {
+          const size_t width = static_cast<size_t>(source_region.GetWidth());
+          const size_t height = static_cast<size_t>(source_region.GetHeight());
+          const size_t rgba_row_bytes = width * 4u;
+          const size_t rows_per_chunk =
+              std::max<size_t>(1u, kGray8ReadbackChunkBytes / rgba_row_bytes);
+          std::vector<uint8_t> rgba(rgba_row_bytes *
+                                    std::min(rows_per_chunk, height));
+          // RGBA/UNSIGNED_BYTE is the only universally supported ReadPixels
+          // combination for normalized fixed-point framebuffers in GLES 3.
+          for (size_t first_row = 0u; first_row < height;
+               first_row += rows_per_chunk) {
+            const size_t row_count =
+                std::min(rows_per_chunk, height - first_row);
+            gl.ReadPixels(
+                source_region.GetX(),
+                source_region.GetY() + static_cast<int64_t>(first_row),
+                source_region.GetWidth(), static_cast<GLsizei>(row_count),
+                GL_RGBA, GL_UNSIGNED_BYTE, rgba.data());
+            const size_t pixel_count = width * row_count;
+            const size_t destination_start =
+                destination_offset + first_row * width;
+            for (size_t i = 0; i < pixel_count; i++) {
+              data[destination_start + i] = rgba[i * 4u];
+            }
+          }
+        });
+    return true;
   }
 
   DeviceBufferGLES::Cast(*destination)

--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles_unittests.cc
@@ -4,6 +4,7 @@
 
 #include <initializer_list>
 #include <tuple>
+#include <vector>
 
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
 #include "gtest/gtest.h"
@@ -42,19 +43,21 @@ namespace {
 
 std::shared_ptr<TextureGLES> CreateTexture(
     const std::shared_ptr<ReactorGLES>& reactor,
-    PixelFormat format) {
+    PixelFormat format,
+    ISize size = {10, 10}) {
   TextureDescriptor tex_desc;
   tex_desc.format = format;
-  tex_desc.size = {10, 10};
+  tex_desc.size = size;
   tex_desc.usage = static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
   auto texture = std::make_shared<TextureGLES>(reactor, tex_desc);
   return texture;
 }
 
 std::shared_ptr<DeviceBufferGLES> CreateBuffer(
-    const std::shared_ptr<ReactorGLES>& reactor) {
+    const std::shared_ptr<ReactorGLES>& reactor,
+    size_t size = 10 * 10 * 4) {
   DeviceBufferDescriptor buffer_desc;
-  buffer_desc.size = 10 * 10 * 4;
+  buffer_desc.size = size;
   buffer_desc.storage_mode = StorageMode::kHostVisible;
   auto allocation = std::make_unique<Allocation>();
   FML_CHECK(allocation->Truncate(Bytes(buffer_desc.size)));
@@ -84,6 +87,7 @@ BlitCopyTextureToBufferCommandGLES CreateCopyTextureToBufferCommand(
   command.source = source;
   command.destination = dest;
   command.source_region = IRect::MakeSize(source->GetTextureDescriptor().size);
+  command.destination_offset = 0u;
   command.label = "TestBlit";
   return command;
 }
@@ -139,6 +143,61 @@ TEST(BlitCommandGLESTest, BlitCopyBufferToTextureCommandGLESBGRA) {
       .Times(1);
 
   EXPECT_TRUE(command.Encode(*reactor));
+}
+
+TEST(BlitCommandGLESTest, BlitCopyBufferToTextureCommandGLESGray8) {
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+  auto& mock_gles_impl_ref = *mock_gles_impl;
+
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+  auto reactor = std::make_shared<TestReactorGLES>();
+  auto worker = std::make_shared<MockWorker>();
+  reactor->AddWorker(worker);
+
+  std::shared_ptr<TextureGLES> dest_texture =
+      CreateTexture(reactor, PixelFormat::kGray8UNormInt);
+  std::shared_ptr<DeviceBufferGLES> source_buffer = CreateBuffer(reactor, 100u);
+  BlitCopyBufferToTextureCommandGLES command =
+      CreateCopyBufferToTextureCommand(source_buffer, dest_texture);
+
+  EXPECT_CALL(mock_gles_impl_ref, TexImage2D(GL_TEXTURE_2D, _, GL_R8, _, _, _,
+                                             GL_RED, GL_UNSIGNED_BYTE, _))
+      .Times(1);
+  EXPECT_CALL(mock_gles_impl_ref, TexSubImage2D(GL_TEXTURE_2D, _, _, _, _, _,
+                                                GL_RED, GL_UNSIGNED_BYTE, _))
+      .Times(1);
+
+  EXPECT_TRUE(command.Encode(*reactor));
+}
+
+TEST(BlitCommandGLESTest, Gray8TextureConfiguresSamplingSwizzleOnce) {
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+  auto& mock_gles_impl_ref = *mock_gles_impl;
+
+  EXPECT_CALL(mock_gles_impl_ref, GenTextures(1, _))
+      .WillOnce(::testing::SetArgPointee<1>(1));
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+  auto reactor = std::make_shared<TestReactorGLES>();
+  auto worker = std::make_shared<MockWorker>();
+  reactor->AddWorker(worker);
+  std::shared_ptr<TextureGLES> texture =
+      CreateTexture(reactor, PixelFormat::kGray8UNormInt);
+
+  EXPECT_CALL(mock_gles_impl_ref,
+              TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_RED))
+      .Times(1);
+  EXPECT_CALL(mock_gles_impl_ref,
+              TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_RED))
+      .Times(1);
+  EXPECT_CALL(mock_gles_impl_ref,
+              TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED))
+      .Times(1);
+  EXPECT_CALL(mock_gles_impl_ref,
+              TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_ONE))
+      .Times(1);
+
+  EXPECT_TRUE(texture->Bind());
+  EXPECT_TRUE(texture->Bind());
 }
 
 // This test makes sure we bind to GL_FRAMEBUFFER so that it's compatible for
@@ -230,6 +289,85 @@ TEST(BlitCommandGLESTest, BlitCopyTextureToBufferCommandGLESBGRA) {
       .Times(1);
 
   EXPECT_TRUE(command.Encode(*reactor));
+}
+
+TEST(BlitCommandGLESTest, BlitCopyTextureToBufferCommandGLESGray8) {
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+  auto& mock_gles_impl_ref = *mock_gles_impl;
+
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+  auto reactor = std::make_shared<TestReactorGLES>();
+  auto worker = std::make_shared<MockWorker>();
+  reactor->AddWorker(worker);
+
+  std::shared_ptr<TextureGLES> source_texture =
+      CreateTexture(reactor, PixelFormat::kGray8UNormInt);
+  std::shared_ptr<DeviceBufferGLES> dest_buffer = CreateBuffer(reactor, 100u);
+  BlitCopyTextureToBufferCommandGLES command =
+      CreateCopyTextureToBufferCommand(source_texture, dest_buffer);
+
+  EXPECT_CALL(mock_gles_impl_ref, CheckFramebufferStatus(_))
+      .WillOnce(Return(GL_FRAMEBUFFER_COMPLETE));
+  EXPECT_CALL(mock_gles_impl_ref,
+              ReadPixels(_, _, 10, 10, GL_RGBA, GL_UNSIGNED_BYTE, _))
+      .WillOnce(
+          [](GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, void* pixels) {
+            auto* rgba = static_cast<uint8_t*>(pixels);
+            for (size_t i = 0; i < 100u; i++) {
+              rgba[i * 4u] = static_cast<uint8_t>(i);
+            }
+          });
+
+  EXPECT_TRUE(command.Encode(*reactor));
+  for (size_t i = 0; i < 100u; i++) {
+    EXPECT_EQ(dest_buffer->GetBufferData()[i], static_cast<uint8_t>(i));
+  }
+}
+
+TEST(BlitCommandGLESTest, Gray8ReadbackUsesBoundedChunks) {
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+  auto& mock_gles_impl_ref = *mock_gles_impl;
+
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
+  auto reactor = std::make_shared<TestReactorGLES>();
+  auto worker = std::make_shared<MockWorker>();
+  reactor->AddWorker(worker);
+
+  constexpr ISize kSize = {1024, 1025};
+  std::shared_ptr<TextureGLES> source_texture =
+      CreateTexture(reactor, PixelFormat::kGray8UNormInt, kSize);
+  std::shared_ptr<DeviceBufferGLES> dest_buffer =
+      CreateBuffer(reactor, kSize.Area());
+  BlitCopyTextureToBufferCommandGLES command =
+      CreateCopyTextureToBufferCommand(source_texture, dest_buffer);
+
+  EXPECT_CALL(mock_gles_impl_ref, CheckFramebufferStatus(_))
+      .WillOnce(Return(GL_FRAMEBUFFER_COMPLETE));
+  auto write_pixels = [](GLint, GLint y, GLsizei width, GLsizei height, GLenum,
+                         GLenum, void* pixels) {
+    auto* rgba = static_cast<uint8_t*>(pixels);
+    for (GLint row = 0; row < height; row++) {
+      for (GLint x = 0; x < width; x++) {
+        const size_t index = static_cast<size_t>(row) * width + x;
+        rgba[index * 4u] = static_cast<uint8_t>(y + row + x);
+      }
+    }
+  };
+  EXPECT_CALL(mock_gles_impl_ref,
+              ReadPixels(0, 0, 1024, 1024, GL_RGBA, GL_UNSIGNED_BYTE, _))
+      .WillOnce(write_pixels);
+  EXPECT_CALL(mock_gles_impl_ref,
+              ReadPixels(0, 1024, 1024, 1, GL_RGBA, GL_UNSIGNED_BYTE, _))
+      .WillOnce(write_pixels);
+
+  EXPECT_TRUE(command.Encode(*reactor));
+  for (int64_t y = 0; y < kSize.height; y++) {
+    for (int64_t x = 0; x < kSize.width; x++) {
+      const size_t index = static_cast<size_t>(y * kSize.width + x);
+      EXPECT_EQ(dest_buffer->GetBufferData()[index],
+                static_cast<uint8_t>(y + x));
+    }
+  }
 }
 
 TEST(BlitCommandGLESTest,

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -207,6 +207,12 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
                                 desc->GetGlVersion().major_version >= 3 ||
                                 desc->HasExtension(kAppleTextureMaxLevelExt);
 
+  // OpenGL ES 3.0 makes R8 color-renderable and texture-filterable, and adds
+  // the texture swizzles needed to sample it as opaque grayscale. ES 2.0 does
+  // not guarantee either part of that lifecycle.
+  supports_gray8_textures_ =
+      desc->IsES() && desc->GetGlVersion().major_version >= 3;
+
   // 2D array textures (GL_TEXTURE_2D_ARRAY, sampled as sampler2DArray) need the
   // 3D texture upload entry points. These are core on desktop GL 3.0 and
   // OpenGL ES 3.0, and reachable below them via GL_EXT_texture_array (desktop
@@ -339,6 +345,10 @@ bool CapabilitiesGLES::SupportsManuallyMippedTextures() const {
   // the levels the texture declares, so a hand-uploaded chain is mipmap
   // incomplete and samples as black.
   return supports_texture_max_level_;
+}
+
+bool CapabilitiesGLES::SupportsGray8Textures() const {
+  return supports_gray8_textures_;
 }
 
 bool CapabilitiesGLES::SupportsExtendedRangeFormats() const {

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
@@ -142,6 +142,9 @@ class CapabilitiesGLES final
   bool SupportsManuallyMippedTextures() const override;
 
   // |Capabilities|
+  bool SupportsGray8Textures() const override;
+
+  // |Capabilities|
   bool SupportsExtendedRangeFormats() const override;
 
   // |Capabilities|
@@ -181,6 +184,7 @@ class CapabilitiesGLES final
   bool supports_32bit_primitive_indices_ = false;
   bool supports_texture_max_level_ = false;
   bool supports_texture_array_ = false;
+  bool supports_gray8_textures_ = false;
   bool is_angle_ = false;
   bool is_es_ = false;
   bool supports_texture_compression_bc_ = false;

--- a/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/formats_gles.cc
@@ -83,6 +83,11 @@ std::optional<PixelFormatGLES> ToPixelFormatGLES(PixelFormat pixel_format,
       format.external_format = GL_ALPHA;
       format.type = GL_UNSIGNED_BYTE;
       break;
+    case PixelFormat::kGray8UNormInt:
+      format.internal_format = GL_R8;
+      format.external_format = GL_RED;
+      format.type = GL_UNSIGNED_BYTE;
+      break;
     case PixelFormat::kR8UNormInt:
       format.internal_format = GL_RED;
       format.external_format = GL_RED;

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/capabilities_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/capabilities_unittests.cc
@@ -24,12 +24,25 @@ TEST(CapabilitiesGLES, CanInitializeWithDefaults) {
   EXPECT_FALSE(capabilities->SupportsReadFromResolve());
   EXPECT_FALSE(capabilities->SupportsDecalSamplerAddressMode());
   EXPECT_FALSE(capabilities->SupportsDeviceTransientTextures());
+  EXPECT_TRUE(capabilities->SupportsGray8Textures());
 
   EXPECT_EQ(capabilities->GetDefaultColorFormat(),
             PixelFormat::kR8G8B8A8UNormInt);
   EXPECT_EQ(capabilities->GetDefaultStencilFormat(), PixelFormat::kS8UInt);
   EXPECT_EQ(capabilities->GetDefaultDepthStencilFormat(),
             PixelFormat::kD24UnormS8Uint);
+}
+
+TEST(CapabilitiesGLES, DoesNotSupportGray8TexturesOnES2) {
+  auto mock_gles = MockGLES::Init(std::nullopt, "OpenGL ES 2.0");
+  auto capabilities = mock_gles->GetProcTable().GetCapabilities();
+  EXPECT_FALSE(capabilities->SupportsGray8Textures());
+}
+
+TEST(CapabilitiesGLES, DoesNotSupportGray8TexturesOnDesktopGL) {
+  auto mock_gles = MockGLES::Init(std::nullopt, "OpenGL 4.0");
+  auto capabilities = mock_gles->GetProcTable().GetCapabilities();
+  EXPECT_FALSE(capabilities->SupportsGray8Textures());
 }
 
 TEST(CapabilitiesGLES, SupportsDecalSamplerAddressMode) {

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -305,6 +305,12 @@ void mockBindTexture(GLenum target, GLuint texture) {
 static_assert(CheckSameSignature<decltype(mockBindTexture),  //
                                  decltype(glBindTexture)>::value);
 
+void mockTexParameteri(GLenum target, GLenum pname, GLint param) {
+  CallMockMethod(&IMockGLESImpl::TexParameteri, target, pname, param);
+}
+static_assert(CheckSameSignature<decltype(mockTexParameteri),  //
+                                 decltype(glTexParameteri)>::value);
+
 void mockBindBufferRange(GLenum target,
                          GLuint index,
                          GLuint buffer,
@@ -553,6 +559,8 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockTexImage2D);
   } else if (strcmp(name, "glBindTexture") == 0) {
     return reinterpret_cast<void*>(mockBindTexture);
+  } else if (strcmp(name, "glTexParameteri") == 0) {
+    return reinterpret_cast<void*>(mockTexParameteri);
   } else if (strcmp(name, "glObjectLabelKHR") == 0) {
     return reinterpret_cast<void*>(mockObjectLabelKHR);
   } else if (strcmp(name, "glGenBuffers") == 0) {

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -27,6 +27,7 @@ class IMockGLESImpl {
   virtual void DeleteTextures(GLsizei size, const GLuint* queries) {}
   virtual void GenTextures(GLsizei n, GLuint* textures) {}
   virtual void BindTexture(GLenum target, GLuint texture) {}
+  virtual void TexParameteri(GLenum target, GLenum pname, GLint param) {}
   virtual void TexImage2D(GLenum target,
                           GLint level,
                           GLint internalformat,
@@ -154,6 +155,10 @@ class MockGLESImpl : public IMockGLESImpl {
               (override));
   MOCK_METHOD(void, GenTextures, (GLsizei n, GLuint* textures), (override));
   MOCK_METHOD(void, BindTexture, (GLenum target, GLuint texture), (override));
+  MOCK_METHOD(void,
+              TexParameteri,
+              (GLenum target, GLenum pname, GLint param),
+              (override));
   MOCK_METHOD(void,
               TexImage2D,
               (GLenum target,

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.cc
@@ -28,6 +28,7 @@ static bool IsDepthStencilFormat(PixelFormat format) {
       return true;
     case PixelFormat::kUnknown:
     case PixelFormat::kA8UNormInt:
+    case PixelFormat::kGray8UNormInt:
     case PixelFormat::kR8UNormInt:
     case PixelFormat::kR8G8UNormInt:
     case PixelFormat::kR8G8B8A8UNormInt:
@@ -407,6 +408,7 @@ static std::optional<GLenum> ToRenderBufferFormat(PixelFormat format) {
       return GL_DEPTH32F_STENCIL8;
     case PixelFormat::kUnknown:
     case PixelFormat::kA8UNormInt:
+    case PixelFormat::kGray8UNormInt:
     case PixelFormat::kR8UNormInt:
     case PixelFormat::kR8G8UNormInt:
     case PixelFormat::kR8G8B8A8UNormIntSRGB:
@@ -630,6 +632,14 @@ bool TextureGLES::Bind() {
         return false;
       }
       gl.BindTexture(target.value(), handle.value());
+      if (GetTextureDescriptor().format == PixelFormat::kGray8UNormInt &&
+          !gray8_swizzle_configured_) {
+        gl.TexParameteri(target.value(), GL_TEXTURE_SWIZZLE_R, GL_RED);
+        gl.TexParameteri(target.value(), GL_TEXTURE_SWIZZLE_G, GL_RED);
+        gl.TexParameteri(target.value(), GL_TEXTURE_SWIZZLE_B, GL_RED);
+        gl.TexParameteri(target.value(), GL_TEXTURE_SWIZZLE_A, GL_ONE);
+        gray8_swizzle_configured_ = true;
+      }
     } break;
     case Type::kRenderBuffer:
     case Type::kRenderBufferMultisampled:

--- a/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/texture_gles.h
@@ -201,6 +201,7 @@ class TextureGLES final : public Texture,
   UniqueHandleGLES cached_fbo_;
   uint32_t cached_fbo_mip_level_ = 0;
   uint32_t cached_fbo_slice_ = 0;
+  bool gray8_swizzle_configured_ = false;
   bool is_valid_ = false;
 
   TextureGLES(std::shared_ptr<ReactorGLES> reactor,

--- a/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl_unittests.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/allocator_mtl_unittests.mm
@@ -25,6 +25,20 @@ namespace testing {
 using AllocatorMTLTest = PlaygroundTest;
 INSTANTIATE_METAL_PLAYGROUND_SUITE(AllocatorMTLTest);
 
+TEST(FormatsMTLTest, Gray8Mapping) {
+  TextureDescriptor desc;
+  desc.format = PixelFormat::kGray8UNormInt;
+  desc.size = {1, 1};
+
+  MTLTextureDescriptor* mtl_desc = ToMTLTextureDescriptor(desc);
+  ASSERT_NE(mtl_desc, nil);
+  EXPECT_EQ(mtl_desc.pixelFormat, MTLPixelFormatR8Unorm);
+  EXPECT_EQ(mtl_desc.swizzle.red, MTLTextureSwizzleRed);
+  EXPECT_EQ(mtl_desc.swizzle.green, MTLTextureSwizzleRed);
+  EXPECT_EQ(mtl_desc.swizzle.blue, MTLTextureSwizzleRed);
+  EXPECT_EQ(mtl_desc.swizzle.alpha, MTLTextureSwizzleOne);
+}
+
 TEST_P(AllocatorMTLTest, DebugTraceMemoryStatistics) {
   auto& context_mtl = ContextMTL::Cast(*GetContext());
   const auto& allocator = context_mtl.GetResourceAllocator();

--- a/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/context_mtl.mm
@@ -83,6 +83,7 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetSupportsCompute(true)
       .SetSupportsComputeSubgroups(DeviceSupportsComputeSubgroups(device))
       .SetSupportsReadFromResolve(true)
+      .SetSupportsGray8Textures(true)
       .SetSupportsDeviceTransientTextures(true)
       .SetDefaultGlyphAtlasFormat(PixelFormat::kA8UNormInt)
       .SetSupportsTriangleFan(false)

--- a/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.h
@@ -100,6 +100,8 @@ constexpr MTLPixelFormat ToMTLPixelFormat(PixelFormat format) {
       return MTLPixelFormatInvalid;
     case PixelFormat::kA8UNormInt:
       return MTLPixelFormatA8Unorm;
+    case PixelFormat::kGray8UNormInt:
+      return MTLPixelFormatR8Unorm;
     case PixelFormat::kR8UNormInt:
       return MTLPixelFormatR8Unorm;
     case PixelFormat::kR8G8UNormInt:

--- a/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/formats_mtl.mm
@@ -90,6 +90,11 @@ MTLTextureDescriptor* ToMTLTextureDescriptor(const TextureDescriptor& desc) {
   auto mtl_desc = [[MTLTextureDescriptor alloc] init];
   mtl_desc.textureType = ToMTLTextureType(desc.type);
   mtl_desc.pixelFormat = ToMTLPixelFormat(desc.format);
+  if (desc.format == PixelFormat::kGray8UNormInt) {
+    mtl_desc.swizzle = MTLTextureSwizzleChannelsMake(
+        MTLTextureSwizzleRed, MTLTextureSwizzleRed, MTLTextureSwizzleRed,
+        MTLTextureSwizzleOne);
+  }
   mtl_desc.sampleCount = static_cast<NSUInteger>(desc.sample_count);
   mtl_desc.width = desc.size.width;
   mtl_desc.height = desc.size.height;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -413,15 +413,7 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
     view_info.subresourceRange.aspectMask = ToVKImageAspectFlags(desc.format);
     view_info.subresourceRange.levelCount = image_info.mipLevels;
     view_info.subresourceRange.layerCount = ToArrayLayerCount(desc);
-
-    // Vulkan does not have an image format that is equivalent to
-    // `MTLPixelFormatA8Unorm`, so we use `R8Unorm` instead. Given that the
-    // shaders expect that alpha channel to be set in the cases, we swizzle.
-    // See: https://github.com/flutter/flutter/issues/115461 for more details.
-    if (desc.format == PixelFormat::kA8UNormInt) {
-      view_info.components.a = vk::ComponentSwizzle::eR;
-      view_info.components.r = vk::ComponentSwizzle::eA;
-    }
+    view_info.components = ToVKComponentMapping(desc.format);
 
     auto [result, image_view] = device.createImageViewUnique(view_info);
     if (result != vk::Result::eSuccess) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -765,6 +765,10 @@ bool CapabilitiesVK::SupportsReadFromResolve() const {
   return false;
 }
 
+bool CapabilitiesVK::SupportsGray8Textures() const {
+  return true;
+}
+
 bool CapabilitiesVK::SupportsDecalSamplerAddressMode() const {
   return true;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -276,6 +276,9 @@ class CapabilitiesVK final : public Capabilities,
   bool SupportsManuallyMippedTextures() const override;
 
   // |Capabilities|
+  bool SupportsGray8Textures() const override;
+
+  // |Capabilities|
   bool SupportsExtendedRangeFormats() const override;
 
   // |Capabilities|

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/formats_vk.h
@@ -154,6 +154,8 @@ constexpr vk::Format ToVKImageFormat(PixelFormat format) {
     case PixelFormat::kA8UNormInt:
       // TODO(csg): This is incorrect. Don't depend on swizzle support for GLES.
       return vk::Format::eR8Unorm;
+    case PixelFormat::kGray8UNormInt:
+      return vk::Format::eR8Unorm;
     case PixelFormat::kR8G8B8A8UNormInt:
       return vk::Format::eR8G8B8A8Unorm;
     case PixelFormat::kR8G8B8A8UNormIntSRGB:
@@ -215,6 +217,28 @@ constexpr vk::Format ToVKImageFormat(PixelFormat format) {
   }
 
   FML_UNREACHABLE();
+}
+
+constexpr vk::ComponentMapping ToVKComponentMapping(PixelFormat format) {
+  vk::ComponentMapping mapping;
+  switch (format) {
+    case PixelFormat::kA8UNormInt:
+      // Vulkan has no alpha-only image format, so A8 is stored as R8 and
+      // swizzled back to alpha. See
+      // https://github.com/flutter/flutter/issues/115461.
+      mapping.a = vk::ComponentSwizzle::eR;
+      mapping.r = vk::ComponentSwizzle::eA;
+      break;
+    case PixelFormat::kGray8UNormInt:
+      mapping.r = vk::ComponentSwizzle::eR;
+      mapping.g = vk::ComponentSwizzle::eR;
+      mapping.b = vk::ComponentSwizzle::eR;
+      mapping.a = vk::ComponentSwizzle::eOne;
+      break;
+    default:
+      break;
+  }
+  return mapping;
 }
 
 constexpr PixelFormat ToPixelFormat(vk::Format format) {
@@ -452,6 +476,7 @@ constexpr bool PixelFormatIsDepthStencil(PixelFormat format) {
   switch (format) {
     case PixelFormat::kUnknown:
     case PixelFormat::kA8UNormInt:
+    case PixelFormat::kGray8UNormInt:
     case PixelFormat::kR8UNormInt:
     case PixelFormat::kR8G8UNormInt:
     case PixelFormat::kR8G8B8A8UNormInt:
@@ -569,6 +594,7 @@ constexpr vk::ImageAspectFlags ToVKImageAspectFlags(PixelFormat format) {
   switch (format) {
     case PixelFormat::kUnknown:
     case PixelFormat::kA8UNormInt:
+    case PixelFormat::kGray8UNormInt:
     case PixelFormat::kR8UNormInt:
     case PixelFormat::kR8G8UNormInt:
     case PixelFormat::kR8G8B8A8UNormInt:
@@ -666,6 +692,7 @@ constexpr vk::ImageAspectFlags ToImageAspectFlags(PixelFormat format) {
     case PixelFormat::kUnknown:
       return {};
     case PixelFormat::kA8UNormInt:
+    case PixelFormat::kGray8UNormInt:
     case PixelFormat::kR8UNormInt:
     case PixelFormat::kR8G8UNormInt:
     case PixelFormat::kR8G8B8A8UNormInt:

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/formats_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/formats_vk_unittests.cc
@@ -23,5 +23,16 @@ TEST(FormatsVKTest, DescriptorMapping) {
             vk::DescriptorType::eInputAttachment);
 }
 
+TEST(FormatsVKTest, Gray8Mapping) {
+  EXPECT_EQ(ToVKImageFormat(PixelFormat::kGray8UNormInt), vk::Format::eR8Unorm);
+
+  const vk::ComponentMapping mapping =
+      ToVKComponentMapping(PixelFormat::kGray8UNormInt);
+  EXPECT_EQ(mapping.r, vk::ComponentSwizzle::eR);
+  EXPECT_EQ(mapping.g, vk::ComponentSwizzle::eR);
+  EXPECT_EQ(mapping.b, vk::ComponentSwizzle::eR);
+  EXPECT_EQ(mapping.a, vk::ComponentSwizzle::eOne);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/capabilities.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities.cc
@@ -102,6 +102,11 @@ class StandardCapabilities final : public Capabilities {
   bool SupportsManuallyMippedTextures() const override { return true; }
 
   // |Capabilities|
+  bool SupportsGray8Textures() const override {
+    return supports_gray8_textures_;
+  }
+
+  // |Capabilities|
   bool SupportsExtendedRangeFormats() const override {
     return supports_extended_range_formats_;
   }
@@ -148,6 +153,7 @@ class StandardCapabilities final : public Capabilities {
                        bool supports_compute,
                        bool supports_compute_subgroups,
                        bool supports_read_from_resolve,
+                       bool supports_gray8_textures,
                        bool supports_decal_sampler_address_mode,
                        bool supports_device_transient_textures,
                        bool supports_triangle_fan,
@@ -171,6 +177,7 @@ class StandardCapabilities final : public Capabilities {
         supports_compute_(supports_compute),
         supports_compute_subgroups_(supports_compute_subgroups),
         supports_read_from_resolve_(supports_read_from_resolve),
+        supports_gray8_textures_(supports_gray8_textures),
         supports_decal_sampler_address_mode_(
             supports_decal_sampler_address_mode),
         supports_device_transient_textures_(supports_device_transient_textures),
@@ -200,6 +207,7 @@ class StandardCapabilities final : public Capabilities {
   bool supports_compute_ = false;
   bool supports_compute_subgroups_ = false;
   bool supports_read_from_resolve_ = false;
+  bool supports_gray8_textures_ = false;
   bool supports_decal_sampler_address_mode_ = false;
   bool supports_device_transient_textures_ = false;
   bool supports_triangle_fan_ = false;
@@ -280,6 +288,11 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetDefaultDepthStencilFormat(
 CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsReadFromResolve(
     bool read_from_resolve) {
   supports_read_from_resolve_ = read_from_resolve;
+  return *this;
+}
+
+CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsGray8Textures(bool value) {
+  supports_gray8_textures_ = value;
   return *this;
 }
 
@@ -366,6 +379,7 @@ std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
       supports_compute_,                                                   //
       supports_compute_subgroups_,                                         //
       supports_read_from_resolve_,                                         //
+      supports_gray8_textures_,                                            //
       supports_decal_sampler_address_mode_,                                //
       supports_device_transient_textures_,                                 //
       supports_triangle_fan_,                                              //

--- a/engine/src/flutter/impeller/renderer/capabilities.h
+++ b/engine/src/flutter/impeller/renderer/capabilities.h
@@ -100,6 +100,10 @@ class Capabilities {
   ///        bounded to the levels the texture declares.
   virtual bool SupportsManuallyMippedTextures() const = 0;
 
+  /// @brief Whether one-byte Gray8 textures can be sampled as `(r, r, r, 1)`,
+  ///        resized, mipmapped, and read back as one byte per pixel.
+  virtual bool SupportsGray8Textures() const = 0;
+
   /// @brief  Returns a supported `PixelFormat` for textures that store
   ///         4-channel colors (red/green/blue/alpha).
   virtual PixelFormat GetDefaultColorFormat() const = 0;
@@ -192,6 +196,8 @@ class CapabilitiesBuilder {
 
   CapabilitiesBuilder& SetSupportsReadFromResolve(bool value);
 
+  CapabilitiesBuilder& SetSupportsGray8Textures(bool value);
+
   CapabilitiesBuilder& SetDefaultColorFormat(PixelFormat value);
 
   CapabilitiesBuilder& SetDefaultStencilFormat(PixelFormat value);
@@ -230,6 +236,7 @@ class CapabilitiesBuilder {
   bool supports_compute_ = false;
   bool supports_compute_subgroups_ = false;
   bool supports_read_from_resolve_ = false;
+  bool supports_gray8_textures_ = false;
   bool supports_decal_sampler_address_mode_ = false;
   bool supports_device_transient_textures_ = false;
   bool supports_triangle_fan_ = false;

--- a/engine/src/flutter/impeller/renderer/capabilities_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities_unittests.cc
@@ -25,6 +25,7 @@ CAPABILITY_TEST(SupportsFramebufferFetch, false);
 CAPABILITY_TEST(SupportsCompute, false);
 CAPABILITY_TEST(SupportsComputeSubgroups, false);
 CAPABILITY_TEST(SupportsReadFromResolve, false);
+CAPABILITY_TEST(SupportsGray8Textures, false);
 CAPABILITY_TEST(SupportsDecalSamplerAddressMode, false);
 CAPABILITY_TEST(SupportsDeviceTransientTextures, false);
 CAPABILITY_TEST(SupportsTriangleFan, false);

--- a/engine/src/flutter/impeller/renderer/testing/mocks.h
+++ b/engine/src/flutter/impeller/renderer/testing/mocks.h
@@ -252,6 +252,7 @@ class MockCapabilities : public Capabilities {
   MOCK_METHOD(bool, SupportsPrimitiveRestart, (), (const override));
   MOCK_METHOD(bool, Supports32BitPrimitiveIndices, (), (const override));
   MOCK_METHOD(bool, SupportsManuallyMippedTextures, (), (const override));
+  MOCK_METHOD(bool, SupportsGray8Textures, (), (const override));
   MOCK_METHOD(bool, SupportsExtendedRangeFormats, (), (const override));
   MOCK_METHOD(bool, SupportsFramebufferRenderMipmap, (), (const override));
   MOCK_METHOD(bool,

--- a/engine/src/flutter/lib/gpu/formats.h
+++ b/engine/src/flutter/lib/gpu/formats.h
@@ -215,6 +215,9 @@ constexpr FlutterGPUPixelFormat FromImpellerPixelFormat(
     case impeller::PixelFormat::kB10G10R10A10XR:
       // Apple-only extended-range formats, not exposed by the Flutter GPU API.
       return FlutterGPUPixelFormat::kUnknown;
+    case impeller::PixelFormat::kGray8UNormInt:
+      // Internal image format, not exposed by the Flutter GPU API.
+      return FlutterGPUPixelFormat::kUnknown;
     case impeller::PixelFormat::kS8UInt:
       return FlutterGPUPixelFormat::kS8UInt;
     case impeller::PixelFormat::kD24UnormS8Uint:

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -238,6 +238,7 @@ if (enable_unittests) {
       "fixtures/FontManifest.json",
       "fixtures/unmultiplied_alpha.png",
       "fixtures/WideGamutIndexed.png",
+      "//flutter/impeller/fixtures/embarcadero.jpg",
       "//flutter/txt/third_party/fonts/Roboto-Medium.ttf",
     ]
   }

--- a/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
@@ -93,10 +93,14 @@ absl::StatusOr<ImageDecoderImpeller::ImageInfo> ToImageInfo(
   }};
 }
 
-SkColorType ChooseCompatibleColorType(SkColorType type) {
+SkColorType ChooseCompatibleColorType(SkColorType type,
+                                      bool supports_gray8_textures) {
   switch (type) {
     case kRGBA_F32_SkColorType:
       return kRGBA_F16_SkColorType;
+    case kGray_8_SkColorType:
+      return supports_gray8_textures ? kGray_8_SkColorType
+                                     : kRGBA_8888_SkColorType;
     default:
       return kRGBA_8888_SkColorType;
   }
@@ -120,6 +124,7 @@ absl::StatusOr<SkImageInfo> CreateImageInfo(
     const SkImageInfo& base_image_info,
     const SkISize& decode_size,
     bool supports_wide_gamut,
+    bool supports_gray8_textures,
     ImageDecoder::TargetPixelFormat target_format) {
   const bool is_wide_gamut =
       supports_wide_gamut ? IsWideGamut(base_image_info.colorSpace()) : false;
@@ -147,7 +152,8 @@ absl::StatusOr<SkImageInfo> CreateImageInfo(
         .makeColorSpace(SkColorSpace::MakeSRGB());
   } else {
     return base_image_info.makeWH(decode_size.width(), decode_size.height())
-        .makeColorType(ChooseCompatibleColorType(base_image_info.colorType()))
+        .makeColorType(ChooseCompatibleColorType(base_image_info.colorType(),
+                                                 supports_gray8_textures))
         .makeAlphaType(alpha_type)
         .makeColorSpace(SkColorSpace::MakeSRGB());
   }
@@ -290,6 +296,8 @@ impeller::PixelFormat ToImpellerPixelFormat(
 std::optional<impeller::PixelFormat> ImageDecoderImpeller::ToPixelFormat(
     SkColorType type) {
   switch (type) {
+    case kGray_8_SkColorType:
+      return impeller::PixelFormat::kGray8UNormInt;
     case kRGBA_8888_SkColorType:
       return impeller::PixelFormat::kR8G8B8A8UNormInt;
     case kBGRA_8888_SkColorType:
@@ -389,7 +397,8 @@ ImageDecoderImpeller::DecompressTexture(
   const SkImageInfo base_image_info =
       ImageDescriptor::ToSkImageInfo(descriptor->image_info());
   const absl::StatusOr<SkImageInfo> image_info = CreateImageInfo(
-      base_image_info, decode_size, supports_wide_gamut, options.target_format);
+      base_image_info, decode_size, supports_wide_gamut,
+      capabilities->SupportsGray8Textures(), options.target_format);
 
   if (!image_info.ok()) {
     return image_info.status();

--- a/engine/src/flutter/lib/ui/painting/image_decoder_no_gl_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_decoder_no_gl_unittests.cc
@@ -8,6 +8,7 @@
 #include "flutter/fml/endianness.h"
 #include "impeller/renderer/capabilities.h"
 #include "include/core/SkColorType.h"
+#include "third_party/skia/include/codec/SkJpegDecoder.h"
 #include "third_party/skia/include/codec/SkPngDecoder.h"
 
 namespace flutter {
@@ -75,6 +76,67 @@ float DecodeBGR10(uint32_t x) {
   const float intercept = min;
   const float slope = (max - min) / 1024.0f;
   return (x * slope) + intercept;
+}
+
+TEST(ImageDecoderNoGLTest, ImpellerPreservesGray8) {
+#if defined(OS_FUCHSIA)
+  GTEST_SKIP() << "Fuchsia can't load the test fixtures.";
+#endif
+  SkCodecs::Register(SkJpegDecoder::Decoder());
+  auto data = flutter::testing::OpenFixtureAsSkData("embarcadero.jpg");
+  ASSERT_TRUE(data);
+
+  ImageGeneratorRegistry registry;
+  std::shared_ptr<ImageGenerator> generator =
+      registry.CreateCompatibleGenerator(data);
+  ASSERT_TRUE(generator);
+  const SkImageInfo source_info = generator->GetInfo();
+  ASSERT_EQ(source_info.colorType(), kGray_8_SkColorType);
+
+  auto descriptor = fml::MakeRefCounted<ImageDescriptor>(std::move(data),
+                                                         std::move(generator));
+
+#if IMPELLER_SUPPORTS_RENDERING
+  const ImageDecoder::Options options = {
+      .target_width = static_cast<uint32_t>(source_info.width()),
+      .target_height = static_cast<uint32_t>(source_info.height()),
+  };
+  const impeller::ISize max_texture_size = {source_info.width(),
+                                            source_info.height()};
+  const size_t pixel_count = static_cast<size_t>(source_info.width()) *
+                             static_cast<size_t>(source_info.height());
+  std::shared_ptr<impeller::Capabilities> fallback_capabilities =
+      impeller::CapabilitiesBuilder()
+          .SetSupportsTextureToTextureBlits(true)
+          .Build();
+  std::shared_ptr<impeller::Capabilities> capabilities =
+      impeller::CapabilitiesBuilder()
+          .SetSupportsTextureToTextureBlits(true)
+          .SetSupportsGray8Textures(true)
+          .Build();
+  std::shared_ptr<impeller::Allocator> allocator =
+      std::make_shared<impeller::TestImpellerAllocator>();
+  absl::StatusOr<ImageDecoderImpeller::DecompressResult> fallback_result =
+      ImageDecoderImpeller::DecompressTexture(
+          descriptor.get(), options, max_texture_size,
+          /*supports_wide_gamut=*/false, fallback_capabilities, allocator);
+
+  ASSERT_TRUE(fallback_result.ok()) << fallback_result.status();
+  EXPECT_EQ(fallback_result->image_info.format,
+            impeller::PixelFormat::kR8G8B8A8UNormInt);
+  EXPECT_EQ(fallback_result->device_buffer->GetDeviceBufferDescriptor().size,
+            pixel_count * 4u);
+
+  absl::StatusOr<ImageDecoderImpeller::DecompressResult> result =
+      ImageDecoderImpeller::DecompressTexture(
+          descriptor.get(), options, max_texture_size,
+          /*supports_wide_gamut=*/false, capabilities, allocator);
+
+  ASSERT_TRUE(result.ok()) << result.status();
+  EXPECT_EQ(result->image_info.format, impeller::PixelFormat::kGray8UNormInt);
+  EXPECT_EQ(result->device_buffer->GetDeviceBufferDescriptor().size,
+            pixel_count);
+#endif  // IMPELLER_SUPPORTS_RENDERING
 }
 
 TEST(ImageDecoderNoGLTest, ImpellerWideGamutDisplayP3) {

--- a/engine/src/flutter/lib/ui/painting/image_encoding_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_impeller.cc
@@ -20,6 +20,8 @@ namespace {
 
 std::optional<SkColorType> ToSkColorType(impeller::PixelFormat format) {
   switch (format) {
+    case impeller::PixelFormat::kGray8UNormInt:
+      return SkColorType::kGray_8_SkColorType;
     case impeller::PixelFormat::kR8G8B8A8UNormInt:
       return SkColorType::kRGBA_8888_SkColorType;
     case impeller::PixelFormat::kR16G16B16A16Float:
@@ -41,8 +43,11 @@ sk_sp<SkImage> ConvertBufferToSkImage(
     const std::shared_ptr<impeller::DeviceBuffer>& buffer,
     SkColorType color_type,
     SkISize dimensions) {
-  SkImageInfo image_info = SkImageInfo::Make(dimensions, color_type,
-                                             SkAlphaType::kPremul_SkAlphaType);
+  const SkAlphaType alpha_type = color_type == kGray_8_SkColorType
+                                     ? SkAlphaType::kOpaque_SkAlphaType
+                                     : SkAlphaType::kPremul_SkAlphaType;
+  SkImageInfo image_info =
+      SkImageInfo::Make(dimensions, color_type, alpha_type);
   SkBitmap bitmap;
   auto func = [](void* addr, void* context) {
     auto buffer =

--- a/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
@@ -554,6 +554,71 @@ TEST(ImageEncodingImpellerTest, ConvertDlImageToSkImage10XR) {
   EXPECT_TRUE(did_call);
 }
 
+TEST(ImageEncodingImpellerTest, ConvertDlImageToSkImageGray8) {
+  sk_sp<MockDlImage> image(new MockDlImage());
+  EXPECT_CALL(*image, GetSize).WillRepeatedly(Return(DlISize(2, 2)));
+
+  impeller::TextureDescriptor desc;
+  desc.format = impeller::PixelFormat::kGray8UNormInt;
+  desc.size = impeller::ISize(2, 2);
+  auto texture = std::make_shared<MockTexture>(desc);
+  EXPECT_CALL(*texture, GetSize).WillRepeatedly(Return(desc.size));
+  EXPECT_CALL(*image, GetImpellerTexture(::testing::_))
+      .WillOnce(Return(texture));
+  std::vector<uint8_t> buffer = {0x00, 0x40, 0x80, 0xFF};
+  auto context = MakeConvertDlImageToSkImageContext(buffer);
+  bool did_call = false;
+  MockSnapshotDelegate snapshot_delegate;
+  EXPECT_CALL(snapshot_delegate, MakeRenderContextCurrent)
+      .WillRepeatedly(Return(true));
+  ImageEncodingImpeller::ConvertDlImageToSkImage(
+      image,
+      [&did_call, &buffer](const fml::StatusOr<sk_sp<SkImage>>& result) {
+        did_call = true;
+        ASSERT_TRUE(result.ok());
+        ASSERT_TRUE(result.value());
+        EXPECT_EQ(result.value()->colorType(), kGray_8_SkColorType);
+        EXPECT_EQ(result.value()->alphaType(), kOpaque_SkAlphaType);
+
+        SkPixmap pixels;
+        ASSERT_TRUE(result.value()->peekPixels(&pixels));
+        for (int y = 0; y < 2; y++) {
+          for (int x = 0; x < 2; x++) {
+            EXPECT_EQ(*pixels.addr8(x, y), buffer[y * 2 + x]);
+          }
+        }
+
+        fml::StatusOr<sk_sp<SkData>> raw_unmodified =
+            EncodeImage(result.value(), ImageByteFormat::kRawUnmodified);
+        ASSERT_TRUE(raw_unmodified.ok());
+        ASSERT_EQ(raw_unmodified.value()->size(), buffer.size());
+        const auto* gray =
+            static_cast<const uint8_t*>(raw_unmodified.value()->data());
+        for (size_t i = 0u; i < buffer.size(); i++) {
+          EXPECT_EQ(gray[i], buffer[i]);
+        }
+
+        fml::StatusOr<sk_sp<SkData>> raw_rgba =
+            EncodeImage(result.value(), ImageByteFormat::kRawRGBA);
+        ASSERT_TRUE(raw_rgba.ok());
+        ASSERT_EQ(raw_rgba.value()->size(), buffer.size() * 4u);
+        const auto* rgba =
+            static_cast<const uint8_t*>(raw_rgba.value()->data());
+        for (size_t i = 0u; i < buffer.size(); i++) {
+          EXPECT_EQ(rgba[i * 4u], buffer[i]);
+          EXPECT_EQ(rgba[i * 4u + 1u], buffer[i]);
+          EXPECT_EQ(rgba[i * 4u + 2u], buffer[i]);
+          EXPECT_EQ(rgba[i * 4u + 3u], 0xFFu);
+        }
+
+        fml::StatusOr<sk_sp<SkData>> png =
+            EncodeImage(result.value(), ImageByteFormat::kPNG);
+        EXPECT_TRUE(png.ok());
+      },
+      snapshot_delegate.GetWeakPtr(), context);
+  EXPECT_TRUE(did_call);
+}
+
 TEST(ImageEncodingImpellerTest, ConvertDlImageToSkImageTextureSizeMismatch) {
   DlISize dl_image_size(100, 100);
   sk_sp<MockDlImage> image(new MockDlImage());

--- a/engine/src/flutter/shell/common/rasterizer.cc
+++ b/engine/src/flutter/shell/common/rasterizer.cc
@@ -926,6 +926,7 @@ Rasterizer::ScreenshotFormat ToScreenshotFormat(impeller::PixelFormat format) {
   switch (format) {
     case impeller::PixelFormat::kUnknown:
     case impeller::PixelFormat::kA8UNormInt:
+    case impeller::PixelFormat::kGray8UNormInt:
     case impeller::PixelFormat::kR8UNormInt:
     case impeller::PixelFormat::kR8G8UNormInt:
     case impeller::PixelFormat::kR8G8B8A8UNormIntSRGB:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/190573

Impeller currently expands decoded 8-bit grayscale images to RGBA8 before allocating the decode destination. As a result, a one-component image uses approximately four times the expected GPU storage, and `ImageByteFormat.rawUnmodified` returns four bytes per pixel instead of preserving the single grayscale channel.

The solution introduces a semantic one-byte `kGray8UNormInt` texture format and preserves Gray8 through decoding when the backend supports its complete lifecycle. Vulkan, Metal, and OpenGL ES 3 store the texture as R8 and apply an `(r, r, r, 1)` sampling swizzle; readback maps it back to Gray8 so `rawUnmodified`, `rawRgba`, resizing, mipmapping, and PNG encoding retain their expected behavior. OpenGL ES 2 and desktop GL keep the existing RGBA8 fallback.

## Performance

Measured with 64 independently decoded and retained 768x512 one-component JPEGs drawn in an 8x8 grid on two physical Android devices. Each measurement used a fresh process and reports the `dumpsys meminfo` Graphics increase from a settled renderer baseline.

| Device and path | Before | After | Difference |
| --- | ---: | ---: | ---: |
| SM-X510, Mali, Vulkan | 147,261 kB / 5.9921 bytes per source pixel | 34,867 kB / 1.4187 bytes per source pixel | -112,394 kB / -76.3% |
| Pixel 3 XL, Adreno, GLES resource context | 118,476 kB / 4.8208 bytes per source pixel | 26,324 kB / 1.0711 bytes per source pixel | -92,152 kB / -77.8% |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.