### PR TITLE
[tool] Migrate InstallCommand to modular dependency injection

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -333,7 +333,7 @@ List<FlutterCommand> generateCommands({
     artifacts: toolDependencies.toolContext.artifacts,
     processManager: toolDependencies.toolContext.processManager,
   ),
-  InstallCommand(verboseHelp: verboseHelp),
+  InstallCommand(toolContext: toolDependencies.toolContext, verboseHelp: verboseHelp),
   LogsCommand(sigint: ProcessSignal.sigint, sigterm: ProcessSignal.sigterm),
   PackagesCommand(),
   PrecacheCommand(

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -30,6 +30,8 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
   @override
   ToolContext get toolContext => super.toolContext!;
 
+  Logger get _logger => toolContext.logger;
+
   @override
   final name = 'install';
 
@@ -87,22 +89,20 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
   }
 
   Future<void> _uninstallApp(ApplicationPackage package, Device device) async {
-    final Logger logger = toolContext.logger;
     if (await device.isAppInstalled(package, userIdentifier: userIdentifier)) {
-      logger.printStatus('Uninstalling $package from $device...');
+      _logger.printStatus('Uninstalling $package from $device...');
       if (!await device.uninstallApp(package, userIdentifier: userIdentifier)) {
-        logger.printError('Uninstalling old version failed');
+        _logger.printError('Uninstalling old version failed');
       }
     } else {
-      logger.printStatus('$package not found on $device, skipping uninstall');
+      _logger.printStatus('$package not found on $device, skipping uninstall');
     }
   }
 
   Future<void> _installApp(ApplicationPackage package, Device device) async {
-    final Logger logger = toolContext.logger;
-    logger.printStatus('Installing $package to $device...');
+    _logger.printStatus('Installing $package to $device...');
 
-    if (!await installApp(device, package, logger: logger, userIdentifier: userIdentifier)) {
+    if (!await installApp(device, package, logger: _logger, userIdentifier: userIdentifier)) {
       throwToolExit('Install failed');
     }
   }

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -13,9 +13,7 @@ import '../device.dart';
 import '../runner/flutter_command.dart';
 
 class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
-  InstallCommand({required ToolContext toolContext, required super.verboseHelp})
-    : _toolContext = toolContext,
-      super(toolContext: toolContext) {
+  InstallCommand({required super.toolContext, required super.verboseHelp}) {
     addBuildModeFlags(verboseHelp: verboseHelp);
     requiresPubspecYaml();
     usesApplicationBinaryOption();
@@ -29,10 +27,8 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
     );
   }
 
-  final ToolContext _toolContext;
-
   @override
-  ToolContext get toolContext => _toolContext;
+  ToolContext get toolContext => super.toolContext!;
 
   @override
   final name = 'install';
@@ -53,7 +49,7 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
 
   String? get _applicationBinaryPath => stringArg(FlutterOptions.kUseApplicationBinary);
   File? get _applicationBinary =>
-      _applicationBinaryPath == null ? null : _toolContext.fs.file(_applicationBinaryPath);
+      _applicationBinaryPath == null ? null : toolContext.fs.file(_applicationBinaryPath);
 
   @override
   Future<void> validateCommand() async {
@@ -91,7 +87,7 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
   }
 
   Future<void> _uninstallApp(ApplicationPackage package, Device device) async {
-    final Logger logger = _toolContext.logger;
+    final Logger logger = toolContext.logger;
     if (await device.isAppInstalled(package, userIdentifier: userIdentifier)) {
       logger.printStatus('Uninstalling $package from $device...');
       if (!await device.uninstallApp(package, userIdentifier: userIdentifier)) {
@@ -103,7 +99,7 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
   }
 
   Future<void> _installApp(ApplicationPackage package, Device device) async {
-    final Logger logger = _toolContext.logger;
+    final Logger logger = toolContext.logger;
     logger.printStatus('Installing $package to $device...');
 
     if (!await installApp(device, package, logger: logger, userIdentifier: userIdentifier)) {

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -13,7 +13,8 @@ import '../device.dart';
 import '../runner/flutter_command.dart';
 
 class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
-  InstallCommand({required super.toolContext, required super.verboseHelp}) {
+  InstallCommand({required ToolContext toolContext, required super.verboseHelp})
+    : super(toolContext: toolContext) {
     addBuildModeFlags(verboseHelp: verboseHelp);
     requiresPubspecYaml();
     usesApplicationBinaryOption();

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -121,19 +121,19 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
 Future<bool> installApp(
   Device device,
   ApplicationPackage package, {
-  Logger? logger,
+  required Logger logger,
   bool uninstall = true,
   String? userIdentifier,
 }) async {
   try {
     if (uninstall && await device.isAppInstalled(package, userIdentifier: userIdentifier)) {
-      logger?.printStatus('Uninstalling old version...');
+      logger.printStatus('Uninstalling old version...');
       if (!await device.uninstallApp(package, userIdentifier: userIdentifier)) {
-        logger?.printWarning('Warning: uninstalling old version failed');
+        logger.printWarning('Warning: uninstalling old version failed');
       }
     }
   } on ProcessException catch (e) {
-    logger?.printError('Error accessing device ${device.id}:\n${e.message}');
+    logger.printError('Error accessing device ${device.id}:\n${e.message}');
   }
 
   return device.installApp(package, userIdentifier: userIdentifier);

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -7,12 +7,15 @@ import '../application_package.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
+import '../base/logger.dart';
+import '../context/tool_context.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 
 class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
-  InstallCommand({required bool verboseHelp}) {
+  InstallCommand({required ToolContext toolContext, required super.verboseHelp})
+    : _toolContext = toolContext,
+      super(toolContext: toolContext) {
     addBuildModeFlags(verboseHelp: verboseHelp);
     requiresPubspecYaml();
     usesApplicationBinaryOption();
@@ -25,6 +28,11 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
       help: 'Uninstall the app if already on the device. Skip install.',
     );
   }
+
+  final ToolContext _toolContext;
+
+  @override
+  ToolContext get toolContext => _toolContext;
 
   @override
   final name = 'install';
@@ -45,7 +53,7 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
 
   String? get _applicationBinaryPath => stringArg(FlutterOptions.kUseApplicationBinary);
   File? get _applicationBinary =>
-      _applicationBinaryPath == null ? null : globals.fs.file(_applicationBinaryPath);
+      _applicationBinaryPath == null ? null : _toolContext.fs.file(_applicationBinaryPath);
 
   @override
   Future<void> validateCommand() async {
@@ -83,40 +91,49 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
   }
 
   Future<void> _uninstallApp(ApplicationPackage package, Device device) async {
+    final Logger logger = _toolContext.logger;
     if (await device.isAppInstalled(package, userIdentifier: userIdentifier)) {
-      globals.printStatus('Uninstalling $package from $device...');
+      logger.printStatus('Uninstalling $package from $device...');
       if (!await device.uninstallApp(package, userIdentifier: userIdentifier)) {
-        globals.printError('Uninstalling old version failed');
+        logger.printError('Uninstalling old version failed');
       }
     } else {
-      globals.printStatus('$package not found on $device, skipping uninstall');
+      logger.printStatus('$package not found on $device, skipping uninstall');
     }
   }
 
   Future<void> _installApp(ApplicationPackage package, Device device) async {
-    globals.printStatus('Installing $package to $device...');
+    final Logger logger = _toolContext.logger;
+    logger.printStatus('Installing $package to $device...');
 
-    if (!await installApp(device, package, userIdentifier: userIdentifier)) {
+    if (!await installApp(device, package, logger: logger, userIdentifier: userIdentifier)) {
       throwToolExit('Install failed');
     }
   }
 }
 
+/// Installs [package] to [device].
+///
+/// When [uninstall] is true and the package is already present on the device,
+/// it uninstalls the existing version before installing.
+///
+/// Returns true if installation succeeded, or false otherwise.
 Future<bool> installApp(
   Device device,
   ApplicationPackage package, {
-  String? userIdentifier,
+  Logger? logger,
   bool uninstall = true,
+  String? userIdentifier,
 }) async {
   try {
     if (uninstall && await device.isAppInstalled(package, userIdentifier: userIdentifier)) {
-      globals.printStatus('Uninstalling old version...');
+      logger?.printStatus('Uninstalling old version...');
       if (!await device.uninstallApp(package, userIdentifier: userIdentifier)) {
-        globals.printWarning('Warning: uninstalling old version failed');
+        logger?.printWarning('Warning: uninstalling old version failed');
       }
     }
   } on ProcessException catch (e) {
-    globals.printError('Error accessing device ${device.id}:\n${e.message}');
+    logger?.printError('Error accessing device ${device.id}:\n${e.message}');
   }
 
   return device.installApp(package, userIdentifier: userIdentifier);

--- a/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
@@ -8,15 +8,19 @@ import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/android/application_package.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/install.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/application_package.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -26,134 +30,159 @@ void main() {
     });
 
     late FileSystem fileSystem;
+    late BufferLogger logger;
+    late FakeToolContext toolContext;
+
     setUp(() {
       fileSystem = MemoryFileSystem.test();
       fileSystem.file('pubspec.yaml').createSync(recursive: true);
+      logger = BufferLogger.test();
+      toolContext = FakeToolContext(fs: fileSystem, logger: logger);
+    });
+
+    testUsingContext('returns 0 when Android is connected and ready for an install', () async {
+      final command = InstallCommand(toolContext: toolContext, verboseHelp: false);
+      command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
+
+      final device = FakeAndroidDevice();
+      testDeviceManager.addAttachedDevice(device);
+
+      await createTestCommandRunner(command).run(<String>['install']);
+      expect(logger.statusText, contains('Installing FakeAndroidApk to Android...'));
+    });
+
+    testUsingContext('returns 1 when targeted device is not Android with --device-user', () async {
+      final command = InstallCommand(toolContext: toolContext, verboseHelp: false);
+      command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
+
+      final device = FakeIOSDevice();
+      testDeviceManager.addAttachedDevice(device);
+
+      expect(
+        () async =>
+            createTestCommandRunner(command).run(<String>['install', '--device-user', '10']),
+        throwsToolExit(message: '--device-user is only supported for Android'),
+      );
+    });
+
+    testUsingContext('returns 0 when iOS is connected and ready for an install', () async {
+      final command = InstallCommand(toolContext: toolContext, verboseHelp: false);
+      command.applicationPackages = FakeApplicationPackageFactory(FakeIOSApp());
+
+      final device = FakeIOSDevice();
+      testDeviceManager.addAttachedDevice(device);
+
+      await createTestCommandRunner(command).run(<String>['install']);
+      expect(logger.statusText, contains('Installing FakeIOSApp to iOS...'));
+    });
+
+    testUsingContext('fails when prebuilt binary not found', () async {
+      final command = InstallCommand(toolContext: toolContext, verboseHelp: false);
+      command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
+
+      final device = FakeAndroidDevice();
+      testDeviceManager.addAttachedDevice(device);
+
+      expect(
+        () async => createTestCommandRunner(
+          command,
+        ).run(<String>['install', '--use-application-binary', 'bogus']),
+        throwsToolExit(message: 'Prebuilt binary bogus does not exist'),
+      );
+    });
+
+    testUsingContext('succeeds using prebuilt binary', () async {
+      final command = InstallCommand(toolContext: toolContext, verboseHelp: false);
+      command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
+
+      final device = FakeAndroidDevice();
+      testDeviceManager.addAttachedDevice(device);
+      fileSystem.file('binary').createSync(recursive: true);
+
+      await createTestCommandRunner(
+        command,
+      ).run(<String>['install', '--use-application-binary', 'binary']);
+      expect(logger.statusText, contains('Installing FakeAndroidApk to Android...'));
+    });
+
+    testUsingContext('Passes flavor to application package.', () async {
+      const flavor = 'free';
+      final command = InstallCommand(toolContext: toolContext, verboseHelp: false);
+      final fakeAppFactory = FakeApplicationPackageFactory(FakeIOSApp());
+      command.applicationPackages = fakeAppFactory;
+
+      final device = FakeIOSDevice();
+      testDeviceManager.addAttachedDevice(device);
+
+      await createTestCommandRunner(command).run(<String>['install', '--flavor', flavor]);
+      expect(fakeAppFactory.buildInfo, isNotNull);
+      expect(fakeAppFactory.buildInfo!.flavor, flavor);
     });
 
     testUsingContext(
-      'returns 0 when Android is connected and ready for an install',
+      'uninstalls app when --uninstall-only is provided and app is installed',
       () async {
-        final command = InstallCommand(verboseHelp: false);
+        final command = InstallCommand(toolContext: toolContext, verboseHelp: false);
+        command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
+
+        final device = FakeAndroidDevice(appInstalled: true);
+        testDeviceManager.addAttachedDevice(device);
+
+        await createTestCommandRunner(command).run(<String>['install', '--uninstall-only']);
+        expect(logger.statusText, contains('Uninstalling FakeAndroidApk from Android...'));
+        expect(device.uninstalled, isTrue);
+      },
+    );
+
+    testUsingContext(
+      'skips uninstall when --uninstall-only is provided and app is not installed',
+      () async {
+        final command = InstallCommand(toolContext: toolContext, verboseHelp: false);
         command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
         final device = FakeAndroidDevice();
         testDeviceManager.addAttachedDevice(device);
 
-        await createTestCommandRunner(command).run(<String>['install']);
-      },
-      overrides: <Type, Generator>{
-        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
-        FileSystem: () => fileSystem,
-        ProcessManager: () => FakeProcessManager.any(),
-      },
-    );
-
-    testUsingContext(
-      'returns 1 when targeted device is not Android with --device-user',
-      () async {
-        final command = InstallCommand(verboseHelp: false);
-        command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
-
-        final device = FakeIOSDevice();
-        testDeviceManager.addAttachedDevice(device);
-
+        await createTestCommandRunner(command).run(<String>['install', '--uninstall-only']);
         expect(
-          () async =>
-              createTestCommandRunner(command).run(<String>['install', '--device-user', '10']),
-          throwsToolExit(message: '--device-user is only supported for Android'),
+          logger.statusText,
+          contains('FakeAndroidApk not found on Android, skipping uninstall'),
         );
-      },
-      overrides: <Type, Generator>{
-        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
-        FileSystem: () => fileSystem,
-        ProcessManager: () => FakeProcessManager.any(),
+        expect(device.uninstalled, isFalse);
       },
     );
 
-    testUsingContext(
-      'returns 0 when iOS is connected and ready for an install',
-      () async {
-        final command = InstallCommand(verboseHelp: false);
-        command.applicationPackages = FakeApplicationPackageFactory(FakeIOSApp());
+    testWithoutContext('installApp uninstalls old version if already installed', () async {
+      final testLogger = BufferLogger.test();
+      final device = FakeAndroidDevice(appInstalled: true);
+      final app = FakeAndroidApk();
 
-        final device = FakeIOSDevice();
-        testDeviceManager.addAttachedDevice(device);
+      final bool result = await installApp(device, app, logger: testLogger);
+      expect(result, isTrue);
+      expect(device.uninstalled, isTrue);
+      expect(testLogger.statusText, contains('Uninstalling old version...'));
+    });
 
-        await createTestCommandRunner(command).run(<String>['install']);
-      },
-      overrides: <Type, Generator>{
-        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
-        FileSystem: () => fileSystem,
-        ProcessManager: () => FakeProcessManager.any(),
-      },
-    );
+    testWithoutContext('installApp logs warning if uninstalling old version fails', () async {
+      final testLogger = BufferLogger.test();
+      final device = FakeAndroidDevice(appInstalled: true, uninstallSucceeds: false);
+      final app = FakeAndroidApk();
 
-    testUsingContext(
-      'fails when prebuilt binary not found',
-      () async {
-        final command = InstallCommand(verboseHelp: false);
-        command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
+      final bool result = await installApp(device, app, logger: testLogger);
+      expect(result, isTrue);
+      expect(testLogger.warningText, contains('Warning: uninstalling old version failed'));
+    });
 
-        final device = FakeAndroidDevice();
-        testDeviceManager.addAttachedDevice(device);
+    testWithoutContext('installApp logs error when ProcessException is thrown', () async {
+      final testLogger = BufferLogger.test();
+      final device = _ThrowingDevice();
+      final app = FakeAndroidApk();
 
-        expect(
-          () async => createTestCommandRunner(
-            command,
-          ).run(<String>['install', '--use-application-binary', 'bogus']),
-          throwsToolExit(message: 'Prebuilt binary bogus does not exist'),
-        );
-      },
-      overrides: <Type, Generator>{
-        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
-        FileSystem: () => fileSystem,
-        ProcessManager: () => FakeProcessManager.any(),
-      },
-    );
-
-    testUsingContext(
-      'succeeds using prebuilt binary',
-      () async {
-        final command = InstallCommand(verboseHelp: false);
-        command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
-
-        final device = FakeAndroidDevice();
-        testDeviceManager.addAttachedDevice(device);
-        fileSystem.file('binary').createSync(recursive: true);
-
-        await createTestCommandRunner(
-          command,
-        ).run(<String>['install', '--use-application-binary', 'binary']);
-      },
-      overrides: <Type, Generator>{
-        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
-        FileSystem: () => fileSystem,
-        ProcessManager: () => FakeProcessManager.any(),
-      },
-    );
-
-    testUsingContext(
-      'Passes flavor to application package.',
-      () async {
-        const flavor = 'free';
-        final command = InstallCommand(verboseHelp: false);
-        final fakeAppFactory = FakeApplicationPackageFactory(FakeIOSApp());
-        command.applicationPackages = fakeAppFactory;
-
-        final device = FakeIOSDevice();
-        testDeviceManager.addAttachedDevice(device);
-
-        await createTestCommandRunner(command).run(<String>['install', '--flavor', flavor]);
-        expect(fakeAppFactory.buildInfo, isNotNull);
-        expect(fakeAppFactory.buildInfo!.flavor, flavor);
-      },
-      overrides: <Type, Generator>{
-        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
-        FileSystem: () => fileSystem,
-        ProcessManager: () => FakeProcessManager.any(),
-      },
-    );
+      final bool result = await installApp(device, app, logger: testLogger);
+      expect(result, isTrue);
+      expect(testLogger.errorText, contains('Error accessing device throwing-device:'));
+      expect(testLogger.errorText, contains('ADB failed'));
+    });
   });
 }
 
@@ -174,9 +203,15 @@ class FakeApplicationPackageFactory extends Fake implements ApplicationPackageFa
   }
 }
 
-class FakeIOSApp extends Fake implements IOSApp {}
+class FakeIOSApp extends Fake implements IOSApp {
+  @override
+  String toString() => 'FakeIOSApp';
+}
 
-class FakeAndroidApk extends Fake implements AndroidApk {}
+class FakeAndroidApk extends Fake implements AndroidApk {
+  @override
+  String toString() => 'FakeAndroidApk';
+}
 
 class FakeIOSDevice extends Fake implements IOSDevice {
   @override
@@ -190,14 +225,30 @@ class FakeIOSDevice extends Fake implements IOSDevice {
 
   @override
   String get name => 'iOS';
+
+  @override
+  String toString() => 'iOS';
 }
 
 class FakeAndroidDevice extends Fake implements AndroidDevice {
+  FakeAndroidDevice({this.appInstalled = false, this.uninstallSucceeds = true});
+
+  final bool appInstalled;
+  final bool uninstallSucceeds;
+  bool uninstalled = false;
+
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
 
   @override
-  Future<bool> isAppInstalled(ApplicationPackage app, {String? userIdentifier}) async => false;
+  Future<bool> isAppInstalled(ApplicationPackage app, {String? userIdentifier}) async =>
+      appInstalled;
+
+  @override
+  Future<bool> uninstallApp(ApplicationPackage app, {String? userIdentifier}) async {
+    uninstalled = true;
+    return uninstallSucceeds;
+  }
 
   @override
   Future<bool> installApp(AndroidApk app, {String? userIdentifier}) async => true;
@@ -207,4 +258,20 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
 
   @override
   bool get ephemeral => true;
+
+  @override
+  String toString() => 'Android';
+}
+
+class _ThrowingDevice extends Fake implements Device {
+  @override
+  String get id => 'throwing-device';
+
+  @override
+  Future<bool> isAppInstalled(ApplicationPackage app, {String? userIdentifier}) async {
+    throw const ProcessException('adb', <String>['shell'], 'ADB failed');
+  }
+
+  @override
+  Future<bool> installApp(ApplicationPackage app, {String? userIdentifier}) async => true;
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
@@ -105,7 +105,7 @@ void main() {
       expect(logger.statusText, contains('Installing FakeAndroidApk to Android...'));
     });
 
-    testUsingContext('Passes flavor to application package.', () async {
+    testUsingContext('passes flavor to application package', () async {
       const flavor = 'free';
       final command = InstallCommand(toolContext: toolContext, verboseHelp: false);
       final fakeAppFactory = FakeApplicationPackageFactory(FakeIOSApp());


### PR DESCRIPTION
## Summary

Part 13 of the modular dependency injection migration.

Migrates `InstallCommand` to modular dependency injection container `ToolContext`, eliminating ambient global references and adding hermetic unit tests.

Part of https://github.com/flutter/flutter/issues/47161