### PR TITLE
run_ios_tests: Allow running from any directory

### DIFF
--- a/docs/engine/testing/Testing-the-engine.md
+++ b/docs/engine/testing/Testing-the-engine.md
@@ -295,7 +295,7 @@ than using the real Flutter framework at `flutter/flutter`.
 The end-to-end test can be executed by running:
 
 ```sh
-testing/ios_scenario_app/run_ios_tests.sh
+engine/src/flutter/testing/ios_scenario_app/run_ios_tests.sh
 ```
 
 Additional end-to-end instrumented tests can be added to [`testing/ios_scenario_app/ios/Scenarios/ScenariosTests`](/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosTests/).

--- a/engine/src/flutter/testing/ios_scenario_app/bin/run_ios_tests.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/bin/run_ios_tests.dart
@@ -18,7 +18,9 @@ void main(List<String> args) async {
     return;
   }
 
-  final Engine? engine = Engine.tryFindWithin();
+  // Search from this script's own location rather than the current directory,
+  // so the script can be run from anywhere.
+  final Engine? engine = Engine.tryFindWithin(path.dirname(path.fromUri(io.Platform.script)));
   if (engine == null) {
     io.stderr.writeln('Must be run from within the engine repository.');
     io.exitCode = 1;

--- a/engine/src/flutter/testing/ios_scenario_app/ios/README.md
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/README.md
@@ -8,16 +8,17 @@ For example, after building `ios_debug_sim_unopt` (to run on Intel Macs) or `ios
 run:
 
 ```sh
-# From the root of the engine repository
-$ ./testing/ios_scenario_app/run_ios_tests.sh ios_debug_sim_unopt
+$ engine/src/flutter/testing/ios_scenario_app/run_ios_tests.sh ios_debug_sim_unopt
 ```
 
 or:
 
 ```sh
-# From the root of the engine repository
-$ ./testing/ios_scenario_app/run_ios_tests.sh ios_debug_sim_unopt_arm64
+$ engine/src/flutter/testing/ios_scenario_app/run_ios_tests.sh ios_debug_sim_unopt_arm64
 ```
+
+The paths above are relative to the root of the checkout, but the script
+resolves everything from its own location, so it can be run from any directory.
 
 To run or debug in Xcode, open the xcodeproj file located in
 `<engine_out_dir>/ios_debug_sim_unopt/ios_scenario_app/Scenarios/Scenarios.xcodeproj`.
@@ -29,10 +30,12 @@ grep for `run_ios_tests.sh`.
 
 ## iOS Platform View Tests
 
-For PlatformView tests on iOS, edit the dictionaries in
-[AppDelegate.m](Scenarios/Scenarios/AppDelegate.m) and
-[GoldenTestManager.m](Scenarios/ScenariosUITests/GoldenTestManager.m) so that
-the correct golden image can be found. Also, add a
+For PlatformView tests on iOS, register the scenario in
+[scenarios.dart](../lib/src/scenarios.dart) and add its launch argument to
+`scenarioArguments` in
+[SceneDelegate.m](Scenarios/Scenarios/SceneDelegate.m). The golden identifier
+is derived from the launch argument -- drop the leading `--` and swap `-` for
+`_` -- so it does not need to be registered anywhere else. Also, add a
 [GoldenPlatformViewTests](Scenarios/ScenariosUITests/GoldenPlatformViewTests.h)
 in [PlatformViewUITests.m](Scenarios/ScenariosUITests/PlatformViewUITests.m).
 

--- a/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosUITests/README.md
+++ b/engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosUITests/README.md
@@ -6,8 +6,8 @@ to communicate with the app. For instance, you won't have access to
 the view controller or engine instances from within the test code.
 
 For this reason, the test code typically uses **launch arguments** to configure
-the app (for example, use [launchArgsMap](../Scenarios/AppDelegate.m) to inform
-the app which `Scenario` to load), and use UIKit UI components to collect test
+the app (for example, use [scenarioArguments](../Scenarios/SceneDelegate.m) to
+inform the app which `Scenario` to load), and use UIKit UI components to collect test
 results (for example, every messsage received on the `display_data` channel adds
 a new `UITextField` to the app, which will be visible to the test code. See [touches_scenario.dart](../../../lib/src/touches_scenario.dart) for an example).
 

--- a/engine/src/flutter/testing/ios_scenario_app/run_ios_tests.sh
+++ b/engine/src/flutter/testing/ios_scenario_app/run_ios_tests.sh
@@ -44,5 +44,5 @@ DART="${DART_BIN}/dart"
 
 "$DART" \
   --disable-dart-dev \
-  testing/ios_scenario_app/bin/run_ios_tests.dart \
+  "$SCRIPT_DIR/bin/run_ios_tests.dart" \
   "$@"


### PR DESCRIPTION
Previously `run_ios_tests.sh` only worked when invoked from `engine/src/flutter` which, to be fair, is what the READMEs tell you to do but there's no reason we need to force that, and we don't for other tests like run_tests.py. This is mostly just post-monorepo-merge cleanup.

Two separate things depended on the working directory:

* The wrapper was resolving `SCRIPT_DIR` from `BASH_SOURCE` but still passed the Dart entrypoint as a relative path, so the VM would report `No such file or directory`.
* `run_ios_tests.dart` called `Engine.tryFindWithin()`, which defaults to the current directory and only walks upward. From the repo root `engine/src` is below the starting point, so the search fails and the script exits with `Must be run from within the engine repository.`

Both now resolve from the script's own location, so the documented invocation keeps working and but invoking from any other directory works too. The Dart side matches the existing usage in
`tools/header_guard_check/lib/header_guard_check.dart:162`.

Also fixed up the READMEs, which had a few other issues... one if which was that I forgot to update them in #190818.

No test changes because this *is* test changes.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
