### PR TITLE
Prevent platform views from stealing text input focus from TextFields

### DIFF
--- a/dev/integration_tests/hybrid_android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
+++ b/dev/integration_tests/hybrid_android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
@@ -11,6 +11,8 @@ import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 
 import java.lang.StringBuilder;
 import java.util.HashMap;
@@ -123,10 +125,22 @@ public class MainActivity extends FlutterActivity implements MethodChannel.Metho
                 synthesizeEvent(methodCall);
                 result.success(null);
                 return;
-             case "getViewHierarchy":
+            case "getViewHierarchy":
                 String viewHierarchy = getSerializedViewHierarchy();
                 result.success(viewHierarchy);
                 return;
+            case "commitText":
+                View fView = getFlutterView();
+                EditorInfo attrs = new EditorInfo();
+                InputConnection conn = fView.onCreateInputConnection(attrs);
+                if (conn != null) {
+                    conn.commitText("updated", 1);
+                    result.success(true);
+                } else {
+                    result.success(false);
+                }
+                return;
+
         }
         result.notImplemented();
     }

--- a/dev/integration_tests/hybrid_android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
+++ b/dev/integration_tests/hybrid_android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
@@ -36,6 +36,8 @@ public class SimplePlatformView implements PlatformView, MethodChannel.MethodCal
             }
         };
         view.setBackgroundColor(0xff0000ff);
+        view.setFocusable(true);
+        view.setFocusableInTouchMode(true);
 
         touchPipe = new TouchPipe(this.methodChannel, view);
     }

--- a/dev/integration_tests/hybrid_android_views/lib/android_platform_view.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/android_platform_view.dart
@@ -53,12 +53,14 @@ class AndroidPlatformView extends StatelessWidget {
             id: params.id,
             viewType: params.viewType,
             layoutDirection: TextDirection.ltr,
+            onFocus: () => params.onFocusChanged(true),
           );
         } else {
           controller = PlatformViewsService.initSurfaceAndroidView(
             id: params.id,
             viewType: params.viewType,
             layoutDirection: TextDirection.ltr,
+            onFocus: () => params.onFocusChanged(true),
           );
         }
         if (onPlatformViewCreated != null) {

--- a/dev/integration_tests/hybrid_android_views/lib/future_data_handler.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/future_data_handler.dart
@@ -16,18 +16,25 @@ typedef DriverHandler = Future<String> Function();
 class FutureDataHandler {
   final Map<String, Completer<DriverHandler>> _handlers = <String, Completer<DriverHandler>>{};
 
+  Completer<DriverHandler> _getCompleter(String key) {
+    return _handlers.putIfAbsent(key, () => Completer<DriverHandler>());
+  }
+
   /// Registers a lazy handler that will be invoked on the next message from the driver.
   Completer<DriverHandler> registerHandler(String key) {
-    _handlers[key] = Completer<DriverHandler>();
-    return _handlers[key]!;
+    final Completer<DriverHandler> completer = _getCompleter(key);
+    if (completer.isCompleted) {
+      _handlers[key] = Completer<DriverHandler>();
+      return _handlers[key]!;
+    }
+    return completer;
   }
 
   Future<String> handleMessage(String? message) async {
-    if (_handlers[message] == null) {
-      return 'Unsupported driver message: $message.\n'
-          'Supported messages are: ${_handlers.keys}.';
+    if (message == null) {
+      return 'null message';
     }
-    final DriverHandler handler = await _handlers[message]!.future;
+    final DriverHandler handler = await _getCompleter(message).future;
     return handler();
   }
 }

--- a/dev/integration_tests/hybrid_android_views/lib/keyboard_unfocus_page.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/keyboard_unfocus_page.dart
@@ -1,0 +1,78 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'android_platform_view.dart';
+import 'future_data_handler.dart';
+import 'page.dart';
+
+class KeyboardUnfocusPage extends PageWidget {
+  const KeyboardUnfocusPage({super.key})
+    : super('Keyboard Unfocus Tests', const ValueKey<String>('KeyboardUnfocusListTile'));
+
+  @override
+  Widget build(BuildContext context) {
+    return const KeyboardUnfocusBody();
+  }
+}
+
+class KeyboardUnfocusBody extends StatefulWidget {
+  const KeyboardUnfocusBody({super.key});
+
+  @override
+  State createState() => KeyboardUnfocusBodyState();
+}
+
+class KeyboardUnfocusBodyState extends State<KeyboardUnfocusBody> {
+  final TextEditingController _editingController = TextEditingController();
+  final FocusNode _textFieldFocusNode = FocusNode();
+  final MethodChannel _integrationChannel = const MethodChannel('android_views_integration');
+  String _textValue = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _editingController.addListener(() {
+      setState(() {
+        _textValue = _editingController.text;
+      });
+    });
+
+    driverDataHandler.registerHandler('commitText').complete(() async {
+      final bool success = await _integrationChannel.invokeMethod<bool>('commitText') ?? false;
+      return success.toString();
+    });
+  }
+
+  @override
+  void dispose() {
+    _editingController.dispose();
+    _textFieldFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      appBar: AppBar(title: const Text('Keyboard Unfocus')),
+      body: Column(
+        children: <Widget>[
+          const SizedBox(
+            key: ValueKey<String>('PlatformViewContainer'),
+            height: 300.0,
+            child: AndroidPlatformView(viewType: 'simple_view', useHybridComposition: true),
+          ),
+          TextField(
+            key: const ValueKey<String>('textfield'),
+            controller: _editingController,
+            focusNode: _textFieldFocusNode,
+          ),
+          Text(_textValue, key: const ValueKey<String>('text_value')),
+        ],
+      ),
+    );
+  }
+}

