### PR TITLE
[stable] [flutter_tools] Invalidate WebEntrypointTarget when plugin set changes

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -54,10 +54,16 @@ class WebEntrypointTarget extends Target {
   @override
   List<Source> get inputs => const <Source>[
     Source.pattern('{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/web.dart'),
+    Source.pattern('{WORKSPACE_DIR}/.dart_tool/package_config.json'),
+    Source.pattern('{PROJECT_DIR}/pubspec.yaml'),
+    Source.pattern('{PROJECT_DIR}/.flutter-plugins-dependencies', optional: true),
   ];
 
   @override
-  List<Source> get outputs => const <Source>[Source.pattern('{BUILD_DIR}/main.dart')];
+  List<Source> get outputs => const <Source>[
+    Source.pattern('{BUILD_DIR}/main.dart'),
+    Source.pattern('{BUILD_DIR}/web_plugin_registrant.dart'),
+  ];
 
   @override
   Future<void> build(Environment environment) async {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -135,6 +135,31 @@ name: foo
   );
 
   test(
+    'WebEntrypointTarget declares package_config.json, pubspec.yaml, and plugin dependencies as inputs',
+    () => testbed.run(() async {
+      const target = WebEntrypointTarget();
+      expect(
+        target.inputs,
+        equals(<Source>[
+          const Source.pattern(
+            '{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/web.dart',
+          ),
+          const Source.pattern('{WORKSPACE_DIR}/.dart_tool/package_config.json'),
+          const Source.pattern('{PROJECT_DIR}/pubspec.yaml'),
+          const Source.pattern('{PROJECT_DIR}/.flutter-plugins-dependencies', optional: true),
+        ]),
+      );
+      expect(
+        target.outputs,
+        equals(<Source>[
+          const Source.pattern('{BUILD_DIR}/main.dart'),
+          const Source.pattern('{BUILD_DIR}/web_plugin_registrant.dart'),
+        ]),
+      );
+    }),
+  );
+
+  test(
     'version.json is created after release build',
     () => testbed.run(() async {
       environment.defines[kBuildMode] = 'release';


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:

https://github.com/flutter/flutter/issues/189128

### Impact Description:

In Flutter Web builds (`flutter build web`), `WebEntrypointTarget` did not declare plugin manifests or package configurations in its target inputs. When web plugins were added or removed between consecutive builds, the build system incorrectly treated `web_plugin_registrant.dart` as up-to-date, resulting in silently unregistered plugins and runtime `MissingPluginException` or build errors in production web applications.

### Changelog Description:

[flutter/189128] Invalidate WebEntrypointTarget and regenerate web_plugin_registrant.dart when web plugins are added or removed.

### Workaround:

Run `flutter clean` before running `flutter build web`.

### Risk:

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:

  - [x] Yes
  - [ ] No

### Validation Steps:

1. Create a web Flutter app, add a plugin, and run `flutter build web`.
2. Add a second web plugin and run `flutter build web` without running `flutter clean`.
3. Confirm that `web_plugin_registrant.dart` is regenerated with both plugins registered.
4. Run `packages/flutter_tools` web build unit tests.
