### PR TITLE
Fix RangeError in PredictiveBackEvent when Android sends EDGE_NONE

### DIFF
--- a/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
+++ b/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
@@ -459,7 +459,7 @@ class _PredictiveBackSharedElementPageTransitionState
         begin: switch (widget.currentBackEvent?.swipeEdge) {
           SwipeEdge.left => Offset(xShift, _getYShiftPosition(screenSize.height)),
           SwipeEdge.right => Offset(-xShift, _getYShiftPosition(screenSize.height)),
-          null => Offset(xShift, _getYShiftPosition(screenSize.height)),
+          SwipeEdge.none || null => Offset(xShift, _getYShiftPosition(screenSize.height)),
         },
         end: Offset.zero,
       ),

--- a/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
+++ b/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
@@ -459,7 +459,7 @@ class _PredictiveBackSharedElementPageTransitionState
         begin: switch (widget.currentBackEvent?.swipeEdge) {
           SwipeEdge.left => Offset(xShift, _getYShiftPosition(screenSize.height)),
           SwipeEdge.right => Offset(-xShift, _getYShiftPosition(screenSize.height)),
-          SwipeEdge.none || null => Offset(xShift, _getYShiftPosition(screenSize.height)),
+          null => Offset(xShift, _getYShiftPosition(screenSize.height)),
         },
         end: Offset.zero,
       ),

--- a/packages/flutter/lib/src/services/predictive_back_event.dart
+++ b/packages/flutter/lib/src/services/predictive_back_event.dart
@@ -16,6 +16,14 @@ enum SwipeEdge {
 
   /// Indicates that the swipe gesture starts from the right edge of the screen.
   right,
+
+  /// Indicates that there was no swipe edge at all.
+  ///
+  /// This corresponds to Android's `BackEvent.EDGE_NONE` and is used when
+  /// the back gesture is triggered by a button press rather than a swipe.
+  ///
+  /// See also: https://developer.android.com/reference/android/window/BackEvent#EDGE_NONE
+  none,
 }
 
 /// Object used to report back gesture progress in Android.
@@ -40,7 +48,11 @@ final class PredictiveBackEvent {
           ? null
           : Offset((touchOffset[0]! as num).toDouble(), (touchOffset[1]! as num).toDouble()),
       progress: (map['progress']! as num).toDouble(),
-      swipeEdge: SwipeEdge.values[map['swipeEdge']! as int],
+      swipeEdge: switch (map['swipeEdge']) {
+        0 => SwipeEdge.left,
+        1 => SwipeEdge.right,
+        2 || _ => SwipeEdge.none,
+      },
     );
   }
 
