### PR TITLE
[stable] [Flutter GPU] Add a project-level Flutter GPU setting to the Linux and Windows embedders

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_dart_project.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_dart_project.cc
@@ -16,6 +16,7 @@ struct _FlDartProject {
 
   FlUIThreadPolicy ui_thread_policy;
   gboolean enable_impeller;
+  gboolean enable_flutter_gpu;
 };
 
 G_DEFINE_TYPE(FlDartProject, fl_dart_project, G_TYPE_OBJECT)
@@ -144,4 +145,17 @@ G_MODULE_EXPORT
 gboolean fl_dart_project_get_enable_impeller(FlDartProject* project) {
   g_return_val_if_fail(FL_IS_DART_PROJECT(project), FALSE);
   return project->enable_impeller;
+}
+
+G_MODULE_EXPORT
+void fl_dart_project_set_enable_flutter_gpu(FlDartProject* project,
+                                            gboolean enable_flutter_gpu) {
+  g_return_if_fail(FL_IS_DART_PROJECT(project));
+  project->enable_flutter_gpu = enable_flutter_gpu;
+}
+
+G_MODULE_EXPORT
+gboolean fl_dart_project_get_enable_flutter_gpu(FlDartProject* project) {
+  g_return_val_if_fail(FL_IS_DART_PROJECT(project), FALSE);
+  return project->enable_flutter_gpu;
 }

--- a/engine/src/flutter/shell/platform/linux/fl_dart_project_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_dart_project_test.cc
@@ -80,3 +80,13 @@ TEST_F(FlDartProjectTest, EnableImpeller) {
   fl_dart_project_set_enable_impeller(project, TRUE);
   EXPECT_TRUE(fl_dart_project_get_enable_impeller(project));
 }
+
+TEST_F(FlDartProjectTest, EnableFlutterGpu) {
+  EXPECT_FALSE(fl_dart_project_get_enable_flutter_gpu(project));
+
+  fl_dart_project_set_enable_flutter_gpu(project, TRUE);
+  EXPECT_TRUE(fl_dart_project_get_enable_flutter_gpu(project));
+
+  fl_dart_project_set_enable_flutter_gpu(project, FALSE);
+  EXPECT_FALSE(fl_dart_project_get_enable_flutter_gpu(project));
+}

--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -812,9 +812,12 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
       break;
   }
 
+  const std::vector<std::string> env_switches =
+      flutter::GetSwitchesFromEnvironment();
+
   gboolean enable_impeller = fl_dart_project_get_enable_impeller(self->project);
   gboolean has_enable_impeller = FALSE;
