### PR TITLE
[WIP] Adds new semantics API

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -13,7 +13,6 @@ library;
 import 'dart:math' as math;
 import 'dart:ui' show lerpDouble;
 
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -1705,37 +1704,63 @@ class _RenderDecoration extends RenderBox
     return false;
   }
 
-  ChildSemanticsConfigurationsResult _childSemanticsConfigurationDelegate(
-    List<SemanticsConfiguration> childConfigs,
-  ) {
-    final builder = ChildSemanticsConfigurationsResultBuilder();
-
-    final mergeGroups = <SemanticsTag, List<SemanticsConfiguration>>{};
-    final tags = <SemanticsTag>{
-      _InputDecoratorState._kPrefixSemanticsTag,
-      _InputDecoratorState._kPrefixIconSemanticsTag,
-      _InputDecoratorState._kSuffixSemanticsTag,
-      _InputDecoratorState._kSuffixIconSemanticsTag,
-    };
-
-    for (final childConfig in childConfigs) {
-      final SemanticsTag? tag = tags.firstWhereOrNull(
-        (SemanticsTag tag) => childConfig.tagsChildrenWith(tag),
-      );
-      if (tag != null) {
-        mergeGroups.putIfAbsent(tag, () => <SemanticsConfiguration>[]).add(childConfig);
-      } else {
-        builder.markAsMergeUp(childConfig);
-      }
-    }
-
-    mergeGroups.values.forEach(builder.markAsSiblingMergeGroup);
-    return builder.build();
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    config.isSemanticBoundary = true;
   }
 
   @override
-  void describeSemanticsConfiguration(SemanticsConfiguration config) {
-    config.childConfigurationsDelegate = _childSemanticsConfigurationDelegate;
+  Iterable<SemanticsNode> assembleSemanticsNodes(
+    SemanticsNode node,
+    SemanticsConfiguration config,
+    Iterable<SemanticsNode> children,
+  ) {
+    SemanticsNode? findNodeTagged(SemanticsTag tag) {
+      for (final n in children) {
+        if (n.isTagged(tag)) {
+          return n;
+        }
+      }
+      return null;
+    }
+
+    SemanticsNode? prefixNode = findNodeTagged(_InputDecoratorState._kPrefixSemanticsTag);
+    final SemanticsNode? prefixIconNode = findNodeTagged(
+      _InputDecoratorState._kPrefixIconSemanticsTag,
+    );
+    if (prefixNode != null && prefixIconNode != null) {
+      prefixNode.mergeWith(prefixIconNode);
+    } else {
+      prefixNode ??= prefixIconNode;
+    }
+
+    SemanticsNode? suffixNode = findNodeTagged(_InputDecoratorState._kSuffixSemanticsTag);
+    final SemanticsNode? suffixIconNode = findNodeTagged(
+      _InputDecoratorState._kSuffixIconSemanticsTag,
+    );
+    if (suffixNode != null && suffixIconNode != null) {
+      suffixNode.mergeWith(suffixIconNode);
+    } else {
+      suffixNode ??= suffixIconNode;
+    }
+
+    final extractedSiblings = <SemanticsNode?>{
+      prefixNode,
+      prefixIconNode,
+      suffixNode,
+      suffixIconNode,
+    };
+    final List<SemanticsNode> fieldChildren = children
+        .where((SemanticsNode n) => !extractedSiblings.contains(n))
+        .toList();
+
+    node.updateWith(config: config, childrenInInversePaintOrder: fieldChildren);
+
+    return <SemanticsNode>[
+      if (prefixNode != null) prefixNode,
+      node,
+      if (suffixNode != null) suffixNode,
+    ];
   }
 }
 
@@ -1829,6 +1854,7 @@ class _AffixText extends StatelessWidget {
           curve: _kTransitionCurve,
           opacity: labelIsFloating ? 1.0 : 0.0,
           child: Semantics(
+            container: true,
             sortKey: semanticsSortKey,
             tagForChildren: semanticsTag,
             child: child ?? (text == null ? null : Text(text!, style: style)),
@@ -2491,6 +2517,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
                       ).merge(iconButtonTheme.style),
                     ),
                     child: Semantics(
+                      container: true,
                       tagForChildren: _kPrefixIconSemanticsTag,
                       child: decoration.prefixIcon,
                     ),
