### PR TITLE
Refresh FormField errors after locale changes

### DIFF
--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -17,6 +17,7 @@ import 'binding.dart';
 import 'focus_manager.dart';
 import 'focus_scope.dart';
 import 'framework.dart';
+import 'localizations.dart';
 import 'media_query.dart';
 import 'navigator.dart';
 import 'pop_scope.dart';
@@ -642,6 +643,7 @@ class FormFieldState<T> extends State<FormField<T>> with RestorationMixin {
   late final RestorableStringN _errorText;
   final RestorableBool _hasInteractedByUser = RestorableBool(false);
   final FocusNode _focusNode = FocusNode();
+  Locale? _locale;
 
   /// The current value of the form field.
   T? get value => _value;
@@ -804,6 +806,11 @@ class FormFieldState<T> extends State<FormField<T>> with RestorationMixin {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    final Locale? locale = Localizations.maybeLocaleOf(context);
+    if (_locale != null && locale != _locale && widget.enabled && hasError) {
+      _validate();
+    }
+    _locale = locale;
     switch (Form.maybeOf(context)?.widget.autovalidateMode) {
       case AutovalidateMode.always:
         WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -1595,6 +1595,70 @@ void main() {
     expect(find.text('test_error'), findsNothing);
   });
 
+  testWidgets('Validator error updates when its localization changes', (WidgetTester tester) async {
+    final formKey = GlobalKey<FormState>();
+    var locale = const Locale('en');
+    late StateSetter setLocale;
+    late BuildContext validatorContext;
+    var validationCount = 0;
+
+    String? validator(String? value) {
+      validationCount += 1;
+      return switch (Localizations.localeOf(validatorContext).languageCode) {
+        'de' => 'German error',
+        _ => 'English error',
+      };
+    }
+
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: const Color(0xFFFFFFFF),
+        builder: (BuildContext context, Widget? child) {
+          return StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              setLocale = setState;
+              return Localizations.override(
+                context: context,
+                locale: locale,
+                child: Builder(
+                  builder: (BuildContext context) {
+                    validatorContext = context;
+                    return Form(
+                      key: formKey,
+                      child: FormField<String>(
+                        validator: validator,
+                        builder: (FormFieldState<String> state) {
+                          return Text(state.errorText ?? 'No error');
+                        },
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+
+    expect(find.text('No error'), findsOneWidget);
+    expect(validationCount, 0);
+
+    expect(formKey.currentState!.validate(), isFalse);
+    await tester.pump();
+    expect(find.text('English error'), findsOneWidget);
+    expect(validationCount, 1);
+
+    setLocale(() {
+      locale = const Locale('de');
+    });
+    await tester.pump();
+
+    expect(find.text('English error'), findsNothing);
+    expect(find.text('German error'), findsOneWidget);
+    expect(validationCount, 2);
+  });
+
   testWidgets('AutovalidateMode.onUnfocus', (WidgetTester tester) async {
     final formKey = GlobalKey<FormState>();
     String? errorText(String? value) => '$value/error';


### PR DESCRIPTION
Updates `FormFieldState` to observe locale changes and rerun the validator only when an enabled field already displays an error. This refreshes localized validation messages without enabling automatic validation for untouched fields.

Fixes #143729.

Tests:

- `./bin/flutter test packages/flutter/test/widgets/form_test.dart`
- `./bin/flutter analyze --no-pub packages/flutter`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