-  for (const auto& env_switch : flutter::GetSwitchesFromEnvironment()) {
+  for (const auto& env_switch : env_switches) {
     if (env_switch == "--enable-impeller" ||
         env_switch == "--enable-impeller=true") {
       enable_impeller = TRUE;
@@ -828,7 +831,7 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   g_autoptr(GPtrArray) command_line_args =
       g_ptr_array_new_with_free_func(g_free);
   g_ptr_array_insert(command_line_args, 0, g_strdup("flutter"));
-  for (const auto& env_switch : flutter::GetSwitchesFromEnvironment()) {
+  for (const auto& env_switch : env_switches) {
     g_ptr_array_add(command_line_args, g_strdup(env_switch.c_str()));
   }
   // Linux (and other desktop platforms) always uses SDFs.
@@ -836,6 +839,23 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
 
   if (enable_impeller && !has_enable_impeller) {
     g_ptr_array_add(command_line_args, g_strdup("--enable-impeller"));
+  }
+
+  // Forward the project's Flutter GPU setting unless an environment switch
+  // already carries it (the switch is presence based, so it is only ever
+  // added, never negated).
+  if (fl_dart_project_get_enable_flutter_gpu(self->project)) {
+    gboolean has_enable_flutter_gpu = FALSE;
+    for (const auto& env_switch : env_switches) {
+      if (env_switch == "--enable-flutter-gpu" ||
+          env_switch == "--enable-flutter-gpu=true") {
+        has_enable_flutter_gpu = TRUE;
+        break;
+      }
+    }
+    if (!has_enable_flutter_gpu) {
+      g_ptr_array_add(command_line_args, g_strdup("--enable-flutter-gpu"));
+    }
   }
 
   gchar** dart_entrypoint_args =

--- a/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
@@ -1008,6 +1008,58 @@ TEST_F(FlEngineTest, DisableImpeller) {
   EXPECT_TRUE(called);
 }
 
+TEST_F(FlEngineTest, EnableFlutterGpuDefault) {
+  bool called = false;
+  fl_engine_get_embedder_api(engine)->Initialize = MOCK_ENGINE_PROC(
+      Initialize,
+      ([&called](size_t version, const FlutterRendererConfig* config,
+                 const FlutterProjectArgs* args, void* user_data,
+                 FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+        called = true;
+        bool has_flutter_gpu_switch = false;
+        for (int i = 0; i < args->command_line_argc; i++) {
+          if (strcmp(args->command_line_argv[i], "--enable-flutter-gpu") == 0) {
+            has_flutter_gpu_switch = true;
+          }
+        }
+        EXPECT_FALSE(has_flutter_gpu_switch);
+        return kSuccess;
+      }));
+  fl_engine_get_embedder_api(engine)->RunInitialized =
+      MOCK_ENGINE_PROC(RunInitialized, ([](auto engine) { return kSuccess; }));
+
+  StartEngine();
+  EXPECT_TRUE(called);
+}
+
+TEST_F(FlEngineTest, EnableFlutterGpu) {
+  fl_dart_project_set_enable_flutter_gpu(project, TRUE);
+
+  bool called = false;
+  fl_engine_get_embedder_api(engine)->Initialize = MOCK_ENGINE_PROC(
+      Initialize,
+      ([&called](size_t version, const FlutterRendererConfig* config,
+                 const FlutterProjectArgs* args, void* user_data,
+                 FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+        called = true;
+        bool has_flutter_gpu_switch = false;
+        for (int i = 0; i < args->command_line_argc; i++) {
+          if (strcmp(args->command_line_argv[i], "--enable-flutter-gpu") == 0) {
+            has_flutter_gpu_switch = true;
+          }
+        }
+        EXPECT_TRUE(has_flutter_gpu_switch);
+        return kSuccess;
+      }));
+  fl_engine_get_embedder_api(engine)->RunInitialized =
+      MOCK_ENGINE_PROC(RunInitialized, ([](auto engine) { return kSuccess; }));
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+  EXPECT_TRUE(called);
+}
+
 TEST_F(FlEngineTest, ChildObjects) {
   // Check objects exist before engine started.
   EXPECT_NE(fl_engine_get_binary_messenger(engine), nullptr);

--- a/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_dart_project.h
+++ b/engine/src/flutter/shell/platform/linux/public/flutter_linux/fl_dart_project.h
@@ -178,6 +178,25 @@ void fl_dart_project_set_enable_impeller(FlDartProject* project,
  */
 gboolean fl_dart_project_get_enable_impeller(FlDartProject* project);
 
+/**
+ * fl_dart_project_set_enable_flutter_gpu:
+ * @project: an #FlDartProject.
+ * @enable_flutter_gpu: whether to enable the Flutter GPU API.
+ *
+ * Sets whether the Flutter GPU API (package:flutter_gpu) should be enabled.
+ * Flutter GPU requires the Impeller renderer.
+ */
+void fl_dart_project_set_enable_flutter_gpu(FlDartProject* project,
+                                            gboolean enable_flutter_gpu);
+
+/**
+ * fl_dart_project_get_enable_flutter_gpu:
+ * @project: an #FlDartProject.
+ *
+ * Returns: %TRUE if the Flutter GPU API is enabled.
+ */
+gboolean fl_dart_project_get_enable_flutter_gpu(FlDartProject* project);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_PUBLIC_FLUTTER_LINUX_FL_DART_PROJECT_H_

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/dart_project_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/dart_project_unittests.cc
@@ -55,4 +55,15 @@ TEST_F(DartProjectTest, DartEntrypointArguments) {
   EXPECT_EQ(returned_arguments[2], "arg3");
 }
 
+TEST_F(DartProjectTest, EnableFlutterGpu) {
+  DartProject project(L"test");
+  EXPECT_FALSE(project.enable_flutter_gpu());
+
+  project.set_enable_flutter_gpu(true);
+  EXPECT_TRUE(project.enable_flutter_gpu());
+
+  project.set_enable_flutter_gpu(false);
+  EXPECT_FALSE(project.enable_flutter_gpu());
+}
+
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/flutter_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/flutter_engine.cc
@@ -27,6 +27,7 @@ FlutterEngine::FlutterEngine(const DartProject& project) {
           project.accessibility_mode());
   c_engine_properties.impeller_switch =
       static_cast<FlutterDesktopImpellerSwitch>(project.impeller_switch());
+  c_engine_properties.enable_flutter_gpu = project.enable_flutter_gpu();
 
   const std::vector<std::string>& entrypoint_args =
       project.dart_entrypoint_arguments();

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
@@ -153,6 +153,16 @@ class DartProject {
   // Defaults to ImpellerSwitch::Default.
   ImpellerSwitch impeller_switch() const { return impeller_switch_; }
 
+  // Sets whether the Flutter GPU API (package:flutter_gpu) is enabled.
+  // Flutter GPU requires the Impeller renderer.
+  void set_enable_flutter_gpu(bool enable_flutter_gpu) {
+    enable_flutter_gpu_ = enable_flutter_gpu;
+  }
+
+  // Returns whether the Flutter GPU API is enabled.
+  // Defaults to false.
+  bool enable_flutter_gpu() const { return enable_flutter_gpu_; }
+
  private:
   // Accessors for internals are private, so that they can be changed if more
   // flexible options for project structures are needed later without it
@@ -185,6 +195,8 @@ class DartProject {
   AccessibilityMode accessibility_mode_ = AccessibilityMode::Default;
   // The Impeller enablement switch.
   ImpellerSwitch impeller_switch_ = ImpellerSwitch::Default;
+  // Whether the Flutter GPU API is enabled.
+  bool enable_flutter_gpu_ = false;
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/flutter_project_bundle.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_project_bundle.cc
@@ -42,6 +42,8 @@ FlutterProjectBundle::FlutterProjectBundle(
   impeller_switch_ =
       static_cast<FlutterImpellerSwitch>(properties.impeller_switch);
 
+  enable_flutter_gpu_ = properties.enable_flutter_gpu;
+
   // Resolve any relative paths.
   if (assets_path_.is_relative() || icu_path_.is_relative() ||
       (!aot_library_path_.empty() && aot_library_path_.is_relative())) {

--- a/engine/src/flutter/shell/platform/windows/flutter_project_bundle.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_project_bundle.h
@@ -97,6 +97,9 @@ class FlutterProjectBundle {
   // Returns the Impeller enablement switch.
   FlutterImpellerSwitch impeller_switch() const { return impeller_switch_; }
 
+  // Returns whether the Flutter GPU API is enabled.
+  bool enable_flutter_gpu() const { return enable_flutter_gpu_; }
+
  private:
   std::filesystem::path assets_path_;
   std::filesystem::path icu_path_;
@@ -124,6 +127,9 @@ class FlutterProjectBundle {
 
   // The Impeller enablement switch.
   FlutterImpellerSwitch impeller_switch_ = FlutterImpellerSwitch::Default;
+
+  // Whether the Flutter GPU API is enabled.
+  bool enable_flutter_gpu_ = false;
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/flutter_project_bundle_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_project_bundle_unittests.cc
@@ -34,6 +34,19 @@ TEST(FlutterProjectBundle, BasicPropertiesRelativePaths) {
   EXPECT_EQ(project.icu_path().filename().string(), "icudtl.dat");
 }
 
+TEST(FlutterProjectBundle, EnableFlutterGpu) {
+  FlutterDesktopEngineProperties properties = {};
+  properties.assets_path = L"foo\\flutter_assets";
+  properties.icu_data_path = L"foo\\icudtl.dat";
+
+  FlutterProjectBundle default_project(properties);
+  EXPECT_FALSE(default_project.enable_flutter_gpu());
+
+  properties.enable_flutter_gpu = true;
+  FlutterProjectBundle project(properties);
+  EXPECT_TRUE(project.enable_flutter_gpu());
+}
+
 TEST(FlutterProjectBundle, SwitchesEmpty) {
   FlutterDesktopEngineProperties properties = {};
   properties.assets_path = L"foo\\flutter_assets";

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.cc
@@ -326,6 +326,16 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
       switches.push_back("--enable-impeller=false");
     }
   }
+  if (project_->enable_flutter_gpu()) {
+    if (std::find(switches.begin(), switches.end(), "--enable-flutter-gpu") ==
+            switches.end() &&
+        std::find(switches.begin(), switches.end(),
+                  "--enable-flutter-gpu=true") == switches.end()) {
+      // Flutter GPU was enabled programmatically, so forward the switch to
+      // the engine.
+      switches.push_back("--enable-flutter-gpu");
+    }
+  }
   std::transform(
       switches.begin(), switches.end(), std::back_inserter(argv),
       [](const std::string& arg) -> const char* { return arg.c_str(); });

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -534,6 +534,115 @@ TEST_F(FlutterWindowsEngineTest, RunWithProjectFlagEnableImpeller) {
   modifier.ReleaseEGLManager();
 }
 
+TEST_F(FlutterWindowsEngineTest, RunWithProjectFlagEnableFlutterGpu) {
+  FlutterWindowsEngineBuilder builder{GetContext()};
+  builder.SetEnableFlutterGpu(true);
+  std::unique_ptr<FlutterWindowsEngine> engine = builder.Build();
+  EngineModifier modifier(engine.get());
+
+  modifier.embedder_api().NotifyDisplayUpdate =
+      MOCK_ENGINE_PROC(NotifyDisplayUpdate,
+                       ([](FLUTTER_API_SYMBOL(FlutterEngine) raw_engine,
+                           const FlutterEngineDisplaysUpdateType update_type,
+                           const FlutterEngineDisplay* embedder_displays,
+                           size_t display_count) { return kSuccess; }));
+
+  modifier.embedder_api().UpdateAccessibilityFeatures = MOCK_ENGINE_PROC(
+      UpdateAccessibilityFeatures,
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+         FlutterAccessibilityFeature flags) { return kSuccess; });
+
+  modifier.embedder_api().UpdateLocales = MOCK_ENGINE_PROC(
+      UpdateLocales, ([](auto engine, const FlutterLocale** locales,
+                         size_t locales_count) { return kSuccess; }));
+
+  modifier.embedder_api().SendPlatformMessage =
+      MOCK_ENGINE_PROC(SendPlatformMessage,
+                       ([](auto engine, auto message) { return kSuccess; }));
+
+  bool run_called = false;
+  modifier.embedder_api().Run = MOCK_ENGINE_PROC(
+      Run, ([&run_called](size_t version, const FlutterRendererConfig* config,
+                          const FlutterProjectArgs* args, void* user_data,
+                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+        run_called = true;
+        *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
+
+        bool has_flutter_gpu_switch = false;
+        for (int i = 0; i < args->command_line_argc; ++i) {
+          if (strcmp(args->command_line_argv[i], "--enable-flutter-gpu") == 0) {
+            has_flutter_gpu_switch = true;
+          }
+        }
+        EXPECT_TRUE(has_flutter_gpu_switch);
+        return kSuccess;
+      }));
+
+  // Set the EGL manager to !nullptr to test ANGLE rendering.
+  modifier.SetEGLManager(std::make_unique<egl::MockManager>());
+
+  engine->Run();
+
+  EXPECT_TRUE(run_called);
+
+  modifier.embedder_api().Shutdown = [](auto engine) { return kSuccess; };
+  modifier.ReleaseEGLManager();
+}
+
+TEST_F(FlutterWindowsEngineTest, RunWithoutProjectFlagEnableFlutterGpu) {
+  FlutterWindowsEngineBuilder builder{GetContext()};
+  std::unique_ptr<FlutterWindowsEngine> engine = builder.Build();
+  EngineModifier modifier(engine.get());
+
+  modifier.embedder_api().NotifyDisplayUpdate =
+      MOCK_ENGINE_PROC(NotifyDisplayUpdate,
+                       ([](FLUTTER_API_SYMBOL(FlutterEngine) raw_engine,
+                           const FlutterEngineDisplaysUpdateType update_type,
+                           const FlutterEngineDisplay* embedder_displays,
+                           size_t display_count) { return kSuccess; }));
+
+  modifier.embedder_api().UpdateAccessibilityFeatures = MOCK_ENGINE_PROC(
+      UpdateAccessibilityFeatures,
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+         FlutterAccessibilityFeature flags) { return kSuccess; });
+
+  modifier.embedder_api().UpdateLocales = MOCK_ENGINE_PROC(
+      UpdateLocales, ([](auto engine, const FlutterLocale** locales,
+                         size_t locales_count) { return kSuccess; }));
+
+  modifier.embedder_api().SendPlatformMessage =
+      MOCK_ENGINE_PROC(SendPlatformMessage,
+                       ([](auto engine, auto message) { return kSuccess; }));
+
+  bool run_called = false;
+  modifier.embedder_api().Run = MOCK_ENGINE_PROC(
+      Run, ([&run_called](size_t version, const FlutterRendererConfig* config,
+                          const FlutterProjectArgs* args, void* user_data,
+                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+        run_called = true;
+        *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
+
+        bool has_flutter_gpu_switch = false;
+        for (int i = 0; i < args->command_line_argc; ++i) {
+          if (strcmp(args->command_line_argv[i], "--enable-flutter-gpu") == 0) {
+            has_flutter_gpu_switch = true;
+          }
+        }
+        EXPECT_FALSE(has_flutter_gpu_switch);
+        return kSuccess;
+      }));
+
+  // Set the EGL manager to !nullptr to test ANGLE rendering.
+  modifier.SetEGLManager(std::make_unique<egl::MockManager>());
+
+  engine->Run();
+
+  EXPECT_TRUE(run_called);
+
+  modifier.embedder_api().Shutdown = [](auto engine) { return kSuccess; };
+  modifier.ReleaseEGLManager();
+}
+
 TEST_F(FlutterWindowsEngineTest, RunWithProjectFlagDisableImpeller) {
   FlutterWindowsEngineBuilder builder{GetContext()};
   builder.SetImpellerSwitch(DisabledImpeller);

--- a/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
+++ b/engine/src/flutter/shell/platform/windows/public/flutter_windows.h
@@ -128,6 +128,11 @@ typedef struct {
 
   // Policy for enabling the Impeller renderer.
   FlutterDesktopImpellerSwitch impeller_switch;
+
+  // Whether to enable the Flutter GPU API (package:flutter_gpu).
+  // Flutter GPU requires the Impeller renderer.
+  // If not set defaults to false.
+  bool enable_flutter_gpu;
 } FlutterDesktopEngineProperties;
 
 // ========== View Controller ==========

--- a/engine/src/flutter/shell/platform/windows/testing/flutter_windows_engine_builder.cc
+++ b/engine/src/flutter/shell/platform/windows/testing/flutter_windows_engine_builder.cc
@@ -75,6 +75,10 @@ void FlutterWindowsEngineBuilder::SetImpellerSwitch(
   properties_.impeller_switch = impeller_switch;
 }
 
+void FlutterWindowsEngineBuilder::SetEnableFlutterGpu(bool enable_flutter_gpu) {
+  properties_.enable_flutter_gpu = enable_flutter_gpu;
+}
+
 void FlutterWindowsEngineBuilder::SetCreateKeyboardHandlerCallbacks(
     KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
     KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan) {

--- a/engine/src/flutter/shell/platform/windows/testing/flutter_windows_engine_builder.h
+++ b/engine/src/flutter/shell/platform/windows/testing/flutter_windows_engine_builder.h
@@ -33,6 +33,8 @@ class FlutterWindowsEngineBuilder {
 
   void SetImpellerSwitch(FlutterDesktopImpellerSwitch impeller_switch);
 
+  void SetEnableFlutterGpu(bool enable_flutter_gpu);
+
   void SetWindowsProcTable(
       std::shared_ptr<WindowsProcTable> windows_proc_table);
 


### PR DESCRIPTION
Cherry-pick of #190684 (`4ff86d444fb94c39c38111f4b9be649bb716dff7`) onto `flutter-3.47-candidate.0`. It applies cleanly with no conflicts.

The 3.47.0 cherry-pick window is already closed, so this is a request to reopen the conversation rather than a routine cherry-pick. The reasoning is under "Why this is requested after the window closed" below, and I am happy to take a no.

### Issue Link:
https://github.com/flutter/flutter/issues/190871

### Why this is requested after the window closed:
This is an API addition rather than a regression fix, so it does not meet the usual bar. Three things make it worth asking about anyway.

Flutter GPU already has a permanent, project-level opt-in on every other platform (`FLTEnableFlutterGPU` in `Info.plist` on iOS and macOS, the `EnableFlutterGPU` manifest key on Android). Linux and Windows are the only platforms with no equivalent, so this closes a parity gap rather than adding new capability.

Release-mode desktop builds compile out `GetSwitchesFromEnvironment` (`engine_switches.cc` guards it with `#ifndef FLUTTER_RELEASE`), so `--enable-flutter-gpu` reaches the engine only under `flutter run`. Without a project-level setter there is no way at all to ship a released Linux or Windows app that uses `package:flutter_gpu`.

It landed on master on August 7, two days after `flutter-3.48-candidate.0` branched on August 5, so it missed both this branch and the next beta branch. If it is not picked up here, the first beta carrying it is 3.49 and the first stable is roughly a quarter out.

### Impacted Users:
Developers shipping Flutter desktop apps on Linux and Windows that use `package:flutter_gpu`, either directly or through a package built on top of it. Issue #167734 has been open since April 2025 with users repeatedly asking how to enable Flutter GPU on Windows, and the most recent comment describes exactly this case, that the command line flag works under `flutter run` but a packaged executable has no way to set it.

### Impact Description:
Production apps on Linux and Windows cannot ship Flutter GPU at all. A release build throws on the first Flutter GPU call with "Flutter GPU must be enabled via the Flutter GPU manifest setting", and that message names only the iOS and Android opt-ins because the desktop ones did not exist. This does not affect development, since `flutter run --enable-flutter-gpu` works, which is what makes it easy to discover the problem only at packaging time.

### Changelog Description:
[flutter/190871] Flutter GPU could not be enabled in release builds on Linux and Windows, since those embedders had no project-level opt-in and release builds ignore engine switches from the environment.

### Workaround:
No practical one. Shipping the app in debug or profile mode is the only way to get the environment switches honored, and neither is shippable. The alternative is patching the embedder and building a custom engine.

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

The change is additive and defaults to off. Both embedders append `--enable-flutter-gpu` only when the project setting is true, and skip it when an environment switch already carries it, so an app that does not opt in produces a byte-identical switch list. Nothing in the engine, Impeller, or the rendering path changes. The Linux side also hoists a repeated `GetSwitchesFromEnvironment()` call into a local, which is behavior neutral.

One caveat worth naming. A `bool enable_flutter_gpu` field is appended to `FlutterDesktopEngineProperties` in the public `flutter_windows.h`, which changes that struct's layout. The header and `flutter_windows.dll` ship together in the SDK artifact cache so they stay consistent, but it is a public C struct change, and once it ships in a stable the shape of the API is locked in.

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

Unit tests cover both embedders. On Linux, `fl_dart_project_test.cc` covers the getter, setter, and default, and `fl_engine_test.cc` covers switch forwarding and the environment switch deduplication. On Windows, `dart_project_unittests.cc`, `flutter_project_bundle_unittests.cc`, and `flutter_windows_engine_unittests.cc` cover the client wrapper, the project bundle, and the engine switch assembly.

### Validation Steps:
1. Create a Flutter app that calls into `package:flutter_gpu` and run it in release mode on Linux or Windows without the new setting. Confirm it throws "Flutter GPU must be enabled via the Flutter GPU manifest setting".
2. On Linux, add `fl_dart_project_set_enable_flutter_gpu(project, TRUE);` in `linux/runner/my_application.cc`. On Windows, add `project.set_enable_flutter_gpu(true);` in `windows/runner/main.cpp`.
3. Build in release mode and launch the packaged binary directly rather than through `flutter run`. Confirm Flutter GPU initializes and renders.
4. Confirm an app that does not set the flag behaves exactly as before.
5. Run the Linux and Windows embedder unit tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
