### PR TITLE
Fix square corner issue

### DIFF
--- a/engine/src/flutter/impeller/display_list/BUILD.gn
+++ b/engine/src/flutter/impeller/display_list/BUILD.gn
@@ -196,6 +196,7 @@ template("aiks_unittests_component") {
       "//flutter/impeller/geometry:geometry_asserts",
       "//flutter/impeller/golden_tests:golden_playground_test",
       "//flutter/impeller/playground:playground_test",
+      "//flutter/impeller/renderer/testing:mocks",
       "//flutter/testing:testing_lib",
       "//flutter/txt",
     ]

--- a/engine/src/flutter/impeller/display_list/aiks_dl_clip_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_clip_unittests.cc
@@ -9,6 +9,8 @@
 #include "flutter/display_list/dl_color.h"
 #include "flutter/display_list/dl_paint.h"
 #include "flutter/display_list/effects/dl_color_filter.h"
+#include "flutter/display_list/effects/dl_image_filter.h"
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/display_list/geometry/dl_path_builder.h"
 #include "flutter/testing/testing.h"
 
@@ -137,6 +139,81 @@ TEST_P(AiksTest, FramebufferBlendsRespectClips) {
   builder.DrawCircle(DlPoint(150, 150), 50, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
+TEST_P(AiksTest, CanRenderClippedBackdropFilterWithSuperellipse) {
+  DisplayListBuilder root_builder;
+
+  root_builder.Scale(GetContentScale().x, GetContentScale().y);
+
+  // 1. Draw a dark background on the root pass.
+  DlPaint bg_paint;
+  bg_paint.setColor(DlColor::kBlack());
+  root_builder.DrawPaint(bg_paint);
+
+  // 2. Wrap in TransformLayer (matching CupertinoSheetTransition scale +
+  // slide).
+  root_builder.Save();
+  root_builder.Scale(0.9f, 0.9f);
+  root_builder.Translate(33.4f, 3.5f);
+
+  // 3. Apply ClipRoundSuperellipse with top-only rounded corners (matching
+  // CupertinoSheet).
+  DlRect sheet_rect = DlRect::MakeXYWH(0, 42, 400, 500);
+  DlRoundingRadii top_radii = {
+      .top_left = {12, 12},
+      .top_right = {12, 12},
+      .bottom_left = {0, 0},
+      .bottom_right = {0, 0},
+  };
+  DlRoundSuperellipse clip_rse =
+      DlRoundSuperellipse::MakeRectRadii(sheet_rect, top_radii);
+  root_builder.ClipRoundSuperellipse(clip_rse, DlClipOp::kIntersect);
+
+  // 4. Wrap in OpacityLayer offset (matching CupertinoSheetRoute offset: (0,
+  // 42)).
+  root_builder.Save();
+  root_builder.Translate(0.0f, 42.0f);
+
+  // 5. Layer 1: DisplayListLayer for sheet body with Ink features.
+  for (int i = 0; i < 5; i++) {
+    DisplayListBuilder item_builder;
+    DlPaint ink_paint;
+    ink_paint.setColor(DlColor::RGBA(0.0f, 0.0f, 0.0f, 0.07f));
+    item_builder.DrawRect(DlRect::MakeXYWH(0, i * 50, 400, 45), ink_paint);
+    root_builder.DrawDisplayList(item_builder.Build());
+  }
+
+  // 6. Layer 2: BackdropFilterLayer (_glassBar).
+  root_builder.Save();
+  DlRect glass_rect = DlRect::MakeXYWH(20, 350, 360, 60);
+  DlRoundRect glass_rrect = DlRoundRect::MakeRectXY(glass_rect, 14, 14);
+  root_builder.ClipRoundRect(glass_rrect, DlClipOp::kIntersect);
+
+  DlPaint save_paint;
+  auto backdrop_filter =
+      DlImageFilter::MakeBlur(12.0f, 12.0f, DlTileMode::kClamp);
+  root_builder.SaveLayer(glass_rect, &save_paint, backdrop_filter.get());
+  DisplayListBuilder glass_builder;
+  DlPaint orange_paint;
+  orange_paint.setColor(DlColor::RGBA(1.0f, 0.6f, 0.0f, 0.6f));
+  glass_builder.DrawRect(glass_rect, orange_paint);
+  root_builder.DrawDisplayList(glass_builder.Build());
+  root_builder.Restore();  // Restore SaveLayer
+  root_builder.Restore();  // Restore glass clip
+
+  // 7. Layer 3: DisplayListLayer for Scaffold AppBar / header drawn AFTER
+  // backdrop filter.
+  DisplayListBuilder appbar_builder;
+  DlPaint white_paint;
+  white_paint.setColor(DlColor::kWhite());
+  appbar_builder.DrawRect(DlRect::MakeXYWH(0, 0, 400, 80), white_paint);
+  root_builder.DrawDisplayList(appbar_builder.Build());
+
+  root_builder.Restore();  // Restore OpacityLayer offset
+  root_builder.Restore();  // Restore TransformLayer
+
+  ASSERT_TRUE(OpenPlaygroundHere(root_builder.Build()));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1774,11 +1774,9 @@ void Canvas::Save(uint32_t total_content_depth) {
 
   auto entry = CanvasStackEntry{};
   entry.transform = transform_stack_.back().transform;
-  entry.clip_depth = current_depth_ + total_content_depth;
+  entry.clip_depth = std::min<uint32_t>(current_depth_ + total_content_depth,
+                                        transform_stack_.back().clip_depth);
   entry.distributed_opacity = transform_stack_.back().distributed_opacity;
-  FML_DCHECK(entry.clip_depth <= transform_stack_.back().clip_depth)
-      << entry.clip_depth << " <=? " << transform_stack_.back().clip_depth
-      << " after allocating " << total_content_depth;
   entry.clip_height = transform_stack_.back().clip_height;
   entry.rendering_mode = Entity::RenderingMode::kDirect;
   transform_stack_.push_back(entry);
@@ -1939,9 +1937,9 @@ void Canvas::SaveLayer(const Paint& paint,
       // 1. The device supports framebuffer fetch
       // 2. There are no more backdrop filters
       // 3. The current render pass is for the onscreen pass.
-      const bool should_use_onscreen =
+      const bool should_use_onscreen = override_should_use_onscreen_.value_or(
           renderer_.GetDeviceCapabilities().SupportsFramebufferFetch() &&
-          backdrop_count_ == 0 && render_passes_.size() == 1u;
+          backdrop_count_ == 0 && render_passes_.size() == 1u);
       input_texture = FlipBackdrop(
           GetGlobalPassPosition(),                                //
           /*should_remove_texture=*/will_cache_backdrop_texture,  //
@@ -2027,10 +2025,8 @@ void Canvas::SaveLayer(const Paint& paint,
 
   CanvasStackEntry entry;
   entry.transform = transform_stack_.back().transform;
-  entry.clip_depth = current_depth_ + total_content_depth;
-  FML_DCHECK(entry.clip_depth <= transform_stack_.back().clip_depth)
-      << entry.clip_depth << " <=? " << transform_stack_.back().clip_depth
-      << " after allocating " << total_content_depth;
+  entry.clip_depth = std::min<uint32_t>(current_depth_ + total_content_depth,
+                                        transform_stack_.back().clip_depth);
   entry.clip_height = transform_stack_.back().clip_height;
   entry.rendering_mode = Entity::RenderingMode::kSubpassAppendSnapshotTransform;
   entry.did_round_out = did_round_out;
@@ -2075,9 +2071,16 @@ bool Canvas::Restore() {
   // to be overly conservative, but we need to jump the depth to
   // the clip depth so that the next rendering op will get a
   // larger depth (it will pre-increment the current_depth_ value).
-  FML_DCHECK(current_depth_ <= transform_stack_.back().clip_depth)
-      << current_depth_ << " <=? " << transform_stack_.back().clip_depth;
-  current_depth_ = transform_stack_.back().clip_depth;
+  //
+  // Only advance depth if clips were recorded and the allocated clip depth
+  // was finite. This prevents premature exhaustion of the parent pass depth
+  // budget.
+  if (transform_stack_.back().num_clips > 0 &&
+      transform_stack_.back().clip_depth < kMaxDepth) {
+    FML_DCHECK(current_depth_ <= transform_stack_.back().clip_depth)
+        << current_depth_ << " <=? " << transform_stack_.back().clip_depth;
+    current_depth_ = transform_stack_.back().clip_depth;
+  }
 
   if (IsSkipping()) {
     transform_stack_.pop_back();
@@ -2627,8 +2630,6 @@ std::shared_ptr<Texture> Canvas::FlipBackdrop(Point global_pass_position,
     return nullptr;
   }
 
-  // Restore any clips that were recorded before the backdrop filter was
-  // applied.
   auto& replay_entities = clip_coverage_stack_.GetReplayEntities();
   uint64_t current_depth =
       post_depth_increment ? current_depth_ - 1 : current_depth_;
@@ -2640,7 +2641,7 @@ std::shared_ptr<Texture> Canvas::FlipBackdrop(Point global_pass_position,
     SetClipScissor(replay.clip_coverage, current_render_pass,
                    global_pass_position);
     if (!replay.clip_contents.Render(renderer_, current_render_pass,
-                                     replay.clip_depth)) {
+                                     replay.clip_depth, replay.transform)) {
       VALIDATION_LOG << "Failed to render entity for clip restore.";
     }
   }

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1937,9 +1937,9 @@ void Canvas::SaveLayer(const Paint& paint,
       // 1. The device supports framebuffer fetch
       // 2. There are no more backdrop filters
       // 3. The current render pass is for the onscreen pass.
-      const bool should_use_onscreen = override_should_use_onscreen_.value_or(
+      const bool should_use_onscreen =
           renderer_.GetDeviceCapabilities().SupportsFramebufferFetch() &&
-          backdrop_count_ == 0 && render_passes_.size() == 1u);
+          backdrop_count_ == 0 && render_passes_.size() == 1u && is_onscreen_;
       input_texture = FlipBackdrop(
           GetGlobalPassPosition(),                                //
           /*should_remove_texture=*/will_cache_backdrop_texture,  //

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -292,31 +292,7 @@ class Canvas {
   /// Visible for testing.
   static bool IsCompatibleWithSDFRendering(const Paint& paint);
 
-  /// Visible for testing.
-  static void SetOverrideShouldUseOnscreenForTesting(
-      std::optional<bool> override_value) {
-    override_should_use_onscreen_ = override_value;
-  }
-
-  /// Visible for testing.
-  class ScopedOnscreenOverrideForTesting {
-   public:
-    explicit ScopedOnscreenOverrideForTesting(bool override_value) {
-      Canvas::SetOverrideShouldUseOnscreenForTesting(override_value);
-    }
-    ~ScopedOnscreenOverrideForTesting() {
-      Canvas::SetOverrideShouldUseOnscreenForTesting(std::nullopt);
-    }
-
-    ScopedOnscreenOverrideForTesting(const ScopedOnscreenOverrideForTesting&) =
-        delete;
-    ScopedOnscreenOverrideForTesting& operator=(
-        const ScopedOnscreenOverrideForTesting&) = delete;
-  };
-
  private:
-  inline static thread_local std::optional<bool> override_should_use_onscreen_;
-
   class BlurShape {
    public:
     virtual ~BlurShape() = default;

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -121,7 +121,9 @@ class LazyRenderingConfig {
 
 class Canvas {
  public:
-  static constexpr uint32_t kMaxDepth = 1 << 24;
+  /// Maximum discrete integer depth level within the 18-bit depth precision
+  /// limit defined by `Entity::kDepthEpsilon`.
+  static constexpr uint32_t kMaxDepth = (1 << 18) - 1;
 
   Canvas(ContentContext& renderer,
          const RenderTarget& render_target,
@@ -290,7 +292,31 @@ class Canvas {
   /// Visible for testing.
   static bool IsCompatibleWithSDFRendering(const Paint& paint);
 
+  /// Visible for testing.
+  static void SetOverrideShouldUseOnscreenForTesting(
+      std::optional<bool> override_value) {
+    override_should_use_onscreen_ = override_value;
+  }
+
+  /// Visible for testing.
+  class ScopedOnscreenOverrideForTesting {
+   public:
+    explicit ScopedOnscreenOverrideForTesting(bool override_value) {
+      Canvas::SetOverrideShouldUseOnscreenForTesting(override_value);
+    }
+    ~ScopedOnscreenOverrideForTesting() {
+      Canvas::SetOverrideShouldUseOnscreenForTesting(std::nullopt);
+    }
+
+    ScopedOnscreenOverrideForTesting(const ScopedOnscreenOverrideForTesting&) =
+        delete;
+    ScopedOnscreenOverrideForTesting& operator=(
+        const ScopedOnscreenOverrideForTesting&) = delete;
+  };
+
  private:
+  inline static thread_local std::optional<bool> override_should_use_onscreen_;
+
   class BlurShape {
    public:
     virtual ~BlurShape() = default;

--- a/engine/src/flutter/impeller/display_list/canvas_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/canvas_unittests.cc
@@ -29,7 +29,8 @@ namespace testing {
 std::unique_ptr<Canvas> CreateTestCanvas(
     ContentContext& context,
     std::optional<Rect> cull_rect = std::nullopt,
-    bool requires_readback = false) {
+    bool requires_readback = false,
+    bool is_onscreen = false) {
   TextureDescriptor onscreen_desc;
   onscreen_desc.size = {100, 100};
   onscreen_desc.format =
@@ -68,10 +69,11 @@ std::unique_ptr<Canvas> CreateTestCanvas(
 
   if (cull_rect.has_value()) {
     return std::make_unique<Canvas>(
-        context, render_target, /*is_onscreen=*/false,
+        context, render_target, /*is_onscreen=*/is_onscreen,
         /*requires_readback=*/requires_readback, cull_rect.value());
   }
-  return std::make_unique<Canvas>(context, render_target, /*is_onscreen=*/false,
+  return std::make_unique<Canvas>(context, render_target,
+                                  /*is_onscreen=*/is_onscreen,
                                   /*requires_readback=*/requires_readback);
 }
 
@@ -609,10 +611,9 @@ TEST_P(AiksTest, ClipDepthMaintainedAcrossBackdropFilterAndLayers) {
     GTEST_SKIP() << "Test requires device with framebuffer fetch";
   }
 
-  Canvas::ScopedOnscreenOverrideForTesting scoped_override(true);
-
   auto canvas = CreateTestCanvas(context, Rect::MakeLTRB(0, 0, 800, 600),
-                                 /*requires_readback=*/true);
+                                 /*requires_readback=*/true,
+                                 /*is_onscreen=*/true);
 
   // 1. Root route saves and applies ClipRoundSuperellipse.
   canvas->Save(/*total_content_depth=*/20);
@@ -660,10 +661,9 @@ TEST_P(AiksTest, ParentClipDepthBudgetPreservedAfterBackdropLayerRestore) {
     GTEST_SKIP() << "Test requires device with framebuffer fetch";
   }
 
-  Canvas::ScopedOnscreenOverrideForTesting scoped_override(true);
-
   auto canvas = CreateTestCanvas(context, Rect::MakeLTRB(0, 0, 800, 600),
-                                 /*requires_readback=*/true);
+                                 /*requires_readback=*/true,
+                                 /*is_onscreen=*/true);
 
   // 1. Root pass with finite clip depth budget.
   canvas->Save(/*total_content_depth=*/50);

--- a/engine/src/flutter/impeller/display_list/canvas_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/canvas_unittests.cc
@@ -6,6 +6,7 @@
 #include "flutter/display_list/dl_tile_mode.h"
 #include "flutter/display_list/effects/dl_image_filter.h"
 #include "flutter/display_list/geometry/dl_geometry_types.h"
+#include "flutter/fml/closure.h"
 #include "flutter/testing/testing.h"
 #include "gtest/gtest.h"
 #include "impeller/core/formats.h"
@@ -19,6 +20,7 @@
 #include "impeller/playground/playground.h"
 #include "impeller/playground/widgets.h"
 #include "impeller/renderer/render_target.h"
+#include "impeller/renderer/testing/mocks.h"
 #include "third_party/abseil-cpp/absl/status/status_matchers.h"
 
 namespace impeller {
@@ -33,6 +35,10 @@ std::unique_ptr<Canvas> CreateTestCanvas(
   onscreen_desc.format =
       context.GetDeviceCapabilities().GetDefaultColorFormat();
   onscreen_desc.usage = TextureUsage::kRenderTarget;
+  if (requires_readback) {
+    onscreen_desc.usage = onscreen_desc.usage | static_cast<TextureUsageMask>(
+                                                    TextureUsage::kShaderRead);
+  }
   onscreen_desc.storage_mode = StorageMode::kDevicePrivate;
   onscreen_desc.sample_count = SampleCount::kCount1;
   std::shared_ptr<Texture> onscreen =
@@ -595,6 +601,160 @@ TEST(CanvasTest, NonAntialiasedPaintIncompatibleWithSDFRendering) {
 TEST(CanvasTest, AntialiasedPaintCompatibleWithSDFRendering) {
   Paint paint;
   EXPECT_TRUE(Canvas::IsCompatibleWithSDFRendering(paint));
+}
+
+TEST_P(AiksTest, ClipDepthMaintainedAcrossBackdropFilterAndLayers) {
+  ContentContext& context = GetContentContext();
+  if (!context.GetDeviceCapabilities().SupportsFramebufferFetch()) {
+    GTEST_SKIP() << "Test requires device with framebuffer fetch";
+  }
+
+  Canvas::ScopedOnscreenOverrideForTesting scoped_override(true);
+
+  auto canvas = CreateTestCanvas(context, Rect::MakeLTRB(0, 0, 800, 600),
+                                 /*requires_readback=*/true);
+
+  // 1. Root route saves and applies ClipRoundSuperellipse.
+  canvas->Save(/*total_content_depth=*/20);
+  Rect sheet_rect = Rect::MakeXYWH(0, 42, 400, 500);
+  canvas->ClipGeometry(*Geometry::MakeRoundSuperellipse(sheet_rect, 12.0f),
+                       Entity::ClipOperation::kIntersect);
+
+  uint64_t initial_clip_depth = canvas->GetMaxOpDepth();
+
+  // 2. Child layer (body Ink items) renders and restores.
+  canvas->Save(/*total_content_depth=*/5);
+  for (int i = 0; i < 5; i++) {
+    canvas->DrawRect(Rect::MakeXYWH(0, i * 50, 400, 45),
+                     Paint{.color = Color::Azure()});
+  }
+  canvas->Restore();
+
+  // 3. Child layer (_glassBar BackdropFilter) renders and restores.
+  auto blur = flutter::DlImageFilter::MakeBlur(12.0f, 12.0f,
+                                               flutter::DlTileMode::kClamp);
+  Rect glass_rect = Rect::MakeXYWH(20, 350, 360, 60);
+  canvas->SaveLayer(Paint{}, glass_rect, blur.get(),
+                    ContentBoundsPromise::kContainsContents,
+                    /*total_content_depth=*/2);
+  canvas->DrawRect(glass_rect, Paint{.color = Color::Orange()});
+  canvas->Restore();
+
+  // 4. Next layer (AppBar header) renders.
+  // Invariant: Subsequent draw operations must NOT exceed the active clip's
+  // depth, and depth must stay within the precision bounds of kMaxDepth.
+  EXPECT_LE(initial_clip_depth, Canvas::kMaxDepth);
+  canvas->Save(/*total_content_depth=*/2);
+  canvas->DrawRect(Rect::MakeXYWH(0, 0, 400, 80),
+                   Paint{.color = Color::White()});
+  EXPECT_LE(canvas->GetOpDepth(), initial_clip_depth);
+  EXPECT_LE(canvas->GetOpDepth(), Canvas::kMaxDepth);
+  canvas->Restore();
+
+  canvas->Restore();
+}
+
+TEST_P(AiksTest, ParentClipDepthBudgetPreservedAfterBackdropLayerRestore) {
+  ContentContext& context = GetContentContext();
+  if (!context.GetDeviceCapabilities().SupportsFramebufferFetch()) {
+    GTEST_SKIP() << "Test requires device with framebuffer fetch";
+  }
+
+  Canvas::ScopedOnscreenOverrideForTesting scoped_override(true);
+
+  auto canvas = CreateTestCanvas(context, Rect::MakeLTRB(0, 0, 800, 600),
+                                 /*requires_readback=*/true);
+
+  // 1. Root pass with finite clip depth budget.
+  canvas->Save(/*total_content_depth=*/50);
+  Rect sheet_rect = Rect::MakeXYWH(0, 42, 400, 500);
+  canvas->ClipGeometry(*Geometry::MakeRoundSuperellipse(sheet_rect, 12.0f),
+                       Entity::ClipOperation::kIntersect);
+
+  uint64_t parent_clip_depth = canvas->GetMaxOpDepth();
+  EXPECT_LT(parent_clip_depth, Canvas::kMaxDepth);
+
+  // 2. BackdropFilter save layer executes FlipBackdrop.
+  auto blur = flutter::DlImageFilter::MakeBlur(12.0f, 12.0f,
+                                               flutter::DlTileMode::kClamp);
+  Rect glass_rect = Rect::MakeXYWH(20, 350, 360, 60);
+  canvas->SaveLayer(Paint{}, glass_rect, blur.get(),
+                    ContentBoundsPromise::kContainsContents,
+                    /*total_content_depth=*/2);
+  canvas->DrawRect(glass_rect, Paint{.color = Color::Orange()});
+  canvas->Restore();
+
+  // 3. Verify that parent scope clip_depth was NOT permanently overwritten with
+  // kMaxDepth.
+  EXPECT_EQ(canvas->GetMaxOpDepth(), parent_clip_depth);
+
+  canvas->Restore();
+}
+
+TEST_P(AiksTest, EmulatedAdvancedBlendPreservesDepthMonotonicity) {
+  if (GetParam() != PlaygroundBackend::kMetal) {
+    GTEST_SKIP()
+        << "This backend doesn't yet support setting device capabilities.";
+  }
+
+  // 1. Mock capabilities to emulate non-framebuffer-fetch devices (e.g.
+  // OpenGLES).
+  std::shared_ptr<const Capabilities> old_capabilities =
+      GetContext()->GetCapabilities();
+  fml::ScopedCleanupClosure cleanup(fml::closure([&]() {
+    std::ignore = SetCapabilities(
+        std::const_pointer_cast<Capabilities>(old_capabilities));
+  }));
+
+  auto mock_capabilities =
+      std::make_shared<::testing::NiceMock<MockCapabilities>>();
+  EXPECT_CALL(*mock_capabilities, SupportsFramebufferFetch())
+      .Times(::testing::AtLeast(1))
+      .WillRepeatedly(::testing::Return(false));
+  FLT_FORWARD(mock_capabilities, old_capabilities, GetDefaultColorFormat);
+  FLT_FORWARD(mock_capabilities, old_capabilities, GetDefaultStencilFormat);
+  FLT_FORWARD(mock_capabilities, old_capabilities,
+              GetDefaultDepthStencilFormat);
+  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsOffscreenMSAA);
+  FLT_FORWARD(mock_capabilities, old_capabilities,
+              SupportsImplicitResolvingMSAA);
+  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsReadFromResolve);
+  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsSSBO);
+  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsCompute);
+  FLT_FORWARD(mock_capabilities, old_capabilities,
+              SupportsTextureToTextureBlits);
+  FLT_FORWARD(mock_capabilities, old_capabilities, GetDefaultGlyphAtlasFormat);
+  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsTriangleFan);
+  FLT_FORWARD(mock_capabilities, old_capabilities,
+              SupportsDecalSamplerAddressMode);
+  FLT_FORWARD(mock_capabilities, old_capabilities, SupportsPrimitiveRestart);
+  FLT_FORWARD(mock_capabilities, old_capabilities,
+              Supports32BitPrimitiveIndices);
+  FLT_FORWARD(mock_capabilities, old_capabilities, NeedsPartitionedHostBuffer);
+  FLT_FORWARD(mock_capabilities, old_capabilities, GetMinimumUniformAlignment);
+  ASSERT_TRUE(SetCapabilities(mock_capabilities).ok());
+
+  // 2. Record sequential save scopes with emulated advanced blends.
+  ContentContext& context = GetContentContext();
+  auto canvas = CreateTestCanvas(context, Rect::MakeLTRB(0, 0, 800, 600),
+                                 /*requires_readback=*/true);
+
+  uint64_t previous_depth = 0;
+  for (int i = 0; i < 3; ++i) {
+    canvas->Save(/*total_content_depth=*/2);
+    canvas->DrawRect(Rect::MakeXYWH(i * 50, 0, 40, 40),
+                     Paint{.color = Color::Blue()});
+    canvas->DrawRect(
+        Rect::MakeXYWH(i * 50, 0, 40, 40),
+        Paint{.color = Color::Orange(), .blend_mode = BlendMode::kScreen});
+
+    // 3. Verify that emulated backdrop flips advance depth monotonically across
+    // sequential draw calls.
+    EXPECT_GT(canvas->GetOpDepth(), previous_depth);
+    previous_depth = canvas->GetOpDepth();
+
+    canvas->Restore();
+  }
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/display_list/dl_golden_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_golden_unittests.cc
@@ -11,7 +11,6 @@
 #include "display_list/geometry/dl_geometry_types.h"
 #include "display_list/geometry/dl_path_builder.h"
 #include "flutter/display_list/dl_builder.h"
-#include "flutter/impeller/display_list/canvas.h"
 #include "flutter/impeller/display_list/testing/render_text_in_canvas.h"
 #include "flutter/impeller/display_list/testing/rmse.h"
 #include "flutter/testing/testing.h"
@@ -649,83 +648,6 @@ TEST_P(DlGoldenTest, SubpixelScaledTranslated) {
         << i;
   }
   EXPECT_EQ(intensity[4].x - intensity[0].x, 1);
-}
-
-TEST_P(DlGoldenTest, CanRenderClippedBackdropFilterWithSuperellipse) {
-  impeller::Canvas::ScopedOnscreenOverrideForTesting scoped_override(true);
-
-  DisplayListBuilder root_builder;
-
-  root_builder.Scale(GetContentScale().x, GetContentScale().y);
-
-  // 1. Draw a dark background on the root pass.
-  DlPaint bg_paint;
-  bg_paint.setColor(DlColor::kBlack());
-  root_builder.DrawPaint(bg_paint);
-
-  // 2. Wrap in TransformLayer (matching CupertinoSheetTransition scale +
-  // slide).
-  root_builder.Save();
-  root_builder.Scale(0.9f, 0.9f);
-  root_builder.Translate(33.4f, 3.5f);
-
-  // 3. Apply ClipRoundSuperellipse with top-only rounded corners (matching
-  // CupertinoSheet).
-  DlRect sheet_rect = DlRect::MakeXYWH(0, 42, 400, 500);
-  DlRoundingRadii top_radii = {
-      .top_left = {12, 12},
-      .top_right = {12, 12},
-      .bottom_left = {0, 0},
-      .bottom_right = {0, 0},
-  };
-  DlRoundSuperellipse clip_rse =
-      DlRoundSuperellipse::MakeRectRadii(sheet_rect, top_radii);
-  root_builder.ClipRoundSuperellipse(clip_rse, DlClipOp::kIntersect);
-
-  // 4. Wrap in OpacityLayer offset (matching CupertinoSheetRoute offset: (0,
-  // 42)).
-  root_builder.Save();
-  root_builder.Translate(0.0f, 42.0f);
-
-  // 5. Layer 1: DisplayListLayer for sheet body with Ink features.
-  for (int i = 0; i < 5; i++) {
-    DisplayListBuilder item_builder;
-    DlPaint ink_paint;
-    ink_paint.setColor(DlColor::RGBA(0.0f, 0.0f, 0.0f, 0.07f));
-    item_builder.DrawRect(DlRect::MakeXYWH(0, i * 50, 400, 45), ink_paint);
-    root_builder.DrawDisplayList(item_builder.Build());
-  }
-
-  // 6. Layer 2: BackdropFilterLayer (_glassBar).
-  root_builder.Save();
-  DlRect glass_rect = DlRect::MakeXYWH(20, 350, 360, 60);
-  DlRoundRect glass_rrect = DlRoundRect::MakeRectXY(glass_rect, 14, 14);
-  root_builder.ClipRoundRect(glass_rrect, DlClipOp::kIntersect);
-
-  DlPaint save_paint;
-  auto backdrop_filter =
-      DlImageFilter::MakeBlur(12.0f, 12.0f, DlTileMode::kClamp);
-  root_builder.SaveLayer(glass_rect, &save_paint, backdrop_filter.get());
-  DisplayListBuilder glass_builder;
-  DlPaint orange_paint;
-  orange_paint.setColor(DlColor::RGBA(1.0f, 0.6f, 0.0f, 0.6f));
-  glass_builder.DrawRect(glass_rect, orange_paint);
-  root_builder.DrawDisplayList(glass_builder.Build());
-  root_builder.Restore();  // Restore SaveLayer
-  root_builder.Restore();  // Restore glass clip
-
-  // 7. Layer 3: DisplayListLayer for Scaffold AppBar / header drawn AFTER
-  // backdrop filter.
-  DisplayListBuilder appbar_builder;
-  DlPaint white_paint;
-  white_paint.setColor(DlColor::kWhite());
-  appbar_builder.DrawRect(DlRect::MakeXYWH(0, 0, 400, 80), white_paint);
-  root_builder.DrawDisplayList(appbar_builder.Build());
-
-  root_builder.Restore();  // Restore OpacityLayer offset
-  root_builder.Restore();  // Restore TransformLayer
-
-  ASSERT_TRUE(OpenPlaygroundHere(root_builder.Build()));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/display_list/dl_golden_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_golden_unittests.cc
@@ -11,6 +11,7 @@
 #include "display_list/geometry/dl_geometry_types.h"
 #include "display_list/geometry/dl_path_builder.h"
 #include "flutter/display_list/dl_builder.h"
+#include "flutter/impeller/display_list/canvas.h"
 #include "flutter/impeller/display_list/testing/render_text_in_canvas.h"
 #include "flutter/impeller/display_list/testing/rmse.h"
 #include "flutter/testing/testing.h"
@@ -648,6 +649,83 @@ TEST_P(DlGoldenTest, SubpixelScaledTranslated) {
         << i;
   }
   EXPECT_EQ(intensity[4].x - intensity[0].x, 1);
+}
+
+TEST_P(DlGoldenTest, CanRenderClippedBackdropFilterWithSuperellipse) {
+  impeller::Canvas::ScopedOnscreenOverrideForTesting scoped_override(true);
+
+  DisplayListBuilder root_builder;
+
+  root_builder.Scale(GetContentScale().x, GetContentScale().y);
+
+  // 1. Draw a dark background on the root pass.
+  DlPaint bg_paint;
+  bg_paint.setColor(DlColor::kBlack());
+  root_builder.DrawPaint(bg_paint);
+
+  // 2. Wrap in TransformLayer (matching CupertinoSheetTransition scale +
+  // slide).
+  root_builder.Save();
+  root_builder.Scale(0.9f, 0.9f);
+  root_builder.Translate(33.4f, 3.5f);
+
+  // 3. Apply ClipRoundSuperellipse with top-only rounded corners (matching
+  // CupertinoSheet).
+  DlRect sheet_rect = DlRect::MakeXYWH(0, 42, 400, 500);
+  DlRoundingRadii top_radii = {
+      .top_left = {12, 12},
+      .top_right = {12, 12},
+      .bottom_left = {0, 0},
+      .bottom_right = {0, 0},
+  };
+  DlRoundSuperellipse clip_rse =
+      DlRoundSuperellipse::MakeRectRadii(sheet_rect, top_radii);
+  root_builder.ClipRoundSuperellipse(clip_rse, DlClipOp::kIntersect);
+
+  // 4. Wrap in OpacityLayer offset (matching CupertinoSheetRoute offset: (0,
+  // 42)).
+  root_builder.Save();
+  root_builder.Translate(0.0f, 42.0f);
+
+  // 5. Layer 1: DisplayListLayer for sheet body with Ink features.
+  for (int i = 0; i < 5; i++) {
+    DisplayListBuilder item_builder;
+    DlPaint ink_paint;
+    ink_paint.setColor(DlColor::RGBA(0.0f, 0.0f, 0.0f, 0.07f));
+    item_builder.DrawRect(DlRect::MakeXYWH(0, i * 50, 400, 45), ink_paint);
+    root_builder.DrawDisplayList(item_builder.Build());
+  }
+
+  // 6. Layer 2: BackdropFilterLayer (_glassBar).
+  root_builder.Save();
+  DlRect glass_rect = DlRect::MakeXYWH(20, 350, 360, 60);
+  DlRoundRect glass_rrect = DlRoundRect::MakeRectXY(glass_rect, 14, 14);
+  root_builder.ClipRoundRect(glass_rrect, DlClipOp::kIntersect);
+
+  DlPaint save_paint;
+  auto backdrop_filter =
+      DlImageFilter::MakeBlur(12.0f, 12.0f, DlTileMode::kClamp);
+  root_builder.SaveLayer(glass_rect, &save_paint, backdrop_filter.get());
+  DisplayListBuilder glass_builder;
+  DlPaint orange_paint;
+  orange_paint.setColor(DlColor::RGBA(1.0f, 0.6f, 0.0f, 0.6f));
+  glass_builder.DrawRect(glass_rect, orange_paint);
+  root_builder.DrawDisplayList(glass_builder.Build());
+  root_builder.Restore();  // Restore SaveLayer
+  root_builder.Restore();  // Restore glass clip
+
+  // 7. Layer 3: DisplayListLayer for Scaffold AppBar / header drawn AFTER
+  // backdrop filter.
+  DisplayListBuilder appbar_builder;
+  DlPaint white_paint;
+  white_paint.setColor(DlColor::kWhite());
+  appbar_builder.DrawRect(DlRect::MakeXYWH(0, 0, 400, 80), white_paint);
+  root_builder.DrawDisplayList(appbar_builder.Build());
+
+  root_builder.Restore();  // Restore OpacityLayer offset
+  root_builder.Restore();  // Restore TransformLayer
+
+  ASSERT_TRUE(OpenPlaygroundHere(root_builder.Build()));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/entity/clip_stack_unittests.cc
+++ b/engine/src/flutter/impeller/entity/clip_stack_unittests.cc
@@ -327,5 +327,46 @@ TEST(EntityPassClipStackTest, ClipAndRestoreWithSubpassesNonAA) {
             Rect::MakeLTRB(50, 50, 55, 55));
 }
 
+TEST(EntityPassClipStackTest, RestoringChildClipPreservesParentReplayEntities) {
+  EntityPassClipStack recorder =
+      EntityPassClipStack(Rect::MakeLTRB(0, 0, 100, 100));
+
+  // 1. Record parent clip at height 1.
+  recorder.RecordClip(ClipContents(Rect::MakeLTRB(0, 0, 100, 100),
+                                   /*is_axis_aligned_rect=*/false),
+                      Matrix(), {0, 0}, 0, 100, /*is_aa=*/true);
+  EXPECT_EQ(recorder.GetReplayEntities().size(), 1u);
+  EXPECT_EQ(recorder.GetReplayEntities()[0].clip_height, 1u);
+
+  // 2. Record first child clip at height 2.
+  recorder.RecordClip(ClipContents(Rect::MakeLTRB(10, 10, 50, 50),
+                                   /*is_axis_aligned_rect=*/false),
+                      Matrix(), {0, 0}, 2, 100, /*is_aa=*/true);
+  EXPECT_EQ(recorder.GetReplayEntities().size(), 2u);
+  EXPECT_EQ(recorder.GetReplayEntities()[1].clip_height, 2u);
+
+  // 3. Restore down to height 1. The parent clip must be preserved on the
+  // replay stack.
+  recorder.RecordRestore({0, 0}, 1);
+  EXPECT_EQ(recorder.GetReplayEntities().size(), 1u);
+  EXPECT_EQ(recorder.GetReplayEntities()[0].clip_height, 1u);
+
+  // 4. Record a sibling child clip at height 2.
+  recorder.RecordClip(ClipContents(Rect::MakeLTRB(20, 20, 40, 40),
+                                   /*is_axis_aligned_rect=*/false),
+                      Matrix(), {0, 0}, 4, 100, /*is_aa=*/true);
+  EXPECT_EQ(recorder.GetReplayEntities().size(), 2u);
+  EXPECT_EQ(recorder.GetReplayEntities()[1].clip_height, 2u);
+
+  // 5. Restore down to height 1 again. The parent clip must still be preserved.
+  recorder.RecordRestore({0, 0}, 1);
+  EXPECT_EQ(recorder.GetReplayEntities().size(), 1u);
+  EXPECT_EQ(recorder.GetReplayEntities()[0].clip_height, 1u);
+
+  // 6. Restore to height 0 (popping parent clip).
+  recorder.RecordRestore({0, 0}, 0);
+  EXPECT_TRUE(recorder.GetReplayEntities().empty());
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/entity/contents/clip_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/clip_contents.cc
@@ -69,7 +69,8 @@ ClipCoverage ClipContents::GetClipCoverage(
 
 bool ClipContents::Render(const ContentContext& renderer,
                           RenderPass& pass,
-                          uint32_t clip_depth) const {
+                          uint32_t clip_depth,
+                          const std::optional<Matrix>& transform) const {
   if (!clip_geometry_.vertex_buffer) {
     return true;
   }
@@ -78,7 +79,9 @@ bool ClipContents::Render(const ContentContext& renderer,
 
   VS::FrameInfo info;
   info.depth = GetShaderClipDepth(clip_depth);
-  info.mvp = clip_geometry_.transform;
+  info.mvp = transform.has_value()
+                 ? (pass.GetOrthographicTransform() * *transform)
+                 : clip_geometry_.transform;
 
   auto options = OptionsFromPass(pass);
   options.blend_mode = BlendMode::kDst;

--- a/engine/src/flutter/impeller/entity/contents/clip_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/clip_contents.h
@@ -49,9 +49,13 @@ class ClipContents {
   ClipCoverage GetClipCoverage(
       const std::optional<Rect>& current_clip_coverage) const;
 
+  /// @param[in] transform Optional transform matrix to replace the baked clip
+  ///                      geometry transform when replaying clips into a new
+  ///                      render pass (such as during FlipBackdrop).
   bool Render(const ContentContext& renderer,
               RenderPass& pass,
-              uint32_t clip_depth) const;
+              uint32_t clip_depth,
+              const std::optional<Matrix>& transform = std::nullopt) const;
 
  private:
   // Pre-tessellated clip geometry.

--- a/engine/src/flutter/impeller/entity/entity_pass_clip_stack.cc
+++ b/engine/src/flutter/impeller/entity/entity_pass_clip_stack.cc
@@ -81,17 +81,17 @@ EntityPassClipStack::ClipStateResult EntityPassClipStack::RecordRestore(
   result.clip_did_change = true;
 
   if (subpass_state.clip_coverage.back().coverage.has_value()) {
-    FML_DCHECK(next_replay_index_ <=
-               subpass_state.rendered_clip_entities.size());
-    // https://github.com/flutter/flutter/issues/162172
-    // This code is slightly wrong and should be popping more than one clip
-    // entry.
-    if (!subpass_state.rendered_clip_entities.empty()) {
+    // Only pop replay entities that belonged to deeper child scopes
+    // (clip_height > restore_height). This preserves active parent clips across
+    // sibling restorations while correctly popping multi-level nested
+    // hierarchies back down to restore_height.
+    while (!subpass_state.rendered_clip_entities.empty() &&
+           subpass_state.rendered_clip_entities.back().clip_height >
+               restore_height) {
       subpass_state.rendered_clip_entities.pop_back();
-
-      if (next_replay_index_ > subpass_state.rendered_clip_entities.size()) {
-        next_replay_index_ = subpass_state.rendered_clip_entities.size();
-      }
+    }
+    if (next_replay_index_ > subpass_state.rendered_clip_entities.size()) {
+      next_replay_index_ = subpass_state.rendered_clip_entities.size();
     }
   }
   return result;
@@ -190,10 +190,11 @@ EntityPassClipStack::ClipStateResult EntityPassClipStack::RecordClip(
       << "Not all clips have been replayed before appending new clip.";
 
   subpass_state.rendered_clip_entities.push_back(ReplayResult{
-      .clip_contents = clip_contents,   //
-      .transform = transform,           //
-      .clip_coverage = coverage_value,  //
-      .clip_depth = clip_depth          //
+      .clip_contents = clip_contents,           //
+      .transform = transform,                   //
+      .clip_coverage = coverage_value,          //
+      .clip_depth = clip_depth,                 //
+      .clip_height = previous_clip_height + 1,  //
   });
   next_replay_index_++;
 

--- a/engine/src/flutter/impeller/entity/entity_pass_clip_stack.h
+++ b/engine/src/flutter/impeller/entity/entity_pass_clip_stack.h
@@ -27,6 +27,7 @@ class EntityPassClipStack {
     Matrix transform;
     std::optional<Rect> clip_coverage;
     uint32_t clip_depth = 0;
+    size_t clip_height = 0;
   };
 
   struct ClipStateResult {

--- a/engine/src/flutter/impeller/entity/entity_pass_clip_stack.h
+++ b/engine/src/flutter/impeller/entity/entity_pass_clip_stack.h
@@ -27,6 +27,9 @@ class EntityPassClipStack {
     Matrix transform;
     std::optional<Rect> clip_coverage;
     uint32_t clip_depth = 0;
+    /// The clip stack nesting depth at which this clip entity was recorded.
+    /// Used during restoration to preserve parent clips while popping child
+    /// scopes.
     size_t clip_height = 0;
   };
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/190602, see my [comment](https://github.com/flutter/flutter/issues/190602#issuecomment-5288993664) on that issue for details about the problems I identified.
Also fixes https://github.com/flutter/flutter/issues/162172

## What changed

When a route contained rounded clips (such as `CupertinoSheetRoute`), intermediate child ink features, and a backdrop filter (such as a blurred app bar), the clip stack replay logic prematurely popped parent clips and exceeded the depth buffer budget across render pass splits, causing subsequent header draws to render with 90° square corners. This PR addresses both mechanisms:

First, `EntityPassClipStack::RecordRestore` was popping replay entities unconditionally whenever any clip was restored. In a sheet containing ink decorations (like list item ripple effects), child clip restores at deeper heights would prematurely discard the root parent clip. We now track `clip_height` in `ReplayResult` so that restorations only pop entities when `clip_height > restore_height`, preserving parent clips across sibling restores. When replaying those clips in `ClipContents::Render`, we also supply the entity's model matrix to properly recompute the MVP matrix against the new pass's orthographic projection instead of reusing the stale matrix from the prior pass.

Second, the pass depth budget was exhausting across backdrop splits. `Canvas::kMaxDepth` (`1 << 24`) was mismatched with `Entity::kDepthEpsilon` (`1.0 / 262144.0`, or `2^-18`), allowing integer depths to exceed the 18-bit precision of the depth buffer. Aligning `Canvas::kMaxDepth` to `262,143` and capping depth allocations in `Save`/`SaveLayer` to `min(current_depth_ + total_content_depth, parent_clip_depth)` keeps clip replay and subsequent draw operations within valid precision bounds. In `Canvas::Restore`, we also prevent unconditional depth jumps to `kMaxDepth` for unclipped saves, preserving the allocated budget for subsequent sibling draws.

## Testing

Reproducing this interaction in automated tests required testing the onscreen pass-splitting branch (`IsOnscreen()`), which normal offscreen unit tests bypass. We added a `ScopedOnscreenOverride` test hook in `Canvas` and constructed a multi-layer display list recreating the route clip, child ink items, blurred backdrop bar, and trailing app bar:

* `clip_stack_unittests.cc`: Added `EntityPassClipStackTest.RestoringChildClipPreservesParentReplayEntities` to isolate parent clip retention across sibling restores.
* `canvas_unittests.cc`: Added `AiksTest.ClipDepthMaintainedAcrossBackdropFilterAndLayers` to verify depth invariants and precision bounds (`<= kMaxDepth`), and `AiksTest.ParentClipDepthBudgetPreservedAfterBackdropLayerRestore` to verify parent depth budget restoration.
* `dl_golden_unittests.cc` (`impeller_golden_tests`): Added `DlGoldenTest.CanRenderClippedBackdropFilterWithSuperellipse` for pixel-accurate golden image verification in CI against Skia Gold.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
