### PR TITLE
[gen_l10n] Preserve script locale inheritance for regional subclasses

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1056,16 +1056,26 @@ class LocalizationsGenerator {
 
   String _generateSubclass(String className, AppResourceBundle bundle) {
     final LocaleInfo locale = bundle.locale;
-    final baseClassName = '$className${LocaleInfo.fromString(locale.languageCode).camelCase()}';
+    final languageLocale = LocaleInfo.fromString(locale.languageCode);
+    var parentLocale = languageLocale;
+    if (locale.scriptCode != null && locale.countryCode != null) {
+      parentLocale = _allBundles
+          .localesForLanguage(locale.languageCode)
+          .firstWhere(
+            (LocaleInfo candidate) =>
+                candidate.scriptCode == locale.scriptCode && candidate.countryCode == null,
+            orElse: () => languageLocale,
+          );
+    }
+    final baseClassName = '$className${parentLocale.camelCase()}';
 
-    // Only mark a message as unimplemented/untranslated for a regional subclass
-    // (e.g. en_US) if it is also missing in the parent base locale (e.g. en).
-    // If it is present in the parent locale, it will be correctly inherited
-    // at runtime via Dart class inheritance, so it shouldn't be reported as missing.
-    final parentLocale = LocaleInfo.fromString(locale.languageCode);
+    // Only mark a message as unimplemented/untranslated if it is missing from
+    // every locale in the subclass's inheritance chain.
     _allMessages
         .where((Message message) {
-          return message.messages[locale] == null && message.messages[parentLocale] == null;
+          return message.messages[locale] == null &&
+              message.messages[parentLocale] == null &&
+              message.messages[languageLocale] == null;
         })
         .forEach((Message message) {
           _addUnimplementedMessage(locale, message.resourceId);
@@ -1075,12 +1085,28 @@ class LocalizationsGenerator {
         .where((Message message) => message.parsedMessages[locale] != null)
         .map((Message message) => _generateMethod(message, locale));
 
+    final bool hasRegionalSubclass =
+        locale.scriptCode != null &&
+        locale.countryCode == null &&
+        _allBundles.localesForLanguage(locale.languageCode).any((LocaleInfo candidate) {
+          return candidate.scriptCode == locale.scriptCode && candidate.countryCode != null;
+        });
+    final parentConstructor = parentLocale == languageLocale ? 'super' : 'super._withLocale';
+    final subclassName = '$className${locale.camelCase()}';
+    // Preserve the public zero-argument constructor while allowing a regional
+    // subclass to initialize the locale name through its script parent.
+    final classMembers = <String>[
+      if (hasRegionalSubclass) '  $subclassName._withLocale(String locale): super(locale);',
+      ...methods,
+    ];
+
     return subclassTemplate
+        .replaceFirst("super('@(localeName)')", "$parentConstructor('@(localeName)')")
         .replaceAll('@(language)', describeLocale(locale.toString()))
         .replaceAll('@(baseLanguageClassName)', baseClassName)
-        .replaceAll('@(class)', '$className${locale.camelCase()}')
+        .replaceAll('@(class)', subclassName)
         .replaceAll('@(localeName)', locale.toString())
-        .replaceAll('@(methods)', methods.join('\n\n'));
+        .replaceAll('@(methods)', classMembers.join('\n\n'));
   }
 
   // Generate the AppLocalizations class, its LocalizationsDelegate subclass,

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1573,6 +1573,53 @@ class AppLocalizationsEn extends AppLocalizations {
       expect(() => getGeneratedFileContent(locale: 'en_US'), throwsException);
     });
 
+    testWithoutContext('uses a script locale as the parent for a regional locale', () {
+      final String untranslatedMessagesFilePath = fs.path.join(
+        'lib',
+        'l10n',
+        'unimplemented_message_translations.json',
+      );
+      setupLocalizations(<String, String>{
+        'en': twoMessageArbFileString,
+        'zh': singleZhMessageArbFileString,
+        'zh_Hant': '''
+{
+  "subtitle": "副標題"
+}''',
+        'zh_Hant_HK': '{}',
+      }, untranslatedMessagesFile: untranslatedMessagesFilePath);
+
+      final String content = getGeneratedFileContent(locale: 'zh');
+      expect(content, contains('class AppLocalizationsZhHant extends AppLocalizationsZh'));
+      expect(content, contains('class AppLocalizationsZhHantHk extends AppLocalizationsZhHant'));
+      expect(content, contains('AppLocalizationsZhHant._withLocale(String locale): super(locale)'));
+      expect(content, contains("AppLocalizationsZhHantHk(): super._withLocale('zh_Hant_HK')"));
+
+      final untranslatedMessages =
+          json.decode(fs.file(untranslatedMessagesFilePath).readAsStringSync())
+              as Map<String, Object?>;
+      expect(untranslatedMessages, <String, Object?>{
+        'zh': <String>['subtitle'],
+      });
+    });
+
+    testWithoutContext('selects parent locales for script and country combinations', () {
+      setupLocalizations(<String, String>{
+        'en': singleMessageArbFileString,
+        'sr': singleMessageArbFileString,
+        'sr_Cyrl_RS': singleMessageArbFileString,
+        'sr_Latn': singleMessageArbFileString,
+        'sr_Latn_RS': singleMessageArbFileString,
+        'sr_RS': singleMessageArbFileString,
+      });
+
+      final String content = getGeneratedFileContent(locale: 'sr');
+      expect(content, contains('class AppLocalizationsSrLatn extends AppLocalizationsSr'));
+      expect(content, contains('class AppLocalizationsSrRs extends AppLocalizationsSr'));
+      expect(content, contains('class AppLocalizationsSrLatnRs extends AppLocalizationsSrLatn'));
+      expect(content, contains('class AppLocalizationsSrCyrlRs extends AppLocalizationsSr'));
+    });
+
     testWithoutContext(
       'language imports are sorted when preferredSupportedLocaleString is given',
       () {


### PR DESCRIPTION
## Summary

When a locale contains language, script, and country subtags, generate its localization subclass from the matching script-only locale when that locale exists. If it does not exist, retain the existing language-level fallback.

The generated script class keeps its public zero-argument constructor and adds a private forwarding constructor for regional subclasses so the full locale name is preserved. Untranslated-message reporting now follows the same inheritance chain.

Fixes #187948.

## Tests

- `dart test test/general.shard/generate_localizations_test.dart --name 'uses a script locale as the parent for a regional locale|selects parent locales for script and country combinations'`
- `dart test test/general.shard/generate_localizations_test.dart test/general.shard/build_system/targets/localizations_test.dart test/commands.shard/hermetic/generate_localizations_test.dart`
- `dart test test/integration.shard/gen_l10n_test.dart --concurrency=1`
- `dart analyze --fatal-infos lib/src/localizations/gen_l10n.dart test/general.shard/generate_localizations_test.dart`
- `flutter analyze lib/src/localizations/gen_l10n.dart test/general.shard/generate_localizations_test.dart`
- `dart format --output=none --set-exit-if-changed lib/src/localizations/gen_l10n.dart test/general.shard/generate_localizations_test.dart`

## AI assistance disclosure

Codex assisted with implementation, tests, and verification.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
