### PR TITLE
Fix MenuAnchor scrollbar safe area padding

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -3648,6 +3648,7 @@ class _MenuPanelState extends State<_MenuPanel> {
     final EdgeInsetsGeometry padding =
         resolve<EdgeInsetsGeometry?>((MenuStyle? style) => style?.padding) ?? EdgeInsets.zero;
     final Offset densityAdjustment = visualDensity.baseSizeAdjustment;
+    final MediaQueryData mediaQuery = MediaQuery.of(context);
     // Per the Material Design team: don't allow the VisualDensity
     // adjustment to reduce the width of the left/right padding. If we
     // did, VisualDensity.compact, the default for desktop/web, would
@@ -3708,17 +3709,27 @@ class _MenuPanelState extends State<_MenuPanel> {
         ).copyWith(scrollbars: false, overscroll: false, physics: const ClampingScrollPhysics()),
         child: PrimaryScrollController(
           controller: scrollController,
-          child: Scrollbar(
-            thumbVisibility: displayScrollbar,
-            child: SingleChildScrollView(
-              controller: scrollController,
-              scrollDirection: widget.orientation,
-              child: Flex(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                textDirection: Directionality.of(context),
-                direction: widget.orientation,
-                mainAxisSize: MainAxisSize.min,
-                children: children,
+          child: MediaQuery.removePadding(
+            context: context,
+            removeLeft: true,
+            removeTop: true,
+            removeRight: true,
+            removeBottom: true,
+            child: Scrollbar(
+              thumbVisibility: displayScrollbar,
+              child: MediaQuery(
+                data: mediaQuery,
+                child: SingleChildScrollView(
+                  controller: scrollController,
+                  scrollDirection: widget.orientation,
+                  child: Flex(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    textDirection: Directionality.of(context),
+                    direction: widget.orientation,
+                    mainAxisSize: MainAxisSize.min,
+                    children: children,
+                  ),
+                ),
               ),
             ),
           ),

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -567,6 +567,54 @@ void main() {
     expect(find.byType(Scrollbar).last, paints..rrect(color: const Color(0xff00ff00)));
   }, variant: TargetPlatformVariant.desktop());
 
+  // Regression test for https://github.com/flutter/flutter/issues/188155.
+  testWidgets('Menu scrollbar does not inherit MediaQuery padding', (WidgetTester tester) async {
+    addTearDown(tester.view.reset);
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.padding = const FakeViewPadding(bottom: 24.0);
+    EdgeInsets? menuItemPadding;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: MenuAnchor(
+            controller: controller,
+            style: const MenuStyle(
+              maximumSize: WidgetStatePropertyAll<Size>(Size.fromHeight(100.0)),
+            ),
+            menuChildren: <Widget>[
+              Builder(
+                builder: (BuildContext context) {
+                  menuItemPadding = MediaQuery.paddingOf(context);
+                  return MenuItemButton(onPressed: () {}, child: const Text('Item 0'));
+                },
+              ),
+              for (int i = 1; i < 4; i++) MenuItemButton(onPressed: () {}, child: Text('Item $i')),
+            ],
+            builder: (BuildContext context, MenuController controller, Widget? child) {
+              return TextButton(onPressed: controller.open, child: const Text('Open menu'));
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open menu'));
+    await tester.pumpAndSettle();
+
+    final CustomPaint scrollbarPaint = tester.widget<CustomPaint>(
+      find.descendant(
+        of: find.byType(Scrollbar),
+        matching: find.byWidgetPredicate(
+          (Widget widget) => widget is CustomPaint && widget.foregroundPainter is ScrollbarPainter,
+        ),
+      ),
+    );
+    final scrollbarPainter = scrollbarPaint.foregroundPainter! as ScrollbarPainter;
+    expect(scrollbarPainter.padding, EdgeInsets.zero);
+    expect(menuItemPadding, const EdgeInsets.only(bottom: 24.0));
+  });
+
   testWidgets('Focus is returned to previous focus before invoking onPressed', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
`MenuAnchor`'s internal `Scrollbar` inherited the root view's `MediaQuery.padding`. On devices with system safe-area padding, this inset the thumb inside the already-positioned menu and prevented it from reaching the end of the menu track.

This change removes the view padding for the scrollbar only, while restoring the original `MediaQueryData` for custom menu content. It also adds a regression test that verifies both behaviors.

Fixes #188155.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] Documentation is not required because this does not change a public API.
- [x] I added a regression test for the change.
- [x] This is not a breaking change and does not require a data-driven fix.
- [x] All existing and new tests are passing.

## Validation

- `./bin/flutter test packages/flutter/test/material/menu_anchor_test.dart` (171 passed, 1 skipped)
- `./bin/flutter analyze --no-pub packages/flutter` (no issues)
- `./bin/dart format packages/flutter/lib/src/material/menu_anchor.dart packages/flutter/test/material/menu_anchor_test.dart` (no changes)

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
