### PR TITLE
iOS: Remove the non-merged thread topology

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -205,7 +205,6 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   FlutterTextureRegistryRelay* _textureRegistry;
 
   FlutterFMLTaskRunner* _platformTaskRunnerWrapper;
-  FlutterFMLTaskRunner* _uiTaskRunnerWrapper;
   FlutterFMLTaskRunner* _rasterTaskRunnerWrapper;
 }
 
@@ -456,7 +455,8 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 }
 
 - (FlutterFMLTaskRunner*)uiTaskRunner {
-  return _uiTaskRunnerWrapper;
+  // The platform and UI threads are always merged on iOS.
+  return _platformTaskRunnerWrapper;
 }
 
 - (FlutterFMLTaskRunner*)rasterTaskRunner {
@@ -582,7 +582,6 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   _threadHost.reset();
   _platformViewsController = nil;
   _platformTaskRunnerWrapper = nil;
-  _uiTaskRunnerWrapper = nil;
   _rasterTaskRunnerWrapper = nil;
 }
 
@@ -806,8 +805,6 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   _shell = std::move(shell);
   _platformTaskRunnerWrapper = [[FlutterFMLTaskRunner alloc]
       initWithTaskRunner:_shell->GetTaskRunners().GetPlatformTaskRunner()];
-  _uiTaskRunnerWrapper =
-      [[FlutterFMLTaskRunner alloc] initWithTaskRunner:_shell->GetTaskRunners().GetUITaskRunner()];
   _rasterTaskRunnerWrapper = [[FlutterFMLTaskRunner alloc]
       initWithTaskRunner:_shell->GetTaskRunners().GetRasterTaskRunner()];
 
@@ -835,16 +832,14 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   return [NSString stringWithFormat:@"%@.%zu", labelPrefix, ++s_shellCount];
 }
 
