### PR TITLE
Adds benchmark for windows shadow text.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -7257,6 +7257,20 @@ targets:
         ]
       task_name: windows_home_scroll_perf__timeline_summary
 
+  - name: Windows windows_text_shadow_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    bringup: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly", "windows"]
+      dependencies: >-
+        [
+          {"dependency": "vs_build", "version": "version:vs2019"}
+        ]
+      task_name: windows_text_shadow_perf__timeline_summary
+
   - name: Windows_arm64 windows_home_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -333,6 +333,7 @@
 /dev/devicelab/bin/tasks/windows_desktop_impeller.dart @jonahwilliams @flutter/engine
 /dev/devicelab/bin/tasks/windows_engine_integration_golden_test.dart @b-luk @flutter/engine
 /dev/devicelab/bin/tasks/windows_home_scroll_perf__timeline_summary.dart @jonahwilliams @flutter/engine
+/dev/devicelab/bin/tasks/windows_text_shadow_perf__timeline_summary.dart @gaaclarke @flutter/engine
 /dev/devicelab/bin/tasks/windows_startup_test.dart @loic-sharma @flutter/desktop
 
 ## Host only framework tests

--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -45,6 +45,7 @@ const String kDrawAtlasPageRouteName = '/draw_atlas';
 const String kAnimatedAdvancedBlend = '/animated_advanced_blend';
 const String kRRectBlurRouteName = '/rrect_blur';
 const String kRSuperellipseBlurRouteName = '/rsuperellipse_blur';
+const String kTextShadowPerfRouteName = '/text_shadow_perf';
 
 const String kOpacityPeepholeOneRectRouteName = '$kOpacityPeepholeRouteName/one_big_rect';
 const String kOpacityPeepholeColumnOfOpacityRouteName =

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -44,6 +44,7 @@ import 'src/simple_animation.dart';
 import 'src/simple_scroll.dart';
 import 'src/sliders.dart';
 import 'src/text.dart';
+import 'src/text_shadow_perf.dart';
 import 'src/very_long_picture_scrolling.dart';
 
 const String kMacrobenchmarks = 'Macrobenchmarks';
@@ -118,6 +119,7 @@ class MacrobenchmarksApp extends StatelessWidget {
             const DrawArcsPage(paintStyle: PaintingStyle.fill),
         kDrawArcsAllStrokeStylesPageRouteName: (BuildContext context) =>
             const DrawArcsPage(paintStyle: PaintingStyle.stroke),
+        kTextShadowPerfRouteName: (BuildContext context) => const TextShadowPerfPage(),
       },
     );
   }
@@ -427,6 +429,13 @@ class HomePage extends StatelessWidget {
             child: const Text('Draw Stroke Style Arcs'),
             onPressed: () {
               Navigator.pushNamed(context, kDrawArcsAllStrokeStylesPageRouteName);
+            },
+          ),
+          ElevatedButton(
+            key: const Key(kTextShadowPerfRouteName),
+            child: const Text('Text Shadow Performance'),
+            onPressed: () {
+              Navigator.pushNamed(context, kTextShadowPerfRouteName);
             },
           ),
         ],

