### PR TITLE
[flutter_tools] find the command name regardless of argument position

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:args/args.dart';
+import 'package:meta/meta.dart';
+
 import 'runner.dart' as runner;
 import 'src/base/context.dart';
 import 'src/base/io.dart';
@@ -58,6 +61,7 @@ import 'src/pre_run_validator.dart';
 import 'src/project_validator.dart';
 import 'src/resident_runner.dart';
 import 'src/runner/flutter_command.dart';
+import 'src/runner/flutter_command_runner.dart';
 import 'src/web/web_runner.dart';
 
 /// Main entry point for commands.
@@ -77,13 +81,12 @@ Future<void> main(List<String> args) async {
     args[slashQuestionHelpIndex] = '-h';
   }
 
-  final bool doctor =
-      (args.isNotEmpty && args.first == 'doctor') ||
-      (args.length == 2 && verbose && args.last == 'doctor');
+  final String? commandName = findCommandName(args);
+  final doctor = commandName == 'doctor';
   final bool help =
       args.contains('-h') ||
       args.contains('--help') ||
-      (args.isNotEmpty && args.first == 'help') ||
+      commandName == 'help' ||
       (args.length == 1 && verbose);
   final bool muteCommandLogging = (help || doctor) && !veryVerbose;
   final bool verboseHelp = help && verbose;
@@ -154,6 +157,25 @@ Future<void> main(List<String> args) async {
     },
     shutdownHooks: globals.shutdownHooks,
   );
+}
+
+/// The name of the command in [args], or null if there isn't one.
+///
+/// Global options can come before the command, so it can't be found by
+/// position. A throwaway parser walks past them instead: trailing options are
+/// disabled, so parsing stops at the command and leaves it at the head of
+/// [ArgResults.rest]. `help` is the exception, since the command runner
+/// registers it on the parser itself and so reports it as a parsed command.
+@visibleForTesting
+String? findCommandName(List<String> args) {
+  final ArgResults results;
+  try {
+    results = FlutterCommandRunner().argParser.parse(args);
+  } on ArgParserException {
+    // The real parser will complain about these later.
+    return null;
+  }
+  return results.command?.name ?? results.rest.firstOrNull;
 }
 
 List<FlutterCommand> generateCommands({required bool verboseHelp, required bool verbose}) =>

--- a/packages/flutter_tools/test/general.shard/executable_test.dart
+++ b/packages/flutter_tools/test/general.shard/executable_test.dart
@@ -1,0 +1,55 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/executable.dart';
+
+import '../src/common.dart';
+
+void main() {
+  group('findCommandName', () {
+    test('finds a command given on its own', () {
+      expect(findCommandName(<String>['doctor']), 'doctor');
+      expect(findCommandName(<String>['help']), 'help');
+    });
+
+    test('finds a command followed by its own arguments', () {
+      expect(findCommandName(<String>['doctor', '-v']), 'doctor');
+      expect(findCommandName(<String>['doctor', '--android-licenses']), 'doctor');
+      expect(findCommandName(<String>['test', 'test/widget_test.dart']), 'test');
+    });
+
+    test('finds a command preceded by global options', () {
+      expect(findCommandName(<String>['-v', 'doctor']), 'doctor');
+      expect(findCommandName(<String>['--no-version-check', 'doctor', '-v']), 'doctor');
+      expect(findCommandName(<String>['--no-version-check', 'help', '-v']), 'help');
+      expect(
+        findCommandName(<String>['--suppress-analytics', '--no-color', 'doctor', '-v']),
+        'doctor',
+      );
+    });
+
+    test('does not mistake the value of a global option for the command', () {
+      expect(findCommandName(<String>['--local-engine', 'host_debug', 'doctor']), 'doctor');
+      expect(findCommandName(<String>['--local-engine=host_debug', 'doctor']), 'doctor');
+      expect(findCommandName(<String>['--wrap-column', '100', 'doctor']), 'doctor');
+      expect(findCommandName(<String>['-d', 'emulator-5554', 'doctor']), 'doctor');
+    });
+
+    test('does not mistake an argument of the command for the command', () {
+      expect(findCommandName(<String>['create', 'doctor']), 'create');
+      expect(findCommandName(<String>['help', 'doctor']), 'help');
+    });
+
+    test('returns null when no command is given', () {
+      expect(findCommandName(<String>[]), isNull);
+      expect(findCommandName(<String>['-v']), isNull);
+      expect(findCommandName(<String>['-h']), isNull);
+      expect(findCommandName(<String>['--version', '-v']), isNull);
+    });
+
+    test('returns null when the global options cannot be parsed', () {
+      expect(findCommandName(<String>['--not-a-real-flag', 'doctor']), isNull);
+    });
+  });
+}

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -62,6 +62,37 @@ void main() {
     expect(result.stdout, isNot(contains('exiting with code 0')));
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/124793
+  testWithoutContext('flutter doctor is not verbose when preceded by a global flag', () async {
+    final ProcessResult result = await processManager.run(<String>[
+      flutterBin,
+      '--no-version-check',
+      'doctor',
+      '-v',
+    ]);
+
+    // Only printed by verbose tool.
+    expect(result.stdout, isNot(contains('exiting with code 0')));
+  });
+
+  testWithoutContext(
+    'flutter help -v shows hidden options when preceded by a global flag',
+    () async {
+      final ProcessResult result = await processManager.run(<String>[
+        flutterBin,
+        '--no-version-check',
+        'help',
+        '-v',
+      ]);
+
+      // Only shown in verbose help.
+      expect(result.stdout, contains('--local-engine'));
+
+      // Only printed by verbose tool.
+      expect(result.stdout, isNot(contains('exiting with code 0')));
+    },
+  );
+
   testWithoutContext('flutter doctor -vv super verbose', () async {
     final ProcessResult result = await processManager.run(<String>[flutterBin, 'doctor', '-vv']);
 


### PR DESCRIPTION
`flutter --no-version-check doctor -v` dumps the full command log, same as `-vv` would. Any global option in front of the command does it, and `help` has the same problem.

The muting check looks for the command by position:

```dart
final bool doctor =
    (args.isNotEmpty && args.first == 'doctor') ||
    (args.length == 2 && verbose && args.last == 'doctor');
```

`['--no-version-check', 'doctor', '-v']` is neither two arguments long nor starts with `doctor`, so it falls through and nothing gets muted.

Parse the global options with a throwaway `FlutterCommandRunner().argParser` instead and take whatever it stops on. It has `allowTrailingOptions: false`, so the command ends up at the head of `rest`. Going through the real parser also keeps `flutter --local-engine host_debug doctor -v` from mistaking `host_debug` for the command, which a plain "first argument without a dash" scan would.

Before:

    $ flutter --no-version-check doctor -v | wc -l
    1542

After:

    $ flutter --no-version-check doctor -v | wc -l
    40

`-vv` still forces the log, and `doctor -v` still prints the extra diagnostics, since `DoctorCommand` gets `verbose` separately from the muting.

I left the `args.length == 1 && verbose` clause in the help check alone. It only catches a bare `flutter -v`, and widening it to "no command at all" would start muting `flutter --version -v`.

Fixes https://github.com/flutter/flutter/issues/124793

I did went over the checklist before this PR