### PR TITLE
[Windows] Avoid null parent dereference in AccessibilityBridge

### DIFF
--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -216,14 +216,11 @@ AccessibilityBridge::CreateRemoveReparentedNodesUpdate() {
 
   for (const auto& node_update : pending_semantics_node_updates_) {
     for (int32_t child_id : node_update.second.children_in_traversal_order) {
-      // Skip nodes that don't exist or have a parent in the current tree.
+      // Skip nodes that don't exist or aren't attached to a parent in the current tree.
       ui::AXNode* child = tree_->GetFromId(child_id);
-      if (!child) {
+      if (!child || !child->parent()) {
         continue;
       }
-
-      // Flutter's root node should never be reparented.
-      assert(child->parent());
 
       // Skip nodes whose parents are unchanged.
       if (child->parent()->id() == node_update.second.id) {

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge_unittests.cc
@@ -14,6 +14,7 @@ namespace flutter {
 namespace testing {
 
 using ::testing::Contains;
+using ::testing::HasSubstr;
 
 FlutterSemanticsFlags kEmptyFlags = FlutterSemanticsFlags{};
 
@@ -475,6 +476,37 @@ TEST(AccessibilityBridgeTest, CanReparentNode) {
       Contains(ui::AXEventGenerator::Event::OTHER_ATTRIBUTE_CHANGED).Times(1));
   EXPECT_THAT(bridge->accessibility_events,
               Contains(ui::AXEventGenerator::Event::ROLE_CHANGED).Times(1));
+}
+
+// A root node can be present in the tree without having a parent. Malformed or
+// transient semantics updates must not make the reparenting check dereference
+// that null parent pointer.
+TEST(AccessibilityBridgeTest, IgnoresNodeWithoutParentWhenCheckingReparenting) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+
+  std::vector<int32_t> root_children{1};
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root", &root_children);
+  FlutterSemanticsNode2 child = CreateSemanticsNode(1, "child");
+
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(child);
+  bridge->CommitUpdates();
+
+  ASSERT_NE(bridge->GetRootAsAXNode(), nullptr);
+  ASSERT_EQ(bridge->GetRootAsAXNode()->id(), 0);
+  ASSERT_EQ(bridge->GetRootAsAXNode()->parent(), nullptr);
+
+  // The root is already in the tree and has no parent. This malformed update
+  // exercises the guard in CreateRemoveReparentedNodesUpdate().
+  std::vector<int32_t> invalid_children{0};
+  child.child_count = static_cast<int32_t>(invalid_children.size());
+  child.children_in_traversal_order = invalid_children.data();
+
+  bridge->AddFlutterSemanticsNodeUpdate(child);
+  bridge->CommitUpdates();
+
+  EXPECT_THAT(bridge->GetTree()->error(), HasSubstr("reparented"));
 }
 
 // Verify that multiple nodes can be moved to new parents.


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR fixes a null-pointer dereference in Windows accessibility bridge. 

While processing pending semantics updates, an AXNode may exist without a parent, which is valid for the semantics root and may also occur during transient tree updates. 

The existing code relied on `assert(child->parent())` to check that the parent existed. In debug builds, the assertion detects the invalid state and terminates the process; in release builds, the assertion is compiled out, so execution continues to `child->parent()->id()`, causing an access violation in `flutter_windows.dll`. 

This change skips nodes without a parent before dereferencing the parent pointer, allowing the Engine to reject the invalid update without crashing.

*This change may resolve #175041.*

*No changes were made to the `flutter/tests` repository, so no migration guide is required.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

## Tests

Added `AccessibilityBridgeTest.IgnoresNodeWithoutParentWhenCheckingReparenting`.

Local Windows Engine compilation and tests were not run because the required Windows toolchain was unavailable. CI validation is required.