### PR TITLE
[analysis] Enable flutter_analyzer_plugin globally in root analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,14 +1,16 @@
 include: analysis_options_common.yaml
 
-# Note: Analyzer plugins (such as flutter_analyzer_plugin) are intentionally
-# configured directly in subpackages (e.g. packages/flutter/lib,
-# packages/flutter/test, packages/flutter_tools) rather than here at the root.
-# This prevents plugins from leaking into excluded or standalone subtrees (like
-# engine/src/flutter) that do not use the framework plugin.
+plugins:
+  flutter_analyzer_plugin:
+    path: dev/flutter_analyzer_plugin
+    diagnostics:
+      avoid_future_catch_error: true
+      no_double_clamp: true
+      no_stopwatches: true
+      protect_public_state_subtypes: true
+      render_box_intrinsics: true
 
 analyzer:
-  errors:
-    plugins_in_inner_options: ignore
   exclude:
     - "bin/cache/**"
       # Ignore protoc generated files

--- a/packages/flutter/lib/analysis_options.yaml
+++ b/packages/flutter/lib/analysis_options.yaml
@@ -1,14 +1,5 @@
 include: ../analysis_options.yaml
 
-plugins:
-  flutter_analyzer_plugin:
-    path: ../../dev/flutter_analyzer_plugin
-    diagnostics:
-      no_double_clamp: true
-      no_stopwatches: true
-      protect_public_state_subtypes: true
-      render_box_intrinsics: true
-
 linter:
   rules:
     # diagnostic_describe_all_properties: true # blocked on https://github.com/dart-lang/sdk/issues/47418

--- a/packages/flutter/test/analysis_options.yaml
+++ b/packages/flutter/test/analysis_options.yaml
@@ -1,11 +1,5 @@
 include: ../analysis_options.yaml
 
-plugins:
-  flutter_analyzer_plugin:
-    path: ../../dev/flutter_analyzer_plugin
-    diagnostics:
-      no_stopwatches: true
-
 linter:
   rules:
     # Tests try to throw and catch things in exciting ways all the time, so

--- a/packages/flutter_tools/analysis_options.yaml
+++ b/packages/flutter_tools/analysis_options.yaml
@@ -9,12 +9,6 @@ analyzer:
     - linux/**
 include: ../analysis_options.yaml
 
-plugins:
-  flutter_analyzer_plugin:
-    path: ../../dev/flutter_analyzer_plugin
-    diagnostics:
-      avoid_future_catch_error: true
-
 linter:
   rules:
     avoid_catches_without_on_clauses: true


### PR DESCRIPTION
## Description

This PR configures `flutter_analyzer_plugin` globally in the repository root `analysis_options.yaml` with all custom diagnostic rules enabled.

### Architectural Context
- `engine/src/flutter/analysis_options.yaml` directly includes `analysis_options_common.yaml` (which contains only the standard analyzer and linter configuration without any `plugins` block). This keeps engine analysis decoupled and ensures the engine never loads the framework analyzer plugin.
- Root `analysis_options.yaml` includes `analysis_options_common.yaml` and configures `plugins: flutter_analyzer_plugin: path: dev/flutter_analyzer_plugin`.
- Redundant plugin declarations and the `plugins_in_inner_options: ignore` suppression in subpackages (`packages/flutter/lib`, `packages/flutter/test`, and `packages/flutter_tools`) have been removed since all framework packages inherit root `analysis_options.yaml`.

### Verification
- `bin/flutter analyze --flutter-repo` passes with 0 issues.
- All unit tests in `dev/flutter_analyzer_plugin` pass (5/5).