### PR TITLE
fix(flutter_tools): check runtime env vars before cached bot state

### DIFF
--- a/packages/flutter_tools/lib/src/base/bot_detector.dart
+++ b/packages/flutter_tools/lib/src/base/bot_detector.dart
@@ -37,12 +37,7 @@ class BotDetector {
       return false;
     }
 
-    if (_persistentToolState.isRunningOnBot != null) {
-      return _persistentToolState.isRunningOnBot!;
-    }
-
-    final bool result =
-        _platform.environment['BOT'] == 'true'
+    if (_platform.environment['BOT'] == 'true'
         // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
         ||
         _platform.environment['TRAVIS'] == 'true' ||
@@ -71,11 +66,16 @@ class BotDetector {
         _platform.environment.containsKey('SWARMING_TASK_ID')
         // Property when running on borg.
         ||
-        _platform.environment.containsKey('BORG_ALLOC_DIR')
-        // Property when running on Azure.
-        ||
-        await _azureDetector.isRunningOnAzure;
+        _platform.environment.containsKey('BORG_ALLOC_DIR')) {
+      _persistentToolState.setIsRunningOnBot(true);
+      return true;
+    }
 
+    if (_persistentToolState.isRunningOnBot != null) {
+      return _persistentToolState.isRunningOnBot!;
+    }
+
+    final bool result = await _azureDetector.isRunningOnAzure;
     _persistentToolState.setIsRunningOnBot(result);
     return result;
   }

--- a/packages/flutter_tools/lib/src/base/bot_detector.dart
+++ b/packages/flutter_tools/lib/src/base/bot_detector.dart
@@ -33,7 +33,6 @@ class BotDetector {
         // When set, GA logs to a local file (normally for tests) so we don't need to filter.
         ||
         _platform.environment.containsKey('FLUTTER_ANALYTICS_LOG_FILE')) {
-      _persistentToolState.setIsRunningOnBot(false);
       return false;
     }
 
@@ -67,7 +66,6 @@ class BotDetector {
         // Property when running on borg.
         ||
         _platform.environment.containsKey('BORG_ALLOC_DIR')) {
-      _persistentToolState.setIsRunningOnBot(true);
       return true;
     }
 

--- a/packages/flutter_tools/lib/src/base/bot_detector.dart
+++ b/packages/flutter_tools/lib/src/base/bot_detector.dart
@@ -65,7 +65,10 @@ class BotDetector {
         _platform.environment.containsKey('SWARMING_TASK_ID')
         // Property when running on borg.
         ||
-        _platform.environment.containsKey('BORG_ALLOC_DIR')) {
+        _platform.environment.containsKey('BORG_ALLOC_DIR')
+        // https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables
+        ||
+        _platform.environment.containsKey('TF_BUILD')) {
       return true;
     }
 

--- a/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
@@ -152,6 +152,19 @@ void main() {
         expect(persistentToolState.isRunningOnBot, isNull);
       });
 
