### PR TITLE
[ImpellerC] Escape spaces in depfile paths

### DIFF
--- a/engine/src/flutter/impeller/compiler/compiler.cc
+++ b/engine/src/flutter/impeller/compiler/compiler.cc
@@ -727,13 +727,20 @@ static std::string JoinStrings(std::vector<std::string> items,
 std::string Compiler::GetDependencyNames(const std::string& separator) const {
   std::vector<std::string> dependencies = included_file_names_;
   dependencies.push_back(Utf8FromPath(options_.file_name));
-  return JoinStrings(dependencies, separator);
+  for (auto& dependency : dependencies) {
+    dependency = EscapeDepfilePath(dependency);
+  }
+  return JoinStrings(std::move(dependencies), separator);
 }
 
 std::unique_ptr<fml::Mapping> Compiler::CreateDepfileContents(
     std::initializer_list<std::string> targets_names) const {
   // https://github.com/ninja-build/ninja/blob/master/src/depfile_parser.cc#L28
-  const auto targets = JoinStrings(targets_names, " ");
+  std::vector<std::string> target_names = targets_names;
+  for (auto& target : target_names) {
+    target = EscapeDepfilePath(target);
+  }
+  const auto targets = JoinStrings(std::move(target_names), " ");
   const auto dependencies = GetDependencyNames(" ");
 
   std::stringstream stream;

--- a/engine/src/flutter/impeller/compiler/compiler_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_unittests.cc
@@ -10,6 +10,7 @@
 #include "impeller/compiler/compiler_test.h"
 #include "impeller/compiler/source_options.h"
 #include "impeller/compiler/types.h"
+#include "impeller/compiler/utilities.h"
 
 namespace impeller {
 namespace compiler {
@@ -668,6 +669,28 @@ TEST_P(CompilerTestRuntime, Mat2Reflection) {
 TEST_P(CompilerTestUnknownPlatform, MustFailDueToUnknownPlatform) {
   ASSERT_FALSE(
       CanCompileAndReflect("sample.frag", SourceType::kFragmentShader));
+}
+
+TEST(CompilerTest, EscapeDepfilePathEscapesSpaces) {
+  EXPECT_EQ(EscapeDepfilePath("/Users/me/Application Support/constants.glsl"),
+            "/Users/me/Application\\ Support/constants.glsl");
+  EXPECT_EQ(EscapeDepfilePath("C:\\my code\\a.frag"), "C:\\my\\ code\\a.frag");
+}
+
+TEST(CompilerTest, EscapeDepfilePathDoublesBackslashesBeforeASpace) {
+  // 2N+1 backslashes followed by a space read back as N backslashes followed
+  // by a space, so a run that ends up next to a space has to be doubled.
+  EXPECT_EQ(EscapeDepfilePath("/tmp/trailing slash\\ /a.frag"),
+            "/tmp/trailing\\ slash\\\\\\ /a.frag");
+}
+
+TEST(CompilerTest, EscapeDepfilePathLeavesEverythingElseAlone) {
+  // Backslashes away from a space are copied through verbatim, which is the
+  // only way a Windows path survives.
+  EXPECT_EQ(EscapeDepfilePath("C:\\src\\flutter\\a.frag"),
+            "C:\\src\\flutter\\a.frag");
+  EXPECT_EQ(EscapeDepfilePath("/plain/path/a.frag"), "/plain/path/a.frag");
+  EXPECT_EQ(EscapeDepfilePath(""), "");
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/compiler/shader_bundle.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle.cc
@@ -282,9 +282,9 @@ static bool OutputBundleDepfile(const Switches& switches,
                                 const std::string& target,
                                 const std::set<std::string>& dependencies) {
   std::stringstream stream;
-  stream << target << ":";
+  stream << EscapeDepfilePath(target) << ":";
   for (const auto& dep : dependencies) {
-    stream << " " << dep;
+    stream << " " << EscapeDepfilePath(dep);
   }
   stream << "\n";
   const auto contents = std::make_shared<std::string>(stream.str());

--- a/engine/src/flutter/impeller/compiler/utilities.cc
+++ b/engine/src/flutter/impeller/compiler/utilities.cc
@@ -31,6 +31,30 @@ std::string Utf8FromPath(const std::filesystem::path& path) {
   return reinterpret_cast<const char*>(path.u8string().c_str());
 }
 
+std::string EscapeDepfilePath(const std::string& path) {
+  std::string result;
+  result.reserve(path.size());
+  size_t backslashes = 0u;
+  for (char character : path) {
+    switch (character) {
+      case '\\':
+        backslashes++;
+        result.push_back(character);
+        break;
+      case ' ':
+        result.append(backslashes + 1u, '\\');
+        result.push_back(character);
+        backslashes = 0u;
+        break;
+      default:
+        result.push_back(character);
+        backslashes = 0u;
+        break;
+    }
+  }
+  return result;
+}
+
 std::string InferShaderNameFromPath(const std::filesystem::path& path) {
   return Utf8FromPath(path.stem());
 }

--- a/engine/src/flutter/impeller/compiler/utilities.h
+++ b/engine/src/flutter/impeller/compiler/utilities.h
@@ -23,6 +23,15 @@ bool SetPermissiveAccess(const std::filesystem::path& p);
 ///         has utf16 paths), the path will get mangled.
 std::string Utf8FromPath(const std::filesystem::path& path);
 
+/// @brief  Escapes a path so it survives a depfile's space separated list.
+///
+///         A space is written as `\ `, and any run of backslashes immediately
+///         before it is doubled, since a parser reads 2N+1 backslashes followed
+///         by a space as N backslashes followed by a space. Backslashes
+///         elsewhere in the path are left alone so that Windows paths, which
+///         Ninja copies through verbatim, keep working.
+std::string EscapeDepfilePath(const std::string& path);
+
 std::string InferShaderNameFromPath(const std::filesystem::path& path);
 
 std::string ToCamelCase(std::string_view string);


### PR DESCRIPTION
`Compiler::CreateDepfileContents` and `OutputBundleDepfile` join dependency paths with plain spaces, so a path containing a space reaches the consumer as two paths that do not exist. An SDK under `~/Library/Application Support` puts a space in front of every bundled `shader_lib` include, which is why this shows up on macOS.

Both writers now go through `EscapeDepfilePath`. A space becomes `\ `, with any run of backslashes in front of it doubled, since 2N+1 backslashes plus a space read back as N backslashes plus a space. Backslashes elsewhere are left as they are: that is the encoding Ninja, flutter_tools' `DepfileService` and the hooks runner's `parseDepFileInputs` all read correctly.

Escaping is covered by unit tests in `compiler_unittests.cc`.

Fixes flutter/flutter#190968

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