--- a/dev/benchmarks/macrobenchmarks/lib/src/text_shadow_perf.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/text_shadow_perf.dart
@@ -1,0 +1,133 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Macrobenchmark page reproducing the text shadow scrolling workload from
+/// https://github.com/flutter/flutter/issues/190395.
+class TextShadowPerfPage extends StatefulWidget {
+  const TextShadowPerfPage({super.key});
+
+  @override
+  State<TextShadowPerfPage> createState() => _TextShadowPerfPageState();
+}
+
+class _TextShadowPerfPageState extends State<TextShadowPerfPage>
+    with SingleTickerProviderStateMixin {
+  late final ScrollController _scrollController;
+  late final AnimationController _animationController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+    _animationController = AnimationController(vsync: this, duration: const Duration(seconds: 10))
+      ..repeat(reverse: true);
+    _animationController.addListener(_onAnimationTick);
+  }
+
+  void _onAnimationTick() {
+    if (_scrollController.hasClients && _scrollController.position.maxScrollExtent > 0) {
+      _scrollController.jumpTo(
+        _animationController.value * _scrollController.position.maxScrollExtent,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _animationController.removeListener(_onAnimationTick);
+    _animationController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const columnCount = 7;
+    const groupsPerColumn = 28;
+
+    return Scaffold(
+      backgroundColor: const Color(0xff080808),
+      body: ScrollConfiguration(
+        behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+        child: SingleChildScrollView(
+          controller: _scrollController,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: List<Widget>.generate(columnCount, (int column) {
+              return Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(6),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: List<Widget>.generate(groupsPerColumn, (int row) {
+                      return _TextShadowGroup(index: column * groupsPerColumn + row);
+                    }),
+                  ),
+                ),
+              );
+            }),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TextShadowGroup extends StatelessWidget {
+  const _TextShadowGroup({required this.index});
+
+  final int index;
+
+  static const List<Shadow> _shadows = <Shadow>[Shadow(blurRadius: 1.0)];
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 230,
+      child: Align(
+        alignment: Alignment.bottomLeft,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                'Synthetic text item $index',
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 10,
+                  fontWeight: FontWeight.bold,
+                  shadows: _shadows,
+                ),
+              ),
+              Row(
+                children: <Widget>[
+                  Text(
+                    '${8 + index % 14}:30',
+                    style: const TextStyle(
+                      color: Color(0xff43ddff),
+                      fontSize: 9,
+                      fontWeight: FontWeight.bold,
+                      shadows: _shadows,
+                    ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    'Ep ${1 + index % 24}',
+                    style: const TextStyle(color: Colors.white70, fontSize: 9, shadows: _shadows),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/dev/benchmarks/macrobenchmarks/test_driver/text_shadow_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/text_shadow_perf_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTest(
+    'text_shadow_perf',
+    kTextShadowPerfRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}

--- a/dev/devicelab/bin/tasks/windows_text_shadow_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/windows_text_shadow_perf__timeline_summary.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.windows;
+  await task(createTextShadowPerfTest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -376,6 +376,16 @@ TaskFunction createTextfieldPerfE2ETest() {
   ).run;
 }
 
+TaskFunction createTextShadowPerfTest({bool? enableImpeller}) {
+  return PerfTest(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test_driver/run_app.dart',
+    'text_shadow_perf',
+    testDriver: 'test_driver/text_shadow_perf_test.dart',
+    enableImpeller: enableImpeller,
+  ).run;
+}
+
 TaskFunction createVeryLongPictureScrollingPerfE2ETest({required bool enableImpeller}) {
   return PerfTest.e2e(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -376,6 +376,7 @@ TaskFunction createTextfieldPerfE2ETest() {
   ).run;
 }
 
+/// Creates a task that runs the text shadow performance benchmark.
 TaskFunction createTextShadowPerfTest({bool? enableImpeller}) {
   return PerfTest(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',


### PR DESCRIPTION
issue https://github.com/flutter/flutter/issues/190395

## test results on macos

   Metric                                     | Stock Engine (host_profile)                | Patched Engine (text-shadow-cache-by-content) | Improvement
  --------------------------------------------|--------------------------------------------|-----------------------------------------------|-------------------------------------------
   Average Raster Time                        | 6.82 ms                                    | 1.11 ms                                       | ~6.1x faster
   90th Percentile Raster Time                | 8.66 ms                                    | 1.72 ms                                       | ~5.0x faster
   99th Percentile Raster Time                | 9.73 ms                                    | 2.53 ms                                       | ~3.8x faster
   Worst Frame Raster Time                    | 10.14 ms                                   | 2.67 ms                                       | ~3.8x faster

The patch is from https://github.com/flutter/flutter/pull/190681

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
