### PR TITLE
[analysis] Migrate verifyNoTestImports to flutter_analyzer_plugin

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -256,7 +256,6 @@ List<Validation> _getValidations({
     Validation('deprecations', 'Deprecations...', () => verifyDeprecations(flutterRoot)),
     Validation('golden-tags', 'Goldens...', () => verifyGoldenTags(flutterPackages)),
     Validation('no-missing-license', 'Licenses...', () => verifyNoMissingLicense(flutterRoot)),
-    Validation('no-test-imports', 'Test imports...', () => verifyNoTestImports(flutterRoot)),
     Validation(
       'no-bad-imports-flutter',
       'Bad imports (framework)...',
@@ -1077,39 +1076,6 @@ Future<void> _verifyNoMissingLicenseForExtension(
       if (header.isNotEmpty) 'followed by the following license text:',
       license,
       if (trailingBlank) '...followed by a blank line.',
-    ]);
-  }
-}
-
-final RegExp _testImportPattern = RegExp(r'''import (['"])([^'"]+_test\.dart)\1''');
-const Set<String> _exemptTestImports = <String>{
-  'package:flutter_test/flutter_test.dart',
-  'hit_test.dart',
-  'package:test_api/src/backend/live_test.dart',
-  'package:integration_test/integration_test.dart',
-};
-
-Future<void> verifyNoTestImports(String workingDirectory) async {
-  final errors = <String>[];
-  assert("// foo\nimport 'binding_test.dart' as binding;\n'".contains(_testImportPattern));
-  final List<File> dartFiles = await _allFiles(
-    path.join(workingDirectory, 'packages'),
-    'dart',
-    minimumMatches: 1500,
-  ).toList();
-  for (final file in dartFiles) {
-    for (final String line in file.readAsLinesSync()) {
-      final Match? match = _testImportPattern.firstMatch(line);
-      if (match != null && !_exemptTestImports.contains(match.group(2))) {
-        errors.add(file.path);
-      }
-    }
-  }
-  // Fail if any errors
-  if (errors.isNotEmpty) {
-    foundError(<String>[
-      '${bold}The following file(s) import a test directly. Test utilities should be in their own file.$reset',
-      ...errors,
     ]);
   }
 }

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -263,7 +263,6 @@ void main() {
     );
   });
 
