### PR TITLE
ignore soon-to-be-removed plugins_in_inner_options issue

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,6 +8,8 @@ include: analysis_options_common.yaml
 
 analyzer:
   errors:
+    # This error code will no longer be reported here. Until dart rolls in, we need to just ignore the issue.
+    # ignore: unrecognized_error_code
     plugins_in_inner_options: ignore
   exclude:
     - "bin/cache/**"


### PR DESCRIPTION
@bkonyi landed https://github.com/flutter/flutter/pull/191022 around the same time I landed https://dart-review.googlesource.com/c/sdk/+/534500. They sort of conflict in that Ben's PR references `plugins_in_inner_options` which my CL deletes. So we can ignore the `unrecognized_error_code` until a roll makes it in.

See https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8673632836896349697/+/u/analyze_Flutter_repositories/stdout which I believe is from the HH bot.
