### PR TITLE
[flutter_tools] Deduplicate iOS port forwards in IOSDevicePortForwarder

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -2019,6 +2019,8 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
   @override
   List<ForwardedPort> forwardedPorts = <ForwardedPort>[];
 
+  final Map<(int, int), Future<int>> _pendingForwards = <(int, int), Future<int>>{};
+
   @visibleForTesting
   void addForwardedPorts(List<ForwardedPort> ports) {
     ports.forEach(forwardedPorts.add);
@@ -2028,6 +2030,27 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
 
   @override
   Future<int> forward(int devicePort, {int? hostPort}) async {
+    for (final ForwardedPort port in forwardedPorts) {
+      if (port.devicePort == devicePort &&
+          (hostPort == null || hostPort == 0 || port.hostPort == hostPort)) {
+        return port.hostPort;
+      }
+    }
+    final (int, int) key = (devicePort, hostPort ?? 0);
+    if (_pendingForwards.containsKey(key)) {
+      return _pendingForwards[key]!;
+    }
+
+    final Future<int> future = _forwardInternal(devicePort, hostPort: hostPort);
+    _pendingForwards[key] = future;
+    try {
+      return await future;
+    } finally {
+      unawaited(_pendingForwards.remove(key));
+    }
+  }
+
+  Future<int> _forwardInternal(int devicePort, {int? hostPort}) async {
     final bool autoselect = hostPort == null || hostPort == 0;
     if (autoselect) {
       final int freePort = await _operatingSystemUtils.findFreePort();

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
@@ -46,4 +46,99 @@ void main() {
       expect(processManager, hasNoRemainingExpectations);
     },
   );
+
+  testWithoutContext(
+    'IOSDevicePortForwarder.forward returns existing forwarded port when devicePort is already forwarded',
+    () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['iproxy', '12345:456', '--udid', '1234'],
+          stdout: 'not empty',
+          environment: kDyLdLibEntry,
+        ),
+      ]);
+      final operatingSystemUtils = FakeOperatingSystemUtils();
+
+      final portForwarder = IOSDevicePortForwarder.test(
+        processManager: processManager,
+        logger: BufferLogger.test(),
+        operatingSystemUtils: operatingSystemUtils,
+      );
+
+      final int hostPort1 = await portForwarder.forward(456);
+      expect(hostPort1, 12345);
+
+      // Second call for the same device port should reuse the existing forward.
+      final int hostPort2 = await portForwarder.forward(456);
+      expect(hostPort2, 12345);
+
+      expect(portForwarder.forwardedPorts.length, 1);
+      expect(processManager, hasNoRemainingExpectations);
+    },
+  );
+
+  testWithoutContext(
+    'IOSDevicePortForwarder.forward deduplicates in-flight forward requests for the same devicePort',
+    () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['iproxy', '12345:456', '--udid', '1234'],
+          stdout: 'not empty',
+          environment: kDyLdLibEntry,
+        ),
+      ]);
+      final operatingSystemUtils = FakeOperatingSystemUtils();
+
+      final portForwarder = IOSDevicePortForwarder.test(
+        processManager: processManager,
+        logger: BufferLogger.test(),
+        operatingSystemUtils: operatingSystemUtils,
+      );
+
+      // Trigger two concurrent forward requests for the same device port.
+      final Future<int> future1 = portForwarder.forward(456);
+      final Future<int> future2 = portForwarder.forward(456);
+
+      final List<int> hostPorts = await Future.wait(<Future<int>>[future1, future2]);
+      expect(hostPorts[0], 12345);
+      expect(hostPorts[1], 12345);
+
+      expect(portForwarder.forwardedPorts.length, 1);
+      expect(processManager, hasNoRemainingExpectations);
+    },
+  );
+
+  testWithoutContext(
+    'IOSDevicePortForwarder.forward allows retry after a failed forward attempt',
+    () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['iproxy', '12345:456', '--udid', '1234'],
+          environment: kDyLdLibEntry,
+          // Empty stdout indicates failure.
+        ),
+        const FakeCommand(
+          command: <String>['iproxy', '12345:456', '--udid', '1234'],
+          stdout: 'not empty',
+          environment: kDyLdLibEntry,
+        ),
+      ]);
+      final operatingSystemUtils = FakeOperatingSystemUtils();
+
+      final portForwarder = IOSDevicePortForwarder.test(
+        processManager: processManager,
+        logger: BufferLogger.test(),
+        operatingSystemUtils: operatingSystemUtils,
+      );
+
+      // First attempt fails.
+      await expectLater(portForwarder.forward(456, hostPort: 12345), throwsA(isA<Exception>()));
+
+      // Subsequent attempt after error can retry and succeed.
+      final int hostPort = await portForwarder.forward(456, hostPort: 12345);
+      expect(hostPort, 12345);
+      expect(portForwarder.forwardedPorts.length, 1);
+      expect(processManager, hasNoRemainingExpectations);
+    },
+  );
 }


### PR DESCRIPTION
When discovering the Dart VM Service URL on iOS devices, ProtocolDiscovery and MDnsVmServiceDiscovery can run concurrently and discover the same device port nearly simultaneously.

IOSDevicePortForwarder.forward did not check if the device port was already forwarded or had an in-flight forward operation, causing multiple iproxy processes to spawn for the same device port and triggering connection resets on active sockets.

This change:
* Deduplicates existing port forwards in IOSDevicePortForwarder by checking forwardedPorts.
* Deduplicates in-flight asynchronous forward operations via _pendingForwards.
* Adds unit tests verifying duplicate sequential, concurrent, and retry behaviors.

Fixes https://github.com/flutter/flutter/issues/191192