### PR TITLE
[flutter_tools] Fix package URI resolution in --experimental-faster-testing

### DIFF
--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -216,7 +216,7 @@ interface class FlutterTestRunner {
     if (packageConfigFile.existsSync()) {
       projectPackageConfig = PackageConfig.parseBytes(
         packageConfigFile.readAsBytesSync(),
-        packageConfigFile.uri,
+        packageConfigFile.absolute.uri,
       );
     } else {
       // We can't use this directly, but need to manually check
@@ -240,7 +240,7 @@ interface class FlutterTestRunner {
         .childFile('package_config.json');
     final PackageConfig flutterToolsPackageConfig = PackageConfig.parseBytes(
       flutterToolsPackageConfigFile.readAsBytesSync(),
-      flutterToolsPackageConfigFile.uri,
+      flutterToolsPackageConfigFile.absolute.uri,
     );
 
     final mergedPackages = <Package>[...projectPackageConfig.packages];
@@ -629,7 +629,7 @@ class SpawnPlugin extends PlatformPlugin {
     );
     final PackageConfig isolateSpawningTesterPackageConfig = PackageConfig.parseBytes(
       isolateSpawningTesterPackageConfigFile.readAsBytesSync(),
-      isolateSpawningTesterPackageConfigFile.uri,
+      isolateSpawningTesterPackageConfigFile.absolute.uri,
     );
 
     final File childTestIsolateSpawnerSourceFile = isolateSpawningTesterDirectory.childFile(

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -216,7 +216,7 @@ interface class FlutterTestRunner {
     if (packageConfigFile.existsSync()) {
       projectPackageConfig = PackageConfig.parseBytes(
         packageConfigFile.readAsBytesSync(),
-        Uri.file(flutterProject.directory.path),
+        packageConfigFile.uri,
       );
     } else {
       // We can't use this directly, but need to manually check

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
@@ -669,6 +670,13 @@ resolution: workspace
           expect(configContents.contains('"name": "test"'), true);
           expect(configContents.contains('"name": "test_api"'), true);
           expect(configContents.contains('"name": "test_core"'), true);
+
+          final config = json.decode(configContents) as Map<String, dynamic>;
+          final packages = config['packages'] as List<dynamic>;
+          final Map<String, dynamic> myApp = packages.cast<Map<String, dynamic>>().firstWhere(
+            (Map<String, dynamic> p) => p['name'] == 'my_app',
+          );
+          expect(myApp['rootUri'], fs.directory('/package').absolute.uri.toString());
         },
       );
       expect(caughtToolExit, true);


### PR DESCRIPTION
When `--experimental-faster-testing` is enabled, the runner reads the package config using `Uri.file(flutterProject.directory.path)` which lacked a trailing slash. This caused relative resolution (using `../`) to resolve to the parent of the project directory (one level too high).

This fix replaces the base URI with `packageConfigFile.uri` which correctly resolves. A regression test verifying the output `rootUri` was added.

Fixes #190784

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