-static flutter::ThreadHost MakeThreadHost(NSString* thread_label,
-                                          const flutter::Settings& settings) {
+static flutter::ThreadHost MakeThreadHost(NSString* thread_label) {
   // The current thread will be used as the platform thread. Ensure that the message loop is
   // initialized.
   fml::MessageLoop::EnsureInitializedForCurrentThread();
 
+  // No dedicated UI thread is created: on iOS the UI thread is always merged onto the platform
+  // thread. FlutterDartProject rejects any other threading configuration at startup.
   uint32_t threadHostType = flutter::ThreadHost::Type::kRaster | flutter::ThreadHost::Type::kIo;
-  if (settings.merged_platform_ui_thread != flutter::Settings::MergedPlatformUIThread::kEnabled) {
-    threadHostType |= flutter::ThreadHost::Type::kUi;
-  }
 
   if ([FlutterEngine isProfilerEnabled]) {
     threadHostType = threadHostType | flutter::ThreadHost::Type::kProfiler;
@@ -853,10 +848,6 @@ static flutter::ThreadHost MakeThreadHost(NSString* thread_label,
   flutter::ThreadHost::ThreadHostConfig host_config(thread_label.UTF8String, threadHostType,
                                                     IOSPlatformThreadConfigSetter);
 
-  host_config.ui_config =
-      fml::Thread::ThreadConfig(flutter::ThreadHost::ThreadHostConfig::MakeThreadName(
-                                    flutter::ThreadHost::Type::kUi, thread_label.UTF8String),
-                                fml::Thread::ThreadPriority::kDisplay);
   host_config.raster_config =
       fml::Thread::ThreadConfig(flutter::ThreadHost::ThreadHostConfig::MakeThreadName(
                                     flutter::ThreadHost::Type::kRaster, thread_label.UTF8String),
@@ -907,7 +898,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 
   NSString* threadLabel = [FlutterEngine generateThreadLabel:self.labelPrefix];
   _threadHost = std::make_shared<flutter::ThreadHost>();
-  *_threadHost = MakeThreadHost(threadLabel, settings);
+  *_threadHost = MakeThreadHost(threadLabel);
 
   __weak FlutterEngine* weakSelf = self;
   flutter::Shell::CreateCallback<flutter::PlatformView> on_create_platform_view =
@@ -927,18 +918,14 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   flutter::Shell::CreateCallback<flutter::Rasterizer> on_create_rasterizer =
       [](flutter::Shell& shell) { return std::make_unique<flutter::Rasterizer>(shell); };
 
-  fml::RefPtr<fml::TaskRunner> ui_runner;
-  if (settings.enable_impeller &&
-      settings.merged_platform_ui_thread == flutter::Settings::MergedPlatformUIThread::kEnabled) {
-    ui_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
-  } else {
-    ui_runner = _threadHost->ui_thread->GetTaskRunner();
-  }
-  flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
-                                    fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
-                                    _threadHost->raster_thread->GetTaskRunner(),     // raster
-                                    ui_runner,                                       // ui
-                                    _threadHost->io_thread->GetTaskRunner()          // io
+  // The platform and UI threads are always merged on iOS, so the UI task runner is the platform
+  // thread's task runner.
+  fml::RefPtr<fml::TaskRunner> platform_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+  flutter::TaskRunners task_runners(threadLabel.UTF8String,                       // label
+                                    platform_runner,                              // platform
+                                    _threadHost->raster_thread->GetTaskRunner(),  // raster
+                                    platform_runner,                              // ui
+                                    _threadHost->io_thread->GetTaskRunner()       // io
   );
 
   // Disable GPU if the app or scene is running in the background.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -580,19 +580,6 @@ FLUTTER_ASSERT_ARC
 #endif  // defined(TARGET_IPHONE_SIMULATOR) && TARGET_IPHONE_SIMULATOR
 }
 
-- (void)testCanUnMergePlatformAndUIThread {
-#if defined(TARGET_IPHONE_SIMULATOR) && TARGET_IPHONE_SIMULATOR
-  auto settings = FLTDefaultSettingsForBundle();
-  settings.merged_platform_ui_thread = flutter::Settings::MergedPlatformUIThread::kDisabled;
-  FlutterDartProject* project = [[FlutterDartProject alloc] initWithSettings:settings];
-  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
-  [engine run];
-
-  XCTAssertNotEqual(engine.shell.GetTaskRunners().GetUITaskRunner(),
-                    engine.shell.GetTaskRunners().GetPlatformTaskRunner());
-#endif  // defined(TARGET_IPHONE_SIMULATOR) && TARGET_IPHONE_SIMULATOR
-}
-
 - (void)testAddSceneDelegateToRegistrar {
   FlutterDartProject* project = [[FlutterDartProject alloc] init];
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"engine" project:project];


### PR DESCRIPTION
iOS runs with the platform and UI threads merged, and it's not possible to create an engine with unmerged platform/ui threads, but `FlutterEngine` still included branches to create the unmerged threads when `Settings::merged_platform_ui_thread` wasn't enabled.

The option to opt-out of merged threads on iOS was removed in #174408 in Aug 2025, and it had been the default configuration for over a year at that point.

Both existing routes to a non-merged thread configuration already failed at startup:

* Setting `FLTEnableMergedPlatformUIThread=false` in Info.plist causes an `FML_CHECK` in `FlutterDartProject.mm` to blow up.
* Setting `--no-enable-merged-platform-ui-thread` or `--merged-platform-ui-thread=disabled` results in them being parsed into Settings::merged_platform_ui_thread in `SettingsFromCommandLine`, and triggers the same `FML_CHECK`.

The only route that didn't trigger an abort() on startup was `-[FlutterDartProject initWithSettings:]`, which is declared in `FlutterDartProject_Internal.h` and isn't part of the framework's public API.

This also removes the last place the iOS embedder checked `Settings::enable_impeller`. Now it's simply assumed.

This is part of cleanup work intended to simplify the iOS embedder prior to an eventual migration to the embedder API.

Issue: https://github.com/flutter/flutter/issues/112232

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
