### PR TITLE
Document that TextField.decoration is merged with InputDecorationTheme

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -424,6 +424,14 @@ class TextField extends StatefulWidget {
   /// By default, draws a horizontal line under the text field but can be
   /// configured to show an icon, label, hint text, and error text.
   ///
+  /// This decoration does not replace the ambient [InputDecorationTheme], it is
+  /// merged with it by [InputDecoration.applyDefaults]. Only the properties
+  /// that are left null here take their value from [InputDecorationTheme.of],
+  /// which in turn defaults to [ThemeData.inputDecorationTheme]. So, for
+  /// example, when the theme specifies a border, passing an [InputDecoration]
+  /// that leaves [InputDecoration.border] null does not remove that border;
+  /// pass `border: InputBorder.none` to opt out of it explicitly.
+  ///
   /// Specify null to remove the decoration entirely (including the
   /// extra padding introduced by the decoration to save space for the labels).
   final InputDecoration? decoration;


### PR DESCRIPTION
`TextField.decoration`'s dartdoc describes what the decoration draws, but never mentions that the value passed here is *combined* with the ambient `InputDecorationTheme` rather than replacing it.

`TextField` builds its effective decoration with `InputDecoration.applyDefaults`:

https://github.com/flutter/flutter/blob/7deb8a4d/packages/flutter/lib/src/material/text_field.dart#L1208-L1210

and `applyDefaults` only substitutes properties that are null on the incoming `InputDecoration` (including `border: border ?? theme.border`). So a theme-provided border survives an `InputDecoration` that simply omits one, which is surprising if you read the property docs alone — that confusion is what #159629 reports.

This adds a paragraph to the `decoration` property documenting the merge and pointing at the explicit opt-out (`border: InputBorder.none`).

This covers the documentation half of #159629. The issue also proposes a `mergeWithTheme`-style flag on `InputDecoration`; that is an API proposal and is deliberately left out of this PR, so the issue should stay open.

*Documentation-only change; no behavior change and no new tests.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
