### PR TITLE
[flutter_tools] Add integration coverage for test presets

### DIFF
--- a/dev/automated_tests/dart_test.yaml
+++ b/dev/automated_tests/dart_test.yaml
@@ -1,0 +1,7 @@
+presets:
+  passing:
+    plain_names:
+      - preset selected
+  filtered:
+    names:
+      - ^command option

--- a/dev/automated_tests/flutter_test/preset_test.dart
+++ b/dev/automated_tests/flutter_test/preset_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('preset selected', () {});
+  test('not selected by the passing preset', () => fail('The preset was not applied.'));
+  test('command option combined selection', () {});
+  test('command option filtered out', () => fail('The command option was not applied.'));
+  test(
+    'outside preset combined selection',
+    () => fail('The preset was not combined with the command option.'),
+  );
+}

--- a/packages/flutter_tools/test/integration.shard/test_test.dart
+++ b/packages/flutter_tools/test/integration.shard/test_test.dart
@@ -328,6 +328,49 @@ void main() {
     );
   });
 
+  testWithoutContext('flutter test supports the short preset option', () async {
+    final ProcessResult result = await _runFlutterTest(
+      'preset',
+      automatedTestsDirectory,
+      flutterTestDirectory,
+      extraArguments: const <String>['-P', 'passing'],
+    );
+    expect(result, const ProcessResultMatcher());
+  });
+
+  testWithoutContext('flutter test supports the long preset option', () async {
+    final ProcessResult result = await _runFlutterTest(
+      'preset',
+      automatedTestsDirectory,
+      flutterTestDirectory,
+      extraArguments: const <String>['--preset=passing'],
+    );
+    expect(result, const ProcessResultMatcher());
+  });
+
+  testWithoutContext('flutter test reports an undefined preset', () async {
+    final ProcessResult result = await _runFlutterTest(
+      'preset',
+      automatedTestsDirectory,
+      flutterTestDirectory,
+      extraArguments: const <String>['--preset=missing'],
+    );
+    expect(
+      result,
+      const ProcessResultMatcher(exitCode: 64, stderrPattern: 'Undefined preset "missing".'),
+    );
+  });
+
+  testWithoutContext('flutter test combines a preset with other test options', () async {
+    final ProcessResult result = await _runFlutterTest(
+      'preset',
+      automatedTestsDirectory,
+      flutterTestDirectory,
+      extraArguments: const <String>['--preset=filtered', '--plain-name=combined selection'],
+    );
+    expect(result, const ProcessResultMatcher());
+  });
+
   testWithoutContext('flutter test should run a test with an exact name in URI format', () async {
     final ProcessResult result = await _runFlutterTest(
       'uri_format',


### PR DESCRIPTION
#190878 added `--preset` / `-P` support to `flutter test`. This PR adds real-command integration coverage for that behavior in both the standard and experimental faster test runners.

The tests exercise the short and long flag forms, an undefined preset, composition with `--plain-name`, and a two-file `--experimental-faster-testing` invocation.

Related to #189191.

## Tests

- `../../bin/flutter test --no-pub test/commands.shard/hermetic/test_test.dart` (56 tests)
- `../../bin/flutter test --no-pub test/integration.shard/test_test.dart --concurrency=1` (39 tests)
- `../../bin/flutter test --no-pub --experimental-faster-testing -P passing flutter_test/preset_test.dart flutter_test/trivial_test.dart`
- `./bin/dart analyze --fatal-infos packages/flutter_tools/lib/src/commands/test.dart packages/flutter_tools/lib/src/test/runner.dart packages/flutter_tools/test/commands.shard/hermetic/test_test.dart packages/flutter_tools/test/integration.shard/test_test.dart dev/automated_tests/flutter_test/preset_test.dart`
- `./bin/dart format --output=none --set-exit-if-changed packages/flutter_tools/lib/src/commands/test.dart packages/flutter_tools/lib/src/test/runner.dart packages/flutter_tools/test/commands.shard/hermetic/test_test.dart packages/flutter_tools/test/integration.shard/test_test.dart dev/automated_tests/flutter_test/preset_test.dart`
- `./bin/flutter analyze --flutter-repo`
- `git diff --check`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement]. The change is limited to flutter_tools tests and does not add widgets.
- [x] I signed the [CLA]. This must be confirmed by the account holder.
- [x] I listed at least one issue that this PR relates to in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`). No public API is added by this test-only change.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported. This is a test-only change and does not alter an API.
- [x] All existing and new tests are passing in the affected suites listed above.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md#deprecations