### PR TITLE
Impeller: Fix for stroked circles with stroke half-width > radius, tessellation scaling

### DIFF
--- a/engine/src/flutter/impeller/tessellator/tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator.cc
@@ -862,11 +862,12 @@ void Tessellator::GenerateStrokedArc(
     const TessellatedVertexProc& proc) {
   Point center = oval_bounds.GetCenter();
   Size base_radii = oval_bounds.GetSize() * 0.5f;
-  // A stroke at least as wide as the radii covers the center of the oval, so
-  // the inner edge is clamped to the center rather than allowed to fold back
-  // through it and self-intersect.
-  Size inner_radii =
-      (base_radii - Size(half_width, half_width)).Max(Size(0.0f, 0.0f));
+
+  // A stroke width wider than the radii would cross the center and
+  // self-intersect. Clamp inner edge to center.
+  Size inner_radii = base_radii - Size(half_width, half_width);
+  inner_radii = inner_radii.Max(Size(0.0f, 0.0f));
+
   Size outer_radii = base_radii + Size(half_width, half_width);
 
   // Starting cap

--- a/engine/src/flutter/impeller/tessellator/tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator.cc
@@ -515,7 +515,7 @@ EllipticalVertexGenerator Tessellator::StrokedCircle(
     return FilledCircle(view_transform, center, radius + half_width);
   }
   auto divisions = ComputeQuadrantDivisions(
-      view_transform.GetMaxBasisLengthXY() * radius + half_width);
+      view_transform.GetMaxBasisLengthXY() * (radius + half_width));
   return EllipticalVertexGenerator(Tessellator::GenerateStrokedCircle,
                                    GetTrigsForDivisions(divisions),
                                    PrimitiveType::kTriangleStrip, 8,

--- a/engine/src/flutter/impeller/tessellator/tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator.cc
@@ -506,20 +506,24 @@ EllipticalVertexGenerator Tessellator::StrokedCircle(
     const Point& center,
     Scalar radius,
     Scalar half_width) {
-  if (half_width > 0) {
-    auto divisions = ComputeQuadrantDivisions(
-        view_transform.GetMaxBasisLengthXY() * radius + half_width);
-    return EllipticalVertexGenerator(Tessellator::GenerateStrokedCircle,
-                                     GetTrigsForDivisions(divisions),
-                                     PrimitiveType::kTriangleStrip, 8,
-                                     {
-                                         .reference_centers = {center, center},
-                                         .radii = {radius, radius},
-                                         .half_width = half_width,
-                                     });
-  } else {
+  if (half_width <= 0) {
     return FilledCircle(view_transform, center, radius);
   }
+  if (half_width >= radius) {
+    // Identical to a filled circle whose radius reaches the outer edge of the
+    // stroke.
+    return FilledCircle(view_transform, center, radius + half_width);
+  }
+  auto divisions = ComputeQuadrantDivisions(
+      view_transform.GetMaxBasisLengthXY() * radius + half_width);
+  return EllipticalVertexGenerator(Tessellator::GenerateStrokedCircle,
+                                   GetTrigsForDivisions(divisions),
+                                   PrimitiveType::kTriangleStrip, 8,
+                                   {
+                                       .reference_centers = {center, center},
+                                       .radii = {radius, radius},
+                                       .half_width = half_width,
+                                   });
 }
 
 ArcVertexGenerator ArcVertexGenerator::MakeFilled(
@@ -858,7 +862,11 @@ void Tessellator::GenerateStrokedArc(
     const TessellatedVertexProc& proc) {
   Point center = oval_bounds.GetCenter();
   Size base_radii = oval_bounds.GetSize() * 0.5f;
-  Size inner_radii = base_radii - Size(half_width, half_width);
+  // A stroke at least as wide as the radii covers the center of the oval, so
+  // the inner edge is clamped to the center rather than allowed to fold back
+  // through it and self-intersect.
+  Size inner_radii =
+      (base_radii - Size(half_width, half_width)).Max(Size(0.0f, 0.0f));
   Size outer_radii = base_radii + Size(half_width, half_width);
 
   // Starting cap

--- a/engine/src/flutter/impeller/tessellator/tessellator_unittests.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator_unittests.cc
@@ -303,6 +303,46 @@ TEST(TessellatorTest, StrokedCircleTessellationVertices) {
   test(Matrix::MakeScale({0.002, 0.002, 0.0}), {}, 1000.0, 10.0);
 }
 
+TEST(TessellatorTest, StrokedCircleWideStrokeTessellationVertices) {
+  Tessellator tessellator;
+
+  // A stroke at least as wide as the radius fills the whole circle.
+  // Verify it tessellates as a filled circle whose radius reaches the outer
+  // edge of the stroke rather than as an annulus with a negative inner radius.
+  auto test = [&tessellator](const Matrix& transform, const Point& center,
+                             Scalar radius, Scalar half_width) {
+    ASSERT_GE(half_width, radius);
+    auto generator =
+        tessellator.StrokedCircle(transform, center, radius, half_width);
+    auto filled =
+        tessellator.FilledCircle(transform, center, radius + half_width);
+
+    EXPECT_EQ(generator.GetTriangleType(), filled.GetTriangleType());
+    EXPECT_EQ(generator.GetVertexCount(), filled.GetVertexCount());
+
+    auto vertices = std::vector<Point>();
+    generator.GenerateVertices([&vertices](const Point& p) {  //
+      vertices.push_back(p);
+    });
+    auto filled_vertices = std::vector<Point>();
+    filled.GenerateVertices([&filled_vertices](const Point& p) {  //
+      filled_vertices.push_back(p);
+    });
+
+    EXPECT_EQ(vertices.size(), generator.GetVertexCount());
+    ASSERT_EQ(vertices.size(), filled_vertices.size());
+    for (size_t i = 0; i < vertices.size(); i++) {
+      EXPECT_POINT_NEAR(vertices[i], filled_vertices[i]) << "vertex " << i;
+    }
+  };
+
+  test({}, {}, 2.0, 2.0);
+  test({}, {}, 2.0, 4.0);
+  test({}, {10, 10}, 2.0, 2.0);
+  test(Matrix::MakeScale({500.0, 500.0, 0.0}), {}, 2.0, 2.0);
+  test(Matrix::MakeScale({0.002, 0.002, 0.0}), {}, 1000.0, 1000.0);
+}
+
 TEST(TessellatorTest, FilledArcStripTessellationVertices) {
   Tessellator tessellator;
 
@@ -377,6 +417,44 @@ TEST(TessellatorTest, FilledArcStripTessellationVertices) {
        Arc(Rect::MakeXYWH(0, 0, 100, 100), Degrees(94), Degrees(322), false));
   test({},
        Arc(Rect::MakeXYWH(0, 0, 100, 100), Degrees(94), Degrees(322), true));
+}
+
+TEST(TessellatorTest, StrokedArcWideStrokeTessellationVertices) {
+  Tessellator tessellator;
+
+  // A stroke at least as wide as the radius reaches the center of the oval.
+  // Verify the inner edge stops at the center so we don't mirror the inner
+  // vertices onto the far side and produce a self-intersecting strip.
+  auto test = [&tessellator](const Matrix& transform, const Arc& arc,
+                             Scalar half_width) {
+    Scalar radius = arc.GetOvalSize().width * 0.5f;
+    ASSERT_GE(half_width, radius);
+    auto generator =
+        tessellator.StrokedArc(transform, arc, Cap::kButt, half_width);
+
+    auto vertices = std::vector<Point>();
+    generator.GenerateVertices([&vertices](const Point& p) {  //
+      vertices.push_back(p);
+    });
+    EXPECT_EQ(vertices.size(), generator.GetVertexCount());
+    ASSERT_EQ(vertices.size() % 2, 0u);
+
+    Point center = arc.GetOvalBounds().GetCenter();
+    for (size_t i = 0; i < vertices.size(); i += 2) {
+      EXPECT_POINT_NEAR(vertices[i], center) << "inner vertex " << i;
+      EXPECT_NEAR((vertices[i + 1] - center).GetLength(), radius + half_width,
+                  kEhCloseEnough)
+          << "outer vertex " << i + 1;
+    }
+  };
+
+  test({}, Arc(Rect::MakeXYWH(0, 0, 100, 100), Degrees(0), Degrees(90), false),
+       50.0);
+  test({}, Arc(Rect::MakeXYWH(0, 0, 100, 100), Degrees(0), Degrees(90), false),
+       75.0);
+  test({},
+       Arc(Rect::MakeXYWH(10, 20, 100, 100), Degrees(94), Degrees(322), false),
+       60.0);
 }
 
 TEST(TessellatorTest, RoundCapLineTessellationVertices) {

--- a/engine/src/flutter/impeller/tessellator/tessellator_unittests.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator_unittests.cc
@@ -306,19 +306,19 @@ TEST(TessellatorTest, StrokedCircleTessellationVertices) {
 TEST(TessellatorTest, StrokedCircleWideStrokeTessellationVertices) {
   Tessellator tessellator;
 
-  // A stroke at least as wide as the radius fills the whole circle.
-  // Verify it tessellates as a filled circle whose radius reaches the outer
-  // edge of the stroke rather than as an annulus with a negative inner radius.
+  // A stroke at least as wide as the radius fills the circle. Verify it
+  // tessellates as a filled circle out to the outer edge of the stroke.
   auto test = [&tessellator](const Matrix& transform, const Point& center,
-                             Scalar radius, Scalar half_width) {
-    ASSERT_GE(half_width, radius);
+                             Scalar radius, Scalar half_width,
+                             const std::string& label) {
+    ASSERT_GE(half_width, radius) << label;
     auto generator =
         tessellator.StrokedCircle(transform, center, radius, half_width);
     auto filled =
         tessellator.FilledCircle(transform, center, radius + half_width);
 
-    EXPECT_EQ(generator.GetTriangleType(), filled.GetTriangleType());
-    EXPECT_EQ(generator.GetVertexCount(), filled.GetVertexCount());
+    EXPECT_EQ(generator.GetTriangleType(), filled.GetTriangleType()) << label;
+    EXPECT_EQ(generator.GetVertexCount(), filled.GetVertexCount()) << label;
 
     auto vertices = std::vector<Point>();
     generator.GenerateVertices([&vertices](const Point& p) {  //
@@ -329,18 +329,20 @@ TEST(TessellatorTest, StrokedCircleWideStrokeTessellationVertices) {
       filled_vertices.push_back(p);
     });
 
-    EXPECT_EQ(vertices.size(), generator.GetVertexCount());
-    ASSERT_EQ(vertices.size(), filled_vertices.size());
+    EXPECT_EQ(vertices.size(), generator.GetVertexCount()) << label;
+    ASSERT_EQ(vertices.size(), filled_vertices.size()) << label;
     for (size_t i = 0; i < vertices.size(); i++) {
-      EXPECT_POINT_NEAR(vertices[i], filled_vertices[i]) << "vertex " << i;
+      EXPECT_POINT_NEAR(vertices[i], filled_vertices[i])
+          << label << ", vertex " << i;
     }
   };
 
-  test({}, {}, 2.0, 2.0);
-  test({}, {}, 2.0, 4.0);
-  test({}, {10, 10}, 2.0, 2.0);
-  test(Matrix::MakeScale({500.0, 500.0, 0.0}), {}, 2.0, 2.0);
-  test(Matrix::MakeScale({0.002, 0.002, 0.0}), {}, 1000.0, 1000.0);
+  test({}, {}, 2.0, 2.0, "half width == radius");
+  test({}, {}, 2.0, 4.0, "half width > radius");
+  test({}, {10, 10}, 2.0, 2.0, "offset center");
+  test(Matrix::MakeScale({500.0, 500.0, 0.0}), {}, 2.0, 2.0, "scaled up");
+  test(Matrix::MakeScale({0.002, 0.002, 0.0}), {}, 1000.0, 1000.0,
+       "scaled down");
 }
 
 TEST(TessellatorTest, FilledArcStripTessellationVertices) {
@@ -422,13 +424,12 @@ TEST(TessellatorTest, FilledArcStripTessellationVertices) {
 TEST(TessellatorTest, StrokedArcWideStrokeTessellationVertices) {
   Tessellator tessellator;
 
-  // A stroke at least as wide as the radius reaches the center of the oval.
-  // Verify the inner edge stops at the center so we don't mirror the inner
-  // vertices onto the far side and produce a self-intersecting strip.
+  // A stroke width wider than the radii would cross the center. Verify the
+  // inner edge stops there rather than folding through and self-intersecting.
   auto test = [&tessellator](const Matrix& transform, const Arc& arc,
-                             Scalar half_width) {
+                             Scalar half_width, const std::string& label) {
     Scalar radius = arc.GetOvalSize().width * 0.5f;
-    ASSERT_GE(half_width, radius);
+    ASSERT_GE(half_width, radius) << label;
     auto generator =
         tessellator.StrokedArc(transform, arc, Cap::kButt, half_width);
 
@@ -436,25 +437,25 @@ TEST(TessellatorTest, StrokedArcWideStrokeTessellationVertices) {
     generator.GenerateVertices([&vertices](const Point& p) {  //
       vertices.push_back(p);
     });
-    EXPECT_EQ(vertices.size(), generator.GetVertexCount());
-    ASSERT_EQ(vertices.size() % 2, 0u);
+    EXPECT_EQ(vertices.size(), generator.GetVertexCount()) << label;
+    ASSERT_EQ(vertices.size() % 2, 0u) << label;
 
     Point center = arc.GetOvalBounds().GetCenter();
     for (size_t i = 0; i < vertices.size(); i += 2) {
-      EXPECT_POINT_NEAR(vertices[i], center) << "inner vertex " << i;
+      EXPECT_POINT_NEAR(vertices[i], center) << label << ", inner vertex " << i;
       EXPECT_NEAR((vertices[i + 1] - center).GetLength(), radius + half_width,
                   kEhCloseEnough)
-          << "outer vertex " << i + 1;
+          << label << ", outer vertex " << i + 1;
     }
   };
 
   test({}, Arc(Rect::MakeXYWH(0, 0, 100, 100), Degrees(0), Degrees(90), false),
-       50.0);
+       50.0, "half width == radius");
   test({}, Arc(Rect::MakeXYWH(0, 0, 100, 100), Degrees(0), Degrees(90), false),
-       75.0);
+       75.0, "half width > radius");
   test({},
        Arc(Rect::MakeXYWH(10, 20, 100, 100), Degrees(94), Degrees(322), false),
-       60.0);
+       60.0, "offset oval, oblique sweep");
 }
 
 TEST(TessellatorTest, RoundCapLineTessellationVertices) {

--- a/engine/src/flutter/impeller/tessellator/tessellator_unittests.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator_unittests.cc
@@ -187,6 +187,32 @@ TEST(TessellatorTest, CircleVertexCounts) {
   }
 }
 
+TEST(TessellatorTest, StrokedCircleVertexCounts) {
+  Tessellator tessellator;
+
+  // The outer edge of a stroked circle sits at |radius| + |half_width|, so it
+  // must be divided at least as finely as a filled circle of that radius to be
+  // within |kCircleTolerance|.
+  auto test = [&tessellator](const Matrix& transform, Scalar radius,
+                             Scalar half_width, const std::string& label) {
+    ASSERT_LT(half_width, radius) << label;
+    auto stroked = tessellator.StrokedCircle(transform, {}, radius, half_width);
+    auto filled = tessellator.FilledCircle(transform, {}, radius + half_width);
+
+    EXPECT_GE(stroked.GetVertexCount() / 8, filled.GetVertexCount() / 4)
+        << label;
+  };
+
+  test({}, 2.0, 1.0, "small radius");
+  test({}, 100.0, 10.0, "large radius");
+  test(Matrix::MakeScale({500.0, 500.0, 0.0}), 2.0, 1.0,
+       "small radius, scaled up");
+  test(Matrix::MakeScale({500.0, 500.0, 0.0}), 100.0, 10.0,
+       "large radius, scaled up");
+  test(Matrix::MakeScale({0.002, 0.002, 0.0}), 1000.0, 10.0,
+       "large radius, scaled down");
+}
+
 TEST(TessellatorTest, FilledCircleTessellationVertices) {
   Tessellator tessellator;
 


### PR DESCRIPTION
`Tessellator::StrokedCircle` delegated to `GenerateStrokedCircle` whenever `half_width > 0`, but that generator zig-zags between an inner and an outer circle and asserts `half_width < radius`, since the inner radius goes negative once the stroke is at least as wide as the radius. That case should render as a filled circle whose radius reaches the outer edge of the stroke.

We were hitting this when enabling construction lines during debugging. With `debugPaintSizeEnabled` set, `RenderSliver.debugPaint` draws a circle of radius 2.0 with a stroke width of 4.0, so toggling construction lines on in unopt builds triggered this `FML_DCHECK`:

```
[FATAL:flutter/impeller/tessellator/tessellator.cc(755)] Check failed: data.half_width > 0 && data.half_width < data.radii.width.
```

`GenerateStrokedArc` had the same issue but didn't assert: the inner radii went negative and the inner edge folded back through the centre of the oval, producing a self-intersecting strip. We now clamp to the centre.

Also fixed a small bug in stroked circle division count scaling. `Tessellator::StrokedCircle` computes its quadrant divisions based on the radius. The radius in this case should be the circle radius + the stroke half-width to get the outer radius of the resulting filled circle.

The effect would be under-tessellation of the outer edge that gets worse with increasing half-width. This tosses a pair of brackets on to scale the whole thing.

Fixes: https://github.com/flutter/flutter/issues/190597

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