@@ -2531,6 +2558,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
                       ).merge(iconButtonTheme.style),
                     ),
                     child: Semantics(
+                      container: true,
                       tagForChildren: _kSuffixIconSemanticsTag,
                       child: decoration.suffixIcon,
                     ),

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3951,9 +3951,11 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   /// By default, the method will annotate `node` with `config` and add the
   /// `children` to it.
   ///
-  /// Subclasses can override this method to add additional [SemanticsNode]s
-  /// to the tree. If new [SemanticsNode]s are instantiated in this method
-  /// they must be disposed in [clearSemantics].
+  /// Deprecated. Override [assembleSemanticsNodes] instead.
+  @Deprecated(
+    'Override assembleSemanticsNodes instead. '
+    'This feature was deprecated after v3.25.0-0.0.pre.',
+  )
   void assembleSemanticsNode(
     SemanticsNode node,
     SemanticsConfiguration config,
@@ -3961,6 +3963,29 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   ) {
     // TODO(a14n): remove the following cast by updating type of parameter in either updateWith or assembleSemanticsNode
     node.updateWith(config: config, childrenInInversePaintOrder: children as List<SemanticsNode>);
+  }
+
+  /// Assemble the [SemanticsNode]s for this [RenderObject].
+  ///
+  /// If [describeSemanticsConfiguration] sets
+  /// [SemanticsConfiguration.isSemanticBoundary] to true, this method is called
+  /// with the `node` created for this [RenderObject], the `config` to be
+  /// applied to that node and the `children` [SemanticsNode]s that descendants
+  /// of this [RenderObject] have generated.
+  ///
+  /// By default, the method will delegate to [assembleSemanticsNode] and return
+  /// a list containing only `node`.
+  ///
+  /// Subclasses can override this method to emit multiple [SemanticsNode]s
+  /// or interleave them. If new [SemanticsNode]s are instantiated in this method
+  /// they must be disposed in [clearSemantics].
+  Iterable<SemanticsNode> assembleSemanticsNodes(
+    SemanticsNode node,
+    SemanticsConfiguration config,
+    Iterable<SemanticsNode> children,
+  ) {
+    assembleSemanticsNode(node, config, children);
+    return <SemanticsNode>[node];
   }
 
   // EVENTS
@@ -6280,7 +6305,11 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         // Create an inner node to hold the configuration and children, and the cachedSemanticsNode will
         // hold the inner node and the sibling nodes so that all of them can be merged together.
         final innerNode = SemanticsNode(showOnScreen: renderObject.showOnScreen);
-        renderObject.assembleSemanticsNode(innerNode, configProvider.effective, children);
+        final Iterable<SemanticsNode> assembledInner = renderObject.assembleSemanticsNodes(
+          innerNode,
+          configProvider.effective,
+          children,
+        );
 
         final config = SemanticsConfiguration()
           ..isSemanticBoundary = true
@@ -6289,16 +6318,26 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         node.updateWith(
           config: config,
           childrenInInversePaintOrder: <SemanticsNode>[
-            innerNode,
+            ...assembledInner,
             ..._producedSiblingNodesAndOwners.keys,
           ],
         );
+        semanticsNodes.clear();
+        semanticsNodes.add(node);
       } else {
-        renderObject.assembleSemanticsNode(node, configProvider.effective, children);
+        final Iterable<SemanticsNode> assembled = renderObject.assembleSemanticsNodes(
+          node,
+          configProvider.effective,
+          children,
+        );
+        semanticsNodes.clear();
+        semanticsNodes.addAll(assembled);
       }
     } else {
       assert(!configProvider.effective.isMergingSemanticsOfDescendants);
       node.updateWith(config: configProvider.effective, childrenInInversePaintOrder: children);
+      semanticsNodes.clear();
+      semanticsNodes.add(node);
     }
   }
 
@@ -6316,10 +6355,9 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
     _mergeSiblingGroup(usedSemanticsIds);
     _buildSemanticsSubtree(usedSemanticsIds: usedSemanticsIds);
 
-    // At this point, the cachedSemanticsNode should be latest semantics node
-    // representing this render object and _producedSiblingNodesAndOwners contains the latest
-    // sibling nodes.
-    semanticsNodes.add(node);
+    // At this point, semanticsNodes contains the latest semantics nodes
+    // representing this render object, and _producedSiblingNodesAndOwners contains the latest
+    // sibling nodes from delegates.
     if (!_needsMergingSiblingNodesIntoSelf) {
       semanticsNodes.addAll(_producedSiblingNodesAndOwners.keys);
     }

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -110,11 +110,13 @@ typedef SemanticsUpdateCallback = void Function(SemanticsUpdate update);
 /// The return value is the arrangement of these configs, including which
 /// configs continue to merge upward and which configs form sibling merge group.
 ///
