### PR TITLE
[native_assets] Record bundled code assets under their install name

### DIFF
--- a/packages/flutter_tools/lib/src/commands/darwin_add_to_app.dart
+++ b/packages/flutter_tools/lib/src/commands/darwin_add_to_app.dart
@@ -348,7 +348,13 @@ class DarwinAddToAppNativeAssets {
         // [KernelAssetAbsolutePath]), and the second string is the actual path.
         if (pathInfo is List<Object?> && pathInfo.length >= 2) {
           final path = pathInfo[1]! as String;
-          result[assetId] = path;
+          // A code asset is recorded under the name it is loaded with, which for
+          // a framework is its `@rpath`-relative install name. Drop the prefix
+          // to get back to where it sits in the bundle.
+          const rpathPrefix = '@rpath/';
+          result[assetId] = path.startsWith(rpathPrefix)
+              ? path.substring(rpathPrefix.length)
+              : path;
         }
       }
     }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -51,14 +51,22 @@ Map<FlutterCodeAsset, KernelAsset> assetTargetLocationsIOS(List<FlutterCodeAsset
   for (final asset in nativeAssets) {
     final String assetId = asset.codeAsset.id;
     final KernelAssetPath path =
-        idToPath[assetId] ?? _targetLocationIOS(asset, alreadyTakenNames).path;
+        idToPath[assetId] ??
+        _targetLocationIOS(asset, alreadyTakenNames, useInstallName: true).path;
     idToPath[assetId] = path;
     result[asset] = KernelAsset(id: assetId, target: asset.target, path: path);
   }
   return result;
 }
 
