### PR TITLE
fix(bottom_sheet): fix dismissal near minimum extent when shouldCloseOnMinExtent

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -323,7 +323,8 @@ class _BottomSheetState extends State<BottomSheet> {
   }
 
   bool extentChanged(DraggableScrollableNotification notification) {
-    if (notification.extent == notification.minExtent && notification.shouldCloseOnMinExtent) {
+    if ((notification.extent - notification.minExtent).abs() < precisionErrorTolerance &&
+        notification.shouldCloseOnMinExtent) {
       widget.onClosing();
     }
     return false;

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -3402,7 +3402,7 @@ class _StandardBottomSheetState extends State<_StandardBottomSheet> {
       scaffold.showBodyScrim(false, 0.0);
     }
     // If the Scaffold.bottomSheet != null, we're a persistent bottom sheet.
-    if (notification.extent == notification.minExtent &&
+    if ((notification.extent - notification.minExtent).abs() < precisionErrorTolerance &&
         scaffold.widget.bottomSheet == null &&
         notification.shouldCloseOnMinExtent) {
       close();

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -732,6 +732,43 @@ void main() {
     expect(find.text('BottomSheet'), findsNothing);
   });
 
+  testWidgets('Standard BottomSheet closes when its extent is nearly its minimum', (
+    WidgetTester tester,
+  ) async {
+    final scaffoldKey = GlobalKey<ScaffoldState>();
+    late BuildContext notificationContext;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          key: scaffoldKey,
+          body: const Center(child: Text('body')),
+        ),
+      ),
+    );
+
+    scaffoldKey.currentState!.showBottomSheet((BuildContext context) {
+      return Builder(
+        builder: (BuildContext context) {
+          notificationContext = context;
+          return const Text('BottomSheet');
+        },
+      );
+    });
+    await tester.pumpAndSettle();
+
+    DraggableScrollableNotification(
+      extent: 0.20000000001,
+      minExtent: 0.2,
+      maxExtent: 1.0,
+      initialExtent: 0.5,
+      context: notificationContext,
+    ).dispatch(notificationContext);
+    await tester.pumpAndSettle();
+
+    expect(find.text('BottomSheet'), findsNothing);
+  });
+
   testWidgets('modal BottomSheet has no top MediaQuery', (WidgetTester tester) async {
     late BuildContext outerContext;
     late BuildContext innerContext;
@@ -1033,6 +1070,46 @@ void main() {
       find.descendant(of: find.byType(BottomSheet), matching: find.byType(Material)),
     );
     expect(material.shadowColor, Colors.transparent);
+  });
+
+  testWidgets('Modal BottomSheet closes when its extent is nearly its minimum', (
+    WidgetTester tester,
+  ) async {
+    final scaffoldKey = GlobalKey<ScaffoldState>();
+    late BuildContext notificationContext;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          key: scaffoldKey,
+          body: const Center(child: Text('body')),
+        ),
+      ),
+    );
+
+    showModalBottomSheet<void>(
+      context: scaffoldKey.currentContext!,
+      builder: (BuildContext context) {
+        return Builder(
+          builder: (BuildContext context) {
+            notificationContext = context;
+            return const Text('BottomSheet');
+          },
+        );
+      },
+    );
+    await tester.pumpAndSettle();
+
+    DraggableScrollableNotification(
+      extent: 0.20000000001,
+      minExtent: 0.2,
+      maxExtent: 1.0,
+      initialExtent: 0.5,
+      context: notificationContext,
+    ).dispatch(notificationContext);
+    await tester.pumpAndSettle();
+
+    expect(find.text('BottomSheet'), findsNothing);
   });
 
   testWidgets('Material2 - Modal BottomSheet with ScrollController has semantics', (


### PR DESCRIPTION
Fixes bottom sheet dismissal when a `DraggableScrollableNotification` extent
is within floating-point precision of `minExtent`, rather than exactly equal.

Updates both `BottomSheet` and `Scaffold` notification handlers and adds
regression tests for modal and standard bottom sheets using
`extent: 0.20000000001` with `minExtent: 0.2`.

## Tests

* `bin/flutter test packages/flutter/test/material/bottom_sheet_test.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.