### PR TITLE
[flutter_tools] Catch exceptions when starting Chrome to launch DevTools

### DIFF
--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -177,7 +177,13 @@ mixin DartDevelopmentServiceLocalOperationsMixin {
     }
     assert(devToolsUri != null);
     logger.printStatus('Launching Flutter DevTools for ${device.device!.name} at $devToolsUri');
-    unawaited(startChrome(<String>[devToolsUri!.toString()]));
+    unawaited(() async {
+      try {
+        await startChrome(<String>[devToolsUri!.toString()]);
+      } on Exception catch (error) {
+        logger.printError('Failed to launch DevTools in browser: $error');
+      }
+    }());
     return true;
   }
 

--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -177,13 +177,15 @@ mixin DartDevelopmentServiceLocalOperationsMixin {
     }
     assert(devToolsUri != null);
     logger.printStatus('Launching Flutter DevTools for ${device.device!.name} at $devToolsUri');
-    unawaited(() async {
+    Future<void> launchChrome() async {
       try {
         await startChrome(<String>[devToolsUri!.toString()]);
       } on Exception catch (error) {
         logger.printError('Failed to launch DevTools in browser: $error');
       }
-    }());
+    }
+
+    unawaited(launchChrome());
     return true;
   }
 

--- a/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
@@ -938,8 +938,7 @@ void main() {
       expect(result, true);
       expect(dds.calledLaunchDevToolsInBrowser, true);
 
-      // Wait for any microtasks to complete to ensure the unawaited future error would have bubbled up.
-      await null;
+      await pumpEventQueue();
 
       expect(
         bufferLogger.errorText,

--- a/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
@@ -896,6 +896,57 @@ void main() {
       expect(dds.calledLaunchDevToolsInBrowser, true);
     });
 
+    testWithoutContext('launchDevToolsInBrowser handles startChrome failure', () async {
+      final portForwarder = FakeProxiedPortForwarder();
+      portForwarder.originalRemotePortReturnValue = 100;
+      portForwarder.forwardReturnValue = 200;
+      final devicePortForwarder = FakeProxiedPortForwarder();
+      final dds = ProxiedDartDevelopmentService(
+        clientDaemonConnection,
+        'test_id',
+        logger: bufferLogger,
+        proxiedPortForwarder: portForwarder,
+        devicePortForwarder: devicePortForwarder,
+      );
+
+      final Stream<DaemonMessage> broadcastOutput = serverDaemonConnection.incomingCommands
+          .asBroadcastStream();
+
+      final Future<void> startFuture = dds.startDartDevelopmentService(
+        Uri.parse('http://127.0.0.1:100/fake'),
+        enableDevTools: true,
+      );
+
+      final DaemonMessage startMessage = await broadcastOutput.first;
+      serverDaemonConnection.sendResponse(startMessage.data['id']!, <String, Object?>{
+        'ddsUri': 'http://127.0.0.1:300/remote',
+        'devToolsUri': 'http://127.0.0.1:300/devtools',
+      });
+
+      await startFuture;
+      expect(dds.devToolsUri, Uri.parse('http://127.0.0.1:300/devtools'));
+
+      final flutterDevice = FakeFlutterDevice()..device = FakeDevice('test_device', 'device');
+
+      final bool result = dds.launchDevToolsInBrowser(
+        flutterDevice,
+        startChrome: (List<String> urls, {List<String>? args}) async {
+          throw ProcessException('chrome', urls, 'Chrome not installed');
+        },
+      );
+
+      expect(result, true);
+      expect(dds.calledLaunchDevToolsInBrowser, true);
+
+      // Wait for any microtasks to complete to ensure the unawaited future error would have bubbled up.
+      await null;
+
+      expect(
+        bufferLogger.errorText,
+        contains('Failed to launch DevTools in browser: ProcessException'),
+      );
+    });
+
     testWithoutContext('launchDevToolsInBrowser returns false if devToolsUri is null', () async {
       final portForwarder = FakeProxiedPortForwarder();
       final devicePortForwarder = FakeProxiedPortForwarder();


### PR DESCRIPTION
## Description
If Google Chrome is not installed, attempting to launch DevTools throws a `ProcessException` from `Chrome.start`. Because this call was unawaited and unhandled, it caused the flutter tool to crash.

This change wraps the `startChrome` invocation in a try-catch block to gracefully catch `Exception`s and log the error message via `logger.printError` instead of crashing.

## Related Issues
Fixes https://github.com/flutter/flutter/issues/182307

## Tests
- Added regression test `launchDevToolsInBrowser handles startChrome failure` in `packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart`.