### PR TITLE
[tool] Define modular dependency injection containers and bootstrapper

### DIFF
--- a/packages/flutter_tools/lib/src/context/android_context.dart
+++ b/packages/flutter_tools/lib/src/context/android_context.dart
@@ -1,0 +1,30 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../android/android_sdk.dart';
+import '../android/android_studio.dart';
+import '../android/gradle_utils.dart';
+import '../android/java.dart';
+
+/// Holds Android-specific dependencies.
+class AndroidContext {
+  AndroidContext({
+    required this.androidSdk,
+    required this.androidStudio,
+    required this.gradleUtils,
+    required this.java,
+  });
+
+  /// Discovers, validates, and manages the local Android SDK and platform tools.
+  final AndroidSdk? androidSdk;
+
+  /// Discovers and inspects local Android Studio installations and embedded JDK paths.
+  final AndroidStudio? androidStudio;
+
+  /// Utility helpers for interacting with Gradle builds and resolving project configs.
+  final GradleUtils gradleUtils;
+
+  /// Discovers and validates the active Java Development Kit (JDK) binary.
+  final Java? java;
+}

--- a/packages/flutter_tools/lib/src/context/apple_context.dart
+++ b/packages/flutter_tools/lib/src/context/apple_context.dart
@@ -1,0 +1,50 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../ios/ios_workflow.dart';
+import '../ios/plist_parser.dart';
+import '../ios/simulators.dart';
+import '../ios/xcodeproj.dart';
+import '../macos/cocoapods.dart';
+import '../macos/cocoapods_validator.dart';
+import '../macos/xcdevice.dart';
+import '../macos/xcode.dart';
+
+/// Holds Apple-specific dependencies.
+class AppleContext {
+  AppleContext({
+    required this.cocoaPods,
+    required this.cocoapodsValidator,
+    required this.iosSimulatorUtils,
+    required this.iosWorkflow,
+    required this.plistParser,
+    required this.xcdevice,
+    required this.xcode,
+    required this.xcodeProjectInterpreter,
+  });
+
+  /// Interacts with and executes CocoaPods dependency management commands.
+  final CocoaPods cocoaPods;
+
+  /// Validates the host CocoaPods installation health and doctor status.
+  final CocoaPodsValidator cocoapodsValidator;
+
+  /// Manages discovery, booting, and queries for iOS simulator devices.
+  final IOSSimulatorUtils iosSimulatorUtils;
+
+  /// Evaluates host readiness and toolchain requirements for iOS workflows.
+  final IOSWorkflow iosWorkflow;
+
+  /// Parses Apple Property List (`.plist`) XML and binary format files.
+  final PlistParser plistParser;
+
+  /// Discovers and interacts with physical iOS devices attached to the host.
+  final XCDevice xcdevice;
+
+  /// Inspects and validates the host Xcode installation and SDK version compliance.
+  final Xcode xcode;
+
+  /// Evaluates Xcode project settings, schemes, and target configurations.
+  final XcodeProjectInterpreter xcodeProjectInterpreter;
+}

--- a/packages/flutter_tools/lib/src/context/tool_context.dart
+++ b/packages/flutter_tools/lib/src/context/tool_context.dart
@@ -1,0 +1,132 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:process/process.dart';
+
+import '../artifacts.dart';
+import '../base/bot_detector.dart';
+import '../base/config.dart';
+import '../base/file_system.dart';
+import '../base/io.dart';
+import '../base/logger.dart';
+import '../base/os.dart';
+import '../base/platform.dart';
+import '../base/process.dart';
+import '../base/signals.dart';
+import '../base/terminal.dart';
+import '../base/time.dart';
+import '../base/user_messages.dart';
+import '../cache.dart';
+import '../custom_devices/custom_devices_config.dart';
+import '../git.dart';
+import '../native_assets.dart';
+import '../pre_run_validator.dart';
+import '../project.dart';
+import '../runner/local_engine.dart';
+import '../version.dart';
+
+/// Holds core, platform-independent dependencies.
+class ToolContext {
+  ToolContext({
+    required this.artifacts,
+    required this.botDetector,
+    required this.cache,
+    required this.config,
+    required this.customDevicesConfig,
+    required this.flutterVersion,
+    required this.fs,
+    required this.git,
+    required this.localEngineLocator,
+    required this.logger,
+    this.nativeAssetsBuilder,
+    required this.os,
+    required this.outputPreferences,
+    required this.platform,
+    required this.preRunValidator,
+    required this.processManager,
+    required this.processUtils,
+    required this.projectFactory,
+    required this.shutdownHooks,
+    required this.signals,
+    required this.stdio,
+    required this.systemClock,
+    required this.terminal,
+    required this.userMessages,
+  });
+
+  /// Cached and host-specific binary artifacts.
+  final Artifacts artifacts;
+
+  /// Detects whether the tool is running in a CI or automated bot environment.
+  final BotDetector botDetector;
+
+  /// Manages cached SDK artifacts, binary downloads, and directory structures.
+  final Cache cache;
+
+  /// Reads and writes user and persistent global configuration settings.
+  final Config config;
+
+  /// Manages user-configured custom device definitions stored on disk.
+  final CustomDevicesConfig customDevicesConfig;
+
+  /// Provides version and git channel info for the current Flutter SDK.
+  final FlutterVersion flutterVersion;
+
+  /// Provides mockable file system operations across host and virtual environments.
+  final FileSystem fs;
+
+  /// Wraps host `git` operations, tracking repository state and branch revisions.
+  final Git git;
+
+  /// Locates local engine builds specified via command-line flags.
+  final LocalEngineLocator localEngineLocator;
+
+  /// Formats and emits console status, trace, warning, and error logs.
+  final Logger logger;
+
+  /// Builds and packages native C/C++ or Rust assets for compilation and tests.
+  final TestCompilerNativeAssetsBuilder? nativeAssetsBuilder;
+
+  /// Operating system utilities and environment queries.
+  final OperatingSystemUtils os;
+
+  /// Manages formatting preferences for console output, such as line wrapping width.
+  final OutputPreferences outputPreferences;
+
+  /// Provides host operating system details and environment variables.
+  final Platform platform;
+
+  /// Validates environment prerequisites and file permissions before command execution.
+  final PreRunValidator preRunValidator;
+
+  /// Spawns and manages external host processes.
+  final ProcessManager processManager;
+
+  /// Utility helpers for executing processes, error handling, and stream capturing.
+  final ProcessUtils processUtils;
+
+  /// Instantiates and caches [FlutterProject] instances for project directories.
+  final FlutterProjectFactory projectFactory;
+
+  /// Manages lifecycle callbacks executed upon tool termination or interrupt signals.
+  final ShutdownHooks shutdownHooks;
+
+  /// Intercepts and dispatches process signals.
+  final Signals signals;
+
+  /// Provides standard I/O streams (`stdin`, `stdout`, `stderr`).
+  final Stdio stdio;
+
+  /// Provides mockable system time interfaces for timed operations.
+  final SystemClock systemClock;
+
+  /// Formats terminal text output, colorization, and ANSI terminal capabilities.
+  final AnsiTerminal terminal;
+
+  /// Centralized templates for user-facing status strings and error messages.
+  final UserMessages userMessages;
+
+  /// Common file system utilities.
+  FileSystemUtils get fileSystemUtils => FileSystemUtils(fileSystem: fs, platform: platform);
+}

--- a/packages/flutter_tools/lib/src/context/tool_dependencies.dart
+++ b/packages/flutter_tools/lib/src/context/tool_dependencies.dart
@@ -39,7 +39,6 @@ import '../ios/iproxy.dart';
 import '../ios/plist_parser.dart';
 import '../ios/simulators.dart';
 import '../ios/xcodeproj.dart';
-import '../isolated/build_targets.dart';
 import '../macos/cocoapods.dart';
 import '../macos/cocoapods_validator.dart';
 import '../macos/xcdevice.dart';
@@ -63,7 +62,7 @@ class ToolDependencies {
     required this.androidContext,
     required this.appleContext,
     required this.buildSystem,
-    required this.buildTargets,
+    this.buildTargets,
     required this.crashReporter,
     required this.toolContext,
   });
