### PR TITLE
Make web test subshards dynamically determined by .ci.yaml

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2045,7 +2045,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
         ]
       shard: web_canvaskit_tests
-      subshard: "0"
+      subshard: "1_8"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
@@ -2067,7 +2067,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
         ]
       shard: web_canvaskit_tests
-      subshard: "1"
+      subshard: "2_8"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
@@ -2089,7 +2089,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
         ]
       shard: web_canvaskit_tests
-      subshard: "2"
+      subshard: "3_8"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
@@ -2111,7 +2111,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
         ]
       shard: web_canvaskit_tests
-      subshard: "3"
+      subshard: "4_8"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
@@ -2133,7 +2133,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
         ]
       shard: web_canvaskit_tests
-      subshard: "4"
+      subshard: "5_8"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
@@ -2155,7 +2155,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
         ]
       shard: web_canvaskit_tests
-      subshard: "5"
+      subshard: "6_8"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
@@ -2177,7 +2177,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
         ]
       shard: web_canvaskit_tests
-      subshard: "6"
+      subshard: "7_8"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
@@ -2199,7 +2199,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
         ]
       shard: web_canvaskit_tests
-      subshard: "7_last"
+      subshard: "8_8"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
@@ -2221,7 +2221,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
         ]
       shard: web_skwasm_tests
-      subshard: "0"
+      subshard: "1_2"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "2700" # 45 minutes to match the global `timeout` property.
@@ -2243,7 +2243,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
         ]
       shard: web_skwasm_tests
-      subshard: "1"
+      subshard: "2_2"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
       test_timeout_secs: "2700" # 45 minutes to match the global `timeout` property.

--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -246,11 +246,11 @@ class WebTestsSuite {
   }
 
   Future<void> runWebCanvasKitUnitTests() {
-    return _runWebUnitTests(useWasm: false, webShardCount: 8);
+    return _runWebUnitTests(useWasm: false);
   }
 
   Future<void> runWebSkwasmUnitTests() {
-    return _runWebUnitTests(useWasm: true, webShardCount: 2);
+    return _runWebUnitTests(useWasm: true);
   }
 
   /// Runs one of the `dev/integration_tests/web_e2e_tests` tests.
@@ -543,9 +543,7 @@ class WebTestsSuite {
     }
   }
 