-/// Use [ChildSemanticsConfigurationsResultBuilder] to generate the return
-/// value.
-typedef ChildSemanticsConfigurationsDelegate = ChildSemanticsConfigurationsResult Function(
-  List<SemanticsConfiguration>,
-);
+/// Deprecated. Use [RenderObject.assembleSemanticsNodes] instead.
+@Deprecated(
+  'Use RenderObject.assembleSemanticsNodes instead. '
+  'This feature was deprecated after v3.25.0-0.0.pre.',
+)
+typedef ChildSemanticsConfigurationsDelegate =
+    ChildSemanticsConfigurationsResult Function(List<SemanticsConfiguration>);
 
 /// Controls how accessibility focus is blocked.
 ///
@@ -632,8 +634,16 @@ class SemanticsTag {
 /// [SemanticsConfiguration.childConfigurationsDelegate] to decide how semantics nodes
 /// should form.
 ///
-/// Use [ChildSemanticsConfigurationsResultBuilder] to build the result.
+/// Deprecated. Use [RenderObject.assembleSemanticsNodes] instead.
+@Deprecated(
+  'Use RenderObject.assembleSemanticsNodes instead. '
+  'This feature was deprecated after v3.25.0-0.0.pre.',
+)
 class ChildSemanticsConfigurationsResult {
+  @Deprecated(
+    'Use RenderObject.assembleSemanticsNodes instead. '
+    'This feature was deprecated after v3.25.0-0.0.pre.',
+  )
   ChildSemanticsConfigurationsResult._(this.mergeUp, this.siblingMergeGroups);
 
   /// Returns the [SemanticsConfiguration]s that are supposed to be merged into
@@ -668,8 +678,18 @@ class ChildSemanticsConfigurationsResult {
 /// [markAsSiblingMergeGroup] to annotate the arrangement of
 /// [SemanticsConfiguration]s. Once all the configs are annotated, use [build]
 /// to generate the [ChildSemanticsConfigurationsResult].
+///
+/// Deprecated. Use [RenderObject.assembleSemanticsNodes] instead.
+@Deprecated(
+  'Use RenderObject.assembleSemanticsNodes instead. '
+  'This feature was deprecated after v3.25.0-0.0.pre.',
+)
 class ChildSemanticsConfigurationsResultBuilder {
   /// Creates a [ChildSemanticsConfigurationsResultBuilder].
+  @Deprecated(
+    'Use RenderObject.assembleSemanticsNodes instead. '
+    'This feature was deprecated after v3.25.0-0.0.pre.',
+  )
   ChildSemanticsConfigurationsResultBuilder();
 
   final List<SemanticsConfiguration> _mergeUp = <SemanticsConfiguration>[];
@@ -3828,6 +3848,28 @@ class SemanticsNode with DiagnosticableTreeMixin {
     );
   }
 
+  /// Merges [other] into this semantics node.
+  ///
+  /// Combines bounding rectangles, flags, strings, actions, and child nodes
+  /// from [other] into this node.
+  void mergeWith(SemanticsNode other) {
+    rect = rect.expandToInclude(other.rect);
+
+    final combinedConfig = SemanticsConfiguration.fromSemanticsNode(this)
+      ..absorb(SemanticsConfiguration.fromSemanticsNode(other));
+
+    combinedConfig._actions
+      ..addAll(_actions)
+      ..addAll(other._actions);
+    combinedConfig._customSemanticsActions
+      ..addAll(_customSemanticsActions)
+      ..addAll(other._customSemanticsActions);
+
+    final mergedChildren = <SemanticsNode>[...?_children, ...?other._children];
+
+    updateWith(config: combinedConfig, childrenInInversePaintOrder: mergedChildren);
+  }
+
   /// Returns a summary of the semantics for this node.
   ///
   /// If this node has [mergeAllDescendantsIntoThisNode], then the returned data
@@ -5263,6 +5305,54 @@ class SemanticsOwner extends ChangeNotifier {
 /// The information provided in the configuration is used to generate the
 /// semantics tree.
 class SemanticsConfiguration {
+  /// Creates an empty semantics configuration.
+  SemanticsConfiguration();
+
+  /// Creates a [SemanticsConfiguration] from a [SemanticsNode].
+  factory SemanticsConfiguration.fromSemanticsNode(SemanticsNode node) {
+    return SemanticsConfiguration()
+      .._identifier = node._identifier
+      .._traversalParentIdentifier = node._traversalParentIdentifier
+      .._traversalChildIdentifier = node._traversalChildIdentifier
+      .._attributedLabel = node._attributedLabel
+      .._attributedValue = node._attributedValue
+      .._attributedIncreasedValue = node._attributedIncreasedValue
+      .._attributedDecreasedValue = node._attributedDecreasedValue
+      .._attributedHint = node._attributedHint
+      .._tooltip = node._tooltip
+      .._hintOverrides = node._hintOverrides
+      .._flags = node._flags
+      .._textDirection = node._textDirection
+      .._sortKey = node._sortKey
+      .._actions.addAll(node._actions)
+      .._customSemanticsActions.addAll(node._customSemanticsActions)
+      .._actionsAsBits = node._actionsAsBits
+      .._textSelection = node._textSelection
+      ..isMultiline = node._isMultiline ?? false
+      .._scrollPosition = node._scrollPosition
+      .._scrollExtentMax = node._scrollExtentMax
+      .._scrollExtentMin = node._scrollExtentMin
+      .._isMergingSemanticsOfDescendants = node._mergeAllDescendantsIntoThisNode
+      ..scrollChildCount = node._scrollChildCount
+      ..scrollIndex = node._scrollIndex
+      ..indexInParent = node.indexInParent
+      .._platformViewId = node._platformViewId
+      .._maxValueLength = node._maxValueLength
+      .._currentValueLength = node._currentValueLength
+      .._headingLevel = node._headingLevel
+      .._linkUrl = node._linkUrl
+      .._role = node._role
+      .._controlsNodes = node._controlsNodes
+      .._validationResult = node._validationResult
+      .._hitTestBehavior = node._hitTestBehavior
+      .._inputType = node._inputType
+      ..locale = node._locale
+      .._minValue = node._minValue
+      .._maxValue = node._maxValue
+      .._tagsForChildren = node.tags == null ? null : Set<SemanticsTag>.of(node.tags!)
+      .._hasBeenAnnotated = true;
+  }
+
   // SEMANTIC BOUNDARY BEHAVIOR
 
   /// Whether the [RenderObject] owner of this configuration wants to own its
@@ -5840,9 +5930,19 @@ class SemanticsConfiguration {
   /// The input list of [SemanticsConfiguration]s can be empty if the rendering
   /// object of this semantics configuration is a leaf node or child rendering
   /// objects do not contribute to the semantics.
+  /// Deprecated. Override [RenderObject.assembleSemanticsNodes] instead.
+  @Deprecated(
+    'Override RenderObject.assembleSemanticsNodes instead. '
+    'This feature was deprecated after v3.25.0-0.0.pre.',
+  )
   ChildSemanticsConfigurationsDelegate? get childConfigurationsDelegate =>
       _childConfigurationsDelegate;
   ChildSemanticsConfigurationsDelegate? _childConfigurationsDelegate;
+
+  @Deprecated(
+    'Override RenderObject.assembleSemanticsNodes instead. '
+    'This feature was deprecated after v3.25.0-0.0.pre.',
+  )
   set childConfigurationsDelegate(ChildSemanticsConfigurationsDelegate? value) {
     assert(value != null);
     _childConfigurationsDelegate = value;
@@ -6742,6 +6842,12 @@ class SemanticsConfiguration {
 
   /// Whether this configuration will tag the child semantics nodes with a
   /// given [SemanticsTag].
+  ///
+  /// Deprecated. Check [SemanticsNode.isTagged] in [RenderObject.assembleSemanticsNodes] instead.
+  @Deprecated(
+    'Check SemanticsNode.isTagged in RenderObject.assembleSemanticsNodes instead. '
+    'This feature was deprecated after v3.25.0-0.0.pre.',
+  )
   bool tagsChildrenWith(SemanticsTag tag) => _tagsForChildren?.contains(tag) ?? false;
 
   Set<SemanticsTag>? _tagsForChildren;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
