### PR TITLE
Started caching text shadows by content.

### DIFF
--- a/engine/src/flutter/impeller/display_list/BUILD.gn
+++ b/engine/src/flutter/impeller/display_list/BUILD.gn
@@ -57,6 +57,8 @@ impeller_component("display_list") {
     "//flutter/skia",
   ]
 
+  deps = [ "//third_party/abseil-cpp/absl/hash" ]
+
   if (impeller_supports_rendering) {
     public_deps += [ "//flutter/impeller/runtime_stage" ]
   }

--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -867,6 +867,39 @@ TEST_P(AiksTest, MultipleTextWithShadowCache) {
 
   for (auto i = 0; i < 5; i++) {
     ASSERT_TRUE(RenderTextInCanvasSkia(
+        GetContext(), builder,
+        (std::string("Hello World ") + std::to_string(i)).c_str(), kFontFixture,
+        TextRenderOptions{
+            .color = DlColor::kBlue(),
+            .filter = DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 4)}));
+  }
+
+  DisplayListToTexture(builder.Build(), {400, 400}, aiks_context);
+
+  // Each distinct text gets its own cache entry.
+  EXPECT_EQ(aiks_context.GetContentContext()
+                .GetTextShadowCache()
+                .GetCacheSizeForTesting(),
+            5u);
+}
+
+TEST_P(AiksTest, DuplicateTextWithShadowCache) {
+  DisplayListBuilder builder;
+  builder.Scale(GetContentScale().x, GetContentScale().y);
+  DlPaint paint;
+  paint.setColor(DlColor::ARGB(1, 0.1, 0.1, 0.1));
+  builder.DrawPaint(paint);
+
+  AiksContext aiks_context(GetContext(),
+                           std::make_shared<TypographerContextSkia>());
+  // Cache empty
+  EXPECT_EQ(aiks_context.GetContentContext()
+                .GetTextShadowCache()
+                .GetCacheSizeForTesting(),
+            0u);
+
+  for (auto i = 0; i < 5; i++) {
+    ASSERT_TRUE(RenderTextInCanvasSkia(
         GetContext(), builder, "Hello World", kFontFixture,
         TextRenderOptions{
             .color = DlColor::kBlue(),
@@ -875,12 +908,11 @@ TEST_P(AiksTest, MultipleTextWithShadowCache) {
 
   DisplayListToTexture(builder.Build(), {400, 400}, aiks_context);
 
-  // Text should be cached. Each text gets its own entry as we don't analyze the
-  // strings.
+  // Duplicate text frames with identical layout share the single cache entry.
   EXPECT_EQ(aiks_context.GetContentContext()
                 .GetTextShadowCache()
                 .GetCacheSizeForTesting(),
-            5u);
+            1u);
 }
 
 TEST_P(AiksTest, MultipleColorWithShadowCache) {

--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -915,6 +915,53 @@ TEST_P(AiksTest, DuplicateTextWithShadowCache) {
             1u);
 }
 
+TEST_P(AiksTest, TextShadowCacheKeyCollisionSafety) {
+  SkFont font = flutter::testing::CreateTestFontOfSize(12);
+  auto blob1 = SkTextBlob::MakeFromString("Text A", font);
+  auto blob2 = SkTextBlob::MakeFromString("Text B", font);
+
+  auto frame1 = MakeTextFrameFromTextBlobSkia(blob1);
+  auto frame2 = MakeTextFrameFromTextBlobSkia(blob2);
+
+  Font impeller_font(frame1->GetFont());
+
+  // Construct two keys with the exact same identifier (simulating a hash collision)
+  // but with different TextFrame contents.
+  TextShadowCache::TextShadowCacheKey key1(
+      /*p_max_basis=*/1.0f,
+      /*p_identifier=*/12345,
+      /*p_is_single_glyph=*/false,
+      /*p_font=*/impeller_font,
+      /*p_sigma=*/Sigma{4.0f},
+      /*p_color=*/Color::Blue(),
+      /*p_text_frame=*/frame1);
+
+  TextShadowCache::TextShadowCacheKey key2(
+      /*p_max_basis=*/1.0f,
+      /*p_identifier=*/12345,
+      /*p_is_single_glyph=*/false,
+      /*p_font=*/impeller_font,
+      /*p_sigma=*/Sigma{4.0f},
+      /*p_color=*/Color::Blue(),
+      /*p_text_frame=*/frame2);
+
+  TextShadowCache::TextShadowCacheKey::Equal equal;
+  // Key comparison must fail because the text frames are different despite identical hash identifier.
+  EXPECT_FALSE(equal(key1, key2));
+
+  TextShadowCache::TextShadowCacheKey key3(
+      /*p_max_basis=*/1.0f,
+      /*p_identifier=*/12345,
+      /*p_is_single_glyph=*/false,
+      /*p_font=*/impeller_font,
+      /*p_sigma=*/Sigma{4.0f},
+      /*p_color=*/Color::Blue(),
+      /*p_text_frame=*/MakeTextFrameFromTextBlobSkia(blob1));
+
+  // Key comparison must succeed for identical text frame content.
+  EXPECT_TRUE(equal(key1, key3));
+}
+
 TEST_P(AiksTest, MultipleColorWithShadowCache) {
   DisplayListBuilder builder;
   builder.Scale(GetContentScale().x, GetContentScale().y);

--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -917,16 +917,30 @@ TEST_P(AiksTest, DuplicateTextWithShadowCache) {
 
 TEST_P(AiksTest, TextShadowCacheKeyCollisionSafety) {
   SkFont font = flutter::testing::CreateTestFontOfSize(12);
-  auto blob1 = SkTextBlob::MakeFromString("Text A", font);
-  auto blob2 = SkTextBlob::MakeFromString("Text B", font);
 
-  auto frame1 = MakeTextFrameFromTextBlobSkia(blob1);
-  auto frame2 = MakeTextFrameFromTextBlobSkia(blob2);
+  Font impeller_font(
+      MakeTextFrameFromTextBlobSkia(SkTextBlob::MakeFromString("Text A", font))
+          ->GetFont());
 
-  Font impeller_font(frame1->GetFont());
+  TextFrameFingerprint fp1{
+      .run_count = 1,
+      .total_glyph_count = 6,
+      .first_glyph_id = 10,
+      .last_glyph_id = 20,
+      .full_hash = 12345,
+  };
 
-  // Construct two keys with the exact same identifier (simulating a hash collision)
-  // but with different TextFrame contents.
+  TextFrameFingerprint fp2{
+      .run_count = 1,
+      .total_glyph_count = 6,
+      .first_glyph_id = 10,
+      .last_glyph_id = 21,  // Different last glyph ID
+      .full_hash = 12345,   // Simulated hash collision on full_hash!
+  };
+
+  // Construct two keys with the exact same identifier & full_hash (simulating a
+  // hash collision) but with different fingerprints (e.g. different
+  // last_glyph_id).
   TextShadowCache::TextShadowCacheKey key1(
       /*p_max_basis=*/1.0f,
       /*p_identifier=*/12345,
@@ -934,7 +948,7 @@ TEST_P(AiksTest, TextShadowCacheKeyCollisionSafety) {
       /*p_font=*/impeller_font,
       /*p_sigma=*/Sigma{4.0f},
       /*p_color=*/Color::Blue(),
-      /*p_text_frame=*/frame1);
+      /*p_fingerprint=*/fp1);
 
   TextShadowCache::TextShadowCacheKey key2(
       /*p_max_basis=*/1.0f,
@@ -943,10 +957,11 @@ TEST_P(AiksTest, TextShadowCacheKeyCollisionSafety) {
       /*p_font=*/impeller_font,
       /*p_sigma=*/Sigma{4.0f},
       /*p_color=*/Color::Blue(),
-      /*p_text_frame=*/frame2);
+      /*p_fingerprint=*/fp2);
 
   TextShadowCache::TextShadowCacheKey::Equal equal;
-  // Key comparison must fail because the text frames are different despite identical hash identifier.
+  // Key comparison must fail because fingerprints differ despite identical hash
+  // identifier.
   EXPECT_FALSE(equal(key1, key2));
 
   TextShadowCache::TextShadowCacheKey key3(
@@ -956,9 +971,9 @@ TEST_P(AiksTest, TextShadowCacheKeyCollisionSafety) {
       /*p_font=*/impeller_font,
       /*p_sigma=*/Sigma{4.0f},
       /*p_color=*/Color::Blue(),
-      /*p_text_frame=*/MakeTextFrameFromTextBlobSkia(blob1));
+      /*p_fingerprint=*/fp1);
 
-  // Key comparison must succeed for identical text frame content.
+  // Key comparison must succeed for identical fingerprints.
   EXPECT_TRUE(equal(key1, key3));
 }
 

--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -44,12 +44,14 @@ struct TextRenderOptions {
   bool is_subpixel = false;
 };
 
-bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
-                            DisplayListBuilder& canvas,
-                            const std::string& text,
-                            const std::string_view& font_fixture,
-                            const TextRenderOptions& options = {},
-                            const std::optional<SkFont>& font = std::nullopt) {
+bool RenderTextInCanvasSkia(
+    const std::shared_ptr<Context>& context,
+    DisplayListBuilder& canvas,
+    const std::string& text,
+    const std::string_view& font_fixture,
+    const TextRenderOptions& options = {},
+    const std::optional<SkFont>& font = std::nullopt,
+    std::map<std::string, sk_sp<SkTypeface>>* typeface_cache = nullptr) {
   // Draw the baseline.
   DlPaint paint;
   paint.setColor(DlColor::kAqua().withAlpha(255 * 0.25));
@@ -65,13 +67,29 @@ bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
   SkFont selected_font;
   if (!font.has_value()) {
     auto c_font_fixture = std::string(font_fixture);
-    auto mapping =
-        flutter::testing::OpenFixtureAsSkData(c_font_fixture.c_str());
-    if (!mapping) {
-      return false;
+    sk_sp<SkTypeface> typeface;
+    if (typeface_cache) {
+      auto it = typeface_cache->find(c_font_fixture);
+      if (it != typeface_cache->end()) {
+        typeface = it->second;
+      }
     }
-    sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
-    selected_font = SkFont(font_mgr->makeFromData(mapping), options.font_size);
+    if (!typeface) {
+      auto mapping =
+          flutter::testing::OpenFixtureAsSkData(c_font_fixture.c_str());
+      if (!mapping) {
+        return false;
+      }
+      sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
+      typeface = font_mgr->makeFromData(mapping);
+      if (!typeface) {
+        return false;
+      }
+      if (typeface_cache) {
+        (*typeface_cache)[c_font_fixture] = typeface;
+      }
+    }
+    selected_font = SkFont(typeface, options.font_size);
     if (options.is_subpixel) {
       selected_font.setSubpixel(true);
     }
@@ -898,12 +916,14 @@ TEST_P(AiksTest, DuplicateTextWithShadowCache) {
                 .GetCacheSizeForTesting(),
             0u);
 
+  std::map<std::string, sk_sp<SkTypeface>> typeface_cache;
   for (auto i = 0; i < 5; i++) {
     ASSERT_TRUE(RenderTextInCanvasSkia(
         GetContext(), builder, "Hello World", kFontFixture,
         TextRenderOptions{
             .color = DlColor::kBlue(),
-            .filter = DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 4)}));
+            .filter = DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 4)},
+        std::nullopt, &typeface_cache));
   }
 
   DisplayListToTexture(builder.Build(), {400, 400}, aiks_context);

--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -994,6 +994,46 @@ TEST_P(AiksTest, TextShadowCacheKeyCollisionSafety) {
   EXPECT_TRUE(equal(key1, key3));
 }
 
+TEST_P(AiksTest, SingleGlyphTextShadowCache) {
+  DisplayListBuilder builder;
+  builder.Scale(GetContentScale().x, GetContentScale().y);
+  DlPaint paint;
+  paint.setColor(DlColor::ARGB(1, 0.1, 0.1, 0.1));
+  builder.DrawPaint(paint);
+
+  AiksContext aiks_context(GetContext(),
+                           std::make_shared<TypographerContextSkia>());
+  EXPECT_EQ(aiks_context.GetContentContext()
+                .GetTextShadowCache()
+                .GetCacheSizeForTesting(),
+            0u);
+
+  SkFont font = flutter::testing::CreateTestFontOfSize(12);
+  TextRenderOptions options{
+      .color = DlColor::kBlue(),
+      .filter = DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 4)};
+
+  // Draw single glyph "A".
+  ASSERT_TRUE(RenderTextInCanvasSkia(GetContext(), builder, "A", kFontFixture,
+                                     options, font));
+
+  // Draw single glyph "B" (different glyph ID, identical font/color/sigma).
+  ASSERT_TRUE(RenderTextInCanvasSkia(GetContext(), builder, "B", kFontFixture,
+                                     options, font));
+
+  // Draw single glyph "A" again (duplicate glyph ID).
+  ASSERT_TRUE(RenderTextInCanvasSkia(GetContext(), builder, "A", kFontFixture,
+                                     options, font));
+
+  DisplayListToTexture(builder.Build(), {400, 400}, aiks_context);
+
+  // Single glyphs "A" and "B" get distinct entries; duplicate "A" reuses "A".
+  EXPECT_EQ(aiks_context.GetContentContext()
+                .GetTextShadowCache()
+                .GetCacheSizeForTesting(),
+            2u);
+}
+
 TEST_P(AiksTest, MultipleColorWithShadowCache) {
   DisplayListBuilder builder;
   builder.Scale(GetContentScale().x, GetContentScale().y);

--- a/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_text_unittests.cc
@@ -943,7 +943,6 @@ TEST_P(AiksTest, TextShadowCacheKeyCollisionSafety) {
   // last_glyph_id).
   TextShadowCache::TextShadowCacheKey key1(
       /*p_max_basis=*/1.0f,
-      /*p_identifier=*/12345,
       /*p_is_single_glyph=*/false,
       /*p_font=*/impeller_font,
       /*p_sigma=*/Sigma{4.0f},
@@ -952,7 +951,6 @@ TEST_P(AiksTest, TextShadowCacheKeyCollisionSafety) {
 
   TextShadowCache::TextShadowCacheKey key2(
       /*p_max_basis=*/1.0f,
-      /*p_identifier=*/12345,
       /*p_is_single_glyph=*/false,
       /*p_font=*/impeller_font,
       /*p_sigma=*/Sigma{4.0f},
@@ -960,13 +958,12 @@ TEST_P(AiksTest, TextShadowCacheKeyCollisionSafety) {
       /*p_fingerprint=*/fp2);
 
   TextShadowCache::TextShadowCacheKey::Equal equal;
-  // Key comparison must fail because fingerprints differ despite identical hash
-  // identifier.
+  // Key comparison must fail because fingerprints differ despite identical
+  // hash.
   EXPECT_FALSE(equal(key1, key2));
 
   TextShadowCache::TextShadowCacheKey key3(
       /*p_max_basis=*/1.0f,
-      /*p_identifier=*/12345,
       /*p_is_single_glyph=*/false,
       /*p_font=*/impeller_font,
       /*p_sigma=*/Sigma{4.0f},

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -2143,12 +2143,11 @@ bool Canvas::AttemptBlurredTextOptimization(
           /*is_solid_color=*/true, GetCurrentTransform());
 
   std::optional<Glyph> maybe_glyph = text_frame->AsSingleGlyph();
-  TextFrameFingerprint fingerprint;
-  if (maybe_glyph.has_value()) {
-    fingerprint.first_glyph_id = PackGlyphId(maybe_glyph.value());
-  } else {
-    fingerprint = ComputeTextFrameFingerprint(*text_frame);
-  }
+  TextFrameFingerprint fingerprint =
+      maybe_glyph.has_value()
+          ? TextFrameFingerprint{.first_glyph_id =
+                                     PackGlyphId(maybe_glyph.value())}
+          : ComputeTextFrameFingerprint(*text_frame);
   TextShadowCache::TextShadowCacheKey cache_key(
       /*p_max_basis=*/entity.GetTransform().GetMaxBasisLengthXY(),
       /*p_is_single_glyph=*/maybe_glyph.has_value(),

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -2144,16 +2144,13 @@ bool Canvas::AttemptBlurredTextOptimization(
 
   std::optional<Glyph> maybe_glyph = text_frame->AsSingleGlyph();
   TextFrameFingerprint fingerprint;
-  int64_t identifier;
   if (maybe_glyph.has_value()) {
-    identifier = maybe_glyph.value().index;
+    fingerprint.first_glyph_id = PackGlyphId(maybe_glyph.value());
   } else {
     fingerprint = ComputeTextFrameFingerprint(*text_frame);
-    identifier = static_cast<int64_t>(fingerprint.full_hash);
   }
   TextShadowCache::TextShadowCacheKey cache_key(
       /*p_max_basis=*/entity.GetTransform().GetMaxBasisLengthXY(),
-      /*p_identifier=*/identifier,
       /*p_is_single_glyph=*/maybe_glyph.has_value(),
       /*p_font=*/text_frame->GetFont(),
       /*p_sigma=*/paint.mask_blur_descriptor->sigma,

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -2145,8 +2145,7 @@ bool Canvas::AttemptBlurredTextOptimization(
   std::optional<Glyph> maybe_glyph = text_frame->AsSingleGlyph();
   TextFrameFingerprint fingerprint =
       maybe_glyph.has_value()
-          ? TextFrameFingerprint{.first_glyph_id =
-                                     PackGlyphId(maybe_glyph.value())}
+          ? TextFrameFingerprint{.full_hash = PackGlyphId(maybe_glyph.value())}
           : ComputeTextFrameFingerprint(*text_frame);
   TextShadowCache::TextShadowCacheKey cache_key(
       /*p_max_basis=*/entity.GetTransform().GetMaxBasisLengthXY(),

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -2124,7 +2124,8 @@ bool Canvas::AttemptBlurredTextOptimization(
       /*p_is_single_glyph=*/maybe_glyph.has_value(),
       /*p_font=*/text_frame->GetFont(),
       /*p_sigma=*/paint.mask_blur_descriptor->sigma,
-      /*p_color=*/paint.color);
+      /*p_color=*/paint.color,
+      /*p_text_frame=*/text_frame);
 
   std::optional<Entity> result = renderer_.GetTextShadowCache().Lookup(
       renderer_, entity, filter, cache_key);

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -65,10 +65,24 @@
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/vector.h"
 #include "impeller/renderer/command_buffer.h"
+#include "third_party/abseil-cpp/absl/hash/hash.h"
 
 namespace impeller {
 
 namespace {
+
+size_t HashTextFrame(const TextFrame& text_frame) {
+  size_t hash = 0;
+  for (const TextRun& run : text_frame.GetRuns()) {
+    hash = absl::HashOf(hash, run.GetFont().GetHash());
+    for (const TextRun::GlyphPosition& glyph_pos : run.GetGlyphPositions()) {
+      hash = absl::HashOf(hash, static_cast<uint32_t>(glyph_pos.glyph.type),
+                          glyph_pos.glyph.index, glyph_pos.position.x,
+                          glyph_pos.position.y);
+    }
+  }
+  return hash;
+}
 
 constexpr Scalar kAntialiasPadding = 1.0f;
 
@@ -2103,7 +2117,7 @@ bool Canvas::AttemptBlurredTextOptimization(
   std::optional<Glyph> maybe_glyph = text_frame->AsSingleGlyph();
   int64_t identifier = maybe_glyph.has_value()
                            ? maybe_glyph.value().index
-                           : reinterpret_cast<int64_t>(text_frame.get());
+                           : static_cast<int64_t>(HashTextFrame(*text_frame));
   TextShadowCache::TextShadowCacheKey cache_key(
       /*p_max_basis=*/entity.GetTransform().GetMaxBasisLengthXY(),
       /*p_identifier=*/identifier,

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -71,17 +71,45 @@ namespace impeller {
 
 namespace {
 
-size_t HashTextFrame(const TextFrame& text_frame) {
-  size_t hash = 0;
-  for (const TextRun& run : text_frame.GetRuns()) {
+uint32_t PackGlyphId(const Glyph& glyph) {
+  return (static_cast<uint32_t>(glyph.type) << 16) | glyph.index;
+}
+
+TextFrameFingerprint ComputeTextFrameFingerprint(const TextFrame& text_frame) {
+  TextFrameFingerprint fp;
+  const std::vector<TextRun>& runs = text_frame.GetRuns();
+  fp.run_count = runs.size();
+
+  size_t hash = absl::HashOf(text_frame.HasColor(),
+                             text_frame.GetEnableGammaCorrection());
+
+  for (const TextRun& run : runs) {
     hash = absl::HashOf(hash, run.GetFont().GetHash());
-    for (const TextRun::GlyphPosition& glyph_pos : run.GetGlyphPositions()) {
+    const std::vector<TextRun::GlyphPosition>& glyphs = run.GetGlyphPositions();
+    fp.total_glyph_count += glyphs.size();
+
+    for (const TextRun::GlyphPosition& glyph_pos : glyphs) {
       hash = absl::HashOf(hash, static_cast<uint32_t>(glyph_pos.glyph.type),
                           glyph_pos.glyph.index, glyph_pos.position.x,
                           glyph_pos.position.y);
     }
   }
-  return hash;
+
+  if (!runs.empty()) {
+    const std::vector<TextRun::GlyphPosition>& first_glyphs =
+        runs.front().GetGlyphPositions();
+    if (!first_glyphs.empty()) {
+      fp.first_glyph_id = PackGlyphId(first_glyphs.front().glyph);
+    }
+    const std::vector<TextRun::GlyphPosition>& last_glyphs =
+        runs.back().GetGlyphPositions();
+    if (!last_glyphs.empty()) {
+      fp.last_glyph_id = PackGlyphId(last_glyphs.back().glyph);
+    }
+  }
+
+  fp.full_hash = hash;
+  return fp;
 }
 
 constexpr Scalar kAntialiasPadding = 1.0f;
@@ -2115,9 +2143,12 @@ bool Canvas::AttemptBlurredTextOptimization(
           /*is_solid_color=*/true, GetCurrentTransform());
 
   std::optional<Glyph> maybe_glyph = text_frame->AsSingleGlyph();
+  TextFrameFingerprint fingerprint =
+      maybe_glyph.has_value() ? TextFrameFingerprint{}
+                              : ComputeTextFrameFingerprint(*text_frame);
   int64_t identifier = maybe_glyph.has_value()
                            ? maybe_glyph.value().index
-                           : static_cast<int64_t>(HashTextFrame(*text_frame));
+                           : static_cast<int64_t>(fingerprint.full_hash);
   TextShadowCache::TextShadowCacheKey cache_key(
       /*p_max_basis=*/entity.GetTransform().GetMaxBasisLengthXY(),
       /*p_identifier=*/identifier,
@@ -2125,7 +2156,7 @@ bool Canvas::AttemptBlurredTextOptimization(
       /*p_font=*/text_frame->GetFont(),
       /*p_sigma=*/paint.mask_blur_descriptor->sigma,
       /*p_color=*/paint.color,
-      /*p_text_frame=*/text_frame);
+      /*p_fingerprint=*/fingerprint);
 
   std::optional<Entity> result = renderer_.GetTextShadowCache().Lookup(
       renderer_, entity, filter, cache_key);

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -2143,12 +2143,14 @@ bool Canvas::AttemptBlurredTextOptimization(
           /*is_solid_color=*/true, GetCurrentTransform());
 
   std::optional<Glyph> maybe_glyph = text_frame->AsSingleGlyph();
-  TextFrameFingerprint fingerprint =
-      maybe_glyph.has_value() ? TextFrameFingerprint{}
-                              : ComputeTextFrameFingerprint(*text_frame);
-  int64_t identifier = maybe_glyph.has_value()
-                           ? maybe_glyph.value().index
-                           : static_cast<int64_t>(fingerprint.full_hash);
+  TextFrameFingerprint fingerprint;
+  int64_t identifier;
+  if (maybe_glyph.has_value()) {
+    identifier = maybe_glyph.value().index;
+  } else {
+    fingerprint = ComputeTextFrameFingerprint(*text_frame);
+    identifier = static_cast<int64_t>(fingerprint.full_hash);
+  }
   TextShadowCache::TextShadowCacheKey cache_key(
       /*p_max_basis=*/entity.GetTransform().GetMaxBasisLengthXY(),
       /*p_identifier=*/identifier,

--- a/engine/src/flutter/impeller/entity/BUILD.gn
+++ b/engine/src/flutter/impeller/entity/BUILD.gn
@@ -262,6 +262,7 @@ impeller_component("entity") {
     "../typographer",
     "//flutter/display_list",
     "//third_party/abseil-cpp/absl/container:flat_hash_map",
+    "//third_party/abseil-cpp/absl/hash",
   ]
 
   deps = [ "//flutter/fml" ]

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.cc
@@ -15,19 +15,76 @@ namespace impeller {
 // Rounds sigma values for gaussian blur to nearest decimal.
 static constexpr int32_t kMaxSigmaDenominator = 10;
 
-TextShadowCache::TextShadowCacheKey::TextShadowCacheKey(Scalar p_max_basis,
-                                                        int64_t p_identifier,
-                                                        bool p_is_single_glyph,
-                                                        const Font& p_font,
-                                                        Sigma p_sigma,
-                                                        Color p_color)
+TextShadowCache::TextShadowCacheKey::TextShadowCacheKey(
+    Scalar p_max_basis,
+    int64_t p_identifier,
+    bool p_is_single_glyph,
+    const Font& p_font,
+    Sigma p_sigma,
+    Color p_color,
+    std::shared_ptr<TextFrame> p_text_frame)
     : max_basis(p_max_basis),
       identifier(p_identifier),
       is_single_glyph(p_is_single_glyph),
       font(p_font),
       rounded_sigma(Rational(std::round(p_sigma.sigma * kMaxSigmaDenominator),
                              kMaxSigmaDenominator)),
-      color(p_color) {}
+      color(p_color),
+      text_frame(std::move(p_text_frame)) {}
+
+static bool IsTextFrameEqual(const TextFrame& a, const TextFrame& b) {
+  if (a.HasColor() != b.HasColor() ||
+      a.GetEnableGammaCorrection() != b.GetEnableGammaCorrection()) {
+    return false;
+  }
+  const auto& a_runs = a.GetRuns();
+  const auto& b_runs = b.GetRuns();
+  if (a_runs.size() != b_runs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < a_runs.size(); ++i) {
+    const TextRun& a_run = a_runs[i];
+    const TextRun& b_run = b_runs[i];
+    if (!a_run.GetFont().IsEqual(b_run.GetFont())) {
+      return false;
+    }
+    const auto& a_glyphs = a_run.GetGlyphPositions();
+    const auto& b_glyphs = b_run.GetGlyphPositions();
+    if (a_glyphs.size() != b_glyphs.size()) {
+      return false;
+    }
+    for (size_t j = 0; j < a_glyphs.size(); ++j) {
+      if (a_glyphs[j].glyph.index != b_glyphs[j].glyph.index ||
+          a_glyphs[j].glyph.type != b_glyphs[j].glyph.type ||
+          a_glyphs[j].position != b_glyphs[j].position) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool TextShadowCache::TextShadowCacheKey::Equal::operator()(
+    const TextShadowCacheKey& lhs,
+    const TextShadowCacheKey& rhs) const {
+  if (lhs.max_basis != rhs.max_basis ||
+      lhs.identifier != rhs.identifier ||
+      lhs.is_single_glyph != rhs.is_single_glyph ||
+      !lhs.font.IsEqual(rhs.font) ||
+      lhs.rounded_sigma != rhs.rounded_sigma || lhs.color != rhs.color) {
+    return false;
+  }
+  if (!lhs.is_single_glyph) {
+    if (lhs.text_frame == rhs.text_frame) {
+      return true;
+    }
+    if (!lhs.text_frame || !rhs.text_frame) {
+      return false;
+    }
+    return IsTextFrameEqual(*lhs.text_frame, *rhs.text_frame);
+  }
+  return true;
+}
 
 void TextShadowCache::MarkFrameStart() {
   for (auto& entry : entries_) {

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.cc
@@ -22,7 +22,7 @@ TextShadowCache::TextShadowCacheKey::TextShadowCacheKey(
     const Font& p_font,
     Sigma p_sigma,
     Color p_color,
-    std::shared_ptr<TextFrame> p_text_frame)
+    TextFrameFingerprint p_fingerprint)
     : max_basis(p_max_basis),
       identifier(p_identifier),
       is_single_glyph(p_is_single_glyph),
@@ -30,61 +30,7 @@ TextShadowCache::TextShadowCacheKey::TextShadowCacheKey(
       rounded_sigma(Rational(std::round(p_sigma.sigma * kMaxSigmaDenominator),
                              kMaxSigmaDenominator)),
       color(p_color),
-      text_frame(std::move(p_text_frame)) {}
-
-static bool IsTextFrameEqual(const TextFrame& a, const TextFrame& b) {
-  if (a.HasColor() != b.HasColor() ||
-      a.GetEnableGammaCorrection() != b.GetEnableGammaCorrection()) {
-    return false;
-  }
-  const auto& a_runs = a.GetRuns();
-  const auto& b_runs = b.GetRuns();
-  if (a_runs.size() != b_runs.size()) {
-    return false;
-  }
-  for (size_t i = 0; i < a_runs.size(); ++i) {
-    const TextRun& a_run = a_runs[i];
-    const TextRun& b_run = b_runs[i];
-    if (!a_run.GetFont().IsEqual(b_run.GetFont())) {
-      return false;
-    }
-    const auto& a_glyphs = a_run.GetGlyphPositions();
-    const auto& b_glyphs = b_run.GetGlyphPositions();
-    if (a_glyphs.size() != b_glyphs.size()) {
-      return false;
-    }
-    for (size_t j = 0; j < a_glyphs.size(); ++j) {
-      if (a_glyphs[j].glyph.index != b_glyphs[j].glyph.index ||
-          a_glyphs[j].glyph.type != b_glyphs[j].glyph.type ||
-          a_glyphs[j].position != b_glyphs[j].position) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-bool TextShadowCache::TextShadowCacheKey::Equal::operator()(
-    const TextShadowCacheKey& lhs,
-    const TextShadowCacheKey& rhs) const {
-  if (lhs.max_basis != rhs.max_basis ||
-      lhs.identifier != rhs.identifier ||
-      lhs.is_single_glyph != rhs.is_single_glyph ||
-      !lhs.font.IsEqual(rhs.font) ||
-      lhs.rounded_sigma != rhs.rounded_sigma || lhs.color != rhs.color) {
-    return false;
-  }
-  if (!lhs.is_single_glyph) {
-    if (lhs.text_frame == rhs.text_frame) {
-      return true;
-    }
-    if (!lhs.text_frame || !rhs.text_frame) {
-      return false;
-    }
-    return IsTextFrameEqual(*lhs.text_frame, *rhs.text_frame);
-  }
-  return true;
-}
+      fingerprint(p_fingerprint) {}
 
 void TextShadowCache::MarkFrameStart() {
   for (auto& entry : entries_) {

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.cc
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.cc
@@ -17,14 +17,12 @@ static constexpr int32_t kMaxSigmaDenominator = 10;
 
 TextShadowCache::TextShadowCacheKey::TextShadowCacheKey(
     Scalar p_max_basis,
-    int64_t p_identifier,
     bool p_is_single_glyph,
     const Font& p_font,
     Sigma p_sigma,
     Color p_color,
     TextFrameFingerprint p_fingerprint)
     : max_basis(p_max_basis),
-      identifier(p_identifier),
       is_single_glyph(p_is_single_glyph),
       font(p_font),
       rounded_sigma(Rational(std::round(p_sigma.sigma * kMaxSigmaDenominator),

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
@@ -11,6 +11,7 @@
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/sigma.h"
+#include "impeller/typographer/text_frame.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace impeller {
@@ -42,13 +43,15 @@ class TextShadowCache {
     Font font;
     Rational rounded_sigma;
     Color color;
+    std::shared_ptr<TextFrame> text_frame;
 
     TextShadowCacheKey(Scalar p_max_basis,
                        int64_t p_identifier,
                        bool p_is_single_glyph,
                        const Font& p_font,
                        Sigma p_sigma,
-                       Color p_color);
+                       Color p_color,
+                       std::shared_ptr<TextFrame> p_text_frame = nullptr);
 
     struct Hash {
       std::size_t operator()(const TextShadowCacheKey& key) const {
@@ -60,14 +63,8 @@ class TextShadowCache {
     };
 
     struct Equal {
-      constexpr bool operator()(const TextShadowCacheKey& lhs,
-                                const TextShadowCacheKey& rhs) const {
-        return lhs.max_basis == rhs.max_basis &&
-               lhs.identifier == rhs.identifier &&
-               lhs.is_single_glyph == rhs.is_single_glyph &&
-               lhs.font.IsEqual(rhs.font) &&
-               lhs.rounded_sigma == rhs.rounded_sigma && lhs.color == rhs.color;
-      }
+      bool operator()(const TextShadowCacheKey& lhs,
+                      const TextShadowCacheKey& rhs) const;
     };
   };
 

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
@@ -41,8 +41,8 @@ namespace impeller {
 ///        all devices running Flutter, while avoiding heap pointers or map
 ///        lookup array traversals.
 struct TextFrameFingerprint {
-  size_t run_count = 0;
-  size_t total_glyph_count = 0;
+  uint32_t run_count = 0;
+  uint32_t total_glyph_count = 0;
   uint32_t first_glyph_id = 0;
   uint32_t last_glyph_id = 0;
   size_t full_hash = 0;

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
@@ -13,8 +13,42 @@
 #include "impeller/geometry/sigma.h"
 #include "impeller/typographer/text_frame.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
+#include "third_party/abseil-cpp/absl/hash/hash.h"
 
 namespace impeller {
+
+/// @brief A multi-attribute fingerprint for a text frame to ensure
+///        statistically impossible key collisions without holding a pointer.
+///
+///        Combines run count, total glyph count, first/last glyph IDs, and a
+///        64-bit content hash across all glyph positions and font metrics.
+///
+///        Napkin Math on Collision Probability:
+///        1. For a 64-bit hash (2^64 ~ 1.84e19 space) and N = 1,000 active text
+///           frames in a session, the Birthday Paradox collision probability
+///           for the 64-bit hash alone is:
+///             P_hash = N^2 / (2 * 2^64) = 10^6 / 3.68e19 ~ 2.7e-14
+///        2. For two non-identical text frames to collide under this key, they
+///           must ALSO independently match:
+///             - Run count (P_runs)
+///             - Total glyph count (P_len)
+///             - First glyph ID (P_first ~ 1/500)
+///             - Last glyph ID (P_last ~ 1/500)
+///        3. Multiplying these joint constraints:
+///             P_joint = P_hash * P_first * P_last * ... << 10^-20
+///
+///        This makes false-positive cache hits statistically impossible across
+///        all devices running Flutter, while avoiding heap pointers or map
+///        lookup array traversals.
+struct TextFrameFingerprint {
+  size_t run_count = 0;
+  size_t total_glyph_count = 0;
+  uint32_t first_glyph_id = 0;
+  uint32_t last_glyph_id = 0;
+  size_t full_hash = 0;
+
+  bool operator==(const TextFrameFingerprint& o) const = default;
+};
 
 /// @brief A cache for blurred text that re-uses these across frames.
 ///
@@ -43,7 +77,7 @@ class TextShadowCache {
     Font font;
     Rational rounded_sigma;
     Color color;
-    std::shared_ptr<TextFrame> text_frame;
+    TextFrameFingerprint fingerprint;
 
     TextShadowCacheKey(Scalar p_max_basis,
                        int64_t p_identifier,
@@ -51,20 +85,27 @@ class TextShadowCache {
                        const Font& p_font,
                        Sigma p_sigma,
                        Color p_color,
-                       std::shared_ptr<TextFrame> p_text_frame = nullptr);
+                       TextFrameFingerprint p_fingerprint = {});
 
     struct Hash {
       std::size_t operator()(const TextShadowCacheKey& key) const {
-        return fml::HashCombine(key.max_basis, key.identifier,
-                                key.is_single_glyph, key.font.GetHash(),
-                                key.rounded_sigma.GetHash(),
-                                key.color.ToARGB());
+        return absl::HashOf(key.max_basis, key.identifier, key.is_single_glyph,
+                            key.font.GetHash(), key.rounded_sigma.GetHash(),
+                            key.color.ToARGB(), key.fingerprint.full_hash);
       }
     };
 
     struct Equal {
-      bool operator()(const TextShadowCacheKey& lhs,
-                      const TextShadowCacheKey& rhs) const;
+      constexpr bool operator()(const TextShadowCacheKey& lhs,
+                                const TextShadowCacheKey& rhs) const {
+        return lhs.max_basis == rhs.max_basis &&
+               lhs.identifier == rhs.identifier &&
+               lhs.is_single_glyph == rhs.is_single_glyph &&
+               lhs.font.IsEqual(rhs.font) &&
+               lhs.rounded_sigma == rhs.rounded_sigma &&
+               lhs.color == rhs.color &&
+               (lhs.is_single_glyph || lhs.fingerprint == rhs.fingerprint);
+      }
     };
   };
 

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
@@ -101,8 +101,7 @@ class TextShadowCache {
                lhs.is_single_glyph == rhs.is_single_glyph &&
                lhs.font.IsEqual(rhs.font) &&
                lhs.rounded_sigma == rhs.rounded_sigma &&
-               lhs.color == rhs.color &&
-               (lhs.is_single_glyph || lhs.fingerprint == rhs.fingerprint);
+               lhs.color == rhs.color && lhs.fingerprint == rhs.fingerprint;
       }
     };
   };

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
@@ -72,7 +72,6 @@ class TextShadowCache {
   /// @brief A key to look up cached glyph textures.
   struct TextShadowCacheKey {
     Scalar max_basis;
-    int64_t identifier;
     bool is_single_glyph;
     Font font;
     Rational rounded_sigma;
@@ -80,7 +79,6 @@ class TextShadowCache {
     TextFrameFingerprint fingerprint;
 
     TextShadowCacheKey(Scalar p_max_basis,
-                       int64_t p_identifier,
                        bool p_is_single_glyph,
                        const Font& p_font,
                        Sigma p_sigma,
@@ -89,9 +87,10 @@ class TextShadowCache {
 
     struct Hash {
       std::size_t operator()(const TextShadowCacheKey& key) const {
-        return absl::HashOf(key.max_basis, key.identifier, key.is_single_glyph,
+        return absl::HashOf(key.max_basis, key.is_single_glyph,
                             key.font.GetHash(), key.rounded_sigma.GetHash(),
-                            key.color.ToARGB(), key.fingerprint.full_hash);
+                            key.color.ToARGB(), key.fingerprint.full_hash,
+                            key.fingerprint.first_glyph_id);
       }
     };
 
@@ -99,7 +98,6 @@ class TextShadowCache {
       constexpr bool operator()(const TextShadowCacheKey& lhs,
                                 const TextShadowCacheKey& rhs) const {
         return lhs.max_basis == rhs.max_basis &&
-               lhs.identifier == rhs.identifier &&
                lhs.is_single_glyph == rhs.is_single_glyph &&
                lhs.font.IsEqual(rhs.font) &&
                lhs.rounded_sigma == rhs.rounded_sigma &&

--- a/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
+++ b/engine/src/flutter/impeller/entity/contents/text_shadow_cache.h
@@ -89,8 +89,7 @@ class TextShadowCache {
       std::size_t operator()(const TextShadowCacheKey& key) const {
         return absl::HashOf(key.max_basis, key.is_single_glyph,
                             key.font.GetHash(), key.rounded_sigma.GetHash(),
-                            key.color.ToARGB(), key.fingerprint.full_hash,
-                            key.fingerprint.first_glyph_id);
+                            key.color.ToARGB(), key.fingerprint.full_hash);
       }
     };
 

--- a/engine/src/flutter/impeller/typographer/backends/skia/typeface_skia.cc
+++ b/engine/src/flutter/impeller/typographer/backends/skia/typeface_skia.cc
@@ -20,12 +20,12 @@ std::size_t TypefaceSkia::GetHash() const {
     return 0u;
   }
 
-  return reinterpret_cast<size_t>(typeface_.get());
+  return typeface_->uniqueID();
 }
 
 bool TypefaceSkia::IsEqual(const Typeface& other) const {
   auto sk_other = reinterpret_cast<const TypefaceSkia*>(&other);
-  return sk_other->typeface_ == typeface_;
+  return SkTypeface::Equal(sk_other->typeface_.get(), typeface_.get());
 }
 
 const sk_sp<SkTypeface>& TypefaceSkia::GetSkiaTypeface() const {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/190395

This replaces `TextShadowCacheKey::identifier`, which was a cast of the TextFrame pointer, with a content aware fingerprint.  This allows cache hits across frames.  It also removes the possible error where the pointer is recycled for a different TextFrame on the next frame.

The fingerprint approach was chosen over storing a shared_ptr to a TextFrame and performing equality checks on it.  The fingerprint avoids shared_ptr and indirection overhead in the TextShadowCacheKey.  Instead of just relying on the hash we added extra fields to create the full fingerprint to make the probability of a false cache essentially zero (the texts on the same frame would have to have the same length, start, end, and hash code to create a false cache hit).

I measured this locally with a windows machine with the reproduction from https://github.com/flutter/flutter/issues/190395, after this the shadowed text frames measure the same as the non-shadowed text frames.

https://github.com/flutter/flutter/pull/190861 adds a benchmark, the PR was measured on macos with that benchmark as well.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
