### PR TITLE
[analysis] Clarify plugin relative path resolution in root analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,10 +1,10 @@
 include: analysis_options_common.yaml
 
-# Note: Analyzer plugins (such as flutter_analyzer_plugin) are intentionally
-# configured directly in subpackages (e.g. packages/flutter/lib,
-# packages/flutter/test, packages/flutter_tools) rather than here at the root.
-# This prevents plugins from leaking into excluded or standalone subtrees (like
-# engine/src/flutter) that do not use the framework plugin.
+# Note: Analyzer plugins (such as flutter_analyzer_plugin) must be configured
+# directly in each subpackage's analysis_options.yaml (with the appropriate
+# relative depth) rather than at the repository root. The Dart analyzer resolves
+# plugin paths relative to the subpackage directory evaluating the options, so
+# relative plugin paths cannot be inherited from root options.
 
 analyzer:
   errors:


### PR DESCRIPTION
## Description

Updates the comment in root `analysis_options.yaml` to accurately explain that analyzer plugin paths are resolved relative to the subpackage directory evaluating the options, so relative plugin paths cannot be inherited from root options.

## Related Issues
N/A

## Tests
- Verified with `bin/flutter analyze --flutter-repo`