### PR TITLE
[flutter_tools] Gracefully handle ping timeouts for custom devices

### DIFF
--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -498,7 +498,13 @@ class CustomDevice extends Device {
   }) async {
     final List<String> interpolated = interpolateCommand(_config.pingCommand, replacementValues);
 
-    final RunResult result = await _processUtils.run(interpolated, timeout: timeout);
+    final RunResult result;
+    try {
+      result = await _processUtils.run(interpolated, timeout: timeout);
+    } on ProcessException catch (e) {
+      _logger.printError('Error pinging custom device $id: $e');
+      return false;
+    }
 
     if (result.exitCode != 0) {
       return false;

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -490,7 +490,7 @@ class CustomDevice extends Device {
   ///
   /// If [timeout] is not null and the process doesn't finish in time,
   /// it will be killed with a SIGTERM, false will be returned and the timeout
-  /// will be reported in the log using [Logger.printError]. If [timeout]
+  /// will be reported in the log using [Logger.printTrace]. If [timeout]
   /// is null, it's treated as if it's an infinite timeout.
   Future<bool> tryPing({
     Duration? timeout,
@@ -502,7 +502,7 @@ class CustomDevice extends Device {
     try {
       result = await _processUtils.run(interpolated, timeout: timeout);
     } on ProcessException catch (e) {
-      _logger.printError('Error pinging custom device $id: $e');
+      _logger.printTrace('Error pinging custom device $id: $e');
       return false;
     }
 

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -8,6 +8,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
@@ -294,6 +295,56 @@ void main() {
       );
 
       expect(await discovery.discoverDevices(), hasLength(0));
+    },
+  );
+
+  testWithoutContext(
+    "CustomDevices.discoverDevices doesn't report device and does not throw when ping command times out",
+    () async {
+      final fs = MemoryFileSystem.test();
+      final Directory dir = fs.directory('custom_devices_config_dir');
+
+      _writeCustomDevicesConfigFile(dir, <CustomDeviceConfig>[testConfig]);
+
+      final logger = BufferLogger.test();
+      final discovery = CustomDevices(
+        featureFlags: TestFeatureFlags(areCustomDevicesEnabled: true),
+        logger: logger,
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: testConfig.pingCommand,
+            exception: const ProcessException('testping', <String>[], 'Process timed out'),
+          ),
+        ]),
+        config: CustomDevicesConfig.test(
+          fileSystem: fs,
+          directory: dir,
+          logger: logger,
+        ),
+      );
+
+      expect(await discovery.discoverDevices(), hasLength(0));
+      expect(logger.errorText, contains('Error pinging custom device testid: ProcessException: Process timed out'));
+    },
+  );
+
+  testWithoutContext(
+    'CustomDevice.tryPing returns false and logs error when ping command times out',
+    () async {
+      final logger = BufferLogger.test();
+      final device = CustomDevice(
+        config: testConfig,
+        logger: logger,
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: testConfig.pingCommand,
+            exception: const ProcessException('testping', <String>[], 'Process timed out'),
+          ),
+        ]),
+      );
+
+      expect(await device.tryPing(), isFalse);
+      expect(logger.errorText, contains('Error pinging custom device testid: ProcessException: Process timed out'));
     },
   );
 

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -316,20 +316,19 @@ void main() {
             exception: const ProcessException('testping', <String>[], 'Process timed out'),
           ),
         ]),
-        config: CustomDevicesConfig.test(
-          fileSystem: fs,
-          directory: dir,
-          logger: logger,
-        ),
+        config: CustomDevicesConfig.test(fileSystem: fs, directory: dir, logger: logger),
       );
 
       expect(await discovery.discoverDevices(), hasLength(0));
-      expect(logger.errorText, contains('Error pinging custom device testid: ProcessException: Process timed out'));
+      expect(
+        logger.traceText,
+        contains('Error pinging custom device testid: ProcessException: Process timed out'),
+      );
     },
   );
 
   testWithoutContext(
-    'CustomDevice.tryPing returns false and logs error when ping command times out',
+    'CustomDevice.tryPing returns false and logs trace when ping command times out',
     () async {
       final logger = BufferLogger.test();
       final device = CustomDevice(
@@ -344,7 +343,10 @@ void main() {
       );
 
       expect(await device.tryPing(), isFalse);
-      expect(logger.errorText, contains('Error pinging custom device testid: ProcessException: Process timed out'));
+      expect(
+        logger.traceText,
+        contains('Error pinging custom device testid: ProcessException: Process timed out'),
+      );
     },
   );
 


### PR DESCRIPTION
When polling custom devices, if a ping command times out, `_processUtils.run` throws a `ProcessException` which was previously unhandled in `CustomDevice.tryPing`. This caused unhandled exceptions to escape `PollingDeviceDiscovery`'s periodic timer and crash the Flutter tool.

This PR catches `ProcessException` in `CustomDevice.tryPing`, logs the error, and returns `false` to mark the device unreachable without crashing the CLI.

Fixes https://github.com/flutter/flutter/issues/191177

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
