### PR TITLE
macOS: Fix macOS 27 os_log compile errors, improve TRACE_VSYNC

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiter.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiter.mm
@@ -20,10 +20,12 @@
 
 // Trace vsync events using os_signpost so that they can be seen in Instruments "Points of
 // Interest".
-#define TRACE_VSYNC(event_type, baton)                                                     \
-  do {                                                                                     \
-    os_log_t log = os_log_create("FlutterVSync", "PointsOfInterest");                      \
-    os_signpost_event_emit(log, OS_SIGNPOST_ID_EXCLUSIVE, event_type, "baton %lx", baton); \
+#define TRACE_VSYNC(event_type, baton)                                                         \
+  do {                                                                                         \
+    static os_log_t log = os_log_create("FlutterVSync", "PointsOfInterest");                   \
+    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")  \
+        os_signpost_event_emit(log, OS_SIGNPOST_ID_EXCLUSIVE, event_type, "baton %lx", baton); \
+    _Pragma("GCC diagnostic pop")                                                              \
   } while (0)
 #else
 #define TRACE_VSYNC(event_type, baton) \


### PR DESCRIPTION
Suppress `-Wignored-attributes` triggered when compiling macOS-specific logging and vsync tracing code.

In the macOS 27 SDK that's part of Xcode 27, Apple appears to have added an `OS_LOG_UNINITIALIZED` macro inside their logging and signposting headers (`os/log.h`, `os/signpost.h`, `os/trace_base.h`). This macro expands to include: `__attribute__((stack_protector_ignore))`.

Because of this, we skip stack protection checks on local formatting buffers generated by logging macros such as `os_log_with_type` and `os_signpost_event_emit`. However, in Flutter, we compile the engine with `-fstack-protector-all`, which causes the build to error out complaining the `stack_protector_ignore` attribute is being ignored:

  error: 'stack_protector_ignore' attribute ignored due to '-fstack-protector-all' option [-Werror,-Wignored-attributes]

This wraps these usages in ignore pragmas to avoid disabling it across the board, which is the same as the approach that was taken in:
* https://github.com/dart-lang/sdk/commit/6bea1b7321870ddcccdf5274563b64977a115e5b
* https://github.com/google/angle/commit/918b93f4c0f145b82871a6c515dce8ed90e7d6e0

This also creates the vsync log once and caches it statically as Apple recommends. `os_log` is already multi-tenant safe.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