+      testWithoutContext('returns true when running on Azure DevOps (TF_BUILD is set)', () async {
+        fakePlatform.environment['TF_BUILD'] = 'True';
+
+        final botDetector = BotDetector(
+          platform: fakePlatform,
+          httpClientFactory: () => FakeHttpClient.list(<FakeRequest>[]),
+          persistentToolState: persistentToolState,
+        );
+
+        expect(await botDetector.isRunningOnBot, isTrue);
+        expect(persistentToolState.isRunningOnBot, isNull);
+      });
+
       testWithoutContext(
         'overrides cached false when CI environment variable is set at runtime without mutating cache',
         () async {

--- a/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
@@ -151,6 +151,62 @@ void main() {
         expect(await botDetector.isRunningOnBot, isTrue);
         expect(persistentToolState.isRunningOnBot, isTrue);
       });
+
+      testWithoutContext(
+        'overrides cached false when CI environment variable is set at runtime',
+        () async {
+          // Simulate an image bake where isRunningOnBot evaluated to false and cached to disk:
+          persistentToolState.setIsRunningOnBot(false);
+          expect(persistentToolState.isRunningOnBot, isFalse);
+
+          fakePlatform.environment['GITHUB_ACTIONS'] = 'true';
+
+          final botDetector = BotDetector(
+            platform: fakePlatform,
+            httpClientFactory: () => FakeHttpClient.list(<FakeRequest>[]),
+            persistentToolState: persistentToolState,
+          );
+
+          expect(await botDetector.isRunningOnBot, isTrue);
+          expect(persistentToolState.isRunningOnBot, isTrue);
+        },
+      );
+
+      testWithoutContext(
+        'overrides cached false when CI=true or SWARMING_TASK_ID is set at runtime',
+        () async {
+          persistentToolState.setIsRunningOnBot(false);
+          expect(persistentToolState.isRunningOnBot, isFalse);
+
+          fakePlatform.environment['CI'] = 'true';
+
+          final botDetector = BotDetector(
+            platform: fakePlatform,
+            httpClientFactory: () => FakeHttpClient.list(<FakeRequest>[]),
+            persistentToolState: persistentToolState,
+          );
+
+          expect(await botDetector.isRunningOnBot, isTrue);
+          expect(persistentToolState.isRunningOnBot, isTrue);
+        },
+      );
+
+      testWithoutContext(
+        'returns cached false when no bot environment variables are set',
+        () async {
+          persistentToolState.setIsRunningOnBot(false);
+          expect(persistentToolState.isRunningOnBot, isFalse);
+
+          final botDetector = BotDetector(
+            platform: fakePlatform,
+            httpClientFactory: () => FakeHttpClient.list(<FakeRequest>[]),
+            persistentToolState: persistentToolState,
+          );
+
+          expect(await botDetector.isRunningOnBot, isFalse);
+          expect(persistentToolState.isRunningOnBot, isFalse);
+        },
+      );
     });
   });
 
@@ -182,19 +238,19 @@ void main() {
 
       expect(await azureDetector.isRunningOnAzure, isTrue);
     });
-    testWithoutContext('isRunningOnAzure returns false when an unexpected exception is thrown', () async {
-      final azureDetector = AzureDetector(
-        httpClientFactory: () => FakeHttpClient.list(<FakeRequest>[
-          FakeRequest(
-            azureUrl,
-            responseError: ArgumentError(
-              'No host specified in URI http:///e2gerror.php',
+    testWithoutContext(
+      'isRunningOnAzure returns false when an unexpected exception is thrown',
+      () async {
+        final azureDetector = AzureDetector(
+          httpClientFactory: () => FakeHttpClient.list(<FakeRequest>[
+            FakeRequest(
+              azureUrl,
+              responseError: ArgumentError('No host specified in URI http:///e2gerror.php'),
             ),
-          ),
-        ]),
-      );
-      expect(await azureDetector.isRunningOnAzure, isFalse);
-    });
+          ]),
+        );
+        expect(await azureDetector.isRunningOnAzure, isFalse);
+      },
+    );
   });
-
 }

--- a/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
@@ -42,7 +42,7 @@ void main() {
         );
 
         expect(await botDetector.isRunningOnBot, isFalse);
