### PR TITLE
[flutter_tools] Resolve includes recursively in AnalysisOptionsMigration

### DIFF
--- a/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart
@@ -2,19 +2,26 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:package_config/package_config.dart';
 import 'package:yaml/yaml.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
 import '../base/file_system.dart';
 import '../base/project_migrator.dart';
+import '../dart/package_map.dart';
 import '../project.dart';
 
 /// Migrates analysis_options.yaml to exclude build and platform directories.
 class AnalysisOptionsMigration extends ProjectMigrator {
-  AnalysisOptionsMigration(FlutterProject project, super.logger)
-    : _analysisOptionsFile = project.directory.childFile('analysis_options.yaml');
+  AnalysisOptionsMigration(FlutterProject project, super.logger, {PackageConfig? packageConfig})
+    : _project = project,
+      _analysisOptionsFile = project.directory.childFile('analysis_options.yaml'),
+      _packageConfig = packageConfig;
 
+  final FlutterProject _project;
   final File _analysisOptionsFile;
+  final PackageConfig? _packageConfig;
+  PackageConfig? _loadedPackageConfig;
 
   @override
   Future<void> migrate() async {
@@ -46,25 +53,15 @@ class AnalysisOptionsMigration extends ProjectMigrator {
       'linux/**',
     ];
 
-    var needsMigration = false;
-    final Object? analyzer = root['analyzer'];
-    if (analyzer is! YamlMap) {
-      needsMigration = true;
-    } else {
-      final exclude = analyzer['exclude'] as Object?;
-      if (exclude is! YamlList) {
-        needsMigration = true;
-      } else {
-        for (final requiredExclude in excludesToExclude) {
-          if (!exclude.contains(requiredExclude)) {
-            needsMigration = true;
-            break;
-          }
-        }
+    final Set<String> activeExcludes = await _collectExcludes(_analysisOptionsFile);
+    final missingExcludes = <String>[];
+    for (final requiredExclude in excludesToExclude) {
+      if (!activeExcludes.contains(requiredExclude)) {
+        missingExcludes.add(requiredExclude);
       }
     }
 
-    if (!needsMigration) {
+    if (missingExcludes.isEmpty) {
       return;
     }
 
@@ -73,18 +70,19 @@ class AnalysisOptionsMigration extends ProjectMigrator {
     );
 
     final editor = YamlEditor(originalContent);
+    final Object? analyzer = root['analyzer'];
 
     try {
       if (analyzer is! YamlMap) {
-        editor.update(<String>['analyzer'], <String, Object>{'exclude': excludesToExclude});
+        editor.update(<String>['analyzer'], <String, Object>{'exclude': missingExcludes});
       } else {
         final exclude = analyzer['exclude'] as Object?;
         if (exclude is! YamlList) {
-          editor.update(<String>['analyzer', 'exclude'], excludesToExclude);
+          editor.update(<String>['analyzer', 'exclude'], missingExcludes);
         } else {
-          for (final requiredExclude in excludesToExclude) {
-            if (!exclude.contains(requiredExclude)) {
-              editor.appendToList(<String>['analyzer', 'exclude'], requiredExclude);
+          for (final missingExclude in missingExcludes) {
+            if (!exclude.contains(missingExclude)) {
+              editor.appendToList(<String>['analyzer', 'exclude'], missingExclude);
             }
           }
         }
@@ -92,6 +90,103 @@ class AnalysisOptionsMigration extends ProjectMigrator {
       _analysisOptionsFile.writeAsStringSync(editor.toString());
     } on Exception catch (e) {
       logger.printError('Failed to migrate analysis_options.yaml: $e');
+    }
+  }
+
+  Future<Set<String>> _collectExcludes(File file, {Set<String> visited = const <String>{}}) async {
+    final String canonicalPath = file.fileSystem.path.normalize(file.absolute.path);
+    if (visited.contains(canonicalPath)) {
+      return <String>{}; // Avoid cycles
+    }
+    if (!file.existsSync()) {
+      return <String>{};
+    }
+    final String content = file.readAsStringSync();
+    final YamlNode root;
+    try {
+      root = loadYamlNode(content);
+    } on YamlException {
+      return <String>{};
+    }
+    if (root is! YamlMap) {
+      return <String>{};
+    }
+
+    final excludes = <String>{};
+    final Object? analyzer = root['analyzer'];
+    if (analyzer is YamlMap) {
+      final Object? exclude = analyzer['exclude'];
+      if (exclude is YamlList) {
+        excludes.addAll(exclude.whereType<String>());
+      }
+    }
+
+    final Object? include = root['include'];
+    final List<String> includes = <String>[];
+    if (include is String) {
+      includes.add(include);
+    } else if (include is YamlList) {
+      includes.addAll(include.whereType<String>());
+    }
+
+    for (final String includeUri in includes) {
+      final File? includedFile = await _resolveInclude(includeUri, file);
+      if (includedFile != null) {
+        excludes.addAll(
+          await _collectExcludes(
+            includedFile,
+            visited: <String>{...visited, canonicalPath},
+          ),
+        );
+      }
+    }
+
+    return excludes;
+  }
+
+  Future<File?> _resolveInclude(String includeUri, File referringFile) async {
+    if (includeUri.startsWith('package:')) {
+      final PackageConfig? packageConfig = await _getPackageConfig();
+      if (packageConfig == null) {
+        return null;
+      }
+      try {
+        final Uri? resolvedUri = packageConfig.resolve(Uri.parse(includeUri));
+        if (resolvedUri != null && resolvedUri.scheme == 'file') {
+          return referringFile.fileSystem.file(resolvedUri);
+        }
+      } on FormatException {
+        // Invalid URI
+      }
+      return null;
+    } else {
+      // Relative path
+      final String path = referringFile.fileSystem.path.join(referringFile.parent.path, includeUri);
+      return referringFile.fileSystem.file(path);
+    }
+  }
+
+  Future<PackageConfig?> _getPackageConfig() async {
+    if (_packageConfig != null) {
+      return _packageConfig;
+    }
+    if (_loadedPackageConfig != null) {
+      return _loadedPackageConfig;
+    }
+    final File? configFile = findPackageConfigFile(_project.directory);
+    if (configFile == null) {
+      return null;
+    }
+    try {
+      _loadedPackageConfig = await loadPackageConfigWithLogging(
+        configFile,
+        logger: logger,
+        throwOnError: false,
+      );
+      return _loadedPackageConfig;
+    } on Exception {
+      // Ignore errors loading package config during migration checks.
+      return null;
     }
   }
 }

--- a/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart
@@ -100,14 +100,19 @@ class AnalysisOptionsMigration extends ProjectMigrator {
   /// or list-based include directives while tracking [visited] canonical paths
   /// to prevent infinite recursion on cyclic includes.
   Future<Set<String>> _collectExcludes(File file, {Set<String> visited = const <String>{}}) async {
-    final String canonicalPath = file.fileSystem.path.normalize(file.absolute.path);
+    final String canonicalPath = file.fileSystem.path.canonicalize(file.path);
     if (visited.contains(canonicalPath)) {
       return <String>{}; // Avoid cycles
     }
     if (!file.existsSync()) {
       return <String>{};
     }
-    final String content = file.readAsStringSync();
+    final String content;
+    try {
+      content = file.readAsStringSync();
+    } on FileSystemException {
+      return <String>{};
+    }
     final YamlNode root;
     try {
       root = loadYamlNode(content);

--- a/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart
@@ -93,6 +93,12 @@ class AnalysisOptionsMigration extends ProjectMigrator {
     }
   }
 
+  /// Recursively collects analyzer `exclude:` patterns from [file] and any
+  /// configuration files referenced via `include:` directives.
+  ///
+  /// Supports both relative paths and `package:` URIs, handling single string
+  /// or list-based include directives while tracking [visited] canonical paths
+  /// to prevent infinite recursion on cyclic includes.
   Future<Set<String>> _collectExcludes(File file, {Set<String> visited = const <String>{}}) async {
     final String canonicalPath = file.fileSystem.path.normalize(file.absolute.path);
     if (visited.contains(canonicalPath)) {
@@ -122,21 +128,18 @@ class AnalysisOptionsMigration extends ProjectMigrator {
     }
 
     final Object? include = root['include'];
-    final List<String> includes = <String>[];
+    final includes = <String>[];
     if (include is String) {
       includes.add(include);
     } else if (include is YamlList) {
       includes.addAll(include.whereType<String>());
     }
 
-    for (final String includeUri in includes) {
+    for (final includeUri in includes) {
       final File? includedFile = await _resolveInclude(includeUri, file);
       if (includedFile != null) {
         excludes.addAll(
-          await _collectExcludes(
-            includedFile,
-            visited: <String>{...visited, canonicalPath},
-          ),
+          await _collectExcludes(includedFile, visited: <String>{...visited, canonicalPath}),
         );
       }
     }

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -426,7 +426,7 @@ class FlutterProject {
     }
 
     final migration = ProjectMigration(<ProjectMigrator>[
-      AnalysisOptionsMigration(this, globals.logger),
+      AnalysisOptionsMigration(this, globals.logger, packageConfig: packageConfig),
     ]);
     await migration.run();
 

--- a/packages/flutter_tools/test/general.shard/migrations/analysis_options_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrations/analysis_options_migration_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/migrations/analysis_options_migration.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
@@ -202,6 +203,174 @@ analyzer:
       expect(migratedContents, contains('macos/**'));
       expect(migratedContents, contains('linux/**'));
     });
+
+    testWithoutContext('skipped if exclusions are inherited via relative include', () async {
+      final _TestContext context = _createTestContext();
+      const analysisOptionsContents = '''
+include: shared_options.yaml
+''';
+      const sharedOptionsContents = '''
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+''';
+
+      context.analysisOptionsFile.writeAsStringSync(analysisOptionsContents);
+      context.memoryFileSystem.file('shared_options.yaml').writeAsStringSync(sharedOptionsContents);
+
+      final migration = AnalysisOptionsMigration(context.mockProject, context.testLogger);
+      await migration.migrate();
+
+      expect(context.analysisOptionsFile.readAsStringSync(), analysisOptionsContents);
+      expect(context.testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('skipped if exclusions are inherited via package include', () async {
+      final _TestContext context = _createTestContext();
+      const analysisOptionsContents = '''
+include: package:shared_options/analysis_options.yaml
+''';
+      const sharedOptionsContents = '''
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+''';
+
+      context.analysisOptionsFile.writeAsStringSync(analysisOptionsContents);
+
+      final Directory sharedPackageDir = context.memoryFileSystem.directory('/shared_options');
+      final File sharedOptionsFile = sharedPackageDir.childFile('lib/analysis_options.yaml');
+      sharedOptionsFile.createSync(recursive: true);
+      sharedOptionsFile.writeAsStringSync(sharedOptionsContents);
+
+      final packageConfig = FakePackageConfig(<String, Uri>{
+        'shared_options': sharedPackageDir.childDirectory('lib').uri,
+      });
+
+      final migration = AnalysisOptionsMigration(
+        context.mockProject,
+        context.testLogger,
+        packageConfig: packageConfig,
+      );
+      await migration.migrate();
+
+      expect(context.analysisOptionsFile.readAsStringSync(), analysisOptionsContents);
+      expect(context.testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('skipped if exclusions are inherited via multiple includes', () async {
+      final _TestContext context = _createTestContext();
+      const analysisOptionsContents = '''
+include:
+  - shared_options_1.yaml
+  - shared_options_2.yaml
+''';
+      const sharedOptions1Contents = '''
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+''';
+      const sharedOptions2Contents = '''
+analyzer:
+  exclude:
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+''';
+
+      context.analysisOptionsFile.writeAsStringSync(analysisOptionsContents);
+      context.memoryFileSystem
+          .file('shared_options_1.yaml')
+          .writeAsStringSync(sharedOptions1Contents);
+      context.memoryFileSystem
+          .file('shared_options_2.yaml')
+          .writeAsStringSync(sharedOptions2Contents);
+
+      final migration = AnalysisOptionsMigration(context.mockProject, context.testLogger);
+      await migration.migrate();
+
+      expect(context.analysisOptionsFile.readAsStringSync(), analysisOptionsContents);
+      expect(context.testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('handles cyclic includes without crashing', () async {
+      final _TestContext context = _createTestContext();
+      const analysisOptionsContents = '''
+include: shared_options_1.yaml
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+''';
+      const sharedOptions1Contents = '''
+include: shared_options_2.yaml
+''';
+      const sharedOptions2Contents = '''
+include: shared_options_1.yaml
+''';
+
+      context.analysisOptionsFile.writeAsStringSync(analysisOptionsContents);
+      context.memoryFileSystem
+          .file('shared_options_1.yaml')
+          .writeAsStringSync(sharedOptions1Contents);
+      context.memoryFileSystem
+          .file('shared_options_2.yaml')
+          .writeAsStringSync(sharedOptions2Contents);
+
+      final migration = AnalysisOptionsMigration(context.mockProject, context.testLogger);
+
+      // Should not throw StackOverflowError or hang
+      await migration.migrate();
+
+      expect(context.analysisOptionsFile.readAsStringSync(), analysisOptionsContents);
+      expect(context.testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('handles invalid exclude types without crashing', () async {
+      final _TestContext context = _createTestContext();
+      const analysisOptionsContents = '''
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+    - 123 # Invalid exclude type (int)
+''';
+
+      context.analysisOptionsFile.writeAsStringSync(analysisOptionsContents);
+
+      final migration = AnalysisOptionsMigration(context.mockProject, context.testLogger);
+
+      // Should not throw TypeError
+      await migration.migrate();
+
+      expect(context.analysisOptionsFile.readAsStringSync(), analysisOptionsContents);
+      expect(context.testLogger.statusText, isEmpty);
+    });
   });
 }
 
@@ -233,4 +402,29 @@ class FakeFlutterProject extends Fake implements FlutterProject {
 
   @override
   final Directory directory;
+}
+
+class FakePackageConfig extends Fake implements PackageConfig {
+  FakePackageConfig(this._packages);
+
+  final Map<String, Uri> _packages;
+
+  @override
+  Uri? resolve(Uri packageUri) {
+    if (packageUri.scheme != 'package') {
+      return null;
+    }
+    final String path = packageUri.path;
+    final int slashIndex = path.indexOf('/');
+    if (slashIndex == -1) {
+      return null;
+    }
+    final String packageName = path.substring(0, slashIndex);
+    final String packagePath = path.substring(slashIndex + 1);
+    final Uri? packageRoot = _packages[packageName];
+    if (packageRoot == null) {
+      return null;
+    }
+    return packageRoot.resolve(packagePath);
+  }
 }

--- a/packages/flutter_tools/test/general.shard/migrations/analysis_options_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrations/analysis_options_migration_test.dart
@@ -371,6 +371,60 @@ analyzer:
       expect(context.analysisOptionsFile.readAsStringSync(), analysisOptionsContents);
       expect(context.testLogger.statusText, isEmpty);
     });
+
+    testWithoutContext('handles unreadable include file without crashing', () async {
+      final _TestContext context = _createTestContext();
+      const analysisOptionsContents = '''
+include: some_dir
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+''';
+
+      context.analysisOptionsFile.writeAsStringSync(analysisOptionsContents);
+      // Create 'some_dir' as a directory so reading it throws FileSystemException
+      context.memoryFileSystem.directory('some_dir').createSync();
+
+      final migration = AnalysisOptionsMigration(context.mockProject, context.testLogger);
+      await migration.migrate();
+
+      expect(context.analysisOptionsFile.readAsStringSync(), analysisOptionsContents);
+      expect(context.testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('handles cyclic includes with different casing without crashing', () async {
+      final _TestContext context = _createTestContext();
+      const analysisOptionsContents = '''
+include: shared_options.yaml
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+''';
+      const sharedOptionsContents = '''
+include: SHARED_OPTIONS.YAML
+''';
+
+      context.analysisOptionsFile.writeAsStringSync(analysisOptionsContents);
+      context.memoryFileSystem.file('shared_options.yaml').writeAsStringSync(sharedOptionsContents);
+
+      final migration = AnalysisOptionsMigration(context.mockProject, context.testLogger);
+      await migration.migrate();
+
+      expect(context.analysisOptionsFile.readAsStringSync(), analysisOptionsContents);
+      expect(context.testLogger.statusText, isEmpty);
+    });
   });
 }
 


### PR DESCRIPTION
## Description

`AnalysisOptionsMigration` was ignoring `include:` directives in `analysis_options.yaml` files, causing it to repeatedly rewrite files that already inherited the required platform and build directory exclusions (such as `build/**`, `android/**`, etc.) from included files (either relative paths or `package:` URIs).

This PR updates `AnalysisOptionsMigration` to:
- Recursively resolve and collect analyzer `exclude:` patterns from `include:` directives.
- Support both relative paths and `package:` URIs for includes (using `PackageConfig`).
- Support multiple includes (when `include` is specified as a YAML list).
- Guard against infinite recursion on cyclic includes using canonical normalized paths.
- Safely extract exclude patterns to prevent crashes on malformed files.
- Pass `PackageConfig` from `ensureReadyForPlatformSpecificTooling` to `AnalysisOptionsMigration`.

## Related Issues
Fixes #191056

## Tests
- Added unit tests in `analysis_options_migration_test.dart`:
  - `skipped if exclusions are inherited via relative include`
  - `skipped if exclusions are inherited via package include`
  - `skipped if exclusions are inherited via multiple includes`
  - `handles cyclic includes without crashing`
  - `handles invalid exclude types without crashing`