### PR TITLE
Don't size or offset the Android platform view before it is laid out

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -167,7 +167,13 @@ class RenderAndroidView extends PlatformViewRenderBox {
     // Android virtual displays cannot have a zero size.
     // Trying to size it to 0 crashes the app, which was happening when starting the app
     // with a locked screen (see: https://github.com/flutter/flutter/issues/20456).
-    if (_state == _PlatformViewState.resizing || size.isEmpty) {
+    //
+    // Don't ask for the size before the first layout either. The controller can be swapped
+    // while a route transition is in flight, and reading the size of a render box that has
+    // not been laid out throws out of this future, where nothing can catch it.
+    // performResize() sizes the platform view once layout has run.
+    // See https://github.com/flutter/flutter/issues/190833.
+    if (_state == _PlatformViewState.resizing || !hasSize || size.isEmpty) {
       return;
     }
 

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -200,7 +200,12 @@ class RenderAndroidView extends PlatformViewRenderBox {
   void _setOffset() {
     SchedulerBinding.instance.addPostFrameCallback((_) async {
       if (!_isDisposed) {
-        if (attached) {
+        // Don't send an offset if not laid out. For example, a RenderBox that
+        // is attached while a route transition is in flight has no position on
+        // screen yet, and asking for one throws out of this frame callback,
+        // where nothing can catch it.
+        // See https://github.com/flutter/flutter/issues/190833.
+        if (attached && hasSize) {
           await _viewController.setOffset(localToGlobal(Offset.zero));
         }
         // Schedule a new post frame callback.

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -345,6 +345,34 @@ void main() {
     });
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/190833.
+  test('RenderAndroidView does not set the platform view offset when not laid out', () {
+    final viewController = FakeAndroidViewController(0);
+    final renderBox = RenderAndroidView(
+      viewController: viewController,
+      hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+      gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
+    );
+    // Attached but not laid out, the state the render box is in when the
+    // platform view is mounted while a route transition is still in flight.
+    renderBox.attach(TestRenderingFlutterBinding.instance.pipelineOwner);
+    expect(renderBox.debugNeedsLayout, isTrue);
+
+    binding.pumpCompleteFrame();
+
+    // The post frame callback ran and left the platform view alone, because
+    // the render box has no position on screen to report yet.
+    expect(viewController.offsets, isEmpty);
+
+    renderBox.detach();
+    layout(renderBox);
+    binding.pumpCompleteFrame();
+
+    expect(viewController.offsets, <Offset>[Offset.zero]);
+
+    renderBox.dispose();
+  });
+
   test('markNeedsPaint does not get called when setting the same viewController', () {
     FakeAsync().run((FakeAsync async) {
       final viewCreation = Completer<void>();

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -373,6 +373,36 @@ void main() {
     renderBox.dispose();
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/190833.
+  test('RenderAndroidView does not size the platform view when not laid out', () async {
+    final renderBox = RenderAndroidView(
+      viewController: FakeAndroidViewController(0),
+      hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+      gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
+    );
+    // Attached but not laid out, the state the render box is in when the
+    // platform view is mounted while a route transition is still in flight.
+    renderBox.attach(TestRenderingFlutterBinding.instance.pipelineOwner);
+    expect(renderBox.debugNeedsLayout, isTrue);
+
+    final viewController = FakeAndroidViewController(1);
+    renderBox.controller = viewController;
+    // The setter does not await the future it starts, so let it complete here.
+    await null;
+
+    // Swapping the controller left the platform view unsized, because the
+    // render box has no size to give it yet.
+    expect(viewController.sizes, isEmpty);
+
+    renderBox.detach();
+    layout(renderBox);
+
+    // performResize does the initial sizing once there is a size to send.
+    expect(viewController.sizes, <Size>[const Size(800, 600)]);
+
+    renderBox.dispose();
+  });
+
   test('markNeedsPaint does not get called when setting the same viewController', () {
     FakeAsync().run((FakeAsync async) {
       final viewCreation = Completer<void>();

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -67,6 +67,9 @@ class FakeAndroidViewController implements AndroidViewController {
   /// Events that are dispatched.
   List<PointerEvent> dispatchedPointerEvents = <PointerEvent>[];
 
+  /// Offsets that are set on the platform view, in the order they were set.
+  final List<Offset> offsets = <Offset>[];
+
   @override
   final int viewId;
 
@@ -80,6 +83,7 @@ class FakeAndroidViewController implements AndroidViewController {
 
   void clearTestingVariables() {
     dispatchedPointerEvents.clear();
+    offsets.clear();
     disposed = false;
     focusCleared = false;
   }
@@ -100,7 +104,9 @@ class FakeAndroidViewController implements AndroidViewController {
   }
 
   @override
-  Future<void> setOffset(Offset off) async {}
+  Future<void> setOffset(Offset off) async {
+    offsets.add(off);
+  }
 
   @override
   int get textureId => 0;

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -70,6 +70,9 @@ class FakeAndroidViewController implements AndroidViewController {
   /// Offsets that are set on the platform view, in the order they were set.
   final List<Offset> offsets = <Offset>[];
 
+  /// Sizes that are set on the platform view, in the order they were set.
+  final List<Size> sizes = <Size>[];
+
   @override
   final int viewId;
 
@@ -84,6 +87,7 @@ class FakeAndroidViewController implements AndroidViewController {
   void clearTestingVariables() {
     dispatchedPointerEvents.clear();
     offsets.clear();
+    sizes.clear();
     disposed = false;
     focusCleared = false;
   }
@@ -100,6 +104,7 @@ class FakeAndroidViewController implements AndroidViewController {
 
   @override
   Future<Size> setSize(Size size) {
+    sizes.add(size);
     return Future<Size>.value(size);
   }
 


### PR DESCRIPTION
`RenderAndroidView` reads its own size from two places that can run before the first layout: the post
frame callback in `_setOffset`, and `_sizePlatformView` when the controller is swapped. A platform view
mounted while a route transition is in flight is attached before its route has laid out, so both throw
`RenderBox was not laid out` from a future that nothing can catch.

Both now check `hasSize` first, the same guard `_handleGlobalPointerEvent` got for the equivalent iOS
crash in #83481. Nothing is lost by waiting: the offset callback reschedules itself every frame, and
`performResize` sizes the platform view as soon as layout gives it a size.

One regression test per path in `packages/flutter/test/rendering/platform_view_test.dart`, both built
the way the existing `RenderUiKitView` test for #83481 is, and both fail without the change.

Fixes https://github.com/flutter/flutter/issues/190833

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
