### PR TITLE
[flutter_tools] Anchor package version extraction regex in Wasm dry-run

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -523,11 +523,13 @@ class Dart2WasmTarget extends Dart2WebTarget {
       final Set<String> privatePackages = {};
       for (final Package package in packageConfigPackages.packages) {
         final String packageName = package.name;
-        if (package.root.toString().contains('hosted/pub.dev')) {
-          final String? packageVersion = RegExp(
-            'hosted/pub\\.dev/${RegExp.escape(packageName)}-([0-9]+\\.[0-9]+\\.[0-9]+(?:-[\\w\\.-]+)?)',
-          ).firstMatch(package.root.toString())?.group(1);
-          hostedPackages[packageName] = packageVersion ?? '?';
+        if (package.root.pathSegments.where((String s) => s.isNotEmpty).toList() case [
+          ...,
+          'hosted',
+          _,
+          final packageFolder,
+        ] when packageFolder.startsWith('$packageName-')) {
+          hostedPackages[packageName] = packageFolder.substring(packageName.length + 1);
         } else {
           privatePackages.add(packageName);
         }

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -529,6 +529,8 @@ class Dart2WasmTarget extends Dart2WebTarget {
           _,
           final packageFolder,
         ] when packageFolder.startsWith('$packageName-')) {
+          // Hosted package directories in .pub-cache follow '<packageName>-<version>'.
+          // Substring past the package name and hyphen to extract the version.
           hostedPackages[packageName] = packageFolder.substring(packageName.length + 1);
         } else {
           privatePackages.add(packageName);

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -525,7 +525,7 @@ class Dart2WasmTarget extends Dart2WebTarget {
         final String packageName = package.name;
         if (package.root.toString().contains('hosted/pub.dev')) {
           final String? packageVersion = RegExp(
-            r'([0-9]+\.[0-9]+\.[0-9]+(?:-[\w\.-]+)?)',
+            'hosted/pub\\.dev/${RegExp.escape(packageName)}-([0-9]+\\.[0-9]+\\.[0-9]+(?:-[\\w\\.-]+)?)',
           ).firstMatch(package.root.toString())?.group(1);
           hostedPackages[packageName] = packageVersion ?? '?';
         } else {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
@@ -611,4 +611,80 @@ package:foo/some/path.dart 6:1 - dart:html unsupported (0)
       expect(event.eventData['E0'], 'foo:1.0.0');
     }),
   );
+
+  test(
+    'wasm dry run extracts package version from custom pub mirrors',
+    () => testbed.run(() async {
+      writePackageConfigFiles(
+        directory: fs.currentDirectory,
+        packages: {
+          'foo': 'file:///opt/flutter/3.22.0/.pub-cache/hosted/pub.flutter-io.cn/foo-1.0.0/',
+        },
+        mainLibName: 'my_app',
+      );
+
+      processManager.addCommand(
+        FakeCommand(
+          command: commandArgs,
+          exitCode: 254,
+          stdout: '''
+Found incompatibilities with WebAssembly.
+
+package:foo/some/path.dart 6:1 - dart:html unsupported (0)
+''',
+        ),
+      );
+      final Dart2WasmTarget target = createTarget();
+      await target.build(environment);
+
+      expect(fakeAnalytics.sentEvents, hasLength(1));
+
+      final Event event = fakeAnalytics.sentEvents[0];
+      expect(event.eventName, equals(DashEvent.flutterWasmDryRunPackage));
+      expect(event.eventData, hasLength(3));
+      expect(event.eventData['result'], 'findings');
+      expect(event.eventData['exitCode'], 254);
+      expect(event.eventData['E0'], 'foo:1.0.0');
+    }),
+  );
+
+  test(
+    'wasm dry run extracts package versions across multiple distinct hosted domains',
+    () => testbed.run(() async {
+      writePackageConfigFiles(
+        directory: fs.currentDirectory,
+        packages: {
+          'foo': 'file:///pubcache/.pub-cache/hosted/pub.dev/foo-1.0.0',
+          'bar': 'file:///pubcache/.pub-cache/hosted/pub.flutter-io.cn/bar-2.0.0',
+          'baz': 'file:///pubcache/.pub-cache/hosted/custom.repo.org%47/baz-3.0.0/',
+        },
+        mainLibName: 'my_app',
+      );
+
+      processManager.addCommand(
+        FakeCommand(
+          command: commandArgs,
+          exitCode: 254,
+          stdout: '''
+Found incompatibilities with WebAssembly.
+
+package:foo/some/path.dart 6:1 - dart:html unsupported (0)
+package:bar/some/path.dart 8:1 - dart:html unsupported (0)
+package:baz/some/path.dart 10:1 - dart:html unsupported (0)
+''',
+        ),
+      );
+      final Dart2WasmTarget target = createTarget();
+      await target.build(environment);
+
+      expect(fakeAnalytics.sentEvents, hasLength(1));
+
+      final Event event = fakeAnalytics.sentEvents[0];
+      expect(event.eventName, equals(DashEvent.flutterWasmDryRunPackage));
+      expect(event.eventData, hasLength(3));
+      expect(event.eventData['result'], 'findings');
+      expect(event.eventData['exitCode'], 254);
+      expect(event.eventData['E0'], 'baz:3.0.0,bar:2.0.0,foo:1.0.0');
+    }),
+  );
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_dry_run_test.dart
@@ -578,4 +578,37 @@ package:morelong/some/path.dart 9:20 - dart:html unsupported (0)
       expect(event.eventData['E0'], 'foo:${_fakePackageVersions['foo']}');
     }),
   );
+  test(
+    'wasm dry run extracts correct package version when ancestor directory contains numbers',
+    () => testbed.run(() async {
+      writePackageConfigFiles(
+        directory: fs.currentDirectory,
+        packages: {'foo': 'file:///opt/flutter/3.22.0/.pub-cache/hosted/pub.dev/foo-1.0.0'},
+        mainLibName: 'my_app',
+      );
+
+      processManager.addCommand(
+        FakeCommand(
+          command: commandArgs,
+          exitCode: 254,
+          stdout: '''
+Found incompatibilities with WebAssembly.
+
+package:foo/some/path.dart 6:1 - dart:html unsupported (0)
+''',
+        ),
+      );
+      final Dart2WasmTarget target = createTarget();
+      await target.build(environment);
+
+      expect(fakeAnalytics.sentEvents, hasLength(1));
+
+      final Event event = fakeAnalytics.sentEvents[0];
+      expect(event.eventName, equals(DashEvent.flutterWasmDryRunPackage));
+      expect(event.eventData, hasLength(3));
+      expect(event.eventData['result'], 'findings');
+      expect(event.eventData['exitCode'], 254);
+      expect(event.eventData['E0'], 'foo:1.0.0');
+    }),
+  );
 }


### PR DESCRIPTION
Anchor the Wasm dry-run package version regex to `hosted/pub.dev/<package_name>-` so that version-like numbers in ancestor directories (e.g. Flutter SDK version paths like `/flutter/3.22.0/`) are not matched as the package version.

Fixes https://github.com/flutter/flutter/issues/190644
