### PR TITLE
iOS: test GPU availability and task queue behaviour

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -10,6 +10,8 @@
 
 #import "flutter/common/settings.h"
 #include "flutter/fml/synchronization/sync_switch.h"
+#include "flutter/lib/ui/window/platform_message.h"
+#include "flutter/lib/ui/window/platform_message_response.h"
 #import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h"
@@ -24,6 +26,24 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 FLUTTER_ASSERT_ARC
+
+namespace {
+// A `PlatformMessageResponse` that records completion.
+//
+// This allows tests to inject an inbound platform message the way the engine's platform view would
+// and observe that it was answered.
+class TestPlatformMessageResponse : public flutter::PlatformMessageResponse {
+ public:
+  static fml::RefPtr<TestPlatformMessageResponse> Create() {
+    return fml::AdoptRef(new TestPlatformMessageResponse());
+  }
+  void Complete(std::unique_ptr<fml::Mapping> data) override { is_complete_ = true; }
+  void CompleteEmpty() override { is_complete_ = true; }
+
+ private:
+  TestPlatformMessageResponse() = default;
+};
+}  // namespace
 
 @protocol TestFlutterPluginWithSceneEvents <NSObject, FlutterPlugin, FlutterSceneLifeCycleDelegate>
 @end
@@ -524,6 +544,128 @@ FLUTTER_ASSERT_ARC
       }));
   XCTAssertFalse(gpuDisabled);
   [mockBundle stopMocking];
