### PR TITLE
et: Fix custom git diff prefix handling

### DIFF
--- a/engine/src/flutter/ci/bin/format.dart
+++ b/engine/src/flutter/ci/bin/format.dart
@@ -227,8 +227,62 @@ abstract class FormatChecker {
     }
   }
 
+  /// Builds a job that diffs the file at [filePath] against
+  /// [formattedContents], the formatter's output for that file.
+  ///
+  /// Because the formatted side arrives on stdin, the resulting patch header
+  /// shows `-` (stdin) as the destination file. Callers rewrite that to the
+  /// real path before applying the patch.
+  ///
+  /// `--src-prefix` and `--dst-prefix` are passed explicitly so that the patch
+  /// always uses git's default `a/` and `b/` prefix. This prevents mismatches
+  /// due for users whose git config sets up alternate prefixes.
+  ///
+  /// See: `diff.mnemonicPrefix`, `diff.noprefix`, `diff.srcPrefix`,
+  /// `diff.dstPrefix`.
+  @protected
+  WorkerJob createDiffJob(String filePath, List<int>? formattedContents) {
+    return WorkerJob(<String>[
+      'git',
+      'diff',
+      '--no-index',
+      '--no-color',
+      '--ignore-cr-at-eol',
+      '--src-prefix=a/',
+      '--dst-prefix=b/',
+      '--',
+      filePath,
+      '-',
+    ], stdinRaw: codeUnitsAsStream(formattedContents));
+  }
+
+  /// RegExp that matches the to-file line of a patch whose destination is `-`
+  /// (stdin), instead of the real path the caller should have rewritten it to.
+  static final RegExp _stdinPatchTarget = RegExp(r'^\+\+\+ b/-$', multiLine: true);
+
+  /// Returns true if [patch] has a to-file line whose destination is `-`.
+  static bool _patchTargetsStdin(String patch) => _stdinPatchTarget.hasMatch(patch);
+
+  /// Applies each of [patches] to the work tree with `git apply`, and returns
+  /// whether they all applied cleanly.
+  ///
+  /// [createDiffJob] produces patches whose output path is `-` (stdin). Every
+  /// patch in [patches] is expected to have had its destination path rewritten
+  /// to the real destination path to prevent files from being written to a file
+  /// at the repository root named `-`.
   @protected
   Future<bool> applyPatch(List<String> patches) async {
+    final List<String> unrewritten = patches.where(_patchTargetsStdin).toList();
+    if (unrewritten.isNotEmpty) {
+      final bool plural = unrewritten.length > 1;
+      error(
+        '${unrewritten.length} patch${plural ? 'es' : ''} still '
+        "${plural ? 'have' : 'has'} '-' as the destination file. Patches must "
+        'have their destination path rewritten to the correct output path.',
+      );
+      unrewritten.forEach(message);
+      return false;
+    }
     final patchPool = ProcessPool(
       processRunner: _processRunner,
       printReport: namedReport('patch'),
@@ -421,18 +475,7 @@ class ClangFormatChecker extends FormatChecker {
     final diffJobs = <WorkerJob>[];
     await for (final WorkerJob completedJob in completedClangFormats) {
       if (completedJob.result.exitCode == 0) {
-        diffJobs.add(
-          WorkerJob(<String>[
-            'git',
-            'diff',
-            '--no-index',
-            '--no-color',
-            '--ignore-cr-at-eol',
-            '--',
-            completedJob.command.last,
-            '-',
-          ], stdinRaw: codeUnitsAsStream(completedJob.result.stdoutRaw)),
-        );
+        diffJobs.add(createDiffJob(completedJob.command.last, completedJob.result.stdoutRaw));
       } else {
         final String formatterCommand = completedJob.command.join(' ');
         error(
@@ -619,18 +662,7 @@ class JavaFormatChecker extends FormatChecker {
     final diffJobs = <WorkerJob>[];
     await for (final WorkerJob completedJob in completedJavaFormats) {
       if (completedJob.result.exitCode == 0) {
-        diffJobs.add(
-          WorkerJob(<String>[
-            'git',
-            'diff',
-            '--no-index',
-            '--no-color',
-            '--ignore-cr-at-eol',
-            '--',
-            completedJob.command.last,
-            '-',
-          ], stdinRaw: codeUnitsAsStream(completedJob.result.stdoutRaw)),
-        );
+        diffJobs.add(createDiffJob(completedJob.command.last, completedJob.result.stdoutRaw));
       } else {
         final String formatterCommand = completedJob.command.join(' ');
         error(
@@ -740,16 +772,7 @@ class GnFormatChecker extends FormatChecker {
     await for (final WorkerJob completedJob in completedJobs) {
       if (completedJob.result.exitCode == 0) {
         diffJobs.add(
-          WorkerJob(<String>[
-            'git',
-            'diff',
-            '--no-index',
-            '--no-color',
-            '--ignore-cr-at-eol',
-            '--',
-            completedJob.name.split(' ').last,
-            '-',
-          ], stdinRaw: codeUnitsAsStream(completedJob.result.stdoutRaw)),
+          createDiffJob(completedJob.name.split(' ').last, completedJob.result.stdoutRaw),
         );
       } else {
         final String formatterCommand = completedJob.command.join(' ');
@@ -868,18 +891,7 @@ class DartFormatChecker extends FormatChecker {
           // The formatter had a problem formatting the file.
           errorJobs.add(completedJob);
         } else if (completedJob.result.exitCode == 1) {
-          diffJobs.add(
-            WorkerJob(<String>[
-              'git',
-              'diff',
-              '--no-index',
-              '--no-color',
-              '--ignore-cr-at-eol',
-              '--',
-              completedJob.command.last,
-              '-',
-            ], stdinRaw: codeUnitsAsStream(completedJob.result.stdoutRaw)),
-          );
+          diffJobs.add(createDiffJob(completedJob.command.last, completedJob.result.stdoutRaw));
         }
       }
       final diffPool = ProcessPool(processRunner: _processRunner, printReport: namedReport('diff'));

--- a/engine/src/flutter/ci/bin/format.dart
+++ b/engine/src/flutter/ci/bin/format.dart
@@ -258,7 +258,10 @@ abstract class FormatChecker {
 
   /// RegExp that matches the to-file line of a patch whose destination is `-`
   /// (stdin), instead of the real path the caller should have rewritten it to.
-  static final RegExp _stdinPatchTarget = RegExp(r'^\+\+\+ b/-$', multiLine: true);
+  ///
+  /// The trailing `\r` is optional so the line is matched whether git emits LF
+  /// or CRLF line endings.
+  static final RegExp _stdinPatchTarget = RegExp(r'^\+\+\+ b/-\r?$', multiLine: true);
 
   /// Returns true if [patch] has a to-file line whose destination is `-`.
   static bool _patchTargetsStdin(String patch) => _stdinPatchTarget.hasMatch(patch);

--- a/engine/src/flutter/ci/test/format_test.dart
+++ b/engine/src/flutter/ci/test/format_test.dart
@@ -183,7 +183,7 @@ void main() {
       final strayFile = io.File(path.join(gitRoot, '-'));
       try {
         fixture.gitAdd();
-        io.Process.runSync(
+        final io.ProcessResult result = io.Process.runSync(
           formatterPath,
           <String>['--check', 'clang', '--fix'],
           workingDirectory: repoDir.path,
@@ -194,6 +194,7 @@ void main() {
           },
         );
 
+        expect(result.exitCode, equals(0), reason: 'Formatter failed: ${result.stderr}');
         expect(strayFile.existsSync(), isFalse);
         final Iterable<FileContentPair> files = fixture.getFileContents();
         for (final pair in files) {

--- a/engine/src/flutter/ci/test/format_test.dart
+++ b/engine/src/flutter/ci/test/format_test.dart
@@ -163,6 +163,51 @@ void main() {
     }
   });
 
+  // The formatter diffs each file against the formatter's output on stdin
+  // (`-`). That causes `git diff` to list a to-file of `-` as well.
+  //
+  // The following settings change the path prefixes git emits in its diffs.
+  // Verify that formatting handles users with these settings.
+  for (final gitSetting in <String>['diff.mnemonicPrefix', 'diff.noprefix']) {
+    test('Can fix C++ formatting errors with $gitSetting set', () {
+      final fixture = TestFileFixture(target.FormatCheck.clang);
+      // git apply resolves paths against the top of the work tree, so a patch
+      // that still targets '-' writes it there rather than under repoDir.
+      final String gitRoot =
+          (io.Process.runSync('git', <String>[
+                    'rev-parse',
+                    '--show-toplevel',
+                  ], workingDirectory: repoDir.path).stdout
+                  as String)
+              .trim();
+      final strayFile = io.File(path.join(gitRoot, '-'));
+      try {
+        fixture.gitAdd();
+        io.Process.runSync(
+          formatterPath,
+          <String>['--check', 'clang', '--fix'],
+          workingDirectory: repoDir.path,
+          environment: <String, String>{
+            'GIT_CONFIG_COUNT': '1',
+            'GIT_CONFIG_KEY_0': gitSetting,
+            'GIT_CONFIG_VALUE_0': 'true',
+          },
+        );
+
+        expect(strayFile.existsSync(), isFalse);
+        final Iterable<FileContentPair> files = fixture.getFileContents();
+        for (final pair in files) {
+          expect(pair.original, equals(pair.formatted));
+        }
+      } finally {
+        if (strayFile.existsSync()) {
+          strayFile.deleteSync();
+        }
+        fixture.gitRemove();
+      }
+    });
+  }
+
   test('Can fix Dart formatting errors', () {
     final fixture = TestFileFixture(target.FormatCheck.dart);
     try {


### PR DESCRIPTION
`et` performs formatting by diffing the repo file against the output of the formatter for that file, which it passes to stdin (`-`). This results in `git diff` outputting the "to" path as `-`. `et` then tries to rewrite that `-` to the repo path.

For users with certain git settings such as `diff.mnemonicPrefix` or `diff.noprefix` the diff path prefixes emitted in the two-line ---/+++ file pair will differ from the default `a/` and `b/`, which the existing `et format` code assumes. The end result is a (silent) failure to rewrite the "to" path, with the result that when we apply the diff, the file is rewritten to a file named `-` at the root of the repo.

We now explicitly pass git diff `--src-prefix` and `--dst-prefix` flags, which override git diff settings such as `diff.mnemonicPrefix`, `diff.noprefix`, `diff.srcPrefix` and `diff.dstPrefix`.

I've extracted the diff job construction into a method that we reuse where needed and added some paranoid error checking to ensure we actually rewrite the path correctly.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above, or I don't feel like filing one.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
