### PR TITLE
[web] expose engine initialization and view handling

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/initialization.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/initialization.dart
@@ -208,6 +208,7 @@ void _setAssetManager(ui_web.AssetManager assetManager) {
   _assetManager = assetManager;
 }
 
+/// Sets the [ui_web.AssetManager] used by the Flutter Engine.
 void setAssetManager(ui_web.AssetManager assetManager) {
   _setAssetManager(assetManager);
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/initialization.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/initialization.dart
@@ -208,6 +208,10 @@ void _setAssetManager(ui_web.AssetManager assetManager) {
   _assetManager = assetManager;
 }
 
+void setAssetManager(ui_web.AssetManager assetManager) {
+  _setAssetManager(assetManager);
+}
+
 Future<void> _downloadAssetFonts() async {
   renderer.fontCollection.clear();
 

--- a/engine/src/flutter/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
+++ b/engine/src/flutter/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
@@ -40,4 +40,63 @@ class FlutterViewManagerProxy {
   JSAny? getInitialData(int viewId) {
     return _viewManager.getOptions(viewId)?.initialData;
   }
+
+  /// Adds a view to the application, embedding it into the host element specified in options.
+  int addView(FlutterViewOptions options) {
+    final FlutterViewConstraints? viewConstraints = options.viewConstraints;
+    return _viewManager
+        .createAndRegisterView(
+          JsFlutterViewOptions(
+            hostElement: options.hostElement as DomElement,
+            viewConstraints: viewConstraints != null
+                ? JsViewConstraints(
+                    minWidth: viewConstraints.minWidth,
+                    maxWidth: viewConstraints.maxWidth,
+                    minHeight: viewConstraints.minHeight,
+                    maxHeight: viewConstraints.maxHeight,
+                  )
+                : null,
+            initialData: options.initialData,
+          ),
+        )
+        .viewId;
+  }
+
+  /// Removes and disposes the view with the given [viewId].
+  void removeView(int viewId) {
+    _viewManager.disposeAndUnregisterView(viewId);
+  }
+}
+
+/// Options for creating a new Flutter view.
+class FlutterViewOptions {
+  FlutterViewOptions({required this.hostElement, this.viewConstraints, this.initialData});
+
+  /// The DOM element into which the Flutter view will be embedded.
+  final JSObject hostElement;
+
+  /// The constraints for the Flutter view.
+  final FlutterViewConstraints? viewConstraints;
+
+  /// Optional initial data to pass to the Flutter view.
+  final Object? initialData;
+}
+
+/// Constraints for the size of a Flutter view.
+///
+/// Attributes are expressed in *logical* pixels.
+class FlutterViewConstraints {
+  FlutterViewConstraints({this.minWidth, this.maxWidth, this.minHeight, this.maxHeight});
+
+  /// The minimum width of the Flutter view.
+  final double? minWidth;
+
+  /// The maximum width of the Flutter view.
+  final double? maxWidth;
+
+  /// The minimum height of the Flutter view.
+  final double? minHeight;
+
+  /// The maximum height of the Flutter view.
+  final double? maxHeight;
 }

--- a/engine/src/flutter/lib/web_ui/lib/ui_web/src/ui_web/initialization.dart
+++ b/engine/src/flutter/lib/web_ui/lib/ui_web/src/ui_web/initialization.dart
@@ -2,8 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:js_interop';
+
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
+
+import 'asset_manager.dart';
 
 /// Bootstraps the Flutter Web engine and app.
 ///
@@ -50,4 +54,37 @@ Future<void> bootstrapEngine({ui.VoidCallback? registerPlugins, ui.VoidCallback?
     // Yield control of the bootstrap procedure to the user.
     loader.didCreateEngineInitializer(bootstrap.prepareEngineInitializer());
   }
+}
+
+/// Initializes the [AssetManager] used by the Flutter Engine.
+///
+/// This is useful when external plugins/tools need to access the [assetManager]
+/// without initializing the full Flutter engine.
+void initializeAssetManager([AssetManager? manager]) {
+  setAssetManager(manager ?? AssetManager());
+}
+
+/// Bootstraps the non-UI services of the Flutter Web engine.
+///
+/// Must only be used when taking full control over the engine initialization,
+/// and must be immediately followed by a call to [bootstrapEngineUi].
+///
+/// The [jsConfiguration] object must only contain valid configuration
+/// properties documented at https://docs.flutter.dev/platform-integration/web/initialization#customize-the-flutter-loader
+Future<void> bootstrapEngineServices({
+  AssetManager? assetManager,
+  JSObject? jsConfiguration,
+}) async {
+  await initializeEngineServices(
+    assetManager: assetManager,
+    jsConfiguration: jsConfiguration as JsFlutterConfiguration?,
+  );
+}
+
+/// Bootstraps the UI services of the Flutter Web engine.
+///
+/// Must only be used when taking full control over the engine initialization, and
+/// must be called immediately after [bootstrapEngineServices].
+Future<void> bootstrapEngineUi() async {
+  await initializeEngineUi();
 }

--- a/engine/src/flutter/lib/web_ui/test/engine/initialization_step_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/initialization_step_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart' as engine;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  test('initializeAssetManager sets ui_web.assetManager', () {
+    final customManager = ui_web.AssetManager(assetsDir: 'custom_assets');
+    ui_web.initializeAssetManager(customManager);
+    expect(ui_web.assetManager, customManager);
+  });
+
+  test('bootstrapEngineServices and bootstrapEngineUi initialize engine in steps', () async {
+    // Reset the engine
+    engine.debugResetEngineInitializationState();
+
+    expect(engine.initializationState, engine.DebugEngineInitializationState.uninitialized);
+
+    final engineConfiguration = JSObject()..setProperty('multiViewEnabled'.toJS, true.toJS);
+
+    await ui_web.bootstrapEngineServices(jsConfiguration: engineConfiguration);
+
+    expect(engine.initializationState, engine.DebugEngineInitializationState.initializedServices);
+    expect(engine.configuration.multiViewEnabled, isTrue);
+
+    await ui_web.bootstrapEngineUi();
+
+    expect(engine.initializationState, engine.DebugEngineInitializationState.initialized);
+  }, skip: ui_web.browser.isFirefox);
+}

--- a/engine/src/flutter/lib/web_ui/test/engine/view_embedder/flutter_views_proxy_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/view_embedder/flutter_views_proxy_test.dart
@@ -106,6 +106,28 @@ Future<void> doTests() async {
         expect(element.decimals, <double>[math.pi, math.e]);
       });
     });
+
+    group('addView and removeView', () {
+      test('can add and remove a view', () {
+        final DomElement host = createDomElement('div');
+        final int viewId = views.addView(
+          FlutterViewOptions(
+            hostElement: host,
+            viewConstraints: FlutterViewConstraints(
+              minWidth: 100.0,
+              maxWidth: 500.0,
+              minHeight: 100.0,
+              maxHeight: 500.0,
+            ),
+          ),
+        );
+        expect(viewManager[viewId], isNotNull);
+        expect(views.getHostElement(viewId), host);
+
+        views.removeView(viewId);
+        expect(viewManager[viewId], isNull);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
This PR exposes engine initialization and view handling functionality from the web engine in `package:web_ui` so that a Dart web application (like Jaspr) can initialize the Flutter engine and add/remove views from inside Dart without needing JS workarounds.

In Jaspr specifically, this will improve on the existing flutter embedding capabilities and make it more seamless, as well as fix plugin initialization for plugins relying on `assetManager` and work towards supporting WASM compilation for embedded flutter apps.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
