### PR TITLE
[flutter_tools] Fix flakiness in PreviewDetector tests

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -257,13 +257,14 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
   );
 
   late final _previewDetector = PreviewDetector(
+    artifacts: artifacts,
+    fs: fs,
+    logger: logger,
+    onChangeDetected: onLegacyChangeDetected,
+    onPubspecChangeDetected: _onPubspecChangeDetected,
     platform: platform,
     previewAnalytics: previewAnalytics,
     project: rootProject,
-    logger: logger,
-    fs: fs,
-    onChangeDetected: onLegacyChangeDetected,
-    onPubspecChangeDetected: _onPubspecChangeDetected,
   );
 
   late final _lspPreviewDetector = LspPreviewDetector(

--- a/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
@@ -38,7 +38,15 @@ class PreviewDetector {
     required this.onPubspecChangeDetected,
     @visibleForTesting this.watcherBuilder = _defaultWatcherBuilder,
     @visibleForTesting this.onPackageConfigChangeDetected,
-  }) : projectRoot = project.directory;
+  }) : projectRoot = _resolveDirectory(project.directory);
+
+  static Directory _resolveDirectory(Directory directory) {
+    try {
+      return directory.fileSystem.directory(directory.resolveSymbolicLinksSync());
+    } on Exception catch (_) {
+      return directory.absolute;
+    }
+  }
 
   final Platform platform;
   final WidgetPreviewAnalytics previewAnalytics;

--- a/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:watcher/watcher.dart';
 
