### PR TITLE
Fix semantics assertion when a sibling merge group is under MergeSemantics

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -6400,7 +6400,9 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
             node.tags!.addAll(tags);
           }
         }
-        node.isMergedIntoParent = parentData?.mergeIntoParent ?? false;
+        node.isMergedIntoParent =
+            configProvider.effective.isMergingSemanticsOfDescendants ||
+            (parentData?.mergeIntoParent ?? false);
       }
     }
     _updateSiblingNodesGeometries();

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -15770,4 +15770,36 @@ void main() {
     );
     expect(tester.getSize(find.byType(InputDecorator)), Size.zero);
   });
+
+  testWidgets('does not assert when an affix sibling merge group is under MergeSemantics', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/191095.
+    //
+    // The InputDecorator affix (here, the prefix) produces a sibling merge group
+    // in its semantics. When the field is wrapped in a MergeSemantics, that
+    // sibling node must be flagged as merged into its parent, otherwise the
+    // semantics compiler asserts `node.isMergedIntoParent`.
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: MergeSemantics(
+            child: TextField(
+              focusNode: focusNode,
+              decoration: const InputDecoration(prefix: SizedBox(width: 12)),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Focusing reveals the prefix affix, which produces the sibling merge group.
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
 }


### PR DESCRIPTION
## Description

Fixes a semantics assertion regression: `Failed assertion: 'node.isMergedIntoParent': is not true` (`semantics.dart`).

When a render object produces a *sibling merge group* in its semantics (for example the `InputDecorator` affix, via `childConfigurationsDelegate`) and an ancestor `MergeSemantics` merges the whole subtree, the produced sibling node was flagged as merged into its parent **only** when its own `parentData` requested it. Under a `MergeSemantics` ancestor, the merge signal lives on the effective configuration (`isMergingSemanticsOfDescendants`), not on the sibling node's `parentData`, so the sibling node was left unmerged and the semantics compiler asserted `node.isMergedIntoParent`.

The fix also treats the sibling node as merged into its parent when the effective configuration is merging the semantics of its descendants:

```dart
node.isMergedIntoParent =
    configProvider.effective.isMergingSemanticsOfDescendants ||
    (parentData?.mergeIntoParent ?? false);
```

This implements the root-cause analysis and proposed fix from @Pante in the issue - thanks for the excellent report and minimal reproduction.

## Tests

Adds a regression test in `input_decorator_test.dart` that wraps a `TextField` (with a prefix affix) in `MergeSemantics`, focuses it to reveal the affix sibling merge group, and verifies no assertion is thrown. The test fails without the fix (throwing the `node.isMergedIntoParent` assertion) and passes with it.

Fixes #191095.

I searched the open pull requests for flutter/flutter and did not find an existing PR addressing this issue before opening this one.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