@@ -50,6 +62,15 @@ final class PredictiveBackEvent {
   /// This represents the touch location that initiates or interacts with the
   /// back gesture. When `null`, it indicates the gesture was not started by a
   /// touch event, such as a back button press in devices with hardware buttons.
+  ///
+  /// The Android `BackEvent` API (`BackEvent.getTouchX()` and
+  /// `BackEvent.getTouchY()`) specifies that these values return `NaN` for
+  /// button-triggered events. The engine maps those `NaN` values to `null`
+  /// here.
+  ///
+  /// See also:
+  ///
+  ///  * https://developer.android.com/reference/android/window/BackEvent#getTouchX()
   final Offset? touchOffset;
 
   /// Returns a value between 0.0 and 1.0 representing how far along the back
@@ -86,7 +107,9 @@ final class PredictiveBackEvent {
       // back button is pressed, but in practice it seems to return 0.0, hence
       // the check for Offset.zero here. This was tested directly in the engine
       // on Android emulator running API 34.
-      touchOffset == null || (progress == 0.0 && touchOffset == Offset.zero);
+      swipeEdge == SwipeEdge.none ||
+      touchOffset == null ||
+      (progress == 0.0 && touchOffset == Offset.zero);
 
   @override
   bool operator ==(Object other) {

--- a/packages/flutter/lib/src/services/predictive_back_event.dart
+++ b/packages/flutter/lib/src/services/predictive_back_event.dart
@@ -16,14 +16,6 @@ enum SwipeEdge {
 
   /// Indicates that the swipe gesture starts from the right edge of the screen.
   right,
-
-  /// Indicates that there was no swipe edge at all.
-  ///
-  /// This corresponds to Android's `BackEvent.EDGE_NONE` and is used when
-  /// the back gesture is triggered by a button press rather than a swipe.
-  ///
-  /// See also: https://developer.android.com/reference/android/window/BackEvent#EDGE_NONE
-  none,
 }
 
 /// Object used to report back gesture progress in Android.
@@ -48,10 +40,12 @@ final class PredictiveBackEvent {
           ? null
           : Offset((touchOffset[0]! as num).toDouble(), (touchOffset[1]! as num).toDouble()),
       progress: (map['progress']! as num).toDouble(),
-      swipeEdge: switch (map['swipeEdge']) {
+      swipeEdge: switch (map['swipeEdge']! as int) {
         0 => SwipeEdge.left,
         1 => SwipeEdge.right,
-        2 || _ => SwipeEdge.none,
+        // Android BackEvent.EDGE_NONE is 2. Unknown values (including
+        // EDGE_NONE) fall back to left so fromMap never throws a RangeError.
+        _ => SwipeEdge.left,
       },
     );
   }
@@ -95,6 +89,10 @@ final class PredictiveBackEvent {
   final double progress;
 
   /// The screen edge from which the swipe gesture starts.
+  ///
+  /// Android's `BackEvent.EDGE_NONE` (value 2) and any unknown platform value
+  /// are mapped to [SwipeEdge.left] so that [PredictiveBackEvent.fromMap] does
+  /// not throw. Button-triggered events are identified by [isButtonEvent].
   final SwipeEdge swipeEdge;
 
   /// Indicates if the event was triggered by a system back button press.
@@ -107,9 +105,7 @@ final class PredictiveBackEvent {
       // back button is pressed, but in practice it seems to return 0.0, hence
       // the check for Offset.zero here. This was tested directly in the engine
       // on Android emulator running API 34.
-      swipeEdge == SwipeEdge.none ||
-      touchOffset == null ||
-      (progress == 0.0 && touchOffset == Offset.zero);
+      touchOffset == null || (progress == 0.0 && touchOffset == Offset.zero);
 
   @override
   bool operator ==(Object other) {

--- a/packages/flutter/test/services/predictive_back_event_test.dart
+++ b/packages/flutter/test/services/predictive_back_event_test.dart
@@ -44,7 +44,7 @@ void main() {
     expect(event.isButtonEvent, isTrue);
   });
 
-  test('fromMap throws when given invalid progress', () async {
+  test('fromMap throws when given progress above 1.0', () async {
     expect(
       () => PredictiveBackEvent.fromMap(const <String?, Object?>{
         'touchOffset': <double>[0.0, 100.0],
@@ -55,15 +55,44 @@ void main() {
     );
   });
 
-  test('fromMap throws when given invalid swipeEdge', () async {
+  test('fromMap throws when given progress below 0.0', () async {
     expect(
       () => PredictiveBackEvent.fromMap(const <String?, Object?>{
         'touchOffset': <double>[0.0, 100.0],
-        'progress': 0.0,
-        'swipeEdge': 2,
+        'progress': -0.1,
+        'swipeEdge': 1,
       }),
-      throwsRangeError,
+      throwsAssertionError,
     );
+  });
+
+  test('fromMap maps swipeEdge 2 (EDGE_NONE) to SwipeEdge.none', () async {
+    // Android's BackEvent.EDGE_NONE has value 2, and is sent when the back
+    // gesture is triggered by a button press rather than a swipe gesture.
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.0,
+      'swipeEdge': 2,
+    });
+    expect(event.swipeEdge, SwipeEdge.none);
+  });
+
+  test('fromMap maps negative swipeEdge to SwipeEdge.none', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.0,
+      'swipeEdge': -1,
+    });
+    expect(event.swipeEdge, SwipeEdge.none);
+  });
+
+  test('fromMap maps large swipeEdge index to SwipeEdge.none', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.0,
+      'swipeEdge': 99,
+    });
+    expect(event.swipeEdge, SwipeEdge.none);
   });
 
   test('equality when created with the same parameters', () async {
@@ -96,5 +125,116 @@ void main() {
     expect(eventA, isNot(equals(eventB)));
     expect(eventA.hashCode, isNot(equals(eventB.hashCode)));
     expect(eventA.toString(), isNot(equals(eventB.toString())));
+  });
+
+  test('isButtonEvent detection', () async {
+    // Case 1: SwipeEdge.none always indicates a button event
+    final event1 = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 0.0],
+      'progress': 0.0,
+      'swipeEdge': 2,
+    });
+    expect(event1.isButtonEvent, isTrue);
+
+    // Case 2: touchOffset is null
+    final event2 = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': null,
+      'progress': 0.0,
+      'swipeEdge': 0,
+    });
+    expect(event2.isButtonEvent, isTrue);
+
+    // Case 3: touchOffset is Offset.zero and progress is 0.0
+    final event3 = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 0.0],
+      'progress': 0.0,
+      'swipeEdge': 0,
+    });
+    expect(event3.isButtonEvent, isTrue);
+
+    // Case 4: Actual swipe gesture — non-zero offset and non-zero progress
+    final event4 = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[100.0, 100.0],
+      'progress': 0.5,
+      'swipeEdge': 0,
+    });
+    expect(event4.isButtonEvent, isFalse);
+
+    // Case 5: Offset.zero but progress is non-zero — not a button event
+    final event5 = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 0.0],
+      'progress': 0.5,
+      'swipeEdge': 0,
+    });
+    expect(event5.isButtonEvent, isFalse);
+
+    // Case 6: Non-zero offset but progress is 0.0 — not a button event
+    final event6 = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[50.0, 50.0],
+      'progress': 0.0,
+      'swipeEdge': 0,
+    });
+    expect(event6.isButtonEvent, isFalse);
+  });
+
+  test('equality with identical object', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.5,
+      'swipeEdge': 0,
+    });
+    // ignore: unrelated_type_equality_checks
+    expect(event == event, isTrue);
+  });
+
+  test('inequality with different runtimeType', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.5,
+      'swipeEdge': 0,
+    });
+    // ignore: unrelated_type_equality_checks
+    expect(event == 'not an event', isFalse);
+  });
+
+  test('inequality when progress differs', () async {
+    final eventA = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.0,
+      'swipeEdge': 0,
+    });
+    final eventB = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.5,
+      'swipeEdge': 0,
+    });
+    expect(eventA, isNot(equals(eventB)));
+    expect(eventA.hashCode, isNot(equals(eventB.hashCode)));
+  });
+
+  test('inequality when swipeEdge differs', () async {
+    final eventA = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.5,
+      'swipeEdge': 0,
+    });
+    final eventB = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[0.0, 100.0],
+      'progress': 0.5,
+      'swipeEdge': 1,
+    });
+    expect(eventA, isNot(equals(eventB)));
+    expect(eventA.hashCode, isNot(equals(eventB.hashCode)));
+  });
+
+  test('fromMap maps SwipeEdge.none and verifies SwipeEdge.none isButtonEvent', () async {
+    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
+      'touchOffset': <double>[50.0, 50.0],
+      'progress': 0.5,
+      'swipeEdge': 2,
+    });
+    expect(event.swipeEdge, SwipeEdge.none);
+    // SwipeEdge.none always means button event, even with non-zero offset/progress
+    expect(event.isButtonEvent, isTrue);
   });
 }