-KernelAsset _targetLocationIOS(FlutterCodeAsset asset, Set<String> alreadyTakenNames) {
+/// [useInstallName] gives the name the asset is loaded with at runtime rather
+/// than the location it is bundled at. The two are different for a framework,
+/// and the native assets manifest needs the former: see [frameworkInstallName].
+KernelAsset _targetLocationIOS(
+  FlutterCodeAsset asset,
+  Set<String> alreadyTakenNames, {
+  bool useInstallName = false,
+}) {
   final LinkMode linkMode = asset.codeAsset.linkMode;
   final KernelAssetPath kernelAssetPath;
   switch (linkMode) {
@@ -70,7 +78,11 @@ KernelAsset _targetLocationIOS(FlutterCodeAsset asset, Set<String> alreadyTakenN
       kernelAssetPath = KernelAssetInProcess();
     case DynamicLoadingBundled _:
       final String fileName = asset.codeAsset.file!.pathSegments.last;
-      kernelAssetPath = KernelAssetAbsolutePath(frameworkUri(fileName, alreadyTakenNames));
+      Uri uri = frameworkUri(fileName, alreadyTakenNames);
+      if (useInstallName) {
+        uri = Uri(path: frameworkInstallName(uri));
+      }
+      kernelAssetPath = KernelAssetAbsolutePath(uri);
     default:
       throw Exception('Unsupported asset link mode $linkMode in asset $asset');
   }
@@ -126,8 +138,7 @@ Future<List<File>> copyNativeCodeAssetsIOS(
       );
     }
 
-    final String dylibFileName = dylibFile.basename;
-    final newInstallName = '@rpath/$dylibFileName.framework/$dylibFileName';
+    final String newInstallName = frameworkInstallName(target);
     final Set<String> oldInstallNames = await getInstallNamesDylib(dylibFile);
     for (final oldInstallName in oldInstallNames) {
       oldToNewInstallNames[oldInstallName] = newInstallName;

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -48,18 +48,23 @@ Map<FlutterCodeAsset, KernelAsset> assetTargetLocationsMacOS(
   for (final asset in nativeAssets) {
     final String assetId = asset.codeAsset.id;
     final KernelAssetPath path =
-        idToPath[assetId] ?? _targetLocationMacOS(asset, absolutePath, alreadyTakenNames).path;
+        idToPath[assetId] ??
+        _targetLocationMacOS(asset, absolutePath, alreadyTakenNames, useInstallName: true).path;
     idToPath[assetId] = path;
     result[asset] = KernelAsset(id: assetId, target: asset.target, path: path);
   }
   return result;
 }
 
+/// [useInstallName] gives the name the asset is loaded with at runtime rather
+/// than the location it is bundled at. The two are different for a framework,
+/// and the native assets manifest needs the former: see [frameworkInstallName].
 KernelAsset _targetLocationMacOS(
   FlutterCodeAsset asset,
   Uri? absolutePath,
-  Set<String> alreadyTakenNames,
-) {
+  Set<String> alreadyTakenNames, {
+  bool useInstallName = false,
+}) {
   final LinkMode linkMode = asset.codeAsset.linkMode;
   final KernelAssetPath kernelAssetPath;
   switch (linkMode) {
@@ -80,6 +85,9 @@ KernelAsset _targetLocationMacOS(
         // "relative" in the context of native assets would be relative to the
         // kernel or aot snapshot.
         uri = frameworkUri(fileName, alreadyTakenNames);
+        if (useInstallName) {
+          uri = Uri(path: frameworkInstallName(uri));
+        }
       }
       kernelAssetPath = KernelAssetAbsolutePath(uri);
     default:
@@ -172,8 +180,7 @@ Future<List<File>> copyNativeCodeAssetsMacOS(
       ),
     );
 
-    final String dylibFileName = dylibFile.basename;
-    final newInstallName = '@rpath/$dylibFileName.framework/$dylibFileName';
+    final String newInstallName = frameworkInstallName(target);
     final Set<String> oldInstallNames = await getInstallNamesDylib(dylibFile);
     for (final oldInstallName in oldInstallNames) {
       oldToNewInstallNames[oldInstallName] = newInstallName;

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
@@ -287,6 +287,17 @@ Uri frameworkUri(String fileName, Set<String> alreadyTakenNames) {
   return Uri(path: '$fileName.framework/$fileName');
 }
 
+/// The install name stamped into the framework bundled at [frameworkUri], which
+/// is also the name it has to be loaded with at runtime.
+///
+/// `dlopen` recognizes a library it has already loaded by the name it is opened
+/// with, and only falls back to identifying the file on disk when that name
+/// matches no install name it knows. A rebuild replaces that file underneath a
+/// debug instance that is still running, so opening an asset by anything other
+/// than its install name maps a second copy of it into the process, and the two
+/// copies do not share the library's global state.
+String frameworkInstallName(Uri frameworkUri) => '@rpath/${frameworkUri.path}';
+
 Map<Architecture?, List<String>> parseOtoolArchitectureSections(String output) {
   // The output of `otool -D`, for example, looks like below. For each
   // architecture, there is a separate section.

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -1004,11 +1004,12 @@ void main() {
   "format-version": [1, 0, 0],
   "native-assets": {
     "ios_arm64": {
-      "package:project/asset1": ["absolute", "Foo.framework/Foo"],
-      "package:project/asset2": ["absolute", "Bar.framework/Bar"]
+      "package:project/asset1": ["absolute", "@rpath/Foo.framework/Foo"],
+      "package:project/asset2": ["absolute", "@rpath/Bar.framework/Bar"],
+      "package:project/asset3": ["system", "/usr/lib/libsqlite3.dylib"]
     },
     "ios_x64": {
-      "package:project/asset1": ["absolute", "Foo.framework/Foo"]
+      "package:project/asset1": ["absolute", "@rpath/Foo.framework/Foo"]
     }
   }
 }
@@ -1018,9 +1019,13 @@ void main() {
         output,
         FlutterDarwinPlatform.ios,
       );
+      // Bundled assets are recorded under their install name and come back as
+      // the location within the bundle. An asset that is not bundled has no
+      // install name to strip.
       expect(assets, <String, String>{
         'package:project/asset1': 'Foo.framework/Foo',
         'package:project/asset2': 'Bar.framework/Bar',
+        'package:project/asset3': '/usr/lib/libsqlite3.dylib',
       });
     });
 
@@ -1037,11 +1042,11 @@ void main() {
   "format-version": [1, 0, 0],
   "native-assets": {
     "macos_x64": {
-      "package:project/asset1": ["absolute", "Foo.framework/Foo"],
-      "package:project/asset2": ["absolute", "Bar.framework/Bar"]
+      "package:project/asset1": ["absolute", "@rpath/Foo.framework/Foo"],
+      "package:project/asset2": ["absolute", "@rpath/Bar.framework/Bar"]
     },
     "macos_arm64": {
-      "package:project/asset1": ["absolute", "Foo.framework/Foo"]
+      "package:project/asset1": ["absolute", "@rpath/Foo.framework/Foo"]
     }
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_swift_package_test.dart
@@ -690,10 +690,12 @@ let package = Package(
         final Directory generatedAppFramework = cacheDirectory.childDirectory(
           'Debug/macosx/App.framework',
         )..createSync(recursive: true);
+        // Bundled code assets are recorded under their install name, which is
+        // where the framework sits in the bundle prefixed with `@rpath/`.
         generatedAppFramework.childFile('Resources/flutter_assets/NativeAssetsManifest.json')
           ..createSync(recursive: true)
           ..writeAsStringSync(
-            '{"native-assets":{"macos_x64":{"package:my_native_asset/my_native_asset.dylib":["absolute","my_native_asset.framework/my_native_asset"]},"macos_arm64":{"package:my_native_asset/my_native_asset.dylib":["absolute","my_native_asset.framework/my_native_asset"]}}}',
+            '{"native-assets":{"macos_x64":{"package:my_native_asset/my_native_asset.dylib":["absolute","@rpath/my_native_asset.framework/my_native_asset"]},"macos_arm64":{"package:my_native_asset/my_native_asset.dylib":["absolute","@rpath/my_native_asset.framework/my_native_asset"]}}}',
           );
         final Directory nativeAssetFramework = cacheDirectory.childDirectory(
           'Debug/macosx/native_assets/my_native_asset.framework',

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_host_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_host_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:code_assets/code_assets.dart';
+import 'package:flutter_tools/src/isolated/native_assets/ios/native_assets.dart';
+import 'package:flutter_tools/src/isolated/native_assets/macos/native_assets.dart';
 import 'package:flutter_tools/src/isolated/native_assets/macos/native_assets_host.dart';
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
 import 'package:hooks_runner/hooks_runner.dart';
@@ -224,5 +226,88 @@ void main() {
     expect(result[pathB]!.length, equals(2));
     expect(result[pathB]!.contains(assetB1), isTrue);
     expect(result[pathB]!.contains(assetB2), isTrue);
+  });
+
+  // The manifest entry is the string the Dart VM passes to `dlopen`, and dyld
+  // recognizes a library it has already loaded by the name it is opened with.
+  // If that name is not the framework's install name, dyld has to fall back on
+  // the file's identity on disk, which a rebuild changes underneath a running
+  // debug instance. The asset then gets mapped a second time. See
+  // https://github.com/flutter/flutter/issues/190799.
+  test('macOS manifest entry is the framework install name', () {
+    final asset = FlutterCodeAsset(
+      codeAsset: CodeAsset(
+        package: 'my_package',
+        name: 'my_asset',
+        linkMode: DynamicLoadingBundled(),
+        file: Uri.file('libmy_asset.dylib'),
+      ),
+      target: Target.fromString('macos_arm64'),
+    );
+    final assets = <FlutterCodeAsset>[asset];
+
+    final Map<FlutterCodeAsset, KernelAsset> manifest = assetTargetLocationsMacOS(assets, null);
+    expect(
+      (manifest[asset]!.path as KernelAssetAbsolutePath).uri.path,
+      equals('@rpath/my_asset.framework/my_asset'),
+    );
+
+    // The framework itself is still bundled without the install name prefix.
+    final Map<KernelAssetPath, List<FlutterCodeAsset>> bundled = fatAssetTargetLocationsMacOS(
+      assets,
+      null,
+    );
+    expect(
+      (bundled.keys.single as KernelAssetAbsolutePath).uri.path,
+      equals('my_asset.framework/my_asset'),
+    );
+  });
+
+  test('macOS flutter tester manifest entry is the host path', () {
+    final asset = FlutterCodeAsset(
+      codeAsset: CodeAsset(
+        package: 'my_package',
+        name: 'my_asset',
+        linkMode: DynamicLoadingBundled(),
+        file: Uri.file('libmy_asset.dylib'),
+      ),
+      target: Target.fromString('macos_arm64'),
+    );
+
+    // The tester loads the dylib from where it was built instead of from a
+    // bundle, and its install name is set to that same absolute path.
+    final Map<FlutterCodeAsset, KernelAsset> manifest = assetTargetLocationsMacOS(
+      <FlutterCodeAsset>[asset],
+      Uri.parse('file:///build/native_assets/macos/'),
+    );
+    expect(
+      (manifest[asset]!.path as KernelAssetAbsolutePath).uri,
+      equals(Uri.parse('file:///build/native_assets/macos/libmy_asset.dylib')),
+    );
+  });
+
+  test('iOS manifest entry is the framework install name', () {
+    final asset = FlutterCodeAsset(
+      codeAsset: CodeAsset(
+        package: 'my_package',
+        name: 'my_asset',
+        linkMode: DynamicLoadingBundled(),
+        file: Uri.file('libmy_asset.dylib'),
+      ),
+      target: Target.fromString('ios_arm64'),
+    );
+    final assets = <FlutterCodeAsset>[asset];
+
+    final Map<FlutterCodeAsset, KernelAsset> manifest = assetTargetLocationsIOS(assets);
+    expect(
+      (manifest[asset]!.path as KernelAssetAbsolutePath).uri.path,
+      equals('@rpath/my_asset.framework/my_asset'),
+    );
+
+    final Map<KernelAssetPath, List<FlutterCodeAsset>> bundled = fatAssetTargetLocationsIOS(assets);
+    expect(
+      (bundled.keys.single as KernelAssetAbsolutePath).uri.path,
+      equals('my_asset.framework/my_asset'),
+    );
   });
 }

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -388,8 +388,9 @@ void main() {
                 // Tests run on host system, so the have the full path on the system.
                 projectUri.resolve('build/native_assets/macos/libbar.dylib').toFilePath()
               else
-                // Apps are a bundle with the dylibs on their dlopen path.
-                'bar.framework/bar',
+                // Apps are a bundle, and the dylibs are opened by the install
+                // name of the framework they are bundled in.
+                '@rpath/bar.framework/bar',
             ]),
           );
           expect(
@@ -400,8 +401,9 @@ void main() {
                 // Tests run on host system, so the have the full path on the system.
                 projectUri.resolve('build/native_assets/macos/libbuz.dylib').toFilePath()
               else
-                // Apps are a bundle with the dylibs on their dlopen path.
-                'buz.framework/buz',
+                // Apps are a bundle, and the dylibs are opened by the install
+                // name of the framework they are bundled in.
+                '@rpath/buz.framework/buz',
             ]),
           );
           // Multi arch.

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_flutter_run_test.dart
@@ -122,4 +122,108 @@ void main() {
       });
     }
   }
