### PR TITLE
Start directional focus traversal from the innermost focused node

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -801,6 +801,20 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// Use [enclosingScope] to look for scopes above this node.
   FocusScopeNode? get nearestScope => enclosingScope;
 
+  /// Returns the innermost [FocusScopeNode.focusedChild] within this node, or
+  /// this node itself if it is not a scope with a focused child.
+  ///
+  /// For a [FocusScopeNode], this recursively descends through the
+  /// [FocusScopeNode.focusedChild] of any nested scopes to find the innermost
+  /// node that would receive focus if the scope were focused. For any other
+  /// [FocusNode], this returns the node itself.
+  ///
+  /// See also:
+  ///
+  ///  * [nearestScope], which also resolves depending on whether the node is
+  ///    a scope, and returns the nearest scope at or above this node.
+  FocusNode get innermostFocusedChild => this;
+
   FocusScopeNode? _enclosingScope;
   void _clearEnclosingScopeCache() {
     final FocusScopeNode? cachedScope = _enclosingScope;
@@ -1412,6 +1426,16 @@ class FocusScopeNode extends FocusNode {
   // A stack of the children that have been set as the focusedChild, most recent
   // last (which is the top of the stack).
   final List<FocusNode> _focusedChildren = <FocusNode>[];
+
+  /// Returns the innermost [focusedChild] within this scope.
+  ///
+  /// If the [focusedChild] of this scope is itself a [FocusScopeNode], this
+  /// recursively descends into it, stopping at the first focused child that
+  /// is not a scope, or at a scope that has no focused child of its own.
+  ///
+  /// Returns this scope if it has no [focusedChild].
+  @override
+  FocusNode get innermostFocusedChild => focusedChild?.innermostFocusedChild ?? this;
 
   /// An iterator over the children that are allowed to be traversed by the
   /// [FocusTraversalPolicy].

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -814,6 +814,9 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     TraversalDirection direction, {
     bool forward = true,
   }) {
+    // A scope's rect spans all of its children, so search from the innermost
+    // focused node to reflect where focus actually is.
+    focusedChild = focusedChild.innermostFocusedChild;
     switch (direction) {
       case TraversalDirection.down:
       case TraversalDirection.up:

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -817,6 +817,11 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     // A scope's rect spans all of its children, so search from the innermost
     // focused node to reflect where focus actually is.
     focusedChild = focusedChild.innermostFocusedChild;
+    // A node that resolves back to the focused node, like an enclosing scope,
+    // would hand focus straight back to it, trapping it there.
+    traversalDescendants = traversalDescendants.where(
+      (FocusNode node) => node.innermostFocusedChild != focusedChild,
+    );
     switch (direction) {
       case TraversalDirection.down:
       case TraversalDirection.up:

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -486,6 +486,43 @@ void main() {
   });
 
   group(FocusScopeNode, () {
+    testWidgets('innermostFocusedChild returns the innermost focused node.', (
+      WidgetTester tester,
+    ) async {
+      final BuildContext context = await setupWidget(tester);
+      final outerScope = FocusScopeNode(debugLabel: 'Outer Scope');
+      addTearDown(outerScope.dispose);
+      final FocusAttachment outerScopeAttachment = outerScope.attach(context);
+      final innerScope = FocusScopeNode(debugLabel: 'Inner Scope');
+      addTearDown(innerScope.dispose);
+      final FocusAttachment innerScopeAttachment = innerScope.attach(context);
+      final child = FocusNode(debugLabel: 'Child');
+      addTearDown(child.dispose);
+      final FocusAttachment childAttachment = child.attach(context);
+      outerScopeAttachment.reparent(
+        parent: tester.binding.focusManager.rootScope,
+      );
+      innerScopeAttachment.reparent(parent: outerScope);
+      childAttachment.reparent(parent: innerScope);
+
+      // A regular node returns itself.
+      expect(child.innermostFocusedChild, equals(child));
+
+      // A scope with no focused child returns itself.
+      expect(outerScope.focusedChild, isNull);
+      expect(outerScope.innermostFocusedChild, equals(outerScope));
+      expect(innerScope.innermostFocusedChild, equals(innerScope));
+
+      child.requestFocus();
+      await tester.pump();
+
+      // Nested scopes return the innermost focused node.
+      expect(outerScope.focusedChild, equals(innerScope));
+      expect(outerScope.innermostFocusedChild, equals(child));
+      expect(innerScope.innermostFocusedChild, equals(child));
+      expect(child.innermostFocusedChild, equals(child));
+    });
+
     testWidgets('Can setFirstFocus on a scope with no manager.', (WidgetTester tester) async {
       final BuildContext context = await setupWidget(tester);
       final scope = FocusScopeNode(debugLabel: 'Scope');

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -3108,6 +3108,99 @@ void main() {
       variant: KeySimulatorTransitModeVariant.all(),
     );
 
+    testWidgets('Up focuses the card directly above when each row is a FocusScope', (
+      WidgetTester tester,
+    ) async {
+      // A vertical list of rows, where each row is its own FocusScope holding
+      // a title and a horizontal list of equal-size cards. Arrow keys move
+      // focus between rows by asking the enclosing scope for a directional
+      // move, so traversal starts from the row scope rather than the card.
+      // Down from the first card of row 0 lands on the first card of row 1.
+      // Up must come back to the first card of row 0, not another card.
+      const rowCount = 3;
+      const cardsPerRow = 4;
+      final rowScopes = List<FocusScopeNode>.generate(
+        rowCount,
+        (int row) => FocusScopeNode(debugLabel: 'Row scope $row'),
+      );
+      final gridNodes = List<List<FocusNode>>.generate(
+        rowCount,
+        (int row) => List<FocusNode>.generate(
+          cardsPerRow,
+          (int col) => FocusNode(debugLabel: 'Card $row-$col'),
+        ),
+      );
+      addTearDown(() {
+        for (final scope in rowScopes) {
+          scope.dispose();
+        }
+        for (final FocusNode node in gridNodes.flattened) {
+          node.dispose();
+        }
+      });
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: ListView(
+            children: List<Widget>.generate(rowCount, (int row) {
+              return FocusScope(
+                node: rowScopes[row],
+                onKeyEvent: (FocusNode node, KeyEvent event) {
+                  if (event is! KeyDownEvent) {
+                    return KeyEventResult.ignored;
+                  }
+                  if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                    rowScopes[row].enclosingScope?.focusInDirection(TraversalDirection.down);
+                    return KeyEventResult.handled;
+                  }
+                  if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                    rowScopes[row].enclosingScope?.focusInDirection(TraversalDirection.up);
+                    return KeyEventResult.handled;
+                  }
+                  return KeyEventResult.ignored;
+                },
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    // Row title, which makes the scope taller than its cards.
+                    const SizedBox(height: 40, width: 100),
+                    SizedBox(
+                      height: 150,
+                      child: ListView(
+                        scrollDirection: Axis.horizontal,
+                        children: List<Widget>.generate(cardsPerRow, (int col) {
+                          return Focus(
+                            focusNode: gridNodes[row][col],
+                            autofocus: row == 0 && col == 0,
+                            child: Container(
+                              width: 360,
+                              margin: const EdgeInsets.only(right: 10),
+                              color: getTestColor(row),
+                            ),
+                          );
+                        }),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(gridNodes[0][0].hasPrimaryFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(gridNodes[1][0].hasPrimaryFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(gridNodes[0][1].hasPrimaryFocus, isFalse);
+      expect(gridNodes[0][0].hasPrimaryFocus, isTrue);
+    });
+
     testWidgets('Arrow focus traversal actions can be re-enabled for text fields.', (
       WidgetTester tester,
     ) async {

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -3201,6 +3201,97 @@ void main() {
       expect(gridNodes[0][0].hasPrimaryFocus, isTrue);
     });
 
+    testWidgets('Up escapes the enclosing scope when the row header is taller than the cards', (
+      WidgetTester tester,
+    ) async {
+      // Same structure as the previous test, but each row's header is taller
+      // than its cards, so a row scope's own rect extends above its focused
+      // card. Up must escape to the row above instead of being trapped by the
+      // enclosing scope handing focus back to the same card.
+      const rowCount = 2;
+      const cardsPerRow = 2;
+      final rowScopes = List<FocusScopeNode>.generate(
+        rowCount,
+        (int row) => FocusScopeNode(debugLabel: 'Row scope $row'),
+      );
+      final gridNodes = List<List<FocusNode>>.generate(
+        rowCount,
+        (int row) => List<FocusNode>.generate(
+          cardsPerRow,
+          (int col) => FocusNode(debugLabel: 'Card $row-$col'),
+        ),
+      );
+      addTearDown(() {
+        for (final scope in rowScopes) {
+          scope.dispose();
+        }
+        for (final FocusNode node in gridNodes.flattened) {
+          node.dispose();
+        }
+      });
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: ListView(
+            children: List<Widget>.generate(rowCount, (int row) {
+              return FocusScope(
+                node: rowScopes[row],
+                onKeyEvent: (FocusNode node, KeyEvent event) {
+                  if (event is! KeyDownEvent) {
+                    return KeyEventResult.ignored;
+                  }
+                  if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                    rowScopes[row].enclosingScope?.focusInDirection(TraversalDirection.down);
+                    return KeyEventResult.handled;
+                  }
+                  if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                    rowScopes[row].enclosingScope?.focusInDirection(TraversalDirection.up);
+                    return KeyEventResult.handled;
+                  }
+                  return KeyEventResult.ignored;
+                },
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    // Row header, taller than the cards below it.
+                    const SizedBox(height: 200, width: 100),
+                    SizedBox(
+                      height: 150,
+                      child: ListView(
+                        scrollDirection: Axis.horizontal,
+                        children: List<Widget>.generate(cardsPerRow, (int col) {
+                          return Focus(
+                            focusNode: gridNodes[row][col],
+                            autofocus: row == 0 && col == 0,
+                            child: Container(
+                              width: 360,
+                              margin: const EdgeInsets.only(right: 10),
+                              color: getTestColor(row),
+                            ),
+                          );
+                        }),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(gridNodes[0][0].hasPrimaryFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(gridNodes[1][0].hasPrimaryFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(gridNodes[1][0].hasPrimaryFocus, isFalse);
+      expect(gridNodes[0][0].hasPrimaryFocus, isTrue);
+    });
+
     testWidgets('Arrow focus traversal actions can be re-enabled for text fields.', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
## Description

Directional focus traversal (arrow Up/Down/Left/Right) starts from the rect of the currently focused child of a scope. When that focused child is itself a `FocusScopeNode`, its rect spans all of its descendants, so the geometric search does not reflect where focus actually is. In a vertical list of rows where each row is a horizontal scrollable of focusable cards, this makes an Up move from a lower row resolve to the wrong sibling in the row above (for example, from the first card of row 1 it lands on the second card of row 0 instead of the first card that is directly above).

This change makes the in-direction traversal descend into the focused child when it is a scope, starting the search from its innermost focused node so the geometry matches the actual focused widget. Existing directional behavior for non-scope focused children is unchanged.

## Issues fixed

Fixes #190653

## Tests

Adds a widget test in `focus_traversal_test.dart` covering a vertical list of rows of horizontally scrollable cards: pressing Down moves to the card directly below, and pressing Up returns to the originating card rather than a side neighbor. No existing tests were modified.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/AI-contributions.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md