### PR TITLE
Scenarios: Fix multiple-clips scenario doc comments

### DIFF
--- a/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
+++ b/engine/src/flutter/testing/ios_scenario_app/lib/src/platform_view.dart
@@ -544,7 +544,7 @@ class PlatformViewClipRectScenario extends Scenario with _BasePlatformViewScenar
 /// Platform view with clip rect, with multiple clips.
 class PlatformViewClipRectMultipleClipsScenario extends Scenario
     with _BasePlatformViewScenarioMixin {
-  /// Constructs a platform view with clip rect scenario.
+  /// Constructs a platform view with clip rect and multiple clips.
   PlatformViewClipRectMultipleClipsScenario(super.view, {required this.id});
 
   /// The platform view identifier.
@@ -616,7 +616,7 @@ class PlatformViewClipRectAfterMovedScenario extends Scenario with _BasePlatform
 /// The clip rect moves with the same transform matrix with the PlatformView.
 class PlatformViewClipRectAfterMovedMultipleClipsScenario extends Scenario
     with _BasePlatformViewScenarioMixin {
-  /// Constructs a platform view with clip rect scenario.
+  /// Constructs a platform view with clip rect after moved and multiple clips.
   PlatformViewClipRectAfterMovedMultipleClipsScenario(super.view, {required this.id});
 
   /// The platform view identifier.
@@ -690,7 +690,7 @@ class PlatformViewClipRRectScenario extends PlatformViewScenario {
 
 /// Platform view with clip rrect, with multiple clips.
 class PlatformViewClipRRectMultipleClipsScenario extends PlatformViewScenario {
-  /// Constructs a platform view with clip rrect scenario.
+  /// Constructs a platform view with clip rrect and multiple clips.
   PlatformViewClipRRectMultipleClipsScenario(super.view, {super.id = 0});
 
   @override
@@ -746,7 +746,7 @@ class PlatformViewLargeClipRRectScenario extends PlatformViewScenario {
 /// Platform view with clip rrect, with multiple clips.
 /// The bounding rect of the rrect is the same as PlatformView and only the corner radii clips the PlatformView.
 class PlatformViewLargeClipRRectMultipleClipsScenario extends PlatformViewScenario {
-  /// Constructs a platform view with large clip rrect scenario.
+  /// Constructs a platform view with large clip rrect and multiple clips.
   PlatformViewLargeClipRRectMultipleClipsScenario(super.view, {super.id = 0});
 
   @override
@@ -794,7 +794,7 @@ class PlatformViewClipPathScenario extends PlatformViewScenario {
 
 /// Platform view with clip path, with multiple clips.
 class PlatformViewClipPathMultipleClipsScenario extends PlatformViewScenario {
-  /// Constructs a platform view with clip path scenario.
+  /// Constructs a platform view with clip path and multiple clips.
   PlatformViewClipPathMultipleClipsScenario(super.view, {super.id = 0});
 
   @override
@@ -845,7 +845,7 @@ class PlatformViewClipRectWithTransformScenario extends PlatformViewScenario {
 
 /// Platform view with clip rect after transformed, with multiple clips.
 class PlatformViewClipRectWithTransformMultipleClipsScenario extends PlatformViewScenario {
-  /// Constructs a platform view with clip rect with transform scenario.
+  /// Constructs a platform view with clip rect with transform and multiple clips.
   PlatformViewClipRectWithTransformMultipleClipsScenario(super.view, {super.id = 0});
 
   @override
@@ -912,7 +912,7 @@ class PlatformViewClipRRectWithTransformScenario extends PlatformViewScenario {
 
 /// Platform view with clip rrect after transformed, with multiple clips.
 class PlatformViewClipRRectWithTransformMultipleClipsScenario extends PlatformViewScenario {
-  /// Constructs a platform view with clip rrect with transform scenario.
+  /// Constructs a platform view with clip rrect with transform and multiple clips.
   PlatformViewClipRRectWithTransformMultipleClipsScenario(super.view, {super.id = 0});
 
   @override
@@ -991,7 +991,7 @@ class PlatformViewLargeClipRRectWithTransformScenario extends PlatformViewScenar
 /// Platform view with clip rrect after transformed, with multiple clips.
 /// The bounding rect of the rrect is the same as PlatformView and only the corner radii clips the PlatformView.
 class PlatformViewLargeClipRRectWithTransformMultipleClipsScenario extends PlatformViewScenario {
-  /// Constructs a platform view with large clip rrect with transform scenario.
+  /// Constructs a platform view with large clip rrect with transform and multiple clips.
   PlatformViewLargeClipRRectWithTransformMultipleClipsScenario(super.view, {super.id = 0});
 
   @override
@@ -1065,7 +1065,7 @@ class PlatformViewClipPathWithTransformScenario extends PlatformViewScenario {
 
 /// Platform view with clip path after transformed, with multiple clips.
 class PlatformViewClipPathWithTransformMultipleClipsScenario extends PlatformViewScenario {
-  /// Constructs a platform view with clip path with transform scenario.
+  /// Constructs a platform view with clip path with transform and multiple clips.
   PlatformViewClipPathWithTransformMultipleClipsScenario(super.view, {super.id = 0});
 
   @override


### PR DESCRIPTION
The `...MultipleClipsScenario` constructors each copy their doc comment from the corresponding single-clip scenario, so none of them mention the extra clip that distinguishes them.

Updates each to say it constructs the multiple-clips variant.

Spotted by Gemini review bot during review of https://github.com/flutter/flutter/pull/190826.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
