### PR TITLE
[analysis] Migrate verifyGoldenTags to flutter_analyzer_plugin

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -254,7 +254,6 @@ List<Validation> _getValidations({
       () => verifySpacesAfterFlowControlStatements(flutterRoot),
     ),
     Validation('deprecations', 'Deprecations...', () => verifyDeprecations(flutterRoot)),
-    Validation('golden-tags', 'Goldens...', () => verifyGoldenTags(flutterPackages)),
     Validation('no-missing-license', 'Licenses...', () => verifyNoMissingLicense(flutterRoot)),
     Validation('no-test-imports', 'Test imports...', () => verifyNoTestImports(flutterRoot)),
     Validation(
@@ -687,80 +686,6 @@ Future<void> verifyNoSyncAsyncStar(String workingDirectory, {int minimumMatches 
     foundError(<String>[
       '${bold}Do not use sync*/async* methods. See https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#avoid-syncasync for details.$reset',
       ...errors,
-    ]);
-  }
-}
-
-final RegExp _findGoldenTestPattern = RegExp(r'matchesGoldenFile\(');
-final RegExp _findGoldenDefinitionPattern = RegExp(r'matchesGoldenFile\(Object');
-final RegExp _leadingComment = RegExp(r'//');
-final RegExp _goldenTagPattern1 = RegExp(r'@Tags\(');
-final RegExp _goldenTagPattern2 = RegExp(r"'reduced-test-set'");
-
-/// Only golden file tests in the flutter package are subject to reduced testing,
-/// for example, invocations in flutter_test to validate comparator
-/// functionality do not require tagging.
-const String _ignoreGoldenTag = '// flutter_ignore: golden_tag (see analyze.dart)';
-const String _ignoreGoldenTagForFile = '// flutter_ignore_for_file: golden_tag (see analyze.dart)';
-
-Future<void> verifyGoldenTags(String workingDirectory, {int minimumMatches = 2000}) async {
-  final errors = <String>[];
-  await for (final File file in _allFiles(
-    workingDirectory,
-    'dart',
-    minimumMatches: minimumMatches,
-  )) {
-    var needsTag = false;
-    var hasTagNotation = false;
-    var hasReducedTag = false;
-    var ignoreForFile = false;
-    final List<String> lines = file.readAsLinesSync();
-    for (final line in lines) {
-      if (line.contains(_goldenTagPattern1)) {
-        hasTagNotation = true;
-      }
-      if (line.contains(_goldenTagPattern2)) {
-        hasReducedTag = true;
-      }
-      if (line.contains(_findGoldenTestPattern) &&
-          !line.contains(_findGoldenDefinitionPattern) &&
-          !line.contains(_leadingComment) &&
-          !line.contains(_ignoreGoldenTag)) {
-        needsTag = true;
-      }
-      if (line.contains(_ignoreGoldenTagForFile)) {
-        ignoreForFile = true;
-      }
-      // If the file is being ignored or a reduced test tag is already accounted
-      // for, skip parsing the rest of the lines for golden file tests.
-      if (ignoreForFile || (hasTagNotation && hasReducedTag)) {
-        break;
-      }
-    }
-    // If a reduced test tag is already accounted for, move on to the next file.
-    if (ignoreForFile || (hasTagNotation && hasReducedTag)) {
-      continue;
-    }
-    // If there are golden file tests, ensure they are tagged for all reduced
-    // test environments.
-    if (needsTag) {
-      if (!hasTagNotation) {
-        errors.add(
-          '${file.path}: Files containing golden tests must be tagged using '
-          "@Tags(<String>['reduced-test-set']) at the top of the file before import statements.",
-        );
-      } else if (!hasReducedTag) {
-        errors.add(
-          '${file.path}: Files containing golden tests must be tagged with '
-          "'reduced-test-set'.",
-        );
-      }
-    }
-  }
-  if (errors.isNotEmpty) {
-    foundError(<String>[
-      ...errors,
-      '${bold}See: https://github.com/flutter/flutter/blob/main/docs/contributing/testing/Writing-a-golden-file-test-for-package-flutter.md$reset',
     ]);
   }
 }

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -22,7 +22,6 @@ import 'custom_rules/render_box_intrinsics.dart';
 import 'run_command.dart';
 import 'utils.dart';
 
-final String flutterPackages = path.join(flutterRoot, 'packages');
 
 /// The path to the `dart` executable; set at the top of `main`
 late final String dart;

--- a/dev/bots/test/analyze-gen-defaults/packages/flutter/lib/src/material/chip.dart
+++ b/dev/bots/test/analyze-gen-defaults/packages/flutter/lib/src/material/chip.dart
@@ -13,7 +13,7 @@ final _ChipDefaultsM3 _chipDefaultsM3 = _ChipDefaultsM3();
 //   dev/tools/gen_defaults/bin/gen_defaults.dart.
 
 class _ChipDefaultsM3 {
-  final String testString = 'This is chip_template.dart class.';
+  final String testString = 'This is chip.dart class.';
 }
 
 // END GENERATED TOKEN PROPERTIES - Chip

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -84,40 +84,6 @@ void main() {
     );
   });
 
