### PR TITLE
ci: Support --target_arch option in prepare_package.dart

### DIFF
--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -59,6 +59,13 @@ Future<void> main(List<String> rawArguments) async {
         'successful creation of the archive. Will publish under this '
         'directory: $baseUrl$releaseFolder',
   );
+  argParser.addOption(
+    'target_arch',
+    allowed: TargetArch.values.map<String>((TargetArch arch) => arch.name),
+    help:
+        'The target architecture of the package to create. '
+        'Defaults to the architecture of the host machine running the script.',
+  );
   argParser.addFlag('force', abbr: 'f', help: 'Overwrite a previously uploaded package.');
   argParser.addFlag(
     'dry_run',
@@ -117,6 +124,10 @@ Future<void> main(List<String> rawArguments) async {
 
   final publish = parsedArguments['publish'] as bool;
   final dryRun = parsedArguments['dry_run'] as bool;
+  final targetArchName = parsedArguments['target_arch'] as String?;
+  final TargetArch? targetArch = targetArchName == null
+      ? null
+      : TargetArch.values.byName(targetArchName);
   final Branch branch = Branch.values.byName(parsedArguments['branch'] as String);
   final creator = ArchiveCreator(
     tempDir,
@@ -125,6 +136,7 @@ Future<void> main(List<String> rawArguments) async {
     branch,
     fs: fs,
     strict: publish && !dryRun,
+    targetArch: targetArch,
   );
   var exitCode = 0;
   late String message;

--- a/dev/bots/prepare_package/archive_creator.dart
+++ b/dev/bots/prepare_package/archive_creator.dart
@@ -30,6 +30,9 @@ class ArchiveCreator {
   ///
   /// If subprocessOutput is true, then output from processes invoked during
   /// archive creation is echoed to stderr and stdout.
+  ///
+  /// If [targetArch] is set, the archive is built for that architecture rather
+  /// than the architecture of the host machine.
   factory ArchiveCreator(
     Directory tempDir,
     Directory outputDir,
@@ -41,6 +44,7 @@ class ArchiveCreator {
     ProcessManager? processManager,
     bool strict = true,
     bool subprocessOutput = true,
+    TargetArch? targetArch,
   }) {
     final Directory flutterRoot = fs.directory(path.join(tempDir.path, 'flutter'));
     final processRunner = ProcessRunner(
@@ -48,6 +52,14 @@ class ArchiveCreator {
       subprocessOutput: subprocessOutput,
       platform: platform,
     )..environment['PUB_CACHE'] = path.join(tempDir.path, '.pub-cache');
+    if (targetArch != null) {
+      // This environment is passed to `bin/internal/update_dart_sdk.{sh,ps1}`,
+      // which run before the tool itself and pick the Dart SDK to download.
+      // `flutter` commands below also pick this up, which results in
+      // `OperatingSystemUtils.hostPlatform` being set and used when we select
+      // which engine artifacts to cache.
+      processRunner.environment['FLUTTER_HOST_ARCH'] = targetArch.name;
+    }
     final String flutterExecutable = path.join(flutterRoot.absolute.path, 'bin', 'flutter');
     final String dartExecutable = path.join(
       flutterRoot.absolute.path,
@@ -71,6 +83,7 @@ class ArchiveCreator {
       httpReader: httpReader ?? http.readBytes,
       flutterExecutable: flutterExecutable,
       dartExecutable: dartExecutable,
+      targetArch: targetArch,
     );
   }
 
@@ -87,6 +100,7 @@ class ArchiveCreator {
     required this.revision,
     required this.strict,
     required this.tempDir,
+    this.targetArch,
   }) : assert(revision.length == 40),
        _processRunner = processRunner,
        _flutter = flutterExecutable,
@@ -98,6 +112,21 @@ class ArchiveCreator {
 
   /// The branch to build the archive for. The branch must contain [revision].
   final Branch branch;
+
+  /// The target host architecture to build the archive for.
+  ///
+  /// This is the host architecture of the Flutter tool inside the archive we
+  /// are building and is used to select the Dart SDK and host engine artifacts
+  /// to be bundled in the archive. For example, if the archive creator is
+  /// running on an arm64 host but producing an SDK to be used by an x64 host,
+  /// this will be x64.
+  ///
+  /// This is passed to the tool via the `FLUTTER_HOST_ARCH` environment
+  /// variable. When null, defaults to the current host architecture.
+  ///
+  /// Warning: The scripts and tool that consume this are the ones in the
+  /// [branch] being packaged, not the ones this script was run from.
+  final TargetArch? targetArch;
 
   /// The git revision hash to build the archive for. This revision has
   /// to be available in the [branch], although it doesn't have to be
@@ -145,7 +174,8 @@ class ArchiveCreator {
   Future<String> get _archiveName async {
     final String os = platform.operatingSystem.toLowerCase();
     // Include the intended host architecture in the file name for non-x64.
-    final arch = await _dartArch == 'x64' ? '' : '${await _dartArch}_';
+    final String effectiveArch = targetArch?.name ?? await _dartArch;
+    final arch = effectiveArch == 'x64' ? '' : '${effectiveArch}_';
     // We don't use .tar.xz on Mac because although it can unpack them
     // on the command line (with tar), the "Archive Utility" that runs
     // when you double-click on them just does some crazy behavior (it
@@ -240,7 +270,22 @@ class ArchiveCreator {
     final result = json.decode(versionJson) as Map<String, dynamic>;
     result.forEach((String key, dynamic value) => versionMap[key] = value.toString());
     versionMap[frameworkVersionTag] = gitVersion;
-    versionMap[dartTargetArchTag] = await _dartArch;
+
+    // The archive filename is derived from [targetArch], but the arch published
+    // in the release metadata is derived from the Dart SDK that was actually
+    // downloaded.
+    //
+    // Perform a paranoid check to be sure that FLUTTER_HOST_ARCH triggered the
+    // download of the artifacts for [targetArch] and fail loudly if not.
+    final String dartArch = await _dartArch;
+    if (targetArch case final TargetArch arch when arch.name != dartArch) {
+      throw PreparePackageException(
+        'Requested an archive for ${arch.name}, but the Dart SDK in the archive '
+        'is $dartArch. Check that FLUTTER_HOST_ARCH was correctly handled in '
+        'bin/internal/update_dart_sdk.sh and bin/internal/update_dart_sdk.ps1.',
+      );
+    }
+    versionMap[dartTargetArchTag] = dartArch;
     return versionMap;
   }
 
@@ -384,7 +429,14 @@ class ArchiveCreator {
   Future<void> _populateCaches() async {
     await _runFlutter(<String>['doctor']);
     await _runFlutter(<String>['update-packages']);
-    await _runFlutter(<String>['precache']);
+    // `FLUTTER_HOST_ARCH` in the environment has already selected the host
+    // artifacts by this point, so this is a no-op. We pass the flag anyway for
+    // future-proofing and so the architecture is recorded in the logs for
+    // visibility/debugging.
+    await _runFlutter(<String>[
+      'precache',
+      if (targetArch case final TargetArch arch) '--host-arch=${arch.name}',
+    ]);
     await _runFlutter(<String>['ide-config']);
 
     // Create each of the templates, since they will call 'pub get' on

--- a/dev/bots/prepare_package/common.dart
+++ b/dev/bots/prepare_package/common.dart
@@ -20,6 +20,13 @@ const String dartTargetArchTag = 'dartTargetArch';
 
 enum Branch { beta, stable, master, main }
 
+/// The CPU architecture a Flutter SDK archive is built for.
+///
+/// This is the architecture of the machine the packaged SDK will run on, which
+/// is not necessarily the architecture of the machine building the package: on
+/// CI we cross-package x64 archives on arm64 macOS hosts.
+enum TargetArch { x64, arm64 }
+
 /// Exception class for when a process fails to run, so we can catch
 /// it and provide something more readable than a stack trace.
 final class PreparePackageException implements Exception {

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -160,9 +160,11 @@ void main() {
       /// [dartArch] is the architecture `dart --version` reports for the Dart
       /// SDK downloaded into the archive. [archiveArch] is the architecture
       /// expected in the archive filename, or null for x64, which is unadorned.
+      /// [precacheArgs] are appended to the `flutter precache` invocation.
       Map<String, List<ProcessResult>?> expectedCalls({
         required String dartArch,
         String? archiveArch,
+        List<String> precacheArgs = const <String>[],
       }) {
         final String createBase = path.join(tempDir.absolute.path, 'create_');
         final archPrefix = archiveArch == null ? '' : '${archiveArch}_';
@@ -194,7 +196,7 @@ void main() {
           if (platform.isWindows) '7za x ${path.join(tempDir.path, 'mingit.zip')}': null,
           '$flutter doctor': null,
           '$flutter update-packages': null,
-          '$flutter precache': null,
+          <String>['$flutter precache', ...precacheArgs].join(' '): null,
           '$flutter ide-config': null,
           '$flutter create --template=app ${createBase}app': null,
           '$flutter create --template=package ${createBase}package': null,
@@ -217,11 +219,13 @@ void main() {
 
       /// The environment expected on every [ArchiveCreator] subprocess.
       ///
-      /// This is the ambient environment, plus the archive's own pub cache.
-      Map<String, String> expectedEnvironment() {
+      /// This is the ambient environment, plus the archive's own pub cache,
+      /// plus the host architecture override when one was requested.
+      Map<String, String> expectedEnvironment({TargetArch? targetArch}) {
         return <String, String>{
           ...platform.environment,
           'PUB_CACHE': path.join(tempDir.path, '.pub-cache'),
+          if (targetArch != null) 'FLUTTER_HOST_ARCH': targetArch.name,
         };
       }
 
@@ -245,6 +249,95 @@ void main() {
         );
         await creator.initializeRepo();
         await creator.createArchive();
+      });
+
+      test('targetArch drives the precache arch and the tool environment', () async {
+        processManager.addCommands(
+          convertResults(
+            expectedCalls(dartArch: 'x64', precacheArgs: <String>['--host-arch=x64']),
+            environment: expectedEnvironment(targetArch: TargetArch.x64),
+          ),
+        );
+        creator = ArchiveCreator(
+          tempDir,
+          tempDir,
+          testRef,
+          Branch.beta,
+          fs: fs,
+          processManager: processManager,
+          subprocessOutput: false,
+          platform: platform,
+          httpReader: fakeHttpReader,
+          targetArch: TargetArch.x64,
+        );
+        await creator.initializeRepo();
+        await creator.createArchive();
+      });
+
+      test('targetArch names a non-x64 archive after the requested arch', () async {
+        processManager.addCommands(
+          convertResults(
+            expectedCalls(
+              dartArch: 'arm64',
+              archiveArch: 'arm64',
+              precacheArgs: <String>['--host-arch=arm64'],
+            ),
+            environment: expectedEnvironment(targetArch: TargetArch.arm64),
+          ),
+        );
+        creator = ArchiveCreator(
+          tempDir,
+          tempDir,
+          testRef,
+          Branch.beta,
+          fs: fs,
+          processManager: processManager,
+          subprocessOutput: false,
+          platform: platform,
+          httpReader: fakeHttpReader,
+          targetArch: TargetArch.arm64,
+        );
+        await creator.initializeRepo();
+        await creator.createArchive();
+      });
+
+      test('throws if the archived Dart SDK does not match targetArch', () async {
+        // The requested arch names the archive, but the arch published in the
+        // release metadata comes from the Dart SDK that was downloaded, so a
+        // disagreement has to fail the build rather than ship a mislabelled
+        // archive.
+        //
+        // The mismatch is caught in initializeRepo, so only the commands up to
+        // and including `dart --version` are ever run.
+        final Map<String, List<ProcessResult>?> calls = expectedCalls(dartArch: 'arm64');
+        final int callsBeforeThrow = calls.keys.toList().indexOf('$dart --version') + 1;
+        processManager.addCommands(
+          convertResults(
+            Map<String, List<ProcessResult>?>.fromEntries(calls.entries.take(callsBeforeThrow)),
+          ),
+        );
+        creator = ArchiveCreator(
+          tempDir,
+          tempDir,
+          testRef,
+          Branch.beta,
+          fs: fs,
+          processManager: processManager,
+          subprocessOutput: false,
+          platform: platform,
+          httpReader: fakeHttpReader,
+          targetArch: TargetArch.x64,
+        );
+        await expectLater(
+          creator.initializeRepo,
+          throwsA(
+            isA<PreparePackageException>().having(
+              (PreparePackageException error) => error.message,
+              'message',
+              contains('Requested an archive for x64, but the Dart SDK in the archive is arm64'),
+            ),
+          ),
+        );
       });
 
       test('throws when a command errors out', () async {


### PR DESCRIPTION
Adds a `--target_arch=<x64|arm64>` option to `dev/bots/prepare_package.dart` to support cross-packaging SDK archives for a target architecture different from the host architecture.

When target arch is specified, we set `FLUTTER_HOST_ARCH` in the environment of each subprocess spawned by the packaging script. This is picked up by `update_dart_sdk.sh` and `update_dart_sdk.ps1` when choosing which Dart SDK to download, and by `OperatingSystemUtils.hostPlatform` when the tool picks which host engine artifacts to cache. Those run from `bin/flutter` before the flutter tool exists, so the environment is the only means we have to pass this setting.

This patch allows arm64 macOS CI hosts to download and cache x64 host engine artifacts when cross-packaging x64 Flutter SDK release archives on an arm64 host (or theoretically vice-versa, but we'll never do that) in the `packaging/packaging` recipe in `packaging.py`.

It's worth noting that the scripts and tool this drives are the ones in the branch being packaged, not the ones this script was run from, so `--target_arch` depends on that branch having cherry-picks to handle both `FLUTTER_HOST_ARCH` support in `bin/internal/update_dart_sdk.{sh,ps1}` (#190421) and the `--host-arch` option of `flutter precache` (#190480).

See: https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/packaging/packaging.py

Issue: https://github.com/flutter/flutter/issues/189144

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
