### PR TITLE
iOS: Document and tidy the embedder API flag

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -267,7 +267,14 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   CGFloat screenHeight = [UIScreen mainScreen].bounds.size.height * scale;
   settings.resource_cache_max_bytes_threshold = screenWidth * screenHeight * 12 * 4;
 
-  // Whether to enable ios embedder api.
+  // Whether to run the iOS embedder on top of the embedder API rather than `Shell` directly.
+  //
+  // This is an opt-in flag while we add support for running on top of the embedder API. Once the
+  // embedder API implementation reaches parity with the default implementation directly on `Shell`
+  // and friends, we'll eventually make this default and support opt-out, before being removed
+  // altogether.
+  //
+  // See: https://github.com/flutter/flutter/issues/112232
   NSNumber* enable_embedder_api =
       [mainBundle objectForInfoDictionaryKey:@"FLTEnableIOSEmbedderAPI"];
   // Change the default only if the option is present.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -248,7 +248,7 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 
   _enableEmbedderAPI = _dartProject.settings.enable_embedder_api;
   if (_enableEmbedderAPI) {
-    NSLog(@"============== iOS: enable_embedder_api is on ==============");
+    [FlutterLogger logInfo:@"Embedder API enabled."];
     _embedderAPI.struct_size = sizeof(FlutterEngineProcTable);
     FlutterEngineGetProcAddresses(&_embedderAPI);
   }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -375,7 +375,6 @@ FLUTTER_ASSERT_ARC
   {
     // Not enable embedder API by default
     auto settings = FLTDefaultSettingsForBundle();
-    settings.enable_software_rendering = true;
     FlutterDartProject* project = [[FlutterDartProject alloc] initWithSettings:settings];
     FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
     XCTAssertFalse(engine.enableEmbedderAPI);
@@ -386,7 +385,6 @@ FLUTTER_ASSERT_ARC
     OCMStub([mockMainBundle objectForInfoDictionaryKey:@"FLTEnableIOSEmbedderAPI"])
         .andReturn(@"YES");
     auto settings = FLTDefaultSettingsForBundle();
-    settings.enable_software_rendering = true;
     FlutterDartProject* project = [[FlutterDartProject alloc] initWithSettings:settings];
     FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
     XCTAssertTrue(engine.enableEmbedderAPI);


### PR DESCRIPTION
`FLTEnableIOSEmbedderAPI` is an existing (unused) switch for the iOS embedder API migration, but we didn't document its expected behaviour where we used it.

This documents its semantics in `FlutterDartProject`: it's opt-in while the migration is in progress, a YES value currently only has the effect of populating `FlutterEngine`'s `FlutterEngineProcTable`. Once the embedder fully supports the embedder API and we've tested for a sufficient period, this will become opt-out and eventually be removed.

This also replaces the `NSLog` banner we emitted when the flag is on with `FlutterLogger`, so the message goes through the same logging path as the rest of the embedder and respects the configured log level.

Also drops two `settings.enable_software_rendering = true` assignments from `testCanEnableDisableEmbedderAPIThroughInfoPlist`. Those were the last references to that setting anywhere in the iOS embedder; nothing has read it on iOS since the software renderer fallback was removed in flutter/flutter#190590.

Issue: https://github.com/flutter/flutter/issues/112232

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
