### PR TITLE
[flutter_tools] Implement generic extension protocol base and isolate runner

### DIFF
--- a/packages/flutter_tools/lib/src/experimental/extension_discovery.dart
+++ b/packages/flutter_tools/lib/src/experimental/extension_discovery.dart
@@ -114,9 +114,6 @@ class ExtensionConnection {
         'ExtensionConnection handshake complete. Capabilities: ${capabilities.services}',
       );
 
-      errorPort.close();
-      exitPort.close();
-
       return ExtensionConnection._(
         isolate: isolate,
         peer: peer,
@@ -125,18 +122,17 @@ class ExtensionConnection {
       );
     } on TimeoutException {
       logger.printTrace('ExtensionConnection handshake timed out.');
-      errorPort.close();
-      exitPort.close();
       receivePort.close();
       isolate?.kill(priority: Isolate.immediate);
       throw TimeoutException('Handshake with tool extension isolate timed out.');
     } on Object catch (error) {
       logger.printTrace('ExtensionConnection spawn failed with error: $error');
-      errorPort.close();
-      exitPort.close();
       receivePort.close();
       isolate?.kill(priority: Isolate.immediate);
       rethrow;
+    } finally {
+      errorPort.close();
+      exitPort.close();
     }
   }
 

--- a/packages/flutter_tools/lib/src/experimental/extension_discovery.dart
+++ b/packages/flutter_tools/lib/src/experimental/extension_discovery.dart
@@ -177,32 +177,6 @@ class ExtensionDiscovery {
     _connections.addAll(connections);
   }
 
