### PR TITLE
Removes building of ci/android_debug_x86 as nobody should be consuming it.

### DIFF
--- a/engine/src/flutter/ci/builders/linux_android_debug_engine.json
+++ b/engine/src/flutter/ci/builders/linux_android_debug_engine.json
@@ -108,50 +108,6 @@
         {
             "archives": [
                 {
-                    "name": "ci/android_debug_x86",
-                    "type": "gcs",
-                    "base_path": "out/ci/android_debug_x86/zip_archives/",
-                    "include_paths": [
-                        "out/ci/android_debug_x86/zip_archives/android-x86/artifacts.zip",
-                        "out/ci/android_debug_x86/zip_archives/android-x86/android-x86-embedder.zip",
-                        "out/ci/android_debug_x86/zip_archives/android-x86/impeller_sdk.zip",
-                        "out/ci/android_debug_x86/zip_archives/android-x86/symbols.zip",
-                        "out/ci/android_debug_x86/zip_archives/download.flutter.io"
-                    ],
-                    "realm": "production"
-                }
-            ],
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/android_debug_x86",
-                "--android",
-                "--android-cpu=x86",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/android_debug_x86",
-            "description": "Produces debug mode artifacts to target x86 Android from a Linux host.",
-            "ninja": {
-                "config": "ci/android_debug_x86",
-                "targets": [
-                    "flutter",
-                    "flutter/shell/platform/android:abi_jars",
-                    "flutter/shell/platform/embedder:embedder-archive",
-                    "flutter/impeller/toolkit/interop:sdk"
-                ]
-            }
-        },
-        {
-            "archives": [
-                {
                     "name": "ci/android_debug_x64",
                     "type": "gcs",
                     "base_path": "out/ci/android_debug_x64/zip_archives/",

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -927,7 +927,6 @@ const _iosBinaryDirs = <List<String>>[
 ];
 
 const _androidBinaryDirs = <List<String>>[
-  <String>['android-x86', 'android-x86/artifacts.zip'],
   <String>['android-x64', 'android-x64/artifacts.zip'],
   <String>['android-arm', 'android-arm/artifacts.zip'],
   <String>['android-arm-profile', 'android-arm-profile/artifacts.zip'],


### PR DESCRIPTION
Continue towards https://github.com/dart-lang/sdk/issues/49969.
Following up on cl/951638160 