### PR TITLE
[stable] [Tool] Fix SwiftPM race condition during parallel Xcode builds

### DIFF
--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -2,15 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:file/file.dart';
 import 'package:file/local.dart' as local_fs;
 import 'package:meta/meta.dart';
 
 import 'common.dart';
 import 'io.dart';
+import 'logger.dart';
 import 'platform.dart';
 import 'process.dart';
 import 'signals.dart';
+import 'terminal.dart';
 
 // package:file/local.dart must not be exported. This exposes LocalFileSystem,
 // which we override to ensure that temporary directories are cleaned up when
@@ -272,4 +276,68 @@ class LocalFileSystem extends local_fs.LocalFileSystem {
   // This only exist because the memory file system does not support a systemTemp that does not exists #74042
   @visibleForTesting
   Directory get superSystemTempDirectory => super.systemTempDirectory;
+}
+
+extension FileSystemLocking on FileSystem {
+  /// Runs [scope] while holding an exclusive file lock on the file at [lockPath].
+  ///
+  /// The lock is released after [scope] completes, even if it throws.
+  ///
+  /// If the lock cannot be acquired immediately, it will retry every 50ms.
+  Future<T> runLocked<T>({
+    required String lockPath,
+    required FutureOr<T> Function() scope,
+    Logger? logger,
+    String? traceMessage,
+    String? warningMessage,
+  }) async {
+    final File lockFile = file(lockPath);
+    var printed = false;
+    RandomAccessFile? openedFile;
+    while (true) {
+      try {
+        lockFile.parent.createSync(recursive: true);
+        openedFile = lockFile.openSync(mode: FileMode.write);
+        openedFile.lockSync();
+        break;
+      } on UnimplementedError {
+        logger?.printTrace(traceMessage ?? 'Locking not supported (UnimplementedError).');
+        break;
+      } on UnsupportedError {
+        logger?.printTrace(traceMessage ?? 'Locking not supported (UnsupportedError).');
+        break;
+      } on FileSystemException catch (e) {
+        final lockFailed = openedFile != null;
+        if (openedFile != null) {
+          try {
+            openedFile.closeSync();
+          } on FileSystemException catch (_) {}
+          openedFile = null;
+        }
+        if (!printed) {
+          final details = lockFailed ? '' : ' (Error: $e)';
+          logger?.printTrace(
+            traceMessage ?? 'Waiting to obtain lock of directory: ${lockFile.path}$details',
+          );
+          logger?.printWarning(
+            warningMessage ?? 'Waiting for another flutter command to release the lock...',
+            color: TerminalColor.grey,
+            fatal: false,
+          );
+          printed = true;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+      }
+    }
+
+    try {
+      return await scope();
+    } finally {
+      if (openedFile != null) {
+        try {
+          openedFile.closeSync();
+        } on FileSystemException {} // ignore: empty_catches
+      }
+    }
+  }
 }

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1457,6 +1457,7 @@ Future<void> injectPlugins(
             templateRenderer: globals.templateRenderer,
             processUtils: globals.processUtils,
             config: globals.config,
+            logger: globals.logger,
           ),
           fileSystem: globals.fs,
           featureFlags: featureFlags,

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -62,6 +62,7 @@ Future<void> processPodsIfNeeded(
       templateRenderer: globals.templateRenderer,
       processUtils: globals.processUtils,
       config: globals.config,
+      logger: globals.logger,
     );
     final FlutterDarwinPlatform platform = xcodeProject is IosProject
         ? FlutterDarwinPlatform.ios

--- a/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
@@ -8,6 +8,7 @@ import '../base/common.dart';
 import '../base/config.dart';
 import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
+import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/template.dart';
 import '../base/version.dart';
@@ -43,88 +44,118 @@ class SwiftPackageManager {
     required TemplateRenderer templateRenderer,
     required ProcessUtils processUtils,
     required Config config,
+    Logger? logger,
   }) : _fileSystem = fileSystem,
        _templateRenderer = templateRenderer,
        _processUtils = processUtils,
-       _config = config;
+       _config = config,
+       _logger = logger;
 
   final FileSystem _fileSystem;
   final TemplateRenderer _templateRenderer;
   final ProcessUtils _processUtils;
   final Config _config;
