### PR TITLE
[stable] [flutter_tools] Validate plugin class/package identifiers to prevent GeneratedPluginRegistrant injection

### DIFF
--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -17,11 +17,41 @@ const kDartPluginClass = 'dartPluginClass';
 /// Constant for 'dartPluginFile' key in plugin maps.
 const kDartFileName = 'dartFileName';
 
+/// Constant for 'fileName' key in plugin maps.
+const kFileName = 'fileName';
+
 /// Constant for 'ffiPlugin' key in plugin maps.
 const kFfiPlugin = 'ffiPlugin';
 
 // Constant for 'defaultPackage' key in plugin maps.
 const kDefaultPackage = 'default_package';
+
+/// Matches a valid native plugin class or dot-separated package identifier.
+///
+/// Plugin `class`/`package` values are interpolated verbatim into the generated
+/// GeneratedPluginRegistrant source files (Java/Kotlin, Swift, Objective-C,
+/// C++). Restricting them to identifier characters prevents a (possibly
+/// transitive) dependency from injecting arbitrary native code into the
+/// consuming app's build via its pubspec plugin declaration.
+final RegExp _pluginIdentifierPattern = RegExp(
+  r'^[a-zA-Z_$][a-zA-Z0-9_$]*(\.[a-zA-Z_$][a-zA-Z0-9_$]*)*$',
+);
+
+/// Whether [value] is a valid native plugin class or dot-separated package
+/// identifier. Callers first confirm the value is a String via the schema type
+/// checks; absent fields are not validated here.
+bool _isValidPluginIdentifier(String value) => _pluginIdentifierPattern.hasMatch(value);
+
+/// Matches a safe relative Dart source path (e.g. `src/foo_web.dart`) ending in
+/// `.dart`. Plugin `fileName`/`dartFileName` values are interpolated into an
+/// `import` in the generated registrant, so they must not contain quotes,
+/// semicolons, whitespace or parent-directory segments.
+final RegExp pluginDartFileNamePattern = RegExp(r'^\w[\w./-]*\.dart$');
+
+/// Whether [value] is a safe relative Dart source path for a plugin. Callers
+/// first confirm the value is a String via the schema type checks.
+bool isValidPluginDartFileName(String value) =>
+    pluginDartFileNamePattern.hasMatch(value) && !value.contains('..');
 
 /// Constant for 'sharedDarwinSource' key in plugin maps.
 /// Can be set for iOS and macOS plugins.
@@ -131,10 +161,34 @@ class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
   bool hasDart() => dartPluginClass != null;
 
   static bool validate(YamlMap yaml) {
-    return (yaml['package'] is String && yaml[kPluginClass] is String) ||
-        yaml[kDartPluginClass] is String ||
+    final Object? package = yaml['package'];
+    final Object? pluginClass = yaml[kPluginClass];
+    final Object? dartPluginClass = yaml[kDartPluginClass];
+
+    final bool hasPluginDeclaration =
+        (package is String && pluginClass is String) ||
+        dartPluginClass is String ||
         yaml[kFfiPlugin] == true ||
         yaml[kDefaultPackage] is String;
+
+    if (!hasPluginDeclaration) {
+      return false;
+    }
+
+    // Validate every identifier that is present, not just the ones that made
+    // the declaration above valid, so a plugin cannot smuggle an unsafe
+    // identifier in alongside an `ffiPlugin` or `default_package` entry.
+    if (package is String && !_isValidPluginIdentifier(package)) {
+      return false;
+    }
+    if (pluginClass is String && !_isValidPluginIdentifier(pluginClass)) {
+      return false;
+    }
+    if (dartPluginClass is String && !_isValidPluginIdentifier(dartPluginClass)) {
+      return false;
+    }
+
+    return true;
   }
 
   static const kConfigKey = 'android';
@@ -288,11 +342,30 @@ class IOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlug
   }
 
   static bool validate(YamlMap yaml) {
-    return yaml[kPluginClass] is String ||
-        yaml[kDartPluginClass] is String ||
+    final Object? pluginClass = yaml[kPluginClass];
+    final Object? dartPluginClass = yaml[kDartPluginClass];
+
+    final bool hasPluginDeclaration =
+        pluginClass is String ||
+        dartPluginClass is String ||
         yaml[kFfiPlugin] == true ||
         yaml[kSharedDarwinSource] == true ||
         yaml[kDefaultPackage] is String;
+
+    if (!hasPluginDeclaration) {
+      return false;
+    }
+
+    // Validate every identifier that is present, not just the ones that made
+    // the declaration above valid.
+    if (pluginClass is String && !_isValidPluginIdentifier(pluginClass)) {
+      return false;
+    }
+    if (dartPluginClass is String && !_isValidPluginIdentifier(dartPluginClass)) {
+      return false;
+    }
+
+    return true;
   }
 
   static const kConfigKey = 'ios';