-
   test('analyze.dart - verifyTabooDocumentation', () async {
     final String result = await capture(
       () => verifyTabooDocumentation(testRootPath, minimumMatches: 1),

--- a/dev/flutter_analyzer_plugin/lib/main.dart
+++ b/dev/flutter_analyzer_plugin/lib/main.dart
@@ -11,6 +11,7 @@ import 'src/rules/no_bad_imports_in_flutter.dart';
 import 'src/rules/no_double_clamp.dart';
 import 'src/rules/no_runtimetype_in_tostring.dart';
 import 'src/rules/no_stopwatches.dart';
+import 'src/rules/no_test_imports.dart';
 import 'src/rules/null_initialized_debug_expensive_fields.dart';
 import 'src/rules/protect_public_state_subtypes.dart';
 import 'src/rules/render_box_intrinsics.dart';
@@ -26,6 +27,7 @@ class FlutterAnalyzerPlugin extends Plugin {
       ..registerWarningRule(NoDoubleClamp())
       ..registerWarningRule(NoRuntimeTypeInToString())
       ..registerWarningRule(NoStopwatches())
+      ..registerWarningRule(NoTestImports())
       ..registerWarningRule(NullInitializedDebugExpensiveFields())
       ..registerWarningRule(ProtectPublicStateSubtypes())
       ..registerWarningRule(RenderBoxIntrinsicCalculationRule())

--- a/dev/flutter_analyzer_plugin/lib/src/rules/no_test_imports.dart
+++ b/dev/flutter_analyzer_plugin/lib/src/rules/no_test_imports.dart
@@ -1,0 +1,57 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
+
+const _testSuffix = '_test.dart';
+
+const Set<String> _exemptTestImports = <String>{
+  'package:flutter_test/flutter_test.dart',
+  'hit_test.dart',
+  'package:test_api/src/backend/live_test.dart',
+  'package:integration_test/integration_test.dart',
+};
+
+/// Verifies that files do not import a test directly.
+class NoTestImports extends AnalysisRule {
+  NoTestImports()
+    : super(name: code.name, description: 'Verify that files do not import a test directly.');
+
+  static const code = LintCode(
+    'no_test_imports',
+    'The following file imports a test directly. Test utilities should be in their own file.',
+    correctionMessage: 'Move test utilities to a non-test file or use an exempt test package.',
+    severity: DiagnosticSeverity.ERROR,
+  );
+
+  @override
+  LintCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(RuleVisitorRegistry registry, RuleContext context) {
+    final visitor = _Visitor(this, context);
+    registry.addImportDirective(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule, this.context);
+
+  final AnalysisRule rule;
+  final RuleContext context;
+
+  @override
+  void visitImportDirective(ImportDirective node) {
+    if (node.uri.stringValue case final String uriStr) {
+      if (uriStr.endsWith(_testSuffix) && !_exemptTestImports.contains(uriStr)) {
+        rule.reportAtNode(node.uri);
+      }
+    }
+  }
+}

--- a/dev/flutter_analyzer_plugin/lib/src/rules/no_test_imports.dart
+++ b/dev/flutter_analyzer_plugin/lib/src/rules/no_test_imports.dart
@@ -23,9 +23,10 @@ class NoTestImports extends AnalysisRule {
   NoTestImports()
     : super(name: code.name, description: 'Verify that files do not import a test directly.');
 
+  /// The [LintCode] for this rule.
   static const code = LintCode(
     'no_test_imports',
-    'The following file imports a test directly. Test utilities should be in their own file.',
+    'Do not import a test file directly. Test utilities should be in their own file.',
     correctionMessage: 'Move test utilities to a non-test file or use an exempt test package.',
     severity: DiagnosticSeverity.ERROR,
   );

--- a/dev/flutter_analyzer_plugin/test/no_test_imports_test.dart
+++ b/dev/flutter_analyzer_plugin/test/no_test_imports_test.dart
@@ -1,0 +1,122 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:analyzer/src/lint/registry.dart';
+import 'package:analyzer/utilities/package_config_file_builder.dart';
+import 'package:analyzer_testing/analysis_rule/analysis_rule.dart';
+import 'package:flutter_analyzer_plugin/src/rules/no_test_imports.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+@reflectiveTest
+class NoTestImportsTest extends AnalysisRuleTest {
+  @override
+  void setUp() {
+    Registry.ruleRegistry.registerWarningRule(NoTestImports());
+    super.setUp();
+
+    newFile('$testPackageLibPath/foo.dart', 'const int foo = 1;');
+    newFile('$testPackageLibPath/hit_test.dart', 'const int hitTest = 1;');
+    newFile('$testPackageLibPath/foo_test.dart', 'const int fooTest = 1;');
+    newPackage('flutter_test').addFile('lib/flutter_test.dart', 'const int flutterTest = 1;');
+    newPackage('test_api').addFile('lib/src/backend/live_test.dart', 'const int liveTest = 1;');
+    newPackage(
+      'integration_test',
+    ).addFile('lib/integration_test.dart', 'const int integrationTest = 1;');
+    newPackage('some_pkg').addFile('lib/bar_test.dart', 'const int barTest = 1;');
+    writeTestPackageConfig(PackageConfigFileBuilder());
+  }
+
+  @override
+  String get analysisRule => NoTestImports.code.name;
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_standard_import() async {
+    const source = '''
+import 'foo.dart';
+
+void main() {
+  const int x = foo;
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_exempt_flutter_test_import() async {
+    const source = '''
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const int x = flutterTest;
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_exempt_hit_test_import() async {
+    const source = '''
+import 'hit_test.dart';
+
+void main() {
+  const int x = hitTest;
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_exempt_live_test_import() async {
+    const source = '''
+import 'package:test_api/src/backend/live_test.dart';
+
+void main() {
+  const int x = liveTest;
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_exempt_integration_test_import() async {
+    const source = '''
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  const int x = integrationTest;
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_relative_test_import_fails() async {
+    const source = '''
+import 'foo_test.dart';
+
+void main() {
+  const int x = fooTest;
+}
+''';
+    await assertDiagnostics(source, [lint(7, 15)]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_package_test_import_fails() async {
+    const source = '''
+import 'package:some_pkg/bar_test.dart';
+
+void main() {
+  const int x = barTest;
+}
+''';
+    await assertDiagnostics(source, [lint(7, 32)]);
+  }
+}
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(NoTestImportsTest);
+  });
+}


### PR DESCRIPTION
Migrates `verifyNoTestImports` from `dev/bots/analyze.dart` to an AST-based `AnalysisRule` (`NoTestImports`) in `dev/flutter_analyzer_plugin`.

## Changes
- Implements `NoTestImports` in `dev/flutter_analyzer_plugin/lib/src/rules/no_test_imports.dart`.
- Adds reflective unit tests in `dev/flutter_analyzer_plugin/test/no_test_imports_test.dart`.
- Registers `NoTestImports` in `dev/flutter_analyzer_plugin/lib/main.dart`.
- Removes `verifyNoTestImports` and `'no-test-imports'` from `dev/bots/analyze.dart`.