### PR TITLE
Reduce iOS pointer latency by dispatching pending input before BeginFrame

### DIFF
--- a/engine/src/flutter/shell/common/animator.cc
+++ b/engine/src/flutter/shell/common/animator.cc
@@ -260,13 +260,22 @@ void Animator::RequestFrame(bool regenerate_layer_trees) {
   // started an expensive operation right after posting this message however.
   // To support that, we need edge triggered wakes on VSync.
 
-  task_runners_.GetUITaskRunner()->PostTask(
-      [self = weak_factory_.GetWeakPtr()]() {
-        if (!self) {
-          return;
-        }
-        self->AwaitVSync();
-      });
+  if (waiter_->CanRegisterCallbackForCurrentVsync()) {
+    // The platform vsync has fired, but its primary callback has not yet been
+    // consumed. Posting AwaitVSync would put it behind the task that consumes
+    // the callback and would defer the frame to the following vsync. Register
+    // immediately in this narrow interval; otherwise preserve the existing
+    // behavior of awaiting vsync from a posted UI task.
+    AwaitVSync();
+  } else {
+    task_runners_.GetUITaskRunner()->PostTask(
+        [self = weak_factory_.GetWeakPtr()]() {
+          if (!self) {
+            return;
+          }
+          self->AwaitVSync();
+        });
+  }
   frame_scheduled_ = true;
 }
 