+
+  if (platform.isMacOS) {
+    // Regression test for https://github.com/flutter/flutter/issues/190799.
+    //
+    // A bundled code asset is stamped with the install name
+    // `@rpath/<name>.framework/<name>`. While NativeAssetsManifest.json records
+    // a different string, dyld cannot recognise the library it already has by
+    // name and identifies it by file instead. That identity holds only until
+    // the file is replaced, which is what rebuilding does to a bundle a debug
+    // instance is still running, and the next `@Native` binding to resolve then
+    // maps a second copy of the asset with its own copy of the library's state.
+    testWithoutContext('code asset is not mapped twice when its file is replaced', () async {
+      await inTempDir((Directory tempDirectory) async {
+        final Directory packageDirectory = await createTestProject(
+          packageName,
+          tempDirectory,
+          withProcessGlobalState: true,
+        );
+        final Directory exampleDirectory = packageDirectory.childDirectory('example');
+        final File mainFile = exampleDirectory.childDirectory('lib').childFile('main.dart');
+        mainFile.writeAsStringSync(_mainDart(loadState: false));
+
+        Object? replaceError;
+        final ProcessTestResult result = await runFlutter(
+          <String>['run', '-dmacos', '--debug'],
+          exampleDirectory.path,
+          <Transition>[
+            // Both patterns have to match before the file is replaced: the app
+            // has to have stored something through the copy it loaded first.
+            Multiple.contains(
+              <Pattern>['Flutter run key commands.', _storedMarker],
+              handler: (String line) {
+                try {
+                  replaceWithCopy(bundledFrameworkBinaryMacOS(exampleDirectory, 'debug'));
+                  // Reloading a `build` that reads the state back resolves a
+                  // binding that has not been resolved yet, so the asset is
+                  // looked up again now that its file is a different one.
+                  mainFile.writeAsStringSync(_mainDart(loadState: true));
+                } on Object catch (error) {
+                  replaceError = error;
+                }
+                return 'r';
+              },
+            ),
+            Barrier.contains('Performing hot reload...'),
+            // The app prints from `build`, so its line and the tool's summary
+            // of the reload can arrive in either order.
+            Multiple.contains(<Pattern>[
+              _loadedMarker,
+              RegExp('Reloaded .*'),
+            ], handler: (String line) => 'q'),
+            Barrier.contains('Application finished.'),
+          ],
+        );
+        // A handler cannot use `expect`, so the failure is carried out here.
+        expect(replaceError, isNull, reason: 'failed to replace the bundled framework');
+        if (result.exitCode != 0) {
+          throw Exception(
+            'flutter run failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}',
+          );
+        }
+        // Mapped twice, the second copy has nothing stored in it and reading
+        // the state back takes the app down before it prints anything.
+        expect(result.stdout.join('\n'), contains('$_loadedMarker 42'));
+      });
+    });
+  }
+}
+
+const _storedMarker = 'native asset state stored';
+const _loadedMarker = 'native asset state loaded:';
+
+/// An app that stores state in the code asset, and reads it back again on a hot
+/// reload once [loadState] is set.
+String _mainDart({required bool loadState}) {
+  final loadLine = loadState ? "    print('$_loadedMarker \${asset.loadState()}');" : '';
+  return '''
+import 'package:flutter/widgets.dart';
+import 'package:$packageName/$packageName.dart' as asset;
+
+void main() => runApp(const StateProbe());
+
+class StateProbe extends StatefulWidget {
+  const StateProbe({super.key});
+
+  @override
+  State<StateProbe> createState() => _StateProbeState();
+}
+
+class _StateProbeState extends State<StateProbe> {
+  @override
+  void initState() {
+    super.initState();
+    asset.storeState(42);
+    print('$_storedMarker');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+$loadLine
+    return const SizedBox();
+  }
+}
+''';
 }

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test_utils.dart
@@ -15,7 +15,11 @@ import '../../src/common.dart';
 import '../test_utils.dart' show ProcessResultMatcher, fileSystem, flutterBin, platform;
 import '../transition_test_utils.dart';
 