--- a/dev/integration_tests/hybrid_android_views/lib/main.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_driver/driver_extension.dart';
 
 import 'future_data_handler.dart';
+import 'keyboard_unfocus_page.dart';
 import 'motion_events_page.dart';
 import 'nested_view_event_page.dart';
 import 'page.dart';
@@ -13,6 +14,7 @@ import 'page.dart';
 final List<PageWidget> _allPages = <PageWidget>[
   const MotionEventsPage(),
   const NestedViewEventPage(),
+  const KeyboardUnfocusPage(),
 ];
 
 void main() {

--- a/dev/integration_tests/hybrid_android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/hybrid_android_views/test_driver/main_test.dart
@@ -162,4 +162,39 @@ Future<void> main() async {
       );
     }, timeout: Timeout.none);
   });
+
+  test('PlatformView does not steal focus from TextField when unfocused', () async {
+    final SerializableFinder keyboardTile = find.byValueKey('KeyboardUnfocusListTile');
+    await driver.tap(keyboardTile);
+
+    // Disable emulation to test real native keyboard behavior.
+    await driver.setTextEntryEmulation(enabled: false);
+
+    await driver.waitFor(find.byValueKey('PlatformViewContainer'));
+    await driver.waitUntilNoTransientCallbacks();
+
+    // Tap text field to focus it and open IME.
+    await driver.tap(find.byValueKey('textfield'));
+    await driver.waitUntilNoTransientCallbacks();
+
+    // Tap platform view (causes native focus shift).
+    await driver.tap(find.byValueKey('PlatformViewContainer'));
+    await driver.waitUntilNoTransientCallbacks();
+
+    // Tap text field again to re-focus it.
+    await driver.tap(find.byValueKey('textfield'));
+    await driver.waitUntilNoTransientCallbacks();
+
+    expect(await driver.requestData('commitText'), 'true');
+    await driver.waitUntilNoTransientCallbacks();
+
+    // Also verify the text field value was updated!
+    final SerializableFinder textValue = find.byValueKey('text_value');
+    expect(await driver.getText(textValue), 'updated');
+
+    // Clean up
+    await driver.setTextEntryEmulation(enabled: true);
+    await driver.waitFor(find.pageBack());
+    await driver.tap(find.pageBack());
+  }, timeout: Timeout.none);
 }

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -1335,6 +1335,7 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
   void _handleFrameworkFocusChanged(bool isFocused) {
     if (!isFocused) {
       _controller?.clearFocus();
+      return;
     }
     SystemChannels.textInput
         .invokeMethod<void>('TextInput.setPlatformViewClient', <String, dynamic>{

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -4167,6 +4167,65 @@ void main() {
       expect(lastPlatformViewTextClient['platformViewId'], viewId);
     });
 
+    testWidgets(
+      'PlatformViewLink does not steal focus from text field when platform view unfocuses',
+      (WidgetTester tester) async {
+        late FakePlatformViewController controller;
+        late int viewId;
+
+        final platformViewLink = PlatformViewLink(
+          viewType: 'test',
+          onCreatePlatformView: (PlatformViewCreationParams params) {
+            viewId = params.id;
+            params.onPlatformViewCreated(params.id);
+            controller = FakePlatformViewController(params.id);
+            return controller;
+          },
+          surfaceFactory: (BuildContext context, PlatformViewController controller) {
+            return PlatformViewSurface(
+              gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+              controller: controller,
+              hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+            );
+          },
+        );
+        await tester.pumpWidget(SizedBox(width: 300, height: 300, child: platformViewLink));
+
+        final Focus platformViewFocusWidget = tester.widget(
+          find.descendant(of: find.byType(PlatformViewLink), matching: find.byType(Focus)),
+        );
+
+        final FocusNode? focusNode = platformViewFocusWidget.focusNode;
+        expect(focusNode, isNotNull);
+        expect(focusNode!.hasFocus, false);
+
+        late Map<String, dynamic> lastPlatformViewTextClient;
+        var callCount = 0;
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.textInput, (
+          MethodCall call,
+        ) {
+          if (call.method == 'TextInput.setPlatformViewClient') {
+            lastPlatformViewTextClient = call.arguments as Map<String, dynamic>;
+            callCount++;
+          }
+          return null;
+        });
+
+        platformViewFocusWidget.focusNode!.requestFocus();
+        await tester.pump();
+
+        expect(focusNode.hasFocus, true);
+        expect(callCount, 1);
+        expect(lastPlatformViewTextClient['platformViewId'], viewId);
+
+        platformViewFocusWidget.focusNode!.unfocus();
+        await tester.pump();
+
+        expect(focusNode.hasFocus, false);
+        expect(callCount, 1);
+      },
+    );
+
     testWidgets('PlatformViewLink focus change reports error when channel fails', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
After a platform view loses focus, it was still invoking `TextInput.setPlatformViewClient` on the text input channel. This overrides the active text input client and breaks typing connections for other Flutter view focused text fields (like `TextField`).

Add the missing early return to  `_handleFrameworkFocusChanged` when `isFocused` is false. The rest of the change is tests, which fail on master:
```
00:19 +6 -1: PlatformView does not steal focus from TextField when unfocused [E]
  Test failed. See exception logs above.
  The test description was: PlatformView does not steal focus from TextField when unfocused
  
  Expected: 'true'
    Actual: 'false'
     Which: is different.
            Expected: true
              Actual: false
```
```
00:00 +103 ~4: Common PlatformView PlatformViewLink does not steal focus from text field when platform view unfocuses
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure was thrown running a test:
Expected: <1>
  Actual: <2>

```
Found while investigating https://github.com/flutter/flutter/issues/147844. 

Fixes https://github.com/flutter/flutter/issues/156659

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
