### PR TITLE
Scenarios: Fix locale test on hosts with several languages

### DIFF
--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosUITests/LocalizationInitializationTest.m
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosUITests/LocalizationInitializationTest.m
@@ -26,15 +26,20 @@ FLUTTER_ASSERT_ARC
   NSTimeInterval timeout = 10.0;
 
   // The locales received by dart:ui are exposed onBeginFrame via semantics label.
-  // There should only be one locale. The list should consist of the default
-  // locale provided by the iOS app.
-  NSArray<NSString*>* preferredLocales = [NSLocale preferredLanguages];
-  XCTAssertEqual(preferredLocales.count, 1);
-  // Dart connects the locale parts with `_` while iOS connects them with `-`.
-  // Converts to dart format before comparing.
-  NSString* localeDart = [preferredLocales.firstObject stringByReplacingOccurrencesOfString:@"-"
-                                                                                 withString:@"_"];
-  NSString* expectedIdentifier = [NSString stringWithFormat:@"[%@]", localeDart];
+  // The list should consist of the default system locale(s) provided by iOS.
+  //
+  // The locales iOS reports are of the form `en-CA`. `dart:ui` reports locales
+  // in the form `en_CA` and formats them as a list `[first, second, ...]`.
+  //
+  // Since this test is sensitive to device locale setup, we can't assume any
+  // particular locale, or any particular number of locales.
+  NSMutableArray<NSString*>* dartLocales = [NSMutableArray array];
+  for (NSString* localeIdentifier in [NSLocale preferredLanguages]) {
+    [dartLocales addObject:[localeIdentifier stringByReplacingOccurrencesOfString:@"-"
+                                                                       withString:@"_"]];
+  }
+  NSString* expectedIdentifier =
+      [NSString stringWithFormat:@"[%@]", [dartLocales componentsJoinedByString:@", "]];
   XCUIElement* textInputSemanticsObject =
       [self.application.textFields matchingIdentifier:expectedIdentifier].element;
   XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:timeout]);


### PR DESCRIPTION
`testNoLocalePrepend` asserted that the host has exactly one preferred language:

    NSArray<NSString*>* preferredLocales = [NSLocale preferredLanguages];
    XCTAssertEqual(preferredLocales.count, 1);

and then built the expected value from `preferredLocales.firstObject` alone. The scenario publishes the whole list dart:ui received as its semantics label, so on a host configured with more than one language, the app will report a list (e.g. `[ja_JP, en_CA]`) while the test looks for `[ja_JP]`.

The goal is to check that we got the right set of locales, but hardcoding the count check to one isn't the right way to do it and causes the test to fail for any developer with more than one language in their locales list. Given that multilingual developers outnumber unilingual ones, this is arguably a bug in the test, or at least an annoyance.

We now build the expected value from every preferred language, joined the way Dart formats the list, and the count assertion is gone.

Tested on my machine which uses 日本語, by English (Canada), where dart:ui reports `[ja_JP, en_CA]`.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
