### PR TITLE
Only check clipboard status while an EditableText is focused

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -63,6 +63,7 @@ import 'text_editing_intents.dart';
 import 'text_selection.dart';
 import 'text_selection_toolbar_anchors.dart';
 import 'ticker_provider.dart';
+import 'transitions.dart';
 import 'undo_history.dart';
 import 'view.dart';
 import 'widget_span.dart';
@@ -2549,6 +2550,38 @@ class EditableTextState extends State<EditableText>
       ? _WebClipboardStatusNotifier()
       : ClipboardStatusNotifier();
 
+  // Whether this state is currently listening to [clipboardStatus].
+  //
+  // The clipboard status is only used to decide whether to advertise a paste
+  // action, which only happens while the field has focus and can be pasted
+  // into. Listening lazily avoids probing the clipboard (which can surface
+  // platform privacy notices) when a text field is merely built or when the
+  // app resumes while the field is not focused.
+  bool _listeningToClipboardStatus = false;
+
+  bool get _shouldListenToClipboardStatus =>
+      _hasFocus && widget.selectionEnabled && !widget.readOnly;
+
+  void _updateClipboardStatusListening() {
+    if (_shouldListenToClipboardStatus == _listeningToClipboardStatus) {
+      return;
+    }
+    if (_shouldListenToClipboardStatus) {
+      _listeningToClipboardStatus = true;
+      // Adding the first listener checks the clipboard if the status is still
+      // unknown. If a previous status is already cached, refresh it explicitly
+      // since the clipboard may have changed while the field was not focused.
+      final wasUnknown = clipboardStatus.value == ClipboardStatus.unknown;
+      clipboardStatus.addListener(_onChangedClipboardStatus);
+      if (!wasUnknown) {
+        clipboardStatus.update();
+      }
+    } else {
+      _listeningToClipboardStatus = false;
+      clipboardStatus.removeListener(_onChangedClipboardStatus);
+    }
+  }
+
   /// Detects whether the Live Text input is enabled.
   ///
   /// See also:
