### PR TITLE
[AGP 9.1.0 Migration #1] Add Android Gradle Plugin Public API migration documentation

### DIFF
--- a/docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md
+++ b/docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md
@@ -1,0 +1,205 @@
+# Migrating the Flutter Gradle Plugin to the AGP Public API Surface
+
+This document is the contributor-facing record of the migration of the Flutter
+Gradle Plugin (FGP) off the legacy Android Gradle Plugin (AGP) DSL/Variant API
+and AGP internals, onto the public API surface shipped in the
+`com.android.tools.build:gradle-api` artifact.
+
+Umbrella issues:
+
+- newDsl flip: https://github.com/flutter/flutter/issues/180137
+- Variant API migration: https://github.com/flutter/flutter/issues/166550
+
+The user-facing breaking-change page draft lives next to this file in
+[`website-page-draft.md`](website-page-draft.md). It must be published to
+`docs.flutter.dev/release/breaking-changes/` before the newDsl flip (phase P9)
+reaches the beta channel.
+
+## Why
+
+AGP 9 (January 2026) deprecated the old DSL and Variant APIs behind the
+`android.newDsl=false` escape hatch. AGP 10 (late 2026) removes those APIs
+entirely **and** removes access to AGP internals — only the public surface of
+the `gradle-api` artifact remains. Today the FGP:
+
+- compiles against the FULL `com.android.tools.build:gradle` artifact
+  (`packages/flutter_tools/gradle/build.gradle.kts`);
+- uses the legacy variant API (`applicationVariants`, `libraryVariants`,
+  `variant.outputs`, `assembleProvider`, `packageApplicationProvider`,
+  `versionCodeOverride`);
+- uses the legacy `BaseExtension`
+  (`FlutterPluginUtils.getLegacyAndroidExtension`);
+- imports one internal DSL class (`com.android.build.gradle.internal.dsl.BuildType`
+  in `plugins/PluginHandler.kt`);
+- imports one internal utility
+  (`com.android.build.gradle.internal.utils.getKotlinAndroidPluginVersion` in
+  `VersionFetcher.kt`);
+- drives `flutter build aar` with legacy dynamic Groovy in
+  `aar_init_script.gradle`.
+
+Flutter templates pin AGP 9.1.0 but ship `android.newDsl=false`, and a tool
+migrator (`disable_new_dsl_migration.dart`) adds the opt-out to existing
+projects. That opt-out dies with AGP 10.
+
+## End state
+
+- The FGP uses only public APIs and compiles against `gradle-api`.
+- Templates no longer ship `android.newDsl=false`.
+- The opt-out **add** migrator is replaced by a **removal** migrator that
+  deletes only the Flutter-added opt-out lines.
+- A fresh `flutter create` app builds with newDsl on.
+
+## Decision records
+
+1. **Min AGP floor: out of scope.** A separate in-flight version bump owns the
+   floor; this migration builds on whatever floor is in effect at landing.
+   Every replacement API used here was verified public in `gradle-api:8.11.1`
+   (decompiled jar inspection). If implementation finds a replacement API that
+   genuinely requires a higher min AGP: document which API and why no
+   compatible alternative exists in this file, then bump — otherwise version
+   floors are untouched by this work.
+2. **"Public in 8.x" does not mean binary-compatible on 9.x.**
+   `AgpCommonExtensionWrapper.kt` exists precisely because the public
+   `CommonExtension` broke between AGP 8 and 9. Mitigation: a CI/test axis
+   compiling the FGP against gradle-api 9.x is mandatory from phase P2 onward,
+   plus a bytecode check (javap grep) that no compiled FGP class references
+   `CommonExtension` as an owner.
+3. **`android.builtInKotlin=false` stays out of scope.** Flipping it requires
+   the separate built-in-Kotlin migration workstream. Users get a second
+   (smaller) gradle.properties churn later; the breaking-change page states
+   this explicitly. Corollary: the P9 removal migrator must anchor on the
+   `android.newDsl` property line — never on marker-comment wording alone —
+   because the template's builtInKotlin marker comment is nearly identical.
+4. **Per-ABI versionCode mechanism.** Do NOT re-implement AGP's flavor-merge
+   precedence via a `finalizeDsl` snapshot. Preferred mechanism (spiked first
+   in P6): read-then-set on `VariantOutput.versionCode` inside `onVariants` —
+   it is seeded with the merged value; set `abiOffset * 1000 + current`,
+   avoiding a self-referential `.map`. Fall back to a snapshot only if
+   read-then-set is impossible; record the outcome here.
+   - *Spike result:* _pending (P6)_.
+5. **`buildModeFor` semantics.** Every variant-scope call uses the
+   `(name, debuggable)` overload with the public `Component.debuggable`.
+   Name-based inference is confined to the one DSL-scope case with no public
+   signal (the library-plugin build-type copy in `PluginHandler`). This
+   preserves add-to-app custom-debuggable matching (a host `staging`
+   debuggable build type maps to debug engine artifacts).
+
+## Replacement map
+
+| Legacy usage | Where | Public replacement | Phase |
+| --- | --- | --- | --- |
+| `internal.utils.getKotlinAndroidPluginVersion` | `VersionFetcher.kt` | delete; rely on existing fallback chain (`kotlin_version` property → `KotlinAndroidPluginWrapper.pluginVersion` → reflection); null when KGP absent is OK | P1 |
+| `compileSdkVersion` string compare (`"android-NN"` substring) | `FlutterPluginUtils.getCompileSdkFromProject`, `PluginHandler` warning | wrapper `compileSdk` / `compileSdkPreview`; numeric compare with defined preview semantics | P1 |
+| `BaseExtension.ndkVersion` | `FlutterPluginUtils.getConfiguredNdkVersion` | wrapper `ndkVersion` | P1 |
+| `buildModeFor(BuildType)` (legacy model type) | `FlutterPluginUtils.kt` | `buildModeFor(name, debuggable)` overload | P2 |
+| `getLegacyAndroidExtension(project).buildTypes` loops | `PluginHandler.kt` | wrapper new-DSL `buildTypes` container | P2 |
+| `internal.dsl.BuildType` live aliasing into plugin projects | `PluginHandler.kt` | `initWith`-based copy on new-DSL `BuildType`; app-specific props only when both sides are `ApplicationBuildType` | P3 |
+| `BaseExtension` / `getLegacyAndroidExtension` (remaining call sites) | `FlutterPluginUtils.kt` | wrapper accessors incl. `externalNativeBuild` | P4 |
+| eager `applicationVariants.configureEach` task creation; mergeAssets/processResources hooks | `FlutterPlugin.kt`, `FlutterPluginUtils.kt` | consolidated `onVariants` block; `CopyFlutterAssetsTask` + `variant.sources.assets.addGeneratedSourceDirectory` | P5 |
+| `variant.outputs` + `packageApplicationProvider` + `doLast` APK copy; `versionCodeOverride` | `FlutterPluginUtils.kt` | `CopyFlutterApksTask` (`SingleArtifact.APK` + `BuiltArtifactsLoader`); read-then-set `VariantOutput.versionCode` | P6 |
+| `libraryVariants.all` × host `applicationVariants.all` cross-wiring | `FlutterPlugin.kt` (add-to-app) | library-side `onVariants` with `Component.debuggable`; no host-project lookup | P7 |
+| dynamic Groovy legacy API in `aar_init_script.gradle` | `aar_init_script.gradle` | `components`-based enumeration; ext-property guard | P8 |
+| `android.newDsl=false` template/migrator | templates, `disable_new_dsl_migration.dart` | drop from templates; `RemoveNewDslOptOutMigration` | P9 |
+| FULL `gradle` artifact dependency | `build.gradle.kts` | `gradle-api` artifact (compile-time proof of zero internal usage) | P10 |
+
+## Phase map
+
+Each phase is one PR-sized change on its own branch. P8 is an independent lane
+(Groovy script, disjoint files); P0/P1 are disjoint from each other; everything
+else serializes through `FlutterPlugin.kt` / `FlutterPluginUtils.kt`.
+
+| Phase | Branch | Size | Summary |
+| --- | --- | --- | --- |
+| P0 | `agp-api-doc` | S | this doc + website page draft |
+| P1 | `agp-internal-utils` | S | VersionFetcher internal util removal; numeric compileSdk compare; ndkVersion via wrapper |
+| P2 | `agp-buildmode-deps` | M | `buildModeFor` overloads; new-DSL flutter dependencies; 9.x compile axis |
+| P3 | `agp-plugin-buildtypes` | M | `initWith` copy for plugin build types; drop internal import; internal-import lint |
+| P4 | `agp-ndk-fallback` | S | delete `BaseExtension`; externalNativeBuild via wrapper |
+| P5 | `agp-assets-onvariants` | L | lazy task registration (5a) + generated-asset-dir wiring (5b) |
+| P6 | `agp-apk-copy-versioncode` | L | `CopyFlutterApksTask`; per-ABI versionCode; app path legacy-free |
+| P7 | `agp-add-to-app` | L | library-side `onVariants`; delete host cross-wiring + P5a legacy fork |
+| P8 | `agp-aar-script` | M | aar_init_script public-API cleanup |
+| P9 | `agp-newdsl-flip` | M | templates drop opt-out; removal migrator; new error handlers |
+| P10 | `agp-gradle-api` | M | dependency swap to `gradle-api`; test migration |
+
+## Cross-cutting rules
+
+- **R1 Lockstep:** any PR changing FGP-emitted message text updates the
+  matching `gradle_errors.dart` matcher and its Dart test in the same PR.
+- **R2 Revert notes:** each PR description carries "revert-safe until phase X
+  lands"; once superseded, policy is fix-forward. At least one full post-submit
+  CI soak between dependent phases (no same-day stacking of P2–P4).
+- **R3 9.x axis:** from P2, gradle unit tests additionally compile against
+  gradle-api 9.x in CI, plus the javap `CommonExtension` bytecode check.
+- **R4 Config-cache:** master baseline established first; the per-phase
+  assertion is "no NEW config-cache violations", not full reuse.
+- **R5 Internal-import lint:** once P3 lands, a checked-in test forbids
+  `com.android.build.gradle.internal.*` imports in `src/main`.
+- **R6 Staged newDsl=true axis:** app flows green from end of P6; add-to-app
+  from P7; aar from P8. The full matrix is the P9 gate.
+
+## Revert-window table
+
+| Phase | Revert window |
+| --- | --- |
+| P0 | always revert-safe |
+| P1–P4 | each until the next phase in the chain lands; then fix-forward |
+| P5 | until P6 lands |
+| P6 / P7 | mutually tolerant (disjoint app/module paths) until P10 |
+| P8 | revert-safe even after P10, but not after P9 |
+| P9 | cleanly revertible in isolation |
+| P10 | cleanly revertible in isolation |
+
+## Features that must break (tracked; updated as implementation learns)
+
+1. **User build scripts using legacy APIs** (`applicationVariants.all`
+   APK-rename recipes) fail under newDsl — the biggest break. Mitigated by new
+   error handlers (P9) and the website page.
+2. **flutter-apk copy**: same names/paths (`app[-abi][-flavor]-<mode>.apk`,
+   byte-matching the current concatenation order), but an UP-TO-DATE-capable
+   finalizer task replaces the `doLast` block; new task names appear in
+   `gradlew tasks`.
+3. **Per-ABI versionCode**: post-`finalizeDsl` user mutations (`afterEvaluate`
+   CI patterns) may behave differently; a runtime divergence warning is added.
+4. **Custom build types → plugins**: live-aliased instances become `initWith`
+   copies; library plugins cannot receive `isDebuggable` (no public setter on
+   `LibraryBuildType`) — plugin-side `BuildConfig.DEBUG`/JNI debuggability may
+   differ for custom debuggable build types; matching preserved via
+   `matchingFallbacks`.
+5. **Asset merge**: flutter assets become a merged source dir instead of a
+   post-merge overwrite; collisions resolve by AGP source-set priority.
+6. **Add-to-app**: the explicit `:app:merge<V>Assets.dependsOn` edge and
+   host-project lookup are removed; `flutter.hostAppProjectName` becomes a
+   no-op with a deprecation warning naming a removal milestone; ordering
+   against `copyFlutterAssets<V>` task names may break.
+7. **Task realization/type**: flutter tasks become lazy `TaskProvider`s, and
+   `copyFlutterAssets<V>` changes type from `org.gradle.api.tasks.Copy` to a
+   custom task class — `tasks.named(..., Copy::class)` casts fail.
+8. **`flutter build aar`**: the singleVariant dedup guard becomes an
+   ext-property/try-catch with a specified error message; variant enumeration
+   moves from `libraryVariants` to `components` — partial user `singleVariant`
+   declarations surface differently.
+9. **newDsl flip**: new projects lose the opt-out; the removal migrator deletes
+   only marker-tagged `android.newDsl` lines (template marker "This newDsl flag
+   was added by the Flutter template"; migrator marker "This newDsl flag was
+   added automatically by Flutter migrator"), anchored on the property line so
+   the adjacent builtInKotlin lines are never touched; hand-added opt-outs are
+   respected.
+10. **compileSdk mismatch warning** becomes a numeric compare with defined
+    preview-vs-numeric semantics; the message keeps a distinctive substring of
+    the old phrasing for searchability.
+
+## Verification matrix
+
+Full matrix at P6, P7, P9, P10; targeted per-phase otherwise.
+
+1. `cd packages/flutter_tools/gradle && ./gradlew test` (+ the R3 9.x axis)
+2. Targeted `integration.shard` tests named in each phase
+3. Scratch-app matrix: apk/appbundle × 3 modes; `--flavor`; `--split-per-abi`
+   (+ apkanalyzer versionCode assertions, including the
+   flavor-defined-versionCode case); `--deferred-components`; plugin with a
+   custom build type; `flutter build aar`; add-to-app source & AAR host flows;
+   `flutter run` / hot restart / `flutter attach`; Windows smoke for the copy
+   tasks
+4. AGP axis: current floor AND 9.1 + `newDsl=false`; staged `newDsl=true` per R6
+5. Config-cache per R4

--- a/docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md
+++ b/docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md
@@ -51,8 +51,9 @@ projects. That opt-out dies with AGP 10.
 
 ## Decision records
 
-1. **Min AGP floor: out of scope.** A separate in-flight version bump owns the
-   floor; this migration builds on whatever floor is in effect at landing.
+1. **Min AGP floor: out of scope.** A separate version bump owned the
+   floor, which has now landed on `master` (PRs #176858 and #177416 bumped the 
+   floor to `8.11.1`). This migration builds seamlessly on that new floor.
    Every replacement API used here was verified public in `gradle-api:8.11.1`
    (decompiled jar inspection). If implementation finds a replacement API that
    genuinely requires a higher min AGP: document which API and why no

--- a/docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md
+++ b/docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md
@@ -163,15 +163,18 @@ else serializes through `FlutterPlugin.kt` / `FlutterPluginUtils.kt`.
    CI patterns) may behave differently; a runtime divergence warning is added.
 4. **Custom build types → plugins**: live-aliased instances become `initWith`
    copies; library plugins cannot receive `isDebuggable` (no public setter on
-   `LibraryBuildType`) — plugin-side `BuildConfig.DEBUG`/JNI debuggability may
-   differ for custom debuggable build types; matching preserved via
-   `matchingFallbacks`.
+   `LibraryBuildType`). **Warning:** If an app uses a custom build type (like `staging`), 
+   the plugin's `BuildConfig.DEBUG` and native (C++/JNI) code may silently compile 
+   in release mode instead of debug mode. Matching is preserved via `matchingFallbacks`, 
+   but C++ debugging will be broken for those custom build types.
 5. **Asset merge**: flutter assets become a merged source dir instead of a
    post-merge overwrite; collisions resolve by AGP source-set priority.
 6. **Add-to-app**: the explicit `:app:merge<V>Assets.dependsOn` edge and
    host-project lookup are removed; `flutter.hostAppProjectName` becomes a
