### PR TITLE
Fixes bug where sibling node fail to update size

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1536,32 +1536,7 @@ base class PipelineOwner with DiagnosticableTreeMixin {
           continue;
         }
 
-        if (!node._semantics.contributesToSemanticsTree) {
-          // This node merely presents its subtree in the mergeup, so we need to clear
-          // the geometry for all the semantics nodes in the mergeup.
-          for (final _RenderObjectSemantics child
-              in node._semantics.mergeUp.whereType<_RenderObjectSemantics>()) {
-            if (child.shouldFormSemanticsNode) {
-              child.geometry = null;
-            } else {
-              // Even though this node does not form a semantics node, it still
-              // represents a group of render objects in the subtree, where a node that
-              // forms a semantics node is in its _children.
-              for (final _RenderObjectSemantics nodeInSubtree in child._children) {
-                assert(nodeInSubtree.shouldFormSemanticsNode);
-                nodeInSubtree.geometry = null;
-              }
-            }
-          }
-          continue;
-        }
-        // If we reach here, this node either forms a node but not a relayout boundary,
-        // or it does not form a node but still contributes to the semantics tree.
-        // In both cases, we need to clear the geometry for all the semantics nodes in
-        // the subtree.
-        for (final _RenderObjectSemantics child in node._semantics._children) {
-          child.geometry = null;
-        }
+        node._semantics._clearSubtreeGeometry();
       }
 
       // Used to invalidate the [_RenderObjectSemantics.firstAncestorNodeWithCleanGeometry] cache.
@@ -6141,15 +6116,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
       );
       child._updateGeometry(newGeometry: childGeometry);
     }
-    for (final _RenderObjectSemantics explicitSiblingChild
-        in siblingMergeGroups
-            .expand<_SemanticsFragment>((List<_SemanticsFragment> group) => group)
-            .whereType<_RenderObjectSemantics>()
-            .expand(
-              (_RenderObjectSemantics siblingChild) => siblingChild.shouldFormSemanticsNode
-                  ? <_RenderObjectSemantics>[siblingChild]
-                  : siblingChild._children,
-            )) {
+    for (final _RenderObjectSemantics explicitSiblingChild in _getExplicitSiblingChildren()) {
       if (onlyDirtyChildren && !explicitSiblingChild.geometryDirty) {
         continue;
       }
@@ -6161,6 +6128,39 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         child: explicitSiblingChild,
       );
       explicitSiblingChild._updateGeometry(newGeometry: childGeometry);
+    }
+  }
+
+  Iterable<_RenderObjectSemantics> _getExplicitSiblingChildren() {
+    return siblingMergeGroups
+        .expand<_SemanticsFragment>((List<_SemanticsFragment> group) => group)
+        .whereType<_RenderObjectSemantics>()
+        .expand(
+          (_RenderObjectSemantics siblingChild) => siblingChild.shouldFormSemanticsNode
+              ? <_RenderObjectSemantics>[siblingChild]
+              : siblingChild._children,
+        );
+  }
+
+  void _clearSubtreeGeometry() {
+    if (!contributesToSemanticsTree) {
+      for (final _RenderObjectSemantics child in mergeUp.whereType<_RenderObjectSemantics>()) {
+        if (child.shouldFormSemanticsNode) {
+          child.geometry = null;
+        } else {
+          for (final _RenderObjectSemantics nodeInSubtree in child._children) {
+            assert(nodeInSubtree.shouldFormSemanticsNode);
+            nodeInSubtree.geometry = null;
+          }
+        }
+      }
+    } else {
+      for (final _RenderObjectSemantics child in _children) {
+        child.geometry = null;
+      }
+    }
+    for (final _RenderObjectSemantics child in _getExplicitSiblingChildren()) {
+      child.geometry = null;
     }
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -6142,6 +6142,8 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         );
   }
 