@@ -381,11 +454,30 @@ class MacOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPl
   }
 
   static bool validate(YamlMap yaml) {
-    return yaml[kPluginClass] is String ||
-        yaml[kDartPluginClass] is String ||
+    final Object? pluginClass = yaml[kPluginClass];
+    final Object? dartPluginClass = yaml[kDartPluginClass];
+
+    final bool hasPluginDeclaration =
+        pluginClass is String ||
+        dartPluginClass is String ||
         yaml[kFfiPlugin] == true ||
         yaml[kSharedDarwinSource] == true ||
         yaml[kDefaultPackage] is String;
+
+    if (!hasPluginDeclaration) {
+      return false;
+    }
+
+    // Validate every identifier that is present, not just the ones that made
+    // the declaration above valid.
+    if (pluginClass is String && !_isValidPluginIdentifier(pluginClass)) {
+      return false;
+    }
+    if (dartPluginClass is String && !_isValidPluginIdentifier(dartPluginClass)) {
+      return false;
+    }
+
+    return true;
   }
 
   static const kConfigKey = 'macos';
@@ -488,10 +580,29 @@ class WindowsPlugin extends PluginPlatform implements NativeOrDartPlugin, Varian
   }
 
   static bool validate(YamlMap yaml) {
-    return yaml[kPluginClass] is String ||
-        yaml[kDartPluginClass] is String ||
+    final Object? pluginClass = yaml[kPluginClass];
+    final Object? dartPluginClass = yaml[kDartPluginClass];
+
+    final bool hasPluginDeclaration =
+        pluginClass is String ||
+        dartPluginClass is String ||
         yaml[kFfiPlugin] == true ||
         yaml[kDefaultPackage] is String;
+
+    if (!hasPluginDeclaration) {
+      return false;
+    }
+
+    // Validate every identifier that is present, not just the ones that made
+    // the declaration above valid.
+    if (pluginClass is String && !_isValidPluginIdentifier(pluginClass)) {
+      return false;
+    }
+    if (dartPluginClass is String && !_isValidPluginIdentifier(dartPluginClass)) {
+      return false;
+    }
+
+    return true;
   }
 
   static const kConfigKey = 'windows';
@@ -575,10 +686,29 @@ class LinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
   }
 
   static bool validate(YamlMap yaml) {
-    return yaml[kPluginClass] is String ||
-        yaml[kDartPluginClass] is String ||
+    final Object? pluginClass = yaml[kPluginClass];
+    final Object? dartPluginClass = yaml[kDartPluginClass];
+
+    final bool hasPluginDeclaration =
+        pluginClass is String ||
+        dartPluginClass is String ||
         yaml[kFfiPlugin] == true ||
         yaml[kDefaultPackage] is String;
+
+    if (!hasPluginDeclaration) {
+      return false;
+    }
+
+    // Validate every identifier that is present, not just the ones that made
+    // the declaration above valid.
+    if (pluginClass is String && !_isValidPluginIdentifier(pluginClass)) {
+      return false;
+    }
+    if (dartPluginClass is String && !_isValidPluginIdentifier(dartPluginClass)) {
+      return false;
+    }
+
+    return true;
   }
 
   static const kConfigKey = 'linux';
@@ -622,19 +752,25 @@ class WebPlugin extends PluginPlatform {
   const WebPlugin({required this.name, required this.pluginClass, required this.fileName});
 
   factory WebPlugin.fromYaml(String name, YamlMap yaml) {
-    if (yaml['pluginClass'] is! String) {
+    final Object? pluginClass = yaml[kPluginClass];
+    if (pluginClass is! String) {
       throwToolExit(
         'The plugin `$name` is missing the required field `pluginClass` in pubspec.yaml',
       );
     }
-    if (yaml['fileName'] is! String) {
+    final Object? fileName = yaml[kFileName];
+    if (fileName is! String) {
       throwToolExit('The plugin `$name` is missing the required field `fileName` in pubspec.yaml');
     }
-    return WebPlugin(
-      name: name,
-      pluginClass: yaml['pluginClass'] as String,
-      fileName: yaml['fileName'] as String,
-    );
+    if (!_isValidPluginIdentifier(pluginClass)) {
+      throwToolExit(
+        'The plugin `$name` has an invalid `pluginClass` in its web plugin declaration.',
+      );
+    }
+    if (!isValidPluginDartFileName(fileName)) {
+      throwToolExit('The plugin `$name` has an invalid `fileName` in its web plugin declaration.');
+    }
+    return WebPlugin(name: name, pluginClass: pluginClass, fileName: fileName);
   }
 
   static const kConfigKey = 'web';

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -389,6 +389,12 @@ class Plugin {
       final dartClass = (platformsYaml[platformKey] as YamlMap)[kDartPluginClass] as String;
       final String dartFileName =
           (platformsYaml[platformKey] as YamlMap)[kDartFileName] as String? ?? '$pluginName.dart';
+      if (!isValidPluginDartFileName(dartFileName)) {
+        throwToolExit(
+          'The plugin `$pluginName` has an invalid `dartFileName` for platform `$platformKey` '
+          'in pubspec.yaml.',
+        );
+      }
       return (dartClass: dartClass, dartFileName: dartFileName);
     }
     return null;

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -2020,6 +2020,81 @@ flutter:
         );
       });
 
