### PR TITLE
Update Material/Cupertino code freeze workflow to leave PR guidance comment

### DIFF
--- a/.github/workflows/freeze.yml
+++ b/.github/workflows/freeze.yml
@@ -22,6 +22,9 @@ jobs:
     name: Check Code Freeze
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'flutter/flutter' }}
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Check for changes in frozen folders
@@ -45,10 +48,37 @@ jobs:
               - 'packages/flutter/test_fixes/material/**'
               - 'packages/flutter/test_fixes/cupertino/**'
 
+      - name: Comment on frozen changes
+        if: github.event_name != 'merge_group' && steps.filter.outputs.frozen == 'true' && !contains(github.event.pull_request.labels.*.name, 'override code freeze')
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const issueNumber = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+            const issueUrl = 'https://github.com/flutter/flutter/issues/188444';
+            const alreadyCommented = comments.some(comment =>
+              comment.body && comment.body.includes(issueUrl)
+            );
+            if (!alreadyCommented) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: 'This pull request contains changes to Material or Cupertino, which are currently frozen in this repository.\n\n' +
+                  'Changes should be made in `material_ui` and/or `cupertino_ui` in the [flutter/packages](https://github.com/flutter/packages) repository.\n\n' +
+                  'Please refer to https://github.com/flutter/flutter/issues/188444 for instructions.',
+              });
+            }
+
       - name: Fail on frozen changes
         if: github.event_name != 'merge_group' && steps.filter.outputs.frozen == 'true' && !contains(github.event.pull_request.labels.*.name, 'override code freeze')
         run: |
           echo "Error: Code changes detected during the current code freeze."
-          echo "If this is a critical fix that must land, please file an issue for team-design."
-          echo "Info: https://github.com/flutter/flutter/issues/184093"
+          echo "Changes to Material and Cupertino should be made in material_ui and/or cupertino_ui in the flutter/packages repository."
+          echo "Info: https://github.com/flutter/flutter/issues/188444"
           exit 1


### PR DESCRIPTION
Updates `.github/workflows/freeze.yml` so that when a PR touches frozen Material or Cupertino files, the workflow posts a comment to the PR informing the author that:

- Material and Cupertino changes in `flutter/flutter` are currently frozen.
- The changes should be made in `material_ui` and/or `cupertino_ui` in the `flutter/packages` repository.
- They can refer to https://github.com/flutter/flutter/issues/188444 for instructions.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