@@ -81,7 +80,7 @@ class ToolDependencies {
   final BuildSystem buildSystem;
 
   /// Factory interface for constructing compile and bundle build targets.
-  final BuildTargets buildTargets;
+  final BuildTargets? buildTargets;
 
   /// Captures and submits unhandled tool crash reports and stack traces.
   final CrashReporter crashReporter;
@@ -275,7 +274,7 @@ class ToolDependencies {
         buildSystem ??
         FlutterBuildSystem(fileSystem: finalFS, logger: finalLogger, platform: finalPlatform);
 
-    final BuildTargets finalBuildTargets = buildTargets ?? const BuildTargetsImpl();
+    final finalBuildTargets = buildTargets;
 
     final CrashReporter finalCrashReporter =
         crashReporter ??

--- a/packages/flutter_tools/lib/src/context/tool_dependencies.dart
+++ b/packages/flutter_tools/lib/src/context/tool_dependencies.dart
@@ -1,0 +1,478 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:process/process.dart';
+import 'package:unified_analytics/unified_analytics.dart';
+
+import '../android/android_sdk.dart';
+import '../android/android_studio.dart';
+import '../android/gradle_utils.dart';
+import '../android/java.dart';
+import '../artifacts.dart';
+import '../base/bot_detector.dart';
+import '../base/config.dart';
+import '../base/error_handling_io.dart';
+import '../base/file_system.dart';
+import '../base/io.dart';
+import '../base/logger.dart';
+import '../base/os.dart';
+import '../base/platform.dart';
+import '../base/process.dart';
+import '../base/signals.dart';
+import '../base/terminal.dart';
+import '../base/time.dart';
+import '../base/user_messages.dart';
+import '../build_system/build_system.dart';
+import '../build_system/build_targets.dart';
+import '../cache.dart';
+import '../custom_devices/custom_devices_config.dart';
+import '../flutter_cache.dart';
+import '../flutter_features.dart';
+import '../flutter_features_config.dart';
+import '../flutter_manifest.dart';
+import '../git.dart';
+import '../ios/ios_workflow.dart';
+import '../ios/iproxy.dart';
+import '../ios/plist_parser.dart';
+import '../ios/simulators.dart';
+import '../ios/xcodeproj.dart';
+import '../isolated/build_targets.dart';
+import '../macos/cocoapods.dart';
+import '../macos/cocoapods_validator.dart';
+import '../macos/xcdevice.dart';
+import '../macos/xcode.dart';
+import '../native_assets.dart';
+import '../persistent_tool_state.dart';
+import '../pre_run_validator.dart';
+import '../project.dart';
+import '../reporting/crash_reporting.dart';
+import '../reporting/unified_analytics.dart';
+import '../runner/local_engine.dart';
+import '../version.dart';
+import 'android_context.dart';
+import 'apple_context.dart';
+import 'tool_context.dart';
+
+/// Bootstraps and manages tool dependencies.
+class ToolDependencies {
+  ToolDependencies({
+    required this.analytics,
+    required this.androidContext,
+    required this.appleContext,
+    required this.buildSystem,
+    required this.buildTargets,
+    required this.crashReporter,
+    required this.toolContext,
+  });
+
+  /// Telemetry and analytics reporter for command and feature usage.
+  final Analytics analytics;
+
+  /// Sub-context containing Android-specific platform services.
+  final AndroidContext androidContext;
+
+  /// Sub-context containing Apple platform services.
+  final AppleContext appleContext;
+
+  /// High-performance compilation and build pipeline orchestrator.
+  final BuildSystem buildSystem;
+
+  /// Factory interface for constructing compile and bundle build targets.
+  final BuildTargets buildTargets;
+
+  /// Captures and submits unhandled tool crash reports and stack traces.
+  final CrashReporter crashReporter;
+
+  /// Core container holding host environment and SDK configuration dependencies.
+  final ToolContext toolContext;
+
+  /// Bootstraps the dependency graph and constructs all three contexts.
+  static Future<ToolDependencies> bootstrap({
+    Analytics? analytics,
+    AndroidSdk? androidSdk,
+    AndroidStudio? androidStudio,
+    BotDetector? botDetector,
+    BuildSystem? buildSystem,
+    BuildTargets? buildTargets,
+    Cache? cache,
+    CocoaPods? cocoaPods,
+    CocoaPodsValidator? cocoapodsValidator,
+    Config? config,
+    CrashReporter? crashReporter,
+    CustomDevicesConfig? customDevicesConfig,
+    FileSystem? fs,
+    Git? git,
+    GradleUtils? gradleUtils,
+    IOSSimulatorUtils? iosSimulatorUtils,
+    IOSWorkflow? iosWorkflow,
+    Java? java,
+    LocalEngineLocator? localEngineLocator,
+    Logger? logger,
+    TestCompilerNativeAssetsBuilder? nativeAssetsBuilder,
+    OutputPreferences? outputPreferences,
+    PersistentToolState? persistentToolState,
+    Platform? platform,
+    PlistParser? plistParser,
+    PreRunValidator? preRunValidator,
+    ProcessManager? processManager,
+    FlutterVersion? flutterVersion,
+    FlutterProjectFactory? projectFactory,
+    ShutdownHooks? shutdownHooks,
+    Stdio? stdio,
+    SystemClock? systemClock,
+    AnsiTerminal? terminal,
+    UserMessages? userMessages,
+    XCDevice? xcdevice,
+    Xcode? xcode,
+    XcodeProjectInterpreter? xcodeProjectInterpreter,
+  }) async {
+    // 1. Core Platform Inputs
+    final Platform finalPlatform = platform ?? const LocalPlatform();
+    final SystemClock finalSystemClock = systemClock ?? const SystemClock();
+    final UserMessages finalUserMessages = userMessages ?? UserMessages();
+    final ShutdownHooks finalShutdownHooks = shutdownHooks ?? ShutdownHooks();
+    final Stdio finalStdio = stdio ?? Stdio();
+
+    // 2. Terminal and Preferences
+    final AnsiTerminal finalTerminal =
+        terminal ??
+        AnsiTerminal(
+          stdio: finalStdio,
+          platform: finalPlatform,
+          now: DateTime.now(),
+          shutdownHooks: finalShutdownHooks,
+        );
+
+    final OutputPreferences finalOutputPreferences =
+        outputPreferences ??
+        OutputPreferences(
+          wrapText: finalStdio.hasTerminal,
+          showColor: finalPlatform.stdoutSupportsAnsi,
+          stdio: finalStdio,
+        );
+
+    // 3. Logger
+    final Logger finalLogger =
+        logger ??
+        (finalPlatform.isWindows
+            ? WindowsStdoutLogger(
+                terminal: finalTerminal,
+                stdio: finalStdio,
+                outputPreferences: finalOutputPreferences,
+              )
+            : StdoutLogger(
+                terminal: finalTerminal,
+                stdio: finalStdio,
+                outputPreferences: finalOutputPreferences,
+              ));
+
+    // 4. File System
+    final finalFS = fs == null
+        ? ErrorHandlingFileSystem(
+            delegate: LocalFileSystem(
+              LocalSignals.instance,
+              Signals.defaultExitSignals,
+              shutdownHooks ?? ShutdownHooks(),
+            ),
+            platform: finalPlatform,
+          )
+        : ErrorHandlingFileSystem(delegate: fs, platform: finalPlatform);
+
+    // 5. Bot Detector and Config
+    final PersistentToolState finalPersistentToolState =
+        persistentToolState ??
+        PersistentToolState(fileSystem: finalFS, logger: finalLogger, platform: finalPlatform);
+
+    final BotDetector finalBotDetector =
+        botDetector ??
+        BotDetector(
+          httpClientFactory: () => HttpClient(),
+          platform: finalPlatform,
+          persistentToolState: finalPersistentToolState,
+        );
+
+    final bool isBot = await finalBotDetector.isRunningOnBot;
+
+    final Config finalConfig =
+        config ??
+        Config(
+          Config.kFlutterSettings,
+          fileSystem: finalFS,
+          logger: finalLogger,
+          platform: finalPlatform,
+        );
+
+    // 6. Process Management & Git (resolving cycle via lazy analytics closure)
+    var finalAnalyticsInitialized = false;
+    late final Analytics finalAnalytics;
+
+    final finalProcessManager = ErrorHandlingProcessManager(
+      delegate: processManager ?? const LocalProcessManager(),
+      platform: finalPlatform,
+      analytics: () => finalAnalyticsInitialized ? finalAnalytics : const NoOpAnalytics(),
+    );
+
+    final finalProcessUtils = ProcessUtils(
+      processManager: finalProcessManager,
+      logger: finalLogger,
+    );
+
+    final Git finalGit =
+        git ?? Git(currentPlatform: finalPlatform, runProcessWith: finalProcessUtils);
+
+    // 7. Flutter Version and Cache
+    final String flutterRoot =
+        Cache.flutterRoot ??
+        Cache.defaultFlutterRoot(
+          platform: finalPlatform,
+          fileSystem: finalFS,
+          userMessages: finalUserMessages,
+        );
+    Cache.flutterRoot ??= flutterRoot;
+
+    final FlutterVersion finalFlutterVersion =
+        flutterVersion ?? FlutterVersion(fs: finalFS, flutterRoot: flutterRoot, git: finalGit);
+
+    // 8. Analytics
+    finalAnalytics =
+        analytics ??
+        getAnalytics(
+          runningOnBot: isBot,
+          flutterVersion: finalFlutterVersion,
+          environment: finalPlatform.environment,
+          clientIde: finalPlatform.environment['FLUTTER_HOST'],
+          config: finalConfig,
+        );
+    finalAnalyticsInitialized = true;
+
+    // 9. Project Factory and Operating System Utilities
+    final FlutterProjectFactory finalProjectFactory =
+        projectFactory ?? FlutterProjectFactory(logger: finalLogger, fileSystem: finalFS);
+
+    final finalOS = OperatingSystemUtils(
+      fileSystem: finalFS,
+      logger: finalLogger,
+      platform: finalPlatform,
+      processManager: finalProcessManager,
+    );
+
+    final Cache finalCache =
+        cache ??
+        FlutterCache(
+          fileSystem: finalFS,
+          logger: finalLogger,
+          platform: finalPlatform,
+          osUtils: finalOS,
+          projectFactory: finalProjectFactory,
+          stdio: finalStdio,
+        );
+
+    // 10. Remaining ToolContext Dependencies
+    final BuildSystem finalBuildSystem =
+        buildSystem ??
+        FlutterBuildSystem(fileSystem: finalFS, logger: finalLogger, platform: finalPlatform);
+
+    final BuildTargets finalBuildTargets = buildTargets ?? const BuildTargetsImpl();
+
+    final CrashReporter finalCrashReporter =
+        crashReporter ??
+        CrashReporter(
+          fileSystem: finalFS,
+          logger: finalLogger,
+          flutterProjectFactory: finalProjectFactory,
+        );
+
+    final CustomDevicesConfig finalCustomDevicesConfig =
+        customDevicesConfig ??
+        CustomDevicesConfig(fileSystem: finalFS, logger: finalLogger, platform: finalPlatform);
+
+    final PreRunValidator finalPreRunValidator =
+        preRunValidator ?? PreRunValidator(fileSystem: finalFS);
+
+    final LocalEngineLocator finalLocalEngineLocator =
+        localEngineLocator ??
+        LocalEngineLocator(
+          userMessages: finalUserMessages,
+          logger: finalLogger,
+          platform: finalPlatform,
+          fileSystem: finalFS,
+          flutterRoot: flutterRoot,
+        );
+
+    final finalNativeAssetsBuilder = nativeAssetsBuilder;
+
+    // 11. AppleContext Dependencies
+    final XcodeProjectInterpreter finalXcodeProjectInterpreter =
+        xcodeProjectInterpreter ??
+        XcodeProjectInterpreter(
+          platform: finalPlatform,
+          processManager: finalProcessManager,
+          logger: finalLogger,
+          fileSystem: finalFS,
+          analytics: finalAnalytics,
+        );
+
+    final Xcode finalXcode =
+        xcode ??
+        Xcode(
+          platform: finalPlatform,
+          processManager: finalProcessManager,
+          logger: finalLogger,
+          fileSystem: finalFS,
+          xcodeProjectInterpreter: finalXcodeProjectInterpreter,
+          userMessages: finalUserMessages,
+        );
+
+    final CocoaPods finalCocoaPods =
+        cocoaPods ??
+        CocoaPods(
+          fileSystem: finalFS,
+          processManager: finalProcessManager,
+          logger: finalLogger,
+          platform: finalPlatform,
+          xcodeProjectInterpreter: finalXcodeProjectInterpreter,
+          analytics: finalAnalytics,
+        );
+
+    final CocoaPodsValidator finalCocoapodsValidator =
+        cocoapodsValidator ?? CocoaPodsValidator(finalCocoaPods, finalUserMessages);
+
+    final finalArtifacts = CachedArtifacts(
+      fileSystem: finalFS,
+      cache: finalCache,
+      platform: finalPlatform,
+      operatingSystemUtils: finalOS,
+    );
+
+    final XCDevice finalXCDevice =
+        xcdevice ??
+        XCDevice(
+          processManager: finalProcessManager,
+          logger: finalLogger,
+          artifacts: finalArtifacts,
+          cache: finalCache,
+          platform: finalPlatform,
+          xcode: finalXcode,
+          iproxy: IProxy(
+            iproxyPath: finalArtifacts.getHostArtifact(HostArtifact.iproxy).path,
+            logger: finalLogger,
+            processManager: finalProcessManager,
+            dyLdLibEntry: finalCache.dyLdLibEntry,
+          ),
+          fileSystem: finalFS,
+          analytics: finalAnalytics,
+          shutdownHooks: finalShutdownHooks,
+        );
+
+    final String projectRoot = findProjectRoot(finalFS) ?? finalFS.currentDirectory.path;
+    final FlutterManifest? projectManifest = FlutterManifest.createFromPath(
+      finalFS.path.join(projectRoot, 'pubspec.yaml'),
+      fileSystem: finalFS,
+      logger: finalLogger,
+    );
+
+    final featureFlags = FlutterFeatureFlags(
+      flutterVersion: finalFlutterVersion,
+      featuresConfig: FlutterFeaturesConfig(
+        globalConfig: finalConfig,
+        platform: finalPlatform,
+        projectManifest: projectManifest,
+      ),
+      platform: finalPlatform,
+    );
+
+    final IOSWorkflow finalIOSWorkflow =
+        iosWorkflow ??
+        IOSWorkflow(featureFlags: featureFlags, xcode: finalXcode, platform: finalPlatform);
+
+    final IOSSimulatorUtils finalIOSSimulatorUtils =
+        iosSimulatorUtils ??
+        IOSSimulatorUtils(
+          logger: finalLogger,
+          operatingSystemUtils: finalOS,
+          processManager: finalProcessManager,
+          xcode: finalXcode,
+        );
+
+    final PlistParser finalPlistParser =
+        plistParser ??
+        PlistParser(fileSystem: finalFS, processManager: finalProcessManager, logger: finalLogger);
+
+    // 12. AndroidContext Dependencies
+    final AndroidStudio? finalAndroidStudio = androidStudio ?? AndroidStudio.latestValid();
+
+    final AndroidSdk? finalAndroidSdk = androidSdk ?? AndroidSdk.locateAndroidSdk();
+
+    final Java? finalJava =
+        java ??
+        Java.find(
+          config: finalConfig,
+          androidStudio: finalAndroidStudio,
+          logger: finalLogger,
+          fileSystem: finalFS,
+          platform: finalPlatform,
+          processManager: finalProcessManager,
+        );
+
+    final GradleUtils finalGradleUtils =
+        gradleUtils ??
+        GradleUtils(
+          platform: finalPlatform,
+          logger: finalLogger,
+          cache: finalCache,
+          operatingSystemUtils: finalOS,
+        );
+
+    return ToolDependencies(
+      analytics: finalAnalytics,
+      androidContext: AndroidContext(
+        androidSdk: finalAndroidSdk,
+        androidStudio: finalAndroidStudio,
+        gradleUtils: finalGradleUtils,
+        java: finalJava,
+      ),
+      appleContext: AppleContext(
+        cocoaPods: finalCocoaPods,
+        cocoapodsValidator: finalCocoapodsValidator,
+        iosSimulatorUtils: finalIOSSimulatorUtils,
+        iosWorkflow: finalIOSWorkflow,
+        plistParser: finalPlistParser,
+        xcdevice: finalXCDevice,
+        xcode: finalXcode,
+        xcodeProjectInterpreter: finalXcodeProjectInterpreter,
+      ),
+      buildSystem: finalBuildSystem,
+      buildTargets: finalBuildTargets,
+      crashReporter: finalCrashReporter,
+      toolContext: ToolContext(
+        artifacts: finalArtifacts,
+        botDetector: finalBotDetector,
+        cache: finalCache,
+        config: finalConfig,
+        customDevicesConfig: finalCustomDevicesConfig,
+        flutterVersion: finalFlutterVersion,
+        fs: finalFS,
+        git: finalGit,
+        localEngineLocator: finalLocalEngineLocator,
+        logger: finalLogger,
+        nativeAssetsBuilder: finalNativeAssetsBuilder,
+        os: finalOS,
+        outputPreferences: finalOutputPreferences,
+        platform: finalPlatform,
+        preRunValidator: finalPreRunValidator,
+        processManager: finalProcessManager,
+        processUtils: finalProcessUtils,
+        projectFactory: finalProjectFactory,
+        shutdownHooks: finalShutdownHooks,
+        signals: LocalSignals.instance,
+        stdio: finalStdio,
+        systemClock: finalSystemClock,
+        terminal: finalTerminal,
+        userMessages: finalUserMessages,
+      ),
+    );
+  }
+}

--- a/packages/flutter_tools/lib/src/context/tool_dependencies.dart
+++ b/packages/flutter_tools/lib/src/context/tool_dependencies.dart
@@ -142,7 +142,7 @@ class ToolDependencies {
         AnsiTerminal(
           stdio: finalStdio,
           platform: finalPlatform,
-          now: DateTime.now(),
+          now: finalSystemClock.now(),
           shutdownHooks: finalShutdownHooks,
         );
 
@@ -175,7 +175,7 @@ class ToolDependencies {
             delegate: LocalFileSystem(
               LocalSignals.instance,
               Signals.defaultExitSignals,
-              shutdownHooks ?? ShutdownHooks(),
+              finalShutdownHooks,
             ),
             platform: finalPlatform,
           )

--- a/packages/flutter_tools/test/general.shard/context/dependency_injection_test.dart
+++ b/packages/flutter_tools/test/general.shard/context/dependency_injection_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/android/android_studio.dart';
 import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_system/build_targets.dart';
 import 'package:flutter_tools/src/context/tool_dependencies.dart';
 import 'package:test/fake.dart';
 import 'package:test/test.dart';
@@ -21,6 +22,8 @@ class FakeAndroidStudio extends Fake implements AndroidStudio {
   @override
   String? get javaPath => null;
 }
+
+class FakeBuildTargets extends Fake implements BuildTargets {}
 
 void main() {
   group('ToolDependencies.bootstrap', () {
@@ -72,7 +75,7 @@ void main() {
       expect(dependencies.analytics, isNotNull);
       expect(dependencies.toolContext.botDetector, isNotNull);
       expect(dependencies.buildSystem, isNotNull);
-      expect(dependencies.buildTargets, isNotNull);
+      expect(dependencies.buildTargets, isNull);
       expect(dependencies.crashReporter, isNotNull);
       expect(dependencies.toolContext.cache, isNotNull);
       expect(dependencies.toolContext.config, isNotNull);
@@ -114,6 +117,20 @@ void main() {
 
       expect(dependencies.androidContext.androidSdk, same(mockSdk));
       expect(dependencies.androidContext.androidStudio, same(mockStudio));
+    });
+
+    testUsingContext('respects explicit overrides for BuildTargets', () async {
+      final mockBuildTargets = FakeBuildTargets();
+
+      final ToolDependencies dependencies = await ToolDependencies.bootstrap(
+        buildTargets: mockBuildTargets,
+        fs: fs,
+        logger: logger,
+        platform: platform,
+        processManager: processManager,
+      );
+
+      expect(dependencies.buildTargets, same(mockBuildTargets));
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/context/dependency_injection_test.dart
+++ b/packages/flutter_tools/test/general.shard/context/dependency_injection_test.dart
@@ -1,0 +1,119 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/android/android_sdk.dart';
+import 'package:flutter_tools/src/android/android_studio.dart';
+import 'package:flutter_tools/src/base/error_handling_io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/context/tool_dependencies.dart';
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+class FakeAndroidSdk extends Fake implements AndroidSdk {}
+
+class FakeAndroidStudio extends Fake implements AndroidStudio {
+  @override
+  String? get javaPath => null;
+}
+
+void main() {
+  group('ToolDependencies.bootstrap', () {
+    late MemoryFileSystem fs;
+    late BufferLogger logger;
+    late FakePlatform platform;
+    late FakeProcessManager processManager;
+
+    setUp(() {
+      fs = MemoryFileSystem.test();
+      logger = BufferLogger.test();
+      platform = FakePlatform(
+        environment: <String, String>{'FLUTTER_ROOT': '/flutter', 'HOME': '/home/user'},
+      );
+      processManager = FakeProcessManager.any();
+
+      // Create flutter root directory and pubspec.yaml to avoid exceptions during bootstrapping
+      fs.directory('/flutter/packages/flutter_tools').createSync(recursive: true);
+      fs.file('/pubspec.yaml').createSync();
+    });
+
+    testUsingContext('successfully bootstraps all contexts with core overrides', () async {
+      // Set up mock Android SDK directory to verify eager location works with overridden FS
+      fs.directory('/home/user/Android/Sdk/licenses').createSync(recursive: true);
+
+      final ToolDependencies dependencies = await ToolDependencies.bootstrap(
+        fs: fs,
+        logger: logger,
+        platform: platform,
+        processManager: processManager,
+      );
+
+      expect(dependencies.toolContext, isNotNull);
+      expect(dependencies.appleContext, isNotNull);
+      expect(dependencies.androidContext, isNotNull);
+
+      // Verify that core overrides were correctly propagated
+      fs.file('/test_override.txt').writeAsStringSync('propagated');
+      expect(
+        dependencies.toolContext.fs.file('/test_override.txt').readAsStringSync(),
+        'propagated',
+      );
+
+      expect(dependencies.toolContext.logger, same(logger));
+      expect(dependencies.toolContext.platform, same(platform));
+      expect(dependencies.toolContext.processManager, isA<ErrorHandlingProcessManager>());
+
+      // Verify that other platform-independent dependencies are constructed
+      expect(dependencies.analytics, isNotNull);
+      expect(dependencies.toolContext.botDetector, isNotNull);
+      expect(dependencies.buildSystem, isNotNull);
+      expect(dependencies.buildTargets, isNotNull);
+      expect(dependencies.crashReporter, isNotNull);
+      expect(dependencies.toolContext.cache, isNotNull);
+      expect(dependencies.toolContext.config, isNotNull);
+      expect(dependencies.toolContext.git, isNotNull);
+      expect(dependencies.toolContext.processUtils, isNotNull);
+      expect(dependencies.toolContext.projectFactory, isNotNull);
+      expect(dependencies.toolContext.shutdownHooks, isNotNull);
+      expect(dependencies.toolContext.stdio, isNotNull);
+      expect(dependencies.toolContext.systemClock, isNotNull);
+      expect(dependencies.toolContext.terminal, isNotNull);
+      expect(dependencies.toolContext.userMessages, isNotNull);
+
+      // Verify AppleContext (eagerly constructed even on Linux)
+      expect(dependencies.appleContext.cocoaPods, isNotNull);
+      expect(dependencies.appleContext.cocoapodsValidator, isNotNull);
+      expect(dependencies.appleContext.iosSimulatorUtils, isNotNull);
+      expect(dependencies.appleContext.iosWorkflow, isNotNull);
+      expect(dependencies.appleContext.plistParser, isNotNull);
+      expect(dependencies.appleContext.xcdevice, isNotNull);
+      expect(dependencies.appleContext.xcode, isNotNull);
+      expect(dependencies.appleContext.xcodeProjectInterpreter, isNotNull);
+
+      // Verify AndroidContext
+      expect(dependencies.androidContext.gradleUtils, isNotNull);
+    });
+
+    testUsingContext('respects explicit overrides for Android SDK and Studio', () async {
+      final mockSdk = FakeAndroidSdk();
+      final mockStudio = FakeAndroidStudio();
+
+      final ToolDependencies dependencies = await ToolDependencies.bootstrap(
+        androidSdk: mockSdk,
+        androidStudio: mockStudio,
+        fs: fs,
+        logger: logger,
+        platform: platform,
+        processManager: processManager,
+      );
+
+      expect(dependencies.androidContext.androidSdk, same(mockSdk));
+      expect(dependencies.androidContext.androidStudio, same(mockStudio));
+    });
+  });
+}

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -6,8 +6,10 @@ import 'dart:async';
 import 'dart:io' as io show IOSink, ProcessSignal, Stdout, StdoutException;
 
 import 'package:dds/dds_launcher.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/android_studio.dart';
+import 'package:flutter_tools/src/android/gradle_utils.dart';
 import 'package:flutter_tools/src/android/java.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/bot_detector.dart';
@@ -16,22 +18,47 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/base/time.dart';
+import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/base/version.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/build_system/build_targets.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/context/android_context.dart';
+import 'package:flutter_tools/src/context/apple_context.dart';
+import 'package:flutter_tools/src/context/tool_context.dart';
+import 'package:flutter_tools/src/context/tool_dependencies.dart';
 import 'package:flutter_tools/src/convert.dart';
+import 'package:flutter_tools/src/custom_devices/custom_devices_config.dart';
 import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/git.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/ios/ios_workflow.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
+import 'package:flutter_tools/src/ios/simulators.dart';
+import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/macos/cocoapods.dart';
+import 'package:flutter_tools/src/macos/cocoapods_validator.dart';
+import 'package:flutter_tools/src/macos/xcdevice.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
+import 'package:flutter_tools/src/native_assets.dart';
+import 'package:flutter_tools/src/pre_run_validator.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/reporting/crash_reporting.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
+import 'package:flutter_tools/src/runner/local_engine.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
-/// Environment with DYLD_LIBRARY_PATH=/path/to/libraries
+import 'context.dart';
+
 class FakeDyldEnvironmentArtifact extends ArtifactSet {
   FakeDyldEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
   @override
@@ -919,7 +946,33 @@ class ClosedStdinController extends Fake implements StreamSink<List<int>> {
   }
 }
 
-class FakeConfig extends Fake implements Config {}
+class FakeConfig extends Fake implements Config {
+  FakeConfig([Map<String, Object?>? values, this.configPath = '/.flutter_settings'])
+    : _values = values ?? <String, Object?>{};
+  final Map<String, Object?> _values;
+
+  @override
+  final String configPath;
+
+  @override
+  Object? getValue(String key) => _values[key];
+
+  @override
+  void setValue(String key, Object value) {
+    _values[key] = value;
+  }
+
+  @override
+  void removeValue(String key) {
+    _values.remove(key);
+  }
+
+  @override
+  bool containsKey(String key) => _values.containsKey(key);
+
+  @override
+  Iterable<String> get keys => _values.keys;
+}
 
 class FakeFileSystemUtils extends Fake implements FileSystemUtils {}
 
@@ -929,8 +982,553 @@ class FakeProcessUtils extends Fake implements ProcessUtils {}
 
 class FakeTemplateRenderer extends Fake implements TemplateRenderer {}
 
-class FakeXcode extends Fake implements Xcode {}
+class FakeXcode extends Fake implements Xcode {
+  FakeXcode({this.currentVersion, this.isDevicectlInstalled = true});
 
-class FakeArtifacts extends Fake implements Artifacts {}
+  @override
+  Version? currentVersion;
 
-class FakeCache extends Fake implements Cache {}
+  @override
+  bool isDevicectlInstalled;
+
+  @override
+  Future<String> sdkLocation(EnvironmentType environmentType) async => '/fake/sdk/path';
+
+  @override
+  List<String> xcrunCommand() => <String>['xcrun'];
+}
+
+class FakeArtifacts extends Fake implements Artifacts {
+  FakeArtifacts({FileSystem? fileSystem}) : _delegate = Artifacts.test(fileSystem: fileSystem);
+
+  final Artifacts _delegate;
+
+  @override
+  LocalEngineInfo? get localEngineInfo => _delegate.localEngineInfo;
+
+  @override
+  bool get usesLocalArtifacts => _delegate.usesLocalArtifacts;
+
+  @override
+  FileSystemEntity getHostArtifact(HostArtifact artifact) => _delegate.getHostArtifact(artifact);
+
+  @override
+  String getArtifactPath(
+    Artifact artifact, {
+    TargetPlatform? platform,
+    BuildMode? mode,
+    EnvironmentType? environmentType,
+  }) => _delegate.getArtifactPath(
+    artifact,
+    platform: platform,
+    mode: mode,
+    environmentType: environmentType,
+  );
+
+  @override
+  String getEngineType(TargetPlatform platform, [BuildMode? mode]) =>
+      _delegate.getEngineType(platform, mode);
+}
+
+class FakeCache extends Fake implements Cache {
+  FakeCache({FileSystem? fileSystem}) : _fileSystem = fileSystem ?? MemoryFileSystem.test();
+
+  final FileSystem _fileSystem;
+
+  @override
+  Future<void> lock() async {}
+
+  @override
+  void releaseLock() {}
+
+  @override
+  Future<void> updateAll(
+    Set<DevelopmentArtifact> requiredArtifacts, {
+    bool offline = false,
+  }) async {}
+
+  @override
+  Directory getRoot() => _fileSystem.directory('/bin/cache');
+
+  @override
+  Directory getCacheDir(String name, {bool shouldCreate = true}) =>
+      _fileSystem.directory('/bin/cache/$name');
+
+  @override
+  Directory getArtifactDirectory(String name) =>
+      _fileSystem.directory('/bin/cache/artifacts/$name');
+
+  @override
+  Directory getWebSdkDirectory() => _fileSystem.directory('/bin/cache/flutter_web_sdk');
+
+  @override
+  MapEntry<String, String> get dyLdLibEntry =>
+      const MapEntry<String, String>('DYLD_LIBRARY_PATH', 'fake_path');
+}
+
+class FakeGit extends Fake implements Git {}
+
+class FakeGradleUtils extends Fake implements GradleUtils {}
+
+class FakeCocoaPods extends Fake implements CocoaPods {}
+
+class FakeCocoaPodsValidator extends Fake implements CocoaPodsValidator {}
+
+class FakeIOSSimulatorUtils extends Fake implements IOSSimulatorUtils {}
+
+class FakeIOSWorkflow extends Fake implements IOSWorkflow {}
+
+class FakeXCDevice extends Fake implements XCDevice {}
+
+class FakeBuildSystem extends Fake implements BuildSystem {}
+
+class FakeBuildTargets extends Fake implements BuildTargets {}
+
+class FakeCrashReporter extends Fake implements CrashReporter {}
+
+class FakeToolDependencies extends Fake implements ToolDependencies {
+  FakeToolDependencies({
+    Analytics? analytics,
+    AndroidContext? androidContext,
+    AppleContext? appleContext,
+    BuildSystem? buildSystem,
+    BuildTargets? buildTargets,
+    CrashReporter? crashReporter,
+    ToolContext? toolContext,
+  }) : _analytics = analytics,
+       _androidContext = androidContext,
+       _appleContext = appleContext,
+       _buildSystem = buildSystem,
+       _buildTargets = buildTargets,
+       _crashReporter = crashReporter,
+       _toolContext = toolContext;
+
+  final Analytics? _analytics;
+  final AndroidContext? _androidContext;
+  final AppleContext? _appleContext;
+  final BuildSystem? _buildSystem;
+  final BuildTargets? _buildTargets;
+  final CrashReporter? _crashReporter;
+  final ToolContext? _toolContext;
+
+  @override
+  Analytics get analytics => _analytics ?? const NoOpAnalytics();
+
+  @override
+  AndroidContext get androidContext => _androidContext ?? FakeAndroidContext();
+
+  @override
+  AppleContext get appleContext => _appleContext ?? FakeAppleContext();
+
+  @override
+  BuildSystem get buildSystem => _buildSystem ?? FakeBuildSystem();
+
+  @override
+  BuildTargets get buildTargets => _buildTargets ?? FakeBuildTargets();
+
+  @override
+  CrashReporter get crashReporter => _crashReporter ?? FakeCrashReporter();
+
+  @override
+  ToolContext get toolContext => _toolContext ?? FakeToolContext();
+}
+
+class FakeToolContext extends Fake implements ToolContext {
+  FakeToolContext({
+    Artifacts? artifacts,
+    BotDetector? botDetector,
+    Cache? cache,
+    Config? config,
+    CustomDevicesConfig? customDevicesConfig,
+    FlutterVersion? flutterVersion,
+    FileSystem? fs,
+    Git? git,
+    LocalEngineLocator? localEngineLocator,
+    Logger? logger,
+    TestCompilerNativeAssetsBuilder? nativeAssetsBuilder,
+    OperatingSystemUtils? os,
+    OutputPreferences? outputPreferences,
+    Platform? platform,
+    PreRunValidator? preRunValidator,
+    ProcessManager? processManager,
+    ProcessUtils? processUtils,
+    FlutterProjectFactory? projectFactory,
+    ShutdownHooks? shutdownHooks,
+    Signals? signals,
+    Stdio? stdio,
+    SystemClock? systemClock,
+    AnsiTerminal? terminal,
+    UserMessages? userMessages,
+  }) : _artifacts = artifacts,
+       _botDetector = botDetector,
+       _cache = cache,
+       _config = config,
+       _customDevicesConfig = customDevicesConfig,
+       _flutterVersion = flutterVersion,
+       _fs = fs,
+       _git = git,
+       _localEngineLocator = localEngineLocator,
+       _logger = logger,
+       _nativeAssetsBuilder = nativeAssetsBuilder,
+       _os = os,
+       _outputPreferences = outputPreferences,
+       _platform = platform,
+       _preRunValidator = preRunValidator,
+       _processManager = processManager,
+       _processUtils = processUtils,
+       _projectFactory = projectFactory,
+       _shutdownHooks = shutdownHooks,
+       _signals = signals,
+       _stdio = stdio,
+       _systemClock = systemClock,
+       _terminal = terminal,
+       _userMessages = userMessages;
+
+  final Artifacts? _artifacts;
+  final BotDetector? _botDetector;
+  final Cache? _cache;
+  final Config? _config;
+  final CustomDevicesConfig? _customDevicesConfig;
+  final FlutterVersion? _flutterVersion;
+  final FileSystem? _fs;
+  final Git? _git;
+  final LocalEngineLocator? _localEngineLocator;
+  final Logger? _logger;
+  final TestCompilerNativeAssetsBuilder? _nativeAssetsBuilder;
+  final OperatingSystemUtils? _os;
+  final OutputPreferences? _outputPreferences;
+  final Platform? _platform;
+  final PreRunValidator? _preRunValidator;
+  final ProcessManager? _processManager;
+  final ProcessUtils? _processUtils;
+  final FlutterProjectFactory? _projectFactory;
+  final ShutdownHooks? _shutdownHooks;
+  final Signals? _signals;
+  final Stdio? _stdio;
+  final SystemClock? _systemClock;
+  final AnsiTerminal? _terminal;
+  final UserMessages? _userMessages;
+
+  @override
+  Artifacts get artifacts => _artifacts ?? FakeArtifacts(fileSystem: fs);
+
+  @override
+  BotDetector get botDetector => _botDetector ?? const FakeBotDetector(false);
+
+  @override
+  Cache get cache => _cache ?? FakeCache(fileSystem: fs);
+
+  @override
+  Config get config => _config ?? FakeConfig();
+
+  @override
+  CustomDevicesConfig get customDevicesConfig =>
+      _customDevicesConfig ??
+      CustomDevicesConfig.test(fileSystem: fs, logger: logger, platform: platform);
+
+  @override
+  FlutterVersion get flutterVersion => _flutterVersion ?? FakeFlutterVersion();
+
+  @override
+  FileSystem get fs => _fs ?? MemoryFileSystem.test();
+
+  @override
+  Git get git => _git ?? Git(currentPlatform: platform, runProcessWith: processUtils);
+
+  @override
+  LocalEngineLocator get localEngineLocator =>
+      _localEngineLocator ??
+      LocalEngineLocator(
+        userMessages: userMessages,
+        logger: logger,
+        platform: platform,
+        fileSystem: fs,
+        flutterRoot: Cache.flutterRoot ?? '',
+      );
+
+  @override
+  Logger get logger => _logger ?? BufferLogger.test();
+
+  @override
+  TestCompilerNativeAssetsBuilder? get nativeAssetsBuilder => _nativeAssetsBuilder;
+
+  @override
+  OperatingSystemUtils get os => _os ?? FakeOperatingSystemUtils();
+
+  @override
+  OutputPreferences get outputPreferences => _outputPreferences ?? OutputPreferences.test();
+
+  @override
+  Platform get platform => _platform ?? FakePlatform();
+
+  @override
+  PreRunValidator get preRunValidator => _preRunValidator ?? const NoOpPreRunValidator();
+
+  @override
+  ProcessManager get processManager => _processManager ?? FakeProcessManager.any();
+
+  @override
+  ProcessUtils get processUtils =>
+      _processUtils ?? ProcessUtils(processManager: processManager, logger: logger);
+
+  @override
+  FlutterProjectFactory get projectFactory =>
+      _projectFactory ?? FlutterProjectFactory(fileSystem: fs, logger: logger);
+
+  @override
+  ShutdownHooks get shutdownHooks => _shutdownHooks ?? ShutdownHooks();
+
+  @override
+  Signals get signals => _signals ?? Signals.test();
+
+  @override
+  Stdio get stdio => _stdio ?? FakeStdio();
+
+  @override
+  SystemClock get systemClock => _systemClock ?? const SystemClock();
+
+  @override
+  AnsiTerminal get terminal => _terminal ?? AnsiTerminal(stdio: stdio, platform: platform);
+
+  @override
+  UserMessages get userMessages => _userMessages ?? UserMessages();
+
+  @override
+  FileSystemUtils get fileSystemUtils => FileSystemUtils(fileSystem: fs, platform: platform);
+}
+
+/// A [ToolContext] that dynamically delegates to [globals] for use in [testUsingContext].
+class DelegatingToolContext extends Fake implements ToolContext {
+  DelegatingToolContext({
+    Artifacts? artifacts,
+    BotDetector? botDetector,
+    Cache? cache,
+    Config? config,
+    CustomDevicesConfig? customDevicesConfig,
+    FlutterVersion? flutterVersion,
+    FileSystem? fs,
+    Git? git,
+    LocalEngineLocator? localEngineLocator,
+    Logger? logger,
+    OperatingSystemUtils? os,
+    OutputPreferences? outputPreferences,
+    Platform? platform,
+    PreRunValidator? preRunValidator,
+    ProcessManager? processManager,
+    ProcessUtils? processUtils,
+    FlutterProjectFactory? projectFactory,
+    ShutdownHooks? shutdownHooks,
+    Signals? signals,
+    Stdio? stdio,
+    SystemClock? systemClock,
+    AnsiTerminal? terminal,
+    UserMessages? userMessages,
+  }) : _artifacts = artifacts,
+       _botDetector = botDetector,
+       _cache = cache,
+       _config = config,
+       _customDevicesConfig = customDevicesConfig,
+       _flutterVersion = flutterVersion,
+       _fs = fs,
+       _git = git,
+       _localEngineLocator = localEngineLocator,
+       _logger = logger,
+       _os = os,
+       _outputPreferences = outputPreferences,
+       _platform = platform,
+       _preRunValidator = preRunValidator,
+       _processManager = processManager,
+       _processUtils = processUtils,
+       _projectFactory = projectFactory,
+       _shutdownHooks = shutdownHooks,
+       _signals = signals,
+       _stdio = stdio,
+       _systemClock = systemClock,
+       _terminal = terminal,
+       _userMessages = userMessages;
+
+  final Artifacts? _artifacts;
+  final BotDetector? _botDetector;
+  final Cache? _cache;
+  final Config? _config;
+  final CustomDevicesConfig? _customDevicesConfig;
+  final FlutterVersion? _flutterVersion;
+  final FileSystem? _fs;
+  final Git? _git;
+  final LocalEngineLocator? _localEngineLocator;
+  final Logger? _logger;
+  final OperatingSystemUtils? _os;
+  final OutputPreferences? _outputPreferences;
+  final Platform? _platform;
+  final PreRunValidator? _preRunValidator;
+  final ProcessManager? _processManager;
+  final ProcessUtils? _processUtils;
+  final FlutterProjectFactory? _projectFactory;
+  final ShutdownHooks? _shutdownHooks;
+  final Signals? _signals;
+  final Stdio? _stdio;
+  final SystemClock? _systemClock;
+  final AnsiTerminal? _terminal;
+  final UserMessages? _userMessages;
+
+  @override
+  Artifacts get artifacts => _artifacts ?? globals.artifacts!;
+
+  @override
+  BotDetector get botDetector => _botDetector ?? globals.botDetector;
+
+  @override
+  Cache get cache => _cache ?? globals.cache;
+
+  @override
+  Config get config => _config ?? globals.config;
+
+  @override
+  CustomDevicesConfig get customDevicesConfig =>
+      _customDevicesConfig ?? globals.customDevicesConfig;
+
+  @override
+  FlutterVersion get flutterVersion => _flutterVersion ?? globals.flutterVersion;
+
+  @override
+  FileSystem get fs => _fs ?? globals.fs;
+
+  @override
+  Git get git => _git ?? globals.git;
+
+  @override
+  LocalEngineLocator get localEngineLocator =>
+      _localEngineLocator ??
+      globals.localEngineLocator ??
+      LocalEngineLocator(
+        userMessages: userMessages,
+        logger: logger,
+        platform: platform,
+        fileSystem: fs,
+        flutterRoot: Cache.flutterRoot ?? '',
+      );
+
+  @override
+  Logger get logger => _logger ?? globals.logger;
+
+  @override
+  OperatingSystemUtils get os => _os ?? globals.os;
+
+  @override
+  OutputPreferences get outputPreferences => _outputPreferences ?? globals.outputPreferences;
+
+  @override
+  Platform get platform => _platform ?? globals.platform;
+
+  @override
+  PreRunValidator get preRunValidator => _preRunValidator ?? const NoOpPreRunValidator();
+
+  @override
+  ProcessManager get processManager => _processManager ?? globals.processManager;
+
+  @override
+  ProcessUtils get processUtils => _processUtils ?? globals.processUtils;
+
+  @override
+  FlutterProjectFactory get projectFactory => _projectFactory ?? globals.projectFactory;
+
+  @override
+  ShutdownHooks get shutdownHooks => _shutdownHooks ?? globals.shutdownHooks;
+
+  @override
+  Signals get signals => _signals ?? globals.signals;
+
+  @override
+  Stdio get stdio => _stdio ?? globals.stdio;
+
+  @override
+  SystemClock get systemClock => _systemClock ?? globals.systemClock;
+
+  @override
+  AnsiTerminal get terminal => _terminal ?? globals.terminal;
+
+  @override
+  UserMessages get userMessages => _userMessages ?? globals.userMessages;
+
+  @override
+  FileSystemUtils get fileSystemUtils => FileSystemUtils(fileSystem: fs, platform: platform);
+}
+
+class FakeAndroidContext extends Fake implements AndroidContext {
+  FakeAndroidContext({
+    AndroidSdk? androidSdk,
+    AndroidStudio? androidStudio,
+    GradleUtils? gradleUtils,
+    Java? java,
+  }) : _androidSdk = androidSdk,
+       _androidStudio = androidStudio,
+       _gradleUtils = gradleUtils,
+       _java = java;
+
+  final AndroidSdk? _androidSdk;
+  final AndroidStudio? _androidStudio;
+  final GradleUtils? _gradleUtils;
+  final Java? _java;
+
+  @override
+  AndroidSdk? get androidSdk => _androidSdk;
+
+  @override
+  AndroidStudio? get androidStudio => _androidStudio;
+
+  @override
+  GradleUtils get gradleUtils => _gradleUtils ?? FakeGradleUtils();
+
+  @override
+  Java? get java => _java;
+}
+
+class FakeAppleContext extends Fake implements AppleContext {
+  FakeAppleContext({
+    CocoaPods? cocoaPods,
+    CocoaPodsValidator? cocoapodsValidator,
+    IOSSimulatorUtils? iosSimulatorUtils,
+    IOSWorkflow? iosWorkflow,
+    PlistParser? plistParser,
+    XCDevice? xcdevice,
+    Xcode? xcode,
+  }) : _cocoaPods = cocoaPods,
+       _cocoapodsValidator = cocoapodsValidator,
+       _iosSimulatorUtils = iosSimulatorUtils,
+       _iosWorkflow = iosWorkflow,
+       _plistParser = plistParser,
+       _xcdevice = xcdevice,
+       _xcode = xcode;
+
+  final CocoaPods? _cocoaPods;
+  final CocoaPodsValidator? _cocoapodsValidator;
+  final IOSSimulatorUtils? _iosSimulatorUtils;
+  final IOSWorkflow? _iosWorkflow;
+  final PlistParser? _plistParser;
+  final XCDevice? _xcdevice;
+  final Xcode? _xcode;
+
+  @override
+  CocoaPods get cocoaPods => _cocoaPods ?? FakeCocoaPods();
+
+  @override
+  CocoaPodsValidator get cocoapodsValidator => _cocoapodsValidator ?? FakeCocoaPodsValidator();
+
+  @override
+  IOSSimulatorUtils get iosSimulatorUtils => _iosSimulatorUtils ?? FakeIOSSimulatorUtils();
+
+  @override
+  IOSWorkflow get iosWorkflow => _iosWorkflow ?? FakeIOSWorkflow();
+
+  @override
+  PlistParser get plistParser => _plistParser ?? FakePlistParser();
+
+  @override
+  XCDevice get xcdevice => _xcdevice ?? FakeXCDevice();
+
+  @override
+  Xcode get xcode => _xcode ?? FakeXcode();
+
+  @override
+  XcodeProjectInterpreter get xcodeProjectInterpreter => FakeXcodeProjectInterpreter();
+}

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -1210,33 +1210,33 @@ class FakeToolContext extends Fake implements ToolContext {
   final UserMessages? _userMessages;
 
   @override
-  Artifacts get artifacts => _artifacts ?? FakeArtifacts(fileSystem: fs);
+  late final Artifacts artifacts = _artifacts ?? FakeArtifacts(fileSystem: fs);
 
   @override
-  BotDetector get botDetector => _botDetector ?? const FakeBotDetector(false);
+  late final BotDetector botDetector = _botDetector ?? const FakeBotDetector(false);
 
   @override
-  Cache get cache => _cache ?? FakeCache(fileSystem: fs);
+  late final Cache cache = _cache ?? FakeCache(fileSystem: fs);
 
   @override
-  Config get config => _config ?? FakeConfig();
+  late final Config config = _config ?? FakeConfig();
 
   @override
-  CustomDevicesConfig get customDevicesConfig =>
+  late final CustomDevicesConfig customDevicesConfig =
       _customDevicesConfig ??
       CustomDevicesConfig.test(fileSystem: fs, logger: logger, platform: platform);
 
   @override
-  FlutterVersion get flutterVersion => _flutterVersion ?? FakeFlutterVersion();
+  late final FlutterVersion flutterVersion = _flutterVersion ?? FakeFlutterVersion();
 
   @override
-  FileSystem get fs => _fs ?? MemoryFileSystem.test();
+  late final FileSystem fs = _fs ?? MemoryFileSystem.test();
 
   @override
-  Git get git => _git ?? Git(currentPlatform: platform, runProcessWith: processUtils);
+  late final Git git = _git ?? Git(currentPlatform: platform, runProcessWith: processUtils);
 
   @override
-  LocalEngineLocator get localEngineLocator =>
+  late final LocalEngineLocator localEngineLocator =
       _localEngineLocator ??
       LocalEngineLocator(
         userMessages: userMessages,
@@ -1247,51 +1247,51 @@ class FakeToolContext extends Fake implements ToolContext {
       );
 
   @override
-  Logger get logger => _logger ?? BufferLogger.test();
+  late final Logger logger = _logger ?? BufferLogger.test();
 
   @override
   TestCompilerNativeAssetsBuilder? get nativeAssetsBuilder => _nativeAssetsBuilder;
 
   @override
-  OperatingSystemUtils get os => _os ?? FakeOperatingSystemUtils();
+  late final OperatingSystemUtils os = _os ?? FakeOperatingSystemUtils();
 
   @override
-  OutputPreferences get outputPreferences => _outputPreferences ?? OutputPreferences.test();
+  late final OutputPreferences outputPreferences = _outputPreferences ?? OutputPreferences.test();
 
   @override
-  Platform get platform => _platform ?? FakePlatform();
+  late final Platform platform = _platform ?? FakePlatform();
 
   @override
-  PreRunValidator get preRunValidator => _preRunValidator ?? const NoOpPreRunValidator();
+  late final PreRunValidator preRunValidator = _preRunValidator ?? const NoOpPreRunValidator();
 
   @override
-  ProcessManager get processManager => _processManager ?? FakeProcessManager.any();
+  late final ProcessManager processManager = _processManager ?? FakeProcessManager.any();
 
   @override
-  ProcessUtils get processUtils =>
+  late final ProcessUtils processUtils =
       _processUtils ?? ProcessUtils(processManager: processManager, logger: logger);
 
   @override
-  FlutterProjectFactory get projectFactory =>
+  late final FlutterProjectFactory projectFactory =
       _projectFactory ?? FlutterProjectFactory(fileSystem: fs, logger: logger);
 
   @override
-  ShutdownHooks get shutdownHooks => _shutdownHooks ?? ShutdownHooks();
+  late final ShutdownHooks shutdownHooks = _shutdownHooks ?? ShutdownHooks();
 
   @override
-  Signals get signals => _signals ?? Signals.test();
+  late final Signals signals = _signals ?? Signals.test();
 
   @override
-  Stdio get stdio => _stdio ?? FakeStdio();
+  late final Stdio stdio = _stdio ?? FakeStdio();
 
   @override
-  SystemClock get systemClock => _systemClock ?? const SystemClock();
+  late final SystemClock systemClock = _systemClock ?? const SystemClock();
 
   @override
-  AnsiTerminal get terminal => _terminal ?? AnsiTerminal(stdio: stdio, platform: platform);
+  late final AnsiTerminal terminal = _terminal ?? AnsiTerminal(stdio: stdio, platform: platform);
 
   @override
-  UserMessages get userMessages => _userMessages ?? UserMessages();
+  late final UserMessages userMessages = _userMessages ?? UserMessages();
 
   @override
   FileSystemUtils get fileSystemUtils => FileSystemUtils(fileSystem: fs, platform: platform);
@@ -1477,7 +1477,7 @@ class FakeAndroidContext extends Fake implements AndroidContext {
   AndroidStudio? get androidStudio => _androidStudio;
 
   @override
-  GradleUtils get gradleUtils => _gradleUtils ?? FakeGradleUtils();
+  late final GradleUtils gradleUtils = _gradleUtils ?? FakeGradleUtils();
 
   @override
   Java? get java => _java;
@@ -1492,13 +1492,15 @@ class FakeAppleContext extends Fake implements AppleContext {
     PlistParser? plistParser,
     XCDevice? xcdevice,
     Xcode? xcode,
+    XcodeProjectInterpreter? xcodeProjectInterpreter,
   }) : _cocoaPods = cocoaPods,
        _cocoapodsValidator = cocoapodsValidator,
        _iosSimulatorUtils = iosSimulatorUtils,
        _iosWorkflow = iosWorkflow,
        _plistParser = plistParser,
        _xcdevice = xcdevice,
-       _xcode = xcode;
+       _xcode = xcode,
+       _xcodeProjectInterpreter = xcodeProjectInterpreter;
 
   final CocoaPods? _cocoaPods;
   final CocoaPodsValidator? _cocoapodsValidator;
@@ -1507,28 +1509,31 @@ class FakeAppleContext extends Fake implements AppleContext {
   final PlistParser? _plistParser;
   final XCDevice? _xcdevice;
   final Xcode? _xcode;
+  final XcodeProjectInterpreter? _xcodeProjectInterpreter;
 
   @override
-  CocoaPods get cocoaPods => _cocoaPods ?? FakeCocoaPods();
+  late final CocoaPods cocoaPods = _cocoaPods ?? FakeCocoaPods();
 
   @override
-  CocoaPodsValidator get cocoapodsValidator => _cocoapodsValidator ?? FakeCocoaPodsValidator();
+  late final CocoaPodsValidator cocoapodsValidator =
+      _cocoapodsValidator ?? FakeCocoaPodsValidator();
 
   @override
-  IOSSimulatorUtils get iosSimulatorUtils => _iosSimulatorUtils ?? FakeIOSSimulatorUtils();
+  late final IOSSimulatorUtils iosSimulatorUtils = _iosSimulatorUtils ?? FakeIOSSimulatorUtils();
 
   @override
-  IOSWorkflow get iosWorkflow => _iosWorkflow ?? FakeIOSWorkflow();
+  late final IOSWorkflow iosWorkflow = _iosWorkflow ?? FakeIOSWorkflow();
 
   @override
-  PlistParser get plistParser => _plistParser ?? FakePlistParser();
+  late final PlistParser plistParser = _plistParser ?? FakePlistParser();
 
   @override
-  XCDevice get xcdevice => _xcdevice ?? FakeXCDevice();
+  late final XCDevice xcdevice = _xcdevice ?? FakeXCDevice();
 
   @override
-  Xcode get xcode => _xcode ?? FakeXcode();
+  late final Xcode xcode = _xcode ?? FakeXcode();
 
   @override
-  XcodeProjectInterpreter get xcodeProjectInterpreter => FakeXcodeProjectInterpreter();
+  late final XcodeProjectInterpreter xcodeProjectInterpreter =
+      _xcodeProjectInterpreter ?? FakeXcodeProjectInterpreter();
 }


### PR DESCRIPTION
## Summary

Part 1 of the modular dependency injection migration.

Defines the foundational modular dependency injection containers and bootstrapper for `flutter_tools`:
1. **`ToolContext`**: Layer 1 OS wrappers (`HostEnvironment`) and Layer 2 SDK state (`ToolConfiguration`).
2. **Nullable Sub-contexts**: `AndroidContext` and `AppleContext` for clean platform isolation.
3. **`ToolDependencies`**: Topologically instantiates and manages the dependency graph at startup with explicit overrides and lazy closures.
4. **Hermetic Test Doubles**: Includes `dependency_injection_test.dart` and fake context doubles.

Followed by Part 2 (#190922) for runner wiring.

Part of https://github.com/flutter/flutter/issues/47161