-  /// Spawns and registers multiple extension isolates concurrently.
-  ///
-  /// Any extension isolate that fails to spawn or complete the handshake is
-  /// logged as an error and omitted from the returned list of connections.
-  Future<List<ExtensionConnection>> spawnAll(
-    List<ExtensionEntryPoint> entryPoints, {
-    Duration timeout = const Duration(seconds: 5),
-  }) async {
-    _logger.printTrace('ExtensionDiscovery spawning ${entryPoints.length} extension isolate(s)...');
-    final List<ExtensionConnection?> results = await Future.wait(
-      entryPoints.map((ExtensionEntryPoint entryPoint) async {
-        try {
-          return await ExtensionConnection.spawn(entryPoint, logger: _logger, timeout: timeout);
-        } on Object catch (error) {
-          _logger.printError('Failed to spawn extension: $error');
-          return null;
-        }
-      }),
-    );
-    final List<ExtensionConnection> newConnections = results
-        .whereType<ExtensionConnection>()
-        .toList();
-    _connections.addAll(newConnections);
-    return newConnections;
-  }
-
   /// Disposes all registered extension isolate connections.
   Future<void> dispose() async {
     _logger.printTrace('ExtensionDiscovery disposing all registered connections.');

--- a/packages/flutter_tools/lib/src/experimental/extension_discovery.dart
+++ b/packages/flutter_tools/lib/src/experimental/extension_discovery.dart
@@ -178,6 +178,9 @@ class ExtensionDiscovery {
   }
 
   /// Spawns and registers multiple extension isolates concurrently.
+  ///
+  /// Any extension isolate that fails to spawn or complete the handshake is
+  /// logged as an error and omitted from the returned list of connections.
   Future<List<ExtensionConnection>> spawnAll(
     List<ExtensionEntryPoint> entryPoints, {
     Duration timeout = const Duration(seconds: 5),

--- a/packages/flutter_tools/lib/src/experimental/extension_discovery.dart
+++ b/packages/flutter_tools/lib/src/experimental/extension_discovery.dart
@@ -62,10 +62,37 @@ class ExtensionConnection {
   }) async {
     logger.printTrace('ExtensionConnection spawning extension isolate...');
     final receivePort = ReceivePort();
+    final errorPort = RawReceivePort();
+    final exitPort = RawReceivePort();
+    final errorCompleter = Completer<Never>();
+
+    errorPort.handler = (Object? error) {
+      if (!errorCompleter.isCompleted) {
+        if (error is List && error.isNotEmpty) {
+          errorCompleter.completeError(StateError('Extension isolate error: ${error[0]}'));
+        } else {
+          errorCompleter.completeError(StateError('Extension isolate error: $error'));
+        }
+      }
+    };
+
+    exitPort.handler = (Object? _) {
+      if (!errorCompleter.isCompleted) {
+        errorCompleter.completeError(
+          StateError('Extension isolate exited unexpectedly before handshake completed.'),
+        );
+      }
+    };
+
     Isolate? isolate;
 
     try {
-      isolate = await Isolate.spawn(entryPoint, receivePort.sendPort);
+      isolate = await Isolate.spawn(
+        entryPoint,
+        receivePort.sendPort,
+        onError: errorPort.sendPort,
+        onExit: exitPort.sendPort,
+      );
       logger.printTrace('ExtensionConnection isolate spawned; connecting IsolateChannel...');
       final channel = IsolateChannel<Object?>.connectReceive(receivePort);
       final peer = json_rpc.Peer.withoutJson(channel);
@@ -73,9 +100,10 @@ class ExtensionConnection {
       unawaited(peer.listen());
 
       logger.printTrace('ExtensionConnection querying extension.getCapabilities...');
-      final Object? responseObj = await peer
-          .sendRequest('extension.getCapabilities')
-          .timeout(timeout);
+      final Object? responseObj = await Future.any<Object?>([
+        peer.sendRequest('extension.getCapabilities'),
+        errorCompleter.future,
+      ]).timeout(timeout);
       if (responseObj is! Map<String, Object?>) {
         throw StateError(
           'Extension handshake failed: extension.getCapabilities did not return a Map.',
@@ -86,6 +114,9 @@ class ExtensionConnection {
         'ExtensionConnection handshake complete. Capabilities: ${capabilities.services}',
       );
 
+      errorPort.close();
+      exitPort.close();
+
       return ExtensionConnection._(
         isolate: isolate,
         peer: peer,
@@ -94,11 +125,15 @@ class ExtensionConnection {
       );
     } on TimeoutException {
       logger.printTrace('ExtensionConnection handshake timed out.');
+      errorPort.close();
+      exitPort.close();
       receivePort.close();
       isolate?.kill(priority: Isolate.immediate);
       throw TimeoutException('Handshake with tool extension isolate timed out.');
     } on Object catch (error) {
       logger.printTrace('ExtensionConnection spawn failed with error: $error');
+      errorPort.close();
+      exitPort.close();
       receivePort.close();
       isolate?.kill(priority: Isolate.immediate);
       rethrow;

--- a/packages/flutter_tools/lib/src/experimental/extension_discovery.dart
+++ b/packages/flutter_tools/lib/src/experimental/extension_discovery.dart
@@ -1,0 +1,180 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:flutter_tools_extension/flutter_tools_extension.dart';
+import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
+import 'package:stream_channel/isolate_channel.dart';
+
+import '../base/logger.dart';
+
+/// Typedef for an extension isolate entrypoint function.
+typedef ExtensionEntryPoint = void Function(SendPort sendPort);
+
+/// Represents an active host-side connection to a running tool extension isolate.
+class ExtensionConnection {
+  ExtensionConnection._({
+    required Isolate isolate,
+    required json_rpc.Peer peer,
+    required this.capabilities,
+    required Logger logger,
+  }) : _isolate = isolate,
+       _peer = peer,
+       _logger = logger;
+
+  Isolate? _isolate;
+  final json_rpc.Peer _peer;
+  final Logger _logger;
+
+  /// The capabilities and supported service namespaces of the extension.
+  final ToolExtensionCapabilities capabilities;
+
+  bool _isDisposed = false;
+
+  /// Sends an RPC request to the extension isolate.
+  Future<Object?> sendRequest(
+    String method, [
+    Object? params,
+    Duration timeout = const Duration(seconds: 5),
+  ]) async {
+    if (_isDisposed) {
+      throw StateError('ExtensionConnection has been disposed.');
+    }
+    _logger.printTrace('ExtensionConnection sending RPC request "$method"...');
+    try {
+      final Object? result = await _peer.sendRequest(method, params).timeout(timeout);
+      _logger.printTrace('ExtensionConnection received response for RPC request "$method".');
+      return result;
+    } catch (error) {
+      _logger.printTrace('ExtensionConnection RPC request "$method" failed with error: $error');
+      rethrow;
+    }
+  }
+
+  /// Spawns an extension isolate from [entryPoint] and completes handshake.
+  static Future<ExtensionConnection> spawn(
+    ExtensionEntryPoint entryPoint, {
+    required Logger logger,
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    logger.printTrace('ExtensionConnection spawning extension isolate...');
+    final receivePort = ReceivePort();
+    Isolate? isolate;
+
+    try {
+      isolate = await Isolate.spawn(entryPoint, receivePort.sendPort);
+      logger.printTrace('ExtensionConnection isolate spawned; connecting IsolateChannel...');
+      final channel = IsolateChannel<Object?>.connectReceive(receivePort);
+      final peer = json_rpc.Peer.withoutJson(channel);
+
+      unawaited(peer.listen());
+
+      logger.printTrace('ExtensionConnection querying extension.getCapabilities...');
+      final Object? responseObj = await peer
+          .sendRequest('extension.getCapabilities')
+          .timeout(timeout);
+      if (responseObj is! Map<String, Object?>) {
+        throw StateError(
+          'Extension handshake failed: extension.getCapabilities did not return a Map.',
+        );
+      }
+      final capabilities = ToolExtensionCapabilities.fromJson(responseObj);
+      logger.printTrace(
+        'ExtensionConnection handshake complete. Capabilities: ${capabilities.services}',
+      );
+
+      return ExtensionConnection._(
+        isolate: isolate,
+        peer: peer,
+        capabilities: capabilities,
+        logger: logger,
+      );
+    } on TimeoutException {
+      logger.printTrace('ExtensionConnection handshake timed out.');
+      receivePort.close();
+      isolate?.kill(priority: Isolate.immediate);
+      throw TimeoutException('Handshake with tool extension isolate timed out.');
+    } on Object catch (error) {
+      logger.printTrace('ExtensionConnection spawn failed with error: $error');
+      receivePort.close();
+      isolate?.kill(priority: Isolate.immediate);
+      rethrow;
+    }
+  }
+
+  /// Disposes the extension isolate connection.
+  Future<void> dispose() async {
+    if (_isDisposed) {
+      return;
+    }
+    _isDisposed = true;
+    _logger.printTrace('ExtensionConnection disposing isolate connection.');
+    try {
+      await _peer.close();
+    } on Object catch (error) {
+      _logger.printTrace('Error closing extension connection peer: $error');
+    } finally {
+      _isolate?.kill(priority: Isolate.immediate);
+      _isolate = null;
+    }
+  }
+}
+
+/// Discovers and manages active tool extension isolate connections.
+class ExtensionDiscovery {
+  /// Creates an [ExtensionDiscovery] instance with required [logger].
+  ExtensionDiscovery({required Logger logger}) : _logger = logger;
+
+  final List<ExtensionConnection> _connections = <ExtensionConnection>[];
+  final Logger _logger;
+
+  /// Active extension connections.
+  List<ExtensionConnection> get connections => List<ExtensionConnection>.unmodifiable(_connections);
+
+  /// Registers an active [connection].
+  void registerConnection(ExtensionConnection connection) {
+    _logger.printTrace('ExtensionDiscovery registering active connection.');
+    _connections.add(connection);
+  }
+
+  /// Registers multiple active [connections].
+  void registerConnections(Iterable<ExtensionConnection> connections) {
+    _logger.printTrace('ExtensionDiscovery registering ${connections.length} connection(s).');
+    _connections.addAll(connections);
+  }
+
+  /// Spawns and registers multiple extension isolates concurrently.
+  Future<List<ExtensionConnection>> spawnAll(
+    List<ExtensionEntryPoint> entryPoints, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    _logger.printTrace('ExtensionDiscovery spawning ${entryPoints.length} extension isolate(s)...');
+    final List<ExtensionConnection?> results = await Future.wait(
+      entryPoints.map((ExtensionEntryPoint entryPoint) async {
+        try {
+          return await ExtensionConnection.spawn(entryPoint, logger: _logger, timeout: timeout);
+        } on Object catch (error) {
+          _logger.printError('Failed to spawn extension: $error');
+          return null;
+        }
+      }),
+    );
+    final List<ExtensionConnection> newConnections = results
+        .whereType<ExtensionConnection>()
+        .toList();
+    _connections.addAll(newConnections);
+    return newConnections;
+  }
+
+  /// Disposes all registered extension isolate connections.
+  Future<void> dispose() async {
+    _logger.printTrace('ExtensionDiscovery disposing all registered connections.');
+    for (final ExtensionConnection connection in _connections) {
+      await connection.dispose();
+    }
+    _connections.clear();
+  }
+}

--- a/packages/flutter_tools/lib/src/experimental/extension_manager.dart
+++ b/packages/flutter_tools/lib/src/experimental/extension_manager.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import '../base/context.dart';
 import '../base/logger.dart';
+import '../base/os.dart';
 import '../features.dart';
 import 'extension_discovery.dart';
 
@@ -21,14 +22,21 @@ class ExtensionManager {
        _discovery = discovery ?? ExtensionDiscovery(logger: logger),
        _featureFlags = featureFlags ?? context.get<FeatureFlags>()!;
 
-  /// The active host operating system platform (e.g. `'linux'`, `'macos'`, `'windows'`).
-  final String hostPlatform;
+  /// The active [HostPlatform].
+  final HostPlatform hostPlatform;
   final Logger _logger;
   final ExtensionDiscovery _discovery;
   final FeatureFlags _featureFlags;
 
   /// Active extension connections compatible with [hostPlatform].
   List<ExtensionConnection> get connections => _discovery.connections;
+
+  /// The operating system name of the host platform (e.g. `'linux'`, `'macos'`, `'windows'`).
+  String get hostPlatformName => switch (hostPlatform) {
+    HostPlatform.darwin_x64 || HostPlatform.darwin_arm64 => 'macos',
+    HostPlatform.linux_x64 || HostPlatform.linux_arm64 || HostPlatform.linux_riscv64 => 'linux',
+    HostPlatform.windows_x64 || HostPlatform.windows_arm64 => 'windows',
+  };
 
   /// Spawns entrypoints without host OS checks; disposes any extension that reports
   /// it does not support [hostPlatform].
@@ -39,21 +47,22 @@ class ExtensionManager {
       return;
     }
     _logger.printTrace(
-      'ExtensionManager initializing for platform "$hostPlatform" with ${entryPoints.length} entrypoint(s).',
+      'ExtensionManager initializing for platform "$hostPlatformName" with ${entryPoints.length} entrypoint(s).',
     );
     for (final entryPoint in entryPoints) {
       final ExtensionConnection connection = await ExtensionConnection.spawn(
         entryPoint,
         logger: _logger,
       );
-      if (connection.capabilities.supportsHostPlatform(hostPlatform)) {
+      if (connection.capabilities.supportsHostPlatform(hostPlatformName) ||
+          connection.capabilities.supportsHostPlatform(hostPlatform.cliName)) {
         _logger.printTrace(
-          'Extension connection supported on host platform "$hostPlatform"; registering.',
+          'Extension connection supported on host platform "$hostPlatformName"; registering.',
         );
         _discovery.registerConnection(connection);
       } else {
         _logger.printTrace(
-          'Extension connection does not support host platform "$hostPlatform" '
+          'Extension connection does not support host platform "$hostPlatformName" '
           '(supported platforms: ${connection.capabilities.supportedPlatforms}); disposing connection.',
         );
         await connection.dispose();

--- a/packages/flutter_tools/lib/src/experimental/extension_manager.dart
+++ b/packages/flutter_tools/lib/src/experimental/extension_manager.dart
@@ -1,0 +1,69 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../base/context.dart';
+import '../base/logger.dart';
+import '../features.dart';
+import 'extension_discovery.dart';
+
+/// Manages active tool extension isolate connections and exposes capability proxies.
+class ExtensionManager {
+  /// Creates an [ExtensionManager] targeting the active [hostPlatform].
+  ExtensionManager({
+    required this.hostPlatform,
+    required Logger logger,
+    ExtensionDiscovery? discovery,
+    FeatureFlags? featureFlags,
+  }) : _logger = logger,
+       _discovery = discovery ?? ExtensionDiscovery(logger: logger),
+       _featureFlags = featureFlags ?? context.get<FeatureFlags>()!;
+
+  /// The active host operating system platform (e.g. `'linux'`, `'macos'`, `'windows'`).
+  final String hostPlatform;
+  final Logger _logger;
+  final ExtensionDiscovery _discovery;
+  final FeatureFlags _featureFlags;
+
+  /// Active extension connections compatible with [hostPlatform].
+  List<ExtensionConnection> get connections => _discovery.connections;
+
+  /// Spawns entrypoints without host OS checks; disposes any extension that reports
+  /// it does not support [hostPlatform].
+  Future<void> initialize({
+    List<ExtensionEntryPoint> entryPoints = const <ExtensionEntryPoint>[],
+  }) async {
+    if (!_featureFlags.isToolExtensionsEnabled) {
+      return;
+    }
+    _logger.printTrace(
+      'ExtensionManager initializing for platform "$hostPlatform" with ${entryPoints.length} entrypoint(s).',
+    );
+    for (final entryPoint in entryPoints) {
+      final ExtensionConnection connection = await ExtensionConnection.spawn(
+        entryPoint,
+        logger: _logger,
+      );
+      if (connection.capabilities.supportsHostPlatform(hostPlatform)) {
+        _logger.printTrace(
+          'Extension connection supported on host platform "$hostPlatform"; registering.',
+        );
+        _discovery.registerConnection(connection);
+      } else {
+        _logger.printTrace(
+          'Extension connection does not support host platform "$hostPlatform" '
+          '(supported platforms: ${connection.capabilities.supportedPlatforms}); disposing connection.',
+        );
+        await connection.dispose();
+      }
+    }
+  }
+
+  /// Disposes all active extension isolate connections.
+  Future<void> dispose() async {
+    _logger.printTrace('ExtensionManager disposing all active connections.');
+    await _discovery.dispose();
+  }
+}

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -88,6 +88,9 @@ abstract class FeatureFlags {
   /// Whether to only build for arm64 when targeting macOS.
   bool get isMacOSArm64OnlyEnabled;
 
+  /// Whether support for tool extensions is enabled.
+  bool get isToolExtensionsEnabled;
+
   /// Whether a particular feature is enabled for the current channel.
   ///
   /// Prefer using one of the specific getters above instead of this API.
@@ -115,6 +118,7 @@ abstract class FeatureFlags {
     uiSceneMigration,
     riscv64,
     macOSArm64Only,
+    toolExtensionsFeature,
   ];
 
   /// All current Flutter feature flags that can be configured.
@@ -322,6 +326,16 @@ const macOSArm64Only = Feature(
       'See https://flutter.dev/go/macos-intel-deprecation for details.',
   configSetting: 'enable-macos-arm64-only',
   environmentOverride: 'FLUTTER_MACOS_ARM64_ONLY',
+  master: FeatureChannelSetting(available: true),
+  beta: FeatureChannelSetting(available: true),
+  stable: FeatureChannelSetting(available: true),
+);
+
+/// Enable tool extensions feature.
+const toolExtensionsFeature = Feature(
+  name: 'support for tool extensions',
+  configSetting: 'enable-tool-extensions',
+  environmentOverride: 'FLUTTER_TOOL_EXTENSIONS',
   master: FeatureChannelSetting(available: true),
   beta: FeatureChannelSetting(available: true),
   stable: FeatureChannelSetting(available: true),

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -337,8 +337,6 @@ const toolExtensionsFeature = Feature(
   configSetting: 'enable-tool-extensions',
   environmentOverride: 'FLUTTER_TOOL_EXTENSIONS',
   master: FeatureChannelSetting(available: true),
-  beta: FeatureChannelSetting(available: true),
-  stable: FeatureChannelSetting(available: true),
 );
 
 /// A [Feature] is a process for conditionally enabling tool features.

--- a/packages/flutter_tools/lib/src/flutter_features.dart
+++ b/packages/flutter_tools/lib/src/flutter_features.dart
@@ -78,6 +78,9 @@ mixin FlutterFeatureFlagsIsEnabled implements FeatureFlags {
 
   @override
   bool get isMacOSArm64OnlyEnabled => isEnabled(macOSArm64Only);
+
+  @override
+  bool get isToolExtensionsEnabled => isEnabled(toolExtensionsFeature);
 }
 
 interface class FlutterFeatureFlags extends FeatureFlags with FlutterFeatureFlagsIsEnabled {

--- a/packages/flutter_tools/lib/src/flutter_features_config.dart
+++ b/packages/flutter_tools/lib/src/flutter_features_config.dart
@@ -102,7 +102,7 @@ interface class FlutterFeaturesConfig {
   /// ENABLE_FOO=any-other-value flutter some-command
   /// ```
   bool? isEnabled(Feature feature) {
-    return _isEnabledByPlatformEnvironment(feature) ?? _isEnabledByConfigValue(feature);
+    return _isEnabledByConfigValue(feature) ?? _isEnabledByPlatformEnvironment(feature);
   }
 
   bool? _isEnabledByConfigValue(Feature feature) {

--- a/packages/flutter_tools/lib/src/flutter_features_config.dart
+++ b/packages/flutter_tools/lib/src/flutter_features_config.dart
@@ -102,7 +102,7 @@ interface class FlutterFeaturesConfig {
   /// ENABLE_FOO=any-other-value flutter some-command
   /// ```
   bool? isEnabled(Feature feature) {
-    return _isEnabledByConfigValue(feature) ?? _isEnabledByPlatformEnvironment(feature);
+    return _isEnabledByPlatformEnvironment(feature) ?? _isEnabledByConfigValue(feature);
   }
 
   bool? _isEnabledByConfigValue(Feature feature) {

--- a/packages/flutter_tools/packages/flutter_tools_extension/lib/flutter_tools_extension.dart
+++ b/packages/flutter_tools/packages/flutter_tools_extension/lib/flutter_tools_extension.dart
@@ -6,8 +6,8 @@
 /// tools extensibility.
 ///
 /// This package defines the platform-agnostic RPC protocol framing, handshake,
-/// and service handler interfaces (`DeviceExtension`, `DiagnosticsExtension`,
-/// `ConfigurationExtension`, etc.) implemented by extension authors.
+/// and service handler interfaces implemented by extension authors.
 library flutter_tools_extension;
 
-// TODO(bkonyi): export extension protocol base classes and service interfaces.
+export 'src/protocol_base/provider.dart';
+export 'src/protocol_base/service.dart';

--- a/packages/flutter_tools/packages/flutter_tools_extension/lib/src/protocol_base/provider.dart
+++ b/packages/flutter_tools/packages/flutter_tools_extension/lib/src/protocol_base/provider.dart
@@ -1,0 +1,80 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
+import 'package:stream_channel/isolate_channel.dart';
+
+import 'service.dart';
+
+/// Entrypoint runner for a Flutter Tool Extension running in an Isolate.
+///
+/// Extension packages invoke [ToolExtensionEntryPoint.run] in their isolate
+/// entrypoint function, passing the initial Isolate send port and list of supported
+/// extension services.
+class ToolExtensionEntryPoint {
+  /// Entrypoint function to serve [services] over the Isolate [sendPort].
+  static Future<void> run(
+    SendPort sendPort,
+    List<ToolExtensionService> services, {
+    List<String>? supportedPlatforms,
+    void Function(String message)? logger,
+  }) async {
+    logger?.call('[ToolExtensionIsolate] Initializing isolate channel...');
+    final channel = IsolateChannel<Object?>.connectSend(sendPort);
+    final peer = json_rpc.Peer.withoutJson(channel);
+
+    final rpcHandlers = <String, ExtensionRpcHandler>{};
+
+    for (final service in services) {
+      logger?.call(
+        '[ToolExtensionIsolate] Initializing service namespace "${service.namespace}"...',
+      );
+      final Map<String, ExtensionRpcHandler> handlers = await service.initialize();
+      handlers.forEach((String method, ExtensionRpcHandler handler) {
+        final fullMethod = '${service.namespace}.$method';
+        if (rpcHandlers.containsKey(fullMethod)) {
+          throw StateError('Duplicate RPC method registered: "$fullMethod"');
+        }
+        rpcHandlers[fullMethod] = handler;
+        logger?.call('[ToolExtensionIsolate] Registered RPC method handler: "$fullMethod"');
+      });
+    }
+
+    final capabilities = ToolExtensionCapabilities(
+      supportedPlatforms: supportedPlatforms ?? const <String>['linux', 'macos', 'windows'],
+      services: services.map((ToolExtensionService s) => s.namespace).toList(),
+    );
+
+    peer.registerMethod('extension.getCapabilities', () {
+      logger?.call('[ToolExtensionIsolate] Handling extension.getCapabilities query.');
+      return capabilities.toMap();
+    });
+
+    rpcHandlers.forEach((String fullMethod, ExtensionRpcHandler handler) {
+      peer.registerMethod(fullMethod, (json_rpc.Parameters params) async {
+        logger?.call('[ToolExtensionIsolate] Handling RPC request "$fullMethod"...');
+        final Object? rawValue = params.value;
+        final Map<String, Object?> paramMap = rawValue is Map
+            ? rawValue.cast<String, Object?>()
+            : <String, Object?>{};
+        try {
+          final Object? result = await handler(paramMap);
+          logger?.call('[ToolExtensionIsolate] RPC request "$fullMethod" completed.');
+          return result;
+        } on Object catch (error, stackTrace) {
+          logger?.call(
+            '[ToolExtensionIsolate] RPC request "$fullMethod" failed: $error\n$stackTrace',
+          );
+          rethrow;
+        }
+      });
+    });
+
+    logger?.call('[ToolExtensionIsolate] Isolate peer listening for RPC requests.');
+    await peer.listen();
+  }
+}

--- a/packages/flutter_tools/packages/flutter_tools_extension/lib/src/protocol_base/provider.dart
+++ b/packages/flutter_tools/packages/flutter_tools_extension/lib/src/protocol_base/provider.dart
@@ -20,7 +20,7 @@ class ToolExtensionEntryPoint {
   static Future<void> run(
     SendPort sendPort,
     List<ToolExtensionService> services, {
-    List<String>? supportedPlatforms,
+    Set<String>? supportedPlatforms,
     void Function(String message)? logger,
   }) async {
     logger?.call('[ToolExtensionIsolate] Initializing isolate channel...');
@@ -45,7 +45,7 @@ class ToolExtensionEntryPoint {
     }
 
     final capabilities = ToolExtensionCapabilities(
-      supportedPlatforms: supportedPlatforms ?? const <String>['linux', 'macos', 'windows'],
+      supportedPlatforms: supportedPlatforms ?? const <String>{'linux', 'macos', 'windows'},
       services: services.map((ToolExtensionService s) => s.namespace).toList(),
     );
 

--- a/packages/flutter_tools/packages/flutter_tools_extension/lib/src/protocol_base/service.dart
+++ b/packages/flutter_tools/packages/flutter_tools_extension/lib/src/protocol_base/service.dart
@@ -32,25 +32,25 @@ class ToolExtensionCapabilities {
   /// Creates [ToolExtensionCapabilities] listing supported [services] and [supportedPlatforms].
   const ToolExtensionCapabilities({
     required this.services,
-    this.supportedPlatforms = const <String>['linux', 'macos', 'windows'],
+    this.supportedPlatforms = const <String>{'linux', 'macos', 'windows'},
   });
 
   /// Deserializes [ToolExtensionCapabilities] from a JSON map payload.
   factory ToolExtensionCapabilities.fromJson(Map<String, Object?> json) {
     final Object? servicesList = json['services'];
-    final services = servicesList is List ? List<String>.from(servicesList) : <String>[];
+    final services = servicesList is Iterable ? List<String>.from(servicesList) : <String>[];
     final Object? platformsList = json['supportedPlatforms'];
-    final supportedPlatforms = platformsList is List
-        ? List<String>.from(platformsList)
-        : const <String>['linux', 'macos', 'windows'];
+    final Set<String> supportedPlatforms = platformsList is Iterable
+        ? platformsList.map((Object? p) => p.toString().toLowerCase()).toSet()
+        : const <String>{'linux', 'macos', 'windows'};
     return ToolExtensionCapabilities(services: services, supportedPlatforms: supportedPlatforms);
   }
 
   /// The list of service namespace identifiers supported by the extension.
   final List<String> services;
 
-  /// The list of host operating system platforms supported by the extension (e.g., `'linux'`).
-  final List<String> supportedPlatforms;
+  /// The set of host operating system platforms supported by the extension in lowercase (e.g., `{'linux'}`).
+  final Set<String> supportedPlatforms;
 
   /// Returns whether the extension supports the given [hostPlatform].
   bool supportsHostPlatform(String hostPlatform) {
@@ -60,6 +60,6 @@ class ToolExtensionCapabilities {
   /// Serializes capabilities to a map payload.
   Map<String, Object?> toMap() => <String, Object?>{
     'services': services,
-    'supportedPlatforms': supportedPlatforms,
+    'supportedPlatforms': supportedPlatforms.toList(),
   };
 }

--- a/packages/flutter_tools/packages/flutter_tools_extension/lib/src/protocol_base/service.dart
+++ b/packages/flutter_tools/packages/flutter_tools_extension/lib/src/protocol_base/service.dart
@@ -1,0 +1,65 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+/// Typedef for an extension RPC handler function.
+typedef ExtensionRpcHandler = FutureOr<Object?> Function(Map<String, Object?> params);
+
+/// Represents a logical service exposed by a Flutter Tool Extension.
+///
+/// Extension authors implement this class to group related RPC endpoints under
+/// a specific [namespace] (e.g. `diagnostics`, `configuration`, `device`, `build`, `templates`).
+abstract class ToolExtensionService {
+  /// The namespace string of the service (e.g. `'diagnostics'`).
+  String get namespace;
+
+  /// Initializes state needed by the service and returns a map of method handlers.
+  ///
+  /// The returned map maps method names (without namespace prefix) to handler functions.
+  Future<Map<String, ExtensionRpcHandler>> initialize();
+
+  /// Cleans up resources held by the service when the extension is shut down.
+  Future<void> shutdown() async {}
+}
+
+/// Represents the capabilities and supported service namespaces reported by an extension.
+@immutable
+class ToolExtensionCapabilities {
+  /// Creates [ToolExtensionCapabilities] listing supported [services] and [supportedPlatforms].
+  const ToolExtensionCapabilities({
+    required this.services,
+    this.supportedPlatforms = const <String>['linux', 'macos', 'windows'],
+  });
+
+  /// Deserializes [ToolExtensionCapabilities] from a JSON map payload.
+  factory ToolExtensionCapabilities.fromJson(Map<String, Object?> json) {
+    final Object? servicesList = json['services'];
+    final services = servicesList is List ? List<String>.from(servicesList) : <String>[];
+    final Object? platformsList = json['supportedPlatforms'];
+    final supportedPlatforms = platformsList is List
+        ? List<String>.from(platformsList)
+        : const <String>['linux', 'macos', 'windows'];
+    return ToolExtensionCapabilities(services: services, supportedPlatforms: supportedPlatforms);
+  }
+
+  /// The list of service namespace identifiers supported by the extension.
+  final List<String> services;
+
+  /// The list of host operating system platforms supported by the extension (e.g., `'linux'`).
+  final List<String> supportedPlatforms;
+
+  /// Returns whether the extension supports the given [hostPlatform].
+  bool supportsHostPlatform(String hostPlatform) {
+    return supportedPlatforms.contains(hostPlatform.toLowerCase());
+  }
+
+  /// Serializes capabilities to a map payload.
+  Map<String, Object?> toMap() => <String, Object?>{
+    'services': services,
+    'supportedPlatforms': supportedPlatforms,
+  };
+}

--- a/packages/flutter_tools/packages/flutter_tools_extension/pubspec.yaml
+++ b/packages/flutter_tools/packages/flutter_tools_extension/pubspec.yaml
@@ -9,5 +9,7 @@ dependencies:
   meta: 1.19.0
   flutter_tools_core:
     path: ../flutter_tools_core
+  json_rpc_2: 4.1.0
+  stream_channel: 2.1.4
 
-# PUBSPEC CHECKSUM: foiaro
+# PUBSPEC CHECKSUM: 608ed1

--- a/packages/flutter_tools/packages/flutter_tools_extension_linux_prototype/lib/flutter_tools_extension_linux_prototype.dart
+++ b/packages/flutter_tools/packages/flutter_tools_extension_linux_prototype/lib/flutter_tools_extension_linux_prototype.dart
@@ -3,10 +3,17 @@
 // found in the LICENSE file.
 
 /// Prototype Linux platform extension package for Flutter tools extensibility.
-///
-/// This package encapsulates all Linux-specific device detection, doctor check
-/// diagnostics, build handlers, and project templates for the custom Linux
-/// extension prototype.
 library flutter_tools_extension_linux_prototype;
 
-// TODO(bkonyi): implement prototype Linux extension entrypoint and services.
+import 'dart:isolate';
+
+import 'package:flutter_tools_extension/flutter_tools_extension.dart';
+
+/// Isolate entrypoint for the prototype Linux Flutter Tool Extension.
+void linuxExtensionEntryPoint(SendPort sendPort) {
+  ToolExtensionEntryPoint.run(
+    sendPort,
+    <ToolExtensionService>[],
+    supportedPlatforms: const <String>['linux'],
+  );
+}

--- a/packages/flutter_tools/packages/flutter_tools_extension_linux_prototype/lib/flutter_tools_extension_linux_prototype.dart
+++ b/packages/flutter_tools/packages/flutter_tools_extension_linux_prototype/lib/flutter_tools_extension_linux_prototype.dart
@@ -14,6 +14,10 @@ void linuxExtensionEntryPoint(SendPort sendPort) {
   ToolExtensionEntryPoint.run(
     sendPort,
     <ToolExtensionService>[],
-    supportedPlatforms: const <String>['linux'],
+    supportedPlatforms: const <String>{'linux'},
+    logger: (String message) {
+      // ignore: avoid_print
+      print('[LinuxExtension] $message');
+    },
   );
 }

--- a/packages/flutter_tools/test/general.shard/extension_protocol/extension_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/extension_protocol/extension_discovery_test.dart
@@ -49,38 +49,32 @@ void main() {
       expect(discovery.connections, isEmpty);
     });
 
-    test('ExtensionDiscovery spawnAll manages multiple extensions', () async {
+    test('ExtensionConnection.spawn throws and cleans up on isolate startup failure', () async {
       final logger = BufferLogger.test();
+      expect(
+        () => ExtensionConnection.spawn(_failingExtensionEntryPoint, logger: logger),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('ExtensionDiscovery registers multiple connections and disposes them', () async {
+      final logger = BufferLogger.test();
+      final ExtensionConnection connection1 = await ExtensionConnection.spawn(
+        _dummyExtensionEntryPoint,
+        logger: logger,
+      );
+      final ExtensionConnection connection2 = await ExtensionConnection.spawn(
+        _dummyExtensionEntryPoint,
+        logger: logger,
+      );
+
       final discovery = ExtensionDiscovery(logger: logger);
-      final List<ExtensionConnection> connections = await discovery.spawnAll(<ExtensionEntryPoint>[
-        _dummyExtensionEntryPoint,
-        _dummyExtensionEntryPoint,
-      ]);
+      discovery.registerConnections(<ExtensionConnection>[connection1, connection2]);
 
-      expect(connections, hasLength(2));
       expect(discovery.connections, hasLength(2));
-
       await discovery.dispose();
       expect(discovery.connections, isEmpty);
     });
-
-    test(
-      'ExtensionDiscovery spawnAll handles individual failure without failing entire batch',
-      () async {
-        final logger = BufferLogger.test();
-        final discovery = ExtensionDiscovery(logger: logger);
-        final List<ExtensionConnection> connections = await discovery.spawnAll(
-          <ExtensionEntryPoint>[_dummyExtensionEntryPoint, _failingExtensionEntryPoint],
-        );
-
-        expect(connections, hasLength(1));
-        expect(discovery.connections, hasLength(1));
-        expect(logger.errorText, contains('Failed to spawn extension'));
-
-        await discovery.dispose();
-        expect(discovery.connections, isEmpty);
-      },
-    );
 
     test(
       'ToolExtensionCapabilities.fromJson eagerly deserializes lists and normalizes platforms',

--- a/packages/flutter_tools/test/general.shard/extension_protocol/extension_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/extension_protocol/extension_discovery_test.dart
@@ -82,15 +82,20 @@ void main() {
       },
     );
 
-    test('ToolExtensionCapabilities.fromJson eagerly deserializes lists', () {
-      final capabilities = ToolExtensionCapabilities.fromJson(const <String, Object?>{
-        'services': <Object?>['diagnostics', 'config'],
-        'supportedPlatforms': <Object?>['linux', 'macos'],
-      });
+    test(
+      'ToolExtensionCapabilities.fromJson eagerly deserializes lists and normalizes platforms',
+      () {
+        final capabilities = ToolExtensionCapabilities.fromJson(const <String, Object?>{
+          'services': <Object?>['diagnostics', 'config'],
+          'supportedPlatforms': <Object?>['Linux', 'MacOS'],
+        });
 
-      expect(capabilities.services, const <String>['diagnostics', 'config']);
-      expect(capabilities.supportedPlatforms, const <String>['linux', 'macos']);
-    });
+        expect(capabilities.services, const <String>['diagnostics', 'config']);
+        expect(capabilities.supportedPlatforms, const <String>{'linux', 'macos'});
+        expect(capabilities.supportsHostPlatform('LINUX'), isTrue);
+        expect(capabilities.supportsHostPlatform('windows'), isFalse);
+      },
+    );
 
     test('ToolExtensionEntryPoint.run rejects duplicate RPC method registration', () async {
       final service1 = _DummyService('test', 'ping');

--- a/packages/flutter_tools/test/general.shard/extension_protocol/extension_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/extension_protocol/extension_discovery_test.dart
@@ -1,0 +1,117 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:isolate';
+
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/experimental/extension_discovery.dart';
+import 'package:flutter_tools_extension/flutter_tools_extension.dart';
+import 'package:test/test.dart';
+
+void _dummyExtensionEntryPoint(SendPort sendPort) {
+  ToolExtensionEntryPoint.run(sendPort, <ToolExtensionService>[]);
+}
+
+void _failingExtensionEntryPoint(SendPort sendPort) {
+  // Throws during isolate initialization before handshake.
+  throw StateError('Simulated isolate startup failure');
+}
+
+class _DummyService extends ToolExtensionService {
+  _DummyService(this.namespace, this.methodName);
+
+  @override
+  final String namespace;
+  final String methodName;
+
+  @override
+  Future<Map<String, ExtensionRpcHandler>> initialize() async {
+    return <String, ExtensionRpcHandler>{methodName: (Map<String, Object?> params) => 'ok'};
+  }
+}
+
+void main() {
+  group('ExtensionDiscovery & Connection Base', () {
+    test('ExtensionConnection completes isolate handshake and retrieves capabilities', () async {
+      final logger = BufferLogger.test();
+      final ExtensionConnection connection = await ExtensionConnection.spawn(
+        _dummyExtensionEntryPoint,
+        logger: logger,
+      );
+      expect(connection.capabilities, isA<ToolExtensionCapabilities>());
+
+      final discovery = ExtensionDiscovery(logger: logger);
+      discovery.registerConnection(connection);
+      expect(discovery.connections, hasLength(1));
+
+      await discovery.dispose();
+      expect(discovery.connections, isEmpty);
+    });
+
+    test('ExtensionDiscovery spawnAll manages multiple extensions', () async {
+      final logger = BufferLogger.test();
+      final discovery = ExtensionDiscovery(logger: logger);
+      final List<ExtensionConnection> connections = await discovery.spawnAll(<ExtensionEntryPoint>[
+        _dummyExtensionEntryPoint,
+        _dummyExtensionEntryPoint,
+      ]);
+
+      expect(connections, hasLength(2));
+      expect(discovery.connections, hasLength(2));
+
+      await discovery.dispose();
+      expect(discovery.connections, isEmpty);
+    });
+
+    test(
+      'ExtensionDiscovery spawnAll handles individual failure without failing entire batch',
+      () async {
+        final logger = BufferLogger.test();
+        final discovery = ExtensionDiscovery(logger: logger);
+        final List<ExtensionConnection> connections = await discovery.spawnAll(
+          <ExtensionEntryPoint>[_dummyExtensionEntryPoint, _failingExtensionEntryPoint],
+        );
+
+        expect(connections, hasLength(1));
+        expect(discovery.connections, hasLength(1));
+        expect(logger.errorText, contains('Failed to spawn extension'));
+
+        await discovery.dispose();
+        expect(discovery.connections, isEmpty);
+      },
+    );
+
+    test('ToolExtensionCapabilities.fromJson eagerly deserializes lists', () {
+      final capabilities = ToolExtensionCapabilities.fromJson(const <String, Object?>{
+        'services': <Object?>['diagnostics', 'config'],
+        'supportedPlatforms': <Object?>['linux', 'macos'],
+      });
+
+      expect(capabilities.services, const <String>['diagnostics', 'config']);
+      expect(capabilities.supportedPlatforms, const <String>['linux', 'macos']);
+    });
+
+    test('ToolExtensionEntryPoint.run rejects duplicate RPC method registration', () async {
+      final service1 = _DummyService('test', 'ping');
+      final service2 = _DummyService('test', 'ping');
+
+      final receivePort = ReceivePort();
+      addTearDown(receivePort.close);
+
+      expect(
+        () => ToolExtensionEntryPoint.run(receivePort.sendPort, <ToolExtensionService>[
+          service1,
+          service2,
+        ]),
+        throwsA(
+          isA<StateError>().having(
+            (StateError e) => e.message,
+            'message',
+            contains('Duplicate RPC method registered: "test.ping"'),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/flutter_tools/test/general.shard/extension_protocol/extension_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/extension_protocol/extension_manager_test.dart
@@ -20,7 +20,7 @@ void _linuxOnlyExtensionEntryPoint(SendPort sendPort) {
   ToolExtensionEntryPoint.run(
     sendPort,
     <ToolExtensionService>[],
-    supportedPlatforms: const <String>['linux'],
+    supportedPlatforms: const <String>{'linux'},
   );
 }
 

--- a/packages/flutter_tools/test/general.shard/extension_protocol/extension_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/extension_protocol/extension_manager_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:isolate';
+
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/experimental/extension_discovery.dart';
+import 'package:flutter_tools/src/experimental/extension_manager.dart';
+import 'package:flutter_tools_extension/flutter_tools_extension.dart';
+import 'package:test/test.dart';
+
+import '../../src/fakes.dart';
+
+void _dummyExtensionEntryPoint(SendPort sendPort) {
+  ToolExtensionEntryPoint.run(sendPort, <ToolExtensionService>[]);
+}
+
+void _linuxOnlyExtensionEntryPoint(SendPort sendPort) {
+  ToolExtensionEntryPoint.run(
+    sendPort,
+    <ToolExtensionService>[],
+    supportedPlatforms: const <String>['linux'],
+  );
+}
+
+void main() {
+  group('ExtensionManager Integration', () {
+    test('ExtensionManager loads extension compatible with hostPlatform', () async {
+      final logger = BufferLogger.test();
+      final manager = ExtensionManager(
+        hostPlatform: 'linux',
+        logger: logger,
+        featureFlags: TestFeatureFlags(isToolExtensionsEnabled: true),
+      );
+      await manager.initialize(entryPoints: <ExtensionEntryPoint>[_dummyExtensionEntryPoint]);
+
+      expect(manager.connections, hasLength(1));
+      await manager.dispose();
+      expect(manager.connections, isEmpty);
+    });
+
+    test('ExtensionManager filters out extension incompatible with hostPlatform', () async {
+      final logger = BufferLogger.test();
+      final manager = ExtensionManager(
+        hostPlatform: 'macos',
+        logger: logger,
+        featureFlags: TestFeatureFlags(isToolExtensionsEnabled: true),
+      );
+      await manager.initialize(entryPoints: <ExtensionEntryPoint>[_linuxOnlyExtensionEntryPoint]);
+
+      expect(manager.connections, isEmpty);
+      await manager.dispose();
+    });
+  });
+}

--- a/packages/flutter_tools/test/general.shard/extension_protocol/extension_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/extension_protocol/extension_manager_test.dart
@@ -5,6 +5,7 @@
 import 'dart:isolate';
 
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/experimental/extension_discovery.dart';
 import 'package:flutter_tools/src/experimental/extension_manager.dart';
 import 'package:flutter_tools_extension/flutter_tools_extension.dart';
@@ -29,7 +30,7 @@ void main() {
     test('ExtensionManager loads extension compatible with hostPlatform', () async {
       final logger = BufferLogger.test();
       final manager = ExtensionManager(
-        hostPlatform: 'linux',
+        hostPlatform: HostPlatform.linux_x64,
         logger: logger,
         featureFlags: TestFeatureFlags(isToolExtensionsEnabled: true),
       );
@@ -43,7 +44,7 @@ void main() {
     test('ExtensionManager filters out extension incompatible with hostPlatform', () async {
       final logger = BufferLogger.test();
       final manager = ExtensionManager(
-        hostPlatform: 'macos',
+        hostPlatform: HostPlatform.darwin_arm64,
         logger: logger,
         featureFlags: TestFeatureFlags(isToolExtensionsEnabled: true),
       );

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -445,6 +445,29 @@ void main() {
       expect(checkFlags.isMacOSArm64OnlyEnabled, isTrue);
     });
   });
+
+  group('Tool Extensions', () {
+    test('is available on all channels', () {
+      expect(
+        toolExtensionsFeature,
+        allOf(<Matcher>[
+          _onChannelIs('master', available: true, enabledByDefault: false),
+          _onChannelIs('stable', available: true, enabledByDefault: false),
+          _onChannelIs('beta', available: true, enabledByDefault: false),
+        ]),
+      );
+    });
+
+    test('can be configured', () {
+      expect(toolExtensionsFeature.configSetting, 'enable-tool-extensions');
+      expect(toolExtensionsFeature.environmentOverride, 'FLUTTER_TOOL_EXTENSIONS');
+    });
+
+    test('forwards to isEnabled', () {
+      final checkFlags = _TestIsGetterForwarding(shouldInvoke: toolExtensionsFeature);
+      expect(checkFlags.isToolExtensionsEnabled, isTrue);
+    });
+  });
 }
 
 final class _FakeFeaturesConfig implements FlutterFeaturesConfig {

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -447,13 +447,13 @@ void main() {
   });
 
   group('Tool Extensions', () {
-    test('is available on all channels', () {
+    test('is available only on master', () {
       expect(
         toolExtensionsFeature,
         allOf(<Matcher>[
           _onChannelIs('master', available: true, enabledByDefault: false),
-          _onChannelIs('stable', available: true, enabledByDefault: false),
-          _onChannelIs('beta', available: true, enabledByDefault: false),
+          _onChannelIs('stable', available: false, enabledByDefault: false),
+          _onChannelIs('beta', available: false, enabledByDefault: false),
         ]),
       );
     });

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -861,6 +861,9 @@ class FakeFlutterFeatures extends FeatureFlags {
   bool get isMacOSArm64OnlyEnabled => _enabled;
 
   @override
+  bool get isToolExtensionsEnabled => _enabled;
+
+  @override
   final List<Feature> allFeatures;
 
   @override

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -554,6 +554,7 @@ class TestFeatureFlags implements FeatureFlags {
     this.isUISceneMigrationEnabled = false,
     this.isRiscv64SupportEnabled = false,
     this.isMacOSArm64OnlyEnabled = false,
+    this.isToolExtensionsEnabled = false,
   });
 
   @override
@@ -617,6 +618,9 @@ class TestFeatureFlags implements FeatureFlags {
   final bool isMacOSArm64OnlyEnabled;
 
   @override
+  final bool isToolExtensionsEnabled;
+
+  @override
   bool isEnabled(Feature feature) {
     return switch (feature) {
       flutterWebFeature => isWebEnabled,
@@ -638,6 +642,7 @@ class TestFeatureFlags implements FeatureFlags {
       riscv64 => isRiscv64SupportEnabled,
       macOSArm64Only => isMacOSArm64OnlyEnabled,
       recordUse => isRecordUseEnabled,
+      toolExtensionsFeature => isToolExtensionsEnabled,
       _ => false,
     };
   }
@@ -664,6 +669,7 @@ class TestFeatureFlags implements FeatureFlags {
     uiSceneMigration,
     riscv64,
     macOSArm64Only,
+    toolExtensionsFeature,
   ];
 
   @override


### PR DESCRIPTION
Part of the tool extensibility prototype effort.

Implements the generic JSON-RPC protocol framing, capability handshake, and isolate runner infrastructure for Flutter tool extensions:
- `ToolExtensionEntryPoint`, `ToolExtensionService`, `ToolExtensionRunner` in `package:flutter_tools_extension`.
- Host-side `ExtensionManager` and `ExtensionDiscovery` in `package:flutter_tools`.

Part of #190746
Part of #190755

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md