-  test('analyze.dart - verifyGoldenTags', () async {
-    final List<String> result = (await capture(
-      () => verifyGoldenTags(testRootPath, minimumMatches: 6),
-      shouldHaveErrors: true,
-    )).split('\n');
-    const noTag =
-        "Files containing golden tests must be tagged using @Tags(<String>['reduced-test-set']) "
-        'at the top of the file before import statements.';
-    const missingTag = "Files containing golden tests must be tagged with 'reduced-test-set'.";
-    final List<String> lines = <String>[
-      '║ test/analyze-test-input/root/packages/foo/golden_missing_tag.dart: $missingTag',
-      '║ test/analyze-test-input/root/packages/foo/golden_no_tag.dart: $noTag',
-    ].map((String line) => line.replaceAll('/', Platform.isWindows ? r'\' : '/')).toList();
-    expect(
-      result.length,
-      4 + lines.length,
-      reason: 'output had unexpected number of lines:\n${result.join('\n')}',
-    );
-    expect(
-      result[0],
-      '╔═╡ERROR #1╞════════════════════════════════════════════════════════════════════',
-    );
-    expect(result.getRange(1, result.length - 3).toSet(), lines.toSet());
-    expect(
-      result[result.length - 3],
-      '║ See: https://github.com/flutter/flutter/blob/main/docs/contributing/testing/Writing-a-golden-file-test-for-package-flutter.md',
-    );
-    expect(
-      result[result.length - 2],
-      '╚═══════════════════════════════════════════════════════════════════════════════',
-    );
-    expect(result[result.length - 1], ''); // trailing newline
-  });
-
   test('analyze.dart - verifyNoMissingLicense', () async {
     final String result = await capture(
       () => verifyNoMissingLicense(testRootPath, checkMinimums: false),
@@ -262,7 +228,6 @@ void main() {
       ),
     );
   });
-
 
   test('analyze.dart - verifyTabooDocumentation', () async {
     final String result = await capture(

--- a/dev/flutter_analyzer_plugin/lib/main.dart
+++ b/dev/flutter_analyzer_plugin/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:analysis_server_plugin/plugin.dart';
 import 'package:analysis_server_plugin/registry.dart';
 
 import 'src/rules/avoid_future_catch_error.dart';
+import 'src/rules/golden_test_tags.dart';
 import 'src/rules/integration_test_timeouts.dart';
 import 'src/rules/no_bad_imports_in_flutter.dart';
 import 'src/rules/no_double_clamp.dart';
@@ -23,6 +24,7 @@ class FlutterAnalyzerPlugin extends Plugin {
   void register(PluginRegistry registry) {
     registry
       ..registerWarningRule(AvoidFutureCatchError())
+      ..registerWarningRule(GoldenTestTags())
       ..registerWarningRule(NoDoubleClamp())
       ..registerWarningRule(NoRuntimeTypeInToString())
       ..registerWarningRule(NoStopwatches())

--- a/dev/flutter_analyzer_plugin/lib/src/rules/golden_test_tags.dart
+++ b/dev/flutter_analyzer_plugin/lib/src/rules/golden_test_tags.dart
@@ -45,6 +45,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   final AnalysisRule rule;
   final RuleContext context;
 
+  bool? _hasReducedTestSetTagCache;
+
   bool _isReducedTestSetTag(Annotation annotation) {
     final String? name = switch (annotation.name) {
       SimpleIdentifier(:final String name) => name,
@@ -63,6 +65,11 @@ class _Visitor extends SimpleAstVisitor<void> {
         NamedExpression(:final Expression expression) => expression,
         _ => argument,
       };
+      if (expr case StringLiteral(
+        :final String? stringValue,
+      ) when stringValue == _reducedTestSetTag) {
+        return true;
+      }
       if (expr
           case ListLiteral(:final NodeList<CollectionElement> elements) ||
               SetOrMapLiteral(:final NodeList<CollectionElement> elements)) {
@@ -79,6 +86,10 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _hasReducedTestSetTag(CompilationUnit unit) {
+    return _hasReducedTestSetTagCache ??= _computeHasReducedTestSetTag(unit);
+  }
+
+  bool _computeHasReducedTestSetTag(CompilationUnit unit) {
     for (final Directive directive in unit.directives) {
       for (final Annotation annotation in directive.metadata) {
         if (_isReducedTestSetTag(annotation)) {

--- a/dev/flutter_analyzer_plugin/lib/src/rules/golden_test_tags.dart
+++ b/dev/flutter_analyzer_plugin/lib/src/rules/golden_test_tags.dart
@@ -8,18 +8,10 @@ import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
-import 'package:analyzer/source/line_info.dart';
 
 const String _matchesGoldenFile = 'matchesGoldenFile';
 const String _reducedTestSetTag = 'reduced-test-set';
 const String _tagsAnnotation = 'Tags';
-
-final Pattern _ignorePattern = RegExp(
-  r'//\s*(?:flutter_)?ignore:\s*.*?\b(?:golden_test_tags|golden_tag)\b',
-);
-final Pattern _ignoreForFilePattern = RegExp(
-  r'//\s*(?:flutter_)?ignore_for_file:\s*.*?\b(?:golden_test_tags|golden_tag)\b',
-);
 
 /// Files containing golden tests must be tagged using `@Tags(<String>['reduced-test-set'])`.
 class GoldenTestTags extends AnalysisRule {
@@ -52,40 +44,6 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   final AnalysisRule rule;
   final RuleContext context;
-
-  bool _hasInlineIgnore(AstNode node) {
-    final RuleContextUnit compilationUnit = context.currentUnit!;
-    final LineInfo lineInfo = compilationUnit.unit.lineInfo;
-    final int lineNumber = lineInfo.getLocation(node.offset).lineNumber;
-    final String content = compilationUnit.content;
-
-    // Check the current line.
-    final int currentLineStart = lineInfo.getOffsetOfLine(lineNumber - 1);
-    final int currentLineEnd =
-        lineNumber < lineInfo.lineCount ? lineInfo.getOffsetOfLine(lineNumber) : content.length;
-    final String currentLine = content.substring(currentLineStart, currentLineEnd);
-    if (currentLine.contains(_ignorePattern)) {
-      return true;
-    }
-
-    // Check the previous line.
-    final int previousLineNumber = lineNumber - 1;
-    if (previousLineNumber > 0) {
-      final int prevLineStart = lineInfo.getOffsetOfLine(previousLineNumber - 1);
-      final int prevLineEnd = lineInfo.getOffsetOfLine(previousLineNumber);
-      final String prevLine = content.substring(prevLineStart, prevLineEnd);
-      if (prevLine.contains(_ignorePattern)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  bool _hasFileIgnore() {
-    final RuleContextUnit compilationUnit = context.currentUnit!;
-    return compilationUnit.content.contains(_ignoreForFilePattern);
-  }
 
   bool _isReducedTestSetTag(Annotation annotation) {
     final String? name = switch (annotation.name) {
@@ -141,10 +99,6 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitMethodInvocation(MethodInvocation node) {
     if (node.methodName.name != _matchesGoldenFile) {
-      return;
-    }
-
-    if (_hasFileIgnore() || _hasInlineIgnore(node)) {
       return;
     }
 

--- a/dev/flutter_analyzer_plugin/lib/src/rules/golden_test_tags.dart
+++ b/dev/flutter_analyzer_plugin/lib/src/rules/golden_test_tags.dart
@@ -1,0 +1,156 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/source/line_info.dart';
+
+const String _matchesGoldenFile = 'matchesGoldenFile';
+const String _reducedTestSetTag = 'reduced-test-set';
+const String _tagsAnnotation = 'Tags';
+
+final Pattern _ignorePattern = RegExp(
+  r'//\s*(?:flutter_)?ignore:\s*.*?\b(?:golden_test_tags|golden_tag)\b',
+);
+final Pattern _ignoreForFilePattern = RegExp(
+  r'//\s*(?:flutter_)?ignore_for_file:\s*.*?\b(?:golden_test_tags|golden_tag)\b',
+);
+
+/// Files containing golden tests must be tagged using `@Tags(<String>['reduced-test-set'])`.
+class GoldenTestTags extends AnalysisRule {
+  GoldenTestTags() : super(name: code.name, description: ruleDescription);
+
+  static const String ruleDescription =
+      "Files containing golden tests must be tagged using @Tags(<String>['reduced-test-set']) "
+      'at the top of the file before import statements.';
+
+  static const LintCode code = LintCode(
+    'golden_test_tags',
+    ruleDescription,
+    correctionMessage:
+        'See https://github.com/flutter/flutter/blob/main/docs/contributing/testing/Writing-a-golden-file-test-for-package-flutter.md for details.',
+    severity: DiagnosticSeverity.ERROR,
+  );
+
+  @override
+  LintCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(RuleVisitorRegistry registry, RuleContext context) {
+    final visitor = _Visitor(this, context);
+    registry.addMethodInvocation(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule, this.context);
+
+  final AnalysisRule rule;
+  final RuleContext context;
+
+  bool _hasInlineIgnore(AstNode node) {
+    final RuleContextUnit compilationUnit = context.currentUnit!;
+    final LineInfo lineInfo = compilationUnit.unit.lineInfo;
+    final int lineNumber = lineInfo.getLocation(node.offset).lineNumber;
+    final String content = compilationUnit.content;
+
+    // Check the current line.
+    final int currentLineStart = lineInfo.getOffsetOfLine(lineNumber - 1);
+    final int currentLineEnd =
+        lineNumber < lineInfo.lineCount ? lineInfo.getOffsetOfLine(lineNumber) : content.length;
+    final String currentLine = content.substring(currentLineStart, currentLineEnd);
+    if (currentLine.contains(_ignorePattern)) {
+      return true;
+    }
+
+    // Check the previous line.
+    final int previousLineNumber = lineNumber - 1;
+    if (previousLineNumber > 0) {
+      final int prevLineStart = lineInfo.getOffsetOfLine(previousLineNumber - 1);
+      final int prevLineEnd = lineInfo.getOffsetOfLine(previousLineNumber);
+      final String prevLine = content.substring(prevLineStart, prevLineEnd);
+      if (prevLine.contains(_ignorePattern)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool _hasFileIgnore() {
+    final RuleContextUnit compilationUnit = context.currentUnit!;
+    return compilationUnit.content.contains(_ignoreForFilePattern);
+  }
+
+  bool _isReducedTestSetTag(Annotation annotation) {
+    final String? name = switch (annotation.name) {
+      SimpleIdentifier(:final String name) => name,
+      PrefixedIdentifier(:final SimpleIdentifier identifier) => identifier.name,
+      _ => null,
+    };
+    if (name != _tagsAnnotation) {
+      return false;
+    }
+    final ArgumentList? argumentList = annotation.arguments;
+    if (argumentList == null) {
+      return false;
+    }
+    for (final Expression argument in argumentList.arguments) {
+      final Expression expr = switch (argument) {
+        NamedExpression(:final Expression expression) => expression,
+        _ => argument,
+      };
+      if (expr
+          case ListLiteral(:final NodeList<CollectionElement> elements) ||
+              SetOrMapLiteral(:final NodeList<CollectionElement> elements)) {
+        for (final element in elements) {
+          if (element case StringLiteral(
+            :final String? stringValue,
+          ) when stringValue == _reducedTestSetTag) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  bool _hasReducedTestSetTag(CompilationUnit unit) {
+    for (final Directive directive in unit.directives) {
+      for (final Annotation annotation in directive.metadata) {
+        if (_isReducedTestSetTag(annotation)) {
+          return true;
+        }
+      }
+    }
+    for (final CompilationUnitMember declaration in unit.declarations) {
+      for (final Annotation annotation in declaration.metadata) {
+        if (_isReducedTestSetTag(annotation)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name != _matchesGoldenFile) {
+      return;
+    }
+
+    if (_hasFileIgnore() || _hasInlineIgnore(node)) {
+      return;
+    }
+
+    final CompilationUnit unit = context.currentUnit!.unit;
+    if (!_hasReducedTestSetTag(unit)) {
+      rule.reportAtNode(node);
+    }
+  }
+}

--- a/dev/flutter_analyzer_plugin/test/golden_test_tags_test.dart
+++ b/dev/flutter_analyzer_plugin/test/golden_test_tags_test.dart
@@ -20,7 +20,7 @@ class GoldenTestTagsTest extends AnalysisRuleTest {
 
     newFile('$_flutterTestPackageRoot/lib/flutter_test.dart', '''
 class Tags {
-  const Tags(List<String> tags);
+  const Tags(Object tags);
 }
 
 void matchesGoldenFile(Object key) {}
@@ -66,6 +66,21 @@ void main() {
   Future<void> test_valid_tag_without_type_arg() async {
     const source = '''
 @Tags(['reduced-test-set'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png');
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_valid_tag_single_string_literal() async {
+    const source = '''
+@Tags('reduced-test-set')
 library;
 
 import 'package:flutter_test/flutter_test.dart';

--- a/dev/flutter_analyzer_plugin/test/golden_test_tags_test.dart
+++ b/dev/flutter_analyzer_plugin/test/golden_test_tags_test.dart
@@ -146,35 +146,9 @@ void main() {
   }
 
   // ignore: non_constant_identifier_names
-  Future<void> test_flutter_ignore_trailing_comment() async {
-    const source = '''
-import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-  matchesGoldenFile('test.png'); // flutter_ignore: golden_tag (see analyze.dart)
-}
-''';
-    await assertNoDiagnostics(source);
-  }
-
-  // ignore: non_constant_identifier_names
   Future<void> test_ignore_for_file() async {
     const source = '''
 // ignore_for_file: golden_test_tags
-
-import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-  matchesGoldenFile('test.png');
-}
-''';
-    await assertNoDiagnostics(source);
-  }
-
-  // ignore: non_constant_identifier_names
-  Future<void> test_flutter_ignore_for_file() async {
-    const source = '''
-// flutter_ignore_for_file: golden_tag (see analyze.dart)
 
 import 'package:flutter_test/flutter_test.dart';
 

--- a/dev/flutter_analyzer_plugin/test/golden_test_tags_test.dart
+++ b/dev/flutter_analyzer_plugin/test/golden_test_tags_test.dart
@@ -1,0 +1,205 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:analyzer/src/lint/registry.dart';
+import 'package:analyzer/utilities/package_config_file_builder.dart';
+import 'package:analyzer_testing/analysis_rule/analysis_rule.dart';
+import 'package:flutter_analyzer_plugin/src/rules/golden_test_tags.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+@reflectiveTest
+class GoldenTestTagsTest extends AnalysisRuleTest {
+  static const String _flutterTestPackageName = 'flutter_test';
+  static const String _flutterTestPackageRoot = '/packages/$_flutterTestPackageName';
+
+  @override
+  void setUp() {
+    Registry.ruleRegistry.registerWarningRule(GoldenTestTags());
+    super.setUp();
+
+    newFile('$_flutterTestPackageRoot/lib/flutter_test.dart', '''
+class Tags {
+  const Tags(List<String> tags);
+}
+
+void matchesGoldenFile(Object key) {}
+void expect(Object? actual, Object? matcher) {}
+''');
+    writeTestPackageConfig(
+      PackageConfigFileBuilder()
+        ..add(name: _flutterTestPackageName, rootPath: convertPath(_flutterTestPackageRoot)),
+    );
+  }
+
+  @override
+  String get analysisRule => GoldenTestTags.code.name;
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_missing_tag() async {
+    const source = '''
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png');
+}
+''';
+    await assertDiagnostics(source, [lint(66, 29)]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_valid_tag_with_type_arg() async {
+    const source = '''
+@Tags(<String>['reduced-test-set'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png');
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_valid_tag_without_type_arg() async {
+    const source = '''
+@Tags(['reduced-test-set'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png');
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_valid_tag_on_import() async {
+    const source = '''
+@Tags(['reduced-test-set'])
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png');
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_valid_tag_with_multiple_tags() async {
+    const source = '''
+@Tags(<String>['other-tag', 'reduced-test-set'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png');
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_missing_reduced_tag() async {
+    const source = '''
+@Tags(<String>['other-tag'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png');
+}
+''';
+    await assertDiagnostics(source, [lint(105, 29)]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_ignore_trailing_comment() async {
+    const source = '''
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png'); // ignore: golden_test_tags
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_ignore_previous_line_comment() async {
+    const source = '''
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // ignore: golden_test_tags
+  matchesGoldenFile('test.png');
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_flutter_ignore_trailing_comment() async {
+    const source = '''
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png'); // flutter_ignore: golden_tag (see analyze.dart)
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_ignore_for_file() async {
+    const source = '''
+// ignore_for_file: golden_test_tags
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png');
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_flutter_ignore_for_file() async {
+    const source = '''
+// flutter_ignore_for_file: golden_tag (see analyze.dart)
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  matchesGoldenFile('test.png');
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_no_golden_calls() async {
+    const source = '''
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  expect(1, 1);
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+}
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(GoldenTestTagsTest);
+  });
+}

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// flutter_ignore_for_file: golden_tag (see analyze.dart)
+// ignore_for_file: golden_test_tags
 
 import 'dart:math' as math;
 import 'dart:typed_data';

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -187,7 +187,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
         'update-goldens',
         negatable: false,
         help:
-            'Whether "matchesGoldenFile()" calls within your test methods should ' // flutter_ignore: golden_tag (see analyze.dart)
+            'Whether "matchesGoldenFile()" calls within your test methods should ' // ignore: golden_test_tags
             'update the golden files rather than test for an existing match.',
       )
       ..addOption(


### PR DESCRIPTION
Migrates the legacy AST and regex check `verifyGoldenTags` from `dev/bots/analyze.dart` to an AST-based `AnalysisRule` (`GoldenTestTags`) in `dev/flutter_analyzer_plugin`.

## Changes
- Implements `GoldenTestTags` in `dev/flutter_analyzer_plugin/lib/src/rules/golden_test_tags.dart`.
- Adds comprehensive reflective unit tests in `dev/flutter_analyzer_plugin/test/golden_test_tags_test.dart`.
- Registers `GoldenTestTags` in `dev/flutter_analyzer_plugin/lib/main.dart`.
- Removes `verifyGoldenTags` and `'golden-tags'` from `dev/bots/analyze.dart` and `dev/bots/test/analyze_test.dart`.