### PR TITLE
[tool] Migrate ScreenshotCommand to modular dependency injection

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -351,7 +351,7 @@ List<FlutterCommand> generateCommands({
     featureFlags: featureFlags,
   ),
   RunCommand(verboseHelp: verboseHelp),
-  ScreenshotCommand(fs: toolDependencies.toolContext.fs),
+  ScreenshotCommand(toolContext: toolDependencies.toolContext),
   ShellCompletionCommand(),
   TestCommand(
     verboseHelp: verboseHelp,

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -7,9 +7,10 @@ import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../context/tool_context.dart';
 import '../convert.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 import '../vmservice.dart';
 
@@ -19,8 +20,12 @@ const _kVmServiceUrl = 'vm-service-url';
 const _kDeviceType = 'device';
 const _kSkiaType = 'skia';
 
+/// The `flutter screenshot` command, which captures a screenshot from a connected device.
 class ScreenshotCommand extends FlutterCommand {
-  ScreenshotCommand({required this.fs}) {
+  ScreenshotCommand({required ToolContext toolContext, VMServiceConnector? vmServiceConnector})
+    : _toolContext = toolContext,
+      _vmServiceConnector = vmServiceConnector ?? connectToVmService,
+      super(toolContext: toolContext) {
     argParser.addOption(
       _kOut,
       abbr: 'o',
@@ -54,7 +59,11 @@ class ScreenshotCommand extends FlutterCommand {
     usesDeviceConnectionOption();
   }
 
-  final FileSystem fs;
+  final ToolContext _toolContext;
+  final VMServiceConnector _vmServiceConnector;
+
+  @override
+  ToolContext get toolContext => _toolContext;
 
   @override
   String get name => 'screenshot';
@@ -104,6 +113,7 @@ class ScreenshotCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    final FileSystem fs = toolContext.fs;
     File? outputFile;
     if (argResults?.wasParsed(_kOut) ?? false) {
       outputFile = fs.file(stringArg(_kOut));
@@ -121,7 +131,9 @@ class ScreenshotCommand extends FlutterCommand {
   }
 
   Future<void> runScreenshot(File? outputFile) async {
-    outputFile ??= globals.fsUtils.getUniqueFile(fs.currentDirectory, 'flutter', 'png');
+    final FileSystem fs = toolContext.fs;
+    final FileSystemUtils fileSystemUtils = toolContext.fileSystemUtils;
+    outputFile ??= fileSystemUtils.getUniqueFile(fs.currentDirectory, 'flutter', 'png');
 
     try {
       await device!.takeScreenshot(outputFile);
@@ -144,20 +156,20 @@ class ScreenshotCommand extends FlutterCommand {
   }
 
   Future<bool> runSkia(File? outputFile) async {
+    final FileSystem fs = toolContext.fs;
+    final FileSystemUtils fileSystemUtils = toolContext.fileSystemUtils;
+    final Logger logger = toolContext.logger;
     final Uri vmServiceUrl = Uri.parse(stringArg(_kVmServiceUrl)!);
-    final FlutterVmService vmService = await connectToVmService(
-      vmServiceUrl,
-      logger: globals.logger,
-    );
+    final FlutterVmService vmService = await _vmServiceConnector(vmServiceUrl, logger: logger);
     final vm_service.Response? skp = await vmService.screenshotSkp();
     if (skp == null) {
-      globals.printError(
+      logger.printError(
         'The Skia picture request failed, probably because the device was '
         'disconnected',
       );
       return false;
     }
-    outputFile ??= globals.fsUtils.getUniqueFile(fs.currentDirectory, 'flutter', 'skp');
+    outputFile ??= fileSystemUtils.getUniqueFile(fs.currentDirectory, 'flutter', 'skp');
     final IOSink sink = outputFile.openWrite();
     sink.add(base64.decode(skp.json?['skp'] as String));
     await sink.close();
@@ -189,9 +201,9 @@ class ScreenshotCommand extends FlutterCommand {
   }
 
   void _showOutputFileInfo(File outputFile) {
-    final int sizeKB = (outputFile.lengthSync()) ~/ 1024;
-    globals.printStatus(
-      'Screenshot written to ${fs.path.relative(outputFile.path)} (${sizeKB}kB).',
-    );
+    final FileSystem fs = toolContext.fs;
+    final Logger logger = toolContext.logger;
+    final int sizeKB = outputFile.lengthSync() ~/ 1024;
+    logger.printStatus('Screenshot written to ${fs.path.relative(outputFile.path)} (${sizeKB}kB).');
   }
 }

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -3,14 +3,17 @@
 // found in the LICENSE file.
 
 import 'package:meta/meta.dart';
+import 'package:process/process.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
+import '../base/platform.dart';
 import '../context/tool_context.dart';
 import '../convert.dart';
 import '../device.dart';
+import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 import '../vmservice.dart';
 
@@ -22,10 +25,8 @@ const _kSkiaType = 'skia';
 
 /// The `flutter screenshot` command, which captures a screenshot from a connected device.
 class ScreenshotCommand extends FlutterCommand {
-  ScreenshotCommand({required ToolContext toolContext, VMServiceConnector? vmServiceConnector})
-    : _toolContext = toolContext,
-      _vmServiceConnector = vmServiceConnector ?? connectToVmService,
-      super(toolContext: toolContext) {
+  ScreenshotCommand({this.fs, super.toolContext, VMServiceConnector? vmServiceConnector})
+    : _vmServiceConnector = vmServiceConnector ?? connectToVmService {
     argParser.addOption(
       _kOut,
       abbr: 'o',
@@ -59,11 +60,22 @@ class ScreenshotCommand extends FlutterCommand {
     usesDeviceConnectionOption();
   }
 
-  final ToolContext _toolContext;
+  final FileSystem? fs;
   final VMServiceConnector _vmServiceConnector;
 
   @override
-  ToolContext get toolContext => _toolContext;
+  ToolContext get toolContext {
+    final ToolContext? explicit = super.toolContext;
+    if (explicit != null) {
+      return explicit;
+    }
+    return _ScreenshotToolContext(
+      fs: fs ?? globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+      processManager: globals.processManager,
+    );
+  }
 
   @override
   String get name => 'screenshot';
@@ -75,7 +87,7 @@ class ScreenshotCommand extends FlutterCommand {
   final String category = FlutterCommandCategory.tools;
 
   @override
-  bool get refreshWirelessDevices => true;
+  bool get refreshWirelessDevices => stringArg(_kType) == _kDeviceType;
 
   @override
   final aliases = <String>['pic'];
@@ -206,4 +218,31 @@ class ScreenshotCommand extends FlutterCommand {
     final int sizeKB = outputFile.lengthSync() ~/ 1024;
     logger.printStatus('Screenshot written to ${fs.path.relative(outputFile.path)} (${sizeKB}kB).');
   }
+}
+
+class _ScreenshotToolContext implements ToolContext {
+  _ScreenshotToolContext({
+    required this.fs,
+    required this.logger,
+    required this.platform,
+    required this.processManager,
+  });
+
+  @override
+  final FileSystem fs;
+
+  @override
+  final Logger logger;
+
+  @override
+  final Platform platform;
+
+  @override
+  final ProcessManager processManager;
+
+  @override
+  FileSystemUtils get fileSystemUtils => FileSystemUtils(fileSystem: fs, platform: platform);
+
+  @override
+  Object? noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -87,7 +87,7 @@ class ScreenshotCommand extends FlutterCommand {
   final String category = FlutterCommandCategory.tools;
 
   @override
-  bool get refreshWirelessDevices => stringArg(_kType) == _kDeviceType;
+  bool get refreshWirelessDevices => argResults == null || stringArg(_kType) == _kDeviceType;
 
   @override
   final aliases = <String>['pic'];

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -66,13 +66,15 @@ class ScreenshotCommand extends FlutterCommand {
 
   FileSystem get fs => toolContext.fs;
 
+  ToolContext? _fallbackToolContext;
+
   @override
   ToolContext get toolContext {
     final ToolContext? explicit = super.toolContext;
     if (explicit != null) {
       return explicit;
     }
-    return _ScreenshotToolContext(
+    return _fallbackToolContext ??= _ScreenshotToolContext(
       fs: _fs ?? globals.fs,
       logger: globals.logger,
       platform: globals.platform,
@@ -244,7 +246,7 @@ class _ScreenshotToolContext implements ToolContext {
   final ProcessManager processManager;
 
   @override
-  FileSystemUtils get fileSystemUtils => FileSystemUtils(fileSystem: fs, platform: platform);
+  late final FileSystemUtils fileSystemUtils = FileSystemUtils(fileSystem: fs, platform: platform);
 
   @override
   Object? noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -3,17 +3,14 @@
 // found in the LICENSE file.
 
 import 'package:meta/meta.dart';
-import 'package:process/process.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
-import '../base/platform.dart';
 import '../context/tool_context.dart';
 import '../convert.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 import '../vmservice.dart';
 
@@ -25,9 +22,8 @@ const _kSkiaType = 'skia';
 
 /// The `flutter screenshot` command, which captures a screenshot from a connected device.
 class ScreenshotCommand extends FlutterCommand {
-  ScreenshotCommand({FileSystem? fs, super.toolContext, VMServiceConnector? vmServiceConnector})
-    : _fs = fs,
-      _vmServiceConnector = vmServiceConnector ?? connectToVmService {
+  ScreenshotCommand({required super.toolContext, VMServiceConnector? vmServiceConnector})
+    : _vmServiceConnector = vmServiceConnector ?? connectToVmService {
     argParser.addOption(
       _kOut,
       abbr: 'o',
@@ -61,26 +57,12 @@ class ScreenshotCommand extends FlutterCommand {
     usesDeviceConnectionOption();
   }
 
-  final FileSystem? _fs;
   final VMServiceConnector _vmServiceConnector;
 
   FileSystem get fs => toolContext.fs;
 
-  ToolContext? _fallbackToolContext;
-
   @override
-  ToolContext get toolContext {
-    final ToolContext? explicit = super.toolContext;
-    if (explicit != null) {
-      return explicit;
-    }
-    return _fallbackToolContext ??= _ScreenshotToolContext(
-      fs: _fs ?? globals.fs,
-      logger: globals.logger,
-      platform: globals.platform,
-      processManager: globals.processManager,
-    );
-  }
+  ToolContext get toolContext => super.toolContext!;
 
   @override
   String get name => 'screenshot';
@@ -223,31 +205,4 @@ class ScreenshotCommand extends FlutterCommand {
     final int sizeKB = outputFile.lengthSync() ~/ 1024;
     logger.printStatus('Screenshot written to ${fs.path.relative(outputFile.path)} (${sizeKB}kB).');
   }
-}
-
-class _ScreenshotToolContext implements ToolContext {
-  _ScreenshotToolContext({
-    required this.fs,
-    required this.logger,
-    required this.platform,
-    required this.processManager,
-  });
-
-  @override
-  final FileSystem fs;
-
-  @override
-  final Logger logger;
-
-  @override
-  final Platform platform;
-
-  @override
-  final ProcessManager processManager;
-
-  @override
-  late final FileSystemUtils fileSystemUtils = FileSystemUtils(fileSystem: fs, platform: platform);
-
-  @override
-  Object? noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -25,8 +25,9 @@ const _kSkiaType = 'skia';
 
 /// The `flutter screenshot` command, which captures a screenshot from a connected device.
 class ScreenshotCommand extends FlutterCommand {
-  ScreenshotCommand({this.fs, super.toolContext, VMServiceConnector? vmServiceConnector})
-    : _vmServiceConnector = vmServiceConnector ?? connectToVmService {
+  ScreenshotCommand({FileSystem? fs, super.toolContext, VMServiceConnector? vmServiceConnector})
+    : _fs = fs,
+      _vmServiceConnector = vmServiceConnector ?? connectToVmService {
     argParser.addOption(
       _kOut,
       abbr: 'o',
@@ -60,8 +61,10 @@ class ScreenshotCommand extends FlutterCommand {
     usesDeviceConnectionOption();
   }
 
-  final FileSystem? fs;
+  final FileSystem? _fs;
   final VMServiceConnector _vmServiceConnector;
+
+  FileSystem get fs => toolContext.fs;
 
   @override
   ToolContext get toolContext {
@@ -70,7 +73,7 @@ class ScreenshotCommand extends FlutterCommand {
       return explicit;
     }
     return _ScreenshotToolContext(
-      fs: fs ?? globals.fs,
+      fs: _fs ?? globals.fs,
       logger: globals.logger,
       platform: globals.platform,
       processManager: globals.processManager,

--- a/packages/flutter_tools/test/commands.shard/hermetic/screenshot_command_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/screenshot_command_test.dart
@@ -34,7 +34,7 @@ void main() {
       expect(command.toolContext, same(toolContext));
     });
 
-    testUsingContext('rasterizer and skia screenshots do not require a device', () async {
+    testWithoutContext('rasterizer and skia screenshots do not require a device', () async {
       final toolContext = FakeToolContext(fs: MemoryFileSystem.test());
       final command = ScreenshotCommand(
         toolContext: toolContext,

--- a/packages/flutter_tools/test/commands.shard/hermetic/screenshot_command_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/screenshot_command_test.dart
@@ -215,7 +215,7 @@ Device 2 (mobile) • 456 • android • 1.2.3
   });
 
   group('Skia screenshot execution', () {
-    testUsingContext('successful Skia screenshot with custom out', () async {
+    testWithoutContext('successful Skia screenshot with custom out', () async {
       final fs = MemoryFileSystem.test();
       final logger = BufferLogger.test();
       final toolContext = FakeToolContext(fs: fs, logger: logger);
@@ -259,7 +259,7 @@ Device 2 (mobile) • 456 • android • 1.2.3
       expect(logger.statusText, contains('Screenshot written to screenshot.skp (0kB).'));
     });
 
-    testUsingContext('failed Skia screenshot when disconnected', () async {
+    testWithoutContext('failed Skia screenshot when disconnected', () async {
       final fs = MemoryFileSystem.test();
       final logger = BufferLogger.test();
       final toolContext = FakeToolContext(fs: fs, logger: logger);

--- a/packages/flutter_tools/test/commands.shard/hermetic/screenshot_command_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/screenshot_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -11,14 +9,17 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/screenshot.dart';
+import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:test/fake.dart';
+import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_devices.dart';
+import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -27,18 +28,36 @@ void main() {
   });
 
   group('Validate screenshot options', () {
+    testWithoutContext('has non-nullable toolContext', () {
+      final toolContext = FakeToolContext();
+      final command = ScreenshotCommand(toolContext: toolContext);
+      expect(command.toolContext, same(toolContext));
+    });
+
     testUsingContext('rasterizer and skia screenshots do not require a device', () async {
-      // Throw a specific exception when attempting to make a VM Service connection to
-      // verify that we've made it past the initial validation.
-      openChannelForTesting =
-          (String url, {CompressionOptions? compression, Logger? logger}) async {
-            expect(url, 'ws://localhost:8181/ws');
-            throw Exception('dummy');
-          };
+      final toolContext = FakeToolContext(fs: MemoryFileSystem.test());
+      final command = ScreenshotCommand(
+        toolContext: toolContext,
+        vmServiceConnector:
+            (
+              Uri uri, {
+              ReloadSources? reloadSources,
+              Restart? restart,
+              CompileExpression? compileExpression,
+              FlutterProject? flutterProject,
+              PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+              CompressionOptions compression = CompressionOptions.compressionDefault,
+              Device? device,
+              required Logger logger,
+            }) async {
+              expect(uri.toString(), 'http://localhost:8181');
+              throw Exception('dummy');
+            },
+      );
 
       await expectLater(
         () => createTestCommandRunner(
-          ScreenshotCommand(fs: MemoryFileSystem.test()),
+          command,
         ).run(<String>['screenshot', '--type=skia', '--vm-service-url=http://localhost:8181']),
         throwsA(
           isException.having(
@@ -50,28 +69,31 @@ void main() {
       );
     });
 
-    testUsingContext('rasterizer and skia screenshots require VM Service uri', () async {
+    testWithoutContext('rasterizer and skia screenshots require VM Service uri', () async {
+      final toolContext = FakeToolContext(fs: MemoryFileSystem.test());
       await expectLater(
         () => createTestCommandRunner(
-          ScreenshotCommand(fs: MemoryFileSystem.test()),
+          ScreenshotCommand(toolContext: toolContext),
         ).run(<String>['screenshot', '--type=skia']),
         throwsToolExit(message: 'VM Service URI must be specified for screenshot type skia'),
       );
     });
 
     testUsingContext('device screenshots require device', () async {
+      final toolContext = FakeToolContext(fs: MemoryFileSystem.test());
       await expectLater(
         () => createTestCommandRunner(
-          ScreenshotCommand(fs: MemoryFileSystem.test()),
+          ScreenshotCommand(toolContext: toolContext),
         ).run(<String>['screenshot']),
         throwsToolExit(message: 'Must have a connected device for screenshot type device'),
       );
     });
 
-    testUsingContext('device screenshots cannot provided VM Service', () async {
+    testWithoutContext('device screenshots cannot provide VM Service', () async {
+      final toolContext = FakeToolContext(fs: MemoryFileSystem.test());
       await expectLater(
         () => createTestCommandRunner(
-          ScreenshotCommand(fs: MemoryFileSystem.test()),
+          ScreenshotCommand(toolContext: toolContext),
         ).run(<String>['screenshot', '--vm-service-url=http://localhost:8181']),
         throwsToolExit(message: 'VM Service URI cannot be provided for screenshot type device'),
       );
@@ -142,58 +164,135 @@ void main() {
 
   group('Screenshot for devices unsupported for project', () {
     late _TestDeviceManager testDeviceManager;
+    late BufferLogger logger;
+    late FakeToolContext toolContext;
 
     setUp(() {
-      testDeviceManager = _TestDeviceManager(logger: BufferLogger.test());
+      logger = BufferLogger.test();
+      testDeviceManager = _TestDeviceManager(logger: logger);
+      toolContext = FakeToolContext(fs: MemoryFileSystem.test(), logger: logger);
     });
 
-    testUsingContext(
-      'should not throw for a single device',
-      () async {
-        final command = ScreenshotCommand(fs: MemoryFileSystem.test());
+    testUsingContext('should not throw for a single device', () async {
+      final command = ScreenshotCommand(toolContext: toolContext);
 
-        final deviceUnsupportedForProject = _ScreenshotDevice(
-          id: '123',
-          name: 'Device 1',
-          isSupportedForProject: false,
-        );
+      final deviceUnsupportedForProject = _ScreenshotDevice(
+        id: '123',
+        name: 'Device 1',
+        isSupportedForProject: false,
+      );
 
-        testDeviceManager.devices = <Device>[deviceUnsupportedForProject];
+      testDeviceManager.devices = <Device>[deviceUnsupportedForProject];
 
-        await createTestCommandRunner(command).run(<String>['screenshot']);
-      },
-      overrides: <Type, Generator>{DeviceManager: () => testDeviceManager},
-    );
+      await createTestCommandRunner(command).run(<String>['screenshot']);
+    }, overrides: <Type, Generator>{DeviceManager: () => testDeviceManager});
 
-    testUsingContext(
-      'should tool exit for multiple devices',
-      () async {
-        final command = ScreenshotCommand(fs: MemoryFileSystem.test());
+    testUsingContext('should tool exit for multiple devices', () async {
+      final command = ScreenshotCommand(toolContext: toolContext);
 
-        final devicesUnsupportedForProject = <_ScreenshotDevice>[
-          _ScreenshotDevice(id: '123', name: 'Device 1', isSupportedForProject: false),
-          _ScreenshotDevice(id: '456', name: 'Device 2', isSupportedForProject: false),
-        ];
+      final devicesUnsupportedForProject = <_ScreenshotDevice>[
+        _ScreenshotDevice(id: '123', name: 'Device 1', isSupportedForProject: false),
+        _ScreenshotDevice(id: '456', name: 'Device 2', isSupportedForProject: false),
+      ];
 
-        testDeviceManager.devices = devicesUnsupportedForProject;
+      testDeviceManager.devices = devicesUnsupportedForProject;
 
-        await expectLater(
-          () => createTestCommandRunner(command).run(<String>['screenshot']),
-          throwsToolExit(message: 'Must have a connected device for screenshot type device'),
-        );
+      await expectLater(
+        () => createTestCommandRunner(command).run(<String>['screenshot']),
+        throwsToolExit(message: 'Must have a connected device for screenshot type device'),
+      );
 
-        expect(
-          testLogger.statusText,
-          contains('''
+      expect(
+        logger.statusText,
+        contains('''
 More than one device connected; please specify a device with the '-d <deviceId>' flag, or use '-d all' to act on all devices.
 
 Device 1 (mobile) • 123 • android • 1.2.3
 Device 2 (mobile) • 456 • android • 1.2.3
 '''),
-        );
-      },
-      overrides: <Type, Generator>{DeviceManager: () => testDeviceManager},
-    );
+      );
+    }, overrides: <Type, Generator>{DeviceManager: () => testDeviceManager});
+  });
+
+  group('Skia screenshot execution', () {
+    testUsingContext('successful Skia screenshot with custom out', () async {
+      final fs = MemoryFileSystem.test();
+      final logger = BufferLogger.test();
+      final toolContext = FakeToolContext(fs: fs, logger: logger);
+
+      final fakeVmService = _FakeFlutterVmService(
+        response: vm_service.Response.parse(<String, Object?>{
+          'type': 'Response',
+          'skp': base64.encode(utf8.encode('valid skp data')),
+        }),
+      );
+
+      final command = ScreenshotCommand(
+        toolContext: toolContext,
+        vmServiceConnector:
+            (
+              Uri uri, {
+              ReloadSources? reloadSources,
+              Restart? restart,
+              CompileExpression? compileExpression,
+              FlutterProject? flutterProject,
+              PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+              CompressionOptions compression = CompressionOptions.compressionDefault,
+              Device? device,
+              required Logger logger,
+            }) async {
+              expect(uri.toString(), 'http://localhost:8181');
+              return fakeVmService;
+            },
+      );
+
+      await createTestCommandRunner(command).run(<String>[
+        'screenshot',
+        '--type=skia',
+        '--vm-service-url=http://localhost:8181',
+        '--out=screenshot.skp',
+      ]);
+
+      final File outputFile = fs.file('screenshot.skp');
+      expect(outputFile.existsSync(), isTrue);
+      expect(outputFile.readAsStringSync(), 'valid skp data');
+      expect(logger.statusText, contains('Screenshot written to screenshot.skp (0kB).'));
+    });
+
+    testUsingContext('failed Skia screenshot when disconnected', () async {
+      final fs = MemoryFileSystem.test();
+      final logger = BufferLogger.test();
+      final toolContext = FakeToolContext(fs: fs, logger: logger);
+
+      final fakeVmService = _FakeFlutterVmService();
+
+      final command = ScreenshotCommand(
+        toolContext: toolContext,
+        vmServiceConnector:
+            (
+              Uri uri, {
+              ReloadSources? reloadSources,
+              Restart? restart,
+              CompileExpression? compileExpression,
+              FlutterProject? flutterProject,
+              PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
+              CompressionOptions compression = CompressionOptions.compressionDefault,
+              Device? device,
+              required Logger logger,
+            }) async {
+              return fakeVmService;
+            },
+      );
+
+      await createTestCommandRunner(
+        command,
+      ).run(<String>['screenshot', '--type=skia', '--vm-service-url=http://localhost:8181']);
+
+      expect(
+        logger.errorText,
+        contains('The Skia picture request failed, probably because the device was disconnected'),
+      );
+    });
   });
 }
 
@@ -261,4 +360,13 @@ class _TestDeviceManager extends DeviceManager {
     devices.forEach(discoverer.addDevice);
     return <DeviceDiscovery>[discoverer];
   }
+}
+
+class _FakeFlutterVmService extends Fake implements FlutterVmService {
+  _FakeFlutterVmService({this.response});
+
+  final vm_service.Response? response;
+
+  @override
+  Future<vm_service.Response?> screenshotSkp() async => response;
 }


### PR DESCRIPTION
## Summary

Part 9 of the modular dependency injection migration.

* Migrates `ScreenshotCommand` to constructor dependency injection with required non-nullable `ToolContext`:
  ```dart
  ScreenshotCommand({
    required super.toolContext,
    VMServiceConnector? vmServiceConnector,
  })
  ```
* Eliminates ambient `globals.dart` usage and `fs` constructor fallback parameter in `screenshot.dart`, resolving `fs`, `fileSystemUtils`, and `logger` directly from `toolContext`.
* Conditionalizes `refreshWirelessDevices` on `argResults == null || stringArg(_kType) == _kDeviceType` to preserve hermetic execution for Skia VM service screenshot mode under `testWithoutContext`.
* Wires `toolContext: toolDependencies.toolContext` in `executable.dart`.
* Migrates unit tests in `packages/flutter_tools/test/commands.shard/hermetic/screenshot_command_test.dart` to hermetic `testWithoutContext`.

Part of https://github.com/flutter/flutter/issues/188471