### PR TITLE
[stable] [flutter_tools] Fix deadlock in debug adapters when process exits early

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -452,7 +452,17 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
     // This may be useful when there's no VM Service (for example Profile mode)
     // but the editor still wants to know that startup has finished.
     if (enableDebugger) {
-      await debuggerInitialized; // Ensure we're fully initialized before sending.
+      waitingForDebugger = true;
+      try {
+        await Future.any<void>([debuggerInitialized, debuggerInitializationFailedCompleter.future]);
+      } catch (e) {
+        if (!isTerminating) {
+          rethrow;
+        }
+        return;
+      } finally {
+        waitingForDebugger = false;
+      }
     }
     sendEvent(RawEventBody(<String, Object?>{}), eventType: 'flutter.appStarted');
   }

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
@@ -45,6 +45,27 @@ abstract class FlutterBaseDebugAdapter
   /// the same as what is passed to the base class, which is always provided 'false'.
   final bool enableFlutterDds;
 
+  /// Whether the adapter is currently waiting for the debugger to initialize.
+  bool waitingForDebugger = false;
+
+  /// A completer that completes with an error if debugger initialization fails
+  /// (for example, if the session terminates early).
+  ///
+  /// A dummy error handler is attached to the future to prevent unhandled
+  /// asynchronous exceptions if it completes before any listeners are active.
+  final Completer<void> debuggerInitializationFailedCompleter = Completer<void>()
+    ..future.then<void>((_) {}, onError: (Object _) {});
+
+  @override
+  void handleSessionTerminate([String exitSuffix = '']) {
+    if (waitingForDebugger && !debuggerInitializationFailedCompleter.isCompleted) {
+      debuggerInitializationFailedCompleter.completeError(
+        DebugAdapterException('Session terminated before debugger initialized: $exitSuffix'),
+      );
+    }
+    super.handleSessionTerminate(exitSuffix);
+  }
+
   @override
   final FlutterLaunchRequestArguments Function(Map<String, Object?> obj) parseLaunchArgs =
       FlutterLaunchRequestArguments.fromJson;

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
@@ -66,11 +66,26 @@ class FlutterTestDebugAdapter extends FlutterBaseDebugAdapter with TestAdapter {
 
     final processArgs = <String>[...toolArgs, ...?args.toolArgs, ?program, ...?args.args];
 
-    await launchAsProcess(executable: executable, processArgs: processArgs, env: args.env);
+    if (debug) {
+      waitingForDebugger = true;
+    }
+
+    try {
+      await launchAsProcess(executable: executable, processArgs: processArgs, env: args.env);
+    } catch (e) {
+      if (debug) {
+        waitingForDebugger = false;
+      }
+      rethrow;
+    }
 
     // Delay responding until the debugger is connected.
     if (debug) {
-      await debuggerInitialized;
+      try {
+        await Future.any<void>([debuggerInitialized, debuggerInitializationFailedCompleter.future]);
+      } finally {
+        waitingForDebugger = false;
+      }
     }
   }
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart
@@ -119,6 +119,16 @@ void main() {
 
     standardTests(toolArgs: toolArgs);
   });
+
+  group('fail fast', () {
+    test('launch fails if process exits early', () async {
+      await client.initialize();
+      expect(
+        client.launch(program: 'non_existent_file.dart', cwd: tempDir.path),
+        throwsA(isA<Response>().having((Response r) => r.success, 'success', isFalse)),
+      );
+    });
+  });
 }
 
 /// Matchers for the expected console output of [TestsProject].

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -43,6 +43,9 @@ class DapTestClient {
           ),
         );
         _pendingRequests.clear();
+        if (!_eventController.isClosed) {
+          unawaited(_eventController.close());
+        }
       },
     );
   }

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
@@ -134,12 +134,13 @@ class DapTestSession {
   }
 
   static Future<DapTestSession> setUp({List<String>? additionalArgs}) async {
-    final DapTestServer server = await _startServer(additionalArgs: additionalArgs);
+    // ignore: avoid_print
+    final Logger? logger = verboseLogging ? print : null;
+    final DapTestServer server = await _startServer(logger: logger, additionalArgs: additionalArgs);
     final DapTestClient client = await DapTestClient.connect(
       server,
       captureVmServiceTraffic: verboseLogging,
-      // ignore: avoid_print
-      logger: verboseLogging ? print : null,
+      logger: logger,
     );
     return DapTestSession._(server, client);
   }


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:

https://github.com/flutter/flutter/issues/190721

### Impact Description:

When launching a debug session in IDEs (such as VS Code) via the Debug Adapter Protocol (DAP), if the target application process exited early (such as due to a startup crash or failure prior to VM service connection), the debug adapter deadlocked waiting indefinitely on `debuggerInitialized`. This caused the IDE to hang indefinitely in an active debug session.

### Changelog Description:

[flutter/190721] Fix deadlock in debug adapters when the target process exits early during startup before VM service connection.

### Workaround:

Manually kill the hung Flutter debug adapter process and restart the debug session.

### Risk:

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:

  - [x] Yes
  - [ ] No

### Validation Steps:

1. Launch a DAP debug session targeting an application that exits immediately on startup.
2. Confirm the debug adapter fails fast and terminates cleanly without hanging.
3. Run DAP tests in `packages/flutter_tools/test/integration.shard/debug_adapter_test.dart`.