@@ -3333,9 +3366,9 @@ class EditableTextState extends State<EditableText>
   void initState() {
     super.initState();
     _liveTextInputStatus?.addListener(_onChangedLiveTextInputStatus);
-    clipboardStatus.addListener(_onChangedClipboardStatus);
     widget.controller.addListener(_didChangeTextEditingValue);
     widget.focusNode.addListener(_handleFocusChanged);
+    _updateClipboardStatusListening();
     _cursorVisibilityNotifier.value = widget.showCursor;
     _spellCheckConfiguration = _inferSpellCheckConfiguration(
       widget.spellCheckConfiguration,
@@ -3594,10 +3627,11 @@ class EditableTextState extends State<EditableText>
     if (widget.showCursor != oldWidget.showCursor) {
       _startOrStopCursorTimerIfNeeded();
     }
+    _updateClipboardStatusListening();
     final bool canPaste = widget.selectionControls is TextSelectionHandleControls
         ? pasteEnabled
         : widget.selectionControls?.canPaste(this) ?? false;
-    if (widget.selectionEnabled && pasteEnabled && canPaste) {
+    if (_listeningToClipboardStatus && pasteEnabled && canPaste) {
       clipboardStatus.update();
     }
   }
@@ -4489,7 +4523,13 @@ class EditableTextState extends State<EditableText>
   // the TextSelectionOverlay means the overlay never has to be recreated when
   // only the builder closure changes.
   Widget _contextMenuBuilder(BuildContext context) {
-    return widget.contextMenuBuilder!(context, this);
+    // The clipboard status may still be resolving when the menu is first
+    // shown, since it is only checked once the field is focused. Rebuild the
+    // menu when the status changes so the paste button reflects the result.
+    return ListenableBuilder(
+      listenable: clipboardStatus,
+      builder: (BuildContext context, Widget? _) => widget.contextMenuBuilder!(context, this),
+    );
   }
 
   TextSelectionOverlay _createSelectionOverlay() {
@@ -4965,6 +5005,7 @@ class EditableTextState extends State<EditableText>
     _openOrCloseInputConnectionIfNeeded();
     _startOrStopCursorTimerIfNeeded();
     _updateOrDisposeSelectionOverlayIfNeeded();
+    _updateClipboardStatusListening();
     if (_hasFocus) {
       // Listen for changing viewInsets, which indicates keyboard showing up.
       WidgetsBinding.instance.addObserver(this);

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -8,6 +8,7 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
+import 'dart:async';
 import 'dart:convert' show jsonDecode;
 import 'dart:math' as math;
 import 'dart:ui';
@@ -17961,9 +17962,11 @@ void main() {
         ),
       );
 
-      expect(calls, equals(kIsWeb ? 0 : 1));
+      // Building an unfocused field does not check the clipboard.
+      expect(calls, 0);
 
-      // Long-press to bring up the context menu.
+      // Long-press to bring up the context menu. This focuses the field, which
+      // checks the clipboard once, and showing the toolbar checks it again.
       final Finder textFinder = find.byType(EditableText);
       await tester.longPress(textFinder);
       tester.state<EditableTextState>(textFinder).showToolbar();
@@ -17971,6 +17974,139 @@ void main() {
 
       expect(calls, equals(kIsWeb ? 0 : 2));
     });
+
+    Widget buildField({bool readOnly = false, bool enableInteractiveSelection = true}) {
+      return MaterialApp(
+        home: EditableText(
+          backgroundCursorColor: Colors.grey,
+          controller: controller,
+          focusNode: focusNode,
+          readOnly: readOnly,
+          enableInteractiveSelection: enableInteractiveSelection,
+          style: textStyle,
+          cursorColor: cursorColor,
+          selectionControls: materialTextSelectionHandleControls,
+          contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
+            return AdaptiveTextSelectionToolbar.editableText(editableTextState: editableTextState);
+          },
+        ),
+      );
+    }
+
+    testWidgets(
+      'the clipboard is not checked on build or app resume while unfocused',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildField());
+        expect(calls, 0);
+
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pump();
+        expect(calls, 0);
+
+        // Rebuilding the field does not check the clipboard either.
+        await tester.pumpWidget(buildField());
+        expect(calls, 0);
+      },
+      skip: kIsWeb, // [intended] web never calls hasStrings.
+    );
+
+    testWidgets(
+      'the clipboard is checked when the field gains focus',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildField());
+        expect(calls, 0);
+
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(calls, 1);
+
+        // Resuming while focused refreshes the status.
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pump();
+        expect(calls, 2);
+
+        // Once unfocused, resuming no longer checks the clipboard.
+        focusNode.unfocus();
+        await tester.pump();
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pump();
+        expect(calls, 2);
+
+        // Focusing again refreshes the cached status.
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(calls, 3);
+      },
+      skip: kIsWeb, // [intended] web never calls hasStrings.
+    );
+
+    testWidgets(
+      'the clipboard is not checked when paste is not possible',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildField(readOnly: true));
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(calls, 0);
+
+        await tester.pumpWidget(buildField(enableInteractiveSelection: false));
+        await tester.pump();
+        expect(calls, 0);
+
+        // Becoming editable and selectable while focused checks the clipboard.
+        await tester.pumpWidget(buildField());
+        await tester.pump();
+        expect(calls, 1);
+      },
+      skip: kIsWeb, // [intended] web never calls hasStrings.
+    );
+
+    testWidgets(
+      'the context menu shows paste once a pending clipboard check resolves',
+      (WidgetTester tester) async {
+        final pending = <Completer<Object?>>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          (MethodCall methodCall) {
+            if (methodCall.method == 'Clipboard.hasStrings') {
+              final completer = Completer<Object?>();
+              pending.add(completer);
+              return completer.future;
+            }
+            return Future<Object?>.value();
+          },
+        );
+        controller.text = 'Atwater Peel Sherbrooke Bonaventure';
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: TextField(controller: controller, focusNode: focusNode),
+            ),
+          ),
+        );
+        expect(pending, isEmpty);
+
+        // Long pressing an unfocused field focuses it and shows the menu in the
+        // same gesture, so the clipboard check is still in flight when the
+        // menu is first built.
+        await tester.longPress(find.byType(TextField));
+        await tester.pump();
+        expect(pending, isNotEmpty);
+        expect(find.text('Copy'), findsOneWidget);
+        expect(find.text('Paste'), findsNothing);
+
+        for (final completer in pending) {
+          completer.complete(<String, dynamic>{'value': true});
+        }
+        await tester.pumpAndSettle();
+        expect(find.text('Copy'), findsOneWidget);
+        expect(find.text('Paste'), findsOneWidget);
+      },
+      skip: kIsWeb, // [intended] web never calls hasStrings.
+      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}),
+    );
   });
 
   testWidgets('Cursor color with an opacity is respected', (WidgetTester tester) async {


### PR DESCRIPTION
`EditableTextState` adds its `ClipboardStatusNotifier` listener in `initState`, which calls `Clipboard.hasStrings()` as soon as a text field is built and again every time the app resumes. `didUpdateWidget` also refreshes the status on every rebuild once the clipboard is known to be pasteable. On Android this shows up as frequent clipboard access without any user intent (see #190654).

The clipboard status is only used to decide whether to advertise a paste action (the toolbar button and `SemanticsAction.paste`), and both of those only exist while the field has focus and paste is possible. This PR makes `EditableText` listen to the notifier only while it is focused, editable and has interactive selection enabled, refreshing the status when focus is gained:

- Building an unfocused field no longer calls `hasStrings`.
- App resume no longer calls `hasStrings` for unfocused fields (the notifier only observes the lifecycle while it has listeners).
- Rebuilds only refresh the status for the focused field.
- Read-only and `enableInteractiveSelection: false` fields never touch the clipboard.

Because the first check may still be in flight when the context menu is shown (e.g. a long press on an unfocused field focuses it and opens the menu in the same gesture), the context menu is wrapped in a `ListenableBuilder` on the notifier so the paste button appears once the status resolves.

The paste button is still only shown when the clipboard has pasteable content, `SemanticsAction.paste` behavior is unchanged, and the web path (`_WebClipboardStatusNotifier`) is untouched. No Material or Cupertino tests needed changes.

Tests added to `editable_text_test.dart` cover: no clipboard access on build or on resume while unfocused, exactly one check on focus and a refresh on re-focus, no access for read-only / non-selectable fields, and the context menu picking up a pending clipboard check.

Fixes #190654

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