+      testUsingContext(
+        'Plugin.fromYaml rejects a plugin class with code-injection characters',
+        () async {
+          // A (possibly transitive) dependency must not be able to smuggle
+          // arbitrary source into the generated GeneratedPluginRegistrant by
+          // declaring a pluginClass that is not a plain identifier.
+          const maliciousYaml = '''
+platforms:
+  macos:
+    pluginClass: "SomePlugin(); evilInjectedCall(); if (false) { SomePlugin"
+''';
+          expect(
+            () => Plugin.fromYaml(
+              'evil_plugin',
+              '',
+              loadYaml(maliciousYaml) as YamlMap,
+              null,
+              const <String>[],
+              fileSystem: globals.fs,
+              isDevDependency: false,
+            ),
+            throwsToolExit(message: 'Invalid plugin specification evil_plugin'),
+          );
+        },
+      );
+
+      testUsingContext(
+        'Plugin.fromYaml rejects a web plugin whose pluginClass/fileName contain injection',
+        () async {
+          const maliciousYaml = '''
+platforms:
+  web:
+    pluginClass: "P; void pwn() {} //"
+    fileName: some_file.dart
+''';
+          expect(
+            () => Plugin.fromYaml(
+              'evil_web_plugin',
+              '',
+              loadYaml(maliciousYaml) as YamlMap,
+              null,
+              const <String>[],
+              fileSystem: globals.fs,
+              isDevDependency: false,
+            ),
+            throwsToolExit(),
+          );
+        },
+      );
+
+      testUsingContext(
+        'Plugin.fromYaml rejects a dartPluginClass with code-injection characters',
+        () async {
+          // A dart plugin class is also interpolated into generated registrant
+          // source, so it must be a plain identifier like the native one.
+          const maliciousYaml = '''
+platforms:
+  android:
+    dartPluginClass: "Evil(); evilInjectedCall(); class Evil"
+''';
+          expect(
+            () => Plugin.fromYaml(
+              'evil_dart_plugin',
+              '',
+              loadYaml(maliciousYaml) as YamlMap,
+              null,
+              const <String>[],
+              fileSystem: globals.fs,
+              isDevDependency: false,
+            ),
+            throwsToolExit(message: 'Invalid plugin specification evil_dart_plugin'),
+          );
+        },
+      );
+
       testUsingContext('createPlatformsYamlMap should create the correct map', () async {
         final YamlMap map = Plugin.createPlatformsYamlMap(
           <String>['ios', 'android', 'linux'],


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:

https://github.com/flutter/flutter/pull/189156

### Impact Description:

Plugin `pluginClass`, `dartPluginClass`, and Android `package` fields are interpolated verbatim into generated `GeneratedPluginRegistrant` native source files (Swift, Objective-C, Java, Kotlin, C++). Previously, validation only checked that these fields were strings, allowing transitive dependencies with malicious or malformed plugin identifiers to inject arbitrary code into `GeneratedPluginRegistrant` during `flutter pub get` or `flutter build`.

### Changelog Description:

[flutter/189156] Validate plugin class and package identifiers to prevent arbitrary code injection into GeneratedPluginRegistrant.

### Workaround:

Inspect transitive dependency `pubspec.yaml` plugin configurations manually.

### Risk:

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:

  - [x] Yes
  - [ ] No

### Validation Steps:

1. Test a plugin declaration containing non-identifier characters in `pluginClass` or `package`.
2. Confirm that the tool rejects the invalid plugin specification.
3. Run `packages/flutter_tools/test/general.shard/plugins_test.dart`.
