### PR TITLE
[analysis] Migrate verifyNoCheckedMode to flutter_analyzer_plugin

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -228,11 +228,6 @@ List<Validation> _getValidations({
       await verifyNoSyncAsyncStar(flutterExamples, minimumMatches: 80);
     }),
     Validation(
-      'no-checked-mode',
-      'Debug mode instead of checked mode...',
-      () => verifyNoCheckedMode(flutterRoot),
-    ),
-    Validation(
       'issue-links',
       'Links for creating GitHub issues...',
       () => verifyIssueLinks(flutterRoot),
@@ -1299,31 +1294,6 @@ Future<void> verifyStockAppLocalizations(String workingDirectory) async {
       'Failed to run "git diff" on localization files of stocks app:',
       result.stderr,
     ]);
-  }
-}
-
-/// Verifies that all instances of "checked mode" have been migrated to "debug mode".
-Future<void> verifyNoCheckedMode(String workingDirectory) async {
-  final String flutterPackages = path.join(workingDirectory, 'packages');
-  final List<File> files = await _allFiles(
-    flutterPackages,
-    'dart',
-    minimumMatches: 400,
-  ).where((File file) => path.extension(file.path) == '.dart').toList();
-  final problems = <String>[];
-  for (final file in files) {
-    var lineCount = 0;
-    for (final String line in file.readAsLinesSync()) {
-      if (line.toLowerCase().contains('checked mode')) {
-        problems.add(
-          '${file.path}:$lineCount uses deprecated "checked mode" instead of "debug mode".',
-        );
-      }
-      lineCount += 1;
-    }
-  }
-  if (problems.isNotEmpty) {
-    foundError(problems);
   }
 }
 

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -263,7 +263,6 @@ void main() {
     );
   });
 