-   no-op with a deprecation warning naming a removal milestone; ordering
-   against `copyFlutterAssets<V>` task names may break.
+   no-op with a deprecation warning naming a removal milestone. Build scripts that 
+   reference Flutter's `copyFlutterAssets<V>` tasks by name (e.g. `tasks.getByPath(...)`) 
+   will crash with a `Task with path ... not found` error because the tasks are now 
+   registered lazily.
 7. **Task realization/type**: flutter tasks become lazy `TaskProvider`s, and
    `copyFlutterAssets<V>` changes type from `org.gradle.api.tasks.Copy` to a
    custom task class — `tasks.named(..., Copy::class)` casts fail.

--- a/docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md
+++ b/docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md
@@ -52,7 +52,7 @@ projects. That opt-out dies with AGP 10.
 ## Decision records
 
 1. **Min AGP floor: out of scope.** A separate version bump owned the
-   floor, which has now landed on `master` (PRs #176858 and #177416 bumped the 
+   floor, which has now landed on `master` (PRs #176858 and #177416 bumped the
    floor to `8.11.1`). This migration builds seamlessly on that new floor.
    Every replacement API used here was verified public in `gradle-api:8.11.1`
    (decompiled jar inspection). If implementation finds a replacement API that
@@ -164,17 +164,17 @@ else serializes through `FlutterPlugin.kt` / `FlutterPluginUtils.kt`.
    CI patterns) may behave differently; a runtime divergence warning is added.
 4. **Custom build types → plugins**: live-aliased instances become `initWith`
    copies; library plugins cannot receive `isDebuggable` (no public setter on
-   `LibraryBuildType`). **Warning:** If an app uses a custom build type (like `staging`), 
-   the plugin's `BuildConfig.DEBUG` and native (C++/JNI) code may silently compile 
-   in release mode instead of debug mode. Matching is preserved via `matchingFallbacks`, 
+   `LibraryBuildType`). **Warning:** If an app uses a custom build type (like `staging`),
+   the plugin's `BuildConfig.DEBUG` and native (C++/JNI) code may silently compile
+   in release mode instead of debug mode. Matching is preserved via `matchingFallbacks`,
    but C++ debugging will be broken for those custom build types.
 5. **Asset merge**: flutter assets become a merged source dir instead of a
    post-merge overwrite; collisions resolve by AGP source-set priority.
 6. **Add-to-app**: the explicit `:app:merge<V>Assets.dependsOn` edge and
    host-project lookup are removed; `flutter.hostAppProjectName` becomes a