--- a/packages/flutter/test/services/predictive_back_event_test.dart
+++ b/packages/flutter/test/services/predictive_back_event_test.dart
@@ -66,33 +66,35 @@ void main() {
     );
   });
 
-  test('fromMap maps swipeEdge 2 (EDGE_NONE) to SwipeEdge.none', () async {
-    // Android's BackEvent.EDGE_NONE has value 2, and is sent when the back
-    // gesture is triggered by a button press rather than a swipe gesture.
+  test('fromMap maps swipeEdge 2 (EDGE_NONE) without throwing', () async {
+    // Android's BackEvent.EDGE_NONE has value 2. Mapping it to an existing
+    // enum value avoids a RangeError; button events are detected via
+    // isButtonEvent (null or zero touchOffset).
     final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
-      'touchOffset': <double>[0.0, 100.0],
+      'touchOffset': <double>[0.0, 0.0],
       'progress': 0.0,
       'swipeEdge': 2,
     });
-    expect(event.swipeEdge, SwipeEdge.none);
+    expect(event.swipeEdge, SwipeEdge.left);
+    expect(event.isButtonEvent, isTrue);
   });
 
-  test('fromMap maps negative swipeEdge to SwipeEdge.none', () async {
+  test('fromMap maps negative swipeEdge without throwing', () async {
     final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
       'touchOffset': <double>[0.0, 100.0],
       'progress': 0.0,
       'swipeEdge': -1,
     });
-    expect(event.swipeEdge, SwipeEdge.none);
+    expect(event.swipeEdge, SwipeEdge.left);
   });
 
