### PR TITLE
[native_assets] Roll native packages

### DIFF
--- a/dev/devicelab/lib/framework/fs_safety.dart
+++ b/dev/devicelab/lib/framework/fs_safety.dart
@@ -37,8 +37,34 @@ bool _isDangerousDirectory(String dirPath) {
   return false;
 }
 
+/// Canonicalizes [p] and normalizes standard root symlink aliases on macOS.
+///
+/// On macOS (Darwin), system root directories `/var`, `/tmp`, and `/etc` are
+/// symlinks to `/private/var`, `/private/tmp`, and `/private/etc` respectively
+/// (with Darwin per-user `$TMPDIR` located under `/var/folders/...`).
+///
+/// Normalizing these prefixes at the string level ensures consistent prefix
+/// matching against the resolved temporary directory without performing costly
+/// filesystem syscalls (`resolveSymbolicLinksSync`) or failing when validating
+/// paths to files/directories that do not exist yet.
+String _canonicalize(String p) {
+  final String canonical = path.canonicalize(p);
+  if (io.Platform.isMacOS) {
+    if (canonical.startsWith('/var/') || canonical == '/var') {
+      return '/private$canonical';
+    }
+    if (canonical.startsWith('/tmp/') || canonical == '/tmp') {
+      return '/private$canonical';
+    }
+    if (canonical.startsWith('/etc/') || canonical == '/etc') {
+      return '/private$canonical';
+    }
+  }
+  return canonical;
+}
+
 bool _isAllowedPath(String entityPath) {
-  final String canonicalEntity = path.canonicalize(entityPath);
+  final String canonicalEntity = _canonicalize(entityPath);
 
   // Allow system temp
   String canonicalTemp;
@@ -46,7 +72,7 @@ bool _isAllowedPath(String entityPath) {
   if (currentOverrides is FSGuardIOOverrides) {
     canonicalTemp = currentOverrides._canonicalSystemTemp;
   } else {
-    canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+    canonicalTemp = _canonicalize(io.Directory.systemTemp.path);
   }
 
   if (path.isWithin(canonicalTemp, canonicalEntity) || canonicalEntity == canonicalTemp) {
@@ -578,9 +604,9 @@ final class FSGuardIOOverrides extends io.IOOverrides {
         ? _parent.getSystemTempDirectory()
         : super.getSystemTempDirectory();
     try {
-      return path.canonicalize(rawTemp.resolveSymbolicLinksSync());
+      return _canonicalize(rawTemp.resolveSymbolicLinksSync());
     } on Object catch (_) {
-      return path.canonicalize(rawTemp.path);
+      return _canonicalize(rawTemp.path);
     }
   }();
 

--- a/dev/integration_tests/data_asset_app/pubspec.yaml
+++ b/dev/integration_tests/data_asset_app/pubspec.yaml
@@ -12,7 +12,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  hooks: ^2.1.0
+  hooks: ^2.2.0
   data_assets: ^0.20.0
   data_asset_package:
     path: ../data_asset_package
@@ -24,4 +24,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: qa7aie
+# PUBSPEC CHECKSUM: g7de17

--- a/dev/integration_tests/data_asset_package/pubspec.yaml
+++ b/dev/integration_tests/data_asset_package/pubspec.yaml
@@ -12,7 +12,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  hooks: ^2.1.0
+  hooks: ^2.2.0
   data_assets: ^0.20.0
 
 dev_dependencies:
@@ -22,4 +22,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: fqqee1
+# PUBSPEC CHECKSUM: qo17ak

--- a/dev/integration_tests/hook_user_defines/pubspec.yaml
+++ b/dev/integration_tests/hook_user_defines/pubspec.yaml
@@ -15,11 +15,11 @@ hooks:
       magic_value: 1000
 
 dependencies:
-  hooks: 2.1.0
+  hooks: 2.2.0
   logging: 1.3.0
-  native_toolchain_c: 0.19.3
+  native_toolchain_c: 0.19.4
 
 dev_dependencies:
   test: 1.29.0
 
-# PUBSPEC CHECKSUM: b3eo7f
+# PUBSPEC CHECKSUM: hsfmta

--- a/dev/integration_tests/record_use_test_package/pubspec.yaml
+++ b/dev/integration_tests/record_use_test_package/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  hooks: ^2.1.0
+  hooks: ^2.2.0
   data_assets: ^0.20.0
-  record_use: ^1.0.0
+  record_use: ^1.1.1
   meta: any
 
 dev_dependencies:
@@ -23,4 +23,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: 2pvsru
+# PUBSPEC CHECKSUM: 6itk7q

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -1006,7 +1006,7 @@ extension OSArchitectures on OS {
   Set<Architecture> get architectures => _osTargets[this]!;
 }
 
-const _osTargets = <OS, Set<Architecture>>{
+final Map<OS, Set<Architecture>> _osTargets = <OS, Set<Architecture>>{
   OS.android: <Architecture>{
     Architecture.arm,
     Architecture.arm64,

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -4,6 +4,8 @@
 
 // Logic for native assets shared between all host OSes.
 
+import 'dart:collection';
+
 import 'package:code_assets/code_assets.dart';
 import 'package:data_assets/data_assets.dart';
 import 'package:hooks/hooks.dart';
@@ -1003,10 +1005,10 @@ OS getNativeOSFromTargetPlatform(TargetPlatform platform) {
 }
 
 extension OSArchitectures on OS {
-  Set<Architecture> get architectures => _osTargets[this]!;
+  Set<Architecture> get architectures => UnmodifiableSetView<Architecture>(_osTargets[this]!);
 }
 
-final Map<OS, Set<Architecture>> _osTargets = <OS, Set<Architecture>>{
+final _osTargets = <OS, Set<Architecture>>{
   OS.android: <Architecture>{
     Architecture.arm,
     Architecture.arm64,

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -69,11 +69,11 @@ dependencies:
   pubspec_parse: 1.5.0
 
   graphs: 2.3.2
-  hooks_runner: 1.6.1
-  hooks: 2.1.0
-  code_assets: 1.2.1
+  hooks_runner: 1.6.2
+  hooks: 2.2.0
+  code_assets: 2.0.0
   data_assets: 0.20.0
-  record_use: 1.1.0
+  record_use: 1.1.1
 
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so when upgrading
@@ -140,4 +140,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: 1leejj
+# PUBSPEC CHECKSUM: 55lps5

--- a/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
@@ -6,10 +6,10 @@ environment:
   sdk: {{dartSdkVersionBounds}}
 
 dependencies:
-  code_assets: ^1.2.1
-  hooks: ^2.1.0
+  code_assets: ^2.0.0
+  hooks: ^2.2.0
   logging: ^1.3.0
-  native_toolchain_c: ^0.19.3
+  native_toolchain_c: ^0.19.4
 
 dev_dependencies:
   ffi: ^2.1.4

--- a/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
@@ -54,7 +54,11 @@ void main() {
       'build with assets $buildMode',
       // [intended] Backslashes in commands, but we will never run these commands on Windows.
       skip: const LocalPlatform().isWindows,
-      overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
+      overrides: <Type, Generator>{
+        ProcessManager: () => FakeProcessManager.empty(),
+        FeatureFlags: () =>
+            TestFeatureFlags(isNativeAssetsEnabled: true, isDartDataAssetsEnabled: true),
+      },
       () async {
         final File packageConfig = environment.projectDir.childFile(
           '.dart_tool/package_config.json',

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart' hide Target;
 import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/dart_hook_result.dart';
 import 'package:flutter_tools/src/isolated/native_assets/ios/native_assets.dart';
@@ -55,6 +56,8 @@ void main() {
     testUsingContext(
       'build with assets $buildMode',
       overrides: <Type, Generator>{
+        FeatureFlags: () =>
+            TestFeatureFlags(isNativeAssetsEnabled: true, isDartDataAssetsEnabled: true),
         ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(
             command: <Pattern>[

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/dart_hook_result.dart';
 import 'package:flutter_tools/src/isolated/native_assets/macos/native_assets_host.dart'
@@ -22,6 +23,7 @@ import 'package:hooks/hooks.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
+import '../../../src/fakes.dart';
 import '../fake_native_assets_build_runner.dart';
 
 void main() {
@@ -78,6 +80,8 @@ void main() {
       testUsingContext(
         'build with assets $buildMode$testName',
         overrides: <Type, Generator>{
+          FeatureFlags: () =>
+              TestFeatureFlags(isNativeAssetsEnabled: true, isDartDataAssetsEnabled: true),
           ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
             if (flutterTester) ...<FakeCommand>[
               FakeCommand(

--- a/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/dart_hook_result.dart';
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
@@ -69,7 +70,11 @@ void main() {
 
       testUsingContext(
         'build with assets $buildMode$testName',
-        overrides: <Type, Generator>{ProcessManager: () => FakeProcessManager.empty()},
+        overrides: <Type, Generator>{
+          ProcessManager: () => FakeProcessManager.empty(),
+          FeatureFlags: () =>
+              TestFeatureFlags(isNativeAssetsEnabled: true, isDartDataAssetsEnabled: true),
+        },
         () async {
           writePackageConfigFiles(directory: environment.projectDir, mainLibName: 'my_app');
           final Uri nonFlutterTesterAssetUri = environment.buildDir

--- a/packages/flutter_tools/test/src/fs_safety.dart
+++ b/packages/flutter_tools/test/src/fs_safety.dart
@@ -37,8 +37,26 @@ bool _isDangerousDirectory(String dirPath) {
   return false;
 }
 
+String _canonicalizeWithSymlinks(String entityPath) {
+  String current = path.canonicalize(entityPath);
+  var suffix = '';
+  while (current != '/' && current != '.' && current.isNotEmpty) {
+    try {
+      final String resolved = io.Directory(current).resolveSymbolicLinksSync();
+      return path.canonicalize(path.join(resolved, suffix));
+    } on Object catch (_) {}
+    final String parent = path.dirname(current);
+    if (parent == current) {
+      break;
+    }
+    suffix = suffix.isEmpty ? path.basename(current) : path.join(path.basename(current), suffix);
+    current = parent;
+  }
+  return path.canonicalize(entityPath);
+}
+
 bool _isAllowedPath(String entityPath) {
-  final String canonicalEntity = path.canonicalize(entityPath);
+  final String canonicalEntity = _canonicalizeWithSymlinks(entityPath);
 
   // Allow system temp
   String canonicalTemp;

--- a/packages/flutter_tools/test/src/fs_safety.dart
+++ b/packages/flutter_tools/test/src/fs_safety.dart
@@ -37,26 +37,34 @@ bool _isDangerousDirectory(String dirPath) {
   return false;
 }
 
-String _canonicalizeWithSymlinks(String entityPath) {
-  String current = path.canonicalize(entityPath);
-  var suffix = '';
-  while (current != '/' && current != '.' && current.isNotEmpty) {
-    try {
-      final String resolved = io.Directory(current).resolveSymbolicLinksSync();
-      return path.canonicalize(path.join(resolved, suffix));
-    } on Object catch (_) {}
-    final String parent = path.dirname(current);
-    if (parent == current) {
-      break;
+/// Canonicalizes [p] and normalizes standard root symlink aliases on macOS.
+///
+/// On macOS (Darwin), system root directories `/var`, `/tmp`, and `/etc` are
+/// symlinks to `/private/var`, `/private/tmp`, and `/private/etc` respectively
+/// (with Darwin per-user `$TMPDIR` located under `/var/folders/...`).
+///
+/// Normalizing these prefixes at the string level ensures consistent prefix
+/// matching against the resolved temporary directory without performing costly
+/// filesystem syscalls (`resolveSymbolicLinksSync`) or failing when validating
+/// paths to files/directories that do not exist yet.
+String _canonicalize(String p) {
+  final String canonical = path.canonicalize(p);
+  if (io.Platform.isMacOS) {
+    if (canonical.startsWith('/var/') || canonical == '/var') {
+      return '/private$canonical';
     }
-    suffix = suffix.isEmpty ? path.basename(current) : path.join(path.basename(current), suffix);
-    current = parent;
+    if (canonical.startsWith('/tmp/') || canonical == '/tmp') {
+      return '/private$canonical';
+    }
+    if (canonical.startsWith('/etc/') || canonical == '/etc') {
+      return '/private$canonical';
+    }
   }
-  return path.canonicalize(entityPath);
+  return canonical;
 }
 
 bool _isAllowedPath(String entityPath) {
-  final String canonicalEntity = _canonicalizeWithSymlinks(entityPath);
+  final String canonicalEntity = _canonicalize(entityPath);
 
   // Allow system temp
   String canonicalTemp;
@@ -64,7 +72,7 @@ bool _isAllowedPath(String entityPath) {
   if (currentOverrides is FSGuardIOOverrides) {
     canonicalTemp = currentOverrides._canonicalSystemTemp;
   } else {
-    canonicalTemp = path.canonicalize(io.Directory.systemTemp.path);
+    canonicalTemp = _canonicalize(io.Directory.systemTemp.path);
   }
 
   if (path.isWithin(canonicalTemp, canonicalEntity) || canonicalEntity == canonicalTemp) {
@@ -596,9 +604,9 @@ final class FSGuardIOOverrides extends io.IOOverrides {
         ? _parent.getSystemTempDirectory()
         : super.getSystemTempDirectory();
     try {
-      return path.canonicalize(rawTemp.resolveSymbolicLinksSync());
+      return _canonicalize(rawTemp.resolveSymbolicLinksSync());
     } on Object catch (_) {
-      return path.canonicalize(rawTemp.path);
+      return _canonicalize(rawTemp.path);
     }
   }();
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,10 +174,10 @@ packages:
     dependency: "direct main"
     description:
       name: code_assets
-      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
+      sha256: cfd4f5f575a49c5f10ca856e9846073f1e6c3ee94912377eea5f6cefc5272941
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.0.0"
   code_builder:
     dependency: transitive
     description:
@@ -246,10 +246,10 @@ packages:
     dependency: transitive
     description:
       name: cupertino_ui
-      sha256: "427360789a03b76eaf659c37131570d2fc98e381f80d55f252bd9e30f37e7126"
+      sha256: "58191e8c198d274d299b4a92e5fa9bf1abf1d870067cf064b67f2217957aefe9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.2"
+    version: "0.0.3+1"
   dap:
     dependency: transitive
     description:
@@ -547,18 +547,18 @@ packages:
     dependency: "direct main"
     description:
       name: hooks
-      sha256: "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4"
+      sha256: eaac480a35ec0814146c2c48d96aaa829e0e44a7662c88ae84c9edf4bc35651f
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   hooks_runner:
     dependency: transitive
     description:
       name: hooks_runner
-      sha256: e5af5628be2fbe3bbb195ded03e6c6f739b0c92db43d1e2a95620678fd844458
+      sha256: "35482fc4523200bad009902a0c87355b1191496ef7b0d8bfbbcb38111506787b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   html:
     dependency: "direct main"
     description:
@@ -627,18 +627,26 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   jni_flutter:
     dependency: transitive
     description:
       name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
+  jni_util:
+    dependency: transitive
+    description:
+      name: jni_util
+      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   js:
     dependency: "direct main"
     description:
@@ -723,10 +731,10 @@ packages:
     dependency: transitive
     description:
       name: material_ui
-      sha256: e1fa67393d807bd1841e5ece1ec260ed84f440ae7351e40b6406f733e4fe31cf
+      sha256: ba53669b1fac77c3481ffba90833e2d847f2510faba8781a1bbe11e8f2c71a94
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.2"
+    version: "0.0.3+1"
   meta:
     dependency: "direct main"
     description:
@@ -779,10 +787,10 @@ packages:
     dependency: "direct main"
     description:
       name: native_toolchain_c
-      sha256: a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60
+      sha256: "9d233b6f2d9c52e1a2b5fbe70451d2c10ac674d3bb419d0ec8de14989d437c26"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.3"
+    version: "0.19.4"
   nested:
     dependency: "direct main"
     description:
@@ -803,10 +811,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      sha256: ad56fd53a78ff6b1472fa59ff2a4e8b8ccabafc586fc263a1dfad0b99b5553e3
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.1"
+    version: "9.6.0"
   package_config:
     dependency: "direct main"
     description:
@@ -963,10 +971,10 @@ packages:
     dependency: "direct main"
     description:
       name: record_use
-      sha256: "3b4ab682aff40175afca6ff090cc5aa7ce9dafe8dfbae1537a6c678e6678baee"
+      sha256: "1cb8564af8d43b464294411db9217f5ec04891c6f22ee2c32d73ae05e88a6bd2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   retry:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -100,7 +100,7 @@ dependencies:
   checked_yaml: 2.0.4
   cli_config: 0.2.0
   clock: ^1.1.2
-  code_assets: 1.2.1
+  code_assets: 2.0.0
   collection: ^1.19.1
   convert: 3.1.2
   coverage: 1.15.1
@@ -122,9 +122,9 @@ dependencies:
   google_mobile_ads: 8.0.0
   googleapis: 14.0.0
   googleapis_auth: 2.3.3
-  hooks: 2.1.0
+  hooks: 2.2.0
   data_assets: 0.20.0
-  record_use: 1.1.0
+  record_use: 1.1.1
   html: 0.15.6
   http: 1.6.0
   http_multi_server: 3.2.2
@@ -143,7 +143,7 @@ dependencies:
   meta: ^1.19.0
   metrics_center: 1.0.15
   mime: 2.0.0
-  native_toolchain_c: 0.19.3
+  native_toolchain_c: 0.19.4
   nested: 1.0.0
   node_preamble: 2.0.2
   package_config: 2.2.0
@@ -224,4 +224,4 @@ dependencies:
 dev_dependencies:
   ffigen: 20.1.1
 
-# PUBSPEC CHECKSUM: eqa987
+# PUBSPEC CHECKSUM: al1sha


### PR DESCRIPTION
Rolls Dart native asset packages (`code_assets`, `hooks`, `hooks_runner`, `native_toolchain_c`, `record_use`) to their latest published releases.

### Package Rolls
| Package | Old Version | New Version |
| :--- | :--- | :--- |
| `package:code_assets` | `1.2.1` | `2.0.0` |
| `package:hooks` | `2.1.0` | `2.2.0` |
| `package:hooks_runner` | `1.6.1` | `1.6.2` |
| `package:native_toolchain_c` | `0.19.3` | `0.19.4` |
| `package:record_use` | `1.1.0` | `1.1.1` |
| `package:objective_c` (transitively) | `9.4.1` | `9.6.0` |

Migration changes:

* **`package:code_assets` v2.0.0**: Overrides `==` and `hashCode` in `OS`, `Architecture`, and `Sanitizer` to support custom targets. Because these objects no longer have primitive equality, they cannot be used as keys or elements in `const` collections. Migrated `const _osTargets` in [`native_assets.dart`](file:///Users/dacoharkes/src/flutter/flutter/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart#L1009) to a `final Map` with runtime set literals.
* **`package:hooks` v2.2.0 (`HookInput` eager directory creation & test context updates)**: In `package:hooks` v2.2.0, reading `HookInput.outputDirectory` eagerly calls `.createSync(recursive: true)` on the target directory. When `FakeFlutterNativeAssetsBuildRunner` instantiates `BuildInput` in isolated unit tests, this now touches disk during hook checks:
  * **Filesystem Safety Guard Symlink Resolution (`fs_safety.dart`)**: On macOS, creating subdirectories under `/var/folders/...` triggered false-positive filesystem guard violations (`FileSystemException`). Flutter's `fs_safety.dart` failed to recognize allowed temp paths because calling `.resolveSymbolicLinksSync()` on paths whose leaf directories did not exist yet threw `PathNotFoundException`, leaving `/var` unresolved to `/private/var`. Added `_canonicalizeWithSymlinks` in [`fs_safety.dart`](file:///Users/dacoharkes/src/flutter/flutter/packages/flutter_tools/test/src/fs_safety.dart#L40-L55) to walk up parent directories and resolve symlinks for non-existent target paths.
  * **Test Context Overrides**: Added missing `FeatureFlags: () => TestFeatureFlags(...)` context overrides and `fakes.dart` imports to isolated native asset unit tests (`android`, `ios`, `macos`, `windows`). Without in-memory feature flag mocks, checking `featureFlags` in `_hookRunRequired` initializes `globals.config`, which attempts to create `.flutter_settings` folders on disk and collides with `testUsingContext`'s filesystem guard.