-   no-op with a deprecation warning naming a removal milestone. Build scripts that 
-   reference Flutter's `copyFlutterAssets<V>` tasks by name (e.g. `tasks.getByPath(...)`) 
-   will crash with a `Task with path ... not found` error because the tasks are now 
+   no-op with a deprecation warning naming a removal milestone. Build scripts that
+   reference Flutter's `copyFlutterAssets<V>` tasks by name (e.g. `tasks.getByPath(...)`)
+   will crash with a `Task with path ... not found` error because the tasks are now
    registered lazily.
 7. **Task realization/type**: flutter tasks become lazy `TaskProvider`s, and
    `copyFlutterAssets<V>` changes type from `org.gradle.api.tasks.Copy` to a

--- a/docs/platforms/android/website-page-draft.md
+++ b/docs/platforms/android/website-page-draft.md
@@ -1,0 +1,191 @@
+# Android builds use the new Android Gradle Plugin DSL and Variant APIs
+
+*Draft breaking-change page for `docs.flutter.dev/release/breaking-changes/`.
+This file is the source of truth until the page is published to
+flutter/website; publishing must complete before the newDsl flip reaches the
+beta channel. Contributor-facing details live in
+[Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md](Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md).*
+
+## Summary
+
+The Flutter Gradle Plugin now uses only the public Android Gradle Plugin (AGP)
+API, and new and migrated Flutter projects build with AGP's new DSL enabled
+(`android.newDsl` is no longer set to `false` by Flutter). Gradle build
+scripts that use the legacy AGP APIs — most commonly
+`android.applicationVariants` — fail to configure and must be migrated to the
+AGP Variant API.
+
+## Background
+
+AGP 9 deprecated the legacy DSL and Variant APIs behind the
+`android.newDsl=false` flag. AGP 10 removes them entirely. Flutter previously
+added `android.newDsl=false` to your `gradle.properties` (via the project
+templates and an automatic migration) to keep legacy builds working. That
+opt-out stops working with AGP 10, so Flutter has migrated its own Gradle
+plugin to the public API and removed the opt-out from templates. A migration
+now *removes* the opt-out lines that Flutter previously added — it only touches
+lines carrying Flutter's marker comments, and prints a message when it does.
+Opt-outs you added by hand are left alone.
+
+`android.builtInKotlin=false` is **not** affected by this change. It is owned
+by the separate built-in-Kotlin migration (tracked in <!-- TODO: link
+built-in-Kotlin tracking issue -->), which means one more (smaller)
+`gradle.properties` change later.
+
+## Migration guide
+
+### Renaming APKs (`applicationVariants.all`)
+
+Before:
+
+```groovy
+android {
+    applicationVariants.all { variant ->
+        variant.outputs.all { output ->
+            outputFileName = "myapp-${variant.versionName}.apk"
+        }
+    }
+}
+```
+
+After (Variant API, `build.gradle` / `build.gradle.kts`):
+
+```kotlin
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        variant.outputs.forEach { output ->
+            // Use variant.name / output.filters and your own naming scheme.
+        }
+    }
+}
+```
+
+For output *file* renames, prefer consuming the built APKs from
+`SingleArtifact.APK` with a task wired through
+`variant.artifacts.use(...)`, or copy/rename in a finalizer task. Flutter's
+own copy step already places APKs at
+`build/app/outputs/flutter-apk/app[-abi][-flavor]-<mode>.apk` with unchanged
+names and paths.
+
+### Setting per-ABI or per-variant versionCode
+
+Before:
+
+```groovy
+android.applicationVariants.all { variant ->
+    variant.outputs.each { output ->
+        output.versionCodeOverride = abiCodes.get(output.getFilter(OutputFile.ABI)) * 1000 + variant.versionCode
+    }
+}
+```
+
+After:
+
+```kotlin
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        variant.outputs.forEach { output ->
+            val abi = output.filters.find { it.filterType == FilterConfiguration.FilterType.ABI }?.identifier
+            val base = output.versionCode.get() ?: 1
+            output.versionCode.set((abiCodes[abi] ?: 0) * 1000 + base)
+        }
+    }
+}
+```
+
+Note: Flutter itself sets per-ABI version codes for `--split-per-abi` inside
+`onVariants`. If your CI mutates version codes in `afterEvaluate`, that runs at
+a different time than before; Flutter prints a warning when it detects a
+divergence between the DSL value and the final output value.
+
+### Custom build types and plugins
+
+Flutter copies your app's custom build types onto Flutter plugin projects so
+they resolve. With the new DSL these are `initWith` copies rather than live
+aliases:
+
+- Set `matchingFallbacks` on custom build types so dependent Android libraries
+  resolve, for example:
+
+  ```kotlin
+  android {
+      buildTypes {
+          create("staging") {
+              initWith(getByName("debug"))
+              matchingFallbacks += listOf("debug", "release")
+          }
+      }
+  }
+  ```
+
+- Library (plugin) projects cannot be marked debuggable through the public
+  API, so a plugin's `BuildConfig.DEBUG` and native (JNI) debuggability can
+  differ from before for custom *debuggable* build types. Variant matching
+  still works via `matchingFallbacks`.
+
+### Add-to-app (Flutter module in a host app)
+
+- Flutter no longer looks up or configures the host `:app` project from the
+  module. The dependency between your host's asset merging and Flutter's asset
+  copy is expressed through the Variant API instead of an explicit
+  `merge<Variant>Assets.dependsOn(...)` edge. Build scripts that reference
+  Flutter's `copyFlutterAssets<Variant>` tasks by name or type may break: the
+  tasks are now registered lazily and are no longer of type
+  `org.gradle.api.tasks.Copy`.
+- `flutter.hostAppProjectName` in `gradle.properties` is now a no-op. Flutter
+  prints a deprecation warning naming the removal milestone. It was only used
+  for the host-project lookup, which no longer exists.
+- Flutter maps host build types to Flutter build modes using the public
+  "debuggable" flag: `profile` stays `profile`, debuggable build types map to
+  `debug`, everything else maps to `release`. If your host has no `profile`
+  build type, add `matchingFallbacks`:
+
+  ```kotlin
+  create("staging") {
+      initWith(getByName("debug"))
+      isDebuggable = true            // staging gets debug Flutter artifacts
+      matchingFallbacks += listOf("debug", "release")
+  }
+  ```
+
+### Flutter plugin authors
+
+- Do not read `android.applicationVariants` / `android.libraryVariants` in
+  plugin build scripts; use `androidComponents.onVariants`.
+- Do not assume Flutter's tasks exist at configuration time or have specific
+  types; look tasks up lazily (`tasks.named`) without a type, or better, wire
+  through Variant API artifacts.
+- Test your plugin's example app with AGP 9+ **without** `android.newDsl=false`.
+
+### `flutter build aar`
+
+Variant enumeration for AAR builds now uses the public `components` API. If
+your module's build script declares `singleVariant(...)` publishing itself,
+Flutter detects the overlap and reports it with an actionable error instead of
+failing inside AGP.
+
+## Escape hatch (temporary)
+
+If you cannot migrate immediately, add the opt-out by hand to
+`android/gradle.properties`:
+
+```properties
+android.newDsl=false
+```
+
+**This stops working with AGP 10** (removal of the legacy APIs). Treat it as a
+short-term unblock only; hand-added opt-outs are never touched by Flutter's
+migrator.
+
+## Timeline
+
+Landed in version: TBD<br>
+In stable release: TBD
+
+## References
+
+- AGP 9 release notes (new DSL):
+  https://developer.android.com/build/releases/agp-9-0-0-release-notes
+- Flutter umbrella issues:
+  [flutter/flutter#180137](https://github.com/flutter/flutter/issues/180137),
+  [flutter/flutter#166550](https://github.com/flutter/flutter/issues/166550)

--- a/docs/platforms/android/website-page-draft.md
+++ b/docs/platforms/android/website-page-draft.md
@@ -177,7 +177,7 @@ aliases:
   an audit of the top 200 plugins for this legacy usage in
   [flutter/flutter#190845](https://github.com/flutter/flutter/issues/190845)).
 - Do not assume Flutter's tasks exist at configuration time or have specific
-  types; look tasks up lazily (`tasks.named`) without a type, or better, wire
+  types; look up tasks lazily (`tasks.named`) without a type, or better, wire
   through Variant API artifacts.
 - Test your plugin's example app with AGP 9+ **without** `android.newDsl=false`.
 

--- a/docs/platforms/android/website-page-draft.md
+++ b/docs/platforms/android/website-page-draft.md
@@ -28,9 +28,9 @@ lines carrying Flutter's marker comments, and prints a message when it does.
 Opt-outs you added by hand are left alone.
 
 `android.builtInKotlin=false` is **not** affected by this change. It is owned
-by the separate built-in-Kotlin migration (tracked in <!-- TODO: link
-built-in-Kotlin tracking issue -->), which means one more (smaller)
-`gradle.properties` change later.
+by the separate built-in-Kotlin migration (tracked in
+[flutter/flutter#184836](https://github.com/flutter/flutter/issues/184836)),
+which means one more (smaller) `gradle.properties` change later.
 
 ## Migration guide
 

--- a/docs/platforms/android/website-page-draft.md
+++ b/docs/platforms/android/website-page-draft.md
@@ -62,7 +62,7 @@ androidComponents {
 }
 ```
 
-For output *file* renames, you must copy or rename the built APKs using a Gradle task. 
+For output *file* renames, you must copy or rename the built APKs using a Gradle task.
 (Note: Flutter's own copy step already places APKs at `build/app/outputs/flutter-apk/app[-abi][-flavor]-<mode>.apk` with unchanged names and paths.)
 
 Example of a simple finalizer task in `build.gradle` (Groovy):
@@ -112,7 +112,7 @@ androidComponents {
 Note: Flutter itself sets per-ABI version codes for `--split-per-abi` inside
 `onVariants`. If your CI mutates version codes in `afterEvaluate`, that runs at
 a different time than before; Flutter prints a warning when it detects a
-divergence between the DSL value and the final output value. To verify your 
+divergence between the DSL value and the final output value. To verify your
 mutations worked, inspect the built APK:
 `apkanalyzer manifest print versionCode build/app/outputs/flutter-apk/app-release.apk`
 
@@ -123,8 +123,8 @@ they resolve. With the new DSL these are `initWith` copies rather than live
 aliases:
 
 - Set `matchingFallbacks` on custom build types so dependent Android libraries
-  resolve. If a third-party plugin does not define your app's custom `staging` 
-  build type, AGP needs to know to safely fall back to compiling the plugin's 
+  resolve. If a third-party plugin does not define your app's custom `staging`
+  build type, AGP needs to know to safely fall back to compiling the plugin's
   `debug` variant rather than failing the build. For example:
 
   ```kotlin
@@ -138,11 +138,11 @@ aliases:
   }
   ```
 
-- **Warning for Plugin Authors / JNI Developers:** Library (plugin) projects cannot 
-  be explicitly marked debuggable through the public AGP API. If an app uses a 
-  custom build type (like `staging`), the plugin's `BuildConfig.DEBUG` and native (C++/JNI) 
-  code may silently compile in release mode instead of debug mode. Variant matching 
-  still works via `matchingFallbacks`, but C++ debugging will be broken for those 
+- **Warning for Plugin Authors / JNI Developers:** Library (plugin) projects cannot
+  be explicitly marked debuggable through the public AGP API. If an app uses a
+  custom build type (like `staging`), the plugin's `BuildConfig.DEBUG` and native (C++/JNI)
+  code may silently compile in release mode instead of debug mode. Variant matching
+  still works via `matchingFallbacks`, but C++ debugging will be broken for those
   custom build types.
 
 ### Add-to-app (Flutter module in a host app)
@@ -151,8 +151,8 @@ aliases:
   module. The dependency between your host's asset merging and Flutter's asset
   copy is expressed through the Variant API instead of an explicit
   `merge<Variant>Assets.dependsOn(...)` edge. Build scripts that reference
-  Flutter's `copyFlutterAssets<Variant>` tasks by name or type will break. 
-  For example, `tasks.getByPath(":flutter:copyFlutterAssetsDebug")` will crash 
+  Flutter's `copyFlutterAssets<Variant>` tasks by name or type will break.
+  For example, `tasks.getByPath(":flutter:copyFlutterAssetsDebug")` will crash
   your build with a `Task with path ... not found` error because the
   tasks are now registered lazily and are no longer of type
   `org.gradle.api.tasks.Copy`.
@@ -199,8 +199,8 @@ If you cannot migrate immediately, add the opt-out by hand to
 android.newDsl=false
 ```
 
-**AGP 10 is expected to remove the legacy APIs**, meaning this opt-out will 
-stop working. Treat it as a short-term unblock only; hand-added opt-outs are 
+**AGP 10 is expected to remove the legacy APIs**, meaning this opt-out will
+stop working. Treat it as a short-term unblock only; hand-added opt-outs are
 never touched by Flutter's migrator.
 
 ## References

--- a/docs/platforms/android/website-page-draft.md
+++ b/docs/platforms/android/website-page-draft.md
@@ -69,15 +69,13 @@ Example of a simple finalizer task in `build.gradle` (Groovy):
 ```groovy
 androidComponents {
     onVariants(selector().all()) { variant ->
-        tasks.named("assemble${variant.name.capitalize()}").configure {
-            it.doLast {
-                copy {
-                    // In AGP 8+, APK is a directory containing the file(s)
-                    from(variant.artifacts.get(com.android.build.api.artifact.SingleArtifact.APK.INSTANCE))
-                    into(layout.buildDirectory.dir("custom-outputs"))
-                    rename { String fileName -> fileName.replace("app", "myapp") }
-                }
-            }
+        def copyTask = tasks.register("copy${variant.name.capitalize()}Apk", Copy) {
+            from(variant.artifacts.get(com.android.build.api.artifact.SingleArtifact.APK.INSTANCE))
+            into(layout.buildDirectory.dir("custom-outputs"))
+            rename { String fileName -> fileName.replace("app", "myapp") }
+        }
+        tasks.matching { it.name == "assemble${variant.name.capitalize()}" }.configureEach {
+            dependsOn(copyTask)
         }
     }
 }

--- a/docs/platforms/android/website-page-draft.md
+++ b/docs/platforms/android/website-page-draft.md
@@ -51,21 +51,37 @@ android {
 After (Variant API, `build.gradle` / `build.gradle.kts`):
 
 ```kotlin
+// Note: androidComponents is a top-level block, peer to android {}
 androidComponents {
     onVariants(selector().all()) { variant ->
         variant.outputs.forEach { output ->
-            // Use variant.name / output.filters and your own naming scheme.
+            // WARNING: VariantOutput in the new API does not have an outputFileName property.
+            // You cannot mutate the filename here.
         }
     }
 }
 ```
 
-For output *file* renames, prefer consuming the built APKs from
-`SingleArtifact.APK` with a task wired through
-`variant.artifacts.use(...)`, or copy/rename in a finalizer task. Flutter's
-own copy step already places APKs at
-`build/app/outputs/flutter-apk/app[-abi][-flavor]-<mode>.apk` with unchanged
-names and paths.
+For output *file* renames, you must copy or rename the built APKs using a Gradle task. 
+(Note: Flutter's own copy step already places APKs at `build/app/outputs/flutter-apk/app[-abi][-flavor]-<mode>.apk` with unchanged names and paths.)
+
+Example of a simple finalizer task in `build.gradle` (Groovy):
+```groovy
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        tasks.named("assemble${variant.name.capitalize()}").configure {
+            it.doLast {
+                copy {
+                    // In AGP 8+, APK is a directory containing the file(s)
+                    from(variant.artifacts.get(com.android.build.api.artifact.SingleArtifact.APK.INSTANCE))
+                    into("${layout.buildDirectory.get()}/custom-outputs")
+                    rename { String fileName -> "myapp-${variant.name}.apk" }
+                }
+            }
+        }
+    }
+}
+```
 
 ### Setting per-ABI or per-variant versionCode
 
@@ -86,7 +102,7 @@ androidComponents {
     onVariants(selector().all()) { variant ->
         variant.outputs.forEach { output ->
             val abi = output.filters.find { it.filterType == FilterConfiguration.FilterType.ABI }?.identifier
-            val base = output.versionCode.get() ?: 1
+            val base = output.versionCode.orNull ?: 1
             output.versionCode.set((abiCodes[abi] ?: 0) * 1000 + base)
         }
     }
@@ -96,7 +112,9 @@ androidComponents {
 Note: Flutter itself sets per-ABI version codes for `--split-per-abi` inside
 `onVariants`. If your CI mutates version codes in `afterEvaluate`, that runs at
 a different time than before; Flutter prints a warning when it detects a
-divergence between the DSL value and the final output value.
+divergence between the DSL value and the final output value. To verify your 
+mutations worked, inspect the built APK:
+`apkanalyzer manifest print versionCode build/app/outputs/flutter-apk/app-release.apk`
 
 ### Custom build types and plugins
 
@@ -105,7 +123,9 @@ they resolve. With the new DSL these are `initWith` copies rather than live
 aliases:
 
 - Set `matchingFallbacks` on custom build types so dependent Android libraries
-  resolve, for example:
+  resolve. If a third-party plugin does not define your app's custom `staging` 
+  build type, AGP needs to know to safely fall back to compiling the plugin's 
+  `debug` variant rather than failing the build. For example:
 
   ```kotlin
   android {
@@ -118,10 +138,12 @@ aliases:
   }
   ```
 
-- Library (plugin) projects cannot be marked debuggable through the public
-  API, so a plugin's `BuildConfig.DEBUG` and native (JNI) debuggability can
-  differ from before for custom *debuggable* build types. Variant matching
-  still works via `matchingFallbacks`.
+- **Warning for Plugin Authors / JNI Developers:** Library (plugin) projects cannot 
+  be explicitly marked debuggable through the public AGP API. If an app uses a 
+  custom build type (like `staging`), the plugin's `BuildConfig.DEBUG` and native (C++/JNI) 
+  code may silently compile in release mode instead of debug mode. Variant matching 
+  still works via `matchingFallbacks`, but C++ debugging will be broken for those 
+  custom build types.
 
 ### Add-to-app (Flutter module in a host app)
 
@@ -129,7 +151,9 @@ aliases:
   module. The dependency between your host's asset merging and Flutter's asset
   copy is expressed through the Variant API instead of an explicit
   `merge<Variant>Assets.dependsOn(...)` edge. Build scripts that reference
-  Flutter's `copyFlutterAssets<Variant>` tasks by name or type may break: the
+  Flutter's `copyFlutterAssets<Variant>` tasks by name or type will break. 
+  For example, `tasks.getByPath(":flutter:copyFlutterAssetsDebug")` will crash 
+  your build with a `Task with path ... not found` error because the
   tasks are now registered lazily and are no longer of type
   `org.gradle.api.tasks.Copy`.
 - `flutter.hostAppProjectName` in `gradle.properties` is now a no-op. Flutter
@@ -151,7 +175,9 @@ aliases:
 ### Flutter plugin authors
 
 - Do not read `android.applicationVariants` / `android.libraryVariants` in
-  plugin build scripts; use `androidComponents.onVariants`.
+  plugin build scripts; use `androidComponents.onVariants`. (We are tracking
+  an audit of the top 200 plugins for this legacy usage in
+  [flutter/flutter#190845](https://github.com/flutter/flutter/issues/190845)).
 - Do not assume Flutter's tasks exist at configuration time or have specific
   types; look tasks up lazily (`tasks.named`) without a type, or better, wire
   through Variant API artifacts.
@@ -173,14 +199,9 @@ If you cannot migrate immediately, add the opt-out by hand to
 android.newDsl=false
 ```
 
-**This stops working with AGP 10** (removal of the legacy APIs). Treat it as a
-short-term unblock only; hand-added opt-outs are never touched by Flutter's
-migrator.
-
-## Timeline
-
-Landed in version: TBD<br>
-In stable release: TBD
+**AGP 10 is expected to remove the legacy APIs**, meaning this opt-out will 
+stop working. Treat it as a short-term unblock only; hand-added opt-outs are 
+never touched by Flutter's migrator.
 
 ## References
 

--- a/docs/platforms/android/website-page-draft.md
+++ b/docs/platforms/android/website-page-draft.md
@@ -74,8 +74,8 @@ androidComponents {
                 copy {
                     // In AGP 8+, APK is a directory containing the file(s)
                     from(variant.artifacts.get(com.android.build.api.artifact.SingleArtifact.APK.INSTANCE))
-                    into("${layout.buildDirectory.get()}/custom-outputs")
-                    rename { String fileName -> "myapp-${variant.name}.apk" }
+                    into(layout.buildDirectory.dir("custom-outputs"))
+                    rename { String fileName -> fileName.replace("app", "myapp") }
                 }
             }
         }


### PR DESCRIPTION
There are 2 files in this pr. One is a document the ai used to keep track of work. More importantly it acts kind of like issues so it references the items in future prs. The second is user facing website documentation. I do not know if we will use it verbatim but for the set of prs lets treat that md doc as human understandable documentation that we must understand before landing the next pr. 

Reviewers: When the pr is out of draft and your comments are fully addressed please prioritize this pr over other work. The review bar is higher, the number of reviews has more people and the work for the next pr is already done. 
 - @reidbaker 
---
Standard review context for this pr stack

This is PR is part of an 11 pr stack to migrate the "newdsl" `gradle-api` specifically in agp 9.1.0. 
The complete stack has pass pre submits, post submits and customer tests. https://flutter-dashboard.appspot.com/#/build?repo=flutter&branch=experimental/agp-gradle-api

All of the code was LLM authored. A mix of manual prompting, automatic prompting, several models and adversarial review. The combined sessions are enough that I cannot include relevant prompts like I have been doing on other prs. 

If you want to review the pr stack you can find it here. These prs will be abandoned/closed as prs land into flutter/flutter. 
1. https://github.com/reidbaker-agent/flutter/pull/1 (branch: agp-api-doc)
2. https://github.com/reidbaker-agent/flutter/pull/2 (branch: agp-internal-utils)
3. https://github.com/reidbaker-agent/flutter/pull/3 (branch: agp-buildmode-deps)
4. https://github.com/reidbaker-agent/flutter/pull/4 (branch: agp-plugin-buildtypes)
5. https://github.com/reidbaker-agent/flutter/pull/5 (branch: agp-ndk-fallback)
6. https://github.com/reidbaker-agent/flutter/pull/6 (branch: agp-assets-onvariants)
7. https://github.com/reidbaker-agent/flutter/pull/7 (branch: agp-apk-copy-versioncode)
8. https://github.com/reidbaker-agent/flutter/pull/8 (branch: agp-add-to-app)
9. https://github.com/reidbaker-agent/flutter/pull/9 (branch: agp-aar-script)
10. https://github.com/reidbaker-agent/flutter/pull/10 (branch: agp-newdsl-flip)
11. https://github.com/reidbaker-agent/flutter/pull/11 (branch: agp-gradle-api)

Follow up work is tracked in https://github.com/flutter/flutter/issues/190964 

This work is urgent in the sense that we are worried that android will publish agp 10 with no opt out but not so urgent that we are willing to break flutter users because we didn't review or understand the code because we were in a rush. 

Breaking changes are expected as part of this work. There are patterns the android team explicitly does not want apps to use and apis that have no equivalent. 

As part of the effort to ensure this work does not slip into ai slop, prs from this stack will be reviewed by me (@reidbaker) before asking for review. Then we will have 2 android expert reviewers also review the every pr.

---
Agent authored pr description
This is PR 1 of 11 in the AGP 9.1.0 / public `gradle-api` migration stack.

It adds the contributor-facing and website draft documentation for the Flutter Gradle Plugin's migration to the Android Gradle Plugin public Variant API, which unblocks building Flutter Android apps with AGP's `newDsl=true` enabled.

Part of flutter/flutter#180137 and flutter/flutter#166550.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