+  /// Clears the geometry of all semantics nodes in the subtree, including any
+  /// explicit sibling children in sibling merge groups.
   void _clearSubtreeGeometry() {
     if (!contributesToSemanticsTree) {
       for (final _RenderObjectSemantics child in mergeUp.whereType<_RenderObjectSemantics>()) {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1536,7 +1536,7 @@ base class PipelineOwner with DiagnosticableTreeMixin {
           continue;
         }
 
-        node._semantics._clearSubtreeGeometry();
+        node._semantics._clearImmediateChildrenGeometry();
       }
 
       // Used to invalidate the [_RenderObjectSemantics.firstAncestorNodeWithCleanGeometry] cache.
@@ -5490,19 +5490,19 @@ typedef _MergeUpAndSiblingMergeGroups = (
 ///
 /// Merge all fragments from [mergeUp] and decide which [_RenderObjectSemantics]
 /// should form a node, i.e. [shouldFormSemanticsNode] is true. Stores the
-/// [_RenderObjectSemantics] that should form a node into [_children].
+/// [_RenderObjectSemantics] that should form a node into [_childrenInSemanticsTree].
 ///
-/// At this point, walking the [_children] forms a tree
+/// At this point, walking the [_childrenInSemanticsTree] forms a tree
 /// that exactly resemble the resulting semantics node tree.
 ///
 /// ### Phase 3
 ///
-/// Walks the [_children] and calculate their
+/// Walks the [_childrenInSemanticsTree] and calculate their
 /// [_SemanticsGeometry] based on renderObject relationship.
 ///
 /// ### Phase 4
 ///
-/// Walks the [_children] and produce semantics node for
+/// Walks the [_childrenInSemanticsTree] and produce semantics node for
 /// each [_RenderObjectSemantics] plus the sibling nodes.
 ///
 /// Phase 2, 3, 4 each depends on previous step to finished updating the
@@ -5560,7 +5560,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
 
   /// A list to store immediate child [_RenderObjectSemantics]s that will form
   /// semantics nodes.
-  final List<_RenderObjectSemantics> _children = <_RenderObjectSemantics>[];
+  final List<_RenderObjectSemantics> _childrenInSemanticsTree = <_RenderObjectSemantics>[];
 
   /// Merge groups that will form additional sibling nodes.
   final List<List<_SemanticsFragment>> siblingMergeGroups = <List<_SemanticsFragment>>[];
@@ -5704,7 +5704,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
 
   static void debugCheckForBuilds(_RenderObjectSemantics node) {
     assert(node.built);
-    node._children.forEach(debugCheckForBuilds);
+    node._childrenInSemanticsTree.forEach(debugCheckForBuilds);
   }
 
   /// Whether this render object semantics will block other render object
@@ -5759,7 +5759,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
 
   /// Updates the [parentData] for the [_RenderObjectSemantics]s in the
   /// rendering subtree and forms a [_RenderObjectSemantics] tree where children
-  /// are stored in [_children].
+  /// are stored in [_childrenInSemanticsTree].
   ///
   /// This method does the phase 1 and 2 of the four phases documented on
   /// [_RenderObjectSemantics].
@@ -5775,7 +5775,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
   /// Merge all fragments from [mergeUp] and decide which [_RenderObjectSemantics]
   /// should form a node. i.e. [shouldFormSemanticsNode] is true. Stores the
   /// [_RenderObjectSemantics] that should form a node with elevation adjustments
-  /// into [_children].
+  /// into [_childrenInSemanticsTree].
   void updateChildren() {
     assert(parentData != null || isRoot, 'parent data can only be null for root rendering object');
     configProvider.reset();
@@ -5822,8 +5822,8 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     siblingMergeGroups.addAll(result.$2);
 
     // Construct tree for nodes that will form semantics nodes.
-    final Set<_RenderObjectSemantics> oldChildren = _children.toSet();
-    _children.clear();
+    final Set<_RenderObjectSemantics> oldChildren = _childrenInSemanticsTree.toSet();
+    _childrenInSemanticsTree.clear();
     if (!contributesToSemanticsTree) {
       return;
     }
@@ -5842,7 +5842,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         in result.$1.whereType<_RenderObjectSemantics>()) {
       assert(childSemantics.contributesToSemanticsTree);
       if (childSemantics.shouldFormSemanticsNode) {
-        for (final _RenderObjectSemantics child in childSemantics._children) {
+        for (final _RenderObjectSemantics child in childSemantics._childrenInSemanticsTree) {
           child.parentInSemanticsTree = childSemantics;
         }
         // In general geometry is only dirty during the first build or markNeedsLayout.
@@ -5867,9 +5867,9 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         if (childSemantics.geometryDirty) {
           renderObject.owner!._nodesNeedingSemanticsGeometryUpdate.add(childSemantics.renderObject);
         }
-        _children.add(childSemantics);
+        _childrenInSemanticsTree.add(childSemantics);
       } else {
-        _children.addAll(childSemantics._children);
+        _childrenInSemanticsTree.addAll(childSemantics._childrenInSemanticsTree);
         siblingMergeGroups.addAll(childSemantics.siblingMergeGroups);
       }
     }
@@ -5877,11 +5877,11 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     // Otherwise, we won't know if this node shouldFormSemanticsNode until the parent
     // of this node determines it.
     if (isRoot || configProvider.effective.isSemanticBoundary) {
-      for (final _RenderObjectSemantics child in _children) {
+      for (final _RenderObjectSemantics child in _childrenInSemanticsTree) {
         child.parentInSemanticsTree = this;
       }
     }
-    oldChildren.removeAll(_children);
+    oldChildren.removeAll(_childrenInSemanticsTree);
     for (final removedChild in oldChildren) {
       if (removedChild.parentInSemanticsTree == this) {
         removedChild.parentInSemanticsTree = null;
@@ -6081,7 +6081,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
   }
 
   /// Updates the [geometry] for this [_RenderObjectSemantics]s and the dirty
-  /// children's subtree in [_children].
+  /// children's subtree in [_childrenInSemanticsTree].
   ///
   /// This method does the phase 3 of the four phases documented on
   /// [_RenderObjectSemantics].
@@ -6103,7 +6103,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
   void _updateChildGeometry({bool onlyDirtyChildren = false}) {
     assert(geometry != null);
     final _SemanticsGeometry parentGeometry = geometry!;
-    for (final _RenderObjectSemantics child in _children) {
+    for (final _RenderObjectSemantics child in _childrenInSemanticsTree) {
       if (onlyDirtyChildren && !child.geometryDirty) {
         continue;
       }
@@ -6138,29 +6138,46 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         .expand(
           (_RenderObjectSemantics siblingChild) => siblingChild.shouldFormSemanticsNode
               ? <_RenderObjectSemantics>[siblingChild]
-              : siblingChild._children,
+              : siblingChild._childrenInSemanticsTree,
         );
   }
 
-  /// Clears the geometry of all semantics nodes in the subtree, including any
+  /// Clears the geometry of all immediate child semantics nodes, including any
   /// explicit sibling children in sibling merge groups.
-  void _clearSubtreeGeometry() {
+  ///
+  /// This is called during [PipelineOwner.flushSemantics] when this render
+  /// object's geometry (such as size, transform, or clip) changes.
+  ///
+  /// Changes to a render object's geometry only affect the relative positions of
+  /// the immediate semantics-forming children directly beneath it. Descendants
+  /// further down the tree have geometries positioned relative to their
+  /// respective parent semantics node, so their geometries remain valid and do
+  /// not need to be cleared.
+  void _clearImmediateChildrenGeometry() {
     if (!contributesToSemanticsTree) {
+      // This node merely presents its subtree in the mergeup, so we need to clear
+      // the geometry for all the semantics nodes in the mergeup.
       for (final _RenderObjectSemantics child in mergeUp.whereType<_RenderObjectSemantics>()) {
         if (child.shouldFormSemanticsNode) {
           child.geometry = null;
         } else {
-          for (final _RenderObjectSemantics nodeInSubtree in child._children) {
+          // Even though this child does not form a semantics node, it still
+          // represents a group of render objects in the subtree, where a node that
+          // forms a semantics node is in its _childrenInSemanticsTree.
+          for (final _RenderObjectSemantics nodeInSubtree in child._childrenInSemanticsTree) {
             assert(nodeInSubtree.shouldFormSemanticsNode);
             nodeInSubtree.geometry = null;
           }
         }
       }
     } else {
-      for (final _RenderObjectSemantics child in _children) {
+      // There won't be mergup for this node. So just clearing its _childrenInSemanticsTree
+      // geometry should be enough.
+      for (final _RenderObjectSemantics child in _childrenInSemanticsTree) {
         child.geometry = null;
       }
     }
+    // Sibling merge groups may also contribute explicit semantics nodes.
     for (final _RenderObjectSemantics child in _getExplicitSiblingChildren()) {
       child.geometry = null;
     }
@@ -6251,7 +6268,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
   /// Builds the semantics subtree under the [cachedSemanticsNode].
   void _buildSemanticsSubtree({required Set<int> usedSemanticsIds}) {
     final children = <SemanticsNode>[];
-    for (final _RenderObjectSemantics child in _children) {
+    for (final _RenderObjectSemantics child in _childrenInSemanticsTree) {
       if (child.parentDataDirty) {
         continue;
       }
@@ -6354,7 +6371,7 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
             assert(fragment.configToMergeUp == null);
             continue;
           }
-          explicitChildren.addAll(fragment._children);
+          explicitChildren.addAll(fragment._childrenInSemanticsTree);
         }
         if (fragment.configToMergeUp != null) {
           fragment.mergesToSibling = true;
@@ -6586,14 +6603,14 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     _containsIncompleteFragment = false;
     mergeUp.clear();
     siblingMergeGroups.clear();
-    _children.clear();
+    _childrenInSemanticsTree.clear();
     semanticsNodes.clear();
     configProvider.clear();
   }
 
   @override
   List<DiagnosticsNode> debugDescribeChildren() {
-    return _children
+    return _childrenInSemanticsTree
         .map<DiagnosticsNode>((_RenderObjectSemantics child) => child.toDiagnosticsNode())
         .toList();
   }

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -2491,6 +2491,60 @@ void main() {
     await tester.pumpAndSettle();
     expect(label10, matchesSemantics(isHidden: false)); // ignore: avoid_redundant_argument_values
   });
+
+  testWidgets(
+    'explicit sibling semantics nodes in siblingMergeGroups update geometry on layout resize',
+    (WidgetTester tester) async {
+      final semantics = SemanticsTester(tester);
+      var width = 200.0;
+      Widget buildFrame() {
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: width,
+              height: 100.0,
+              child: _SiblingGroupWidget(
+                child: Semantics(
+                  label: 'sibling',
+                  child: const SizedBox(width: 50.0, height: 50.0),
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildFrame());
+      final Rect initialRect = find.semantics.byLabel('sibling').evaluate().first.rect;
+
+      width = 400.0;
+      await tester.pumpWidget(buildFrame());
+      final Rect updatedRect = find.semantics.byLabel('sibling').evaluate().first.rect;
+
+      expect(initialRect, isNot(updatedRect));
+      semantics.dispose();
+    },
+  );
+}
+
+class _SiblingGroupWidget extends SingleChildRenderObjectWidget {
+  const _SiblingGroupWidget({super.child});
+
+  @override
+  _RenderSiblingGroup createRenderObject(BuildContext context) => _RenderSiblingGroup();
+}
+
+class _RenderSiblingGroup extends RenderProxyBox {
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    config.childConfigurationsDelegate = (List<SemanticsConfiguration> childConfigs) {
+      final builder = ChildSemanticsConfigurationsResultBuilder();
+      builder.markAsSiblingMergeGroup(childConfigs);
+      return builder.build();
+    };
+  }
 }
 
 class CustomSortKey extends OrdinalSortKey {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

the clear geometry didn't consider explicit child geometry change in sibling merge group subtree.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
