### PR TITLE
[Android] Fix edge-to-edge IME inset animation jump

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1194,7 +1194,8 @@ public class FlutterView extends FrameLayout
             this.flutterEngine
                 .getPlatformViewsController(), // TODO(gmackall): this can be changed to take a pvc
             // delegator.
-            this.flutterEngine.getPlatformViewsController2());
+            this.flutterEngine.getPlatformViewsController2(),
+            this.flutterEngine.getPlatformChannel());
 
     try {
       textServicesManager =

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -223,6 +223,11 @@ public class PlatformChannel {
     this.platformMessageHandler = platformMessageHandler;
   }
 
+  /** Returns whether the platform is currently displaying Flutter edge-to-edge. */
+  public boolean isEdgeToEdgeEnabled() {
+    return platformMessageHandler != null && platformMessageHandler.isEdgeToEdgeEnabled();
+  }
+
   /** Informs Flutter of a change in the SystemUI overlays. */
   public void systemChromeChanged(boolean overlaysAreVisible) {
     Log.v(TAG, "Sending 'systemUIChange' message.");
@@ -493,6 +498,11 @@ public class PlatformChannel {
      * be set to transparent, making the buttons and icons hover over the fullscreen application.
      */
     void showSystemUiMode(@NonNull SystemUiMode mode);
+
+    /** Returns whether the platform is currently displaying Flutter edge-to-edge. */
+    default boolean isEdgeToEdgeEnabled() {
+      return false;
+    }
 
     /**
      * The Flutter application would like the Android system to notify the framework when the system

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
@@ -19,6 +19,7 @@ import androidx.annotation.VisibleForTesting;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 
 // Loosely based off of
 // https://github.com/android/user-interface-samples/blob/main/WindowInsetsAnimation/app/src/main/java/com/google/android/samples/insetsanimation/RootViewDeferringInsetsCallback.kt
@@ -56,6 +57,7 @@ class ImeSyncDeferringInsetsCallback {
   private AnimationCallback animationCallback;
   private InsetsListener insetsListener;
   private ImeVisibilityListener imeVisibilityListener;
+  private final BooleanSupplier isEdgeToEdgeEnabled;
 
   // True when an animation that matches deferredInsetTypes is active.
   //
@@ -76,7 +78,12 @@ class ImeSyncDeferringInsetsCallback {
   private boolean needsSave = false;
 
   ImeSyncDeferringInsetsCallback(@NonNull View view) {
+    this(view, () -> false);
+  }
+
+  ImeSyncDeferringInsetsCallback(@NonNull View view, @NonNull BooleanSupplier isEdgeToEdgeEnabled) {
     this.view = view;
+    this.isEdgeToEdgeEnabled = isEdgeToEdgeEnabled;
     this.animationCallback = new AnimationCallback();
     this.insetsListener = new InsetsListener();
   }
@@ -149,15 +156,17 @@ class ImeSyncDeferringInsetsCallback {
 
       // Pre 15, the IME insets include the height of the navigation bar. If the app
       // isn't laid out behind the navigation bar, this causes the IME insets to be too large during
-      // the animation.  To fix this, we subtract the navigationBars bottom inset if the system UI
-      // flags for laying out behind the navigation bar aren't present.
+      // the animation. To fix this, subtract the navigationBars bottom inset unless Flutter's
+      // edge-to-edge system UI mode is active or legacy system UI flags lay the app out behind the
+      // navigation bar.
       int excludedInsets = 0;
       int systemUiFlags = view.getWindowSystemUiVisibility();
-      if (Build.VERSION.SDK_INT < API_LEVELS.API_35) {
-        if ((systemUiFlags & View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION) == 0
-            && (systemUiFlags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0) {
-          excludedInsets = insets.getInsets(WindowInsets.Type.navigationBars()).bottom;
-        }
+      boolean isLaidOutBehindNavigation =
+          isEdgeToEdgeEnabled.getAsBoolean()
+              || (systemUiFlags & View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION) != 0
+              || (systemUiFlags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) != 0;
+      if (Build.VERSION.SDK_INT < API_LEVELS.API_35 && !isLaidOutBehindNavigation) {
+        excludedInsets = insets.getInsets(WindowInsets.Type.navigationBars()).bottom;
       }
 
       WindowInsets.Builder builder = new WindowInsets.Builder(lastWindowInsets);

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -32,6 +32,7 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.inputmethod.EditorInfoCompat;
 import io.flutter.Log;
 import io.flutter.embedding.android.KeyboardManager;
+import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.embedding.engine.systemchannels.ScribeChannel;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel.TextEditState;
@@ -39,6 +40,7 @@ import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.plugin.platform.PlatformViewsController2;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.function.BooleanSupplier;
 
 /** Android implementation of the text input plugin. */
 public class TextInputPlugin implements ListenableEditingState.EditingStateWatcher {
@@ -76,6 +78,40 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
       @NonNull ScribeChannel scribeChannel,
       @NonNull PlatformViewsController platformViewsController,
       @NonNull PlatformViewsController2 platformViewsController2) {
+    this(
+        view,
+        textInputChannel,
+        scribeChannel,
+        platformViewsController,
+        platformViewsController2,
+        () -> false);
+  }
+
+  @SuppressLint("NewApi")
+  public TextInputPlugin(
+      @NonNull View view,
+      @NonNull TextInputChannel textInputChannel,
+      @NonNull ScribeChannel scribeChannel,
+      @NonNull PlatformViewsController platformViewsController,
+      @NonNull PlatformViewsController2 platformViewsController2,
+      @NonNull PlatformChannel platformChannel) {
+    this(
+        view,
+        textInputChannel,
+        scribeChannel,
+        platformViewsController,
+        platformViewsController2,
+        platformChannel::isEdgeToEdgeEnabled);
+  }
+
+  @SuppressLint("NewApi")
+  TextInputPlugin(
+      @NonNull View view,
+      @NonNull TextInputChannel textInputChannel,
+      @NonNull ScribeChannel scribeChannel,
+      @NonNull PlatformViewsController platformViewsController,
+      @NonNull PlatformViewsController2 platformViewsController2,
+      @NonNull BooleanSupplier isEdgeToEdgeEnabled) {
     mView = view;
     // Create a default object.
     mEditable = new ListenableEditingState(null, mView);
@@ -90,7 +126,7 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
     // the Flutter view to grow and shrink to accommodate Android
     // controlled keyboard animations.
     if (Build.VERSION.SDK_INT >= API_LEVELS.API_30) {
-      imeSyncCallback = new ImeSyncDeferringInsetsCallback(view);
+      imeSyncCallback = new ImeSyncDeferringInsetsCallback(view, isEdgeToEdgeEnabled);
       imeSyncCallback.install();
 
       // When the IME is hidden, we need to restart the input method manager to accomodate

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -110,6 +110,11 @@ public class PlatformPlugin {
         }
 
         @Override
+        public boolean isEdgeToEdgeEnabled() {
+          return PlatformPlugin.this.isEdgeToEdge;
+        }
+
+        @Override
         public void setSystemUiChangeListener() {
           setSystemChromeChangeListener();
         }

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java
@@ -5,6 +5,8 @@
 package io.flutter.embedding.engine.systemchannels;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -25,6 +27,23 @@ import org.mockito.ArgumentCaptor;
 
 @RunWith(AndroidJUnit4.class)
 public class PlatformChannelTest {
+  @Test
+  public void isEdgeToEdgeEnabled_delegatesToPlatformMessageHandler() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    DartExecutor dartExecutor = new DartExecutor(mockFlutterJNI, mock(AssetManager.class));
+    PlatformChannel platformChannel = new PlatformChannel(dartExecutor);
+    PlatformChannel.PlatformMessageHandler mockMessageHandler =
+        mock(PlatformChannel.PlatformMessageHandler.class);
+    when(mockMessageHandler.isEdgeToEdgeEnabled()).thenReturn(true);
+    platformChannel.setPlatformMessageHandler(mockMessageHandler);
+
+    assertTrue(platformChannel.isEdgeToEdgeEnabled());
+    verify(mockMessageHandler).isEdgeToEdgeEnabled();
+
+    platformChannel.setPlatformMessageHandler(null);
+    assertFalse(platformChannel.isEdgeToEdgeEnabled());
+  }
+
   @Test
   public void platformChannel_hasStringsMessage() {
     MethodChannel rawChannel = mock(MethodChannel.class);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallbackTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallbackTest.java
@@ -1,0 +1,110 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugin.editing;
+
+import static io.flutter.Build.API_LEVELS;
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.annotation.TargetApi;
+import android.graphics.Insets;
+import android.view.View;
+import android.view.WindowInsets;
+import android.view.WindowInsetsAnimation;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.annotation.Config;
+
+@TargetApi(API_LEVELS.API_30)
+@Config(sdk = {API_LEVELS.API_30, API_LEVELS.API_34})
+@RunWith(AndroidJUnit4.class)
+public class ImeSyncDeferringInsetsCallbackTest {
+  private static final int FINAL_IME_BOTTOM_INSET = 100;
+  private static final int NAVIGATION_BAR_BOTTOM_INSET = 40;
+
+  @Test
+  public void imeAnimation_modernEdgeToEdgeIncludesNavigationBarInsets() {
+    int[] dispatchedImeInsets = dispatchTerminalImeInsets(true, 0, FINAL_IME_BOTTOM_INSET);
+
+    assertArrayEquals(
+        new int[] {FINAL_IME_BOTTOM_INSET, FINAL_IME_BOTTOM_INSET}, dispatchedImeInsets);
+  }
+
+  @Test
+  public void imeAnimation_nonEdgeToEdgeExcludesNavigationBarInsets() {
+    int[] dispatchedImeInsets =
+        dispatchTerminalImeInsets(false, 0, FINAL_IME_BOTTOM_INSET + NAVIGATION_BAR_BOTTOM_INSET);
+
+    assertArrayEquals(
+        new int[] {FINAL_IME_BOTTOM_INSET, FINAL_IME_BOTTOM_INSET}, dispatchedImeInsets);
+  }
+
+  @SuppressWarnings("deprecation")
+  // SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION.
+  @Test
+  public void imeAnimation_legacyEdgeToEdgeIncludesNavigationBarInsets() {
+    int[] dispatchedImeInsets =
+        dispatchTerminalImeInsets(
+            false, View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION, FINAL_IME_BOTTOM_INSET);
+
+    assertArrayEquals(
+        new int[] {FINAL_IME_BOTTOM_INSET, FINAL_IME_BOTTOM_INSET}, dispatchedImeInsets);
+  }
+
+  @SuppressWarnings("deprecation")
+  // getWindowSystemUiVisibility.
+  private int[] dispatchTerminalImeInsets(
+      boolean enableModernEdgeToEdge,
+      int windowSystemUiVisibility,
+      int terminalProgressImeBottomInset) {
+    View view = mock(View.class);
+    when(view.getWindowSystemUiVisibility()).thenReturn(windowSystemUiVisibility);
+
+    AtomicBoolean isEdgeToEdgeEnabled = new AtomicBoolean(false);
+    ImeSyncDeferringInsetsCallback callback =
+        new ImeSyncDeferringInsetsCallback(view, isEdgeToEdgeEnabled::get);
+    WindowInsetsAnimation animation = mock(WindowInsetsAnimation.class);
+    when(animation.getTypeMask()).thenReturn(WindowInsets.Type.ime());
+
+    callback.getAnimationCallback().onPrepare(animation);
+    WindowInsets finalInsets =
+        new WindowInsets.Builder()
+            .setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, FINAL_IME_BOTTOM_INSET))
+            .build();
+    callback.getInsetsListener().onApplyWindowInsets(view, finalInsets);
+
+    // The callback is installed before the framework can request a system UI mode, so the
+    // edge-to-edge state must be read when the animation progresses rather than at construction.
+    isEdgeToEdgeEnabled.set(enableModernEdgeToEdge);
+    WindowInsets terminalProgressInsets =
+        new WindowInsets.Builder()
+            .setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, terminalProgressImeBottomInset))
+            .setInsets(
+                WindowInsets.Type.navigationBars(), Insets.of(0, 0, 0, NAVIGATION_BAR_BOTTOM_INSET))
+            .build();
+    callback
+        .getAnimationCallback()
+        .onProgress(terminalProgressInsets, Collections.singletonList(animation));
+
+    ArgumentCaptor<WindowInsets> progressInsetsCaptor = ArgumentCaptor.forClass(WindowInsets.class);
+    verify(view).onApplyWindowInsets(progressInsetsCaptor.capture());
+
+    callback.getAnimationCallback().onEnd(animation);
+
+    ArgumentCaptor<WindowInsets> endInsetsCaptor = ArgumentCaptor.forClass(WindowInsets.class);
+    verify(view).dispatchApplyWindowInsets(endInsetsCaptor.capture());
+
+    return new int[] {
+      progressInsetsCaptor.getValue().getInsets(WindowInsets.Type.ime()).bottom,
+      endInsetsCaptor.getValue().getInsets(WindowInsets.Type.ime()).bottom
+    };
+  }
+}

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -593,16 +593,19 @@ public class PlatformPluginTest {
     when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
     when(mockActivity.getWindow()).thenReturn(fakeWindow);
     PlatformPlugin platformPlugin = new PlatformPlugin(mockActivity, mockPlatformChannel);
+    assertFalse(platformPlugin.mPlatformMessageHandler.isEdgeToEdgeEnabled());
 
     try (MockedStatic<WindowCompat> windowCompatMock = mockStatic(WindowCompat.class)) {
       // First, enter edge-to-edge mode.
       platformPlugin.mPlatformMessageHandler.showSystemUiMode(
           PlatformChannel.SystemUiMode.EDGE_TO_EDGE);
+      assertTrue(platformPlugin.mPlatformMessageHandler.isEdgeToEdgeEnabled());
       windowCompatMock.verify(() -> WindowCompat.setDecorFitsSystemWindows(fakeWindow, false));
 
       // Then switch to immersive.
       platformPlugin.mPlatformMessageHandler.showSystemUiMode(
           PlatformChannel.SystemUiMode.IMMERSIVE);
+      assertFalse(platformPlugin.mPlatformMessageHandler.isEdgeToEdgeEnabled());
 
       // Should restore decor fits system windows when leaving edge-to-edge.
       windowCompatMock.verify(() -> WindowCompat.setDecorFitsSystemWindows(fakeWindow, true));

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -35,6 +35,7 @@ import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorView;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.embedding.engine.systemchannels.MouseCursorChannel;
+import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.embedding.engine.systemchannels.PlatformViewCreationRequest;
 import io.flutter.embedding.engine.systemchannels.PlatformViewTouch;
 import io.flutter.embedding.engine.systemchannels.ScribeChannel;
@@ -753,6 +754,7 @@ public class PlatformViewsController2Test {
     when(engine.getRenderer()).thenReturn(new FlutterRenderer(jni));
     when(engine.getMouseCursorChannel()).thenReturn(mock(MouseCursorChannel.class));
     when(engine.getTextInputChannel()).thenReturn(mock(TextInputChannel.class));
+    when(engine.getPlatformChannel()).thenReturn(mock(PlatformChannel.class));
     when(engine.getSettingsChannel()).thenReturn(new SettingsChannel(executor));
     when(engine.getScribeChannel()).thenReturn(mock(ScribeChannel.class));
     when(engine.getPlatformViewsController2()).thenReturn(PlatformViewsController2);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -41,6 +41,7 @@ import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.embedding.engine.systemchannels.MouseCursorChannel;
+import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.embedding.engine.systemchannels.PlatformViewCreationRequest;
 import io.flutter.embedding.engine.systemchannels.PlatformViewTouch;
 import io.flutter.embedding.engine.systemchannels.ScribeChannel;
@@ -2124,6 +2125,7 @@ public class PlatformViewsControllerTest {
     when(engine.getRenderer()).thenReturn(new FlutterRenderer(jni));
     when(engine.getMouseCursorChannel()).thenReturn(mock(MouseCursorChannel.class));
     when(engine.getTextInputChannel()).thenReturn(mock(TextInputChannel.class));
+    when(engine.getPlatformChannel()).thenReturn(mock(PlatformChannel.class));
     when(engine.getSettingsChannel()).thenReturn(new SettingsChannel(executor));
     when(engine.getScribeChannel()).thenReturn(mock(ScribeChannel.class));
     when(engine.getPlatformViewsController()).thenReturn(platformViewsController);


### PR DESCRIPTION
## What this changes

On Android API 30–34, `ImeSyncDeferringInsetsCallback` decides whether to exclude the navigation bar from animated IME insets by reading legacy `systemUiVisibility` flags. Flutter's modern `SystemUiMode.edgeToEdge` implementation clears those flags and uses `WindowCompat.setDecorFitsSystemWindows(false)` instead, so the callback misclassifies an edge-to-edge window as non-edge-to-edge.

As a result, `onProgress` subtracts the navigation-bar inset while `onEnd` dispatches the full settled IME inset. Widgets following `viewInsets.bottom` therefore receive a one-frame terminal correction equal to the navigation-bar height.

This PR exposes `PlatformPlugin`'s currently applied Flutter edge-to-edge state through `PlatformChannel`, passes a dynamic query to the IME callback, and uses it alongside the existing legacy-flag fallback. The state is queried during animation because the text input plugin can be constructed before Dart selects its system UI mode.

The existing five-argument `TextInputPlugin` constructor remains supported, and the new `PlatformMessageHandler` method has a default implementation for embedding compatibility.

## Validation

- Added API 30 and API 34 regression coverage for modern Flutter edge-to-edge, non-edge-to-edge, and legacy edge-to-edge modes.
- Added channel delegation and edge-to-edge state-transition coverage.
- Ran the complete `TextInputPluginTest`, `PlatformChannelTest`, and `PlatformPluginTest` suites.
- Built `//flutter/shell/platform/android:android_jar` for `android_debug_unopt_arm64`.
- Ran Java formatting, whitespace, header, and pre-push checks.
- Validated the local engine on a Galaxy SM-G780F running Android 13/API 33 with Samsung three-button navigation. Before the fix, the bottom sheet's final top positions were `194 → 192 → 170 px`; with the fix they progressed `179 → 176 → 174 → 172 → 171 → 171 → 170 px` and remained stable, with no terminal snap or overlap.

Fixes #190974.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