+import '../artifacts.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
@@ -29,17 +30,19 @@ Watcher _defaultWatcherBuilder(String path) {
 
 class PreviewDetector {
   PreviewDetector({
-    required this.platform,
-    required this.previewAnalytics,
-    required this.project,
+    required this.artifacts,
     required this.fs,
     required this.logger,
     required this.onChangeDetected,
     required this.onPubspecChangeDetected,
-    @visibleForTesting this.watcherBuilder = _defaultWatcherBuilder,
+    required this.platform,
+    required this.previewAnalytics,
+    required this.project,
     @visibleForTesting this.onPackageConfigChangeDetected,
+    @visibleForTesting this.watcherBuilder = _defaultWatcherBuilder,
   }) : projectRoot = project.directory;
 
+  final Artifacts artifacts;
   final Platform platform;
   final WidgetPreviewAnalytics previewAnalytics;
   final FlutterProject project;
@@ -127,9 +130,13 @@ class PreviewDetector {
   }
 
   Future<void> _initializeAnalysisContextCollection() async {
+    final String sdkPath = artifacts.getArtifactPath(Artifact.engineDartSdkPath);
+    final bool sdkExists =
+        fs.path.isAbsolute(sdkPath) && PhysicalResourceProvider.INSTANCE.getFolder(sdkPath).exists;
     _collection = AnalysisContextCollection(
       includedPaths: <String>[projectRoot.absolute.path],
       resourceProvider: PhysicalResourceProvider.INSTANCE,
+      sdkPath: sdkExists ? sdkPath : null,
     );
 
     // Find the initial set of previews.

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -5,6 +5,7 @@
 import 'package:dart_style/dart_style.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -265,7 +266,12 @@ void main() {
         ..childFile('lib/src/transitive_error.dart').writeAsStringSync(kTransitiveErrorLibrary)
         ..childFile('lib/src/custom_previews.dart').writeAsStringSync(kCustomPreviews);
       project = FlutterProject.fromDirectoryTest(projectDir);
+      final String? sdkPath = Cache.flutterRoot != null
+          ? fs.path.join(Cache.flutterRoot!, 'bin', 'cache', 'dart-sdk')
+          : null;
+      final Artifacts artifacts = FakeArtifacts(sdkPath: sdkPath);
       previewDetector = PreviewDetector(
+        artifacts: artifacts,
         platform: FakePlatform(),
         previewAnalytics: WidgetPreviewAnalytics(
           analytics: getInitializedFakeAnalyticsInstance(

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_173895_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_173895_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -34,6 +35,7 @@ void main() {
         fs.systemTempDirectory.createTempSync('root'),
       );
       previewDetector = PreviewDetector(
+        artifacts: Artifacts.test(fileSystem: fs),
         // Explicitly set the platform to Windows.
         platform: FakePlatform(operatingSystem: 'windows'),
         previewAnalytics: WidgetPreviewAnalytics(

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_178317_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_178317_test.dart
@@ -5,9 +5,11 @@
 import 'dart:async';
 
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/widget_preview/analytics.dart';
 import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
@@ -31,13 +33,19 @@ void main() {
     }
 
     setUp(() {
+      Cache.flutterRoot = getFlutterRoot();
       fs = MemoryFileSystem.test(
         style: const LocalPlatform().isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
       );
       watcher = FakeWatcher();
       logger = BufferLogger.test();
       project = FlutterProject.fromDirectoryTest(fs.systemTempDirectory.createTempSync('root'));
+      final String? sdkPath = Cache.flutterRoot != null
+          ? fs.path.join(Cache.flutterRoot!, 'bin', 'cache', 'dart-sdk')
+          : null;
+      final Artifacts artifacts = FakeArtifacts(sdkPath: sdkPath);
       previewDetector = PreviewDetector(
+        artifacts: artifacts,
         platform: FakePlatform(),
         previewAnalytics: WidgetPreviewAnalytics(
           analytics: getInitializedFakeAnalyticsInstance(

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -83,7 +84,11 @@ PreviewDetector createTestPreviewDetector() {
   _projectRoot = _fs.systemTempDirectory.createTempSync('root');
   final FlutterProject project = FlutterProject.fromDirectory(_projectRoot!);
 
+  final String sdkPath = _fs.path.join(Cache.flutterRoot!, 'bin', 'cache', 'dart-sdk');
+  final Artifacts artifacts = FakeArtifacts(sdkPath: sdkPath);
+
   return PreviewDetector(
+    artifacts: artifacts,
     platform: FakePlatform(),
     previewAnalytics: WidgetPreviewAnalytics(
       analytics: getInitializedFakeAnalyticsInstance(

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
@@ -166,6 +166,10 @@ Future<String> waitForPubspecChangeDetected({
     }
     completer.complete(path);
   };
+  // Short delay to allow the file watcher (especially FSEvents on macOS) to
+  // fully initialize and start listening for events before we trigger the
+  // change operation.
+  await Future<void>.delayed(const Duration(milliseconds: 100));
   await changeOperation();
   return completer.future;
 }
@@ -181,6 +185,10 @@ Future<String> waitForPackageConfigChangeDetected({
     }
     completer.complete(path);
   };
+  // Short delay to allow the file watcher (especially FSEvents on macOS) to
+  // fully initialize and start listening for events before we trigger the
+  // change operation.
+  await Future<void>.delayed(const Duration(milliseconds: 100));
   await changeOperation();
   return completer.future;
 }
@@ -200,6 +208,10 @@ Future<void> waitForChangeDetected({
     onChangeDetected(updated);
     completer.complete();
   };
+  // Short delay to allow the file watcher (especially FSEvents on macOS) to
+  // fully initialize and start listening for events before we trigger the
+  // change operation.
+  await Future<void>.delayed(const Duration(milliseconds: 100));
   await changeOperation();
   await completer.future;
 }
@@ -220,6 +232,10 @@ Future<void> waitForNChangesDetected({
       completer.complete();
     }
   };
+  // Short delay to allow the file watcher (especially FSEvents on macOS) to
+  // fully initialize and start listening for events before we trigger the
+  // change operation.
+  await Future<void>.delayed(const Duration(milliseconds: 100));
   await changeOperation();
   await completer.future;
 }

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/preview_detector_regression_178472_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/preview_detector_regression_178472_test.dart
@@ -5,9 +5,11 @@
 import 'dart:async';
 
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/widget_preview/analytics.dart';
 import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
@@ -28,11 +30,17 @@ void main() {
     late BufferLogger logger;
 
     setUp(() {
+      Cache.flutterRoot = getFlutterRoot();
       fs = LocalFileSystem.test(signals: FakeSignals());
       watcher = FakeWatcher();
       logger = BufferLogger.test();
       project = FlutterProject.fromDirectoryTest(fs.systemTempDirectory.createTempSync('root'));
+      final String? sdkPath = Cache.flutterRoot != null
+          ? fs.path.join(Cache.flutterRoot!, 'bin', 'cache', 'dart-sdk')
+          : null;
+      final Artifacts artifacts = FakeArtifacts(sdkPath: sdkPath);
       previewDetector = PreviewDetector(
+        artifacts: artifacts,
         platform: FakePlatform(),
         previewAnalytics: WidgetPreviewAnalytics(
           analytics: getInitializedFakeAnalyticsInstance(

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -999,9 +999,11 @@ class FakeXcode extends Fake implements Xcode {
 }
 
 class FakeArtifacts extends Fake implements Artifacts {
-  FakeArtifacts({FileSystem? fileSystem}) : _delegate = Artifacts.test(fileSystem: fileSystem);
+  FakeArtifacts({FileSystem? fileSystem, this.sdkPath})
+    : _delegate = Artifacts.test(fileSystem: fileSystem);
 
   final Artifacts _delegate;
+  final String? sdkPath;
 
   @override
   LocalEngineInfo? get localEngineInfo => _delegate.localEngineInfo;
@@ -1018,12 +1020,17 @@ class FakeArtifacts extends Fake implements Artifacts {
     TargetPlatform? platform,
     BuildMode? mode,
     EnvironmentType? environmentType,
-  }) => _delegate.getArtifactPath(
-    artifact,
-    platform: platform,
-    mode: mode,
-    environmentType: environmentType,
-  );
+  }) {
+    if (artifact == Artifact.engineDartSdkPath && sdkPath != null) {
+      return sdkPath!;
+    }
+    return _delegate.getArtifactPath(
+      artifact,
+      platform: platform,
+      mode: mode,
+      environmentType: environmentType,
+    );
+  }
 
   @override
   String getEngineType(TargetPlatform platform, [BuildMode? mode]) =>


### PR DESCRIPTION
Resolve flakiness/timeout in `PreviewDetector` tests.

### Root Cause
- The test `PreviewDetector can detect changes in the pubspec.yaml` was timing out because the file watcher (especially FSEvents on macOS) was not fully initialized before the file change operation was triggered, causing it to miss the event.
- Symbolic links in the project root directory were not resolved, which affected watcher behavior in JetSki worktrees.

### Fix
- Resolved symbolic links in `PreviewDetector`'s project root directory.
- Added a 100ms delay before triggering file changes in test helpers to allow the watcher to initialize.

Fixes https://github.com/flutter/flutter/issues/189849