@@ -297,6 +306,11 @@ void Animator::OnAllViewsRendered() {
 void Animator::ScheduleSecondaryVsyncCallback(uintptr_t id,
                                               const fml::closure& callback) {
   waiter_->ScheduleSecondaryCallback(id, callback);
+}
+
+void Animator::SchedulePreFrameVsyncCallback(uintptr_t id,
+                                             const fml::closure& callback) {
+  waiter_->SchedulePreFrameCallback(id, callback);
 }
 
 void Animator::ScheduleMaybeClearTraceFlowIds() {

--- a/engine/src/flutter/shell/common/animator.cc
+++ b/engine/src/flutter/shell/common/animator.cc
@@ -260,7 +260,8 @@ void Animator::RequestFrame(bool regenerate_layer_trees) {
   // started an expensive operation right after posting this message however.
   // To support that, we need edge triggered wakes on VSync.
 
-  if (waiter_->CanRegisterCallbackForCurrentVsync()) {
+  if (task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread() &&
+      waiter_->CanRegisterCallbackForCurrentVsync()) {
     // The platform vsync has fired, but its primary callback has not yet been
     // consumed. Posting AwaitVSync would put it behind the task that consumes
     // the callback and would defer the frame to the following vsync. Register

--- a/engine/src/flutter/shell/common/animator.h
+++ b/engine/src/flutter/shell/common/animator.h
@@ -100,12 +100,17 @@ class Animator final {
   ///           callback (`Animator::RequestFrame` is not called), this
   ///           secondary callback will still be executed at vsync.
   ///
-  ///           This callback is used to provide the vsync signal needed by
-  ///           `SmoothPointerDataDispatcher`, and for our own flow events.
-  ///
-  /// @see      `PointerDataDispatcher::ScheduleSecondaryVsyncCallback`.
+  ///           This callback is used for input flow events.
   void ScheduleSecondaryVsyncCallback(uintptr_t id,
                                       const fml::closure& callback);
+
+  /// Schedules work at the next vsync before its primary frame callback is
+  /// consumed. A frame synchronously requested by this work can participate in
+  /// the same vsync.
+  ///
+  /// @see `PointerDataDispatcher::Delegate::SchedulePreFrameVsyncCallback`.
+  void SchedulePreFrameVsyncCallback(uintptr_t id,
+                                     const fml::closure& callback);
 
   // Enqueue |trace_flow_id| into |trace_flow_ids_|.  The flow event will be
   // ended at either the next frame, or the next vsync interval with no active

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -592,6 +592,11 @@ void Engine::DoDispatchPacket(std::unique_ptr<PointerDataPacket> packet,
   }
 }
 
+void Engine::SchedulePreFrameVsyncCallback(uintptr_t id,
+                                           const fml::closure& callback) {
+  animator_->SchedulePreFrameVsyncCallback(id, callback);
+}
+
 void Engine::ScheduleSecondaryVsyncCallback(uintptr_t id,
                                             const fml::closure& callback) {
   animator_->ScheduleSecondaryVsyncCallback(id, callback);

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -918,8 +918,11 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
                         uint64_t trace_flow_id) override;
 
   // |PointerDataDispatcher::Delegate|
+  void SchedulePreFrameVsyncCallback(uintptr_t id,
+                                     const fml::closure& callback) override;
+
   void ScheduleSecondaryVsyncCallback(uintptr_t id,
-                                      const fml::closure& callback) override;
+                                      const fml::closure& callback);
 
   //----------------------------------------------------------------------------
   /// @brief      Get the last Entrypoint that was used in the RunConfiguration

--- a/engine/src/flutter/shell/common/pointer_data_dispatcher.cc
+++ b/engine/src/flutter/shell/common/pointer_data_dispatcher.cc
@@ -45,11 +45,11 @@ void SmoothPointerDataDispatcher::DispatchPacket(
                                                  trace_flow_id);
   }
   is_pointer_data_in_progress_ = true;
-  ScheduleSecondaryVsyncCallback();
+  SchedulePreFrameVsyncCallback();
 }
 
-void SmoothPointerDataDispatcher::ScheduleSecondaryVsyncCallback() {
-  delegate_.ScheduleSecondaryVsyncCallback(
+void SmoothPointerDataDispatcher::SchedulePreFrameVsyncCallback() {
+  delegate_.SchedulePreFrameVsyncCallback(
       reinterpret_cast<uintptr_t>(this),
       [dispatcher = weak_factory_.GetWeakPtr()]() {
         if (dispatcher && dispatcher->is_pointer_data_in_progress_) {
@@ -69,7 +69,7 @@ void SmoothPointerDataDispatcher::DispatchPendingPacket() {
                                                pending_trace_flow_id_);
   pending_packet_ = nullptr;
   pending_trace_flow_id_ = -1;
-  ScheduleSecondaryVsyncCallback();
+  SchedulePreFrameVsyncCallback();
 }
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/common/pointer_data_dispatcher.h
+++ b/engine/src/flutter/shell/common/pointer_data_dispatcher.h
@@ -48,20 +48,18 @@ class PointerDataDispatcher {
                                   uint64_t trace_flow_id) = 0;
 
     //--------------------------------------------------------------------------
-    /// @brief    Schedule a secondary callback to be executed right after the
-    ///           main `VsyncWaiter::AsyncWaitForVsync` callback (which is added
-    ///           by `Animator::RequestFrame`).
+    /// @brief    Schedule a callback to execute immediately before the main
+    ///           `VsyncWaiter::AsyncWaitForVsync` callback.
     ///
     ///           Like the callback in `AsyncWaitForVsync`, this callback is
     ///           only scheduled to be called once per |id|, and it will be
     ///           called in the UI thread. If there is no AsyncWaitForVsync
     ///           callback (`Animator::RequestFrame` is not called), this
-    ///           secondary callback will still be executed at vsync.
+    ///           pre-frame callback will still be executed at vsync.
     ///
     ///           This callback is used to provide the vsync signal needed by
-    ///           `SmoothPointerDataDispatcher`, and for `Animator` input flow
-    ///           events.
-    virtual void ScheduleSecondaryVsyncCallback(
+    ///           `SmoothPointerDataDispatcher` before a frame begins.
+    virtual void SchedulePreFrameVsyncCallback(
         uintptr_t id,
         const fml::closure& callback) = 0;
   };
@@ -119,7 +117,7 @@ class DefaultPointerDataDispatcher : public PointerDataDispatcher {
 /// `runtime_controller_->DispatchPointerDataPacket` is always called right
 /// away. That's because `is_pointer_data_in_progress_` will always be false
 /// when `DispatchPacket` is called since it will be cleared by the end of a
-/// frame through `ScheduleSecondaryVsyncCallback`. This is the case for all
+/// frame through `SchedulePreFrameVsyncCallback`. This is the case for all
 /// Android/iOS devices before iPhone X/XS.
 ///
 /// If the input event is irregular, but with a random latency of no more than
@@ -149,7 +147,7 @@ class SmoothPointerDataDispatcher : public DefaultPointerDataDispatcher {
 
  private:
   void DispatchPendingPacket();
-  void ScheduleSecondaryVsyncCallback();
+  void SchedulePreFrameVsyncCallback();
 
   // If non-null, this will be a pending pointer data packet for the next frame
   // to consume. This is used to smooth out the irregular drag events delivery.

--- a/engine/src/flutter/shell/common/vsync_waiter.cc
+++ b/engine/src/flutter/shell/common/vsync_waiter.cc
@@ -43,7 +43,7 @@ void VsyncWaiter::AsyncWaitForVsync(const Callback& callback) {
       return;
     }
     callback_ = callback;
-    if (vsync_fire_in_progress_) {
+    if (vsync_fire_sequence_number_ > vsync_fire_consumed_sequence_number_) {
       return;
     }
     if (!pre_frame_callbacks_.empty() || !secondary_callbacks_.empty()) {
@@ -56,7 +56,7 @@ void VsyncWaiter::AsyncWaitForVsync(const Callback& callback) {
 
 bool VsyncWaiter::CanRegisterCallbackForCurrentVsync() {
   std::scoped_lock lock(callback_mutex_);
-  return vsync_fire_in_progress_;
+  return vsync_fire_sequence_number_ > vsync_fire_consumed_sequence_number_;
 }
 
 void VsyncWaiter::SchedulePreFrameCallback(uintptr_t id,
@@ -79,7 +79,7 @@ void VsyncWaiter::SchedulePreFrameCallback(uintptr_t id,
                            "MultipleCallsToPreFrameVsyncInFrameInterval");
       return;
     }
-    if (vsync_fire_in_progress_) {
+    if (vsync_fire_sequence_number_ > vsync_fire_consumed_sequence_number_) {
       if (!callbacks_originally_empty) {
         return;
       }
@@ -111,7 +111,7 @@ void VsyncWaiter::ScheduleSecondaryCallback(uintptr_t id,
                            "MultipleCallsToSecondaryVsyncInFrameInterval");
       return;
     }
-    if (vsync_fire_in_progress_) {
+    if (vsync_fire_sequence_number_ > vsync_fire_consumed_sequence_number_) {
       if (!callbacks_originally_empty) {
         return;
       }
@@ -134,6 +134,7 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
   FML_DCHECK(fml::TimePoint::Now() >= frame_start_time);
 
   bool had_primary_callback = false;
+  uint64_t vsync_fire_sequence_number = 0;
   std::vector<fml::closure> pre_frame_callbacks;
   std::vector<fml::closure> secondary_callbacks;
 
@@ -150,9 +151,11 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
     secondary_callbacks_.clear();
     // Do not take callback_ until after the pre-frame callbacks have run. They
     // may synchronously process input and register a primary callback that can
-    // still be rendered for this vsync.
-    vsync_fire_in_progress_ =
-        had_primary_callback || !pre_frame_callbacks.empty();
+    // still be rendered for this vsync. Track the generation so consuming an
+    // older callback cannot close a newer vsync's registration window.
+    if (had_primary_callback || !pre_frame_callbacks.empty()) {
+      vsync_fire_sequence_number = ++vsync_fire_sequence_number_;
+    }
   }
 
   if (!had_primary_callback && pre_frame_callbacks.empty() &&
@@ -180,12 +183,16 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
     std::shared_ptr<VsyncWaiter> waiter = shared_from_this();
     task_runners_.GetUITaskRunner()->PostTask(
         [waiter, ui_task_queue_id, frame_start_time, frame_target_time,
-         pause_secondary_tasks]() {
+         pause_secondary_tasks, vsync_fire_sequence_number]() {
           Callback callback;
           {
             std::scoped_lock lock(waiter->callback_mutex_);
             waiter->callback_.swap(callback);
-            waiter->vsync_fire_in_progress_ = false;
+            if (vsync_fire_sequence_number >
+                waiter->vsync_fire_consumed_sequence_number_) {
+              waiter->vsync_fire_consumed_sequence_number_ =
+                  vsync_fire_sequence_number;
+            }
           }
 
           if (callback) {

--- a/engine/src/flutter/shell/common/vsync_waiter.cc
+++ b/engine/src/flutter/shell/common/vsync_waiter.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/common/vsync_waiter.h"
 
+#include <vector>
+
 #include "flow/frame_timings.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/fml/trace_event.h"
@@ -41,13 +43,51 @@ void VsyncWaiter::AsyncWaitForVsync(const Callback& callback) {
       return;
     }
     callback_ = callback;
-    if (!secondary_callbacks_.empty()) {
-      // Return directly as `AwaitVSync` is already called by
-      // `ScheduleSecondaryCallback`.
+    if (vsync_fire_in_progress_) {
+      return;
+    }
+    if (!pre_frame_callbacks_.empty() || !secondary_callbacks_.empty()) {
+      // Return directly as a callback has already armed the vsync waiter.
       return;
     }
   }
   AwaitVSync();
+}
+
+bool VsyncWaiter::CanRegisterCallbackForCurrentVsync() {
+  std::scoped_lock lock(callback_mutex_);
+  return vsync_fire_in_progress_;
+}
+
+void VsyncWaiter::SchedulePreFrameCallback(uintptr_t id,
+                                           const fml::closure& callback) {
+  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
+
+  if (!callback) {
+    return;
+  }
+
+  TRACE_EVENT0("flutter", "SchedulePreFrameCallback");
+
+  {
+    std::scoped_lock lock(callback_mutex_);
+    const bool callbacks_originally_empty =
+        pre_frame_callbacks_.empty() && secondary_callbacks_.empty();
+    auto [_, inserted] = pre_frame_callbacks_.emplace(id, callback);
+    if (!inserted) {
+      TRACE_EVENT_INSTANT0("flutter",
+                           "MultipleCallsToPreFrameVsyncInFrameInterval");
+      return;
+    }
+    if (vsync_fire_in_progress_) {
+      if (!callbacks_originally_empty) {
+        return;
+      }
+    } else if (callback_ || !callbacks_originally_empty) {
+      return;
+    }
+  }
+  AwaitVSyncForSecondaryCallback();
 }
 
 void VsyncWaiter::ScheduleSecondaryCallback(uintptr_t id,
@@ -62,7 +102,8 @@ void VsyncWaiter::ScheduleSecondaryCallback(uintptr_t id,
 
   {
     std::scoped_lock lock(callback_mutex_);
-    bool secondary_callbacks_originally_empty = secondary_callbacks_.empty();
+    const bool callbacks_originally_empty =
+        pre_frame_callbacks_.empty() && secondary_callbacks_.empty();
     auto [_, inserted] = secondary_callbacks_.emplace(id, callback);
     if (!inserted) {
       // Multiple schedules must result in a single callback per frame interval.
@@ -70,14 +111,17 @@ void VsyncWaiter::ScheduleSecondaryCallback(uintptr_t id,
                            "MultipleCallsToSecondaryVsyncInFrameInterval");
       return;
     }
-    if (callback_) {
+    if (vsync_fire_in_progress_) {
+      if (!callbacks_originally_empty) {
+        return;
+      }
+    } else if (callback_) {
       // Return directly as `AwaitVSync` is already called by
       // `AsyncWaitForVsync`.
       return;
-    }
-    if (!secondary_callbacks_originally_empty) {
-      // Return directly as `AwaitVSync` is already called by
-      // `ScheduleSecondaryCallback`.
+    } else if (!callbacks_originally_empty) {
+      // Return directly as another callback has already armed the vsync
+      // waiter.
       return;
     }
   }
@@ -89,19 +133,30 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
                                bool pause_secondary_tasks) {
   FML_DCHECK(fml::TimePoint::Now() >= frame_start_time);
 
-  Callback callback;
+  bool had_primary_callback = false;
+  std::vector<fml::closure> pre_frame_callbacks;
   std::vector<fml::closure> secondary_callbacks;
 
   {
     std::scoped_lock lock(callback_mutex_);
-    callback_.swap(callback);
+    had_primary_callback = static_cast<bool>(callback_);
+    for (auto& pair : pre_frame_callbacks_) {
+      pre_frame_callbacks.push_back(std::move(pair.second));
+    }
+    pre_frame_callbacks_.clear();
     for (auto& pair : secondary_callbacks_) {
       secondary_callbacks.push_back(std::move(pair.second));
     }
     secondary_callbacks_.clear();
+    // Do not take callback_ until after the pre-frame callbacks have run. They
+    // may synchronously process input and register a primary callback that can
+    // still be rendered for this vsync.
+    vsync_fire_in_progress_ =
+        had_primary_callback || !pre_frame_callbacks.empty();
   }
 
-  if (!callback && secondary_callbacks.empty()) {
+  if (!had_primary_callback && pre_frame_callbacks.empty() &&
+      secondary_callbacks.empty()) {
     // This means that the vsync waiter implementation fired a callback for a
     // request we did not make. This is a paranoid check but we still want to
     // make sure we catch misbehaving vsync implementations.
@@ -109,37 +164,52 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
     return;
   }
 
-  if (callback) {
-    const uint64_t flow_identifier = fml::tracing::TraceNonce();
-    if (pause_secondary_tasks) {
-      PauseDartEventLoopTasks();
-    }
+  const bool may_have_primary_callback =
+      had_primary_callback || !pre_frame_callbacks.empty();
+  if (may_have_primary_callback && pause_secondary_tasks) {
+    PauseDartEventLoopTasks();
+  }
 
-    // The base trace ensures that flows have a root to begin from if one does
-    // not exist. The trace viewer will ignore traces that have no base event
-    // trace. While all our message loops insert a base trace trace
-    // (MessageLoop::RunExpiredTasks), embedders may not.
-    TRACE_EVENT0_WITH_FLOW_IDS("flutter", "VsyncFireCallback",
-                               /*flow_id_count=*/1,
-                               /*flow_ids=*/&flow_identifier);
+  for (auto& pre_frame_callback : pre_frame_callbacks) {
+    task_runners_.GetUITaskRunner()->PostTask(std::move(pre_frame_callback));
+  }
 
-    TRACE_FLOW_BEGIN("flutter", kVsyncFlowName, flow_identifier);
-
+  if (may_have_primary_callback) {
     fml::TaskQueueId ui_task_queue_id =
         task_runners_.GetUITaskRunner()->GetTaskQueueId();
+    std::shared_ptr<VsyncWaiter> waiter = shared_from_this();
     task_runners_.GetUITaskRunner()->PostTask(
-        [ui_task_queue_id, callback, flow_identifier, frame_start_time,
-         frame_target_time, pause_secondary_tasks]() {
-          FML_TRACE_EVENT_WITH_FLOW_IDS(
-              "flutter", kVsyncTraceName, /*flow_id_count=*/1,
-              /*flow_ids=*/&flow_identifier, "StartTime", frame_start_time,
-              "TargetTime", frame_target_time);
-          std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder =
-              std::make_unique<FrameTimingsRecorder>();
-          frame_timings_recorder->RecordVsync(frame_start_time,
-                                              frame_target_time);
-          callback(std::move(frame_timings_recorder));
-          TRACE_FLOW_END("flutter", kVsyncFlowName, flow_identifier);
+        [waiter, ui_task_queue_id, frame_start_time, frame_target_time,
+         pause_secondary_tasks]() {
+          Callback callback;
+          {
+            std::scoped_lock lock(waiter->callback_mutex_);
+            waiter->callback_.swap(callback);
+            waiter->vsync_fire_in_progress_ = false;
+          }
+
+          if (callback) {
+            const uint64_t flow_identifier = fml::tracing::TraceNonce();
+
+            // The base trace ensures that flows have a root to begin from if
+            // one does not exist. The trace viewer will ignore traces that
+            // have no base event trace. While all our message loops insert a
+            // base trace (MessageLoop::RunExpiredTasks), embedders may not.
+            TRACE_EVENT0_WITH_FLOW_IDS("flutter", "VsyncFireCallback",
+                                       /*flow_id_count=*/1,
+                                       /*flow_ids=*/&flow_identifier);
+            TRACE_FLOW_BEGIN("flutter", kVsyncFlowName, flow_identifier);
+            FML_TRACE_EVENT_WITH_FLOW_IDS(
+                "flutter", kVsyncTraceName, /*flow_id_count=*/1,
+                /*flow_ids=*/&flow_identifier, "StartTime", frame_start_time,
+                "TargetTime", frame_target_time);
+            std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder =
+                std::make_unique<FrameTimingsRecorder>();
+            frame_timings_recorder->RecordVsync(frame_start_time,
+                                                frame_target_time);
+            callback(std::move(frame_timings_recorder));
+            TRACE_FLOW_END("flutter", kVsyncFlowName, flow_identifier);
+          }
           if (pause_secondary_tasks) {
             ResumeDartEventLoopTasks(ui_task_queue_id);
           }

--- a/engine/src/flutter/shell/common/vsync_waiter.h
+++ b/engine/src/flutter/shell/common/vsync_waiter.h
@@ -87,12 +87,12 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
  private:
   std::mutex callback_mutex_;
   Callback callback_;
-  // True after FireCallback receives a platform vsync and until its primary
-  // callback is taken on the UI task runner. Keeping callback_ available during
-  // this interval lets pre-frame input handling register work for the current
-  // vsync. Pre-frame and secondary callbacks added during this interval are
-  // retained for the next vsync.
-  bool vsync_fire_in_progress_ = false;
+  // The latest platform vsync generation posted to the UI task runner and the
+  // latest generation whose primary callback task has begun. Their difference
+  // preserves the registration window even if another platform vsync arrives
+  // while the UI thread is still processing the previous generation.
+  uint64_t vsync_fire_sequence_number_ = 0;
+  uint64_t vsync_fire_consumed_sequence_number_ = 0;
   std::unordered_map<uintptr_t, fml::closure> pre_frame_callbacks_;
   std::unordered_map<uintptr_t, fml::closure> secondary_callbacks_;
 

--- a/engine/src/flutter/shell/common/vsync_waiter.h
+++ b/engine/src/flutter/shell/common/vsync_waiter.h
@@ -29,10 +29,19 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
 
   void AsyncWaitForVsync(const Callback& callback);
 
+  /// Returns whether a primary callback registered now can participate in a
+  /// platform vsync that has fired but has not yet been consumed on the UI task
+  /// runner.
+  bool CanRegisterCallbackForCurrentVsync();
+
+  /// Adds a callback for key |id| to run immediately before the primary frame
+  /// callback at the next vsync. A primary callback registered synchronously
+  /// while a pre-frame callback is running participates in the same vsync.
+  void SchedulePreFrameCallback(uintptr_t id, const fml::closure& callback);
+
   /// Add a secondary callback for key |id| for the next vsync.
   ///
-  /// See also |PointerDataDispatcher::ScheduleSecondaryVsyncCallback| and
-  /// |Animator::ScheduleMaybeClearTraceFlowIds|.
+  /// See also |Animator::ScheduleMaybeClearTraceFlowIds|.
   void ScheduleSecondaryCallback(uintptr_t id, const fml::closure& callback);
 
  protected:
@@ -68,8 +77,9 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
   // as AwaitVSync().
   virtual void AwaitVSyncForSecondaryCallback() { AwaitVSync(); }
 
-  // Schedules the callback on the UI task runner. Needs to be invoked as close
-  // to the `frame_start_time` as possible.
+  // Schedules the pre-frame, primary, and secondary callbacks on the UI task
+  // runner in that order. Needs to be invoked as close to the
+  // `frame_start_time` as possible.
   void FireCallback(fml::TimePoint frame_start_time,
                     fml::TimePoint frame_target_time,
                     bool pause_secondary_tasks = true);
@@ -77,6 +87,13 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
  private:
   std::mutex callback_mutex_;
   Callback callback_;
+  // True after FireCallback receives a platform vsync and until its primary
+  // callback is taken on the UI task runner. Keeping callback_ available during
+  // this interval lets pre-frame input handling register work for the current
+  // vsync. Pre-frame and secondary callbacks added during this interval are
+  // retained for the next vsync.
+  bool vsync_fire_in_progress_ = false;
+  std::unordered_map<uintptr_t, fml::closure> pre_frame_callbacks_;
   std::unordered_map<uintptr_t, fml::closure> secondary_callbacks_;
 
   void PauseDartEventLoopTasks();

--- a/engine/src/flutter/shell/common/vsync_waiter_unittests.cc
+++ b/engine/src/flutter/shell/common/vsync_waiter_unittests.cc
@@ -4,6 +4,8 @@
 #define FML_USED_ON_EMBEDDER
 
 #include <initializer_list>
+#include <string>
+#include <vector>
 
 #include "flutter/common/settings.h"
 #include "flutter/common/task_runners.h"
@@ -23,6 +25,13 @@ class TestVsyncWaiter : public VsyncWaiter {
 
   int await_vsync_call_count_ = 0;
 
+  void SimulateVsync() {
+    const fml::TimePoint frame_start_time = fml::TimePoint::Now();
+    FireCallback(frame_start_time,
+                 frame_start_time + fml::TimeDelta::FromMilliseconds(16),
+                 false);
+  }
+
  protected:
   void AwaitVSync() override { await_vsync_call_count_++; }
 };
@@ -37,13 +46,102 @@ TEST(VsyncWaiterTest, NoUnneededAwaitVsync) {
   const flutter::TaskRunners task_runners(prefix, task_runner, task_runner,
                                           task_runner, task_runner);
 
-  TestVsyncWaiter vsync_waiter(task_runners);
+  auto vsync_waiter = std::make_shared<TestVsyncWaiter>(task_runners);
 
-  vsync_waiter.ScheduleSecondaryCallback(1, [] {});
-  EXPECT_EQ(vsync_waiter.await_vsync_call_count_, 1);
+  vsync_waiter->ScheduleSecondaryCallback(1, [] {});
+  EXPECT_EQ(vsync_waiter->await_vsync_call_count_, 1);
 
-  vsync_waiter.ScheduleSecondaryCallback(2, [] {});
-  EXPECT_EQ(vsync_waiter.await_vsync_call_count_, 1);
+  vsync_waiter->ScheduleSecondaryCallback(2, [] {});
+  EXPECT_EQ(vsync_waiter->await_vsync_call_count_, 1);
+}
+
+TEST(VsyncWaiterTest, PreFrameCallbackRunsBeforePrimaryAndSecondaryCallbacks) {
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+  const flutter::TaskRunners task_runners("vsync_waiter_callback_order_test",
+                                          task_runner, task_runner, task_runner,
+                                          task_runner);
+  auto vsync_waiter = std::make_shared<TestVsyncWaiter>(task_runners);
+  std::vector<std::string> callback_order;
+
+  vsync_waiter->SchedulePreFrameCallback(
+      1, [&callback_order] { callback_order.push_back("pre-frame"); });
+  vsync_waiter->AsyncWaitForVsync(
+      [&callback_order](auto) { callback_order.push_back("primary"); });
+  vsync_waiter->ScheduleSecondaryCallback(
+      2, [&callback_order] { callback_order.push_back("secondary"); });
+
+  EXPECT_EQ(vsync_waiter->await_vsync_call_count_, 1);
+  vsync_waiter->SimulateVsync();
+  fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+
+  EXPECT_EQ(callback_order,
+            (std::vector<std::string>{"pre-frame", "primary", "secondary"}));
+}
+
+TEST(VsyncWaiterTest, PrimaryScheduledByPreFrameCallbackJoinsCurrentVsync) {
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+  const flutter::TaskRunners task_runners("vsync_waiter_late_primary_test",
+                                          task_runner, task_runner, task_runner,
+                                          task_runner);
+  auto vsync_waiter = std::make_shared<TestVsyncWaiter>(task_runners);
+  std::vector<std::string> callback_order;
+
+  vsync_waiter->SchedulePreFrameCallback(1, [&] {
+    callback_order.push_back("pre-frame");
+    EXPECT_TRUE(vsync_waiter->CanRegisterCallbackForCurrentVsync());
+    vsync_waiter->AsyncWaitForVsync(
+        [&](auto) { callback_order.push_back("primary"); });
+  });
+  vsync_waiter->ScheduleSecondaryCallback(
+      2, [&] { callback_order.push_back("secondary"); });
+
+  EXPECT_EQ(vsync_waiter->await_vsync_call_count_, 1);
+  vsync_waiter->SimulateVsync();
+  fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+
+  EXPECT_EQ(callback_order,
+            (std::vector<std::string>{"pre-frame", "primary", "secondary"}));
+  EXPECT_FALSE(vsync_waiter->CanRegisterCallbackForCurrentVsync());
+  // The primary callback joined the already-fired vsync rather than arming a
+  // second one.
+  EXPECT_EQ(vsync_waiter->await_vsync_call_count_, 1);
+}
+
+TEST(VsyncWaiterTest, PreFrameCallbackScheduledAfterFireTargetsNextVsync) {
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+  const flutter::TaskRunners task_runners("vsync_waiter_next_vsync_test",
+                                          task_runner, task_runner, task_runner,
+                                          task_runner);
+  auto vsync_waiter = std::make_shared<TestVsyncWaiter>(task_runners);
+  std::vector<std::string> callback_order;
+
+  vsync_waiter->SchedulePreFrameCallback(
+      1, [&] { callback_order.push_back("current pre-frame"); });
+  vsync_waiter->AsyncWaitForVsync(
+      [&](auto) { callback_order.push_back("current primary"); });
+  EXPECT_EQ(vsync_waiter->await_vsync_call_count_, 1);
+
+  vsync_waiter->SimulateVsync();
+  EXPECT_TRUE(vsync_waiter->CanRegisterCallbackForCurrentVsync());
+
+  // This callback was registered after the platform vsync fired, so it must
+  // arm and wait for the next vsync instead of joining the current one.
+  vsync_waiter->SchedulePreFrameCallback(
+      2, [&] { callback_order.push_back("next pre-frame"); });
+  EXPECT_EQ(vsync_waiter->await_vsync_call_count_, 2);
+
+  fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+  EXPECT_EQ(callback_order,
+            (std::vector<std::string>{"current pre-frame", "current primary"}));
+
+  vsync_waiter->SimulateVsync();
+  fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+  EXPECT_EQ(callback_order,
+            (std::vector<std::string>{"current pre-frame", "current primary",
+                                      "next pre-frame"}));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/shell/common/vsync_waiter_unittests.cc
+++ b/engine/src/flutter/shell/common/vsync_waiter_unittests.cc
@@ -9,6 +9,7 @@
 
 #include "flutter/common/settings.h"
 #include "flutter/common/task_runners.h"
+#include "flutter/shell/common/pointer_data_dispatcher.h"
 #include "flutter/shell/common/switches.h"
 
 #include "gtest/gtest.h"
@@ -34,6 +35,33 @@ class TestVsyncWaiter : public VsyncWaiter {
 
  protected:
   void AwaitVSync() override { await_vsync_call_count_++; }
+};
+
+class TestPointerDataDispatcherDelegate final
+    : public PointerDataDispatcher::Delegate {
+ public:
+  explicit TestPointerDataDispatcherDelegate(
+      const std::shared_ptr<TestVsyncWaiter>& vsync_waiter)
+      : vsync_waiter_(vsync_waiter) {}
+
+  void DoDispatchPacket(std::unique_ptr<PointerDataPacket> /*packet*/,
+                        uint64_t /*trace_flow_id*/) override {
+    dispatched_packet_count_++;
+    vsync_waiter_->AsyncWaitForVsync([this](auto) {
+      packet_counts_at_primary_callback_.push_back(dispatched_packet_count_);
+    });
+  }
+
+  void SchedulePreFrameVsyncCallback(uintptr_t id,
+                                     const fml::closure& callback) override {
+    vsync_waiter_->SchedulePreFrameCallback(id, callback);
+  }
+
+  int dispatched_packet_count_ = 0;
+  std::vector<int> packet_counts_at_primary_callback_;
+
+ private:
+  std::shared_ptr<TestVsyncWaiter> vsync_waiter_;
 };
 
 TEST(VsyncWaiterTest, NoUnneededAwaitVsync) {
@@ -142,6 +170,34 @@ TEST(VsyncWaiterTest, PreFrameCallbackScheduledAfterFireTargetsNextVsync) {
   EXPECT_EQ(callback_order,
             (std::vector<std::string>{"current pre-frame", "current primary",
                                       "next pre-frame"}));
+}
+
+TEST(VsyncWaiterTest, SmoothPointerDataJoinsTheSameVsync) {
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+  const flutter::TaskRunners task_runners("smooth_pointer_same_vsync_test",
+                                          task_runner, task_runner, task_runner,
+                                          task_runner);
+  auto vsync_waiter = std::make_shared<TestVsyncWaiter>(task_runners);
+  TestPointerDataDispatcherDelegate delegate(vsync_waiter);
+  SmoothPointerDataDispatcher dispatcher(delegate);
+
+  dispatcher.DispatchPacket(std::make_unique<PointerDataPacket>(0), 1);
+  dispatcher.DispatchPacket(std::make_unique<PointerDataPacket>(0), 2);
+
+  // The first packet is dispatched immediately and the second is held until
+  // the pre-frame phase.
+  EXPECT_EQ(delegate.dispatched_packet_count_, 1);
+  EXPECT_EQ(vsync_waiter->await_vsync_call_count_, 1);
+
+  vsync_waiter->SimulateVsync();
+  fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+
+  // Flushing the pending packet before the primary callback lets the frame
+  // consume both packets at this vsync. Flushing it as a secondary callback
+  // would leave the first frame with only one packet.
+  EXPECT_EQ(delegate.dispatched_packet_count_, 2);
+  EXPECT_EQ(delegate.packet_counts_at_primary_callback_, (std::vector<int>{2}));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/shell/common/vsync_waiter_unittests.cc
+++ b/engine/src/flutter/shell/common/vsync_waiter_unittests.cc
@@ -172,6 +172,41 @@ TEST(VsyncWaiterTest, PreFrameCallbackScheduledAfterFireTargetsNextVsync) {
                                       "next pre-frame"}));
 }
 
+TEST(VsyncWaiterTest, OlderVsyncCannotCloseNewerRegistrationWindow) {
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+  const flutter::TaskRunners task_runners("vsync_waiter_generation_test",
+                                          task_runner, task_runner, task_runner,
+                                          task_runner);
+  auto vsync_waiter = std::make_shared<TestVsyncWaiter>(task_runners);
+  std::vector<std::string> callback_order;
+
+  vsync_waiter->SchedulePreFrameCallback(
+      1, [&] { callback_order.push_back("current pre-frame"); });
+  vsync_waiter->AsyncWaitForVsync(
+      [&](auto) { callback_order.push_back("current primary"); });
+  vsync_waiter->SimulateVsync();
+
+  // Arm another vsync before the UI task for the current primary callback has
+  // run, as can happen when the UI thread is blocked for a frame interval.
+  vsync_waiter->SchedulePreFrameCallback(
+      2, [&] { callback_order.push_back("next pre-frame"); });
+  task_runner->PostTask([&] {
+    callback_order.push_back("between primary callbacks");
+    EXPECT_TRUE(vsync_waiter->CanRegisterCallbackForCurrentVsync());
+    vsync_waiter->AsyncWaitForVsync(
+        [&](auto) { callback_order.push_back("next primary"); });
+  });
+  vsync_waiter->SimulateVsync();
+
+  fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+  EXPECT_EQ(callback_order,
+            (std::vector<std::string>{"current pre-frame", "current primary",
+                                      "between primary callbacks",
+                                      "next pre-frame", "next primary"}));
+  EXPECT_FALSE(vsync_waiter->CanRegisterCallbackForCurrentVsync());
+}
+
 TEST(VsyncWaiterTest, SmoothPointerDataJoinsTheSameVsync) {
   fml::MessageLoop::EnsureInitializedForCurrentThread();
   auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();


### PR DESCRIPTION
## Description

Fixes #190917

On iOS, `SmoothPointerDataDispatcher` may hold the latest pointer packet until VSync to smooth irregular input delivery.

Previously, the pending packet was released from a secondary VSync callback, after the primary frame callback for that VSync had already been posted.

As a result, pointer data synchronized to VSync N could not affect the frame associated with VSync N. If processing that pointer data requested a frame, the request would instead wait for VSync N+1, adding a full display interval to the input-to-render path.

In other words, the pointer packet was synchronized to one VSync but could only be rendered by the following one.

## Changes

This change adds a bounded pre-frame callback phase to `VsyncWaiter`.

The callback order becomes:

1. A platform VSync fires.
2. Pre-frame callbacks run on the UI task runner.
3. The primary frame callback is consumed and runs.
4. Secondary callbacks run.

`SmoothPointerDataDispatcher` now releases its pending pointer packet during the pre-frame phase instead of from a secondary callback.

The primary callback is intentionally left available until pre-frame work has completed. If processing the pointer packet requests a frame while the platform VSync has already fired but its primary callback has not yet been consumed, `Animator` registers that callback synchronously.

This allows the newly requested frame to participate in the current VSync rather than posting `AwaitVSync` behind the already queued primary-frame task and waiting for the following VSync.

The same-VSync registration window is deliberately narrow. It begins when the platform VSync fires and ends when the primary callback is consumed on the UI task runner. Pre-frame or secondary callbacks registered after the current callback snapshot are kept for the next VSync.

This preserves the existing smoothing behavior of `SmoothPointerDataDispatcher`. The change only ensures that pointer data released for a VSync can be consumed by the frame associated with that same VSync.

## Before and after

<img height="1000" alt="Smooth pointer dispatch before and after" src="https://github.com/user-attachments/assets/1de8886c-1cfa-4df1-8824-4cdc925e4c7f" />

Before:

```text
VSync N
  → BeginFrame N
  → release pending pointer
  → request frame
  → wait for VSync N+1
````

After:

```text
VSync N
  → release pending pointer
  → request/attach frame callback
  → BeginFrame N
```

The pending pointer packet is still synchronized to VSync, but it no longer incurs an additional frame solely because it was dispatched after the primary callback.

## Tests

Added coverage verifies that:

* pre-frame, primary, and secondary callbacks execute in that order;
* a primary callback requested by pre-frame work can join the same already-fired VSync without arming another VSync;
* pre-frame work registered after the current VSync callback snapshot targets the next VSync;
* a packet held by `SmoothPointerDataDispatcher` is dispatched before the primary callback and can be consumed by the frame associated with the same VSync.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.