### PR TITLE
Lerp HSVColor and HSLColor hue along the shortest arc

### DIFF
--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -28,9 +28,11 @@ double _getHue(double red, double green, double blue, double max, double delta) 
 }
 
 double _lerpHue(double a, double b, double t) {
-  double delta = (b - a) % 360.0;
+  double delta = b - a;
   if (delta > 180.0) {
     delta -= 360.0;
+  } else if (delta < -180.0) {
+    delta += 360.0;
   }
   return (a + delta * t) % 360.0;
 }

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -27,6 +27,14 @@ double _getHue(double red, double green, double blue, double max, double delta) 
   return hue;
 }
 
+double _lerpHue(double a, double b, double t) {
+  double delta = (b - a) % 360.0;
+  if (delta > 180.0) {
+    delta -= 360.0;
+  }
+  return (a + delta * t) % 360.0;
+}
+
 Color _colorFromHue(double alpha, double hue, double chroma, double secondary, double match) {
   final (double red, double green, double blue) = switch (hue) {
     < 60.0 => (chroma, secondary, 0.0),
@@ -187,7 +195,7 @@ class HSVColor {
     }
     return HSVColor.fromAHSV(
       clampDouble(lerpDouble(a.alpha, b.alpha, t)!, 0.0, 1.0),
-      lerpDouble(a.hue, b.hue, t)! % 360.0,
+      _lerpHue(a.hue, b.hue, t),
       clampDouble(lerpDouble(a.saturation, b.saturation, t)!, 0.0, 1.0),
       clampDouble(lerpDouble(a.value, b.value, t)!, 0.0, 1.0),
     );
@@ -370,7 +378,7 @@ class HSLColor {
     }
     return HSLColor.fromAHSL(
       clampDouble(lerpDouble(a.alpha, b.alpha, t)!, 0.0, 1.0),
-      lerpDouble(a.hue, b.hue, t)! % 360.0,
+      _lerpHue(a.hue, b.hue, t),
       clampDouble(lerpDouble(a.saturation, b.saturation, t)!, 0.0, 1.0),
       clampDouble(lerpDouble(a.lightness, b.lightness, t)!, 0.0, 1.0),
     );

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -192,6 +192,20 @@ void main() {
     expect(at(300.0, 60.0, -0.5).hue, moreOrLessEquals(240.0));
   });
 
+  test('HSVColor lerps antipodal hues reversibly.', () {
+    HSVColor at(double startHue, double endHue, double t) => HSVColor.lerp(
+      HSVColor.fromAHSV(1.0, startHue, 1.0, 1.0),
+      HSVColor.fromAHSV(1.0, endHue, 1.0, 1.0),
+      t,
+    )!;
+
+    expect(at(0.0, 180.0, 0.5).hue, moreOrLessEquals(90.0));
+    expect(at(180.0, 0.0, 0.5).hue, moreOrLessEquals(90.0));
+
+    expect(at(60.0, 240.0, 0.75).hue, moreOrLessEquals(195.0));
+    expect(at(240.0, 60.0, 0.25).hue, moreOrLessEquals(195.0));
+  });
+
   test('HSVColor lerps saturation correctly.', () {
     final output = <Color>[];
     const startColor = HSVColor.fromAHSV(1.0, 0.0, 0.0, 1.0);
@@ -460,6 +474,20 @@ void main() {
 
     expect(at(300.0, 60.0, 1.5).hue, moreOrLessEquals(120.0));
     expect(at(300.0, 60.0, -0.5).hue, moreOrLessEquals(240.0));
+  });
+
+  test('HSLColor lerps antipodal hues reversibly.', () {
+    HSLColor at(double startHue, double endHue, double t) => HSLColor.lerp(
+      HSLColor.fromAHSL(1.0, startHue, 0.5, 0.5),
+      HSLColor.fromAHSL(1.0, endHue, 0.5, 0.5),
+      t,
+    )!;
+
+    expect(at(0.0, 180.0, 0.5).hue, moreOrLessEquals(90.0));
+    expect(at(180.0, 0.0, 0.5).hue, moreOrLessEquals(90.0));
+
+    expect(at(60.0, 240.0, 0.75).hue, moreOrLessEquals(195.0));
+    expect(at(240.0, 60.0, 0.25).hue, moreOrLessEquals(195.0));
   });
 
   test('HSLColor lerps saturation correctly.', () {

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -135,34 +135,61 @@ void main() {
   test('HSVColor lerps hue correctly.', () {
     final output = <Color>[];
     const startColor = HSVColor.fromAHSV(1.0, 0.0, 1.0, 1.0);
-    const endColor = HSVColor.fromAHSV(1.0, 360.0, 1.0, 1.0);
+    const endColor = HSVColor.fromAHSV(1.0, 180.0, 1.0, 1.0);
 
     for (var t = -0.5; t < 1.5; t += 0.1) {
       output.add(HSVColor.lerp(startColor, endColor, t)!.toColor());
     }
     final expectedColors = <Color>[
-      const Color(0xff00ffff),
-      const Color(0xff0066ff),
-      const Color(0xff3300ff),
+      const Color(0xff8000ff),
       const Color(0xffcc00ff),
+      const Color(0xffff00e6),
       const Color(0xffff0099),
+      const Color(0xffff004c),
       const Color(0xffff0000),
+      const Color(0xffff4c00),
       const Color(0xffff9900),
+      const Color(0xffffe600),
       const Color(0xffccff00),
+      const Color(0xff80ff00),
       const Color(0xff33ff00),
+      const Color(0xff00ff19),
       const Color(0xff00ff66),
+      const Color(0xff00ffb2),
       const Color(0xff00ffff),
+      const Color(0xff00b3ff),
       const Color(0xff0066ff),
+      const Color(0xff001aff),
       const Color(0xff3300ff),
-      const Color(0xffcc00ff),
-      const Color(0xffff0099),
-      const Color(0xffff0000),
-      const Color(0xffff9900),
-      const Color(0xffccff00),
-      const Color(0xff33ff00),
-      const Color(0xff00ff66),
     ];
     expect(output, equals(expectedColors));
+  });
+
+  test('HSVColor lerps hue along the shortest arc.', () {
+    HSVColor at(double startHue, double endHue, double t) => HSVColor.lerp(
+      HSVColor.fromAHSV(1.0, startHue, 1.0, 1.0),
+      HSVColor.fromAHSV(1.0, endHue, 1.0, 1.0),
+      t,
+    )!;
+
+    expect(at(300.0, 60.0, 0.25).hue, moreOrLessEquals(330.0));
+    expect(at(300.0, 60.0, 0.5).hue, moreOrLessEquals(0.0));
+    expect(at(300.0, 60.0, 0.75).hue, moreOrLessEquals(30.0));
+
+    expect(at(60.0, 300.0, 0.25).hue, moreOrLessEquals(30.0));
+    expect(at(60.0, 300.0, 0.5).hue, moreOrLessEquals(0.0));
+    expect(at(60.0, 300.0, 0.75).hue, moreOrLessEquals(330.0));
+
+    expect(at(350.0, 10.0, 0.5).hue, moreOrLessEquals(0.0));
+    expect(at(10.0, 350.0, 0.5).hue, moreOrLessEquals(0.0));
+
+    expect(at(20.0, 200.0, 0.5).hue, moreOrLessEquals(110.0));
+    expect(at(0.0, 90.0, 0.5).hue, moreOrLessEquals(45.0));
+
+    expect(at(0.0, 360.0, 0.5).hue, moreOrLessEquals(0.0));
+
+    expect(at(300.0, 60.0, 1.5).hue, moreOrLessEquals(120.0));
+    expect(at(300.0, 60.0, -0.5).hue, moreOrLessEquals(240.0));
   });
 
   test('HSVColor lerps saturation correctly.', () {
@@ -378,34 +405,61 @@ void main() {
   test('HSLColor lerps hue correctly.', () {
     final output = <Color>[];
     const startColor = HSLColor.fromAHSL(1.0, 0.0, 0.5, 0.5);
-    const endColor = HSLColor.fromAHSL(1.0, 360.0, 0.5, 0.5);
+    const endColor = HSLColor.fromAHSL(1.0, 180.0, 0.5, 0.5);
 
     for (var t = -0.5; t < 1.5; t += 0.1) {
       output.add(HSLColor.lerp(startColor, endColor, t)!.toColor());
     }
     final expectedColors = <Color>[
-      const Color(0xff40bfbf),
-      const Color(0xff4073bf),
-      const Color(0xff5940bf),
+      const Color(0xff8040bf),
       const Color(0xffa640bf),
+      const Color(0xffbf40b3),
       const Color(0xffbf408c),
+      const Color(0xffbf4066),
       const Color(0xffbf4040),
+      const Color(0xffbf6640),
       const Color(0xffbf8c40),
+      const Color(0xffbfb340),
       const Color(0xffa6bf40),
+      const Color(0xff80bf40),
       const Color(0xff59bf40),
+      const Color(0xff40bf4c),
       const Color(0xff40bf73),
+      const Color(0xff40bf99),
       const Color(0xff40bfbf),
+      const Color(0xff4099bf),
       const Color(0xff4073bf),
+      const Color(0xff404dbf),
       const Color(0xff5940bf),
-      const Color(0xffa640bf),
-      const Color(0xffbf408c),
-      const Color(0xffbf4040),
-      const Color(0xffbf8c40),
-      const Color(0xffa6bf40),
-      const Color(0xff59bf40),
-      const Color(0xff40bf73),
     ];
     expect(output, equals(expectedColors));
+  });
+
+  test('HSLColor lerps hue along the shortest arc.', () {
+    HSLColor at(double startHue, double endHue, double t) => HSLColor.lerp(
+      HSLColor.fromAHSL(1.0, startHue, 0.5, 0.5),
+      HSLColor.fromAHSL(1.0, endHue, 0.5, 0.5),
+      t,
+    )!;
+
+    expect(at(300.0, 60.0, 0.25).hue, moreOrLessEquals(330.0));
+    expect(at(300.0, 60.0, 0.5).hue, moreOrLessEquals(0.0));
+    expect(at(300.0, 60.0, 0.75).hue, moreOrLessEquals(30.0));
+
+    expect(at(60.0, 300.0, 0.25).hue, moreOrLessEquals(30.0));
+    expect(at(60.0, 300.0, 0.5).hue, moreOrLessEquals(0.0));
+    expect(at(60.0, 300.0, 0.75).hue, moreOrLessEquals(330.0));
+
+    expect(at(350.0, 10.0, 0.5).hue, moreOrLessEquals(0.0));
+    expect(at(10.0, 350.0, 0.5).hue, moreOrLessEquals(0.0));
+
+    expect(at(20.0, 200.0, 0.5).hue, moreOrLessEquals(110.0));
+    expect(at(0.0, 90.0, 0.5).hue, moreOrLessEquals(45.0));
+
+    expect(at(0.0, 360.0, 0.5).hue, moreOrLessEquals(0.0));
+
+    expect(at(300.0, 60.0, 1.5).hue, moreOrLessEquals(120.0));
+    expect(at(300.0, 60.0, -0.5).hue, moreOrLessEquals(240.0));
   });
 
   test('HSLColor lerps saturation correctly.', () {


### PR DESCRIPTION
Hue is an angle but we lerped it like a plain number so anything crossing 0 took the long way round. 300 to 60 should be a 120 hop through red (it was doing 240 through cyan)

Added a `_lerpHue` helper that folds the delta into (-180, 180] first (used by both lerps)

Heads up - 0 -> 360 doesn't sweep the wheel anymore since its the same angle. Two tests relied on that so I moved them to 0 -> 180

fixes #138301 

_(I used antigravity to help with that fix) and I went over the checklist_

<img width="640" height="290" alt="hue-lerp" src="https://github.com/user-attachments/assets/9b28ab69-886f-48e6-bec7-e4989d4d1b11" />