### PR TITLE
Expose skipTraversal in FocusableActionDetector

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1177,6 +1177,7 @@ class FocusableActionDetector extends StatefulWidget {
     this.autofocus = false,
     this.descendantsAreFocusable = true,
     this.descendantsAreTraversable = true,
+    this.skipTraversal,
     this.shortcuts,
     this.actions,
     this.onShowFocusHighlight,
@@ -1207,6 +1208,9 @@ class FocusableActionDetector extends StatefulWidget {
 
   /// {@macro flutter.widgets.Focus.descendantsAreTraversable}
   final bool descendantsAreTraversable;
+
+  /// {@macro flutter.widgets.Focus.skipTraversal}
+  final bool? skipTraversal;
 
   /// {@macro flutter.widgets.actions.actions}
   final Map<Type, Action<Intent>>? actions;
@@ -1394,6 +1398,7 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
         autofocus: widget.autofocus,
         descendantsAreFocusable: widget.descendantsAreFocusable,
         descendantsAreTraversable: widget.descendantsAreTraversable,
+        skipTraversal: widget.skipTraversal,
         canRequestFocus: _canRequestFocus,
         onFocusChange: _handleFocusChange,
         includeSemantics: widget.includeFocusSemantics,

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -289,6 +289,7 @@ class Focus extends StatefulWidget {
   bool get canRequestFocus => _canRequestFocus ?? focusNode?.canRequestFocus ?? true;
   final bool? _canRequestFocus;
 
+  /// {@template flutter.widgets.Focus.skipTraversal}
   /// Sets the [FocusNode.skipTraversal] flag on the focus node so that it won't
   /// be visited by the [FocusTraversalPolicy].
   ///
@@ -298,6 +299,7 @@ class Focus extends StatefulWidget {
   /// This is different from [FocusNode.canRequestFocus] because it only implies
   /// that the widget can't be reached via traversal, not that it can't be
   /// focused. It may still be focused explicitly.
+  /// {@endtemplate}
   bool get skipTraversal => _skipTraversal ?? focusNode?.skipTraversal ?? false;
   final bool? _skipTraversal;
 

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -1007,6 +1007,61 @@ void main() {
       expect(innerFocus().skipTraversal, isTrue);
     });
 
+    testWidgets('FocusableActionDetector can be skipped by focus traversal', (
+      WidgetTester tester,
+    ) async {
+      final buttonNode1 = FocusNode(debugLabel: 'Button Node 1');
+      final detectorNode = FocusNode(debugLabel: 'Detector Node');
+      final buttonNode2 = FocusNode(debugLabel: 'Button Node 2');
+
+      addTearDown(() {
+        buttonNode1.dispose();
+        detectorNode.dispose();
+        buttonNode2.dispose();
+      });
+
+      Widget build({bool? skipTraversal}) {
+        return TestWidgetsApp(
+          home: Column(
+            children: <Widget>[
+              TestButton(onPressed: () {}, focusNode: buttonNode1, child: const Text('Node 1')),
+              FocusableActionDetector(
+                focusNode: detectorNode,
+                skipTraversal: skipTraversal,
+                child: const Text('Detector'),
+              ),
+              TestButton(onPressed: () {}, focusNode: buttonNode2, child: const Text('Node 2')),
+            ],
+          ),
+        );
+      }
+
+      // By default the detector takes part in traversal.
+      await tester.pumpWidget(build());
+      buttonNode1.requestFocus();
+      await tester.pump();
+      primaryFocus!.nextFocus();
+      await tester.pump();
+      expect(detectorNode.hasFocus, isTrue);
+      expect(buttonNode2.hasFocus, isFalse);
+
+      // With skipTraversal, traversal moves straight past it to the next node.
+      await tester.pumpWidget(build(skipTraversal: true));
+      buttonNode1.requestFocus();
+      await tester.pump();
+      primaryFocus!.nextFocus();
+      await tester.pump();
+      expect(detectorNode.hasFocus, isFalse);
+      expect(buttonNode2.hasFocus, isTrue);
+
+      // Skipping traversal does not make it unfocusable: it can still be
+      // focused explicitly, which is the whole point of skipTraversal over
+      // canRequestFocus.
+      detectorNode.requestFocus();
+      await tester.pump();
+      expect(detectorNode.hasFocus, isTrue);
+    });
+
     testWidgets('FocusableActionDetector can exclude Focus semantics', (WidgetTester tester) async {
       await tester.pumpWidget(
         TestWidgetsApp(

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -987,6 +987,26 @@ void main() {
       expect(buttonNode2.hasFocus, isFalse);
     });
 
+    testWidgets('FocusableActionDetector forwards skipTraversal to Focus', (
+      WidgetTester tester,
+    ) async {
+      Focus innerFocus() => tester.widget<Focus>(
+        find
+            .descendant(of: find.byType(FocusableActionDetector), matching: find.byType(Focus))
+            .first,
+      );
+
+      await tester.pumpWidget(
+        const TestWidgetsApp(home: FocusableActionDetector(child: Text('a'))),
+      );
+      expect(innerFocus().skipTraversal, isFalse);
+
+      await tester.pumpWidget(
+        const TestWidgetsApp(home: FocusableActionDetector(skipTraversal: true, child: Text('a'))),
+      );
+      expect(innerFocus().skipTraversal, isTrue);
+    });
+
     testWidgets('FocusableActionDetector can exclude Focus semantics', (WidgetTester tester) async {
       await tester.pumpWidget(
         TestWidgetsApp(


### PR DESCRIPTION
`FocusableActionDetector` wraps a `Focus` widget internally and forwards `focusNode`, `autofocus`, `descendantsAreFocusable`, and `descendantsAreTraversable`, but not `skipTraversal`. That leaves no way to keep a `FocusableActionDetector` in the focus chain for key events while excluding it from focus traversal, even though the inner `Focus` already supports exactly that.

This adds a `skipTraversal` parameter to `FocusableActionDetector` and passes it straight through to the inner `Focus`. It is typed `bool?` to match `Focus.skipTraversal`, so the default of `null` keeps the current behavior and `Focus` still resolves it to `false` unless a focus node overrides it. The `skipTraversal` documentation on `Focus` is pulled into a `{@template flutter.widgets.Focus.skipTraversal}` block so `FocusableActionDetector` can reuse it with `{@macro}`, the same convention already used for `descendantsAreFocusable` and `descendantsAreTraversable`.

This revives #187356, which picked up an LGTM before it was auto closed after 21 days without a reply. That earlier PR also bundled some unrelated private named parameter changes that drew review comments, so this version is trimmed down to just the `skipTraversal` forwarding plus its test.

Fixes #187093

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
