### PR TITLE
[flutter_tools] Fix deadlock in debug adapters when process exits early

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -466,17 +466,16 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
       waitingForDebugger = true;
       try {
         await Future.any<void>([debuggerInitialized, debuggerInitializationFailedCompleter.future]);
-        sendEvent(RawEventBody(<String, Object?>{}), eventType: 'flutter.appStarted');
       } catch (e) {
         if (!isTerminating) {
           rethrow;
         }
+        return;
       } finally {
         waitingForDebugger = false;
       }
-    } else {
-      sendEvent(RawEventBody(<String, Object?>{}), eventType: 'flutter.appStarted');
     }
+    sendEvent(RawEventBody(<String, Object?>{}), eventType: 'flutter.appStarted');
   }
 
   /// Handles the app.stop event from Flutter.

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -463,9 +463,20 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
     // This may be useful when there's no VM Service (for example Profile mode)
     // but the editor still wants to know that startup has finished.
     if (enableDebugger) {
-      await debuggerInitialized; // Ensure we're fully initialized before sending.
+      waitingForDebugger = true;
+      try {
+        await Future.any<void>([debuggerInitialized, debuggerInitializationFailedCompleter.future]);
+        sendEvent(RawEventBody(<String, Object?>{}), eventType: 'flutter.appStarted');
+      } catch (e) {
+        if (!isTerminating) {
+          rethrow;
+        }
+      } finally {
+        waitingForDebugger = false;
+      }
+    } else {
+      sendEvent(RawEventBody(<String, Object?>{}), eventType: 'flutter.appStarted');
     }
-    sendEvent(RawEventBody(<String, Object?>{}), eventType: 'flutter.appStarted');
   }
 
   /// Handles the app.stop event from Flutter.

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
@@ -54,7 +54,7 @@ abstract class FlutterBaseDebugAdapter
   /// A dummy error handler is attached to the future to prevent unhandled
   /// asynchronous exceptions if it completes before any listeners are active.
   final Completer<void> debuggerInitializationFailedCompleter = Completer<void>()
-    ..future.catchError((Object _) {});
+    ..future.then<void>((_) {}, onError: (Object _) {});
 
   @override
   void handleSessionTerminate([String exitSuffix = '']) {

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
@@ -45,6 +45,19 @@ abstract class FlutterBaseDebugAdapter
   /// the same as what is passed to the base class, which is always provided 'false'.
   final bool enableFlutterDds;
 
+  bool waitingForDebugger = false;
+  final Completer<void> debuggerInitializationFailedCompleter = Completer<void>();
+
+  @override
+  void handleSessionTerminate([String exitSuffix = '']) {
+    if (waitingForDebugger && !debuggerInitializationFailedCompleter.isCompleted) {
+      debuggerInitializationFailedCompleter.completeError(
+        DebugAdapterException('Session terminated before debugger initialized: $exitSuffix'),
+      );
+    }
+    super.handleSessionTerminate(exitSuffix);
+  }
+
   @override
   final FlutterLaunchRequestArguments Function(Map<String, Object?> obj) parseLaunchArgs =
       FlutterLaunchRequestArguments.fromJson;

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
@@ -45,8 +45,16 @@ abstract class FlutterBaseDebugAdapter
   /// the same as what is passed to the base class, which is always provided 'false'.
   final bool enableFlutterDds;
 
+  /// Whether the adapter is currently waiting for the debugger to initialize.
   bool waitingForDebugger = false;
-  final Completer<void> debuggerInitializationFailedCompleter = Completer<void>();
+
+  /// A completer that completes with an error if debugger initialization fails
+  /// (for example, if the session terminates early).
+  ///
+  /// A dummy error handler is attached to the future to prevent unhandled
+  /// asynchronous exceptions if it completes before any listeners are active.
+  final Completer<void> debuggerInitializationFailedCompleter = Completer<void>()
+    ..future.catchError((Object _) {});
 
   @override
   void handleSessionTerminate([String exitSuffix = '']) {

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
@@ -66,11 +66,26 @@ class FlutterTestDebugAdapter extends FlutterBaseDebugAdapter with TestAdapter {
 
     final processArgs = <String>[...toolArgs, ...?args.toolArgs, ?program, ...?args.args];
 
-    await launchAsProcess(executable: executable, processArgs: processArgs, env: args.env);
+    if (debug) {
+      waitingForDebugger = true;
+    }
+
+    try {
+      await launchAsProcess(executable: executable, processArgs: processArgs, env: args.env);
+    } catch (e) {
+      if (debug) {
+        waitingForDebugger = false;
+      }
+      rethrow;
+    }
 
     // Delay responding until the debugger is connected.
     if (debug) {
-      await debuggerInitialized;
+      try {
+        await Future.any<void>([debuggerInitialized, debuggerInitializationFailedCompleter.future]);
+      } finally {
+        waitingForDebugger = false;
+      }
     }
   }
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart
@@ -119,6 +119,16 @@ void main() {
 
     standardTests(toolArgs: toolArgs);
   });
+
+  group('fail fast', () {
+    test('launch fails if process exits early', () async {
+      await client.initialize();
+      expect(
+        client.launch(program: 'non_existent_file.dart', cwd: tempDir.path),
+        throwsA(isA<Response>().having((Response r) => r.success, 'success', isFalse)),
+      );
+    });
+  });
 }
 
 /// Matchers for the expected console output of [TestsProject].

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -39,6 +39,9 @@ class DapTestClient {
           ),
         );
         _pendingRequests.clear();
+        if (!_eventController.isClosed) {
+          unawaited(_eventController.close());
+        }
       },
     );
   }

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
@@ -130,12 +130,13 @@ class DapTestSession {
   }
 
   static Future<DapTestSession> setUp({List<String>? additionalArgs}) async {
-    final DapTestServer server = await _startServer(additionalArgs: additionalArgs);
+    // ignore: avoid_print
+    final Logger? logger = verboseLogging ? print : null;
+    final DapTestServer server = await _startServer(logger: logger, additionalArgs: additionalArgs);
     final DapTestClient client = await DapTestClient.connect(
       server,
       captureVmServiceTraffic: verboseLogging,
-      // ignore: avoid_print
-      logger: verboseLogging ? print : null,
+      logger: logger,
     );
     return DapTestSession._(server, client);
   }


### PR DESCRIPTION
When launching a debug session, if the target process exited early (e.g., due to a startup error, non-existent target, or failure before the VM service connects), the debug adapter would deadlock waiting indefinitely for `debuggerInitialized` to complete.

This change:
1. Tracks `waitingForDebugger` and adds a `debuggerInitializationFailedCompleter` in `FlutterBaseDebugAdapter`.
2. Completes `debuggerInitializationFailedCompleter` with a `DebugAdapterException` in `handleSessionTerminate` if `waitingForDebugger` is active.
3. In `FlutterTestDebugAdapter.launchImpl` and `FlutterDebugAdapter._handleAppStarted`, races `debuggerInitialized` against `debuggerInitializationFailedCompleter.future` via `Future.any`, allowing the adapter to fail fast and terminate cleanly without hanging.
4. Adds a regression integration test verifying fail-fast behavior when the target process exits early.

Fixes https://github.com/flutter/flutter/issues/190721

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
