### PR TITLE
[flutter_tools] Switch 'flutter analyze' to use dart/workspace/analysis/complete

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -50,7 +50,6 @@ class AnalyzeOnce extends AnalyzeBase {
       throwToolExit('Nothing to analyze.', exitCode: 0);
     }
 
-    final analysisCompleter = Completer<void>();
     final errors = <AnalysisError>[];
 
     final server = AnalysisServer(
@@ -68,20 +67,6 @@ class AnalyzeOnce extends AnalyzeBase {
     Stopwatch? timer;
     Status? progress;
     try {
-      StreamSubscription<bool>? subscription;
-
-      void handleAnalysisStatus(bool isAnalyzing) {
-        if (!isAnalyzing) {
-          analysisCompleter.complete();
-          subscription?.cancel();
-          subscription = null;
-        }
-      }
-
-      subscription = server.onAnalyzing.listen(
-        (bool isAnalyzing) => handleAnalysisStatus(isAnalyzing),
-      );
-
       void handleAnalysisErrors(FileAnalysisErrors fileErrors) {
         errors.addAll(fileErrors.errors);
       }
@@ -89,18 +74,18 @@ class AnalyzeOnce extends AnalyzeBase {
       server.onErrors.listen(handleAnalysisErrors);
 
       await server.start();
-      // Completing the future in the callback can't fail.
+
+      // Capture if the server exits unexpectedly.
+      final exitErrorCompleter = Completer<void>();
       unawaited(
         server.onExit.then<void>((int? exitCode) {
-          if (!analysisCompleter.isCompleted) {
-            analysisCompleter.completeError(
-              // Include the last 20 lines of server output in exception message
-              _AnalysisServerExitException(
-                'analysis server exited with code $exitCode and output:\n${server.getLogs(20)}',
-                exitCode,
-              ),
-            );
-          }
+          exitErrorCompleter.completeError(
+            // Include the last 20 lines of server output in exception message
+            _AnalysisServerExitException(
+              'analysis server exited with code $exitCode and output:\n${server.getLogs(20)}',
+              exitCode,
+            ),
+          );
         }),
       );
 
@@ -113,8 +98,10 @@ class AnalyzeOnce extends AnalyzeBase {
           ? logger.startProgress('Analyzing $message...')
           : null;
 
+      // Wait for analysis to complete, or the server to exit and produce
+      // an error.
       try {
-        await analysisCompleter.future;
+        await Future.any([server.waitForAnalysis(), exitErrorCompleter.future]);
       } on _AnalysisServerExitException catch (error) {
         throwToolExit(error.message, exitCode: error.exitCode);
       }

--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -50,34 +50,18 @@ class AnalysisServer {
   final _errorsController = StreamController<FileAnalysisErrors>.broadcast();
   var _didServerErrorOccur = false;
 
-  /// Whether the server is currently analyzing.
-  bool get isAnalyzing => _isAnalyzing;
-  bool _isAnalyzing = false;
-
-  /// Returns a [Future] that completes when the server is no longer analyzing.
+  /// Returns a [Future] that completes when the server has completed any
+  /// in-progress initialization or analysis.
   ///
-  /// If [delay] is provided, this method will wait for that duration before
-  /// checking if the server is analyzing. if the server starts analyzing during
-  /// that duration, it will wait for analysis to complete.
+  /// This method will wait for [delay] before calling the server. If not
+  /// provided, defaults to 100ms.
   ///
   /// This is useful to avoid the race condition where analysis hasn't started
   /// yet after a file change.
   Future<void> waitForAnalysis({Duration delay = const Duration(milliseconds: 100)}) async {
-    if (_isAnalyzing) {
-      await onAnalyzing.firstWhere((bool analyzing) => !analyzing);
-    }
-    if (delay != Duration.zero) {
-      // Wait for analysis to potentially start.
-      try {
-        await onAnalyzing.firstWhere((bool analyzing) => analyzing).timeout(delay);
-        // If analysis started, wait for it to finish.
-        if (_isAnalyzing) {
-          await onAnalyzing.firstWhere((bool analyzing) => !analyzing);
-        }
-      } on TimeoutException {
-        // Analysis didn't start within the delay, so we assume it's not going to.
-      }
-    }
+    await Future<void>.delayed(delay);
+
+    await sendRequest('dart/workspace/analysis/complete', {});
   }
 
   var _id = 0;
@@ -146,6 +130,12 @@ class AnalysisServer {
 
   bool get didServerErrorOccur => _didServerErrorOccur;
 
+  /// A stream of booleans indicating that the server is starting or stopping
+  /// analysis.
+  ///
+  /// These statuses are intended to show progress to a user and not intended
+  /// as a reliable indicator that all analysis has completed. To know when
+  /// analysis has definitely completed, use [waitForAnalysis].
   Stream<bool> get onAnalyzing => _analyzingController.stream;
 
   Stream<FileAnalysisErrors> get onErrors => _errorsController.stream;
@@ -307,10 +297,8 @@ class AnalysisServer {
     if (value is Map<String, Object?>) {
       final kind = value['kind'] as String?;
       if (kind == 'begin') {
-        _isAnalyzing = true;
         _analyzingController.add(true);
       } else if (kind == 'end') {
-        _isAnalyzing = false;
         _analyzingController.add(false);
       }
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/analysis_server_mock.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analysis_server_mock.dart
@@ -1,0 +1,175 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import '../../src/fake_process_manager.dart' as test_process_manager;
+
+/// A mock LSP server that allows a test to control analysis status, progress
+/// notifications and diagnostics.
+class MockLspServerProcess extends test_process_manager.FakeProcess {
+  factory MockLspServerProcess() {
+    final stdinController = StreamController<List<int>>();
+    final stdinSink = IOSink(stdinController.sink);
+    final exitCompleter = Completer<void>();
+    return MockLspServerProcess._(stdinController, stdin: stdinSink, exitCompleter: exitCompleter);
+  }
+
+  MockLspServerProcess._(
+    this._stdinController, {
+    required super.stdin,
+    required Completer<void> exitCompleter,
+  }) : _exitCompleter = exitCompleter,
+       super(completer: exitCompleter) {
+    _stdinController.stream.transform(utf8.decoder).listen(_handleStdinChunk);
+  }
+
+  final StreamController<List<int>> _stdinController;
+  final StringBuffer _inputBuffer = StringBuffer();
+  final StreamController<List<int>> _stdoutController = StreamController<List<int>>();
+  final Completer<void> _exitCompleter;
+
+  Completer<void>? _analysisCompleter;
+  final Completer<Map<String, Object?>> _initializeRequestCompleter = Completer();
+  Future<Map<String, Object?>> get initializeRequest => _initializeRequestCompleter.future;
+
+  @override
+  Stream<List<int>> get stdout => _stdoutController.stream;
+
+  /// Starts simulated analysis on the server, but does not wait for it.
+  void triggerSimulatedAnalysis({Uri? diagnosticsFor, int diagnosticsCount = 1}) {
+    unawaited(
+      runSimulatedAnalysis(diagnosticsFor: diagnosticsFor, diagnosticsCount: diagnosticsCount),
+    );
+  }
+
+  /// Simulates analysis on the server.
+  ///
+  /// This will trigger a progress notification indicating that analysis has
+  /// started, optionally send [diagnosticsCount] diagnostics for
+  /// [diagnosticsFor], then send a progress notification indicating that anlaysis has ended.
+  Future<void> runSimulatedAnalysis({Uri? diagnosticsFor, int diagnosticsCount = 1}) async {
+    _simulateAnalysisStart();
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    if (diagnosticsFor != null) {
+      _simulateDiagnostics(diagnosticsFor, diagnosticsCount);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+
+    _simulateAnalysisEnd();
+  }
+
+  /// Causes the process to write a Dart VM Service banner to stdout.
+  void triggerVmServiceUriBanner() {
+    _writeRawOutput('The Dart VM service is listening on http://127.0.0.1:65155/ZkxDXuYz2Aw=/\n');
+  }
+
+  Future<void> _handleRequest(Map<String, Object?> request) async {
+    switch (request['method']) {
+      case 'initialize':
+        _initializeRequestCompleter.complete(request);
+        _writeAsLspToStdout(
+          jsonEncode({
+            'jsonrpc': '2.0',
+            'id': request['id'],
+            'result': {'capabilities': <String, Object?>{}},
+          }),
+        );
+      case 'dart/workspace/analysis/complete':
+        await _analysisCompleter?.future;
+        _sendResponse(request['id'], null);
+    }
+  }
+
+  void _handleStdinChunk(String chunk) {
+    _inputBuffer.write(chunk);
+    var input = _inputBuffer.toString();
+    while (true) {
+      final int headerEnd = input.indexOf('\r\n\r\n');
+      if (headerEnd == -1) {
+        break;
+      }
+      final String header = input.substring(0, headerEnd);
+      final Match? contentLengthMatch = RegExp(r'Content-Length: (\d+)').firstMatch(header);
+      if (contentLengthMatch == null) {
+        throw StateError('LSP request is missing a Content-Length header.');
+      }
+      final int contentLength = int.parse(contentLengthMatch.group(1)!);
+      final int messageEnd = headerEnd + 4 + contentLength;
+      if (input.length < messageEnd) {
+        break;
+      }
+      final String message = input.substring(headerEnd + 4, messageEnd);
+      unawaited(_handleRequest(jsonDecode(message) as Map<String, Object?>));
+      input = input.substring(messageEnd);
+    }
+    _inputBuffer
+      ..clear()
+      ..write(input);
+  }
+
+  void _sendNotification(String method, Map<String, Object?> params) {
+    _writeAsLspToStdout(
+      jsonEncode(<String, Object?>{'jsonrpc': '2.0', 'method': method, 'params': params}),
+    );
+  }
+
+  void _sendResponse(Object? id, Map<String, Object?>? result) {
+    _writeAsLspToStdout(jsonEncode({'jsonrpc': '2.0', 'id': id, 'result': result}));
+  }
+
+  void _simulateAnalysisEnd() {
+    _analysisCompleter?.complete();
+    _analysisCompleter = null;
+    _sendNotification(r'$/progress', <String, Object?>{
+      'token': 'analyze',
+      'value': <String, Object?>{'kind': 'end'},
+    });
+  }
+
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) {
+    _exitCompleter.complete();
+    return super.kill();
+  }
+
+  void _simulateAnalysisStart() {
+    if (_analysisCompleter case null || Completer(isCompleted: true)) {
+      _analysisCompleter = Completer<void>();
+      _sendNotification(r'$/progress', <String, Object?>{
+        'token': 'analyze',
+        'value': <String, Object?>{'kind': 'begin'},
+      });
+    }
+  }
+
+  void _simulateDiagnostics(Uri targetUri, int count) {
+    _sendNotification('textDocument/publishDiagnostics', {
+      'uri': targetUri.toString(),
+      'diagnostics': <Object?>[
+        for (var i = 0; i < count; i++)
+          <String, Object?>{
+            'range': <String, Object?>{
+              'start': <String, Object?>{'line': 99 + i, 'character': 4},
+              'end': <String, Object?>{'line': 99 + i, 'character': 4},
+            },
+            'severity': 2,
+            'code': '500',
+            'message': "It's an error.",
+          },
+      ],
+    });
+  }
+
+  void _writeAsLspToStdout(String message) {
+    _stdoutController.add(utf8.encode('Content-Length: ${message.length}\r\n\r\n$message'));
+  }
+
+  void _writeRawOutput(String output) {
+    _stdoutController.add(utf8.encode(output));
+  }
+}

--- a/packages/flutter_tools/test/commands.shard/hermetic/analysis_server_mock.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analysis_server_mock.dart
@@ -28,12 +28,12 @@ class MockLspServerProcess extends test_process_manager.FakeProcess {
   }
 
   final StreamController<List<int>> _stdinController;
-  final StringBuffer _inputBuffer = StringBuffer();
-  final StreamController<List<int>> _stdoutController = StreamController<List<int>>();
+  final _inputBuffer = StringBuffer();
+  final _stdoutController = StreamController<List<int>>();
   final Completer<void> _exitCompleter;
 
   Completer<void>? _analysisCompleter;
-  final Completer<Map<String, Object?>> _initializeRequestCompleter = Completer();
+  final _initializeRequestCompleter = Completer<Map<String, Object?>>();
   Future<Map<String, Object?>> get initializeRequest => _initializeRequestCompleter.future;
 
   @override

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -17,7 +17,6 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/analyze.dart';
 import 'package:flutter_tools/src/dart/analysis.dart';
 import 'package:flutter_tools/src/project_validator.dart';
-import 'package:path/path.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -319,7 +318,7 @@ void main() {
     // Trigger analysis and diagnostics for an existing file.
     final File targetFile = fileSystem.directory('directoryA').childFile('foo')
       ..createSync(recursive: true);
-    final Uri targetUri = toUri(targetFile.path);
+    final Uri targetUri = fileSystem.path.toUri(targetFile.path);
     process.triggerSimulatedAnalysis(diagnosticsFor: targetUri);
 
     while (!logger.statusText.contains('analyzed 1 file')) {
@@ -368,7 +367,7 @@ void main() {
 
     // Trigger analysis and diagnostics for a non-existing file.
     final File targetFile = fileSystem.directory('directoryA').childFile('foo');
-    final Uri targetUri = toUri(targetFile.path);
+    final Uri targetUri = fileSystem.path.toUri(targetFile.path);
     process.triggerSimulatedAnalysis(diagnosticsFor: targetUri);
 
     while (!logger.statusText.contains('analyzed 1 file')) {
@@ -470,7 +469,7 @@ void main() {
     // Simulate some diagnostics coming and going. The file must exist.
     final File targetFile = fileSystem.directory('directoryA').childFile('foo')
       ..createSync(recursive: true);
-    final Uri targetUri = toUri(targetFile.path);
+    final Uri targetUri = fileSystem.path.toUri(targetFile.path);
 
     await process.runSimulatedAnalysis(diagnosticsFor: targetUri); // 1 new
     await process.runSimulatedAnalysis(diagnosticsFor: targetUri, diagnosticsCount: 0); // 1 fixed

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -16,13 +16,14 @@ import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/analyze.dart';
 import 'package:flutter_tools/src/dart/analysis.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project_validator.dart';
+import 'package:path/path.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 import '../../src/test_flutter_command_runner.dart';
+import 'analysis_server_mock.dart';
 
 void main() {
   setUpAll(() {
@@ -33,10 +34,12 @@ void main() {
   late FileSystem fileSystem;
   late Platform platform;
   late AnsiTerminal terminal;
-  late Logger logger;
+  late BufferLogger logger;
 
   setUp(() {
-    fileSystem = globals.localFileSystem;
+    fileSystem = MemoryFileSystem.test(
+      style: const LocalPlatform().isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
+    );
     platform = const LocalPlatform();
     terminal = AnsiTerminal(platform: platform, stdio: Stdio());
     logger = BufferLogger(outputPreferences: OutputPreferences.test(), terminal: terminal);
@@ -69,74 +72,17 @@ void main() {
   ''');
   }
 
-  group('analyze --watch', () {
-    testUsingContext('AnalysisServer success', () async {
-      final fileSystem = MemoryFileSystem.test();
-      final Directory tempDir = fileSystem.systemTempDirectory.createTempSync(
-        'flutter_analysis_test.',
-      );
-      createSampleProject(tempDir);
-
-      final stdin = StreamController<List<int>>();
-      final processManager = FakeProcessManager.list(<FakeCommand>[
-        FakeCommand(
-          command: const <String>[
-            'Artifact.engineDartSdkPath/bin/dart',
-            'language-server',
-            '--dart-sdk',
-            'Artifact.engineDartSdkPath',
-            '--disable-server-feature-completion',
-            '--disable-server-feature-search',
-            '--suppress-analytics',
-          ],
-          stdin: IOSink(stdin.sink),
-          stdout:
-              'Content-Length: 36\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{}}'
-              'Content-Length: 93\r\n\r\n'
-              r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-              '"value":{"kind":"begin"}}}'
-              'Content-Length: 91\r\n\r\n'
-              r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-              '"value":{"kind":"end"}}}',
-        ),
-      ]);
-
-      final server = AnalysisServer(
-        'Artifact.engineDartSdkPath',
-        <String>[tempDir.path],
-        fileSystem: fileSystem,
-        platform: FakePlatform(),
-        processManager: processManager,
-        logger: logger,
-        terminal: terminal,
-        suppressAnalytics: true,
-      );
-
-      var errorCount = 0;
-      server.onErrors.listen((FileAnalysisErrors errors) => errorCount += errors.errors.length);
-
-      await server.start();
-      await server.waitForAnalysis();
-
-      expect(errorCount, 0);
-
-      await server.dispose();
-      expect(processManager, hasNoRemainingExpectations);
-    });
-  });
-
-  testUsingContext('AnalysisServer errors', () async {
-    final fileSystem = MemoryFileSystem.test();
+  testUsingContext('AnalysisServer success', () async {
     final Directory tempDir = fileSystem.systemTempDirectory.createTempSync(
       'flutter_analysis_test.',
     );
-    createSampleProject(tempDir, brokenCode: true);
+    createSampleProject(tempDir);
 
-    final stdin = StreamController<List<int>>();
+    final process = MockLspServerProcess();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
-        command: const <String>[
-          'Artifact.engineDartSdkPath/bin/dart',
+        command: <String>[
+          fileSystem.path.join('Artifact.engineDartSdkPath', 'bin', 'dart'),
           'language-server',
           '--dart-sdk',
           'Artifact.engineDartSdkPath',
@@ -144,20 +90,7 @@ void main() {
           '--disable-server-feature-search',
           '--suppress-analytics',
         ],
-        stdin: IOSink(stdin.sink),
-        stdout:
-            'Content-Length: 36\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{}}'
-            'Content-Length: 93\r\n\r\n'
-            r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-            '"value":{"kind":"begin"}}}'
-            'Content-Length: 249\r\n\r\n'
-            '{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{'
-            '"uri":"file:///directoryA/foo","diagnostics":[{"range":{"start":{"line":99,'
-            '"character":4},"end":{"line":99,"character":4}},"severity":2,"code":"500",'
-            '"message":"It\'s an error."}]}}'
-            'Content-Length: 91\r\n\r\n'
-            r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-            '"value":{"kind":"end"}}}',
+        process: process,
       ),
     ]);
 
@@ -176,6 +109,53 @@ void main() {
     server.onErrors.listen((FileAnalysisErrors errors) => errorCount += errors.errors.length);
 
     await server.start();
+    process.triggerSimulatedAnalysis();
+    await server.waitForAnalysis();
+
+    expect(errorCount, 0);
+
+    await server.dispose();
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
+  testUsingContext('AnalysisServer errors', () async {
+    final Directory tempDir = fileSystem.systemTempDirectory.createTempSync(
+      'flutter_analysis_test.',
+    );
+    createSampleProject(tempDir, brokenCode: true);
+
+    final process = MockLspServerProcess();
+    final processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          fileSystem.path.join('Artifact.engineDartSdkPath', 'bin', 'dart'),
+          'language-server',
+          '--dart-sdk',
+          'Artifact.engineDartSdkPath',
+          '--disable-server-feature-completion',
+          '--disable-server-feature-search',
+          '--suppress-analytics',
+        ],
+        process: process,
+      ),
+    ]);
+
+    final server = AnalysisServer(
+      'Artifact.engineDartSdkPath',
+      <String>[tempDir.path],
+      fileSystem: fileSystem,
+      platform: FakePlatform(),
+      processManager: processManager,
+      logger: logger,
+      terminal: terminal,
+      suppressAnalytics: true,
+    );
+
+    var errorCount = 0;
+    server.onErrors.listen((FileAnalysisErrors errors) => errorCount += errors.errors.length);
+
+    await server.start();
+    process.triggerSimulatedAnalysis(diagnosticsFor: Uri.parse('file:///directoryA/foo'));
     await server.waitForAnalysis();
 
     expect(errorCount, greaterThan(0));
@@ -185,17 +165,16 @@ void main() {
   });
 
   testUsingContext('Returns no errors when source is error-free', () async {
-    final fileSystem = MemoryFileSystem.test();
     final Directory tempDir = fileSystem.systemTempDirectory.createTempSync(
       'flutter_analysis_test.',
     );
     createSampleProject(tempDir);
 
-    final stdin = StreamController<List<int>>();
+    final process = MockLspServerProcess();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
-        command: const <String>[
-          'Artifact.engineDartSdkPath/bin/dart',
+        command: <String>[
+          fileSystem.path.join('Artifact.engineDartSdkPath', 'bin', 'dart'),
           'language-server',
           '--dart-sdk',
           'Artifact.engineDartSdkPath',
@@ -203,15 +182,7 @@ void main() {
           '--disable-server-feature-search',
           '--suppress-analytics',
         ],
-        stdin: IOSink(stdin.sink),
-        stdout:
-            'Content-Length: 36\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{}}'
-            'Content-Length: 93\r\n\r\n'
-            r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-            '"value":{"kind":"begin"}}}'
-            'Content-Length: 91\r\n\r\n'
-            r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-            '"value":{"kind":"end"}}}',
+        process: process,
       ),
     ]);
 
@@ -231,6 +202,7 @@ void main() {
       errorCount += errors.errors.length;
     });
     await server.start();
+    process.triggerSimulatedAnalysis();
     await server.waitForAnalysis();
     expect(errorCount, 0);
     await server.dispose();
@@ -238,7 +210,7 @@ void main() {
   });
 
   testUsingContext('Can run AnalysisService without suppressing analytics', () async {
-    final stdin = StreamController<List<int>>();
+    final process = MockLspServerProcess();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>[
@@ -249,9 +221,7 @@ void main() {
           '--disable-server-feature-completion',
           '--disable-server-feature-search',
         ],
-        stdin: IOSink(stdin.sink),
-        stdout:
-            'Content-Length: 53\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}\r\n',
+        process: process,
       ),
     ]);
 
@@ -259,7 +229,7 @@ void main() {
     final command = AnalyzeCommand(
       terminal: Terminal.test(),
       artifacts: artifacts,
-      logger: BufferLogger.test(),
+      logger: logger,
       platform: FakePlatform(),
       fileSystem: MemoryFileSystem.test(),
       processManager: processManager,
@@ -270,13 +240,13 @@ void main() {
     final commandRunner = TestFlutterCommandRunner();
     commandRunner.addCommand(command);
     unawaited(commandRunner.run(<String>['analyze', '--watch']));
-    await stdin.stream.first;
+    await process.initializeRequest;
 
     expect(processManager, hasNoRemainingExpectations);
   });
 
   testUsingContext('Can run AnalysisService with customized cache location', () async {
-    final stdin = StreamController<List<int>>();
+    final process = MockLspServerProcess();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>[
@@ -288,9 +258,7 @@ void main() {
           '--disable-server-feature-search',
           '--suppress-analytics',
         ],
-        stdin: IOSink(stdin.sink),
-        stdout:
-            'Content-Length: 53\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}\r\n',
+        process: process,
       ),
     ]);
 
@@ -298,7 +266,7 @@ void main() {
     final command = AnalyzeCommand(
       terminal: Terminal.test(),
       artifacts: artifacts,
-      logger: BufferLogger.test(),
+      logger: logger,
       platform: FakePlatform(),
       fileSystem: MemoryFileSystem.test(),
       processManager: processManager,
@@ -309,28 +277,13 @@ void main() {
     final commandRunner = TestFlutterCommandRunner();
     commandRunner.addCommand(command);
     unawaited(commandRunner.run(<String>['analyze', '--watch']));
-    await stdin.stream.first;
+    await process.initializeRequest;
 
     expect(processManager, hasNoRemainingExpectations);
   });
 
   testUsingContext('Can run AnalysisService with customized cache location --watch', () async {
-    // Use Windows style on Windows host so Uri.toFilePath() parses it correctly with drive letters.
-    final fileSystem = MemoryFileSystem.test(
-      style: const LocalPlatform().isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
-    );
-    fileSystem.directory('directoryA').childFile('foo').createSync(recursive: true);
-
-    final logger = BufferLogger.test();
-
-    final fooUri = fileSystem.path.toUri(fileSystem.path.absolute('directoryA', 'foo')).toString();
-    final diagnosticsJson =
-        '{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{'
-        '"uri":"$fooUri","diagnostics":[{"range":{"start":{"line":99,'
-        '"character":4},"end":{"line":99,"character":4}},"severity":2,"code":"500",'
-        '"message":"It\'s an error."}]}}';
-
-    final stdin = StreamController<List<int>>();
+    final process = MockLspServerProcess();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: <String>[
@@ -342,17 +295,7 @@ void main() {
           '--disable-server-feature-search',
           '--suppress-analytics',
         ],
-        stdin: IOSink(stdin.sink),
-        stdout:
-            'Content-Length: 36\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{}}'
-            'Content-Length: 93\r\n\r\n'
-            r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-            '"value":{"kind":"begin"}}}'
-            'Content-Length: ${diagnosticsJson.length}\r\n\r\n'
-            '$diagnosticsJson'
-            'Content-Length: 91\r\n\r\n'
-            r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-            '"value":{"kind":"end"}}}',
+        process: process,
       ),
     ]);
 
@@ -371,6 +314,13 @@ void main() {
     final commandRunner = TestFlutterCommandRunner();
     commandRunner.addCommand(command);
     unawaited(commandRunner.run(<String>['analyze', '--watch']));
+    await process.initializeRequest;
+
+    // Trigger analysis and diagnostics for an existing file.
+    final File targetFile = fileSystem.directory('directoryA').childFile('foo')
+      ..createSync(recursive: true);
+    final Uri targetUri = toUri(targetFile.path);
+    process.triggerSimulatedAnalysis(diagnosticsFor: targetUri);
 
     while (!logger.statusText.contains('analyzed 1 file')) {
       await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -383,8 +333,7 @@ void main() {
   });
 
   testUsingContext('AnalysisService --watch skips errors from non-files', () async {
-    final logger = BufferLogger.test();
-    final stdin = StreamController<List<int>>();
+    final process = MockLspServerProcess();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>[
@@ -396,20 +345,7 @@ void main() {
           '--disable-server-feature-search',
           '--suppress-analytics',
         ],
-        stdin: IOSink(stdin.sink),
-        stdout:
-            'Content-Length: 36\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{}}'
-            'Content-Length: 93\r\n\r\n'
-            r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-            '"value":{"kind":"begin"}}}'
-            'Content-Length: 249\r\n\r\n'
-            '{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{'
-            '"uri":"file:///directoryA/bar","diagnostics":[{"range":{"start":{"line":99,'
-            '"character":4},"end":{"line":99,"character":4}},"severity":2,"code":"500",'
-            '"message":"It\'s an error."}]}}'
-            'Content-Length: 91\r\n\r\n'
-            r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-            '"value":{"kind":"end"}}}',
+        process: process,
       ),
     ]);
 
@@ -428,6 +364,12 @@ void main() {
     final commandRunner = TestFlutterCommandRunner();
     commandRunner.addCommand(command);
     unawaited(commandRunner.run(<String>['analyze', '--watch']));
+    await process.initializeRequest;
+
+    // Trigger analysis and diagnostics for a non-existing file.
+    final File targetFile = fileSystem.directory('directoryA').childFile('foo');
+    final Uri targetUri = toUri(targetFile.path);
+    process.triggerSimulatedAnalysis(diagnosticsFor: targetUri);
 
     while (!logger.statusText.contains('analyzed 1 file')) {
       await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -445,8 +387,7 @@ void main() {
       // invoke json.decode(...) on the VM service message.
       //
       // Regression test for https://github.com/flutter/flutter/issues/58391.
-      final logger = BufferLogger.test();
-      final stdin = StreamController<List<int>>();
+      final process = MockLspServerProcess();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
           command: const <String>[
@@ -458,21 +399,7 @@ void main() {
             '--disable-server-feature-search',
             '--suppress-analytics',
           ],
-          stdin: IOSink(stdin.sink),
-          stdout:
-              'The Dart VM service is listening on http://127.0.0.1:65155/ZkxDXuYz2Aw=/\n'
-              'Content-Length: 36\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{}}'
-              'Content-Length: 93\r\n\r\n'
-              r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-              '"value":{"kind":"begin"}}}'
-              'Content-Length: 249\r\n\r\n'
-              '{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{'
-              '"uri":"file:///directoryA/bar","diagnostics":[{"range":{"start":{"line":99,'
-              '"character":4},"end":{"line":99,"character":4}},"severity":2,"code":"500",'
-              '"message":"It\'s an error."}]}}'
-              'Content-Length: 91\r\n\r\n'
-              r'{"jsonrpc":"2.0","method":"$/progress","params":{"token":"analyze",'
-              '"value":{"kind":"end"}}}',
+          process: process,
         ),
       ]);
 
@@ -491,6 +418,10 @@ void main() {
       final commandRunner = TestFlutterCommandRunner();
       commandRunner.addCommand(command);
       unawaited(commandRunner.run(<String>['analyze', '--watch']));
+      await process.initializeRequest;
+      process
+        ..triggerVmServiceUriBanner()
+        ..triggerSimulatedAnalysis(diagnosticsFor: Uri.parse('file:///directoryA/foo'));
 
       while (!logger.statusText.contains('analyzed 1 file')) {
         await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -501,4 +432,66 @@ void main() {
       expect(processManager, hasNoRemainingExpectations);
     },
   );
+
+  testUsingContext('AnalysisService --watch handles errors coming and going', () async {
+    final process = MockLspServerProcess();
+    final processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          fileSystem.path.join('Artifact.engineDartSdkPath', 'bin', 'dart'),
+          'language-server',
+          '--dart-sdk',
+          'Artifact.engineDartSdkPath',
+          '--disable-server-feature-completion',
+          '--disable-server-feature-search',
+          '--suppress-analytics',
+        ],
+        process: process,
+      ),
+    ]);
+
+    final artifacts = Artifacts.test();
+    final command = AnalyzeCommand(
+      terminal: Terminal.test(),
+      artifacts: artifacts,
+      logger: logger,
+      platform: FakePlatform(),
+      fileSystem: fileSystem,
+      processManager: processManager,
+      allProjectValidators: <ProjectValidator>[],
+      suppressAnalytics: true,
+    );
+
+    final commandRunner = TestFlutterCommandRunner();
+    commandRunner.addCommand(command);
+    unawaited(commandRunner.run(<String>['analyze', '--watch']));
+    await process.initializeRequest;
+
+    // Simulate some diagnostics coming and going. The file must exist.
+    final File targetFile = fileSystem.directory('directoryA').childFile('foo')
+      ..createSync(recursive: true);
+    final Uri targetUri = toUri(targetFile.path);
+
+    await process.runSimulatedAnalysis(diagnosticsFor: targetUri); // 1 new
+    await process.runSimulatedAnalysis(diagnosticsFor: targetUri, diagnosticsCount: 0); // 1 fixed
+    await process.runSimulatedAnalysis(diagnosticsFor: targetUri, diagnosticsCount: 2); // 2 new
+    await process.runSimulatedAnalysis(diagnosticsFor: targetUri, diagnosticsCount: 0); // 2 fixed
+
+    // Wait for the final line we expect.
+    while (!logger.statusText.contains('2 fixed')) {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+
+    expect(
+      logger.statusText.split('\n'),
+      containsAllInOrder([
+        contains('1 new'),
+        contains('1 fixed'),
+        contains('2 new'),
+        contains('2 fixed'),
+      ]),
+    );
+    expect(logger.errorText, isEmpty);
+    expect(processManager, hasNoRemainingExpectations);
+  });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:convert';
-
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -20,8 +17,8 @@ import 'package:flutter_tools/src/project_validator.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/fake_process_manager.dart' as test_process_manager;
 import '../../src/test_flutter_command_runner.dart';
+import 'analysis_server_mock.dart';
 
 const _kFlutterRoot = '/data/flutter';
 const SIGABRT = -6;
@@ -156,10 +153,7 @@ void main() {
     testUsingContext(
       '--flutter-repo analyzes everything in the flutterRoot',
       () async {
-        final streamController = StreamController<List<int>>();
-        final sink = IOSink(streamController.sink);
-        final exitCompleter = Completer<void>();
-        final process = _CustomLspProcess(stdin: sink, exitCompleter: exitCompleter);
+        final process = MockLspServerProcess();
         processManager.addCommands(<FakeCommand>[
           FakeCommand(
             // artifact paths are from Artifacts.test() and stable
@@ -176,41 +170,9 @@ void main() {
           ),
         ]);
 
-        final buffer = StringBuffer();
-        final messageReceived = Completer<void>();
-        String? firstMessage;
-
-        streamController.stream.transform(utf8.decoder).listen((String chunk) {
-          buffer.write(chunk);
-          final current = buffer.toString();
-          if (current.contains('{') && firstMessage == null) {
-            final int startIndex = current.indexOf('{');
-            firstMessage = current.substring(startIndex);
-            final request = jsonDecode(firstMessage!) as Map<String, Object?>;
-            if (request['method'] == 'initialize') {
-              process.addResponse(
-                '{"jsonrpc":"2.0","id":1,"result":'
-                '{"capabilities":{"window":{"workDoneProgress":true}}}}',
-              );
-              process.addResponse(
-                r'{"jsonrpc":"2.0","method":"$/progress","params":'
-                r'{"token":"analyze","value":{"kind":"begin"}}}',
-              );
-              process.addResponse(
-                r'{"jsonrpc":"2.0","method":"$/progress","params":'
-                r'{"token":"analyze","value":{"kind":"end"}}}',
-              );
-              exitCompleter.complete();
-              messageReceived.complete();
-            }
-          }
-        });
-
         await runner.run(<String>['analyze', '--flutter-repo']);
 
-        expect(firstMessage, isNotNull);
-        final request = jsonDecode(firstMessage!) as Map<String, Object?>;
-        expect(request['method'], 'initialize');
+        final Map<String, Object?> request = await process.initializeRequest;
         final params = request['params']! as Map<String, Object?>;
         expect(
           params['workspaceFolders'] as List?,
@@ -270,18 +232,4 @@ bool inRepo(List<String>? fileList, FileSystem fileSystem) {
     }
   }
   return false;
-}
-
-class _CustomLspProcess extends test_process_manager.FakeProcess {
-  _CustomLspProcess({super.stdin, Completer<void>? exitCompleter})
-    : super(completer: exitCompleter);
-
-  final StreamController<List<int>> _stdoutController = StreamController<List<int>>();
-
-  @override
-  Stream<List<int>> get stdout => _stdoutController.stream;
-
-  void addResponse(String message) {
-    _stdoutController.add(utf8.encode('Content-Length: ${message.length}\r\n\r\n$message'));
-  }
 }


### PR DESCRIPTION
This updates the `flutter analyze` implementation for one-shot analysis from relying on the progress notifications to instead using the custom `dart/workspace/analysis/complete` request. This request waits for analysis to complete before returning and handles waiting for server + plugin startup plus any in-progress analysis for both server and plugins.

This will avoid `flutter analyze` terminating too early in the case of slow plugin startups or hanging if we debounce progress notifications for short analysis.

The `--watch` mode continues to use the progress notifications, since it uses them to report progress to the user and not as a signal for being complete.

As part of this, I extracted a mock LSP server to simplify the tests a little, since the implementation of the fake server is a bit more complex now.

Fixes [#190839](https://github.com/flutter/flutter/issues/190839)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