-  test('fromMap maps large swipeEdge index to SwipeEdge.none', () async {
+  test('fromMap maps large swipeEdge index without throwing', () async {
     final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
       'touchOffset': <double>[0.0, 100.0],
       'progress': 0.0,
       'swipeEdge': 99,
     });
-    expect(event.swipeEdge, SwipeEdge.none);
+    expect(event.swipeEdge, SwipeEdge.left);
   });
 
   test('equality when created with the same parameters', () async {
@@ -128,7 +130,8 @@ void main() {
   });
 
   test('isButtonEvent detection', () async {
-    // Case 1: SwipeEdge.none always indicates a button event
+    // Case 1: Android EDGE_NONE (swipeEdge 2) with zero offset — the crash
+    // payload from https://github.com/flutter/flutter/issues/186168.
     final event1 = PredictiveBackEvent.fromMap(const <String?, Object?>{
       'touchOffset': <double>[0.0, 0.0],
       'progress': 0.0,
@@ -225,16 +228,5 @@ void main() {
     });
     expect(eventA, isNot(equals(eventB)));
     expect(eventA.hashCode, isNot(equals(eventB.hashCode)));
-  });
-
-  test('fromMap maps SwipeEdge.none and verifies SwipeEdge.none isButtonEvent', () async {
-    final event = PredictiveBackEvent.fromMap(const <String?, Object?>{
-      'touchOffset': <double>[50.0, 50.0],
-      'progress': 0.5,
-      'swipeEdge': 2,
-    });
-    expect(event.swipeEdge, SwipeEdge.none);
-    // SwipeEdge.none always means button event, even with non-zero offset/progress
-    expect(event.isButtonEvent, isTrue);
   });
 }


### PR DESCRIPTION
This is the **framework/services-only** split of https://github.com/flutter/flutter/pull/185140, per [Piinks' decoupling guidance](https://github.com/flutter/flutter/pull/185140#issuecomment-4874037032) and the Material/Cupertino freeze in this repository ([#188444](https://github.com/flutter/flutter/issues/188444)).

On some Android 14+ devices, the platform sends `swipeEdge: 2` (`BackEvent.EDGE_NONE`) for button-triggered predictive back events. `PredictiveBackEvent.fromMap` previously indexed `SwipeEdge.values[2]`, which threw a `RangeError` because the enum only has `left` and `right`.

This PR:

- Maps platform `swipeEdge` values explicitly (`0` → left, `1` → right, `2` and unknown → left) so `fromMap` never throws
- Leaves `SwipeEdge` unchanged (no new `none` value), because adding an enum case would require an exhaustive-switch update in frozen Material code
- Continues to treat button events via `isButtonEvent` (`touchOffset == null` or `Offset.zero` with zero progress), which matches the crash payload from the issue

Material widget tests and transition behavior for `EDGE_NONE` belong in `material_ui` in flutter/packages. A dedicated `SwipeEdge.none` value can be added later if Material is no longer frozen here, or ported with that follow-up.

Fixes https://github.com/flutter/flutter/issues/186168

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.