### PR TITLE
iOS: Don't discard GPU state set before an engine runs

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -295,23 +295,33 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 
 // Updates `isGpuDisabled` from the current lifecycle state and propagates to shell if available.
 //
-// The state has to be manually read at points where we don't receive a state transition:
-// * When the engine is created, to determine if background or foreground.
-// * In app extensions, when a view controller is attached or detached.
+// This is process-level state that controls whether or not it's safe to submit work to the GPU.
+// Submitting GPU work while the app is backgrounded results in immediate process termination.
+//
+// For apps, we can read the state from `UIApplication.sharedApplication`.
 //
 // In an app extension, the state may be unreadable: there is no `UIApplication`, and the scene is
 // nil until the attached view controller's view is attached to a window's view hierarchy. In these
 // cases, we leave `isGpuDisabled` unmodified. This avoids the possibility of a crash from
 // incorrectly re-enabling the GPU on an engine that was disabled during backgrounding.
+//
+// Aside from on state transitions, the state has to be manually read and updated at the following
+// points:
+//
+// * When the engine is created, to determine if background or foreground.
+// * In app extensions, when a view controller is attached or detached.
+//
 - (void)updateGpuAvailabilityFromLifecycleState {
-  // When UIApplication.sharedApplication is available, it's authoritative.
+  // When UIApplication.sharedApplication is available, it's authoritative for
+  // the process.
   UIApplication* application = FlutterSharedApplication.application;
   if (application) {
     self.isGpuDisabled = application.applicationState == UIApplicationStateBackground;
     return;
   }
 
-  // Otherwise, check if the view is attached to a Window, and query the scene.
+  // Otherwise, we're in an app extension.
+  // Check if the view is attached to a Window, and query the scene.
   UIWindowScene* scene = self.viewController.viewIfLoaded.window.windowScene;
   if (scene) {
     self.isGpuDisabled = scene.activationState == UISceneActivationStateBackground;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -276,6 +276,7 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
                object:nil];
 
   [self setUpLifecycleNotifications:center];
+  [self updateGpuAvailabilityFromLifecycleState];
 
   [center addObserver:self
              selector:@selector(onLocaleUpdated:)
@@ -290,6 +291,31 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 + (FlutterEngine*)engineForIdentifier:(int64_t)identifier {
   NSAssert([[NSThread currentThread] isMainThread], @"Must be called on the main thread.");
   return (__bridge FlutterEngine*)reinterpret_cast<void*>(identifier);
+}
+
+// Updates `isGpuDisabled` from the current lifecycle state and propagates to shell if available.
+//
+// The state has to be manually read at points where we don't receive a state transition:
+// * When the engine is created, to determine if background or foreground.
+// * In app extensions, when a view controller is attached or detached.
+//
+// In an app extension, the state may be unreadable: there is no `UIApplication`, and the scene is
+// nil until the attached view controller's view is attached to a window's view hierarchy. In these
+// cases, we leave `isGpuDisabled` unmodified. This avoids the possibility of a crash from
+// incorrectly re-enabling the GPU on an engine that was disabled during backgrounding.
+- (void)updateGpuAvailabilityFromLifecycleState {
+  // When UIApplication.sharedApplication is available, it's authoritative.
+  UIApplication* application = FlutterSharedApplication.application;
+  if (application) {
+    self.isGpuDisabled = application.applicationState == UIApplicationStateBackground;
+    return;
+  }
+
+  // Otherwise, check if the view is attached to a Window, and query the scene.
+  UIWindowScene* scene = self.viewController.viewIfLoaded.window.windowScene;
+  if (scene) {
+    self.isGpuDisabled = scene.activationState == UISceneActivationStateBackground;
+  }
 }
 
 - (void)setUpLifecycleNotifications:(NSNotificationCenter*)center {
@@ -520,6 +546,10 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 - (void)setViewController:(FlutterViewController*)viewController {
   FML_DCHECK(self.platformView);
   _viewController = viewController;
+
+  // Attaching a view controller makes it possible for app extensions to check GPU availability.
+  [self updateGpuAvailabilityFromLifecycleState];
+
   self.platformView->SetOwnerViewController(_viewController);
   [self maybeSetupPlatformViewChannels];
   [self updateDisplays];
@@ -927,13 +957,6 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                                     platform_runner,                              // ui
                                     _threadHost->io_thread->GetTaskRunner()       // io
   );
-
-  // Disable GPU if the app or scene is running in the background.
-  self.isGpuDisabled = self.viewController
-                           ? self.viewController.stateIsBackground
-                           : FlutterSharedApplication.application &&
-                                 FlutterSharedApplication.application.applicationState ==
-                                     UIApplicationStateBackground;
 
   // Create the shell. This is a blocking operation.
   std::unique_ptr<flutter::Shell> shell = flutter::Shell::Create(
@@ -1474,6 +1497,12 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 }
 
 - (void)setIsGpuDisabled:(BOOL)value {
+  // `fml::SyncSwitch::SetSwitch` notifies its observers whether or not the value changed and is a
+  // blocking call. The Metal backend observes it to drain pending image uploads or flush tasks
+  // awaiting the GPU. Bail out early if unchanged so we only propagate state changes.
+  if (value == _isGpuDisabled) {
+    return;
+  }
   if (_shell) {
     _shell->SetGpuAvailability(value ? flutter::GpuAvailability::kUnavailable
                                      : flutter::GpuAvailability::kAvailable);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -544,33 +544,83 @@ class TestPlatformMessageResponse : public flutter::PlatformMessageResponse {
   [mockBundle stopMocking];
 }
 
-// Locks in current behaviour for GPU state reset, which is arguably wrong.
+// Verifies a value assigned to `isGpuDisabled` before the engine runs is set on the shell.
 //
-// If `isGpuDisabled` is set before the engine runs, it is silently discarded, because
-// `createShell:` assigns to the property from the live view controller or application state
-// immediately before creating the shell.
+// The property is public and readwrite, so an embedder that knows it is starting an engine into the
+// background can set it before `run`. Reading the lifecycle state anywhere on the creation path
+// would overwrite that assignment, and the caller has no way to observe it happening.
 //
-// `createShell:` *does* need to sample the current lifecycle state there. Background/foreground
-// notifications only fire on transitions, so an engine created while the app is already
-// backgrounded would otherwise never know about it. However, this sampling is implemented as an
-// unconditional assignment to a public readwrite property, so it also destroys any state previously
-// set by the caller.
-//
-// TODO(cbracken): https://github.com/flutter/flutter/issues/190835
-//
-// Move this sampling to `init` and `setViewController:` and stop `createShell:` from clobbering
-// this state, then change this test to asserts the opposite of what it currently does.
-- (void)testGpuStateIsDerivedFromApplicationStateWhenShellIsCreated {
+// See: https://github.com/flutter/flutter/issues/190835
+- (void)testGpuStateSetBeforeRunIsAppliedToShell {
   FlutterDartProject* project = [[FlutterDartProject alloc] init];
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
 
-  // Claim the GPU is disabled before the shell exists.
-  //
-  // There is no view controller and the test host is foregrounded, so creating the shell must
-  // overwrite this with NO.
   engine.isGpuDisabled = YES;
   XCTAssertTrue(engine.isGpuDisabled);
 
+  [engine run];
+
+  XCTAssertTrue(engine.isGpuDisabled);
+
+  BOOL gpuDisabled = NO;
+  [engine shell].GetIsGpuDisabledSyncSwitch()->Execute(
+      fml::SyncSwitch::Handlers().SetIfTrue([&] { gpuDisabled = YES; }).SetIfFalse([&] {
+        gpuDisabled = NO;
+      }));
+  XCTAssertTrue(gpuDisabled);
+}
+
+// Verifies an engine created while the application is backgrounded starts with the GPU disabled.
+//
+// Lifecycle notifications only report transitions. Verify that we explicitly check GPU state on
+// creation.
+//
+// See: https://github.com/flutter/flutter/issues/190835
+- (void)testGpuIsDisabledWhenCreatedWhileBackgrounded {
+  id mockApplication = OCMClassMock([UIApplication class]);
+  OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
+  OCMStub([mockApplication applicationState]).andReturn(UIApplicationStateBackground);
+  [self addTeardownBlock:^{
+    [mockApplication stopMocking];
+  }];
+
+  FlutterDartProject* project = [[FlutterDartProject alloc] init];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
+
+  // Read at init. No notification could have arrived yet.
+  XCTAssertTrue(engine.isGpuDisabled);
+
+  [engine run];
+
+  BOOL gpuDisabled = NO;
+  [engine shell].GetIsGpuDisabledSyncSwitch()->Execute(
+      fml::SyncSwitch::Handlers().SetIfTrue([&] { gpuDisabled = YES; }).SetIfFalse([&] {
+        gpuDisabled = NO;
+      }));
+  XCTAssertTrue(gpuDisabled);
+}
+
+// Verifies an engine created while the app is foregrounded starts with the GPU available, and that
+// detaching a view controller re-enables the GPU on an engine that currently has it disabled.
+//
+// Attaching or detaching a view controller must re-read the lifecycle state and update the current
+// engine GPU state. An engine disabled by an earlier background transition must come back up with
+// the GPU available once the application reads as foregrounded.
+//
+// This is specifically testing *app* scenarios, where `UIApplication.sharedApplication` is
+// available.
+//
+// See: https://github.com/flutter/flutter/issues/190835
+- (void)testGpuIsEnabledWhenCreatedWhileForegrounded {
+  id mockApplication = OCMClassMock([UIApplication class]);
+  OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
+  OCMStub([mockApplication applicationState]).andReturn(UIApplicationStateActive);
+  [self addTeardownBlock:^{
+    [mockApplication stopMocking];
+  }];
+
+  FlutterDartProject* project = [[FlutterDartProject alloc] init];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
   [engine run];
 
   XCTAssertFalse(engine.isGpuDisabled);
@@ -581,6 +631,72 @@ class TestPlatformMessageResponse : public flutter::PlatformMessageResponse {
         gpuDisabled = NO;
       }));
   XCTAssertFalse(gpuDisabled);
+
+  // Detaching re-reads the lifecycle state. The application is readable, so the read must overwrite
+  // this rather than preserve it.
+  engine.isGpuDisabled = YES;
+  engine.viewController = nil;
+
+  XCTAssertFalse(engine.isGpuDisabled);
+
+  gpuDisabled = YES;
+  [engine shell].GetIsGpuDisabledSyncSwitch()->Execute(
+      fml::SyncSwitch::Handlers().SetIfTrue([&] { gpuDisabled = YES; }).SetIfFalse([&] {
+        gpuDisabled = NO;
+      }));
+  XCTAssertFalse(gpuDisabled);
+}
+
+// Verifies that detaching a view controller leaves the GPU disabled when the lifecycle state cannot
+// be read.
+//
+// Attaching or detaching a view controller re-reads the lifecycle state. In an app extension, there
+// is no `UIApplication`, and no scene without a view controller whose view is attached to a
+// window's view hierarchy, so we have no source to check. The value determined by the last scene
+// notification is the only information available, so we preserve that.
+//
+// In particular, an engine disabled while its scene is backgrounded must stay disabled, since
+// rendering in the background will result in app termination.
+//
+// See: https://github.com/flutter/flutter/issues/190835
+- (void)testGpuStateIsPreservedWhenLifecycleStateIsUnknown {
+  // Declaring `NSExtension` puts `FlutterSharedApplication` into its app extension configuration
+  // rather than stubbing its result.
+  //
+  // `isAvailable` is NO, `application` returns nil without touching `UIApplication`, and the engine
+  // registers the scene observers rather than the application ones.
+  id mockBundle = OCMPartialMock([NSBundle mainBundle]);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"NSExtension"]).andReturn(@{
+    @"NSExtensionPointIdentifier" : @"com.apple.share-services"
+  });
+  [self addTeardownBlock:^{
+    [mockBundle stopMocking];
+  }];
+  XCTAssertNil(FlutterSharedApplication.application);
+
+  FlutterDartProject* project = [[FlutterDartProject alloc] init];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
+  [engine run];
+
+  // The scene notification is the only signal available in this configuration, and the engine is
+  // observing for it because the bundle declares an extension.
+  [[NSNotificationCenter defaultCenter]
+      postNotification:[NSNotification notificationWithName:UISceneDidEnterBackgroundNotification
+                                                     object:nil
+                                                   userInfo:nil]];
+  XCTAssertTrue(engine.isGpuDisabled);
+
+  // Detaching re-reads the lifecycle state, and must find no source to overwrite the above with.
+  engine.viewController = nil;
+
+  XCTAssertTrue(engine.isGpuDisabled);
+
+  BOOL gpuDisabled = NO;
+  [engine shell].GetIsGpuDisabledSyncSwitch()->Execute(
+      fml::SyncSwitch::Handlers().SetIfTrue([&] { gpuDisabled = YES; }).SetIfFalse([&] {
+        gpuDisabled = NO;
+      }));
+  XCTAssertTrue(gpuDisabled);
 }
 
 // Verifies a handler registered against a background FlutterTaskQueue runs off the platform thread.


### PR DESCRIPTION
Previously, a value assigned to `isGpuDisabled` before the engine ran was silently discarded: `createShell:` checked the current lifecycle state by assigning to the public property immediately before creating the shell, so the caller's value never actually reached `Shell::Create`. We now pass this through where it's safe to do so.

The existing GPU state check is necessary: lifecycle notifications only report transitions, so an engine created while the app is already backgrounded won't receive one and needs to check the state explicitly on startup. However, the placement can be updated so we don't overwrite the user-specified state except when it's necessary (e.g. the user specified the GPU is enabled but the app is backgrounded).

For apps, we can check `UIApplication.sharedApplication` directly. App extensions have no `sharedApplication` so need to check against the `UIScene`, but that's only reachable via a view that's been mounted in a window view hierarchy. As a result, we also need to check the state when we attach the view controller to see if it's different from the current state.

In the case of an app extension where the view controller hasn't been mounted, the safest thing to do is leave the state alone. Enabling while backgrounded would result in the app being terminated.

Fixes: https://github.com/flutter/flutter/issues/190835
Issue: https://github.com/flutter/flutter/issues/112232


<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