-Future<Directory> createTestProject(String packageName, Directory tempDirectory) async {
+Future<Directory> createTestProject(
+  String packageName,
+  Directory tempDirectory, {
+  bool withProcessGlobalState = false,
+}) async {
   final ProcessResult result = processManager.runSync(<String>[
     flutterBin,
     'create',
@@ -48,6 +52,10 @@ Future<Directory> createTestProject(String packageName, Directory tempDirectory)
   await addUserDefine(packageName, packageDirectory);
 
   await addDynamicallyLinkedNativeLibrary(packageName, packageDirectory);
+
+  if (withProcessGlobalState) {
+    await addProcessGlobalState(packageName, packageDirectory);
+  }
 
   final ProcessResult result2 = await processManager.run(<String>[
     flutterBin,
@@ -273,6 +281,92 @@ extension on BuildInput {
   final Directory hookDirectory = packageDirectory.childDirectory('hook');
   final File builderFile = hookDirectory.childFile('build.dart');
   await builderFile.writeAsString(builderSource);
+}
+
+/// Adds a pair of native functions that share state through a heap allocation
+/// the native library holds on to.
+///
+/// `storeState` allocates and remembers a value, `loadState` reads it back
+/// through the remembered pointer. Reading it back only works while both calls
+/// land in the same copy of the library, which makes the pair a probe for
+/// whether the code asset was mapped into the process more than once.
+///
+/// `loadState` gets its own binding so that it resolves the asset again on
+/// first use, rather than reusing whatever `storeState` resolved.
+Future<void> addProcessGlobalState(String packageName, Directory packageDirectory) async {
+  final Directory srcDirectory = packageDirectory.childDirectory('src');
+
+  await srcDirectory.childFile('$packageName.h').writeAsString('''
+
+FFI_PLUGIN_EXPORT void store_state(intptr_t value);
+
+FFI_PLUGIN_EXPORT intptr_t load_state(void);
+''', mode: FileMode.append);
+
+  await srcDirectory.childFile('$packageName.c').writeAsString('''
+
+typedef struct {
+  intptr_t value;
+} state_t;
+
+static state_t* state = NULL;
+
+FFI_PLUGIN_EXPORT void store_state(intptr_t value) {
+  state = malloc(sizeof(state_t));
+  state->value = value;
+}
+
+// Reads through `state` without checking it, on purpose. A second copy of this
+// library in the same process gets its own `state`, which no one has stored
+// anything in, and reading through it takes the process down the same way a
+// real code asset does.
+FFI_PLUGIN_EXPORT intptr_t load_state(void) {
+  return state->value;
+}
+''', mode: FileMode.append);
+
+  final Directory libDirectory = packageDirectory.childDirectory('lib');
+
+  await libDirectory.childFile('${packageName}_bindings_generated.dart').writeAsString('''
+
+@ffi.Native<ffi.Void Function(ffi.IntPtr)>()
+external void store_state(int value);
+
+@ffi.Native<ffi.IntPtr Function()>()
+external int load_state();
+''', mode: FileMode.append);
+
+  await libDirectory.childFile('$packageName.dart').writeAsString('''
+
+/// Remembers [value] in an allocation held by the native library.
+void storeState(int value) => bindings.store_state(value);
+
+/// Reads back what [storeState] remembered.
+int loadState() => bindings.load_state();
+''', mode: FileMode.append);
+}
+
+/// The framework binary a macOS app bundle resolves its code asset to.
+File bundledFrameworkBinaryMacOS(Directory appDirectory, String buildMode) {
+  return appDirectory
+      .childDirectory('build/$hostOs/Build/Products/${buildMode.upperCaseFirst()}/')
+      .childDirectory('$exampleAppName.app')
+      .childDirectory('Contents/Frameworks')
+      .childDirectory('$packageName.framework')
+      .childDirectory('Versions')
+      .childDirectory('A')
+      .childFile(packageName);
+}
+
+/// Replaces [file] with a byte for byte copy of itself.
+///
+/// The copy occupies a different inode, which is the identity dyld falls back
+/// on for an image it cannot match by install name. Rebuilding a bundle that a
+/// debug instance is still running does the same thing to it.
+void replaceWithCopy(File file) {
+  final File copy = file.parent.childFile('${file.basename}.copy');
+  file.copySync(copy.path);
+  copy.renameSync(file.path);
 }
 
 Future<void> pinDependencies(File pubspecFile) async {


### PR DESCRIPTION
On macOS and iOS, `flutter_tools` stamps a bundled code asset's framework with the install name
`@rpath/<name>.framework/<name>`, but records that asset in `NativeAssetsManifest.json` as
`<name>.framework/<name>`. The manifest entry is the string the Dart VM hands to `dlopen`, so the two
never match. dyld cannot recognize the library under a name it has no install name for, so it falls
back on identifying the file on disk, and that identity only holds until the file is replaced.
Rebuilding an app while a debug instance is still running replaces it, so the next lazily resolved
`@Native` binding maps a second copy of the asset into the process. Two copies of a C library do not
share its global state, and a handle produced by the first copy is not valid in the second. For
`package:sqlite3` that is a segfault on the first write after a rebuild, and the operation is lost.

Both strings now come from one `frameworkInstallName` helper, so the name stamped into the framework
and the name recorded in the manifest cannot drift apart again. The framework is still bundled at the
unprefixed path, and `DarwinAddToAppNativeAssets.parseNativeAssetsManifest` drops the prefix for the
add-to-app and Swift Package callers that use the manifest to find the framework on disk.

The `flutter test` path is unchanged. The tester loads the dylib from where it was built and its
install name is already the absolute path that the manifest records, which is why `dart run` and
`flutter test` never showed this.

Fixes https://github.com/flutter/flutter/issues/190799

The reporter of that issue measured the dyld behaviour on macOS, including that a manifest entry of
`@rpath/<name>.framework/<name>` resolves through `dlopen` and leaves a single mapping across a
rebuild. iOS goes through the same helper and had the same mismatch, so it is fixed here too. I do
not have a Mac, so beyond the unit tests added here I am relying on the existing macOS native assets
integration tests (`flutter run` with a bundled code asset, in all three build modes) on CI.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
