### PR TITLE
[flutter_tools] Use JSON_INPUT COMPILE_EXPRESSION for expression evaluation

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -1079,25 +1079,25 @@ class DefaultResidentCompiler implements ResidentCompiler {
       return null;
     }
 
-    final String inputKey = const Uuid().v4();
     server.stdin
-      ..writeln('compile-expression $inputKey')
-      ..writeln(request.expression);
-    request.definitions?.forEach(server.stdin.writeln);
-    server.stdin.writeln(inputKey);
-    request.definitionTypes?.forEach(server.stdin.writeln);
-    server.stdin.writeln(inputKey);
-    request.typeDefinitions?.forEach(server.stdin.writeln);
-    server.stdin.writeln(inputKey);
-    request.typeBounds?.forEach(server.stdin.writeln);
-    server.stdin.writeln(inputKey);
-    request.typeDefaults?.forEach(server.stdin.writeln);
-    server.stdin
-      ..writeln(inputKey)
-      ..writeln(request.libraryUri ?? '')
-      ..writeln(request.klass ?? '')
-      ..writeln(request.method ?? '')
-      ..writeln(request.isStatic);
+      ..writeln('JSON_INPUT')
+      ..writeln(
+        json.encode(<String, Object?>{
+          'type': 'COMPILE_EXPRESSION',
+          'data': <String, Object?>{
+            'expression': request.expression,
+            'definitions': request.definitions ?? <String>[],
+            'definitionTypes': request.definitionTypes ?? <String>[],
+            'typeDefinitions': request.typeDefinitions ?? <String>[],
+            'typeBounds': request.typeBounds ?? <String>[],
+            'typeDefaults': request.typeDefaults ?? <String>[],
+            'libraryUri': request.libraryUri ?? '',
+            'class': request.klass,
+            'method': request.method,
+            'static': request.isStatic,
+          },
+        }),
+      );
 
     return _stdoutHandler.compilerOutput?.future;
   }

