### PR TITLE
[stable] [flutter_tools] Fix impellerc Windows Unicode crash and improve diagnostics

### DIFF
--- a/engine/src/flutter/impeller/compiler/switches.cc
+++ b/engine/src/flutter/impeller/compiler/switches.cc
@@ -239,7 +239,7 @@ Switches::Switches(const fml::CommandLine& command_line)
     }
 
     auto dir = std::make_shared<fml::UniqueFD>(fml::OpenDirectoryReadOnly(
-        *working_directory, include_dir_absolute.string().c_str()));
+        *working_directory, Utf8FromPath(include_dir_absolute).c_str()));
     if (!dir || !dir->is_valid()) {
       continue;
     }

--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
@@ -265,7 +265,7 @@ class ShaderCompiler {
       final List<String> shaderTargets = _shaderTargetsFromTargetPlatform(targetPlatform);
       final List<String> cmd = makeImpellercCommand(shaderTargets);
       _logger.printTrace('impellerc command: $cmd');
-      final ProcessResult result = await _runCommand(cmd);
+      ProcessResult result = await _runCommand(cmd);
       if (result.exitCode != 0) {
         // Maybe retry impellerc command without --sksl.
         if (!(shaderTargets.length > 1 && shaderTargets.contains('--sksl'))) {
@@ -286,6 +286,7 @@ class ShaderCompiler {
         if (retryResult.exitCode != 0) {
           // Retry failed.
           _logger.printError('impellerc failure: ${retryResult.stderr}');
+          result = retryResult;
           failure = true;
         } else {
           // Retry succeeded. Don't fail, but log a warning message and the sksl
@@ -302,9 +303,15 @@ class ShaderCompiler {
 
       if (failure) {
         if (fatal) {
+          final String? hint = _getHelpfulHint(result, input, outputPath, impellerc.path);
+          final message =
+              'Shader compilation of "${input.path}" to "$outputPath" '
+              'failed with exit code ${result.exitCode}.'
+              '${hint != null ? '\n$hint' : ''}';
           throw ShaderCompilerException._(
-            'Shader compilation of "${input.path}" to "$outputPath" '
-            'failed with exit code ${result.exitCode}.',
+            message,
+            stdout: result.stdout as String?,
+            stderr: result.stderr as String?,
           );
         }
         return false;
@@ -320,9 +327,46 @@ class ShaderCompiler {
     return true;
   }
 
+  String? _getHelpfulHint(
+    ProcessResult result,
+    File input,
+    String outputPath,
+    String impellercPath,
+  ) {
+    final int exitCode = result.exitCode;
+    if (_platform.isMacOS && exitCode == -9) {
+      return 'The shader compiler (impellerc) may have been blocked by macOS Gatekeeper or run out of memory (OOM).\n'
+          'To resolve Gatekeeper issues, try running:\n'
+          '  xattr -d com.apple.quarantine "$impellercPath"';
+    }
+
+    final bool isWindowsAbort = _platform.isWindows && exitCode == 3;
+    final bool isPosixAbort = (_platform.isMacOS || _platform.isLinux) && exitCode == -6;
+
+    if (isWindowsAbort || isPosixAbort) {
+      var hint = 'The shader compiler (impellerc) aborted during compilation.';
+      if (_platform.isWindows) {
+        final bool hasNonAscii =
+            RegExp(r'[^\x00-\x7F]').hasMatch(input.path) ||
+            RegExp(r'[^\x00-\x7F]').hasMatch(outputPath);
+        if (hasNonAscii) {
+          hint +=
+              '\nWarning: The path contains non-ASCII characters, which is known to cause crashes on Windows.\n'
+              'Try moving your project to a path containing only ASCII characters.';
+        }
+      }
+      return hint;
+    }
+    return null;
+  }
+
   Future<ProcessResult> _runCommand(List<String> command) async {
     try {
-      return await _processManager.run(command, stderrEncoding: utf8);
+      return await _processManager.run(
+        command,
+        stdoutEncoding: utf8AllowMalformed,
+        stderrEncoding: utf8AllowMalformed,
+      );
     } on ProcessException catch (e) {
       if (_isBlockedBySecurityPolicy(e)) {
         throw _SecurityPolicyBlockException(e);
@@ -363,10 +407,26 @@ class _SecurityPolicyBlockException implements Exception {
 }
 
 class ShaderCompilerException implements Exception {
-  ShaderCompilerException._(this.message);
+  ShaderCompilerException._(this.message, {this.stdout, this.stderr});
 
   final String message;
+  final String? stdout;
+  final String? stderr;
 
   @override
-  String toString() => 'ShaderCompilerException: $message\n\n';
+  String toString() {
+    final buffer = StringBuffer();
+    buffer.write('ShaderCompilerException: $message\n');
+    final String? stdout = this.stdout;
+    if (stdout != null && stdout.trim().isNotEmpty) {
+      buffer.writeln('Stdout:');
+      buffer.writeln(stdout.trim());
+    }
+    final String? stderr = this.stderr;
+    if (stderr != null && stderr.trim().isNotEmpty) {
+      buffer.writeln('Stderr:');
+      buffer.writeln(stderr.trim());
+    }
+    return buffer.toString();
+  }
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -244,6 +244,8 @@ void main() {
           '"/output/shaders/my_shader.frag" failed with exit code 1.',
         ),
       );
+      expect(e.stdout, 'impellerc stdout');
+      expect(e.stderr, 'impellerc stderr');
     }
 
     expect(fileSystem.file(outputPath).existsSync(), false);
@@ -1033,5 +1035,221 @@ void main() {
 
       expect(headerLine.allMatches(logger.errorText).length, 2);
     });
+  });
+
+  group('ShaderCompiler hints and diagnostics', () {
+    Future<void> expectShaderCompilerException({
+      required ShaderCompiler shaderCompiler,
+      required String inputPath,
+      required String outputPath,
+      required List<Matcher> matchers,
+    }) async {
+      await expectLater(
+        shaderCompiler.compileShader(
+          input: fileSystem.file(inputPath),
+          outputPath: outputPath,
+          targetPlatform: TargetPlatform.web_javascript,
+        ),
+        throwsA(
+          isA<ShaderCompilerException>().having(
+            (ShaderCompilerException e) => e.toString(),
+            'toString()',
+            allOf(matchers),
+          ),
+        ),
+      );
+    }
+
+    testWithoutContext('macOS and exit code -9 adds Gatekeeper/OOM hint', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: -9,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(operatingSystem: 'macos'),
+      );
+
+      await expectShaderCompilerException(
+        shaderCompiler: shaderCompiler,
+        inputPath: notFragPath,
+        outputPath: outputPath,
+        matchers: <Matcher>[
+          contains('blocked by macOS Gatekeeper or run out of memory (OOM)'),
+          contains('xattr -d com.apple.quarantine'),
+        ],
+      );
+    });
+
+    testWithoutContext('macOS and exit code -6 adds abort hint', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: -6,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(operatingSystem: 'macos'),
+      );
+
+      await expectShaderCompilerException(
+        shaderCompiler: shaderCompiler,
+        inputPath: notFragPath,
+        outputPath: outputPath,
+        matchers: <Matcher>[
+          contains('The shader compiler (impellerc) aborted during compilation.'),
+        ],
+      );
+    });
+
+    testWithoutContext('Linux and exit code -6 adds abort hint', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: -6,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(),
+      );
+
+      await expectShaderCompilerException(
+        shaderCompiler: shaderCompiler,
+        inputPath: notFragPath,
+        outputPath: outputPath,
+        matchers: <Matcher>[
+          contains('The shader compiler (impellerc) aborted during compilation.'),
+        ],
+      );
+    });
+
+    testWithoutContext('Windows and exit code 3 adds abort hint', () async {
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            impellerc,
+            '--sksl',
+            '--iplr',
+            '--json',
+            '--sl=$outputPath',
+            '--spirv=$outputSpirvPath',
+            '--input=$notFragPath',
+            '--input-type=frag',
+            '--include=$fragDir',
+            '--include=$shaderLibDir',
+          ],
+          exitCode: 3,
+        ),
+      ]);
+      final shaderCompiler = ShaderCompiler(
+        processManager: processManager,
+        logger: logger,
+        fileSystem: fileSystem,
+        artifacts: artifacts,
+        platform: FakePlatform(operatingSystem: 'windows'),
+      );
+
+      await expectShaderCompilerException(
+        shaderCompiler: shaderCompiler,
+        inputPath: notFragPath,
+        outputPath: outputPath,
+        matchers: <Matcher>[
+          contains('The shader compiler (impellerc) aborted during compilation.'),
+          isNot(contains('Warning: The path contains non-ASCII characters')),
+        ],
+      );
+    });
+
+    testWithoutContext(
+      'Windows and exit code 3 with Unicode path adds Unicode path warning '
+      '(regression test for https://github.com/flutter/flutter/issues/190233)',
+      () async {
+        const unicodeFragPath = '/shaders/my_shåder.frag';
+        const unicodeOutputPath = '/output/shaders/my_shåder.frag';
+        const unicodeOutputSpirvPath = '/output/shaders/my_shåder.frag.spirv';
+        fileSystem.file(unicodeFragPath).createSync(recursive: true);
+
+        final processManager = FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: <String>[
+              impellerc,
+              '--sksl',
+              '--iplr',
+              '--json',
+              '--sl=$unicodeOutputPath',
+              '--spirv=$unicodeOutputSpirvPath',
+              '--input=$unicodeFragPath',
+              '--input-type=frag',
+              '--include=$fragDir',
+              '--include=$shaderLibDir',
+            ],
+            exitCode: 3,
+          ),
+        ]);
+        final shaderCompiler = ShaderCompiler(
+          processManager: processManager,
+          logger: logger,
+          fileSystem: fileSystem,
+          artifacts: artifacts,
+          platform: FakePlatform(operatingSystem: 'windows'),
+        );
+
+        await expectShaderCompilerException(
+          shaderCompiler: shaderCompiler,
+          inputPath: unicodeFragPath,
+          outputPath: unicodeOutputPath,
+          matchers: <Matcher>[
+            contains('The shader compiler (impellerc) aborted during compilation.'),
+            contains('Warning: The path contains non-ASCII characters'),
+          ],
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:

https://github.com/flutter/flutter/issues/190233

### Impact Description:

On Windows, the Impeller shader compiler (`impellerc`) crashes when project directories or include paths contain non-ASCII/Unicode characters (such as localized usernames or paths). Additionally, `flutter_tools` obscured `impellerc`'s stdout and stderr output during `ShaderCompilerException`. This was identified as a top-10 crash signature in Flutter stable release 3.44.8.

### Changelog Description:

[flutter/190233] Fix impellerc crash on Windows when paths contain Unicode characters, and improve shader compiler error diagnostics.

### Workaround:

Move the Flutter project to a directory path containing exclusively ASCII characters.

### Risk:

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:

  - [x] Yes
  - [ ] No

### Validation Steps:

1. On Windows, create a Flutter project in a directory path containing Unicode characters (e.g. `C:\Users\тест\flutter_project`).
2. Run `flutter build windows` or `flutter run` with Impeller enabled.
3. Confirm shader compilation succeeds without crashing.
