### PR TITLE
ci: Extract shared expected calls in prepare_package tests

### DIFF
--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -155,184 +155,93 @@ void main() {
         tryToDelete(tempDir);
       });
 
-      test('sets PUB_CACHE properly', () async {
+      /// The subprocesses expected during archive creation, keyed by command-line.
+      ///
+      /// [dartArch] is the architecture `dart --version` reports for the Dart
+      /// SDK downloaded into the archive. [archiveArch] is the architecture
+      /// expected in the archive filename, or null for x64, which is unadorned.
+      Map<String, List<ProcessResult>?> expectedCalls({
+        required String dartArch,
+        String? archiveArch,
+      }) {
         final String createBase = path.join(tempDir.absolute.path, 'create_');
+        final archPrefix = archiveArch == null ? '' : '${archiveArch}_';
         final String archiveName = path.join(
           tempDir.absolute.path,
-          'flutter_${platformName}_v1.2.3-beta${platform.isLinux ? '.tar.xz' : '.zip'}',
+          'flutter_${platformName}_${archPrefix}v1.2.3-beta'
+          '${platform.isLinux ? '.tar.xz' : '.zip'}',
         );
+        return <String, List<ProcessResult>?>{
+          'git clone -b beta https://flutter.googlesource.com/mirrors/flutter': null,
+          'git reset --hard $testRef': null,
+          'git remote set-url origin https://github.com/flutter/flutter.git': null,
+          'git gc --prune=now --aggressive': null,
+          'git describe --tags --exact-match $testRef': <ProcessResult>[
+            ProcessResult(0, 0, 'v1.2.3', ''),
+          ],
+          '$flutter --version --machine': <ProcessResult>[
+            ProcessResult(0, 0, '{"dartSdkVersion": "3.2.1"}', ''),
+            ProcessResult(0, 0, '{"dartSdkVersion": "3.2.1"}', ''),
+          ],
+          '$dart --version': <ProcessResult>[
+            ProcessResult(
+              0,
+              0,
+              'Dart SDK version: 2.17.0-63.0.beta (beta) (Wed Jan 26 03:48:52 2022 -0800) on "${platformName}_$dartArch"',
+              '',
+            ),
+          ],
+          if (platform.isWindows) '7za x ${path.join(tempDir.path, 'mingit.zip')}': null,
+          '$flutter doctor': null,
+          '$flutter update-packages': null,
+          '$flutter precache': null,
+          '$flutter ide-config': null,
+          '$flutter create --template=app ${createBase}app': null,
+          '$flutter create --template=package ${createBase}package': null,
+          '$flutter create --template=plugin ${createBase}plugin': null,
+          '$flutter pub cache list': <ProcessResult>[ProcessResult(0, 0, '{"packages":{}}', '')],
+          'git clean -f -x -- **/.packages': null,
+          'git clean -f -x -- **/.dart_tool/': null,
+          if (platform.isMacOS)
+            'codesign -vvvv --check-notarization ${path.join(tempDir.path, 'flutter', 'bin', 'cache', 'dart-sdk', 'bin', 'dart')}':
+                null,
+          if (platform.isWindows) 'attrib -h .git': null,
+          if (platform.isWindows)
+            '7za a -tzip -mx=9 $archiveName flutter': null
+          else if (platform.isMacOS)
+            'zip -r -9 --symlinks $archiveName flutter': null
+          else if (platform.isLinux)
+            'tar cJf $archiveName --verbose flutter': null,
+        };
+      }
 
+      /// The environment expected on every [ArchiveCreator] subprocess.
+      ///
+      /// This is the ambient environment, plus the archive's own pub cache.
+      Map<String, String> expectedEnvironment() {
+        return <String, String>{
+          ...platform.environment,
+          'PUB_CACHE': path.join(tempDir.path, '.pub-cache'),
+        };
+      }
+
+      test('sets PUB_CACHE properly', () async {
         processManager.addCommands(
-          convertResults(<String, List<ProcessResult>?>{
-            'git clone -b beta https://flutter.googlesource.com/mirrors/flutter': null,
-            'git reset --hard $testRef': null,
-            'git remote set-url origin https://github.com/flutter/flutter.git': null,
-            'git gc --prune=now --aggressive': null,
-            'git describe --tags --exact-match $testRef': <ProcessResult>[
-              ProcessResult(0, 0, 'v1.2.3', ''),
-            ],
-            '$flutter --version --machine': <ProcessResult>[
-              ProcessResult(0, 0, '{"dartSdkVersion": "3.2.1"}', ''),
-              ProcessResult(0, 0, '{"dartSdkVersion": "3.2.1"}', ''),
-            ],
-            '$dart --version': <ProcessResult>[
-              ProcessResult(
-                0,
-                0,
-                'Dart SDK version: 2.17.0-63.0.beta (beta) (Wed Jan 26 03:48:52 2022 -0800) on "${platformName}_x64"',
-                '',
-              ),
-            ],
-            if (platform.isWindows) '7za x ${path.join(tempDir.path, 'mingit.zip')}': null,
-            '$flutter doctor': null,
-            '$flutter update-packages': null,
-            '$flutter precache': null,
-            '$flutter ide-config': null,
-            '$flutter create --template=app ${createBase}app': null,
-            '$flutter create --template=package ${createBase}package': null,
-            '$flutter create --template=plugin ${createBase}plugin': null,
-            '$flutter pub cache list': <ProcessResult>[ProcessResult(0, 0, '{"packages":{}}', '')],
-            'git clean -f -x -- **/.packages': null,
-            'git clean -f -x -- **/.dart_tool/': null,
-            if (platform.isMacOS)
-              'codesign -vvvv --check-notarization ${path.join(tempDir.path, 'flutter', 'bin', 'cache', 'dart-sdk', 'bin', 'dart')}':
-                  null,
-            if (platform.isWindows) 'attrib -h .git': null,
-            if (platform.isWindows)
-              '7za a -tzip -mx=9 $archiveName flutter': null
-            else if (platform.isMacOS)
-              'zip -r -9 --symlinks $archiveName flutter': null
-            else if (platform.isLinux)
-              'tar cJf $archiveName --verbose flutter': null,
-          }),
+          convertResults(expectedCalls(dartArch: 'x64'), environment: expectedEnvironment()),
         );
         await creator.initializeRepo();
         await creator.createArchive();
       });
 
       test('calls the right commands for archive output', () async {
-        final String createBase = path.join(tempDir.absolute.path, 'create_');
-        final String archiveName = path.join(
-          tempDir.absolute.path,
-          'flutter_${platformName}_v1.2.3-beta${platform.isLinux ? '.tar.xz' : '.zip'}',
-        );
-        final calls = <String, List<ProcessResult>?>{
-          'git clone -b beta https://flutter.googlesource.com/mirrors/flutter': null,
-          'git reset --hard $testRef': null,
-          'git remote set-url origin https://github.com/flutter/flutter.git': null,
-          'git gc --prune=now --aggressive': null,
-          'git describe --tags --exact-match $testRef': <ProcessResult>[
-            ProcessResult(0, 0, 'v1.2.3', ''),
-          ],
-          '$flutter --version --machine': <ProcessResult>[
-            ProcessResult(0, 0, '{"dartSdkVersion": "3.2.1"}', ''),
-            ProcessResult(0, 0, '{"dartSdkVersion": "3.2.1"}', ''),
-          ],
-          '$dart --version': <ProcessResult>[
-            ProcessResult(
-              0,
-              0,
-              'Dart SDK version: 2.17.0-63.0.beta (beta) (Wed Jan 26 03:48:52 2022 -0800) on "${platformName}_x64"',
-              '',
-            ),
-          ],
-          if (platform.isWindows) '7za x ${path.join(tempDir.path, 'mingit.zip')}': null,
-          '$flutter doctor': null,
-          '$flutter update-packages': null,
-          '$flutter precache': null,
-          '$flutter ide-config': null,
-          '$flutter create --template=app ${createBase}app': null,
-          '$flutter create --template=package ${createBase}package': null,
-          '$flutter create --template=plugin ${createBase}plugin': null,
-          '$flutter pub cache list': <ProcessResult>[ProcessResult(0, 0, '{"packages":{}}', '')],
-          'git clean -f -x -- **/.packages': null,
-          'git clean -f -x -- **/.dart_tool/': null,
-          if (platform.isMacOS)
-            'codesign -vvvv --check-notarization ${path.join(tempDir.path, 'flutter', 'bin', 'cache', 'dart-sdk', 'bin', 'dart')}':
-                null,
-          if (platform.isWindows) 'attrib -h .git': null,
-          if (platform.isWindows)
-            '7za a -tzip -mx=9 $archiveName flutter': null
-          else if (platform.isMacOS)
-            'zip -r -9 --symlinks $archiveName flutter': null
-          else if (platform.isLinux)
-            'tar cJf $archiveName --verbose flutter': null,
-        };
-        processManager.addCommands(convertResults(calls));
-        creator = ArchiveCreator(
-          tempDir,
-          tempDir,
-          testRef,
-          Branch.beta,
-          fs: fs,
-          processManager: processManager,
-          subprocessOutput: false,
-          platform: platform,
-          httpReader: fakeHttpReader,
-        );
+        processManager.addCommands(convertResults(expectedCalls(dartArch: 'x64')));
         await creator.initializeRepo();
         await creator.createArchive();
       });
 
       test('adds the arch name to the archive for non-x64', () async {
-        final String createBase = path.join(tempDir.absolute.path, 'create_');
-        final String archiveName = path.join(
-          tempDir.absolute.path,
-          'flutter_${platformName}_arm64_v1.2.3-beta${platform.isLinux ? '.tar.xz' : '.zip'}',
-        );
-        final calls = <String, List<ProcessResult>?>{
-          'git clone -b beta https://flutter.googlesource.com/mirrors/flutter': null,
-          'git reset --hard $testRef': null,
-          'git remote set-url origin https://github.com/flutter/flutter.git': null,
-          'git gc --prune=now --aggressive': null,
-          'git describe --tags --exact-match $testRef': <ProcessResult>[
-            ProcessResult(0, 0, 'v1.2.3', ''),
-          ],
-          '$flutter --version --machine': <ProcessResult>[
-            ProcessResult(0, 0, '{"dartSdkVersion": "3.2.1"}', ''),
-            ProcessResult(0, 0, '{"dartSdkVersion": "3.2.1"}', ''),
-          ],
-          '$dart --version': <ProcessResult>[
-            ProcessResult(
-              0,
-              0,
-              'Dart SDK version: 2.17.0-63.0.beta (beta) (Wed Jan 26 03:48:52 2022 -0800) on "${platformName}_arm64"',
-              '',
-            ),
-          ],
-          if (platform.isWindows) '7za x ${path.join(tempDir.path, 'mingit.zip')}': null,
-          '$flutter doctor': null,
-          '$flutter update-packages': null,
-          '$flutter precache': null,
-          '$flutter ide-config': null,
-          '$flutter create --template=app ${createBase}app': null,
-          '$flutter create --template=package ${createBase}package': null,
-          '$flutter create --template=plugin ${createBase}plugin': null,
-          '$flutter pub cache list': <ProcessResult>[ProcessResult(0, 0, '{"packages":{}}', '')],
-          'git clean -f -x -- **/.packages': null,
-          'git clean -f -x -- **/.dart_tool/': null,
-          if (platform.isMacOS)
-            'codesign -vvvv --check-notarization ${path.join(tempDir.path, 'flutter', 'bin', 'cache', 'dart-sdk', 'bin', 'dart')}':
-                null,
-          if (platform.isWindows) 'attrib -h .git': null,
-          if (platform.isWindows)
-            '7za a -tzip -mx=9 $archiveName flutter': null
-          else if (platform.isMacOS)
-            'zip -r -9 --symlinks $archiveName flutter': null
-          else if (platform.isLinux)
-            'tar cJf $archiveName --verbose flutter': null,
-        };
-        processManager.addCommands(convertResults(calls));
-        creator = ArchiveCreator(
-          tempDir,
-          tempDir,
-          testRef,
-          Branch.beta,
-          fs: fs,
-          processManager: processManager,
-          subprocessOutput: false,
-          platform: platform,
-          httpReader: fakeHttpReader,
+        processManager.addCommands(
+          convertResults(expectedCalls(dartArch: 'arm64', archiveArch: 'arm64')),
         );
         await creator.initializeRepo();
         await creator.createArchive();
@@ -1228,18 +1137,26 @@ void main() {
   }
 }
 
-List<FakeCommand> convertResults(Map<String, List<ProcessResult>?> results) {
+/// Converts a map of command lines to their results into [FakeCommand]s.
+///
+/// If [environment] is given, each command is additionally expected to run with
+/// exactly that environment.
+List<FakeCommand> convertResults(
+  Map<String, List<ProcessResult>?> results, {
+  Map<String, String>? environment,
+}) {
   final commands = <FakeCommand>[];
   for (final String key in results.keys) {
     final List<ProcessResult>? candidates = results[key];
     final List<String> args = key.split(' ');
     if (candidates == null) {
-      commands.add(FakeCommand(command: args));
+      commands.add(FakeCommand(command: args, environment: environment));
     } else {
       for (final ProcessResult result in candidates) {
         commands.add(
           FakeCommand(
             command: args,
+            environment: environment,
             exitCode: result.exitCode,
             stderr: result.stderr.toString(),
             stdout: result.stdout.toString(),


### PR DESCRIPTION
Three of the `ArchiveCreator` tests each carried their own copy of the same ~60 line map of expected subprocess invocations, differing only in the architecture `dart --version` reports and the name of the output archive. This extracts that map into an `expectedCalls` helper parameterised on those two values, and drops the redundant re-construction of `creator` that two of them did on top of `setUp`.

Also adds an `expectedEnvironment` helper and passes it through `convertResults`. We never verified the environment `ArchiveCreator` runs its subprocesses with, so the `sets PUB_CACHE properly` test wasn't actually checking `PUB_CACHE`.

The `non-strict mode calls the right commands` and `fails if binary is not codesigned` tests build nearly the same map, but differ in enough other ways that I've left them as-is.

This is pre-factoring for the `--target_arch` option added in a followup patch, which introduces further variants of these expectations.

Issue: https://github.com/flutter/flutter/issues/189144

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