+  final Logger? _logger;
 
-  /// Creates a Swift Package called 'FlutterGeneratedPluginSwiftPackage' that
-  /// has dependencies on Flutter plugins that are compatible with Swift
-  /// Package Manager.
   Future<void> generatePluginsSwiftPackage(
     List<Plugin> plugins,
     FlutterDarwinPlatform platform,
     XcodeBasedProject project, {
     bool flutterAsADependency = true,
   }) async {
-    final Directory symlinkDirectory = project.relativeSwiftPackagesDirectory;
-    ErrorHandlingFileSystem.deleteIfExists(symlinkDirectory, recursive: true);
-    symlinkDirectory.createSync(recursive: true);
+    final String lockPath = project.ephemeralDirectory.childFile('.swift_pm.lock').path;
+    await _fileSystem.runLocked<void>(
+      lockPath: lockPath,
+      logger: _logger,
+      traceMessage:
+          'Waiting to be able to obtain lock of Swift Package Manager directory: $lockPath',
+      warningMessage:
+          'Waiting for another flutter command to release the Swift Package Manager lock...',
+      scope: () async {
+        final Directory symlinkDirectory = project.relativeSwiftPackagesDirectory;
+        try {
+          symlinkDirectory.createSync(recursive: true);
+        } on FileSystemException catch (e) {
+          if (!_fileSystem.isDirectorySync(symlinkDirectory.path)) {
+            throwToolExit(
+              'Failed to create Swift Packages directory at "${symlinkDirectory.path}": $e',
+            );
+          }
+        }
 
-    final (
-      List<SwiftPackagePackageDependency> packageDependencies,
-      List<SwiftPackageTargetDependency> targetDependencies,
-    ) = _dependenciesForPlugins(
-      plugins: plugins,
-      platform: platform,
-      symlinkDirectory: symlinkDirectory,
-      pathRelativeTo: project.flutterPluginSwiftPackageDirectory.path,
+        final (
+          List<SwiftPackagePackageDependency> packageDependencies,
+          List<SwiftPackageTargetDependency> targetDependencies,
+          Set<String> expectedBasenames,
+        ) = _dependenciesForPlugins(
+          plugins: plugins,
+          platform: platform,
+          symlinkDirectory: symlinkDirectory,
+          pathRelativeTo: project.flutterPluginSwiftPackageDirectory.path,
+        );
+
+        // If there aren't any Swift Package plugins and the project hasn't been
+        // migrated yet, don't generate a Swift package or migrate the app since
+        // it's not needed. If the project has already been migrated, regenerate
+        // the Package.swift even if there are no dependencies in case there
+        // were dependencies previously.
+        if (packageDependencies.isEmpty && !project.flutterPluginSwiftPackageInProjectSettings) {
+          _cleanStaleSymlinks(
+            symlinkDirectory: symlinkDirectory,
+            expectedBasenames: expectedBasenames,
+            keepFlutterFramework: false,
+          );
+          return;
+        }
+
+        // Add Flutter framework Swift package dependency
+        if (flutterAsADependency) {
+          final (
+            SwiftPackagePackageDependency flutterFrameworkPackageDependency,
+            SwiftPackageTargetDependency flutterFrameworkTargetDependency,
+          ) = _dependencyForFlutterFramework(
+            pathRelativeTo: project.flutterPluginSwiftPackageDirectory.path,
+            platform: platform,
+            project: project,
+          );
+          packageDependencies.add(flutterFrameworkPackageDependency);
+          targetDependencies.add(flutterFrameworkTargetDependency);
+        }
+
+        // FlutterGeneratedPluginSwiftPackage must be statically linked to ensure
+        // any dynamic dependencies are linked to Runner and prevent undefined symbols.
+        final generatedProduct = SwiftPackageProduct.library(
+          name: kFlutterGeneratedPluginSwiftPackageName,
+          targets: <String>[kFlutterGeneratedPluginSwiftPackageName],
+          libraryType: SwiftPackageLibraryType.static,
+        );
+
+        final generatedTarget = SwiftPackageTarget.defaultTarget(
+          name: kFlutterGeneratedPluginSwiftPackageName,
+          dependencies: targetDependencies,
+        );
+
+        final pluginsPackage = SwiftPackage(
+          manifest: project.flutterPluginSwiftPackageManifest,
+          name: kFlutterGeneratedPluginSwiftPackageName,
+          platforms: <SwiftPackageSupportedPlatform>[platform.supportedPackagePlatform],
+          products: <SwiftPackageProduct>[generatedProduct],
+          dependencies: packageDependencies,
+          targets: <SwiftPackageTarget>[generatedTarget],
+          templateRenderer: _templateRenderer,
+        );
+        pluginsPackage.createSwiftPackage();
+
+        _cleanStaleSymlinks(
+          symlinkDirectory: symlinkDirectory,
+          expectedBasenames: expectedBasenames,
+          keepFlutterFramework: flutterAsADependency,
+        );
+      },
     );
-
-    // If there aren't any Swift Package plugins and the project hasn't been
-    // migrated yet, don't generate a Swift package or migrate the app since
-    // it's not needed. If the project has already been migrated, regenerate
-    // the Package.swift even if there are no dependencies in case there
-    // were dependencies previously.
-    if (packageDependencies.isEmpty && !project.flutterPluginSwiftPackageInProjectSettings) {
-      return;
-    }
-
-    // Add Flutter framework Swift package dependency
-    if (flutterAsADependency) {
-      final (
-        SwiftPackagePackageDependency flutterFrameworkPackageDependency,
-        SwiftPackageTargetDependency flutterFrameworkTargetDependency,
-      ) = _dependencyForFlutterFramework(
-        pathRelativeTo: project.flutterPluginSwiftPackageDirectory.path,
-        platform: platform,
-        project: project,
-      );
-      packageDependencies.add(flutterFrameworkPackageDependency);
-      targetDependencies.add(flutterFrameworkTargetDependency);
-    }
-
-    // FlutterGeneratedPluginSwiftPackage must be statically linked to ensure
-    // any dynamic dependencies are linked to Runner and prevent undefined symbols.
-    final generatedProduct = SwiftPackageProduct.library(
-      name: kFlutterGeneratedPluginSwiftPackageName,
-      targets: <String>[kFlutterGeneratedPluginSwiftPackageName],
-      libraryType: SwiftPackageLibraryType.static,
-    );
-
-    final generatedTarget = SwiftPackageTarget.defaultTarget(
-      name: kFlutterGeneratedPluginSwiftPackageName,
-      dependencies: targetDependencies,
-    );
-
-    final pluginsPackage = SwiftPackage(
-      manifest: project.flutterPluginSwiftPackageManifest,
-      name: kFlutterGeneratedPluginSwiftPackageName,
-      platforms: <SwiftPackageSupportedPlatform>[platform.supportedPackagePlatform],
-      products: <SwiftPackageProduct>[generatedProduct],
-      dependencies: packageDependencies,
-      targets: <SwiftPackageTarget>[generatedTarget],
-      templateRenderer: _templateRenderer,
-    );
-    pluginsPackage.createSwiftPackage();
   }
 
-  (List<SwiftPackagePackageDependency>, List<SwiftPackageTargetDependency>)
+  (List<SwiftPackagePackageDependency>, List<SwiftPackageTargetDependency>, Set<String>)
   _dependenciesForPlugins({
     required List<Plugin> plugins,
     required FlutterDarwinPlatform platform,
@@ -133,6 +164,7 @@ class SwiftPackageManager {
   }) {
     final packageDependencies = <SwiftPackagePackageDependency>[];
     final targetDependencies = <SwiftPackageTargetDependency>[];
+    final expectedBasenames = <String>{};
 
     for (final plugin in plugins) {
       final String? pluginSwiftPackageManifestPath = plugin.pluginSwiftPackageManifestPath(
@@ -174,6 +206,7 @@ class SwiftPackageManager {
 
       final Link pluginSymlink = symlinkDirectory.childLink(basename);
       _createPluginSymlink(pluginSymlink: pluginSymlink, packagePath: packagePath);
+      expectedBasenames.add(basename);
 
       final String packageRelativePath = _fileSystem.path.relative(
         pluginSymlink.path,
@@ -195,7 +228,7 @@ class SwiftPackageManager {
         ),
       );
     }
-    return (packageDependencies, targetDependencies);
+    return (packageDependencies, targetDependencies, expectedBasenames);
   }
 
   /// Safely creates a symlink at [pluginSymlink] pointing to [packagePath].
@@ -453,5 +486,38 @@ class SwiftPackageManager {
     project.flutterPluginSwiftPackageManifest.writeAsStringSync(
       manifestContents.replaceFirst(oldSupportedPlatform, newSupportedPlatform),
     );
+  }
+
+  /// Cleans up any stale or unreferenced plugin symlinks from the project's
+  /// symlink directory.
+  ///
+  /// When plugins are removed from `pubspec.yaml` or updated to versions that
+  /// no longer use Swift Package Manager, their old symlinks remain on disk.
+  /// This method removes them to prevent Xcode compilation failures caused by
+  /// trying to resolve broken or obsolete symlinks.
+  void _cleanStaleSymlinks({
+    required Directory symlinkDirectory,
+    required Set<String> expectedBasenames,
+    required bool keepFlutterFramework,
+  }) {
+    if (!symlinkDirectory.existsSync()) {
+      return;
+    }
+    try {
+      for (final FileSystemEntity entity in symlinkDirectory.listSync()) {
+        final String name = _fileSystem.path.basename(entity.path);
+        if (name == 'FlutterFramework') {
+          if (!keepFlutterFramework) {
+            ErrorHandlingFileSystem.deleteIfExists(entity, recursive: true);
+          }
+          continue;
+        }
+        if (!expectedBasenames.contains(name)) {
+          ErrorHandlingFileSystem.deleteIfExists(entity, recursive: true);
+        }
+      }
+    } on FileSystemException catch (_) {
+      // Ignore errors, as another process might be concurrently modifying the directory.
+    }
   }
 }

--- a/packages/flutter_tools/lib/src/macos/swift_packages.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_packages.dart
@@ -18,7 +18,10 @@ const _swiftPackageTemplate = '''
 
 import PackageDescription
 
-{{#hasSwiftCodeBefore}}\n{{swiftCodeBefore}}\n\n{{/hasSwiftCodeBefore}}
+{{#hasSwiftCodeBefore}}
+{{swiftCodeBefore}}
+
+{{/hasSwiftCodeBefore}}
 let package = Package(
     name: "{{packageName}}",
     {{#platforms}}
@@ -120,11 +123,17 @@ class SwiftPackage {
       final Directory targetDirectory = _manifest.parent
           .childDirectory('Sources')
           .childDirectory(target.name);
-      if (generateEmptySources &&
-          (!targetDirectory.existsSync() || targetDirectory.listSync().isEmpty)) {
+      if (generateEmptySources) {
         final File requiredSwiftFile = targetDirectory.childFile('${target.name}.swift');
-        requiredSwiftFile.createSync(recursive: true);
-        requiredSwiftFile.writeAsStringSync(_swiftPackageSourceTemplate);
+        // Skip creating placeholder sources if sources already exist in the
+        // target directory to avoid unnecessary file writes during build.
+        final bool hasSources =
+            requiredSwiftFile.existsSync() ||
+            (targetDirectory.existsSync() && targetDirectory.listSync().isNotEmpty);
+        if (!hasSources) {
+          requiredSwiftFile.createSync(recursive: true);
+          requiredSwiftFile.writeAsStringSync(_swiftPackageSourceTemplate);
+        }
       }
     }
 
@@ -132,8 +141,24 @@ class SwiftPackage {
       _swiftPackageTemplate,
       _templateContext,
     );
-    _manifest.createSync(recursive: true);
-    _manifest.writeAsStringSync(renderedTemplate);
+
+    // Skip writing Package.swift if the existing file content is identical to
+    // renderedTemplate. Preserving file modification time (mtime) prevents
+    // Xcode and Swift Package Manager from invalidating caches and re-resolving
+    // dependencies during parallel builds.
+    var shouldWrite = true;
+    try {
+      if (_manifest.existsSync() && _manifest.readAsStringSync() == renderedTemplate) {
+        shouldWrite = false;
+      }
+    } on FileSystemException {
+      // If reading fails, write it anyway.
+    }
+
+    if (shouldWrite) {
+      _manifest.createSync(recursive: true);
+      _manifest.writeAsStringSync(renderedTemplate);
+    }
   }
 
   String? _formatPlatforms() {

--- a/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
@@ -502,8 +502,11 @@ class FakeMacOSProject extends Fake implements MacOSProject {
       hostAppRoot.childDirectory('Runner.xcodeproj').childFile('project.pbxproj');
 
   @override
-  Directory get flutterSwiftPackagesDirectory =>
-      hostAppRoot.childDirectory('Flutter').childDirectory('ephemeral').childDirectory('Packages');
+  Directory get ephemeralDirectory =>
+      hostAppRoot.childDirectory('Flutter').childDirectory('ephemeral');
+
+  @override
+  Directory get flutterSwiftPackagesDirectory => ephemeralDirectory.childDirectory('Packages');
 
   @override
   Directory get relativeSwiftPackagesDirectory =>
@@ -551,8 +554,11 @@ class FakeIosProject extends Fake implements IosProject {
       hostAppRoot.childDirectory('Runner.xcodeproj').childFile('project.pbxproj');
 
   @override
-  Directory get flutterSwiftPackagesDirectory =>
-      hostAppRoot.childDirectory('Flutter').childDirectory('ephemeral').childDirectory('Packages');
+  Directory get ephemeralDirectory =>
+      hostAppRoot.childDirectory('Flutter').childDirectory('ephemeral');
+
+  @override
+  Directory get flutterSwiftPackagesDirectory => ephemeralDirectory.childDirectory('Packages');
 
   @override
   Directory get relativeSwiftPackagesDirectory =>

--- a/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
@@ -738,6 +739,173 @@ let package = Package(
             );
           });
         });
+
+        group('concurrency and optimization', () {
+          late MemoryFileSystem fs;
+          late LockTrackingFileSystem trackingFs;
+          late FakeProcessManager processManager;
+          late BufferLogger logger;
+          late FakeXcodeProject project;
+          late SwiftPackageManager spm;
+
+          setUp(() {
+            fs = MemoryFileSystem.test();
+            trackingFs = LockTrackingFileSystem(fs);
+            processManager = FakeProcessManager.any();
+            logger = BufferLogger.test();
+            project = FakeXcodeProject(platform: platform.name, fileSystem: trackingFs);
+
+            spm = SwiftPackageManager(
+              fileSystem: trackingFs,
+              templateRenderer: const MustacheTemplateRenderer(),
+              processUtils: ProcessUtils(processManager: processManager, logger: logger),
+              config: FakeConfig(),
+              logger: logger,
+            );
+          });
+
+          testWithoutContext('acquires and releases lock successfully', () async {
+            project.xcodeProjectInfoFile.createSync(recursive: true);
+            project.xcodeProjectInfoFile.writeAsStringSync('FlutterGeneratedPluginSwiftPackage');
+
+            await spm.generatePluginsSwiftPackage(<Plugin>[], platform, project);
+
+            expect(trackingFs.lockCount, 1);
+            expect(trackingFs.unlockCount, 1);
+            expect(trackingFs.lockAttempts, 1);
+          });
+
+          testWithoutContext(
+            'retries lock on FileSystemException and eventually succeeds',
+            () async {
+              project.xcodeProjectInfoFile.createSync(recursive: true);
+              project.xcodeProjectInfoFile.writeAsStringSync('FlutterGeneratedPluginSwiftPackage');
+
+              trackingFs.throwErrorOnLock = true;
+              trackingFs.throwErrorOnLockTimes = 2; // Fail twice, succeed on 3rd attempt
+
+              await spm.generatePluginsSwiftPackage(<Plugin>[], platform, project);
+
+              expect(trackingFs.lockCount, 1);
+              expect(trackingFs.unlockCount, 3); // Closed on every retry + final release
+              expect(trackingFs.lockAttempts, 3); // 2 failures + 1 success
+
+              // Verify the warning was printed to the logger
+              expect(
+                logger.warningText,
+                contains(
+                  'Waiting for another flutter command to release the Swift Package Manager lock...',
+                ),
+              );
+            },
+          );
+
+          testWithoutContext('proceeds without lock on UnimplementedError', () async {
+            project.xcodeProjectInfoFile.createSync(recursive: true);
+            project.xcodeProjectInfoFile.writeAsStringSync('FlutterGeneratedPluginSwiftPackage');
+
+            trackingFs.throwUnimplementedOnLock = true;
+
+            await spm.generatePluginsSwiftPackage(<Plugin>[], platform, project);
+
+            expect(trackingFs.lockCount, 0); // No successful locks recorded
+            expect(trackingFs.unlockCount, 1); // Still closed
+            expect(trackingFs.lockAttempts, 1); // 1 attempt that threw
+          });
+
+          testWithoutContext(
+            'non-destructive symlink update: preserves active, creates new, deletes obsolete',
+            () async {
+              project.xcodeProjectInfoFile.createSync(recursive: true);
+              project.xcodeProjectInfoFile.writeAsStringSync('FlutterGeneratedPluginSwiftPackage');
+
+              final plugin1 = FakePlugin(
+                name: 'plugin_1',
+                platforms: <String, PluginPlatform>{platform.name: FakePluginPlatform()},
+              );
+              final plugin2 = FakePlugin(
+                name: 'plugin_2',
+                platforms: <String, PluginPlatform>{platform.name: FakePluginPlatform()},
+              );
+              final plugin3 = FakePlugin(
+                name: 'plugin_3',
+                platforms: <String, PluginPlatform>{platform.name: FakePluginPlatform()},
+              );
+
+              // Pre-populate symlink directory with plugin_1 (active), plugin_3 (obsolete), and a stale file
+              final Directory symlinkDir = project.relativeSwiftPackagesDirectory;
+              symlinkDir.createSync(recursive: true);
+
+              final Link link1 = symlinkDir.childLink('plugin_1-1.0.0');
+              link1.createSync('${plugin1.path}/${platform.name}/plugin_1');
+
+              final Link link3 = symlinkDir.childLink('plugin_3-1.0.0');
+              link3.createSync('${plugin3.path}/${platform.name}/plugin_3');
+
+              final File staleFile = symlinkDir.childFile('stale_file.txt');
+              staleFile.createSync();
+              staleFile.writeAsStringSync('stale content');
+
+              // Create fake Package.swift manifests for active plugins to prevent them from being skipped
+              trackingFs
+                  .file('${plugin1.path}/${platform.name}/${plugin1.name}/Package.swift')
+                  .createSync(recursive: true);
+              trackingFs
+                  .file('${plugin2.path}/${platform.name}/${plugin2.name}/Package.swift')
+                  .createSync(recursive: true);
+
+              // Reset tracking counters after pre-population
+              trackingFs.linkCreateCount.clear();
+              trackingFs.linkDeleteCount.clear();
+
+              // Run with plugin_1 and plugin_2
+              await spm.generatePluginsSwiftPackage(<Plugin>[plugin1, plugin2], platform, project);
+
+              // Verify plugin_1 was preserved (not deleted, not recreated)
+              expect(trackingFs.linkDeleteCount['plugin_1-1.0.0'], isNull);
+              expect(trackingFs.linkCreateCount['plugin_1-1.0.0'], isNull);
+
+              // Verify plugin_2 was created
+              expect(trackingFs.linkCreateCount['plugin_2-1.0.0'], 1);
+
+              // Verify plugin_3 was deleted
+              expect(trackingFs.linkDeleteCount['plugin_3-1.0.0'], 1);
+              expect(symlinkDir.childLink('plugin_3-1.0.0').existsSync(), isFalse);
+
+              // Verify stale file was deleted
+              expect(staleFile.existsSync(), isFalse);
+            },
+          );
+
+          testWithoutContext(
+            'optimizes Package.swift generation: does not rewrite if identical',
+            () async {
+              project.xcodeProjectInfoFile.createSync(recursive: true);
+              project.xcodeProjectInfoFile.writeAsStringSync('FlutterGeneratedPluginSwiftPackage');
+
+              final plugin1 = FakePlugin(
+                name: 'plugin_1',
+                platforms: <String, PluginPlatform>{platform.name: FakePluginPlatform()},
+              );
+              trackingFs
+                  .file('${plugin1.path}/${platform.name}/${plugin1.name}/Package.swift')
+                  .createSync(recursive: true);
+
+              // Reset write count after setup to only track writes during SPM generation
+              trackingFs.writeCount = 0;
+
+              // First run: generates Package.swift and placeholders
+              await spm.generatePluginsSwiftPackage(<Plugin>[plugin1], platform, project);
+              expect(trackingFs.writeCount, 4); // 2 Package.swift + 2 placeholder .swift files
+
+              trackingFs.writeCount = 0;
+
+              // Second run with same plugin: should skip writing everything
+              await spm.generatePluginsSwiftPackage(<Plugin>[plugin1], platform, project);
+              expect(trackingFs.writeCount, 0); // All skipped!
+            },
+          );
+        });
       });
     }
   });
@@ -760,8 +928,11 @@ class FakeXcodeProject extends Fake implements IosProject {
   String hostAppProjectName = 'Runner';
 
   @override
-  Directory get flutterSwiftPackagesDirectory =>
-      hostAppRoot.childDirectory('Flutter').childDirectory('ephemeral').childDirectory('Packages');
+  Directory get ephemeralDirectory =>
+      hostAppRoot.childDirectory('Flutter').childDirectory('ephemeral');
+
+  @override
+  Directory get flutterSwiftPackagesDirectory => ephemeralDirectory.childDirectory('Packages');
 
   @override
   Directory get relativeSwiftPackagesDirectory =>
@@ -868,5 +1039,165 @@ class _ErrorInjectingLink extends ForwardingFileSystemEntity<Link, io.Link> with
       throw err;
     }
     super.createSync(target, recursive: recursive);
+  }
+}
+
+class LockTrackingFileSystem extends ForwardingFileSystem {
+  LockTrackingFileSystem(super.delegate);
+
+  int lockCount = 0;
+  int unlockCount = 0;
+  int lockAttempts = 0;
+  int writeCount = 0;
+  bool throwErrorOnLock = false;
+  int throwErrorOnLockTimes = 0;
+  bool throwUnimplementedOnLock = false;
+
+  final Map<String, int> linkDeleteCount = <String, int>{};
+  final Map<String, int> linkCreateCount = <String, int>{};
+
+  @override
+  Directory directory(dynamic path) => _TrackingDirectory(this, delegate.directory(path));
+
+  @override
+  File file(dynamic path) => _TrackingFile(this, delegate.file(path));
+
+  @override
+  Link link(dynamic path) => _TrackingLink(this, delegate.link(path));
+}
+
+class _TrackingDirectory extends ForwardingFileSystemEntity<Directory, io.Directory>
+    with ForwardingDirectory {
+  _TrackingDirectory(this._fileSystem, this.delegate);
+
+  final LockTrackingFileSystem _fileSystem;
+
+  @override
+  final io.Directory delegate;
+
+  @override
+  FileSystem get fileSystem => _fileSystem;
+
+  @override
+  File wrapFile(io.File delegate) => _fileSystem.file(delegate.path);
+
+  @override
+  Directory wrapDirectory(io.Directory delegate) => _fileSystem.directory(delegate.path);
+
+  @override
+  Link wrapLink(io.Link delegate) => _fileSystem.link(delegate.path);
+
+  @override
+  Directory childDirectory(String basename) =>
+      fileSystem.directory(fileSystem.path.join(path, basename));
+
+  @override
+  File childFile(String basename) => fileSystem.file(fileSystem.path.join(path, basename));
+
+  @override
+  Link childLink(String basename) => fileSystem.link(fileSystem.path.join(path, basename));
+}
+
+class _TrackingFile extends ForwardingFileSystemEntity<File, io.File> with ForwardingFile {
+  _TrackingFile(this._fileSystem, this.delegate);
+
+  final LockTrackingFileSystem _fileSystem;
+
+  @override
+  final io.File delegate;
+
+  @override
+  FileSystem get fileSystem => _fileSystem;
+
+  @override
+  File wrapFile(io.File delegate) => _fileSystem.file(delegate.path);
+
+  @override
+  Directory wrapDirectory(io.Directory delegate) => _fileSystem.directory(delegate.path);
+
+  @override
+  Link wrapLink(io.Link delegate) => _fileSystem.link(delegate.path);
+
+  @override
+  void writeAsStringSync(
+    String contents, {
+    FileMode mode = FileMode.write,
+    Encoding encoding = utf8,
+    bool flush = false,
+  }) {
+    _fileSystem.writeCount++;
+    super.writeAsStringSync(contents, mode: mode, encoding: encoding, flush: flush);
+  }
+
+  @override
+  RandomAccessFile openSync({FileMode mode = FileMode.read}) {
+    final RandomAccessFile delegateOpened = super.openSync(mode: mode);
+    if (path.endsWith('.swift_pm.lock')) {
+      return _LockTrackingRandomAccessFile(_fileSystem, delegateOpened);
+    }
+    return delegateOpened;
+  }
+}
+
+class _LockTrackingRandomAccessFile extends Fake implements RandomAccessFile {
+  _LockTrackingRandomAccessFile(this._fileSystem, this._delegate);
+
+  final LockTrackingFileSystem _fileSystem;
+  final RandomAccessFile _delegate;
+
+  @override
+  void lockSync([FileLock mode = FileLock.exclusive, int start = 0, int end = -1]) {
+    _fileSystem.lockAttempts++;
+    if (_fileSystem.throwUnimplementedOnLock) {
+      throw UnimplementedError('Lock not supported');
+    }
+    if (_fileSystem.throwErrorOnLock) {
+      if (_fileSystem.throwErrorOnLockTimes > 0) {
+        _fileSystem.throwErrorOnLockTimes--;
+        throw const FileSystemException('Lock failed');
+      }
+    }
+    _fileSystem.lockCount++;
+  }
+
+  @override
+  void closeSync() {
+    _fileSystem.unlockCount++;
+    _delegate.closeSync();
+  }
+}
+
+class _TrackingLink extends ForwardingFileSystemEntity<Link, io.Link> with ForwardingLink {
+  _TrackingLink(this._fileSystem, this.delegate);
+
+  final LockTrackingFileSystem _fileSystem;
+
+  @override
+  final io.Link delegate;
+
+  @override
+  FileSystem get fileSystem => _fileSystem;
+
+  @override
+  File wrapFile(io.File delegate) => _fileSystem.file(delegate.path);
+
+  @override
+  Directory wrapDirectory(io.Directory delegate) => _fileSystem.directory(delegate.path);
+
+  @override
+  Link wrapLink(io.Link delegate) => _fileSystem.link(delegate.path);
+
+  @override
+  void createSync(String target, {bool recursive = false}) {
+    final String name = _fileSystem.path.basename(path);
+    _fileSystem.linkCreateCount[name] = (_fileSystem.linkCreateCount[name] ?? 0) + 1;
+    super.createSync(target, recursive: recursive);
+  }
+
+  @override
+  void deleteSync({bool recursive = false}) {
+    final String name = _fileSystem.path.basename(path);
+    _fileSystem.linkDeleteCount[name] = (_fileSystem.linkDeleteCount[name] ?? 0) + 1;
+    super.deleteSync(recursive: recursive);
   }
 }


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/188446

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)?
Does it impact development (ex. flutter doctor crashes when Android Studio is installed),
or the shipping of production apps (the app crashes on launch).
This information is for domain experts and release engineers to understand the consequences of saying yes or no to the cherry pick.

The Flutter tool experiences a race condition when preparing the Swift Packages directory during parallel Xcode builds, leading to `FileSystemException` (OS Error: Directory not empty, errno = 66) or `PathExistsException`. This is one of the top crashers identified in the Flutter 3.44.3 stable release. It impacts development when building multi-target iOS/macOS applications in parallel.

### Changelog Description:
Explain this cherry pick:
* In one line that is accessible to most Flutter developers.
* That describes the state prior to the fix.
* That includes which platforms are impacted.
See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples.

[flutter/188446] When building multi-target applications in parallel on iOS and macOS, a race condition in SwiftPM integration causes FileSystemException.

### Workaround:
Is there a workaround for this issue?

Run Xcode builds sequentially (disable parallel target builds) or build targets one by one.

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

1. Enable Swift PM in a Flutter project.
2. Add multiple targets (e.g. App and Share Extension) that use Swift PM plugins.
3. Build the project in Xcode with parallel builds enabled.
4. Verify the build succeeds without `FileSystemException` or `PathExistsException` in `ephemeral/Packages`.
