### PR TITLE
[stable] [flutter_tools] Fix hot reload for workspace member packages in lib/ (#190284)

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -87,7 +87,7 @@ class WebEntrypointTarget extends Target {
     // does not have an entry for the user's application or if the main file is
     // outside of the lib/ directory.
     final String importedEntrypoint =
-        packageConfig.toPackageUri(importUri)?.toString() ?? importUri.toString();
+        packageConfig.toPackageUriForWorkspace(importUri)?.toString() ?? importUri.toString();
 
     await injectBuildTimePluginFilesForWebPlatform(
       flutterProject,

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -23,6 +23,7 @@ import 'base/utils.dart';
 import 'build_info.dart';
 import 'bundle.dart';
 import 'convert.dart';
+import 'dart/package_map.dart';
 
 /// Opt-in changes to the dart compilers.
 const kDartCompilerExperiments = <String>[];
@@ -291,7 +292,7 @@ class KernelCompiler {
       final File mainFile = _fileSystem.file(mainPath);
       final Uri mainFileUri = mainFile.uri;
       if (packagesPath != null) {
-        mainUri = packageConfig.toPackageUri(mainFileUri)?.toString();
+        mainUri = packageConfig.toPackageUriForWorkspace(mainFileUri)?.toString();
       }
       mainUri ??= toMultiRootPath(
         mainFileUri,
@@ -314,7 +315,7 @@ class KernelCompiler {
     if (dartPluginRegistrant != null && dartPluginRegistrant.existsSync()) {
       final Uri dartPluginRegistrantFileUri = dartPluginRegistrant.uri;
       dartPluginRegistrantUri =
-          packageConfig.toPackageUri(dartPluginRegistrantFileUri)?.toString() ??
+          packageConfig.toPackageUriForWorkspace(dartPluginRegistrantFileUri)?.toString() ??
           toMultiRootPath(
             dartPluginRegistrantFileUri,
             _fileSystemScheme,
@@ -853,13 +854,15 @@ class DefaultResidentCompiler implements ResidentCompiler {
     _stdoutHandler._suppressCompilerMessages = request.suppressErrors;
 
     final String mainUri =
-        request.packageConfig.toPackageUri(request.mainUri)?.toString() ??
+        request.packageConfig.toPackageUriForWorkspace(request.mainUri)?.toString() ??
         toMultiRootPath(request.mainUri, fileSystemScheme, fileSystemRoots, _platform.isWindows);
 
     String? additionalSourceUri;
     if (request.additionalSourceUri != null) {
       additionalSourceUri =
-          request.packageConfig.toPackageUri(request.additionalSourceUri!)?.toString() ??
+          request.packageConfig
+              .toPackageUriForWorkspace(request.additionalSourceUri!)
+              ?.toString() ??
           toMultiRootPath(
             request.additionalSourceUri!,
             fileSystemScheme,
@@ -898,7 +901,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
           message = fileUri.toString();
         } else {
           message =
-              request.packageConfig.toPackageUri(fileUri)?.toString() ??
+              request.packageConfig.toPackageUriForWorkspace(fileUri)?.toString() ??
               toMultiRootPath(fileUri, fileSystemScheme, fileSystemRoots, _platform.isWindows);
         }
         server.stdin.writeln(message);

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -131,3 +131,38 @@ Future<PackageConfig> loadPackageConfigWithLogging(
   }
   return result;
 }
+
+extension PackageConfigWorkspaceExtension on PackageConfig {
+  /// Converts a [fileUri] to a `package:` URI, finding the most specific
+  /// package whose [Package.packageUriRoot] is a prefix of [fileUri].
+  ///
+  /// The default [PackageConfig.toPackageUri] may match an outer package first
+  /// when pub workspace member packages are located under the workspace root
+  /// package's `lib/` directory.
+  Uri? toPackageUriForWorkspace(Uri fileUri) {
+    if (fileUri.isScheme('package')) {
+      return fileUri;
+    }
+    final path = fileUri.toString();
+    Package? bestMatch;
+    String? bestMatchRoot;
+
+    for (final Package package in packages) {
+      final rootPath = package.packageUriRoot.toString();
+      final rootPathWithSlash = rootPath.endsWith('/') ? rootPath : '$rootPath/';
+      if (path.startsWith(rootPathWithSlash)) {
+        if (bestMatchRoot == null || rootPathWithSlash.length > bestMatchRoot.length) {
+          bestMatch = package;
+          bestMatchRoot = rootPathWithSlash;
+        }
+      }
+    }
+
+    if (bestMatch == null || bestMatchRoot == null) {
+      return null;
+    }
+
+    final String rest = path.substring(bestMatchRoot.length);
+    return Uri(scheme: 'package', path: '${bestMatch.name}/$rest');
+  }
+}

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -26,6 +26,7 @@ import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../dart/language_version.dart';
+import '../dart/package_map.dart';
 import '../devfs.dart';
 import '../device.dart';
 import '../flutter_plugins.dart';
@@ -710,7 +711,7 @@ class ResidentWebRunner extends ResidentRunner {
       // the web_plugin_registrant.dart file alongside the generated main.dart
       const generatedImport = 'web_plugin_registrant.dart';
 
-      Uri? importedEntrypoint = packageConfig!.toPackageUri(mainUri);
+      Uri? importedEntrypoint = packageConfig!.toPackageUriForWorkspace(mainUri);
       // Special handling for entrypoints that are not under lib, such as test scripts.
       if (importedEntrypoint == null) {
         final String parent = _fileSystem.file(mainUri).parent.path;

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -25,6 +25,7 @@ import '../base/platform.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../convert.dart';
+import '../dart/package_map.dart';
 import '../globals.dart' as globals;
 import '../web/bootstrap.dart';
 import '../web/chrome.dart';
@@ -347,7 +348,7 @@ class WebAssetServer implements AssetReader {
                 PackageUriMapper(packageConfig),
                 digestProvider,
                 BuildSettings(
-                  appEntrypoint: packageConfig.toPackageUri(
+                  appEntrypoint: packageConfig.toPackageUriForWorkspace(
                     fileSystem.file(entrypoint).absolute.uri,
                   ),
                   canaryFeatures: canaryFeatures,
@@ -361,7 +362,7 @@ class WebAssetServer implements AssetReader {
                 PackageUriMapper(packageConfig),
                 digestProvider,
                 BuildSettings(
-                  appEntrypoint: packageConfig.toPackageUri(
+                  appEntrypoint: packageConfig.toPackageUriForWorkspace(
                     fileSystem.file(entrypoint).absolute.uri,
                   ),
                   canaryFeatures: canaryFeatures,

--- a/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
@@ -131,6 +131,62 @@ void main() {
     expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
+  testWithoutContext(
+    'incremental compile sends correct package URI for pub workspace member package located under root lib/',
+    () async {
+      final packageConfig = PackageConfig(<Package>[
+        Package(
+          'root',
+          Uri.parse('file:///workspace/'),
+          packageUriRoot: Uri.parse('file:///workspace/lib/'),
+        ),
+        Package(
+          'member',
+          Uri.parse('file:///workspace/lib/member/'),
+          packageUriRoot: Uri.parse('file:///workspace/lib/member/lib/'),
+        ),
+      ]);
+
+      fakeProcessManager.addCommand(
+        FakeCommand(
+          command: const <String>[
+            ...frontendServerCommand,
+            '--initialize-from-dill',
+            expectedCachePath,
+            '--verbosity=error',
+          ],
+          stdout: 'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0',
+          stdin: frontendServerStdIn,
+        ),
+      );
+
+      await generator.recompile(
+        Uri.parse('file:///workspace/lib/main.dart'),
+        null,
+        outputPath: '/build/',
+        packageConfig: packageConfig,
+        fs: MemoryFileSystem(),
+        projectRootPath: '',
+      );
+      expect(frontendServerStdIn.getAndClear(), 'compile package:root/main.dart\n');
+
+      await _accept(generator, frontendServerStdIn, '');
+      await _reject(generatorStdoutHandler, generator, frontendServerStdIn, '', '');
+
+      await _recompile(
+        generatorStdoutHandler,
+        generator,
+        frontendServerStdIn,
+        'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n',
+        mainUri: Uri.parse('file:///workspace/lib/main.dart'),
+        expectedMainUri: 'package:root/main.dart',
+        updatedUris: <Uri>[Uri.parse('file:///workspace/lib/member/lib/foo.dart')],
+        expectedUpdatedUris: <String>['package:member/foo.dart'],
+        packageConfig: packageConfig,
+      );
+    },
+  );
+
   testWithoutContext('incremental compile single dart compile with filesystem scheme', () async {
     fakeProcessManager.addCommand(
       FakeCommand(
@@ -648,6 +704,7 @@ Future<void> _recompile(
   String expectedMainUri = '/path/to/main.dart',
   List<Uri>? updatedUris,
   List<String>? expectedUpdatedUris,
+  PackageConfig? packageConfig,
 }) async {
   mainUri ??= Uri.parse('/path/to/main.dart');
   updatedUris ??= <Uri>[mainUri];
@@ -657,7 +714,7 @@ Future<void> _recompile(
     mainUri,
     updatedUris,
     outputPath: '/build/',
-    packageConfig: PackageConfig.empty,
+    packageConfig: packageConfig ?? PackageConfig.empty,
     suppressErrors: suppressErrors,
     fs: MemoryFileSystem(),
     projectRootPath: '',

--- a/packages/flutter_tools/test/general.shard/dart/package_map_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/package_map_test.dart
@@ -135,4 +135,36 @@ void main() {
       },
     );
   });
+
+  group('PackageConfigWorkspaceExtension', () {
+    testWithoutContext('toPackageUriForWorkspace finds most specific package in pub workspace', () {
+      final packageConfig = PackageConfig(<Package>[
+        Package(
+          'root',
+          Uri.parse('file:///workspace/'),
+          packageUriRoot: Uri.parse('file:///workspace/lib/'),
+        ),
+        Package(
+          'member',
+          Uri.parse('file:///workspace/lib/member/'),
+          packageUriRoot: Uri.parse('file:///workspace/lib/member/lib/'),
+        ),
+      ]);
+
+      expect(
+        packageConfig.toPackageUriForWorkspace(Uri.parse('file:///workspace/lib/foo.dart')),
+        Uri.parse('package:root/foo.dart'),
+      );
+      expect(
+        packageConfig.toPackageUriForWorkspace(
+          Uri.parse('file:///workspace/lib/member/lib/bar.dart'),
+        ),
+        Uri.parse('package:member/bar.dart'),
+      );
+      expect(
+        packageConfig.toPackageUriForWorkspace(Uri.parse('package:member/bar.dart')),
+        Uri.parse('package:member/bar.dart'),
+      );
+    });
+  });
 }


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:

https://github.com/flutter/flutter/issues/190284

### Impact Description:

In Dart/Pub workspaces where member packages are nested under the workspace root package's `lib/` directory, package URI resolution matched the shorter outer root prefix. This produced invalid package URIs that did not match the isolate compilation graph, causing `ResidentCompiler` to report `Reloaded 0 of N libraries` and silently ignore source edits during hot reload.

### Changelog Description:

[flutter/190284] Fix hot reload failing to reload edits in nested Pub workspace member packages located under root lib/.

### Workaround:

Restructure the workspace directory layout to avoid nesting member packages under `lib/`, or restart the app after edits.

### Risk:

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:

  - [x] Yes
  - [ ] No

### Validation Steps:

1. Create a Pub workspace with a member package located under `lib/member_pkg/`.
2. Run `flutter run`, modify a file inside the nested package, and trigger hot reload (`r`).
3. Confirm that edits reload properly and are reflected in the running application.
4. Run `packages/flutter_tools/test/general.shard/compile_incremental_test.dart`.
