### PR TITLE
Fix drag frame scheduling and reduce iOS input latency

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios.mm
@@ -101,7 +101,7 @@ void PlatformViewIOS::attachView() {
 
 PointerDataDispatcherMaker PlatformViewIOS::GetDispatcherMaker() {
   return [](DefaultPointerDataDispatcher::Delegate& delegate) {
-    return std::make_unique<SmoothPointerDataDispatcher>(delegate);
+    return std::make_unique<DefaultPointerDataDispatcher>(delegate);
   };
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -17,6 +17,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'basic.dart';
 import 'framework.dart';
@@ -293,6 +294,10 @@ class ScrollDragController implements Drag {
   Duration? _lastNonStationaryTimestamp;
   bool _retainMomentum;
 
+  /// Prevents registering multiple post-frame callbacks while preserving a
+  /// frame request made by input during an already scheduled frame.
+  bool _nextInputFrameCallbackScheduled = false;
+
   /// Null if already in motion or has no [motionStartDistanceThreshold].
   double? _offsetSinceLastStop;
 
@@ -319,6 +324,25 @@ class ScrollDragController implements Drag {
   static const double _bigThresholdBreakDistance = 24.0;
 
   bool get _reversed => axisDirectionIsReversed(delegate.axisDirection);
+
+  /// Ensures that an input update schedules a subsequent frame even when a
+  /// frame is already pending.
+  void _scheduleInputFrame() {
+    final SchedulerBinding scheduler = SchedulerBinding.instance;
+    if (!scheduler.hasScheduledFrame) {
+      scheduler.scheduleFrame();
+      return;
+    }
+    if (_nextInputFrameCallbackScheduled) {
+      return;
+    }
+
+    _nextInputFrameCallbackScheduled = true;
+    scheduler.addPostFrameCallback((timeStamp) {
+      _nextInputFrameCallbackScheduled = false;
+      scheduler.scheduleFrame();
+    }, debugLabel: 'ScrollDragController.scheduleInputFrame');
+  }
 
   /// Updates the controller's link to the [ScrollActivityDelegate].
   ///
@@ -413,6 +437,7 @@ class ScrollDragController implements Drag {
       offset = -offset;
     }
     delegate.applyUserOffset(offset);
+    _scheduleInputFrame();
   }
 
   @override

--- a/packages/flutter/test/widgets/scroll_activity_test.dart
+++ b/packages/flutter/test/widgets/scroll_activity_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/scheduler.dart';
@@ -360,6 +361,40 @@ void main() {
       areCreateAndDispose,
     );
   });
+
+  testWidgets(
+    '$ScrollDragController preserves an input frame request made before a pending frame',
+    (WidgetTester tester) async {
+      final controller = ScrollDragController(
+        delegate: _ScrollActivityDelegate(),
+        details: DragStartDetails(),
+      );
+      addTearDown(controller.dispose);
+
+      final details = DragUpdateDetails(
+        delta: const Offset(0.0, 1.0),
+        primaryDelta: 1.0,
+        globalPosition: Offset.zero,
+      );
+
+      // The first input update schedules a frame.
+      controller.update(details);
+      expect(SchedulerBinding.instance.hasScheduledFrame, isTrue);
+
+      // A second input update arrives while that frame is still pending.
+      // Its frame request must be preserved for the following frame.
+      controller.update(details);
+
+      // Pump the already pending frame. The second input update should have
+      // scheduled another frame to run afterwards.
+      await tester.pump();
+      expect(SchedulerBinding.instance.hasScheduledFrame, isTrue);
+
+      // Pump the preserved frame. No further frame should remain scheduled.
+      await tester.pump();
+      expect(SchedulerBinding.instance.hasScheduledFrame, isFalse);
+    },
+  );
 }
 
 class PageView62209 extends StatefulWidget {


### PR DESCRIPTION
## Background

On iOS, Flutter currently uses `SmoothPointerDataDispatcher`, which may defer pointer packets to a secondary VSync when pointer data arrives while a previous packet/frame is still in progress.

While investigating scroll input latency, I found that this deferral can add noticeable delay to pointer delivery.

Measurements also showed that iOS touch input often arrives shortly before the next frame begins. This suggested that immediately dispatching those pointer packets could allow many drag updates to be reflected in the following frame without the additional delay introduced by `SmoothPointerDataDispatcher`.

However, replacing `SmoothPointerDataDispatcher` with `DefaultPointerDataDispatcher` exposed a separate frame scheduling issue in the framework.

## Problem

A drag update may arrive while another frame is already scheduled.

In that case, the scroll position is updated, but the currently scheduled frame may already be too far along to include that update. If no later frame request is preserved, the visual update can be deferred until a subsequent input event schedules another frame.

In my testing on iOS, this could result in drag updates being rendered on every other frame after removing `SmoothPointerDataDispatcher`.

Conceptually:

```text
input A
  -> schedules frame N

frame N begins

input B
  -> scroll position changes
  -> frame N is already scheduled/in progress
  -> no later frame request is preserved

frame N completes

input C
  -> schedules another frame
````

The issue appears to depend on the relative timing between input delivery and frame scheduling, rather than being inherently specific to iOS.

As an additional comparison, Android measurements on a 60 Hz display showed pointer events arriving at approximately 120 Hz and independently of the display frame cadence. This suggests that framework scheduling should not rely on input delivery being aligned with VSync.

## Changes

This PR makes two related changes:

1. Use `DefaultPointerDataDispatcher` on iOS instead of `SmoothPointerDataDispatcher`.
2. Preserve a subsequent frame request when a drag update arrives while another frame is already scheduled.

The second change is not restricted to iOS because the underlying scheduling condition is not platform-specific.

## Measurements

I instrumented the pointer-to-scroll-to-frame path and compared the existing implementation with the modified one.

Focused input-to-applied-frame latency:

| Metric | Existing Flutter | Modified |
| ------ | ---------------: | -------: |
| Median |         18.32 ms |  1.90 ms |
| p90    |         18.72 ms |  2.24 ms |

Scroll update to applied frame:

| Metric | Existing Flutter | Modified |
| ------ | ---------------: | -------: |
| Median |        16.493 ms | 0.279 ms |

Pointer processing time itself changed much less than the final input-to-frame latency. This suggests that most of the improvement comes from the scroll update being reflected in an earlier frame, rather than from faster gesture processing.

Rare higher-latency samples still exist. This change does not attempt to eliminate those by intentionally delaying input, since doing so would trade common-case latency for tighter timing consistency.

## Graph

<img width="980" height="560" alt="latency" src="https://github.com/user-attachments/assets/861bd9be-cbe4-4fed-9fb1-2bcd7b214b1e" />

<img width="1250" height="1130" alt="timeline" src="https://github.com/user-attachments/assets/75a77bb0-c074-4a06-83ef-e33da2557f5c" />

## Source

Raw CSV data and timeline visualizations are attached below.

[measurements.zip](https://github.com/user-attachments/files/30870933/measurements.zip)

## Tests

Added a regression test for `ScrollDragController` to verify that a frame request is preserved when another frame is already pending.

The test covers the following sequence:

1. A drag update schedules a frame.
2. Another drag update arrives before that frame is pumped.
3. After the pending frame is pumped, another frame remains scheduled.
4. After the preserved frame is pumped, no additional frame remains scheduled.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.