### PR TITLE
Fix wide gamut condition on metal playground tests

### DIFF
--- a/engine/src/flutter/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/engine/src/flutter/impeller/golden_tests/golden_playground_test_mac.cc
@@ -205,7 +205,7 @@ void GoldenPlaygroundTest::SetUp() {
       switches.flags.use_sdfs = true;
       [[fallthrough]];
     case PlaygroundBackend::kMetal:
-      if (!DoesSupportWideGamutTests()) {
+      if (switches.enable_wide_gamut && !DoesSupportWideGamutTests()) {
         GTEST_SKIP()
             << "This metal device doesn't support wide gamut golden tests.";
       }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/191209.

In [`golden_playground_test_mac.cc`](https://github.com/flutter/flutter/blob/8e817f5b10eb226c09f5724baabdc7f2731e9f47/engine/src/flutter/impeller/golden_tests/golden_playground_test_mac.cc), `GoldenPlaygroundTest::SetUp()` was unconditionally skipping all Metal and MetalSDF golden tests whenever `DoesSupportWideGamutTests()` returned `false`. On devices without wide gamut support (such as `Mac_x64` CI runners and Intel Macs), this caused standard sRGB golden tests to be skipped.

This PR restricts the `DoesSupportWideGamutTests()` check to tests that explicitly require wide gamut (`switches.enable_wide_gamut`), allowing standard sRGB Metal and MetalSDF golden tests to execute.

Tested locally on a macOS machine without wide gamut display support. Now only the tests which require wide gamut are skipped, instead of all of them.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