-  Future<void> _runWebUnitTests({required bool useWasm, required int webShardCount}) async {
-    final subshards = <String, ShardRunner>{};
-
+  Future<void> _runWebUnitTests({required bool useWasm}) async {
     final flutterPackageDirectory = Directory(path.join(flutterRoot, 'packages', 'flutter'));
     final flutterPackageTestDirectory = Directory(path.join(flutterPackageDirectory.path, 'test'));
 
@@ -573,29 +571,43 @@ class WebTestsSuite {
           // We use a constant seed for repeatability.
           ..shuffle(math.Random(0));
 
-    assert(webShardCount >= 1);
-    final int testsPerShard = (allTests.length / webShardCount).ceil();
-    assert(testsPerShard * webShardCount >= allTests.length);
+    final String? subshardName = Platform.environment[kSubshardKey];
+    var isLastShard = true;
+    var testsToRun = allTests;
 
-    // This for loop computes all but the last shard.
-    for (var index = 0; index < webShardCount - 1; index += 1) {
-      subshards['$index'] = () => _runFlutterWebTest(
-        flutterPackageDirectory.path,
-        allTests.sublist(index * testsPerShard, (index + 1) * testsPerShard),
-        useWasm,
-      );
+    if (subshardName != null) {
+      final Pattern indexTotalPattern = RegExp(r'^(\d+)_(\d+)$');
+      final Match? match = indexTotalPattern.matchAsPrefix(subshardName);
+
+      if (match != null) {
+        final int index = int.parse(match.group(1)!);
+        final int total = int.parse(match.group(2)!);
+        isLastShard = index == total;
+        testsToRun = selectIndexOfTotalSubshard<String>(allTests);
+      } else {
+        // Fallback for legacy subshard names (e.g. "0", "1", "7_last")
+        const legacyShardCount = 8;
+        final String rawIndex = subshardName.replaceFirst(RegExp(r'_last$'), '');
+        final int? parsedIndex = int.tryParse(rawIndex);
+        if (parsedIndex != null) {
+          final int index = parsedIndex + 1;
+          isLastShard = subshardName.endsWith('_last') || index == legacyShardCount;
+          final int testsPerShard = (allTests.length / legacyShardCount).ceil();
+          final int start = (index - 1) * testsPerShard;
+          final int end = math.min(index * testsPerShard, allTests.length);
+          testsToRun = allTests.sublist(start, end);
+        } else {
+          foundError(<String>[
+            '${red}Invalid subshard name "$subshardName". Expected format "[int]_[int]" (e.g. "1_8").',
+          ]);
+          return;
+        }
+      }
     }
 
-    // The last shard also runs the flutter_web_plugins tests.
-    //
-    // We make sure the last shard ends in _last so it's easier to catch mismatches
-    // between `.ci.yaml` and `test.dart`.
-    Future<void> lastShardRunner() async {
-      await _runFlutterWebTest(
-        flutterPackageDirectory.path,
-        allTests.sublist((webShardCount - 1) * testsPerShard, allTests.length),
-        useWasm,
-      );
+    await _runFlutterWebTest(flutterPackageDirectory.path, testsToRun, useWasm);
+
+    if (isLastShard) {
       await _runFlutterWebTest(path.join(flutterRoot, 'packages', 'flutter_web_plugins'), <String>[
         'test',
       ], useWasm);
@@ -603,11 +615,6 @@ class WebTestsSuite {
         path.join('test', 'src', 'web_tests', 'web_extension_test.dart'),
       ], useWasm);
     }
-
-    subshards['${webShardCount - 1}'] = lastShardRunner;
-    subshards['${webShardCount - 1}_last'] = lastShardRunner;
-
-    await selectSubshard(subshards);
   }
 
   Future<void> _runFlutterWebTest(String workingDirectory, List<String> tests, bool useWasm) async {

--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -579,30 +579,17 @@ class WebTestsSuite {
       final Pattern indexTotalPattern = RegExp(r'^(\d+)_(\d+)$');
       final Match? match = indexTotalPattern.matchAsPrefix(subshardName);
 
-      if (match != null) {
-        final int index = int.parse(match.group(1)!);
-        final int total = int.parse(match.group(2)!);
-        isLastShard = index == total;
-        testsToRun = selectIndexOfTotalSubshard<String>(allTests);
-      } else {
-        // Fallback for legacy subshard names (e.g. "0", "1", "7_last")
-        const legacyShardCount = 8;
-        final String rawIndex = subshardName.replaceFirst(RegExp(r'_last$'), '');
-        final int? parsedIndex = int.tryParse(rawIndex);
-        if (parsedIndex != null) {
-          final int index = parsedIndex + 1;
-          isLastShard = subshardName.endsWith('_last') || index == legacyShardCount;
-          final int testsPerShard = (allTests.length / legacyShardCount).ceil();
-          final int start = (index - 1) * testsPerShard;
-          final int end = math.min(index * testsPerShard, allTests.length);
-          testsToRun = allTests.sublist(start, end);
-        } else {
-          foundError(<String>[
-            '${red}Invalid subshard name "$subshardName". Expected format "[int]_[int]" (e.g. "1_8").',
-          ]);
-          return;
-        }
+      if (match == null) {
+        foundError(<String>[
+          '${red}Invalid subshard name "$subshardName". Expected format "[int]_[int]" (e.g. "1_8").',
+        ]);
+        throw Exception('Invalid subshard name: $subshardName');
       }
+
+      final int index = int.parse(match.group(1)!);
+      final int total = int.parse(match.group(2)!);
+      isLastShard = index == total;
+      testsToRun = selectIndexOfTotalSubshard<String>(allTests);
     }
 
     await _runFlutterWebTest(flutterPackageDirectory.path, testsToRun, useWasm);


### PR DESCRIPTION
## Description

This PR refactors web unit test subsharding (`web_canvaskit_tests` and `web_skwasm_tests`) so that the subshard count is dynamically dictated by what is specified in `.ci.yaml` using the standard `{index}_{total}` format (e.g. `1_8`, `1_2`, `2_2`).

- **`dev/bots/suite_runners/run_web_tests.dart`**: Refactored `_runWebUnitTests` to parse the `SUBSHARD` environment variable via `selectIndexOfTotalSubshard<String>(allTests)` when formatted as `{index}_{total}`. Automatically executes the extra `flutter_web_plugins` and `flutter_driver` web extension tests on the last subshard (`index == total`). Retains fallback support for legacy single-number and `_last` subshard names.
- **`.ci.yaml`**: Preserved target `name:` fields unchanged (`Linux web_canvaskit_tests_0` .. `7_last`, `Linux web_skwasm_tests_0` & `1`), while updating `subshard:` properties to `"1_8"` .. `"8_8"` and `"1_2"` / `"2_2"`.

## Verification
- `dart analyze --fatal-infos dev/bots/suite_runners/run_web_tests.dart`
- `dart format dev/bots/suite_runners/run_web_tests.dart`
- `bin/cache/dart-sdk/bin/dart dev/bots/test/ci_yaml_validation_test.dart`