### PR TITLE
Fix accessibility_inspector service extensions map mutability

### DIFF
--- a/packages/flutter/lib/src/widgets/accessibility_inspector.dart
+++ b/packages/flutter/lib/src/widgets/accessibility_inspector.dart
@@ -42,16 +42,24 @@ class AccessibilityInspector {
     _semanticsHandle = null;
   }
 
+  /// Enables semantics inspection on the connected application.
+  ///
+  /// Returns a mutable map as required by [BindingBase.registerServiceExtension],
+  /// which mutates the returned map to append metadata.
   Future<Map<String, Object?>> _enableSemantics(Map<String, String> parameters) async {
     _semanticsHandle ??= SemanticsBinding.instance.ensureSemantics();
-    return const <String, Object?>{};
+    return <String, Object?>{};
   }
 
+  /// Disposes accessibility semantics state.
+  ///
+  /// Returns a mutable map as required by [BindingBase.registerServiceExtension].
   Future<Map<String, Object?>> _disposeSemantics(Map<String, String> parameters) async {
     resetAllState();
-    return const <String, Object?>{};
+    return <String, Object?>{};
   }
 
+  /// Evaluates and returns the semantics tree hierarchy of the application.
   Future<Map<String, Object?>> _getSemanticsTree(Map<String, String> parameters) async {
     if (!SemanticsBinding.instance.semanticsEnabled) {
       return <String, Object?>{'error': 'Semantics not enabled.'};

--- a/packages/flutter/test/widgets/accessibility_inspector_test.dart
+++ b/packages/flutter/test/widgets/accessibility_inspector_test.dart
@@ -72,10 +72,13 @@ void main() {
     expect(disabledResult['needsFrame'], isNull);
 
     // Calling enableSemantics enables semantics without returning the tree.
-    final Map<String, Object?> enableResult = await callExtension(
-      AccessibilityServiceExtensions.enableSemantics.extensionName,
-    );
+    // Ensure the returned map is mutable (required by BindingBase.registerServiceExtension).
+    final Map<String, Object?> enableResult =
+        await accessibilityExtensions[AccessibilityServiceExtensions
+            .enableSemantics
+            .extensionName]!(const <String, String>{});
     expect(enableResult, isEmpty);
+    expect(() => enableResult['type'] = '_extensionType', returnsNormally);
 
     // Calling getSemanticsTree schedules a frame and returns an error map indicating root is null.
     final Map<String, Object?> result1 = await callExtension(
@@ -142,10 +145,13 @@ void main() {
     );
 
     // Calling disposeSemantics succeeds and cleans up semantics handle.
-    final Map<String, Object?> disposeResult = await callExtension(
-      AccessibilityServiceExtensions.disposeSemantics.extensionName,
-    );
+    // Ensure the returned map is mutable.
+    final Map<String, Object?> disposeResult =
+        await accessibilityExtensions[AccessibilityServiceExtensions
+            .disposeSemantics
+            .extensionName]!(const <String, String>{});
     expect(disposeResult, isEmpty);
+    expect(() => disposeResult['type'] = '_extensionType', returnsNormally);
 
     AccessibilityInspector.instance.resetAllState();
   }, semanticsEnabled: false);


### PR DESCRIPTION
## Description
This PR fixes an issue in `AccessibilityInspector` service extensions (`ext.flutter.accessibility.enableSemantics` and `ext.flutter.accessibility.disposeSemantics`):

Fix `Cannot modify unmodifiable map` when calling the VM service:

   `BindingBase.registerServiceExtension` mutates the returned map to append metadata (`result['type'] = '_extensionType'`). Returning `const <String, Object?>{}` caused an `Unsupported operation: Cannot modify unmodifiable map` exception on Web. Updating the return values to mutable `<String, Object?>{}` fixes this issue.




## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
