### PR TITLE
Preserve destination Hero child state during flights

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -3503,12 +3503,18 @@ Widget _navBarHeroLaunchPadBuilder(BuildContext context, Size heroSize, Widget c
 }
 
 /// Navigation bars' hero flight shuttle builder.
-Widget _navBarHeroFlightShuttleBuilder(HeroFlightDetails details) {
-  assert(details.fromHeroContext.widget is Hero);
-  assert(details.toHeroContext.widget is Hero);
+Widget _navBarHeroFlightShuttleBuilder(
+  BuildContext flightContext,
+  Animation<double> animation,
+  HeroFlightDirection flightDirection,
+  BuildContext fromHeroContext,
+  BuildContext toHeroContext,
+) {
+  assert(fromHeroContext.widget is Hero);
+  assert(toHeroContext.widget is Hero);
 
-  final fromHeroWidget = details.fromHeroContext.widget as Hero;
-  final toHeroWidget = details.toHeroContext.widget as Hero;
+  final fromHeroWidget = fromHeroContext.widget as Hero;
+  final toHeroWidget = toHeroContext.widget as Hero;
 
   assert(fromHeroWidget.child is _TransitionableNavigationBar);
   assert(toHeroWidget.child is _TransitionableNavigationBar);
@@ -3525,16 +3531,16 @@ Widget _navBarHeroFlightShuttleBuilder(HeroFlightDetails details) {
     'The to nav bar to Hero must have been mounted in the previous frame',
   );
 
-  switch (details.direction) {
+  switch (flightDirection) {
     case HeroFlightDirection.push:
       return _NavigationBarTransition(
-        animation: details.animation,
+        animation: animation,
         bottomNavBar: fromNavBar,
         topNavBar: toNavBar,
       );
     case HeroFlightDirection.pop:
       return _NavigationBarTransition(
-        animation: details.animation,
+        animation: animation,
         bottomNavBar: toNavBar,
         topNavBar: fromNavBar,
       );

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -3503,18 +3503,12 @@ Widget _navBarHeroLaunchPadBuilder(BuildContext context, Size heroSize, Widget c
 }
 
 /// Navigation bars' hero flight shuttle builder.
-Widget _navBarHeroFlightShuttleBuilder(
-  BuildContext flightContext,
-  Animation<double> animation,
-  HeroFlightDirection flightDirection,
-  BuildContext fromHeroContext,
-  BuildContext toHeroContext,
-) {
-  assert(fromHeroContext.widget is Hero);
-  assert(toHeroContext.widget is Hero);
+Widget _navBarHeroFlightShuttleBuilder(HeroFlightDetails details) {
+  assert(details.fromHeroContext.widget is Hero);
+  assert(details.toHeroContext.widget is Hero);
 
-  final fromHeroWidget = fromHeroContext.widget as Hero;
-  final toHeroWidget = toHeroContext.widget as Hero;
+  final fromHeroWidget = details.fromHeroContext.widget as Hero;
+  final toHeroWidget = details.toHeroContext.widget as Hero;
 
   assert(fromHeroWidget.child is _TransitionableNavigationBar);
   assert(toHeroWidget.child is _TransitionableNavigationBar);
@@ -3531,16 +3525,16 @@ Widget _navBarHeroFlightShuttleBuilder(
     'The to nav bar to Hero must have been mounted in the previous frame',
   );
 
-  switch (flightDirection) {
+  switch (details.direction) {
     case HeroFlightDirection.push:
       return _NavigationBarTransition(
-        animation: animation,
+        animation: details.animation,
         bottomNavBar: fromNavBar,
         topNavBar: toNavBar,
       );
     case HeroFlightDirection.pop:
       return _NavigationBarTransition(
-        animation: animation,
+        animation: details.animation,
         bottomNavBar: toNavBar,
         topNavBar: fromNavBar,
       );

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -42,46 +42,14 @@ typedef HeroPlaceholderBuilder = Widget Function(BuildContext context, Size hero
 /// A function that lets [Hero]es self supply a [Widget] that is shown during the
 /// hero's flight from one route to another instead of default (which is to
 /// show the destination route's instance of the Hero).
-typedef HeroFlightShuttleBuilder = Widget Function(HeroFlightDetails details);
-
-/// The information available to a [HeroFlightShuttleBuilder].
-class HeroFlightDetails {
-  /// Creates the details for a hero flight shuttle.
-  const HeroFlightDetails({
-    required this.context,
-    required this.animation,
-    required this.direction,
-    required this.fromHeroContext,
-    required this.toHeroContext,
-    required this.fromHeroChild,
-    required this.toHeroChild,
-  });
-
-  /// The build context of the flight overlay.
-  final BuildContext context;
-
-  /// The animation that drives the hero flight.
-  final Animation<double> animation;
-
-  /// The direction of the hero flight.
-  final HeroFlightDirection direction;
-
-  /// The build context of the source [Hero].
-  final BuildContext fromHeroContext;
-
-  /// The build context of the destination [Hero].
-  final BuildContext toHeroContext;
-
-  /// The child of the source [Hero].
-  ///
-  /// Unlike [toHeroChild], this child remains mounted in the source route during
-  /// a push flight and is not prepared for state-preserving reparenting.
-  final Widget fromHeroChild;
-
-  /// The destination Hero child, prepared to preserve its [State] while it is
-  /// reparented between the destination route and the flight overlay.
-  final Widget toHeroChild;
-}
+typedef HeroFlightShuttleBuilder =
+    Widget Function(
+      BuildContext flightContext,
+      Animation<double> animation,
+      HeroFlightDirection flightDirection,
+      BuildContext fromHeroContext,
+      BuildContext toHeroContext,
+    );
 
 typedef _OnFlightEnded = void Function(_HeroFlight flight);
 
@@ -256,10 +224,6 @@ class Hero extends StatefulWidget {
   /// If none is provided, the destination route's Hero child is shown in-flight
   /// by default.
   ///
-  /// The [HeroFlightDetails.toHeroChild] passed to this builder preserves
-  /// its [State] when moved into the shuttle. Custom shuttles can wrap that
-  /// child without resetting its state.
-  ///
   /// ## Limitations
   ///
   /// If a widget built by [flightShuttleBuilder] takes part in a [Navigator]
@@ -308,6 +272,23 @@ class Hero extends StatefulWidget {
   ///
   /// If this property is null, [Hero.curve].flipped is used.
   final Curve? reverseCurve;
+
+  /// Returns the child of the [Hero] associated with [context],
+  /// prepared for use in a [HeroFlightShuttleBuilder].
+  ///
+  /// The returned widget preserves the existing element subtree and [State] of
+  /// the Hero's child when it is moved into the flight overlay.
+  ///
+  /// The [context] must be one of the `fromHeroContext` or `toHeroContext` values
+  /// passed to a [HeroFlightShuttleBuilder].
+  static Widget flightShuttleChildOf(BuildContext context) {
+    assert(context.widget is Hero, 'Hero.flightShuttleChildOf must be called with a Hero context.');
+
+    final element = context as StatefulElement;
+    final state = element.state as _HeroState;
+
+    return KeyedSubtree(key: state._key, child: state.widget.child);
+  }
 
   // Returns a map of all of the heroes in `context` indexed by hero tag that
   // should be considered for animation when `navigator` transitions from one
@@ -605,15 +586,11 @@ class _HeroFlight {
   // The OverlayEntry WidgetBuilder callback for the hero's overlay.
   Widget _buildOverlay(BuildContext context) {
     shuttle ??= manifest.shuttleBuilder(
-      HeroFlightDetails(
-        context: context,
-        animation: manifest.animation,
-        direction: manifest.type,
-        fromHeroContext: manifest.fromHero.context,
-        toHeroContext: manifest.toHero.context,
-        fromHeroChild: manifest.fromHero.widget.child,
-        toHeroChild: KeyedSubtree(key: manifest.toHero._key, child: manifest.toHero.widget.child),
-      ),
+      context,
+      manifest.animation,
+      manifest.type,
+      manifest.fromHero.context,
+      manifest.toHero.context,
     );
     assert(shuttle != null);
 
@@ -1095,34 +1072,35 @@ class HeroController extends NavigatorObserver {
     _flights.remove(flight.manifest.tag)?.dispose();
   }
 
-  Widget _defaultHeroFlightShuttleBuilder(HeroFlightDetails details) {
-    final MediaQueryData? toMediaQueryData = MediaQuery.maybeOf(details.toHeroContext);
-    final MediaQueryData? fromMediaQueryData = MediaQuery.maybeOf(details.fromHeroContext);
+  Widget _defaultHeroFlightShuttleBuilder(
+    BuildContext flightContext,
+    Animation<double> animation,
+    HeroFlightDirection flightDirection,
+    BuildContext fromHeroContext,
+    BuildContext toHeroContext,
+  ) {
+    final Widget toHeroChild = Hero.flightShuttleChildOf(toHeroContext);
+
+    final MediaQueryData? toMediaQueryData = MediaQuery.maybeOf(toHeroContext);
+    final MediaQueryData? fromMediaQueryData = MediaQuery.maybeOf(fromHeroContext);
 
     if (toMediaQueryData == null || fromMediaQueryData == null) {
-      return details.toHeroChild;
+      return toHeroChild;
     }
 
     final EdgeInsets fromHeroPadding = fromMediaQueryData.padding;
     final EdgeInsets toHeroPadding = toMediaQueryData.padding;
 
     return AnimatedBuilder(
-      animation: details.animation,
-      child: details.toHeroChild,
+      animation: animation,
       builder: (BuildContext context, Widget? child) {
         return MediaQuery(
           data: toMediaQueryData.copyWith(
-            padding: (details.direction == HeroFlightDirection.push)
-                ? EdgeInsetsTween(
-                    begin: fromHeroPadding,
-                    end: toHeroPadding,
-                  ).evaluate(details.animation)
-                : EdgeInsetsTween(
-                    begin: toHeroPadding,
-                    end: fromHeroPadding,
-                  ).evaluate(details.animation),
+            padding: (flightDirection == HeroFlightDirection.push)
+                ? EdgeInsetsTween(begin: fromHeroPadding, end: toHeroPadding).evaluate(animation)
+                : EdgeInsetsTween(begin: toHeroPadding, end: fromHeroPadding).evaluate(animation),
           ),
-          child: child!,
+          child: toHeroChild,
         );
       },
     );

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -1100,9 +1100,10 @@ class HeroController extends NavigatorObserver {
                 ? EdgeInsetsTween(begin: fromHeroPadding, end: toHeroPadding).evaluate(animation)
                 : EdgeInsetsTween(begin: toHeroPadding, end: fromHeroPadding).evaluate(animation),
           ),
-          child: toHeroChild,
+          child: child!,
         );
       },
+      child: toHeroChild,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -42,14 +42,46 @@ typedef HeroPlaceholderBuilder = Widget Function(BuildContext context, Size hero
 /// A function that lets [Hero]es self supply a [Widget] that is shown during the
 /// hero's flight from one route to another instead of default (which is to
 /// show the destination route's instance of the Hero).
-typedef HeroFlightShuttleBuilder =
-    Widget Function(
-      BuildContext flightContext,
-      Animation<double> animation,
-      HeroFlightDirection flightDirection,
-      BuildContext fromHeroContext,
-      BuildContext toHeroContext,
-    );
+typedef HeroFlightShuttleBuilder = Widget Function(HeroFlightDetails details);
+
+/// The information available to a [HeroFlightShuttleBuilder].
+class HeroFlightDetails {
+  /// Creates the details for a hero flight shuttle.
+  const HeroFlightDetails({
+    required this.context,
+    required this.animation,
+    required this.direction,
+    required this.fromHeroContext,
+    required this.toHeroContext,
+    required this.fromHeroChild,
+    required this.toHeroChild,
+  });
+
+  /// The build context of the flight overlay.
+  final BuildContext context;
+
+  /// The animation that drives the hero flight.
+  final Animation<double> animation;
+
+  /// The direction of the hero flight.
+  final HeroFlightDirection direction;
+
+  /// The build context of the source [Hero].
+  final BuildContext fromHeroContext;
+
+  /// The build context of the destination [Hero].
+  final BuildContext toHeroContext;
+
+  /// The child of the source [Hero].
+  ///
+  /// Unlike [toHeroChild], this child remains mounted in the source route during
+  /// a push flight and is not prepared for state-preserving reparenting.
+  final Widget fromHeroChild;
+
+  /// The destination Hero child, prepared to preserve its [State] while it is
+  /// reparented between the destination route and the flight overlay.
+  final Widget toHeroChild;
+}
 
 typedef _OnFlightEnded = void Function(_HeroFlight flight);
 
@@ -223,6 +255,10 @@ class Hero extends StatefulWidget {
   ///
   /// If none is provided, the destination route's Hero child is shown in-flight
   /// by default.
+  ///
+  /// The [HeroFlightDetails.toHeroChild] passed to this builder preserves
+  /// its [State] when moved into the shuttle. Custom shuttles can wrap that
+  /// child without resetting its state.
   ///
   /// ## Limitations
   ///
@@ -569,11 +605,15 @@ class _HeroFlight {
   // The OverlayEntry WidgetBuilder callback for the hero's overlay.
   Widget _buildOverlay(BuildContext context) {
     shuttle ??= manifest.shuttleBuilder(
-      context,
-      manifest.animation,
-      manifest.type,
-      manifest.fromHero.context,
-      manifest.toHero.context,
+      HeroFlightDetails(
+        context: context,
+        animation: manifest.animation,
+        direction: manifest.type,
+        fromHeroContext: manifest.fromHero.context,
+        toHeroContext: manifest.toHero.context,
+        fromHeroChild: manifest.fromHero.widget.child,
+        toHeroChild: KeyedSubtree(key: manifest.toHero._key, child: manifest.toHero.widget.child),
+      ),
     );
     assert(shuttle != null);
 
@@ -1055,35 +1095,34 @@ class HeroController extends NavigatorObserver {
     _flights.remove(flight.manifest.tag)?.dispose();
   }
 
-  Widget _defaultHeroFlightShuttleBuilder(
-    BuildContext flightContext,
-    Animation<double> animation,
-    HeroFlightDirection flightDirection,
-    BuildContext fromHeroContext,
-    BuildContext toHeroContext,
-  ) {
-    final toHero = toHeroContext.widget as Hero;
-
-    final MediaQueryData? toMediaQueryData = MediaQuery.maybeOf(toHeroContext);
-    final MediaQueryData? fromMediaQueryData = MediaQuery.maybeOf(fromHeroContext);
+  Widget _defaultHeroFlightShuttleBuilder(HeroFlightDetails details) {
+    final MediaQueryData? toMediaQueryData = MediaQuery.maybeOf(details.toHeroContext);
+    final MediaQueryData? fromMediaQueryData = MediaQuery.maybeOf(details.fromHeroContext);
 
     if (toMediaQueryData == null || fromMediaQueryData == null) {
-      return toHero.child;
+      return details.toHeroChild;
     }
 
     final EdgeInsets fromHeroPadding = fromMediaQueryData.padding;
     final EdgeInsets toHeroPadding = toMediaQueryData.padding;
 
     return AnimatedBuilder(
-      animation: animation,
+      animation: details.animation,
+      child: details.toHeroChild,
       builder: (BuildContext context, Widget? child) {
         return MediaQuery(
           data: toMediaQueryData.copyWith(
-            padding: (flightDirection == HeroFlightDirection.push)
-                ? EdgeInsetsTween(begin: fromHeroPadding, end: toHeroPadding).evaluate(animation)
-                : EdgeInsetsTween(begin: toHeroPadding, end: fromHeroPadding).evaluate(animation),
+            padding: (details.direction == HeroFlightDirection.push)
+                ? EdgeInsetsTween(
+                    begin: fromHeroPadding,
+                    end: toHeroPadding,
+                  ).evaluate(details.animation)
+                : EdgeInsetsTween(
+                    begin: toHeroPadding,
+                    end: fromHeroPadding,
+                  ).evaluate(details.animation),
           ),
-          child: toHero.child,
+          child: child!,
         );
       },
     );

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -1822,28 +1822,45 @@ Future<void> main() async {
 
     expect(destinationTracker.states, hasLength(1));
     final State<_LifecycleTrackingWidget> destinationState = destinationTracker.states.single;
+    expect(destinationTracker.disposals, 0);
+    expect(destinationState.mounted, isTrue);
+    expect(homeTracker.states, hasLength(1));
+    expect(homeTracker.disposals, 0);
+    expect(homeState.mounted, isTrue);
 
     // Start the push flight. The destination child moves into the overlay.
     await tester.pump();
     expect(destinationTracker.states, hasLength(1));
     expect(destinationTracker.disposals, 0);
     expect(destinationState.mounted, isTrue);
+    expect(homeTracker.states, hasLength(1));
+    expect(homeTracker.disposals, 0);
+    expect(homeState.mounted, isTrue);
 
     // Finish the push flight. The same State moves back into the destination route.
     await tester.pumpAndSettle();
     expect(destinationTracker.states, hasLength(1));
     expect(destinationTracker.disposals, 0);
     expect(destinationState.mounted, isTrue);
+    expect(homeTracker.states, hasLength(1));
+    expect(homeTracker.disposals, 0);
+    expect(homeState.mounted, isTrue);
 
     // Start the pop flight. The home Hero is now the destination Hero.
     navigatorKey.currentState!.pop();
     await tester.pump();
+    expect(destinationTracker.states, hasLength(1));
+    expect(destinationTracker.disposals, 0);
+    expect(destinationState.mounted, isTrue);
     expect(homeTracker.states, hasLength(1));
     expect(homeTracker.disposals, 0);
     expect(homeState.mounted, isTrue);
 
     // Finish the pop flight and verify that the original home State is restored.
     await tester.pumpAndSettle();
+    expect(destinationTracker.states, hasLength(1));
+    expect(destinationTracker.disposals, 1);
+    expect(destinationState.mounted, isFalse);
     expect(homeTracker.states, hasLength(1));
     expect(homeTracker.disposals, 0);
     expect(homeState.mounted, isTrue);

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -554,9 +554,16 @@ Future<void> main() async {
                   return Hero(
                     tag: 'hero',
                     child: Container(),
-                    flightShuttleBuilder: (HeroFlightDetails details) {
-                      return Container(key: heroKey);
-                    },
+                    flightShuttleBuilder:
+                        (
+                          BuildContext flightContext,
+                          Animation<double> animation,
+                          HeroFlightDirection flightDirection,
+                          BuildContext fromHeroContext,
+                          BuildContext toHeroContext,
+                        ) {
+                          return Container(key: heroKey);
+                        },
                   );
                 },
                 settings: s,
@@ -572,9 +579,16 @@ Future<void> main() async {
           return Hero(
             tag: 'hero',
             child: Container(),
-            flightShuttleBuilder: (HeroFlightDetails details) {
-              return Container(key: heroKey);
-            },
+            flightShuttleBuilder:
+                (
+                  BuildContext flightContext,
+                  Animation<double> animation,
+                  HeroFlightDirection flightDirection,
+                  BuildContext fromHeroContext,
+                  BuildContext toHeroContext,
+                ) {
+                  return Container(key: heroKey);
+                },
           );
         },
       ),
@@ -602,9 +616,16 @@ Future<void> main() async {
                   return Hero(
                     tag: 'hero',
                     child: Container(),
-                    flightShuttleBuilder: (HeroFlightDetails details) {
-                      return Container(key: heroKey);
-                    },
+                    flightShuttleBuilder:
+                        (
+                          BuildContext flightContext,
+                          Animation<double> animation,
+                          HeroFlightDirection flightDirection,
+                          BuildContext fromHeroContext,
+                          BuildContext toHeroContext,
+                        ) {
+                          return Container(key: heroKey);
+                        },
                   );
                 },
                 settings: s,
@@ -1828,47 +1849,6 @@ Future<void> main() async {
     expect(homeState.mounted, isTrue);
   });
 
-  testWidgets('Destination Hero child state is preserved when a custom shuttle wraps the child', (
-    WidgetTester tester,
-  ) async {
-    final navigatorKey = GlobalKey<NavigatorState>();
-    final destinationTracker = _LifecycleTracker();
-
-    // Build the source Hero.
-    await tester.pumpWidget(
-      MaterialApp(
-        navigatorKey: navigatorKey,
-        home: const Hero(tag: 'H', child: SizedBox(width: 100, height: 100)),
-      ),
-    );
-
-    // Push a route whose custom shuttle wraps the destination Hero child.
-    navigatorKey.currentState!.push(
-      MaterialPageRoute<void>(
-        builder: (BuildContext context) => Hero(
-          tag: 'H',
-          flightShuttleBuilder: (HeroFlightDetails details) =>
-              ColoredBox(color: const Color(0xFF000000), child: details.toHeroChild),
-          child: _LifecycleTrackingWidget(destinationTracker),
-        ),
-      ),
-    );
-    await tester.pump();
-    final State<_LifecycleTrackingWidget> destinationState = destinationTracker.states.single;
-
-    // Start the flight. The wrapped destination child keeps the same State in the overlay.
-    await tester.pump();
-    expect(destinationTracker.states, hasLength(1));
-    expect(destinationTracker.disposals, 0);
-    expect(destinationState.mounted, isTrue);
-
-    // Finish the flight. The same State returns to the destination route.
-    await tester.pumpAndSettle();
-    expect(destinationTracker.states, hasLength(1));
-    expect(destinationTracker.disposals, 0);
-    expect(destinationState.mounted, isTrue);
-  });
-
   testWidgets('Hero createRectTween', (WidgetTester tester) async {
     RectTween createRectTween(Rect? begin, Rect? end) {
       return MaterialRectCenterArcTween(begin: begin, end: end);
@@ -2243,9 +2223,16 @@ Future<void> main() async {
                             child: Hero(
                               tag: 'a',
                               child: const Text('bar'),
-                              flightShuttleBuilder: (HeroFlightDetails details) {
-                                return const Text('baz');
-                              },
+                              flightShuttleBuilder:
+                                  (
+                                    BuildContext flightContext,
+                                    Animation<double> animation,
+                                    HeroFlightDirection flightDirection,
+                                    BuildContext fromHeroContext,
+                                    BuildContext toHeroContext,
+                                  ) {
+                                    return const Text('baz');
+                                  },
                             ),
                           );
                         },
@@ -2278,9 +2265,16 @@ Future<void> main() async {
               Hero(
                 tag: 'a',
                 child: const Text('foo'),
-                flightShuttleBuilder: (HeroFlightDetails details) {
-                  return const Text('baz');
-                },
+                flightShuttleBuilder:
+                    (
+                      BuildContext flightContext,
+                      Animation<double> animation,
+                      HeroFlightDirection flightDirection,
+                      BuildContext fromHeroContext,
+                      BuildContext toHeroContext,
+                    ) {
+                      return const Text('baz');
+                    },
               ),
               Builder(
                 builder: (BuildContext context) {
@@ -2326,9 +2320,16 @@ Future<void> main() async {
               Hero(
                 tag: 'a',
                 child: const Text('foo'),
-                flightShuttleBuilder: (HeroFlightDetails details) {
-                  return const Text('fromHero text');
-                },
+                flightShuttleBuilder:
+                    (
+                      BuildContext flightContext,
+                      Animation<double> animation,
+                      HeroFlightDirection flightDirection,
+                      BuildContext fromHeroContext,
+                      BuildContext toHeroContext,
+                    ) {
+                      return const Text('fromHero text');
+                    },
               ),
               Builder(
                 builder: (BuildContext context) {
@@ -2342,9 +2343,16 @@ Future<void> main() async {
                             child: Hero(
                               tag: 'a',
                               child: const Text('bar'),
-                              flightShuttleBuilder: (HeroFlightDetails details) {
-                                return const Text('toHero text');
-                              },
+                              flightShuttleBuilder:
+                                  (
+                                    BuildContext flightContext,
+                                    Animation<double> animation,
+                                    HeroFlightDirection flightDirection,
+                                    BuildContext fromHeroContext,
+                                    BuildContext toHeroContext,
+                                  ) {
+                                    return const Text('toHero text');
+                                  },
                             ),
                           );
                         },
@@ -3167,7 +3175,13 @@ Future<void> main() async {
     WidgetTester tester,
   ) async {
     var shuttlesBuilt = 0;
-    Widget shuttleBuilder(HeroFlightDetails details) {
+    Widget shuttleBuilder(
+      BuildContext flightContext,
+      Animation<double> animation,
+      HeroFlightDirection flightDirection,
+      BuildContext fromHeroContext,
+      BuildContext toHeroContext,
+    ) {
       shuttlesBuilt += 1;
       return const Text("I'm flying in a jetplane");
     }
@@ -4021,7 +4035,7 @@ Future<void> main() async {
         alignment: alignment,
         child: Hero(
           tag: 'hero',
-          flightShuttleBuilder: (HeroFlightDetails details) {
+          flightShuttleBuilder: (_, _, _, _, _) {
             return const SizedBox(key: shuttleKey, width: 100.0, height: 100.0);
           },
           child: const SizedBox(width: 100.0, height: 100.0),

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -307,6 +307,37 @@ class _SimpleState extends State<_SimpleStatefulWidget> {
   Widget build(BuildContext context) => Text(state.toString());
 }
 
+class _LifecycleTrackingWidget extends StatefulWidget {
+  const _LifecycleTrackingWidget(this.tracker);
+
+  final _LifecycleTracker tracker;
+
+  @override
+  State<_LifecycleTrackingWidget> createState() => _LifecycleTrackingState();
+}
+
+class _LifecycleTrackingState extends State<_LifecycleTrackingWidget> {
+  @override
+  void initState() {
+    super.initState();
+    widget.tracker.states.add(this);
+  }
+
+  @override
+  void dispose() {
+    widget.tracker.disposals += 1;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.expand();
+}
+
+class _LifecycleTracker {
+  final List<State<_LifecycleTrackingWidget>> states = <State<_LifecycleTrackingWidget>>[];
+  int disposals = 0;
+}
+
 class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({super.key, this.value = '123'});
   final String value;
@@ -523,16 +554,9 @@ Future<void> main() async {
                   return Hero(
                     tag: 'hero',
                     child: Container(),
-                    flightShuttleBuilder:
-                        (
-                          BuildContext flightContext,
-                          Animation<double> animation,
-                          HeroFlightDirection flightDirection,
-                          BuildContext fromHeroContext,
-                          BuildContext toHeroContext,
-                        ) {
-                          return Container(key: heroKey);
-                        },
+                    flightShuttleBuilder: (HeroFlightDetails details) {
+                      return Container(key: heroKey);
+                    },
                   );
                 },
                 settings: s,
@@ -548,16 +572,9 @@ Future<void> main() async {
           return Hero(
             tag: 'hero',
             child: Container(),
-            flightShuttleBuilder:
-                (
-                  BuildContext flightContext,
-                  Animation<double> animation,
-                  HeroFlightDirection flightDirection,
-                  BuildContext fromHeroContext,
-                  BuildContext toHeroContext,
-                ) {
-                  return Container(key: heroKey);
-                },
+            flightShuttleBuilder: (HeroFlightDetails details) {
+              return Container(key: heroKey);
+            },
           );
         },
       ),
@@ -585,16 +602,9 @@ Future<void> main() async {
                   return Hero(
                     tag: 'hero',
                     child: Container(),
-                    flightShuttleBuilder:
-                        (
-                          BuildContext flightContext,
-                          Animation<double> animation,
-                          HeroFlightDirection flightDirection,
-                          BuildContext fromHeroContext,
-                          BuildContext toHeroContext,
-                        ) {
-                          return Container(key: heroKey);
-                        },
+                    flightShuttleBuilder: (HeroFlightDetails details) {
+                      return Container(key: heroKey);
+                    },
                   );
                 },
                 settings: s,
@@ -1755,6 +1765,110 @@ Future<void> main() async {
     expect(find.text('456'), findsOneWidget);
   });
 
+  testWidgets('Destination Hero child state is preserved during push and pop flights', (
+    WidgetTester tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    final homeTracker = _LifecycleTracker();
+    final destinationTracker = _LifecycleTracker();
+
+    // Build the source Hero and remember its child State for the later pop flight.
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: Hero(
+          tag: 'H',
+          child: SizedBox(width: 100, height: 100, child: _LifecycleTrackingWidget(homeTracker)),
+        ),
+      ),
+    );
+    final State<_LifecycleTrackingWidget> homeState = homeTracker.states.single;
+
+    // Push a route and build its destination Hero before the flight starts.
+    navigatorKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => Hero(
+          tag: 'H',
+          child: SizedBox(
+            width: 200,
+            height: 200,
+            child: _LifecycleTrackingWidget(destinationTracker),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(destinationTracker.states, hasLength(1));
+    final State<_LifecycleTrackingWidget> destinationState = destinationTracker.states.single;
+
+    // Start the push flight. The destination child moves into the overlay.
+    await tester.pump();
+    expect(destinationTracker.states, hasLength(1));
+    expect(destinationTracker.disposals, 0);
+    expect(destinationState.mounted, isTrue);
+
+    // Finish the push flight. The same State moves back into the destination route.
+    await tester.pumpAndSettle();
+    expect(destinationTracker.states, hasLength(1));
+    expect(destinationTracker.disposals, 0);
+    expect(destinationState.mounted, isTrue);
+
+    // Start the pop flight. The home Hero is now the destination Hero.
+    navigatorKey.currentState!.pop();
+    await tester.pump();
+    expect(homeTracker.states, hasLength(1));
+    expect(homeTracker.disposals, 0);
+    expect(homeState.mounted, isTrue);
+
+    // Finish the pop flight and verify that the original home State is restored.
+    await tester.pumpAndSettle();
+    expect(homeTracker.states, hasLength(1));
+    expect(homeTracker.disposals, 0);
+    expect(homeState.mounted, isTrue);
+  });
+
+  testWidgets('Destination Hero child state is preserved when a custom shuttle wraps the child', (
+    WidgetTester tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    final destinationTracker = _LifecycleTracker();
+
+    // Build the source Hero.
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Hero(tag: 'H', child: SizedBox(width: 100, height: 100)),
+      ),
+    );
+
+    // Push a route whose custom shuttle wraps the destination Hero child.
+    navigatorKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => Hero(
+          tag: 'H',
+          flightShuttleBuilder: (HeroFlightDetails details) =>
+              ColoredBox(color: const Color(0xFF000000), child: details.toHeroChild),
+          child: _LifecycleTrackingWidget(destinationTracker),
+        ),
+      ),
+    );
+    await tester.pump();
+    final State<_LifecycleTrackingWidget> destinationState = destinationTracker.states.single;
+
+    // Start the flight. The wrapped destination child keeps the same State in the overlay.
+    await tester.pump();
+    expect(destinationTracker.states, hasLength(1));
+    expect(destinationTracker.disposals, 0);
+    expect(destinationState.mounted, isTrue);
+
+    // Finish the flight. The same State returns to the destination route.
+    await tester.pumpAndSettle();
+    expect(destinationTracker.states, hasLength(1));
+    expect(destinationTracker.disposals, 0);
+    expect(destinationState.mounted, isTrue);
+  });
+
   testWidgets('Hero createRectTween', (WidgetTester tester) async {
     RectTween createRectTween(Rect? begin, Rect? end) {
       return MaterialRectCenterArcTween(begin: begin, end: end);
@@ -2129,16 +2243,9 @@ Future<void> main() async {
                             child: Hero(
                               tag: 'a',
                               child: const Text('bar'),
-                              flightShuttleBuilder:
-                                  (
-                                    BuildContext flightContext,
-                                    Animation<double> animation,
-                                    HeroFlightDirection flightDirection,
-                                    BuildContext fromHeroContext,
-                                    BuildContext toHeroContext,
-                                  ) {
-                                    return const Text('baz');
-                                  },
+                              flightShuttleBuilder: (HeroFlightDetails details) {
+                                return const Text('baz');
+                              },
                             ),
                           );
                         },
@@ -2171,16 +2278,9 @@ Future<void> main() async {
               Hero(
                 tag: 'a',
                 child: const Text('foo'),
-                flightShuttleBuilder:
-                    (
-                      BuildContext flightContext,
-                      Animation<double> animation,
-                      HeroFlightDirection flightDirection,
-                      BuildContext fromHeroContext,
-                      BuildContext toHeroContext,
-                    ) {
-                      return const Text('baz');
-                    },
+                flightShuttleBuilder: (HeroFlightDetails details) {
+                  return const Text('baz');
+                },
               ),
               Builder(
                 builder: (BuildContext context) {
@@ -2226,16 +2326,9 @@ Future<void> main() async {
               Hero(
                 tag: 'a',
                 child: const Text('foo'),
-                flightShuttleBuilder:
-                    (
-                      BuildContext flightContext,
-                      Animation<double> animation,
-                      HeroFlightDirection flightDirection,
-                      BuildContext fromHeroContext,
-                      BuildContext toHeroContext,
-                    ) {
-                      return const Text('fromHero text');
-                    },
+                flightShuttleBuilder: (HeroFlightDetails details) {
+                  return const Text('fromHero text');
+                },
               ),
               Builder(
                 builder: (BuildContext context) {
@@ -2249,16 +2342,9 @@ Future<void> main() async {
                             child: Hero(
                               tag: 'a',
                               child: const Text('bar'),
-                              flightShuttleBuilder:
-                                  (
-                                    BuildContext flightContext,
-                                    Animation<double> animation,
-                                    HeroFlightDirection flightDirection,
-                                    BuildContext fromHeroContext,
-                                    BuildContext toHeroContext,
-                                  ) {
-                                    return const Text('toHero text');
-                                  },
+                              flightShuttleBuilder: (HeroFlightDetails details) {
+                                return const Text('toHero text');
+                              },
                             ),
                           );
                         },
@@ -3081,13 +3167,7 @@ Future<void> main() async {
     WidgetTester tester,
   ) async {
     var shuttlesBuilt = 0;
-    Widget shuttleBuilder(
-      BuildContext flightContext,
-      Animation<double> animation,
-      HeroFlightDirection flightDirection,
-      BuildContext fromHeroContext,
-      BuildContext toHeroContext,
-    ) {
+    Widget shuttleBuilder(HeroFlightDetails details) {
       shuttlesBuilt += 1;
       return const Text("I'm flying in a jetplane");
     }
@@ -3941,7 +4021,7 @@ Future<void> main() async {
         alignment: alignment,
         child: Hero(
           tag: 'hero',
-          flightShuttleBuilder: (_, _, _, _, _) {
+          flightShuttleBuilder: (HeroFlightDetails details) {
             return const SizedBox(key: shuttleKey, width: 100.0, height: 100.0);
           },
           child: const SizedBox(width: 100.0, height: 100.0),


### PR DESCRIPTION
Fixes #191053

## Description

This change preserves the `State` of a destination Hero's child while it moves between the destination route and the Hero overlay.

Previously, the destination Hero child was mounted three separate times during a push transition:

1. When the destination route was initially built.
2. When the child was mounted in the Hero overlay.
3. When the child returned to the destination route after the flight.

Each mount created a new `Element` and `State`, causing the original State to be disposed and reset during the transition.

The destination Hero child is now reparented using the existing `GlobalKey` owned by `_HeroState`. This allows Flutter to move the existing element subtree between the destination route and the Hero overlay instead of recreating it.

## Hero.flightShuttleChildOf

`HeroFlightShuttleBuilder` keeps its existing five-argument signature, avoiding a breaking API change.

A new `Hero.flightShuttleChildOf` method allows a shuttle builder to obtain the existing Hero child subtree prepared for reparenting:

```dart
flightShuttleBuilder: (
  flightContext,
  animation,
  flightDirection,
  fromHeroContext,
  toHeroContext,
) {
  return Material(
    child: Hero.flightShuttleChildOf(toHeroContext),
  );
}
````

The method uses the `Hero` context already provided to `HeroFlightShuttleBuilder` to access the corresponding `_HeroState` and return the child wrapped with its existing `GlobalKey`.

This preserves the child's existing `Element` and `State` when it is moved into the flight overlay, without exposing the internal `GlobalKey` or changing the `HeroFlightShuttleBuilder` callback signature.

The default Hero shuttle also uses the same state-preserving child.

## Before

```text
Destination route:
State 1 initState

Hero flight starts:
State 2 initState
State 1 dispose

Hero flight completes:
State 3 initState
State 2 dispose
```

## After

The same destination State is reparented throughout the flight:

```text
Destination route
    ↓
Hero overlay
    ↓
Destination route
```

`initState` is called once, and the State is not disposed during the transition.

## Tests

Added regression coverage verifying that:

- The destination Hero child preserves its State during push flights.
- The destination Hero child preserves its State during pop flights.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.