--- a/packages/flutter_tools/test/general.shard/compile_expression_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_expression_test.dart
@@ -70,51 +70,148 @@ void main() {
   });
 
   testWithoutContext('compile expression can compile single expression', () async {
-    final compileResponseCompleter = Completer<List<int>>();
-    final compileExpressionResponseCompleter = Completer<List<int>>();
+    final stdoutController = StreamController<List<int>>();
+    processManager.process.stdout = stdoutController.stream;
+
     fileSystem.file('/path/to/main.dart.dill')
       ..createSync(recursive: true)
       ..writeAsBytesSync(<int>[1, 2, 3, 4]);
 
-    processManager.process.stdout = Stream<List<int>>.fromFutures(<Future<List<int>>>[
-      compileResponseCompleter.future,
-      compileExpressionResponseCompleter.future,
-    ]);
-    compileResponseCompleter.complete(
-      Future<List<int>>.value(
-        utf8.encode('result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n'),
-      ),
+    final Future<CompilerOutput?> compileFuture = generator.recompile(
+      Uri.file('/path/to/main.dart'),
+      null,
+      /* invalidatedFiles */
+      outputPath: '/build/',
+      packageConfig: PackageConfig.empty,
+      projectRootPath: '',
+      fs: fileSystem,
     );
+    stdoutController.add(
+      utf8.encode('result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n'),
+    );
+    final CompilerOutput? output = await compileFuture;
+    expect(frontendServerStdIn.getAndClear(), 'compile file:///path/to/main.dart\n');
+    expect(testLogger.errorText, equals('line1\nline2\n'));
+    expect(output!.outputFilename, equals('/path/to/main.dart.dill'));
 
-    await generator
-        .recompile(
-          Uri.file('/path/to/main.dart'),
-          null,
-          /* invalidatedFiles */
-          outputPath: '/build/',
-          packageConfig: PackageConfig.empty,
-          projectRootPath: '',
-          fs: fileSystem,
-        )
-        .then((CompilerOutput? output) {
-          expect(frontendServerStdIn.getAndClear(), 'compile file:///path/to/main.dart\n');
-          expect(testLogger.errorText, equals('line1\nline2\n'));
-          expect(output!.outputFilename, equals('/path/to/main.dart.dill'));
+    fileSystem.file('/path/to/main.dart.dill.incremental')
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(<int>[1, 2, 3, 4]);
 
-          compileExpressionResponseCompleter.complete(
-            Future<List<int>>.value(
-              utf8.encode(
-                'result def\nline1\nline2\ndef\ndef /path/to/main.dart.dill.incremental 0\n',
-              ),
-            ),
-          );
-          generator
-              .compileExpression('2+2', null, null, null, null, null, null, null, null, false)
-              .then((CompilerOutput? outputExpression) {
-                expect(outputExpression, isNotNull);
-                expect(outputExpression!.expressionData, <int>[1, 2, 3, 4]);
-              });
-        });
+    final Future<CompilerOutput?> expressionFuture = generator.compileExpression(
+      '2+2',
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+    );
+    stdoutController.add(
+      utf8.encode('result def\nline1\nline2\ndef /path/to/main.dart.dill.incremental 0\n'),
+    );
+    final CompilerOutput? outputExpression = await expressionFuture;
+    expect(outputExpression, isNotNull);
+    expect(outputExpression!.expressionData, <int>[1, 2, 3, 4]);
+
+    final List<String> stdinLines = frontendServerStdIn.getAndClear().trim().split('\n');
+    expect(stdinLines, hasLength(2));
+    expect(stdinLines[0], 'JSON_INPUT');
+    expect(
+      json.decode(stdinLines[1]),
+      <String, Object?>{
+        'type': 'COMPILE_EXPRESSION',
+        'data': <String, Object?>{
+          'expression': '2+2',
+          'definitions': <String>[],
+          'definitionTypes': <String>[],
+          'typeDefinitions': <String>[],
+          'typeBounds': <String>[],
+          'typeDefaults': <String>[],
+          'libraryUri': '',
+          'class': null,
+          'method': null,
+          'static': false,
+        },
+      },
+    );
+    await stdoutController.close();
+  });
+
+  testWithoutContext('compile expression sends JSON_INPUT for multiline expressions', () async {
+    final stdoutController = StreamController<List<int>>();
+    processManager.process.stdout = stdoutController.stream;
+
+    fileSystem.file('/path/to/main.dart.dill')
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(<int>[1, 2, 3, 4]);
+    fileSystem.file('/path/to/main.dart.dill.incremental')
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(<int>[1, 2, 3, 4]);
+
+    final Future<CompilerOutput?> compileFuture = generator.recompile(
+      Uri.file('/path/to/main.dart'),
+      null,
+      /* invalidatedFiles */
+      outputPath: '/build/',
+      packageConfig: PackageConfig.empty,
+      projectRootPath: '',
+      fs: fileSystem,
+    );
+    stdoutController.add(
+      utf8.encode('result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n'),
+    );
+    final CompilerOutput? output = await compileFuture;
+    expect(frontendServerStdIn.getAndClear(), 'compile file:///path/to/main.dart\n');
+    expect(testLogger.errorText, equals('line1\nline2\n'));
+    expect(output!.outputFilename, equals('/path/to/main.dart.dill'));
+
+    const multilineExpression = 'final a = 1;\nfinal b = 2;\na + b;';
+    final Future<CompilerOutput?> expressionFuture = generator.compileExpression(
+      multilineExpression,
+      <String>['def1'],
+      <String>['int'],
+      <String>['TypeDef1'],
+      <String>['TypeBound1'],
+      <String>['TypeDefault1'],
+      'package:foo/foo.dart',
+      'FooClass',
+      'fooMethod',
+      false,
+    );
+    stdoutController.add(
+      utf8.encode('result def\nline1\nline2\ndef /path/to/main.dart.dill.incremental 0\n'),
+    );
+    final CompilerOutput? outputExpression = await expressionFuture;
+
+    expect(outputExpression, isNotNull);
+    expect(outputExpression!.expressionData, <int>[1, 2, 3, 4]);
+
+    final List<String> stdinLines = frontendServerStdIn.getAndClear().trim().split('\n');
+    expect(stdinLines, hasLength(2));
+    expect(stdinLines[0], 'JSON_INPUT');
+    expect(
+      json.decode(stdinLines[1]),
+      <String, Object?>{
+        'type': 'COMPILE_EXPRESSION',
+        'data': <String, Object?>{
+          'expression': multilineExpression,
+          'definitions': <String>['def1'],
+          'definitionTypes': <String>['int'],
+          'typeDefinitions': <String>['TypeDef1'],
+          'typeBounds': <String>['TypeBound1'],
+          'typeDefaults': <String>['TypeDefault1'],
+          'libraryUri': 'package:foo/foo.dart',
+          'class': 'FooClass',
+          'method': 'fooMethod',
+          'static': false,
+        },
+      },
+    );
+    await stdoutController.close();
   });
 
   testWithoutContext('compile expressions without awaiting', () async {


### PR DESCRIPTION
## Description

When evaluating expressions in Flutter debug sessions, `DefaultResidentCompiler._compileExpression` was communicating with `frontend_server` using the legacy line-delimited protocol (`compile-expression <boundaryKey>`). Because `frontend_server`'s state machine transitions out of expression parsing upon receiving the first newline character, multi-line expressions had only their first line evaluated, with subsequent lines misread as variable definitions.

This PR updates `DefaultResidentCompiler._compileExpression` in `packages/flutter_tools/lib/src/compile.dart` to use the structured `JSON_INPUT` protocol with `'type': 'COMPILE_EXPRESSION'` (mirroring `COMPILE_EXPRESSION_JS` in `_compileExpressionToJs`), safely encoding multi-line expressions and scope definitions into a single JSON payload.

## Fixes

Fixes https://github.com/flutter/flutter/issues/55731

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md