-        expect(persistentToolState.isRunningOnBot, isFalse);
+        expect(persistentToolState.isRunningOnBot, isNull);
       });
 
       testWithoutContext('does not cache BOT environment variable', () async {
@@ -55,12 +55,12 @@ void main() {
         );
 
         expect(await botDetector.isRunningOnBot, isTrue);
-        expect(persistentToolState.isRunningOnBot, isTrue);
+        expect(persistentToolState.isRunningOnBot, isNull);
 
         fakePlatform.environment['BOT'] = 'false';
 
         expect(await botDetector.isRunningOnBot, isFalse);
-        expect(persistentToolState.isRunningOnBot, isFalse);
+        expect(persistentToolState.isRunningOnBot, isNull);
       });
 
       testWithoutContext('returns false unconditionally if FLUTTER_HOST is set', () async {
@@ -74,7 +74,7 @@ void main() {
         );
 
         expect(await botDetector.isRunningOnBot, isFalse);
-        expect(persistentToolState.isRunningOnBot, isFalse);
+        expect(persistentToolState.isRunningOnBot, isNull);
       });
 
       testWithoutContext('returns false with and without a terminal attached', () async {
@@ -107,7 +107,7 @@ void main() {
         );
 
         expect(await botDetector.isRunningOnBot, isFalse);
-        expect(persistentToolState.isRunningOnBot, isFalse);
+        expect(persistentToolState.isRunningOnBot, isNull);
       });
 
       testWithoutContext('returns true when azure metadata is reachable', () async {
@@ -149,11 +149,11 @@ void main() {
         );
 
         expect(await botDetector.isRunningOnBot, isTrue);
-        expect(persistentToolState.isRunningOnBot, isTrue);
+        expect(persistentToolState.isRunningOnBot, isNull);
       });
 
       testWithoutContext(
-        'overrides cached false when CI environment variable is set at runtime',
+        'overrides cached false when CI environment variable is set at runtime without mutating cache',
         () async {
           // Simulate an image bake where isRunningOnBot evaluated to false and cached to disk:
           persistentToolState.setIsRunningOnBot(false);
@@ -168,26 +168,34 @@ void main() {
           );
 
           expect(await botDetector.isRunningOnBot, isTrue);
-          expect(persistentToolState.isRunningOnBot, isTrue);
+          expect(persistentToolState.isRunningOnBot, isFalse);
         },
       );
 
       testWithoutContext(
-        'overrides cached false when CI=true or SWARMING_TASK_ID is set at runtime',
+        'running with CI=true does not poison persistentToolState for subsequent runs',
         () async {
           persistentToolState.setIsRunningOnBot(false);
           expect(persistentToolState.isRunningOnBot, isFalse);
 
+          // Invocation 1: Ran in a subshell or test runner with CI=true
           fakePlatform.environment['CI'] = 'true';
-
-          final botDetector = BotDetector(
+          final botDetector1 = BotDetector(
             platform: fakePlatform,
             httpClientFactory: () => FakeHttpClient.list(<FakeRequest>[]),
             persistentToolState: persistentToolState,
           );
+          expect(await botDetector1.isRunningOnBot, isTrue);
+          expect(persistentToolState.isRunningOnBot, isFalse);
 
-          expect(await botDetector.isRunningOnBot, isTrue);
-          expect(persistentToolState.isRunningOnBot, isTrue);
+          // Invocation 2: Normal interactive terminal run (no CI variable)
+          fakePlatform.environment.clear();
+          final botDetector2 = BotDetector(
+            platform: fakePlatform,
+            httpClientFactory: () => FakeHttpClient.list(<FakeRequest>[]),
+            persistentToolState: persistentToolState,
+          );
+          expect(await botDetector2.isRunningOnBot, isFalse);
         },
       );
 


### PR DESCRIPTION
## Description

`BotDetector` currently latches detection results to persistent disk state (`tool_state`), causing two issues:
* **Pre-baked CI Images**: When Docker/VM images run `flutter doctor` during build, `BotDetector` writes `{"is-bot": false}` to disk. When executed in CI (`GITHUB_ACTIONS=true` / `CI=true`), the cached `false` short-circuits evaluation, bypassing runtime CI environment variables.
* **Ephemeral Env Var Latching**: In-memory env vars are process-level state (<1µs lookup). Persisting them to disk latches transient subshell/script context into `tool_state` for future interactive runs.

## Changes

* **Fast in-memory checks first**: Reorder `BotDetector.isRunningOnBot` to evaluate runtime env vars (`BOT=false`, `CI`, `GITHUB_ACTIONS`, `TRAVIS`, `BORG_ALLOC_DIR`, etc.) before reading persistent cache.
* **Zero disk writes on env checks**: Remove `_persistentToolState.setIsRunningOnBot` from in-memory checks.
* **Restrict cache to hardware/IMDS probes**: `_persistentToolState.isRunningOnBot` now only caches `_azureDetector.isRunningOnAzure` to avoid 250ms–1s timeout stalls on non-Azure machines.
* **Tests**: Add unit tests in `bot_detector_test.dart` verifying runtime env overrides and cache isolation across runs.