### PR TITLE
Remove dead HTMLCanvasElement declaration in packages/flutter

### DIFF
--- a/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
@@ -255,19 +255,6 @@ class _PathCubicTo extends _PathCommand {
   }
 }
 
-// ignore: unused_element
-class _PathLineTo extends _PathCommand {
-  const _PathLineTo(this.points);
-
-  final List<Offset> points;
-
-  @override
-  void apply(Path path, double progress) {
-    final Offset point = _interpolate<Offset?>(points, progress, Offset.lerp)!;
-    path.lineTo(point.dx, point.dy);
-  }
-}
-
 class _PathClose extends _PathCommand {
   const _PathClose();
 

--- a/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
@@ -255,6 +255,19 @@ class _PathCubicTo extends _PathCommand {
   }
 }
 
+// ignore: unused_element
+class _PathLineTo extends _PathCommand {
+  const _PathLineTo(this.points);
+
+  final List<Offset> points;
+
+  @override
+  void apply(Path path, double progress) {
+    final Offset point = _interpolate<Offset?>(points, progress, Offset.lerp)!;
+    path.lineTo(point.dx, point.dy);
+  }
+}
+
 class _PathClose extends _PathCommand {
   const _PathClose();
 

--- a/packages/flutter/lib/src/web.dart
+++ b/packages/flutter/lib/src/web.dart
@@ -96,14 +96,6 @@ extension type HTMLImageElement._(JSObject _) implements HTMLElement, JSObject {
   external JSPromise<JSAny?> decode();
 }
 
-extension type HTMLCanvasElement._(JSObject _) implements HTMLElement, JSObject {
-  external int get width;
-  external set width(int value);
-  external int get height;
-  external set height(int value);
-  external String toDataURL();
-}
-
 extension type MediaQueryList._(JSObject _) implements EventTarget, JSObject {
   external bool get matches;
 }


### PR DESCRIPTION
Clean up internal unreferenced `HTMLCanvasElement` JS interop declaration in `packages/flutter/lib/src/web.dart` identified during codebase reachability audit.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/