-
   test('analyze.dart - verifyTabooDocumentation', () async {
     final String result = await capture(
       () => verifyTabooDocumentation(testRootPath, minimumMatches: 1),

--- a/dev/flutter_analyzer_plugin/lib/main.dart
+++ b/dev/flutter_analyzer_plugin/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:analysis_server_plugin/registry.dart';
 import 'src/rules/avoid_future_catch_error.dart';
 import 'src/rules/integration_test_timeouts.dart';
 import 'src/rules/no_bad_imports_in_flutter.dart';
+import 'src/rules/no_checked_mode.dart';
 import 'src/rules/no_double_clamp.dart';
 import 'src/rules/no_runtimetype_in_tostring.dart';
 import 'src/rules/no_stopwatches.dart';
@@ -23,6 +24,7 @@ class FlutterAnalyzerPlugin extends Plugin {
   void register(PluginRegistry registry) {
     registry
       ..registerWarningRule(AvoidFutureCatchError())
+      ..registerWarningRule(NoCheckedMode())
       ..registerWarningRule(NoDoubleClamp())
       ..registerWarningRule(NoRuntimeTypeInToString())
       ..registerWarningRule(NoStopwatches())

--- a/dev/flutter_analyzer_plugin/lib/main.dart
+++ b/dev/flutter_analyzer_plugin/lib/main.dart
@@ -26,18 +26,18 @@ class FlutterAnalyzerPlugin extends Plugin {
   void register(PluginRegistry registry) {
     registry
       ..registerWarningRule(AvoidFutureCatchError())
+      ..registerWarningRule(DeprecationSyntax())
+      ..registerWarningRule(IntegrationTestTimeouts())
+      ..registerWarningRule(NoBadImportsInFlutter())
       ..registerWarningRule(NoCheckedMode())
       ..registerWarningRule(NoDoubleClamp())
-      ..registerWarningRule(DeprecationSyntax())
       ..registerWarningRule(NoRuntimeTypeInToString())
       ..registerWarningRule(NoStopwatches())
       ..registerWarningRule(NoSyncAsyncStar())
       ..registerWarningRule(NullInitializedDebugExpensiveFields())
       ..registerWarningRule(ProtectPublicStateSubtypes())
       ..registerWarningRule(RenderBoxIntrinsicCalculationRule())
-      ..registerWarningRule(NoBadImportsInFlutter())
-      ..registerWarningRule(SkipTestComments())
-      ..registerWarningRule(IntegrationTestTimeouts());
+      ..registerWarningRule(SkipTestComments());
   }
 
   @override

--- a/dev/flutter_analyzer_plugin/lib/src/rules/no_checked_mode.dart
+++ b/dev/flutter_analyzer_plugin/lib/src/rules/no_checked_mode.dart
@@ -1,0 +1,68 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
+
+/// An analysis rule that verifies that "checked mode" is not used.
+class NoCheckedMode extends AnalysisRule {
+  NoCheckedMode() : super(name: code.name, description: 'Verify that "checked mode" is not used.');
+
+  static const LintCode code = LintCode(
+    'no_checked_mode',
+    'Uses deprecated "checked mode" instead of "debug mode".',
+    correctionMessage: 'Replace "checked mode" with "debug mode".',
+    severity: DiagnosticSeverity.ERROR,
+  );
+
+  @override
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(RuleVisitorRegistry registry, RuleContext context) {
+    final visitor = _Visitor(this, context);
+    registry
+      ..addSimpleStringLiteral(this, visitor)
+      ..addInterpolationString(this, visitor)
+      ..addComment(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule, this.context);
+
+  final AnalysisRule rule;
+  final RuleContext context;
+
+  static const _targetText = 'checked mode';
+
+  @override
+  void visitSimpleStringLiteral(SimpleStringLiteral node) {
+    if (node.value.toLowerCase().contains(_targetText)) {
+      rule.reportAtNode(node);
+    }
+  }
+
+  @override
+  void visitInterpolationString(InterpolationString node) {
+    if (node.value.toLowerCase().contains(_targetText)) {
+      rule.reportAtNode(node);
+    }
+  }
+
+  @override
+  void visitComment(Comment node) {
+    for (final Token token in node.tokens) {
+      if (token.lexeme.toLowerCase().contains(_targetText)) {
+        rule.reportAtNode(node);
+        return;
+      }
+    }
+  }
+}

--- a/dev/flutter_analyzer_plugin/test/no_checked_mode_test.dart
+++ b/dev/flutter_analyzer_plugin/test/no_checked_mode_test.dart
@@ -1,0 +1,91 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:analyzer/src/lint/registry.dart';
+import 'package:analyzer_testing/analysis_rule/analysis_rule.dart';
+import 'package:analyzer_testing/src/analysis_rule/pub_package_resolution.dart';
+import 'package:flutter_analyzer_plugin/src/rules/no_checked_mode.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+@reflectiveTest
+class NoCheckedModeTest extends AnalysisRuleTest {
+  @override
+  void setUp() {
+    Registry.ruleRegistry.registerWarningRule(NoCheckedMode());
+    super.setUp();
+  }
+
+  @override
+  String get analysisRule => NoCheckedMode.code.name;
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_valid_code() async {
+    const source = r'''
+// This is a debug mode comment.
+/// This documentation mentions debug mode.
+void validFunction() {
+  const String message = 'Running in debug mode';
+  final String debugMode = 'debug mode';
+  print('Status: $debugMode');
+}
+''';
+    await assertNoDiagnostics(source);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_simple_string_literal() async {
+    const source = '''
+void test() {
+  const String bad = 'This is checked mode.';
+}
+''';
+    await assertDiagnostics(source, <ExpectedDiagnostic>[lint(35, 23)]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_simple_string_literal_case_insensitive() async {
+    const source = '''
+void test() {
+  const String bad = 'CHECKED MODE active';
+}
+''';
+    await assertDiagnostics(source, <ExpectedDiagnostic>[lint(35, 21)]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_interpolation_string() async {
+    const source = r'''
+void test(String value) {
+  print('Value $value in checked mode');
+}
+''';
+    await assertDiagnostics(source, <ExpectedDiagnostic>[lint(47, 17)]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_doc_comment() async {
+    const source = '''
+/// Doc comment explaining checked mode.
+void test() {}
+''';
+    await assertDiagnostics(source, <ExpectedDiagnostic>[lint(0, 40)]);
+  }
+
+  // ignore: non_constant_identifier_names
+  Future<void> test_multiline_doc_comment() async {
+    const source = '''
+/**
+ * Explanation about checked mode.
+ */
+void test() {}
+''';
+    await assertDiagnostics(source, <ExpectedDiagnostic>[lint(0, 42)]);
+  }
+}
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(NoCheckedModeTest);
+  });
+}


### PR DESCRIPTION
Migrates `verifyNoCheckedMode` from `dev/bots/analyze.dart` to an AST-based `AnalysisRule` (`NoCheckedMode`) in `dev/flutter_analyzer_plugin`.

## Changes
- Implements `NoCheckedMode` in `dev/flutter_analyzer_plugin/lib/src/rules/no_checked_mode.dart`.
- Adds unit tests in `dev/flutter_analyzer_plugin/test/no_checked_mode_test.dart`.
- Registers `NoCheckedMode` in `dev/flutter_analyzer_plugin/lib/main.dart`.
- Removes `verifyNoCheckedMode` and `'no-checked-mode'` from `dev/bots/analyze.dart`.