+}
+
+// Locks in current behaviour for GPU state reset, which is arguably wrong.
+//
+// If `isGpuDisabled` is set before the engine runs, it is silently discarded, because
+// `createShell:` assigns to the property from the live view controller or application state
+// immediately before creating the shell.
+//
+// `createShell:` *does* need to sample the current lifecycle state there. Background/foreground
+// notifications only fire on transitions, so an engine created while the app is already
+// backgrounded would otherwise never know about it. However, this sampling is implemented as an
+// unconditional assignment to a public readwrite property, so it also destroys any state previously
+// set by the caller.
+//
+// TODO(cbracken): https://github.com/flutter/flutter/issues/190835
+//
+// Move this sampling to `init` and `setViewController:` and stop `createShell:` from clobbering
+// this state, then change this test to asserts the opposite of what it currently does.
+- (void)testGpuStateIsDerivedFromApplicationStateWhenShellIsCreated {
+  FlutterDartProject* project = [[FlutterDartProject alloc] init];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
+
+  // Claim the GPU is disabled before the shell exists.
+  //
+  // There is no view controller and the test host is foregrounded, so creating the shell must
+  // overwrite this with NO.
+  engine.isGpuDisabled = YES;
+  XCTAssertTrue(engine.isGpuDisabled);
+
+  [engine run];
+
+  XCTAssertFalse(engine.isGpuDisabled);
+
+  BOOL gpuDisabled = YES;
+  [engine shell].GetIsGpuDisabledSyncSwitch()->Execute(
+      fml::SyncSwitch::Handlers().SetIfTrue([&] { gpuDisabled = YES; }).SetIfFalse([&] {
+        gpuDisabled = NO;
+      }));
+  XCTAssertFalse(gpuDisabled);
+}
+
+// Verifies a handler registered against a background FlutterTaskQueue runs off the platform thread.
+//
+// Using the `FlutterTaskQueue` public API, a plugin may register a channel handler against a
+// background queue and expect to be called off the platform thread. `PlatformMessageHandlerIosTest`
+// tests the handler in isolation, but doesn't cover the full path an actual plugin takes:
+//
+// `-[FlutterEngine makeBackgroundTaskQueue]` and
+// `-[FlutterEngine setMessageHandlerOnChannel:binaryMessageHandler:taskQueue:]`.
+//
+// The embedder API has no equivalent concept: `EmbedderPlatformMessageHandler` always trampolines
+// to the platform thread, so this contract has to be reproduced explicitly during embedder API
+// migration.
+//
+// `testNilTaskQueueDeliversOnThePlatformThread`, tests the other direction.
+- (void)testBackgroundTaskQueueDeliversOffThePlatformThread {
+  FlutterDartProject* project = [[FlutterDartProject alloc] init];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
+  [engine run];
+
+  NSObject<FlutterTaskQueue>* taskQueue = [engine makeBackgroundTaskQueue];
+  XCTAssertNotNil(taskQueue);
+
+  NSString* channel = @"com.example.background";
+  XCTestExpectation* didCallHandler = [self expectationWithDescription:@"didCallHandler"];
+  FlutterBinaryMessengerConnection connection =
+      [engine setMessageHandlerOnChannel:channel
+                    binaryMessageHandler:^(NSData* _Nullable message, FlutterBinaryReply reply) {
+                      XCTAssertFalse([NSThread isMainThread]);
+                      reply(nil);
+                      [didCallHandler fulfill];
+                    }
+                               taskQueue:taskQueue];
+  XCTAssertTrue(connection > 0);
+
+  // Deliver a message the way the platform view would on receiving one from the engine.
+  auto response = TestPlatformMessageResponse::Create();
+  engine.platformView->GetPlatformMessageHandlerIos()->HandlePlatformMessage(
+      std::make_unique<flutter::PlatformMessage>(channel.UTF8String, response));
+
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  XCTAssertTrue(response->is_complete());
+
+  [engine cleanUpConnection:connection];
+}
+
+// Verifies a handler registered without a task queue runs on the platform thread.
+//
+// Together with `testBackgroundTaskQueueDeliversOffThePlatformThread` locks in the invariant that
+// the task queue argument, and nothing else, decides the thread. The default is the platform
+// thread, which needs to be preserved throughout embedder API migration: this is what allows
+// plugins interact with UIKit directly from their channel handlers.
+//
+// This is the half the embedder API migration is most likely to cause to pass by accident.
+// `EmbedderPlatformMessageHandler` trampolines everything to the platform thread, so an
+// implementation that never leaves it goes green here and fails only in
+// `testBackgroundTaskQueueDeliversOffThePlatformThread`.
+- (void)testNilTaskQueueDeliversOnThePlatformThread {
+  FlutterDartProject* project = [[FlutterDartProject alloc] init];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
+  [engine run];
+
+  NSString* channel = @"com.example.platform";
+  XCTestExpectation* didCallHandler = [self expectationWithDescription:@"didCallHandler"];
+  FlutterBinaryMessengerConnection connection =
+      [engine setMessageHandlerOnChannel:channel
+                    binaryMessageHandler:^(NSData* _Nullable message, FlutterBinaryReply reply) {
+                      XCTAssertTrue([NSThread isMainThread]);
+                      reply(nil);
+                      [didCallHandler fulfill];
+                    }
+                               taskQueue:nil];
+  XCTAssertTrue(connection > 0);
+
+  auto response = TestPlatformMessageResponse::Create();
+  engine.platformView->GetPlatformMessageHandlerIos()->HandlePlatformMessage(
+      std::make_unique<flutter::PlatformMessage>(channel.UTF8String, response));
+
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  XCTAssertTrue(response->is_complete());
+
+  [engine cleanUpConnection:connection];
 }
 
 - (void)testLifeCycleNotificationSceneWillConnect {


### PR DESCRIPTION
Adds tests for two behaviours the embedder API migration has to preserve, both at the layer a plugin or the framework actually sees rather than the layer the current implementation happens to use:

First is GPU availability:

Currently, `createShell:` re-derives `isGpuDisabled` from the live view controller or application state immediately before creating the shell, and clobbers whatever the property was set to beforehand. This is an easy thing to get wrong later: the "obvious" handling via `FlutterEngineRun` would be to take the initial GPU availability as a project argument, but passing the property straight through would resurrect exactly the stale value this code goes out of its way to drop.

Second is Task queues:

`PlatformMessageHandlerIosTest` covers `PlatformMessageHandlerIos` behaviour on its own, but nothing covered the path a plugin takes to reach it, through
* `-[FlutterEngine makeBackgroundTaskQueue]`
* `-[FlutterEngine setMessageHandlerOnChannel:binaryMessageHandler:taskQueue:]`

`EmbedderPlatformMessageHandler` always trampolines to the platform thread, so both halves of that contract will have to be rebuilt explicitly for embedder API migration.

The GPU test locks in the current behaviour. I'll address the TODO in the next patch to clean up the API. But this is a nice way to document/verify the behavioural diff in the tests.

Issue: https://github.com/flutter/flutter/issues/112232
Issue: https://github.com/flutter/flutter/issues/190835

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
