### PR TITLE
[tool] Migrate DevicesCommand to modular dependency injection

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -313,12 +313,7 @@ List<FlutterCommand> generateCommands({
   CreateCommand(verboseHelp: verboseHelp, extensionTemplateManager: extensionTemplateManager),
   DaemonCommand(hidden: !verboseHelp),
   DebugAdapterCommand(verboseHelp: verboseHelp),
-  DevicesCommand(
-    deviceManager: globals.deviceManager!,
-    doctor: globals.doctor!,
-    toolContext: toolDependencies.toolContext,
-    verboseHelp: verboseHelp,
-  ),
+  DevicesCommand(toolContext: toolDependencies.toolContext, verboseHelp: verboseHelp),
   DoctorCommand(
     verbose: verbose,
     toolContext: toolDependencies.toolContext,

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -196,9 +196,8 @@ Future<void> main(List<String> args) async {
 String? findCommandName(List<String> args, {ToolContext? toolContext}) {
   final ArgResults results;
   try {
-    results = FlutterCommandRunner(
-      toolContext: toolContext ?? _FallbackToolContext(),
-    ).argParser.parse(args);
+    results = FlutterCommandRunner(toolContext: toolContext ?? _FallbackToolContext()).argParser
+        .parse(args);
   } on ArgParserException {
     // The real parser will complain about these later.
     return null;
@@ -313,7 +312,12 @@ List<FlutterCommand> generateCommands({
   CreateCommand(verboseHelp: verboseHelp, extensionTemplateManager: extensionTemplateManager),
   DaemonCommand(hidden: !verboseHelp),
   DebugAdapterCommand(verboseHelp: verboseHelp),
-  DevicesCommand(toolContext: toolDependencies.toolContext, verboseHelp: verboseHelp),
+  DevicesCommand(
+    deviceManager: globals.deviceManager!,
+    doctor: globals.doctor!,
+    toolContext: toolDependencies.toolContext,
+    verboseHelp: verboseHelp,
+  ),
   DoctorCommand(
     verbose: verbose,
     toolContext: toolDependencies.toolContext,

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -313,7 +313,12 @@ List<FlutterCommand> generateCommands({
   CreateCommand(verboseHelp: verboseHelp, extensionTemplateManager: extensionTemplateManager),
   DaemonCommand(hidden: !verboseHelp),
   DebugAdapterCommand(verboseHelp: verboseHelp),
-  DevicesCommand(verboseHelp: verboseHelp),
+  DevicesCommand(
+    deviceManager: globals.deviceManager,
+    doctor: globals.doctor,
+    toolContext: toolDependencies.toolContext,
+    verboseHelp: verboseHelp,
+  ),
   DoctorCommand(
     verbose: verbose,
     toolContext: toolDependencies.toolContext,

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -314,8 +314,8 @@ List<FlutterCommand> generateCommands({
   DaemonCommand(hidden: !verboseHelp),
   DebugAdapterCommand(verboseHelp: verboseHelp),
   DevicesCommand(
-    deviceManager: globals.deviceManager,
-    doctor: globals.doctor,
+    deviceManager: globals.deviceManager!,
+    doctor: globals.doctor!,
     toolContext: toolDependencies.toolContext,
     verboseHelp: verboseHelp,
   ),

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -11,18 +11,18 @@ import '../context/tool_context.dart';
 import '../convert.dart';
 import '../device.dart';
 import '../doctor.dart';
+import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 
 /// The `flutter devices` command, which lists all connected devices.
 class DevicesCommand extends FlutterCommand {
   DevicesCommand({
-    required DeviceManager deviceManager,
-    required Doctor doctor,
-    required ToolContext toolContext,
+    DeviceManager? deviceManager,
+    Doctor? doctor,
+    super.toolContext,
     super.verboseHelp,
-  }) : _deviceManager = deviceManager,
-       _doctor = doctor,
-       super(toolContext: toolContext) {
+  }) : _deviceManager = deviceManager ?? globals.deviceManager!,
+       _doctor = doctor ?? globals.doctor! {
     addMachineOutputFlag(verboseHelp: verboseHelp);
     argParser.addOption(
       'timeout',
@@ -99,37 +99,38 @@ class DevicesCommand extends FlutterCommand {
 
 class DevicesCommandOutput {
   factory DevicesCommandOutput({
-    required Platform platform,
     required Logger logger,
-    DeviceManager? deviceManager,
-    Duration? deviceDiscoveryTimeout,
+    required Platform platform,
     DeviceConnectionInterface? deviceConnectionInterface,
+    Duration? deviceDiscoveryTimeout,
+    DeviceManager? deviceManager,
   }) {
+    final DeviceManager effectiveDeviceManager = deviceManager ?? globals.deviceManager!;
     if (platform.isMacOS) {
       return DevicesCommandOutputWithExtendedWirelessDeviceDiscovery(
-        logger: logger,
-        deviceManager: deviceManager,
-        deviceDiscoveryTimeout: deviceDiscoveryTimeout,
         deviceConnectionInterface: deviceConnectionInterface,
+        deviceDiscoveryTimeout: deviceDiscoveryTimeout,
+        deviceManager: effectiveDeviceManager,
+        logger: logger,
       );
     }
     return DevicesCommandOutput._private(
-      logger: logger,
-      deviceManager: deviceManager,
-      deviceDiscoveryTimeout: deviceDiscoveryTimeout,
       deviceConnectionInterface: deviceConnectionInterface,
+      deviceDiscoveryTimeout: deviceDiscoveryTimeout,
+      deviceManager: effectiveDeviceManager,
+      logger: logger,
     );
   }
 
   DevicesCommandOutput._private({
-    required Logger logger,
-    required DeviceManager? deviceManager,
-    required this.deviceDiscoveryTimeout,
     required this.deviceConnectionInterface,
+    required this.deviceDiscoveryTimeout,
+    required DeviceManager deviceManager,
+    required Logger logger,
   }) : _deviceManager = deviceManager,
        _logger = logger;
 
-  final DeviceManager? _deviceManager;
+  final DeviceManager _deviceManager;
   final Logger _logger;
   final Duration? deviceDiscoveryTimeout;
   final DeviceConnectionInterface? deviceConnectionInterface;
@@ -161,15 +162,11 @@ class DevicesCommandOutput {
   }
 
   Future<void> findAndOutputAllTargetDevices({required bool machine}) async {
-    var attachedDevices = <Device>[];
-    var wirelessDevices = <Device>[];
-    if (_deviceManager != null) {
-      // Refresh the cache and then get the attached and wireless devices from
-      // the cache.
-      await _deviceManager.refreshAllDevices(timeout: deviceDiscoveryTimeout);
-      attachedDevices = await _getAttachedDevices(_deviceManager);
-      wirelessDevices = await _getWirelessDevices(_deviceManager);
-    }
+    // Refresh the cache and then get the attached and wireless devices from
+    // the cache.
+    await _deviceManager.refreshAllDevices(timeout: deviceDiscoveryTimeout);
+    final List<Device> attachedDevices = await _getAttachedDevices(_deviceManager);
+    final List<Device> wirelessDevices = await _getWirelessDevices(_deviceManager);
     final List<Device> allDevices = attachedDevices + wirelessDevices;
 
     if (machine) {
@@ -202,7 +199,7 @@ class DevicesCommandOutput {
   Future<void> _printDiagnostics({required bool foundAny}) async {
     final status = StringBuffer();
     status.writeln();
-    final List<String> diagnostics = await _deviceManager?.getDeviceDiagnostics() ?? <String>[];
+    final List<String> diagnostics = await _deviceManager.getDeviceDiagnostics();
     if (diagnostics.isNotEmpty) {
       for (final diagnostic in diagnostics) {
         status.writeln(diagnostic);
@@ -238,10 +235,10 @@ const _noWirelessDevicesFoundMessage = 'No wireless devices were found.';
 
 class DevicesCommandOutputWithExtendedWirelessDeviceDiscovery extends DevicesCommandOutput {
   DevicesCommandOutputWithExtendedWirelessDeviceDiscovery({
+    required super.deviceManager,
     required super.logger,
-    super.deviceManager,
-    super.deviceDiscoveryTimeout,
     super.deviceConnectionInterface,
+    super.deviceDiscoveryTimeout,
   }) : super._private();
 
   @override
@@ -254,25 +251,20 @@ class DevicesCommandOutputWithExtendedWirelessDeviceDiscovery extends DevicesCom
     }
 
     if (machine) {
-      final List<Device> devices =
-          await _deviceManager?.refreshAllDevices(
-            filter: DeviceDiscoveryFilter(deviceConnectionInterface: deviceConnectionInterface),
-            timeout: DeviceManager.minimumWirelessDeviceDiscoveryTimeout,
-          ) ??
-          <Device>[];
+      final List<Device> devices = await _deviceManager.refreshAllDevices(
+        filter: DeviceDiscoveryFilter(deviceConnectionInterface: deviceConnectionInterface),
+        timeout: DeviceManager.minimumWirelessDeviceDiscoveryTimeout,
+      );
       await printDevicesAsJson(devices);
       return;
     }
 
-    final Future<void>? extendedWirelessDiscovery = _deviceManager
-        ?.refreshExtendedWirelessDeviceDiscoverers(
+    final Future<void> extendedWirelessDiscovery = _deviceManager
+        .refreshExtendedWirelessDeviceDiscoverers(
           timeout: DeviceManager.minimumWirelessDeviceDiscoveryTimeout,
         );
 
-    var attachedDevices = <Device>[];
-    if (_deviceManager != null) {
-      attachedDevices = await _getAttachedDevices(_deviceManager);
-    }
+    final List<Device> attachedDevices = await _getAttachedDevices(_deviceManager);
 
     // Number of lines to clear starts at 1 because it's inclusive of the line
     // the cursor is on, which will be blank for this use case.
@@ -298,10 +290,7 @@ class DevicesCommandOutputWithExtendedWirelessDeviceDiscovery extends DevicesCom
 
     final Status waitingStatus = _logger.startSpinner();
     await extendedWirelessDiscovery;
-    var wirelessDevices = <Device>[];
-    if (_deviceManager != null) {
-      wirelessDevices = await _getWirelessDevices(_deviceManager);
-    }
+    final List<Device> wirelessDevices = await _getWirelessDevices(_deviceManager);
     waitingStatus.stop();
 
     final Terminal terminal = _logger.terminal;

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import '../base/common.dart';
+import '../context/tool_context.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/terminal.dart';
@@ -10,18 +11,17 @@ import '../base/utils.dart';
 import '../convert.dart';
 import '../device.dart';
 import '../doctor.dart';
-import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 
 /// The `flutter devices` command, which lists all connected devices.
 class DevicesCommand extends FlutterCommand {
   DevicesCommand({
-    DeviceManager? deviceManager,
-    Doctor? doctor,
-    super.toolContext,
+    required DeviceManager deviceManager,
+    required Doctor doctor,
+    required super.toolContext,
     super.verboseHelp,
-  }) : _deviceManager = deviceManager ?? globals.deviceManager!,
-       _doctor = doctor ?? globals.doctor! {
+  }) : _deviceManager = deviceManager,
+       _doctor = doctor {
     addMachineOutputFlag(verboseHelp: verboseHelp);
     argParser.addOption(
       'timeout',
@@ -46,6 +46,9 @@ class DevicesCommand extends FlutterCommand {
   final String category = FlutterCommandCategory.tools;
 
   @override
+  ToolContext get toolContext => super.toolContext!;
+
+  @override
   Duration? get deviceDiscoveryTimeout {
     if (argResults?['timeout'] != null) {
       final int? timeoutSeconds = int.tryParse(stringArg('timeout')!);
@@ -60,8 +63,8 @@ class DevicesCommand extends FlutterCommand {
   @override
   Future<void> validateCommand() {
     if (argResults?['timeout'] != null) {
-      final Logger logger = toolContext?.logger ?? globals.logger;
-      final Terminal terminal = toolContext?.terminal ?? globals.logger.terminal;
+      final Logger logger = toolContext.logger;
+      final Terminal terminal = toolContext.terminal;
       logger.printWarning(
         '${terminal.warningMark} The "--timeout" argument is deprecated; use "--${FlutterOptions.kDeviceTimeout}" instead.',
       );
@@ -80,8 +83,8 @@ class DevicesCommand extends FlutterCommand {
     }
 
     final output = DevicesCommandOutput(
-      platform: toolContext?.platform ?? globals.platform,
-      logger: toolContext?.logger ?? globals.logger,
+      platform: toolContext.platform,
+      logger: toolContext.logger,
       deviceManager: _deviceManager,
       deviceDiscoveryTimeout: deviceDiscoveryTimeout,
       deviceConnectionInterface: deviceConnectionInterface,
@@ -218,8 +221,9 @@ class DevicesCommandOutput {
 
   Future<void> printDevicesAsJson(List<Device> devices) async {
     _logger.printStatus(
-      const JsonEncoder.withIndent('  ')
-          .convert(await Future.wait(devices.map((Device d) => d.toJson()))),
+      const JsonEncoder.withIndent(
+        '  ',
+      ).convert(await Future.wait(devices.map((Device d) => d.toJson()))),
     );
   }
 }

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -16,9 +16,9 @@ import '../runner/flutter_command.dart';
 /// The `flutter devices` command, which lists all connected devices.
 class DevicesCommand extends FlutterCommand {
   DevicesCommand({
+    required DeviceManager deviceManager,
+    required Doctor doctor,
     required ToolContext toolContext,
-    DeviceManager? deviceManager,
-    Doctor? doctor,
     super.verboseHelp,
   }) : _deviceManager = deviceManager,
        _doctor = doctor,
@@ -34,8 +34,8 @@ class DevicesCommand extends FlutterCommand {
     usesDeviceConnectionOption();
   }
 
-  final DeviceManager? _deviceManager;
-  final Doctor? _doctor;
+  final DeviceManager _deviceManager;
+  final Doctor _doctor;
 
   @override
   ToolContext get toolContext => super.toolContext!;
@@ -75,7 +75,7 @@ class DevicesCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    if (_doctor?.canListAnything == false) {
+    if (!_doctor.canListAnything) {
       throwToolExit(
         "Unable to locate a development device; please run 'flutter doctor' for "
         'information about installing additional components.',

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -97,23 +97,22 @@ class DevicesCommandOutput {
   factory DevicesCommandOutput({
     required Logger logger,
     required Platform platform,
+    required DeviceManager deviceManager,
     DeviceConnectionInterface? deviceConnectionInterface,
     Duration? deviceDiscoveryTimeout,
-    DeviceManager? deviceManager,
   }) {
-    final DeviceManager effectiveDeviceManager = deviceManager ?? globals.deviceManager!;
     if (platform.isMacOS) {
       return DevicesCommandOutputWithExtendedWirelessDeviceDiscovery(
         deviceConnectionInterface: deviceConnectionInterface,
         deviceDiscoveryTimeout: deviceDiscoveryTimeout,
-        deviceManager: effectiveDeviceManager,
+        deviceManager: deviceManager,
         logger: logger,
       );
     }
     return DevicesCommandOutput._private(
       deviceConnectionInterface: deviceConnectionInterface,
       deviceDiscoveryTimeout: deviceDiscoveryTimeout,
-      deviceManager: effectiveDeviceManager,
+      deviceManager: deviceManager,
       logger: logger,
     );
   }

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -7,13 +7,22 @@ import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/terminal.dart';
 import '../base/utils.dart';
+import '../context/tool_context.dart';
 import '../convert.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
+import '../doctor.dart';
 import '../runner/flutter_command.dart';
 
+/// The `flutter devices` command, which lists all connected devices.
 class DevicesCommand extends FlutterCommand {
-  DevicesCommand({bool verboseHelp = false}) {
+  DevicesCommand({
+    required ToolContext toolContext,
+    DeviceManager? deviceManager,
+    Doctor? doctor,
+    super.verboseHelp,
+  }) : _deviceManager = deviceManager,
+       _doctor = doctor,
+       super(toolContext: toolContext) {
     addMachineOutputFlag(verboseHelp: verboseHelp);
     argParser.addOption(
       'timeout',
@@ -24,6 +33,12 @@ class DevicesCommand extends FlutterCommand {
     usesDeviceTimeoutOption();
     usesDeviceConnectionOption();
   }
+
+  final DeviceManager? _deviceManager;
+  final Doctor? _doctor;
+
+  @override
+  ToolContext get toolContext => super.toolContext!;
 
   @override
   final name = 'devices';
@@ -49,8 +64,10 @@ class DevicesCommand extends FlutterCommand {
   @override
   Future<void> validateCommand() {
     if (argResults?['timeout'] != null) {
-      globals.printWarning(
-        '${globals.logger.terminal.warningMark} The "--timeout" argument is deprecated; use "--${FlutterOptions.kDeviceTimeout}" instead.',
+      final Logger logger = toolContext.logger;
+      final AnsiTerminal terminal = toolContext.terminal;
+      logger.printWarning(
+        '${terminal.warningMark} The "--timeout" argument is deprecated; use "--${FlutterOptions.kDeviceTimeout}" instead.',
       );
     }
     return super.validateCommand();
@@ -58,7 +75,7 @@ class DevicesCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    if (globals.doctor?.canListAnything != true) {
+    if (_doctor?.canListAnything == false) {
       throwToolExit(
         "Unable to locate a development device; please run 'flutter doctor' for "
         'information about installing additional components.',
@@ -67,9 +84,9 @@ class DevicesCommand extends FlutterCommand {
     }
 
     final output = DevicesCommandOutput(
-      platform: globals.platform,
-      logger: globals.logger,
-      deviceManager: globals.deviceManager,
+      platform: toolContext.platform,
+      logger: toolContext.logger,
+      deviceManager: _deviceManager,
       deviceDiscoveryTimeout: deviceDiscoveryTimeout,
       deviceConnectionInterface: deviceConnectionInterface,
     );
@@ -302,7 +319,7 @@ class DevicesCommandOutputWithExtendedWirelessDeviceDiscovery extends DevicesCom
       _logger.printStatus(terminal.clearLines(numLinesToClear), newline: false);
     }
 
-    if (attachedDevices.isNotEmpty || !_logger.terminal.supportsColor) {
+    if (attachedDevices.isNotEmpty || !terminal.supportsColor) {
       _logger.printStatus('');
     }
 

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -139,20 +139,20 @@ class DevicesCommandOutput {
       deviceConnectionInterface == null ||
       deviceConnectionInterface == DeviceConnectionInterface.wireless;
 
-  Future<List<Device>> _getAttachedDevices(DeviceManager deviceManager) async {
+  Future<List<Device>> _getAttachedDevices() async {
     if (!_includeAttachedDevices) {
       return <Device>[];
     }
-    return deviceManager.getAllDevices(
+    return _deviceManager.getAllDevices(
       filter: DeviceDiscoveryFilter(deviceConnectionInterface: DeviceConnectionInterface.attached),
     );
   }
 
-  Future<List<Device>> _getWirelessDevices(DeviceManager deviceManager) async {
+  Future<List<Device>> _getWirelessDevices() async {
     if (!_includeWirelessDevices) {
       return <Device>[];
     }
-    return deviceManager.getAllDevices(
+    return _deviceManager.getAllDevices(
       filter: DeviceDiscoveryFilter(deviceConnectionInterface: DeviceConnectionInterface.wireless),
     );
   }
@@ -161,8 +161,8 @@ class DevicesCommandOutput {
     // Refresh the cache and then get the attached and wireless devices from
     // the cache.
     await _deviceManager.refreshAllDevices(timeout: deviceDiscoveryTimeout);
-    final List<Device> attachedDevices = await _getAttachedDevices(_deviceManager);
-    final List<Device> wirelessDevices = await _getWirelessDevices(_deviceManager);
+    final List<Device> attachedDevices = await _getAttachedDevices();
+    final List<Device> wirelessDevices = await _getWirelessDevices();
     final List<Device> allDevices = attachedDevices + wirelessDevices;
 
     if (machine) {
@@ -218,9 +218,8 @@ class DevicesCommandOutput {
 
   Future<void> printDevicesAsJson(List<Device> devices) async {
     _logger.printStatus(
-      const JsonEncoder.withIndent(
-        '  ',
-      ).convert(await Future.wait(devices.map((Device d) => d.toJson()))),
+      const JsonEncoder.withIndent('  ')
+          .convert(await Future.wait(devices.map((Device d) => d.toJson()))),
     );
   }
 }
@@ -260,7 +259,7 @@ class DevicesCommandOutputWithExtendedWirelessDeviceDiscovery extends DevicesCom
           timeout: DeviceManager.minimumWirelessDeviceDiscoveryTimeout,
         );
 
-    final List<Device> attachedDevices = await _getAttachedDevices(_deviceManager);
+    final List<Device> attachedDevices = await _getAttachedDevices();
 
     // Number of lines to clear starts at 1 because it's inclusive of the line
     // the cursor is on, which will be blank for this use case.
@@ -286,7 +285,7 @@ class DevicesCommandOutputWithExtendedWirelessDeviceDiscovery extends DevicesCom
 
     final Status waitingStatus = _logger.startSpinner();
     await extendedWirelessDiscovery;
-    final List<Device> wirelessDevices = await _getWirelessDevices(_deviceManager);
+    final List<Device> wirelessDevices = await _getWirelessDevices();
     waitingStatus.stop();
 
     final Terminal terminal = _logger.terminal;

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -163,13 +163,12 @@ class DevicesCommandOutput {
   Future<void> findAndOutputAllTargetDevices({required bool machine}) async {
     var attachedDevices = <Device>[];
     var wirelessDevices = <Device>[];
-    final DeviceManager? deviceManager = _deviceManager;
-    if (deviceManager != null) {
+    if (_deviceManager != null) {
       // Refresh the cache and then get the attached and wireless devices from
       // the cache.
-      await deviceManager.refreshAllDevices(timeout: deviceDiscoveryTimeout);
-      attachedDevices = await _getAttachedDevices(deviceManager);
-      wirelessDevices = await _getWirelessDevices(deviceManager);
+      await _deviceManager.refreshAllDevices(timeout: deviceDiscoveryTimeout);
+      attachedDevices = await _getAttachedDevices(_deviceManager);
+      wirelessDevices = await _getWirelessDevices(_deviceManager);
     }
     final List<Device> allDevices = attachedDevices + wirelessDevices;
 
@@ -271,9 +270,8 @@ class DevicesCommandOutputWithExtendedWirelessDeviceDiscovery extends DevicesCom
         );
 
     var attachedDevices = <Device>[];
-    final DeviceManager? deviceManager = _deviceManager;
-    if (deviceManager != null) {
-      attachedDevices = await _getAttachedDevices(deviceManager);
+    if (_deviceManager != null) {
+      attachedDevices = await _getAttachedDevices(_deviceManager);
     }
 
     // Number of lines to clear starts at 1 because it's inclusive of the line
@@ -301,8 +299,8 @@ class DevicesCommandOutputWithExtendedWirelessDeviceDiscovery extends DevicesCom
     final Status waitingStatus = _logger.startSpinner();
     await extendedWirelessDiscovery;
     var wirelessDevices = <Device>[];
-    if (deviceManager != null) {
-      wirelessDevices = await _getWirelessDevices(deviceManager);
+    if (_deviceManager != null) {
+      wirelessDevices = await _getWirelessDevices(_deviceManager);
     }
     waitingStatus.stop();
 

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -7,7 +7,6 @@ import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/terminal.dart';
 import '../base/utils.dart';
-import '../context/tool_context.dart';
 import '../convert.dart';
 import '../device.dart';
 import '../doctor.dart';
@@ -38,9 +37,6 @@ class DevicesCommand extends FlutterCommand {
   final Doctor _doctor;
 
   @override
-  ToolContext get toolContext => super.toolContext!;
-
-  @override
   final name = 'devices';
 
   @override
@@ -64,8 +60,8 @@ class DevicesCommand extends FlutterCommand {
   @override
   Future<void> validateCommand() {
     if (argResults?['timeout'] != null) {
-      final Logger logger = toolContext.logger;
-      final AnsiTerminal terminal = toolContext.terminal;
+      final Logger logger = super.toolContext?.logger ?? globals.logger;
+      final Terminal terminal = super.toolContext?.terminal ?? globals.logger.terminal;
       logger.printWarning(
         '${terminal.warningMark} The "--timeout" argument is deprecated; use "--${FlutterOptions.kDeviceTimeout}" instead.',
       );
@@ -84,8 +80,8 @@ class DevicesCommand extends FlutterCommand {
     }
 
     final output = DevicesCommandOutput(
-      platform: toolContext.platform,
-      logger: toolContext.logger,
+      platform: super.toolContext?.platform ?? globals.platform,
+      logger: super.toolContext?.logger ?? globals.logger,
       deviceManager: _deviceManager,
       deviceDiscoveryTimeout: deviceDiscoveryTimeout,
       deviceConnectionInterface: deviceConnectionInterface,
@@ -123,8 +119,8 @@ class DevicesCommandOutput {
   }
 
   DevicesCommandOutput._private({
-    required this.deviceConnectionInterface,
-    required this.deviceDiscoveryTimeout,
+    this.deviceConnectionInterface,
+    this.deviceDiscoveryTimeout,
     required DeviceManager deviceManager,
     required Logger logger,
   }) : _deviceManager = deviceManager,

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -60,8 +60,8 @@ class DevicesCommand extends FlutterCommand {
   @override
   Future<void> validateCommand() {
     if (argResults?['timeout'] != null) {
-      final Logger logger = super.toolContext?.logger ?? globals.logger;
-      final Terminal terminal = super.toolContext?.terminal ?? globals.logger.terminal;
+      final Logger logger = toolContext?.logger ?? globals.logger;
+      final Terminal terminal = toolContext?.terminal ?? globals.logger.terminal;
       logger.printWarning(
         '${terminal.warningMark} The "--timeout" argument is deprecated; use "--${FlutterOptions.kDeviceTimeout}" instead.',
       );
@@ -80,8 +80,8 @@ class DevicesCommand extends FlutterCommand {
     }
 
     final output = DevicesCommandOutput(
-      platform: super.toolContext?.platform ?? globals.platform,
-      logger: super.toolContext?.logger ?? globals.logger,
+      platform: toolContext?.platform ?? globals.platform,
+      logger: toolContext?.logger ?? globals.logger,
       deviceManager: _deviceManager,
       deviceDiscoveryTimeout: deviceDiscoveryTimeout,
       deviceConnectionInterface: deviceConnectionInterface,
@@ -93,6 +93,7 @@ class DevicesCommand extends FlutterCommand {
   }
 }
 
+/// Output generator for the [DevicesCommand].
 class DevicesCommandOutput {
   factory DevicesCommandOutput({
     required Logger logger,
@@ -118,10 +119,10 @@ class DevicesCommandOutput {
   }
 
   DevicesCommandOutput._private({
-    this.deviceConnectionInterface,
-    this.deviceDiscoveryTimeout,
     required DeviceManager deviceManager,
     required Logger logger,
+    this.deviceConnectionInterface,
+    this.deviceDiscoveryTimeout,
   }) : _deviceManager = deviceManager,
        _logger = logger;
 

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -3,11 +3,11 @@
 // found in the LICENSE file.
 
 import '../base/common.dart';
-import '../context/tool_context.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/terminal.dart';
 import '../base/utils.dart';
+import '../context/tool_context.dart';
 import '../convert.dart';
 import '../device.dart';
 import '../doctor.dart';
@@ -221,9 +221,8 @@ class DevicesCommandOutput {
 
   Future<void> printDevicesAsJson(List<Device> devices) async {
     _logger.printStatus(
-      const JsonEncoder.withIndent(
-        '  ',
-      ).convert(await Future.wait(devices.map((Device d) => d.toJson()))),
+      const JsonEncoder.withIndent('  ')
+          .convert(await Future.wait(devices.map((Device d) => d.toJson()))),
     );
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -63,12 +63,17 @@ void main() {
       });
 
       testWithoutContext('returns 0 when called', () async {
-        final command = DevicesCommand(toolContext: FakeToolContext(platform: platform));
+        final command = DevicesCommand(
+          deviceManager: _FakeDeviceManager(),
+          doctor: _FakeDoctor(),
+          toolContext: FakeToolContext(platform: platform),
+        );
         await createTestCommandRunner(command).run(<String>['devices']);
       });
 
       testWithoutContext('throws ToolExit when Doctor cannot list anything', () async {
         final command = DevicesCommand(
+          deviceManager: _FakeDeviceManager(),
           doctor: _FakeDoctor(canListAnything: false),
           toolContext: FakeToolContext(platform: platform),
         );
@@ -83,8 +88,9 @@ void main() {
       testWithoutContext('no error when no connected devices', () async {
         final logger = BufferLogger.test();
         final command = DevicesCommand(
-          toolContext: FakeToolContext(logger: logger, platform: platform),
           deviceManager: NoDevicesManager(),
+          doctor: _FakeDoctor(),
+          toolContext: FakeToolContext(logger: logger, platform: platform),
         );
         await createTestCommandRunner(command).run(<String>['devices']);
         expect(
@@ -117,8 +123,9 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
           testWithoutContext('Outputs parsable JSON', () async {
             final logger = BufferLogger.test();
             final command = DevicesCommand(
-              toolContext: FakeToolContext(logger: logger, platform: platform),
               deviceManager: _FakeDeviceManager(devices: deviceList),
+              doctor: _FakeDoctor(),
+              toolContext: FakeToolContext(logger: logger, platform: platform),
             );
             await createTestCommandRunner(command).run(<String>['devices', '--machine']);
             expect(json.decode(logger.statusText), <Map<String, Object>>[
@@ -132,8 +139,9 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
             testWithoutContext('filtered to attached', () async {
               final logger = BufferLogger.test();
               final command = DevicesCommand(
-                toolContext: FakeToolContext(logger: logger, platform: platform),
                 deviceManager: _FakeDeviceManager(devices: deviceList),
+                doctor: _FakeDoctor(),
+                toolContext: FakeToolContext(logger: logger, platform: platform),
               );
               await createTestCommandRunner(
                 command,
@@ -147,8 +155,9 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
             testWithoutContext('filtered to wireless', () async {
               final logger = BufferLogger.test();
               final command = DevicesCommand(
-                toolContext: FakeToolContext(logger: logger, platform: platform),
                 deviceManager: _FakeDeviceManager(devices: deviceList),
+                doctor: _FakeDoctor(),
+                toolContext: FakeToolContext(logger: logger, platform: platform),
               );
               await createTestCommandRunner(
                 command,
@@ -161,8 +170,9 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
         testWithoutContext('available devices and diagnostics', () async {
           final logger = BufferLogger.test();
           final command = DevicesCommand(
-            toolContext: FakeToolContext(logger: logger, platform: platform),
             deviceManager: _FakeDeviceManager(devices: deviceList),
+            doctor: _FakeDoctor(),
+            toolContext: FakeToolContext(logger: logger, platform: platform),
           );
           await createTestCommandRunner(command).run(<String>['devices']);
           expect(logger.statusText, '''
@@ -185,8 +195,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
           testWithoutContext('filtered to attached', () async {
             final logger = BufferLogger.test();
             final command = DevicesCommand(
-              toolContext: FakeToolContext(logger: logger, platform: platform),
               deviceManager: _FakeDeviceManager(devices: deviceList),
+              doctor: _FakeDoctor(),
+              toolContext: FakeToolContext(logger: logger, platform: platform),
             );
             await createTestCommandRunner(
               command,
@@ -207,8 +218,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
           testWithoutContext('filtered to wireless', () async {
             final logger = BufferLogger.test();
             final command = DevicesCommand(
-              toolContext: FakeToolContext(logger: logger, platform: platform),
               deviceManager: _FakeDeviceManager(devices: deviceList),
+              doctor: _FakeDoctor(),
+              toolContext: FakeToolContext(logger: logger, platform: platform),
             );
             await createTestCommandRunner(
               command,
@@ -236,8 +248,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
         testWithoutContext('available devices and diagnostics', () async {
           final logger = BufferLogger.test();
           final command = DevicesCommand(
-            toolContext: FakeToolContext(logger: logger, platform: platform),
             deviceManager: _FakeDeviceManager(devices: deviceList),
+            doctor: _FakeDoctor(),
+            toolContext: FakeToolContext(logger: logger, platform: platform),
           );
           await createTestCommandRunner(command).run(<String>['devices']);
           expect(logger.statusText, '''
@@ -263,8 +276,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
         testWithoutContext('available devices and diagnostics', () async {
           final logger = BufferLogger.test();
           final command = DevicesCommand(
-            toolContext: FakeToolContext(logger: logger, platform: platform),
             deviceManager: _FakeDeviceManager(devices: deviceList),
+            doctor: _FakeDoctor(),
+            toolContext: FakeToolContext(logger: logger, platform: platform),
           );
           await createTestCommandRunner(command).run(<String>['devices']);
           expect(logger.statusText, '''
@@ -287,7 +301,11 @@ If you expected another device to be detected, please run "flutter doctor" to di
       });
 
       testWithoutContext('returns 0 when called', () async {
-        final command = DevicesCommand(toolContext: FakeToolContext(platform: platform));
+        final command = DevicesCommand(
+          deviceManager: _FakeDeviceManager(),
+          doctor: _FakeDoctor(),
+          toolContext: FakeToolContext(platform: platform),
+        );
         await createTestCommandRunner(command).run(<String>['devices']);
       });
 
@@ -295,8 +313,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
         testWithoutContext('no error', () async {
           final logger = BufferLogger.test();
           final command = DevicesCommand(
-            toolContext: FakeToolContext(logger: logger, platform: platform),
             deviceManager: NoDevicesManager(),
+            doctor: _FakeDoctor(),
+            toolContext: FakeToolContext(logger: logger, platform: platform),
           );
           await createTestCommandRunner(command).run(<String>['devices']);
           expect(
@@ -317,8 +336,9 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
           testWithoutContext('filtered to attached', () async {
             final logger = BufferLogger.test();
             final command = DevicesCommand(
-              toolContext: FakeToolContext(logger: logger, platform: platform),
               deviceManager: NoDevicesManager(),
+              doctor: _FakeDoctor(),
+              toolContext: FakeToolContext(logger: logger, platform: platform),
             );
             await createTestCommandRunner(
               command,
@@ -335,8 +355,9 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
           testWithoutContext('filtered to wireless', () async {
             final logger = BufferLogger.test();
             final command = DevicesCommand(
-              toolContext: FakeToolContext(logger: logger, platform: platform),
               deviceManager: NoDevicesManager(),
+              doctor: _FakeDoctor(),
+              toolContext: FakeToolContext(logger: logger, platform: platform),
             );
             await createTestCommandRunner(
               command,
@@ -377,8 +398,9 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
           testWithoutContext('Outputs parsable JSON', () async {
             final logger = BufferLogger.test();
             final command = DevicesCommand(
-              toolContext: FakeToolContext(logger: logger, platform: platform),
               deviceManager: _FakeDeviceManager(devices: deviceList),
+              doctor: _FakeDoctor(),
+              toolContext: FakeToolContext(logger: logger, platform: platform),
             );
             await createTestCommandRunner(command).run(<String>['devices', '--machine']);
             expect(json.decode(logger.statusText), <Map<String, Object>>[
@@ -393,8 +415,9 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
             testWithoutContext('filtered to attached', () async {
               final logger = BufferLogger.test();
               final command = DevicesCommand(
-                toolContext: FakeToolContext(logger: logger, platform: platform),
                 deviceManager: _FakeDeviceManager(devices: deviceList),
+                doctor: _FakeDoctor(),
+                toolContext: FakeToolContext(logger: logger, platform: platform),
               );
               await createTestCommandRunner(
                 command,
@@ -408,8 +431,9 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
             testWithoutContext('filtered to wireless', () async {
               final logger = BufferLogger.test();
               final command = DevicesCommand(
-                toolContext: FakeToolContext(logger: logger, platform: platform),
                 deviceManager: _FakeDeviceManager(devices: deviceList),
+                doctor: _FakeDoctor(),
+                toolContext: FakeToolContext(logger: logger, platform: platform),
               );
               await createTestCommandRunner(
                 command,
@@ -425,8 +449,9 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
         testWithoutContext('available devices and diagnostics', () async {
           final logger = BufferLogger.test();
           final command = DevicesCommand(
-            toolContext: FakeToolContext(logger: logger, platform: platform),
             deviceManager: _FakeDeviceManager(devices: deviceList),
+            doctor: _FakeDoctor(),
+            toolContext: FakeToolContext(logger: logger, platform: platform),
           );
           await createTestCommandRunner(command).run(<String>['devices']);
           expect(logger.statusText, '''
@@ -466,12 +491,13 @@ Checking for wireless devices...
 
           testWithoutContext('available devices and diagnostics', () async {
             final command = DevicesCommand(
+              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+              doctor: _FakeDoctor(),
               toolContext: FakeToolContext(
                 logger: fakeLogger,
                 platform: platform,
                 terminal: terminal,
               ),
-              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
             );
             await createTestCommandRunner(command).run(<String>['devices']);
 
@@ -502,8 +528,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
 
           testWithoutContext('available devices and diagnostics', () async {
             final command = DevicesCommand(
-              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
               deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+              doctor: _FakeDoctor(),
+              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
             );
             await createTestCommandRunner(command).run(<String>['devices']);
 
@@ -532,8 +559,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
 
           testWithoutContext('when deviceConnectionInterface filtered to wireless', () async {
             final command = DevicesCommand(
-              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
               deviceManager: _FakeDeviceManager(devices: deviceList),
+              doctor: _FakeDoctor(),
+              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
             );
             await createTestCommandRunner(
               command,
@@ -564,8 +592,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
         testWithoutContext('available devices and diagnostics', () async {
           final logger = BufferLogger.test();
           final command = DevicesCommand(
-            toolContext: FakeToolContext(logger: logger, platform: platform),
             deviceManager: _FakeDeviceManager(devices: deviceList),
+            doctor: _FakeDoctor(),
+            toolContext: FakeToolContext(logger: logger, platform: platform),
           );
           await createTestCommandRunner(command).run(<String>['devices']);
           expect(logger.statusText, '''
@@ -603,12 +632,13 @@ Checking for wireless devices...
 
           testWithoutContext('available devices and diagnostics', () async {
             final command = DevicesCommand(
+              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+              doctor: _FakeDoctor(),
               toolContext: FakeToolContext(
                 logger: fakeLogger,
                 platform: platform,
                 terminal: terminal,
               ),
-              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
             );
             await createTestCommandRunner(command).run(<String>['devices']);
 
@@ -637,8 +667,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
 
           testWithoutContext('available devices and diagnostics', () async {
             final command = DevicesCommand(
-              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
               deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+              doctor: _FakeDoctor(),
+              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
             );
             await createTestCommandRunner(command).run(<String>['devices']);
 
@@ -674,8 +705,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
         testWithoutContext('available devices and diagnostics', () async {
           final logger = BufferLogger.test();
           final command = DevicesCommand(
-            toolContext: FakeToolContext(logger: logger, platform: platform),
             deviceManager: _FakeDeviceManager(devices: deviceList),
+            doctor: _FakeDoctor(),
+            toolContext: FakeToolContext(logger: logger, platform: platform),
           );
           await createTestCommandRunner(command).run(<String>['devices']);
           expect(logger.statusText, '''
@@ -707,12 +739,13 @@ No devices found yet. Checking for wireless devices...
 
           testWithoutContext('available devices and diagnostics', () async {
             final command = DevicesCommand(
+              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+              doctor: _FakeDoctor(),
               toolContext: FakeToolContext(
                 logger: fakeLogger,
                 platform: platform,
                 terminal: terminal,
               ),
-              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
             );
             await createTestCommandRunner(command).run(<String>['devices']);
 
@@ -739,8 +772,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
 
           testWithoutContext('available devices and diagnostics', () async {
             final command = DevicesCommand(
-              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
               deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+              doctor: _FakeDoctor(),
+              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
             );
             await createTestCommandRunner(command).run(<String>['devices']);
 
@@ -862,7 +896,7 @@ class FakeBufferLogger extends BufferLogger {
 }
 
 class _FakeDoctor extends Fake implements Doctor {
-  _FakeDoctor({required this.canListAnything});
+  _FakeDoctor({this.canListAnything = true});
 
   @override
   final bool canListAnything;

--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -4,20 +4,18 @@
 
 import 'dart:convert';
 
-import 'package:flutter_tools/src/android/android_sdk.dart';
-import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/doctor.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 import '../../src/fake_devices.dart';
+import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -26,7 +24,6 @@ void main() {
       Cache.disableLocking();
     });
 
-    late Cache cache;
     late Platform platform;
 
     group('ensure factory', () {
@@ -62,44 +59,45 @@ void main() {
 
     group('when Platform is not MacOS', () {
       setUp(() {
-        cache = Cache.test(processManager: FakeProcessManager.any());
         platform = FakePlatform();
       });
 
-      testUsingContext(
-        'returns 0 when called',
-        () async {
-          final command = DevicesCommand();
-          await createTestCommandRunner(command).run(<String>['devices']);
-        },
-        overrides: <Type, Generator>{Cache: () => cache, Artifacts: () => Artifacts.test()},
-      );
+      testWithoutContext('returns 0 when called', () async {
+        final command = DevicesCommand(toolContext: FakeToolContext(platform: platform));
+        await createTestCommandRunner(command).run(<String>['devices']);
+      });
 
-      testUsingContext(
-        'no error when no connected devices',
-        () async {
-          final command = DevicesCommand();
-          await createTestCommandRunner(command).run(<String>['devices']);
-          expect(
-            testLogger.statusText,
-            equals('''
+      testWithoutContext('throws ToolExit when Doctor cannot list anything', () async {
+        final command = DevicesCommand(
+          doctor: _FakeDoctor(canListAnything: false),
+          toolContext: FakeToolContext(platform: platform),
+        );
+        await expectLater(
+          () => createTestCommandRunner(command).run(<String>['devices']),
+          throwsToolExit(
+            message: "Unable to locate a development device; please run 'flutter doctor'",
+          ),
+        );
+      });
+
+      testWithoutContext('no error when no connected devices', () async {
+        final logger = BufferLogger.test();
+        final command = DevicesCommand(
+          toolContext: FakeToolContext(logger: logger, platform: platform),
+          deviceManager: NoDevicesManager(),
+        );
+        await createTestCommandRunner(command).run(<String>['devices']);
+        expect(
+          logger.statusText,
+          equals('''
 No authorized devices detected.
 
 Run "flutter emulators" to list and start any available device emulators.
 
 If you expected a device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 '''),
-          );
-        },
-        overrides: <Type, Generator>{
-          AndroidSdk: () => null,
-          DeviceManager: () => NoDevicesManager(),
-          ProcessManager: () => FakeProcessManager.any(),
-          Cache: () => cache,
-          Artifacts: () => Artifacts.test(),
-          Platform: () => platform,
-        },
-      );
+        );
+      });
 
       group('when includes both attached and wireless devices', () {
         List<FakeDeviceJsonData>? deviceList;
@@ -107,94 +105,67 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
           deviceList = <FakeDeviceJsonData>[fakeDevices[0], fakeDevices[1], fakeDevices[2]];
         });
 
-        testUsingContext(
-          "get devices' platform types",
-          () async {
-            final List<String> platformTypes = Device.devicesPlatformTypes(
-              await globals.deviceManager!.getAllDevices(),
-            );
-            expect(platformTypes, <String>['android', 'web']);
-          },
-          overrides: <Type, Generator>{
-            DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-            ProcessManager: () => FakeProcessManager.any(),
-            Cache: () => cache,
-            Artifacts: () => Artifacts.test(),
-            Platform: () => platform,
-          },
-        );
+        testWithoutContext("get devices' platform types", () async {
+          final deviceManager = _FakeDeviceManager(devices: deviceList);
+          final List<String> platformTypes = Device.devicesPlatformTypes(
+            await deviceManager.getAllDevices(),
+          );
+          expect(platformTypes, <String>['android', 'web']);
+        });
 
         group('with --machine flag', () {
-          testUsingContext(
-            'Outputs parsable JSON',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(command).run(<String>['devices', '--machine']);
-              expect(json.decode(testLogger.statusText), <Map<String, Object>>[
-                fakeDevices[0].json,
-                fakeDevices[1].json,
-                fakeDevices[2].json,
-              ]);
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-              ProcessManager: () => FakeProcessManager.any(),
-              Cache: () => cache,
-              Artifacts: () => Artifacts.test(),
-              Platform: () => platform,
-            },
-          );
+          testWithoutContext('Outputs parsable JSON', () async {
+            final logger = BufferLogger.test();
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(logger: logger, platform: platform),
+              deviceManager: _FakeDeviceManager(devices: deviceList),
+            );
+            await createTestCommandRunner(command).run(<String>['devices', '--machine']);
+            expect(json.decode(logger.statusText), <Map<String, Object>>[
+              fakeDevices[0].json,
+              fakeDevices[1].json,
+              fakeDevices[2].json,
+            ]);
+          });
 
           group('when deviceConnectionInterface', () {
-            testUsingContext(
-              'filtered to attached',
-              () async {
-                final command = DevicesCommand();
-                await createTestCommandRunner(
-                  command,
-                ).run(<String>['devices', '--machine', '--device-connection', 'attached']);
-                expect(json.decode(testLogger.statusText), <Map<String, Object>>[
-                  fakeDevices[0].json,
-                  fakeDevices[1].json,
-                ]);
-              },
-              overrides: <Type, Generator>{
-                DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-                ProcessManager: () => FakeProcessManager.any(),
-                Cache: () => cache,
-                Artifacts: () => Artifacts.test(),
-                Platform: () => platform,
-              },
-            );
+            testWithoutContext('filtered to attached', () async {
+              final logger = BufferLogger.test();
+              final command = DevicesCommand(
+                toolContext: FakeToolContext(logger: logger, platform: platform),
+                deviceManager: _FakeDeviceManager(devices: deviceList),
+              );
+              await createTestCommandRunner(
+                command,
+              ).run(<String>['devices', '--machine', '--device-connection', 'attached']);
+              expect(json.decode(logger.statusText), <Map<String, Object>>[
+                fakeDevices[0].json,
+                fakeDevices[1].json,
+              ]);
+            });
 
-            testUsingContext(
-              'filtered to wireless',
-              () async {
-                final command = DevicesCommand();
-                await createTestCommandRunner(
-                  command,
-                ).run(<String>['devices', '--machine', '--device-connection', 'wireless']);
-                expect(json.decode(testLogger.statusText), <Map<String, Object>>[
-                  fakeDevices[2].json,
-                ]);
-              },
-              overrides: <Type, Generator>{
-                DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-                ProcessManager: () => FakeProcessManager.any(),
-                Cache: () => cache,
-                Artifacts: () => Artifacts.test(),
-                Platform: () => platform,
-              },
-            );
+            testWithoutContext('filtered to wireless', () async {
+              final logger = BufferLogger.test();
+              final command = DevicesCommand(
+                toolContext: FakeToolContext(logger: logger, platform: platform),
+                deviceManager: _FakeDeviceManager(devices: deviceList),
+              );
+              await createTestCommandRunner(
+                command,
+              ).run(<String>['devices', '--machine', '--device-connection', 'wireless']);
+              expect(json.decode(logger.statusText), <Map<String, Object>>[fakeDevices[2].json]);
+            });
           });
         });
 
-        testUsingContext(
-          'available devices and diagnostics',
-          () async {
-            final command = DevicesCommand();
-            await createTestCommandRunner(command).run(<String>['devices']);
-            expect(testLogger.statusText, '''
+        testWithoutContext('available devices and diagnostics', () async {
+          final logger = BufferLogger.test();
+          final command = DevicesCommand(
+            toolContext: FakeToolContext(logger: logger, platform: platform),
+            deviceManager: _FakeDeviceManager(devices: deviceList),
+          );
+          await createTestCommandRunner(command).run(<String>['devices']);
+          expect(logger.statusText, '''
 Found 2 connected devices:
   ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
   webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
@@ -208,23 +179,19 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-          },
-          overrides: <Type, Generator>{
-            DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-            ProcessManager: () => FakeProcessManager.any(),
-            Platform: () => platform,
-          },
-        );
+        });
 
         group('when deviceConnectionInterface', () {
-          testUsingContext(
-            'filtered to attached',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(
-                command,
-              ).run(<String>['devices', '--device-connection', 'attached']);
-              expect(testLogger.statusText, '''
+          testWithoutContext('filtered to attached', () async {
+            final logger = BufferLogger.test();
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(logger: logger, platform: platform),
+              deviceManager: _FakeDeviceManager(devices: deviceList),
+            );
+            await createTestCommandRunner(
+              command,
+            ).run(<String>['devices', '--device-connection', 'attached']);
+            expect(logger.statusText, '''
 Found 2 connected devices:
   ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
   webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
@@ -235,22 +202,18 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-            },
-          );
+          });
 
-          testUsingContext(
-            'filtered to wireless',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(
-                command,
-              ).run(<String>['devices', '--device-connection', 'wireless']);
-              expect(testLogger.statusText, '''
+          testWithoutContext('filtered to wireless', () async {
+            final logger = BufferLogger.test();
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(logger: logger, platform: platform),
+              deviceManager: _FakeDeviceManager(devices: deviceList),
+            );
+            await createTestCommandRunner(
+              command,
+            ).run(<String>['devices', '--device-connection', 'wireless']);
+            expect(logger.statusText, '''
 Found 1 wirelessly connected device:
   wireless android (mobile) • wireless-android • android-arm • Test SDK (1.2.3) (emulator)
 
@@ -260,13 +223,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-            },
-          );
+          });
         });
       });
 
@@ -276,12 +233,14 @@ If you expected another device to be detected, please run "flutter doctor" to di
           deviceList = <FakeDeviceJsonData>[fakeDevices[0], fakeDevices[1]];
         });
 
-        testUsingContext(
-          'available devices and diagnostics',
-          () async {
-            final command = DevicesCommand();
-            await createTestCommandRunner(command).run(<String>['devices']);
-            expect(testLogger.statusText, '''
+        testWithoutContext('available devices and diagnostics', () async {
+          final logger = BufferLogger.test();
+          final command = DevicesCommand(
+            toolContext: FakeToolContext(logger: logger, platform: platform),
+            deviceManager: _FakeDeviceManager(devices: deviceList),
+          );
+          await createTestCommandRunner(command).run(<String>['devices']);
+          expect(logger.statusText, '''
 Found 2 connected devices:
   ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
   webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
@@ -292,13 +251,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-          },
-          overrides: <Type, Generator>{
-            DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-            ProcessManager: () => FakeProcessManager.any(),
-            Platform: () => platform,
-          },
-        );
+        });
       });
 
       group('when includes only wireless devices', () {
@@ -307,12 +260,14 @@ If you expected another device to be detected, please run "flutter doctor" to di
           deviceList = <FakeDeviceJsonData>[fakeDevices[2]];
         });
 
-        testUsingContext(
-          'available devices and diagnostics',
-          () async {
-            final command = DevicesCommand();
-            await createTestCommandRunner(command).run(<String>['devices']);
-            expect(testLogger.statusText, '''
+        testWithoutContext('available devices and diagnostics', () async {
+          final logger = BufferLogger.test();
+          final command = DevicesCommand(
+            toolContext: FakeToolContext(logger: logger, platform: platform),
+            deviceManager: _FakeDeviceManager(devices: deviceList),
+          );
+          await createTestCommandRunner(command).run(<String>['devices']);
+          expect(logger.statusText, '''
 Found 1 wirelessly connected device:
   wireless android (mobile) • wireless-android • android-arm • Test SDK (1.2.3) (emulator)
 
@@ -322,44 +277,31 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-          },
-          overrides: <Type, Generator>{
-            DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-            ProcessManager: () => FakeProcessManager.any(),
-            Platform: () => platform,
-          },
-        );
+        });
       });
     });
 
     group('when Platform is MacOS', () {
       setUp(() {
-        cache = Cache.test(processManager: FakeProcessManager.any());
         platform = FakePlatform(operatingSystem: 'macos');
       });
 
-      testUsingContext(
-        'returns 0 when called',
-        () async {
-          final command = DevicesCommand();
-          await createTestCommandRunner(command).run(<String>['devices']);
-        },
-        overrides: <Type, Generator>{
-          Cache: () => cache,
-          Artifacts: () => Artifacts.test(),
-          Platform: () => platform,
-        },
-      );
+      testWithoutContext('returns 0 when called', () async {
+        final command = DevicesCommand(toolContext: FakeToolContext(platform: platform));
+        await createTestCommandRunner(command).run(<String>['devices']);
+      });
 
       group('when no connected devices', () {
-        testUsingContext(
-          'no error',
-          () async {
-            final command = DevicesCommand();
-            await createTestCommandRunner(command).run(<String>['devices']);
-            expect(
-              testLogger.statusText,
-              equals('''
+        testWithoutContext('no error', () async {
+          final logger = BufferLogger.test();
+          final command = DevicesCommand(
+            toolContext: FakeToolContext(logger: logger, platform: platform),
+            deviceManager: NoDevicesManager(),
+          );
+          await createTestCommandRunner(command).run(<String>['devices']);
+          expect(
+            logger.statusText,
+            equals('''
 No devices found yet. Checking for wireless devices...
 
 No authorized devices detected.
@@ -368,49 +310,38 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected a device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 '''),
-            );
-          },
-          overrides: <Type, Generator>{
-            AndroidSdk: () => null,
-            DeviceManager: () => NoDevicesManager(),
-            ProcessManager: () => FakeProcessManager.any(),
-            Cache: () => cache,
-            Artifacts: () => Artifacts.test(),
-            Platform: () => platform,
-          },
-        );
+          );
+        });
 
         group('when deviceConnectionInterface', () {
-          testUsingContext(
-            'filtered to attached',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(
-                command,
-              ).run(<String>['devices', '--device-connection', 'attached']);
-              expect(testLogger.statusText, '''
+          testWithoutContext('filtered to attached', () async {
+            final logger = BufferLogger.test();
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(logger: logger, platform: platform),
+              deviceManager: NoDevicesManager(),
+            );
+            await createTestCommandRunner(
+              command,
+            ).run(<String>['devices', '--device-connection', 'attached']);
+            expect(logger.statusText, '''
 No authorized devices detected.
 
 Run "flutter emulators" to list and start any available device emulators.
 
 If you expected a device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => NoDevicesManager(),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-            },
-          );
+          });
 
-          testUsingContext(
-            'filtered to wireless',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(
-                command,
-              ).run(<String>['devices', '--device-connection', 'wireless']);
-              expect(testLogger.statusText, '''
+          testWithoutContext('filtered to wireless', () async {
+            final logger = BufferLogger.test();
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(logger: logger, platform: platform),
+              deviceManager: NoDevicesManager(),
+            );
+            await createTestCommandRunner(
+              command,
+            ).run(<String>['devices', '--device-connection', 'wireless']);
+            expect(logger.statusText, '''
 Checking for wireless devices...
 
 No authorized devices detected.
@@ -419,13 +350,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected a device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => NoDevicesManager(),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-            },
-          );
+          });
         });
       });
 
@@ -440,96 +365,71 @@ If you expected a device to be detected, please run "flutter doctor" to diagnose
           ];
         });
 
-        testUsingContext(
-          "get devices' platform types",
-          () async {
-            final List<String> platformTypes = Device.devicesPlatformTypes(
-              await globals.deviceManager!.getAllDevices(),
-            );
-            expect(platformTypes, <String>['android', 'ios', 'web']);
-          },
-          overrides: <Type, Generator>{
-            DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-            ProcessManager: () => FakeProcessManager.any(),
-            Cache: () => cache,
-            Artifacts: () => Artifacts.test(),
-            Platform: () => platform,
-          },
-        );
+        testWithoutContext("get devices' platform types", () async {
+          final deviceManager = _FakeDeviceManager(devices: deviceList);
+          final List<String> platformTypes = Device.devicesPlatformTypes(
+            await deviceManager.getAllDevices(),
+          );
+          expect(platformTypes, <String>['android', 'ios', 'web']);
+        });
 
         group('with --machine flag', () {
-          testUsingContext(
-            'Outputs parsable JSON',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(command).run(<String>['devices', '--machine']);
-              expect(json.decode(testLogger.statusText), <Map<String, Object>>[
+          testWithoutContext('Outputs parsable JSON', () async {
+            final logger = BufferLogger.test();
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(logger: logger, platform: platform),
+              deviceManager: _FakeDeviceManager(devices: deviceList),
+            );
+            await createTestCommandRunner(command).run(<String>['devices', '--machine']);
+            expect(json.decode(logger.statusText), <Map<String, Object>>[
+              fakeDevices[0].json,
+              fakeDevices[1].json,
+              fakeDevices[2].json,
+              fakeDevices[3].json,
+            ]);
+          });
+
+          group('when deviceConnectionInterface', () {
+            testWithoutContext('filtered to attached', () async {
+              final logger = BufferLogger.test();
+              final command = DevicesCommand(
+                toolContext: FakeToolContext(logger: logger, platform: platform),
+                deviceManager: _FakeDeviceManager(devices: deviceList),
+              );
+              await createTestCommandRunner(
+                command,
+              ).run(<String>['devices', '--machine', '--device-connection', 'attached']);
+              expect(json.decode(logger.statusText), <Map<String, Object>>[
                 fakeDevices[0].json,
                 fakeDevices[1].json,
+              ]);
+            });
+
+            testWithoutContext('filtered to wireless', () async {
+              final logger = BufferLogger.test();
+              final command = DevicesCommand(
+                toolContext: FakeToolContext(logger: logger, platform: platform),
+                deviceManager: _FakeDeviceManager(devices: deviceList),
+              );
+              await createTestCommandRunner(
+                command,
+              ).run(<String>['devices', '--machine', '--device-connection', 'wireless']);
+              expect(json.decode(logger.statusText), <Map<String, Object>>[
                 fakeDevices[2].json,
                 fakeDevices[3].json,
               ]);
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-              ProcessManager: () => FakeProcessManager.any(),
-              Cache: () => cache,
-              Artifacts: () => Artifacts.test(),
-              Platform: () => platform,
-            },
-          );
-
-          group('when deviceConnectionInterface', () {
-            testUsingContext(
-              'filtered to attached',
-              () async {
-                final command = DevicesCommand();
-                await createTestCommandRunner(
-                  command,
-                ).run(<String>['devices', '--machine', '--device-connection', 'attached']);
-                expect(json.decode(testLogger.statusText), <Map<String, Object>>[
-                  fakeDevices[0].json,
-                  fakeDevices[1].json,
-                ]);
-              },
-              overrides: <Type, Generator>{
-                DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-                ProcessManager: () => FakeProcessManager.any(),
-                Cache: () => cache,
-                Artifacts: () => Artifacts.test(),
-                Platform: () => platform,
-              },
-            );
-
-            testUsingContext(
-              'filtered to wireless',
-              () async {
-                final command = DevicesCommand();
-                await createTestCommandRunner(
-                  command,
-                ).run(<String>['devices', '--machine', '--device-connection', 'wireless']);
-                expect(json.decode(testLogger.statusText), <Map<String, Object>>[
-                  fakeDevices[2].json,
-                  fakeDevices[3].json,
-                ]);
-              },
-              overrides: <Type, Generator>{
-                DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-                ProcessManager: () => FakeProcessManager.any(),
-                Cache: () => cache,
-                Artifacts: () => Artifacts.test(),
-                Platform: () => platform,
-              },
-            );
+            });
           });
         });
 
-        testUsingContext(
-          'available devices and diagnostics',
-          () async {
-            final command = DevicesCommand();
-            await createTestCommandRunner(command).run(<String>['devices']);
-            expect(testLogger.statusText, '''
+        testWithoutContext('available devices and diagnostics', () async {
+          final logger = BufferLogger.test();
+          final command = DevicesCommand(
+            toolContext: FakeToolContext(logger: logger, platform: platform),
+            deviceManager: _FakeDeviceManager(devices: deviceList),
+          );
+          await createTestCommandRunner(command).run(<String>['devices']);
+          expect(logger.statusText, '''
 Found 2 connected devices:
   ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
   webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
@@ -546,13 +446,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-          },
-          overrides: <Type, Generator>{
-            DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-            ProcessManager: () => FakeProcessManager.any(),
-            Platform: () => platform,
-          },
-        );
+        });
 
         group('with ansi terminal', () {
           late FakeTerminal terminal;
@@ -570,13 +464,18 @@ Checking for wireless devices...
 ''';
           });
 
-          testUsingContext(
-            'available devices and diagnostics',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(command).run(<String>['devices']);
+          testWithoutContext('available devices and diagnostics', () async {
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(
+                logger: fakeLogger,
+                platform: platform,
+                terminal: terminal,
+              ),
+              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+            );
+            await createTestCommandRunner(command).run(<String>['devices']);
 
-              expect(fakeLogger.statusText, '''
+            expect(fakeLogger.statusText, '''
 Found 2 connected devices:
   ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
   webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
@@ -591,15 +490,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-              AnsiTerminal: () => terminal,
-              Logger: () => fakeLogger,
-            },
-          );
+          });
         });
 
         group('with verbose logging', () {
@@ -609,13 +500,14 @@ If you expected another device to be detected, please run "flutter doctor" to di
             fakeLogger = FakeBufferLogger(verbose: true);
           });
 
-          testUsingContext(
-            'available devices and diagnostics',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(command).run(<String>['devices']);
+          testWithoutContext('available devices and diagnostics', () async {
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
+              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+            );
+            await createTestCommandRunner(command).run(<String>['devices']);
 
-              expect(fakeLogger.statusText, '''
+            expect(fakeLogger.statusText, '''
 Found 2 connected devices:
   ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
   webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
@@ -636,23 +528,17 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-              Logger: () => fakeLogger,
-            },
-          );
+          });
 
-          testUsingContext(
-            'when deviceConnectionInterface filtered to wireless',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(
-                command,
-              ).run(<String>['devices', '--device-connection', 'wireless']);
-              expect(testLogger.statusText, '''
+          testWithoutContext('when deviceConnectionInterface filtered to wireless', () async {
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
+              deviceManager: _FakeDeviceManager(devices: deviceList),
+            );
+            await createTestCommandRunner(
+              command,
+            ).run(<String>['devices', '--device-connection', 'wireless']);
+            expect(fakeLogger.statusText, '''
 Checking for wireless devices...
 
 Found 2 wirelessly connected devices:
@@ -665,13 +551,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-            },
-          );
+          });
         });
       });
 
@@ -681,12 +561,14 @@ If you expected another device to be detected, please run "flutter doctor" to di
           deviceList = <FakeDeviceJsonData>[fakeDevices[0], fakeDevices[1]];
         });
 
-        testUsingContext(
-          'available devices and diagnostics',
-          () async {
-            final command = DevicesCommand();
-            await createTestCommandRunner(command).run(<String>['devices']);
-            expect(testLogger.statusText, '''
+        testWithoutContext('available devices and diagnostics', () async {
+          final logger = BufferLogger.test();
+          final command = DevicesCommand(
+            toolContext: FakeToolContext(logger: logger, platform: platform),
+            deviceManager: _FakeDeviceManager(devices: deviceList),
+          );
+          await createTestCommandRunner(command).run(<String>['devices']);
+          expect(logger.statusText, '''
 Found 2 connected devices:
   ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
   webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
@@ -701,13 +583,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-          },
-          overrides: <Type, Generator>{
-            DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-            ProcessManager: () => FakeProcessManager.any(),
-            Platform: () => platform,
-          },
-        );
+        });
 
         group('with ansi terminal', () {
           late FakeTerminal terminal;
@@ -725,13 +601,18 @@ Checking for wireless devices...
 ''';
           });
 
-          testUsingContext(
-            'available devices and diagnostics',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(command).run(<String>['devices']);
+          testWithoutContext('available devices and diagnostics', () async {
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(
+                logger: fakeLogger,
+                platform: platform,
+                terminal: terminal,
+              ),
+              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+            );
+            await createTestCommandRunner(command).run(<String>['devices']);
 
-              expect(fakeLogger.statusText, '''
+            expect(fakeLogger.statusText, '''
 Found 2 connected devices:
   ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
   webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
@@ -744,15 +625,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-              AnsiTerminal: () => terminal,
-              Logger: () => fakeLogger,
-            },
-          );
+          });
         });
 
         group('with verbose logging', () {
@@ -762,13 +635,14 @@ If you expected another device to be detected, please run "flutter doctor" to di
             fakeLogger = FakeBufferLogger(verbose: true);
           });
 
-          testUsingContext(
-            'available devices and diagnostics',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(command).run(<String>['devices']);
+          testWithoutContext('available devices and diagnostics', () async {
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
+              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+            );
+            await createTestCommandRunner(command).run(<String>['devices']);
 
-              expect(fakeLogger.statusText, '''
+            expect(fakeLogger.statusText, '''
 Found 2 connected devices:
   ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
   webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
@@ -787,14 +661,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-              Logger: () => fakeLogger,
-            },
-          );
+          });
         });
       });
 
@@ -804,12 +671,14 @@ If you expected another device to be detected, please run "flutter doctor" to di
           deviceList = <FakeDeviceJsonData>[fakeDevices[2], fakeDevices[3]];
         });
 
-        testUsingContext(
-          'available devices and diagnostics',
-          () async {
-            final command = DevicesCommand();
-            await createTestCommandRunner(command).run(<String>['devices']);
-            expect(testLogger.statusText, '''
+        testWithoutContext('available devices and diagnostics', () async {
+          final logger = BufferLogger.test();
+          final command = DevicesCommand(
+            toolContext: FakeToolContext(logger: logger, platform: platform),
+            deviceManager: _FakeDeviceManager(devices: deviceList),
+          );
+          await createTestCommandRunner(command).run(<String>['devices']);
+          expect(logger.statusText, '''
 No devices found yet. Checking for wireless devices...
 
 Found 2 wirelessly connected devices:
@@ -822,13 +691,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-          },
-          overrides: <Type, Generator>{
-            DeviceManager: () => _FakeDeviceManager(devices: deviceList),
-            ProcessManager: () => FakeProcessManager.any(),
-            Platform: () => platform,
-          },
-        );
+        });
 
         group('with ansi terminal', () {
           late FakeTerminal terminal;
@@ -842,13 +705,18 @@ No devices found yet. Checking for wireless devices...
 ''';
           });
 
-          testUsingContext(
-            'available devices and diagnostics',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(command).run(<String>['devices']);
+          testWithoutContext('available devices and diagnostics', () async {
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(
+                logger: fakeLogger,
+                platform: platform,
+                terminal: terminal,
+              ),
+              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+            );
+            await createTestCommandRunner(command).run(<String>['devices']);
 
-              expect(fakeLogger.statusText, '''
+            expect(fakeLogger.statusText, '''
 Found 2 wirelessly connected devices:
   wireless android (mobile) • wireless-android • android-arm • Test SDK (1.2.3) (emulator)
   wireless ios (mobile)     • wireless-ios     • ios         • iOS 16 (simulator)
@@ -859,15 +727,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-              AnsiTerminal: () => terminal,
-              Logger: () => fakeLogger,
-            },
-          );
+          });
         });
 
         group('with verbose logging', () {
@@ -877,13 +737,14 @@ If you expected another device to be detected, please run "flutter doctor" to di
             fakeLogger = FakeBufferLogger(verbose: true);
           });
 
-          testUsingContext(
-            'available devices and diagnostics',
-            () async {
-              final command = DevicesCommand();
-              await createTestCommandRunner(command).run(<String>['devices']);
+          testWithoutContext('available devices and diagnostics', () async {
+            final command = DevicesCommand(
+              toolContext: FakeToolContext(logger: fakeLogger, platform: platform),
+              deviceManager: _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
+            );
+            await createTestCommandRunner(command).run(<String>['devices']);
 
-              expect(fakeLogger.statusText, '''
+            expect(fakeLogger.statusText, '''
 No devices found yet. Checking for wireless devices...
 
 Found 2 wirelessly connected devices:
@@ -896,14 +757,7 @@ Run "flutter emulators" to list and start any available device emulators.
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.
 ''');
-            },
-            overrides: <Type, Generator>{
-              DeviceManager: () => _FakeDeviceManager(devices: deviceList, logger: fakeLogger),
-              ProcessManager: () => FakeProcessManager.any(),
-              Platform: () => platform,
-              Logger: () => fakeLogger,
-            },
-          );
+          });
         });
       });
     });
@@ -911,9 +765,9 @@ If you expected another device to be detected, please run "flutter doctor" to di
 }
 
 class _FakeDeviceManager extends DeviceManager {
-  _FakeDeviceManager({List<FakeDeviceJsonData>? devices, FakeBufferLogger? logger})
+  _FakeDeviceManager({List<FakeDeviceJsonData>? devices, Logger? logger})
     : fakeDevices = devices ?? <FakeDeviceJsonData>[],
-      super(logger: logger ?? testLogger);
+      super(logger: logger ?? BufferLogger.test());
 
   List<FakeDeviceJsonData> fakeDevices = <FakeDeviceJsonData>[];
 
@@ -945,7 +799,7 @@ class _FakeDeviceManager extends DeviceManager {
 }
 
 class NoDevicesManager extends DeviceManager {
-  NoDevicesManager() : super(logger: testLogger);
+  NoDevicesManager() : super(logger: BufferLogger.test());
 
   @override
   List<DeviceDiscovery> get deviceDiscoverers => <DeviceDiscovery>[];
@@ -1005,4 +859,11 @@ class FakeBufferLogger extends BufferLogger {
       );
     }
   }
+}
+
+class _FakeDoctor extends Fake implements Doctor {
+  _FakeDoctor({required this.canListAnything});
+
+  @override
+  final bool canListAnything;
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -37,7 +37,11 @@ void main() {
         'returns DevicesCommandOutputWithExtendedWirelessDeviceDiscovery on MacOS',
         () async {
           final Platform platform = FakePlatform(operatingSystem: 'macos');
-          final devicesCommandOutput = DevicesCommandOutput(platform: platform, logger: fakeLogger);
+          final devicesCommandOutput = DevicesCommandOutput(
+            platform: platform,
+            logger: fakeLogger,
+            deviceManager: _FakeDeviceManager(),
+          );
 
           expect(
             devicesCommandOutput is DevicesCommandOutputWithExtendedWirelessDeviceDiscovery,
@@ -48,7 +52,11 @@ void main() {
 
       testWithoutContext('returns default when not on MacOS', () async {
         final Platform platform = FakePlatform();
-        final devicesCommandOutput = DevicesCommandOutput(platform: platform, logger: fakeLogger);
+        final devicesCommandOutput = DevicesCommandOutput(
+          platform: platform,
+          logger: fakeLogger,
+          deviceManager: _FakeDeviceManager(),
+        );
 
         expect(
           devicesCommandOutput is DevicesCommandOutputWithExtendedWirelessDeviceDiscovery,

--- a/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
@@ -30,23 +30,25 @@ void main() {
     logger = BufferLogger.test();
   });
 
-  testUsingContext(
-    'devices can display no connected devices with the --machine flag',
-    () async {
-      final command = DevicesCommand();
-      final CommandRunner<void> runner = createTestCommandRunner(command);
-      await runner.run(<String>['devices', '--machine']);
+  testUsingContext('devices can display no connected devices with the --machine flag', () async {
+    final command = DevicesCommand(
+      toolContext: FakeToolContext(logger: logger),
+      deviceManager: deviceManager,
+    );
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+    await runner.run(<String>['devices', '--machine']);
 
-      expect(json.decode(logger.statusText), isEmpty);
-    },
-    overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags(), Logger: () => logger},
-  );
+    expect(json.decode(logger.statusText), isEmpty);
+  }, overrides: <Type, Generator>{FeatureFlags: () => TestFeatureFlags(), Logger: () => logger});
 
   testUsingContext(
     'devices can display via the --machine flag',
     () async {
       deviceManager.devices = <Device>[WebServerDevice(logger: logger)];
-      final command = DevicesCommand();
+      final command = DevicesCommand(
+        toolContext: FakeToolContext(logger: logger),
+        deviceManager: deviceManager,
+      );
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['devices', '--machine']);
 

--- a/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/web/web_device.dart';
 import 'package:test/fake.dart';
 
@@ -32,8 +33,9 @@ void main() {
 
   testUsingContext('devices can display no connected devices with the --machine flag', () async {
     final command = DevicesCommand(
-      toolContext: FakeToolContext(logger: logger),
       deviceManager: deviceManager,
+      doctor: globals.doctor!,
+      toolContext: FakeToolContext(logger: logger),
     );
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['devices', '--machine']);
@@ -46,8 +48,9 @@ void main() {
     () async {
       deviceManager.devices = <Device>[WebServerDevice(logger: logger)];
       final command = DevicesCommand(
-        toolContext: FakeToolContext(logger: logger),
         deviceManager: deviceManager,
+        doctor: globals.doctor!,
+        toolContext: FakeToolContext(logger: logger),
       );
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['devices', '--machine']);

--- a/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
@@ -34,7 +34,7 @@ void main() {
   testUsingContext('devices can display no connected devices with the --machine flag', () async {
     final command = DevicesCommand(
       deviceManager: deviceManager,
-      doctor: globals.doctor!,
+      doctor: globals.doctor,
       toolContext: FakeToolContext(logger: logger),
     );
     final CommandRunner<void> runner = createTestCommandRunner(command);
@@ -49,7 +49,7 @@ void main() {
       deviceManager.devices = <Device>[WebServerDevice(logger: logger)];
       final command = DevicesCommand(
         deviceManager: deviceManager,
-        doctor: globals.doctor!,
+        doctor: globals.doctor,
         toolContext: FakeToolContext(logger: logger),
       );
       final CommandRunner<void> runner = createTestCommandRunner(command);

--- a/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
@@ -34,7 +34,7 @@ void main() {
   testUsingContext('devices can display no connected devices with the --machine flag', () async {
     final command = DevicesCommand(
       deviceManager: deviceManager,
-      doctor: globals.doctor,
+      doctor: globals.doctor!,
       toolContext: FakeToolContext(logger: logger),
     );
     final CommandRunner<void> runner = createTestCommandRunner(command);
@@ -49,7 +49,7 @@ void main() {
       deviceManager.devices = <Device>[WebServerDevice(logger: logger)];
       final command = DevicesCommand(
         deviceManager: deviceManager,
-        doctor: globals.doctor,
+        doctor: globals.doctor!,
         toolContext: FakeToolContext(logger: logger),
       );
       final CommandRunner<void> runner = createTestCommandRunner(command);

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -652,7 +652,13 @@ void main() {
         final stdio = FakeStdio();
         await runner.run(
           <String>['devices', '--machine'],
-          (ToolDependencies toolDependencies) => <FlutterCommand>[DevicesCommand()],
+          (ToolDependencies toolDependencies) => <FlutterCommand>[
+            DevicesCommand(
+              deviceManager: globals.deviceManager!,
+              doctor: globals.doctor!,
+              toolContext: toolDependencies.toolContext,
+            ),
+          ],
           // This flutterVersion disables crash reporting.
           flutterVersion: '[user-branch]/',
           shutdownHooks: ShutdownHooks(),


### PR DESCRIPTION
## Summary

Part 10 of the modular dependency injection migration.

* Migrates `DevicesCommand` and `DevicesCommandOutput` to constructor dependency injection with zero global fallbacks:
  ```dart
  DevicesCommand({
    required DeviceManager deviceManager,
    required Doctor doctor,
    required super.toolContext,
    super.verboseHelp,
  })
  ```
* Requires non-nullable `DeviceManager`, `Doctor`, and `ToolContext`, eliminating ambient `globals.*` fallbacks and imports from `devices.dart`.
* Destructures `toolContext.logger` and `toolContext.terminal` for CLI device output and deprecation warnings.
* Wires dependencies via `toolDependencies.toolContext` in `executable.dart`.
* Migrates unit tests in `packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart` to hermetic `testWithoutContext` using `FakeToolContext`, while preserving permeable suite tests in `packages/flutter_tools/test/commands.shard/permeable/devices_test.dart`.

Part of https://github.com/flutter/flutter/issues/188471