### PR TITLE
[flutter_tools] Handle all DartDevelopmentServiceExceptions gracefully in resident web runner

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -406,14 +406,12 @@ class ResidentWebRunner extends ResidentRunner {
         stackTrace: stackTrace,
       );
       throwToolExit('Failed to connect to the web debug service.');
-    } on DartDevelopmentServiceException catch (error) {
+    } on DartDevelopmentServiceException catch (error, stackTrace) {
       // The application may have started shutting down before DDS was able to finish establishing
       // its connection to DWDS. Don't treat this as an unhandled exception.
       appFailedToStart();
-      if (error.errorCode == DartDevelopmentServiceException.failedToStartError) {
-        throwToolExit(kExitMessage);
-      }
-      rethrow;
+      _logger.printError(error.toString(), stackTrace: stackTrace);
+      throwToolExit(kExitMessage);
     } on Exception {
       appFailedToStart();
       rethrow;

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -410,7 +410,9 @@ class ResidentWebRunner extends ResidentRunner {
       // The application may have started shutting down before DDS was able to finish establishing
       // its connection to DWDS. Don't treat this as an unhandled exception.
       appFailedToStart();
-      _logger.printError(error.toString(), stackTrace: stackTrace);
+      if (error.errorCode != DartDevelopmentServiceException.failedToStartError) {
+        _logger.printError(error.message, stackTrace: stackTrace);
+      }
       throwToolExit(kExitMessage);
     } on Exception {
       appFailedToStart();

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -290,6 +290,26 @@ name: my_app
   );
 
   testUsingContext(
+    'Does not crash if DDS fails to upgrade WebSocket during startup',
+    () async {
+      final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice);
+      fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
+      setupMocks();
+      webDevFS.exception = DartDevelopmentServiceException.connectionIssue(
+        'WebSocketChannelException: WebSocketException: Connection to '
+        "'http://127.0.0.1:62932/9fVOXxsamo0=/ws#' was not upgraded to websocket",
+      );
+
+      await expectLater(residentWebRunner.run(), throwsToolExit());
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+    },
+  );
+
+  testUsingContext(
     'WebRunner copies compiled app.dill to cache during startup',
     () async {
       final debuggingOptions = DebuggingOptions.enabled(

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -275,12 +275,14 @@ name: my_app
     'Does not crash if the application exits during DDS startup',
     () async {
       // Regression test for https://github.com/flutter/flutter/issues/178151
-      final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice);
+      final logger = BufferLogger.test();
+      final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice, logger: logger);
       fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
       setupMocks();
       webDevFS.exception = DartDevelopmentServiceException.failedToStart();
 
       await expectLater(residentWebRunner.run(), throwsToolExit());
+      expect(logger.errorText, isEmpty);
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -292,15 +294,17 @@ name: my_app
   testUsingContext(
     'Does not crash if DDS fails to upgrade WebSocket during startup',
     () async {
-      final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice);
+      final logger = BufferLogger.test();
+      final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice, logger: logger);
       fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
       setupMocks();
-      webDevFS.exception = DartDevelopmentServiceException.connectionIssue(
-        'WebSocketChannelException: WebSocketException: Connection to '
-        "'http://127.0.0.1:62932/9fVOXxsamo0=/ws#' was not upgraded to websocket",
-      );
+      const errorMessage =
+          'WebSocketChannelException: WebSocketException: Connection to '
+          "'http://127.0.0.1:62932/9fVOXxsamo0=/ws#' was not upgraded to websocket";
+      webDevFS.exception = DartDevelopmentServiceException.connectionIssue(errorMessage);
 
       await expectLater(residentWebRunner.run(), throwsToolExit());
+      expect(logger.errorText, contains(errorMessage));
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,


### PR DESCRIPTION
## Description

This PR ensures that `ResidentWebRunner` catches all variants of `DartDevelopmentServiceException` during startup, rather than just `failedToStartError`.

When DDS fails to establish a WebSocket connection or upgrade the connection to DWDS (e.g., if the target browser exits prematurely or rejects the handshake), `package:dds` throws `DartDevelopmentServiceException.connectionIssue(...)` with `errorCode = DartDevelopmentServiceException.connectionError` (Code 3), rather than `failedToStartError` (Code 2).

Previously, `ResidentWebRunner` only caught `failedToStartError` and rethrew all other `DartDevelopmentServiceException`s, which caused the CLI to crash with an unhandled top-level exception.

With this change, we catch all `DartDevelopmentServiceException`s, log the error details with stack trace, perform necessary cleanup, and gracefully exit via `throwToolExit(kExitMessage)`.

## Related Issues
Fixes https://github.com/flutter/flutter/issues/191179

## Tests
Added a new unit test in `resident_web_runner_test.dart`:
- `Does not crash if DDS fails to upgrade WebSocket during startup`
