### PR TITLE
Fix PrimaryScrollController attached to multiple scroll views in TabBarView keep-alive tabs (#81152)

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1990,6 +1990,7 @@ class _TabBarViewState extends State<TabBarView> {
     } else {
       _pageController!.jumpToPage(_currentIndex!);
     }
+    context.dependOnInheritedWidgetOfExactType<PrimaryScrollController>();
     _updateChildren();
   }
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -2034,16 +2034,17 @@ class _TabBarViewState extends State<TabBarView> {
     _childrenWithKey = KeyedSubtree.ensureUniqueKeysForList(
       widget.children.map<Widget>((Widget child) {
         final int tabIndex = index++;
+        final Widget semanticsChild = Semantics(role: SemanticsRole.tabPanel, child: child);
         final Widget wrappedChild;
         if (tabIndex == _currentIndex && ancestor != null && ancestor.controller != null) {
           wrappedChild = PrimaryScrollController(
             controller: ancestor.controller!,
             automaticallyInheritForPlatforms: ancestor.automaticallyInheritForPlatforms,
             scrollDirection: ancestor.scrollDirection,
-            child: child,
+            child: semanticsChild,
           );
         } else {
-          wrappedChild = PrimaryScrollController.none(child: child);
+          wrappedChild = PrimaryScrollController.none(child: semanticsChild);
         }
         return wrappedChild;
       }).toList(),

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1990,6 +1990,7 @@ class _TabBarViewState extends State<TabBarView> {
     } else {
       _pageController!.jumpToPage(_currentIndex!);
     }
+    _updateChildren();
   }
 
   @override
@@ -1999,6 +2000,7 @@ class _TabBarViewState extends State<TabBarView> {
       _updateTabController();
       _currentIndex = _controller!.index;
       _jumpToPage(_currentIndex!);
+      _updateChildren();
     }
     if (widget.viewportFraction != oldWidget.viewportFraction) {
       _pageController?.dispose();
@@ -2026,7 +2028,25 @@ class _TabBarViewState extends State<TabBarView> {
   }
 
   void _updateChildren() {
-    _childrenWithKey = KeyedSubtree.ensureUniqueKeysForList(widget.children);
+    final PrimaryScrollController? ancestor = context.findAncestorWidgetOfExactType<PrimaryScrollController>();
+    int index = 0;
+    _childrenWithKey = KeyedSubtree.ensureUniqueKeysForList(
+      widget.children.map<Widget>((Widget child) {
+        final int tabIndex = index++;
+        final Widget wrappedChild;
+        if (tabIndex == _currentIndex && ancestor != null && ancestor.controller != null) {
+          wrappedChild = PrimaryScrollController(
+            controller: ancestor.controller!,
+            automaticallyInheritForPlatforms: ancestor.automaticallyInheritForPlatforms,
+            scrollDirection: ancestor.scrollDirection,
+            child: child,
+          );
+        } else {
+          wrappedChild = PrimaryScrollController.none(child: child);
+        }
+        return wrappedChild;
+      }).toList(),
+    );
   }
 
   void _handleTabControllerAnimationTick() {
@@ -2124,12 +2144,12 @@ class _TabBarViewState extends State<TabBarView> {
       final bool pageChanged = (page - _controller!.index).abs() > 1.0;
       if (pageChanged) {
         _controller!.index = page.round();
-        _currentIndex =_controller!.index;
+        _changeCurrentIndex(_controller!.index);
       }
       _syncControllerOffset();
     } else if (notification is ScrollEndNotification) {
       _controller!.index = page.round();
-      _currentIndex = _controller!.index;
+      _changeCurrentIndex(_controller!.index);
       if (!_controller!.indexIsChanging) {
         _syncControllerOffset();
       }
@@ -2137,6 +2157,17 @@ class _TabBarViewState extends State<TabBarView> {
     _scrollUnderwayCount -= 1;
 
     return false;
+  }
+
+  void _changeCurrentIndex(int newIndex) {
+    if (_currentIndex != newIndex) {
+      _currentIndex = newIndex;
+      if (mounted) {
+        setState(() {
+          _updateChildren();
+        });
+      }
+    }
   }
 
   bool _debugScheduleCheckHasValidChildrenCount() {

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -7158,4 +7158,63 @@ void main() {
     labelSize = tester.getSize(find.text('Tab 1'));
     expect(labelSize, equals(const Size(140.5, 40.0)));
   }, skip: isBrowser && !isSkiaWeb); // https://github.com/flutter/flutter/issues/87543
+
+  testWidgets("PrimaryScrollController is not attached to multiple scroll views in TabBarView's keep-alive tabs", (WidgetTester tester) async {
+    final TabController controller = TabController(length: 2, vsync: const TestVSync());
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            bottom: TabBar(
+              controller: controller,
+              tabs: const <Widget>[Tab(text: 'Tab 0'), Tab(text: 'Tab 1')],
+            ),
+          ),
+          body: TabBarView(
+            controller: controller,
+            children: const <Widget>[
+              _KeepAliveTab(name: '0'),
+              _KeepAliveTab(name: '1'),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    // Switch to Tab 1
+    await tester.tap(find.text('Tab 1'));
+    await tester.pumpAndSettle();
+
+    final ScrollController primaryController = PrimaryScrollController.of(tester.element(find.byType(TabBarView)));
+    expect(() => primaryController.position, returnsNormally);
+  });
 }
+
+class _KeepAliveTab extends StatefulWidget {
+  const _KeepAliveTab({required this.name});
+
+  final String name;
+
+  @override
+  State<_KeepAliveTab> createState() => _KeepAliveTabState();
+}
+
+class _KeepAliveTabState extends State<_KeepAliveTab> with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return ListView(
+      primary: true,
+      children: List<Widget>.generate(
+        20,
+        (int index) => ListTile(title: Text('${widget.name}: $index')),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Description

Fixes #81152

This PR resolves an assertion crash (`ScrollController attached to multiple scroll views`) when using `TabBarView` with kept-alive tabs (`AutomaticKeepAliveClientMixin`) and primary scroll views (like `ListView(primary: true)`).

### Changes
- Updated `_TabBarViewState` in `packages/flutter/lib/src/material/tabs.dart` to scope `PrimaryScrollController`:
  - Active tab (`tabIndex == _currentIndex`) inherits and forwards the ancestor `PrimaryScrollController`.
  - Inactive tabs (`tabIndex != _currentIndex`) are wrapped in `PrimaryScrollController.none`.
- Registered `PrimaryScrollController` dependency in `didChangeDependencies` via `context.dependOnInheritedWidgetOfExactType<PrimaryScrollController>()` so `TabBarView` correctly updates when the ancestor controller changes.
- Maintained identical widget hierarchy (`KeyedSubtree -> Semantics -> PrimaryScrollController -> child`) for both active and inactive states to prevent element unmounting or state disposal.
- Added regression test `PrimaryScrollController is not attached to multiple scroll views in TabBarView's keep-alive tabs` in `packages/flutter/test/material/tabs_test.dart`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect images of].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests pass.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect images of]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-images-of
[CLA]: https://cla.developers.google.com/
