### PR TITLE
feat(templates): add 'c: tfw4' label to Wasm issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/09_wasm.yml
+++ b/.github/ISSUE_TEMPLATE/09_wasm.yml
@@ -1,7 +1,7 @@
 name: Report a Flutter WebAssembly (Wasm) issue
 description: |
   You hit a compilation, packaging, or runtime blocker while targeting WebAssembly (Wasm) in Flutter Web.
-labels: ['platform-web', 'e: wasm']
+labels: ['platform-web', 'e: wasm', 'c: tfw4']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Add the `c: tfw4` category label to `.github/ISSUE_TEMPLATE/09_wasm.yml` to automatically categorize and route incoming community issue reports during the "Try Flutter Web with WebAssembly" (TFW^4) campaign week.