### PR TITLE
[Android] Fix respecting`--enable-software-rendering` in the embedding

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
@@ -349,7 +349,9 @@ import java.util.Set;
           "If you are attempting to set --enable-software-rendering via Intent extras to launch a Flutter component outside of using the Flutter CLI, note that support for setting engine flags on Android via Intents in release mode will soon be dropped; see https://github.com/flutter/flutter/issues/172553 for more information on this breaking change. To migrate, set the "
               + FlutterEngineFlags.ENABLE_SOFTWARE_RENDERING.metadataKey
               + " metadata in the application manifest. See https://github.com/flutter/flutter/blob/main/docs/engine/Flutter-Android-Engine-Flags.md for more info.");
-    } else {
+    }
+
+    if (!useSoftwareRendering) {
       // Check manifest for software rendering configuration.
       useSoftwareRendering = flutterLoader.getSofwareRenderingEnabledViaManifest();
     }

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
@@ -145,7 +145,7 @@ public class FlutterEngineConnectionRegistryTest {
   }
 
   @Test
-  public void attachToActivityConfiguresSoftwareRendering() {
+  public void attachToActivityConfiguresSoftwareRenderingViaManifest() {
     Context context = mock(Context.class);
     FlutterEngine flutterEngine = mock(FlutterEngine.class);
     PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
@@ -171,6 +171,70 @@ public class FlutterEngineConnectionRegistryTest {
     registry.attachToActivity(appComponent, lifecycle);
 
     verify(platformViewsController).setSoftwareRendering(true);
+  }
+
+  @Test
+  public void attachToActivityConfiguresSoftwareRenderingViaIntent() {
+    Context context = mock(Context.class);
+    FlutterEngine flutterEngine = mock(FlutterEngine.class);
+    PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
+    FlutterLoader flutterLoader = mock(FlutterLoader.class);
+    ExclusiveAppComponent<Activity> appComponent = mock(ExclusiveAppComponent.class);
+    Activity activity = mock(Activity.class);
+    Lifecycle lifecycle = mock(Lifecycle.class);
+
+    when(flutterEngine.getPlatformViewsController()).thenReturn(platformViewsController);
+    PlatformViewsControllerDelegator platformViewsControllerDelegator =
+        mock(PlatformViewsControllerDelegator.class);
+    when(flutterEngine.getPlatformViewsControllerDelegator())
+        .thenReturn(platformViewsControllerDelegator);
+    when(flutterEngine.getDartExecutor()).thenReturn(mock(DartExecutor.class));
+    when(flutterEngine.getRenderer()).thenReturn(mock(FlutterRenderer.class));
+    FlutterEngineConnectionRegistry registry =
+        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader, null);
+
+    when(flutterLoader.getSofwareRenderingEnabledViaManifest()).thenReturn(false);
+    when(appComponent.getAppComponent()).thenReturn(activity);
+    Intent intent = mock(Intent.class);
+    when(intent.getBooleanExtra(FlutterShellArgs.ARG_KEY_ENABLE_SOFTWARE_RENDERING, false))
+        .thenReturn(true);
+    when(activity.getIntent()).thenReturn(intent);
+
+    registry.attachToActivity(appComponent, lifecycle);
+
+    verify(platformViewsController).setSoftwareRendering(true);
+  }
+
+  @Test
+  public void attachToActivityDisablesSoftwareRendering() {
+    Context context = mock(Context.class);
+    FlutterEngine flutterEngine = mock(FlutterEngine.class);
+    PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
+    FlutterLoader flutterLoader = mock(FlutterLoader.class);
+    ExclusiveAppComponent<Activity> appComponent = mock(ExclusiveAppComponent.class);
+    Activity activity = mock(Activity.class);
+    Lifecycle lifecycle = mock(Lifecycle.class);
+
+    when(flutterEngine.getPlatformViewsController()).thenReturn(platformViewsController);
+    PlatformViewsControllerDelegator platformViewsControllerDelegator =
+        mock(PlatformViewsControllerDelegator.class);
+    when(flutterEngine.getPlatformViewsControllerDelegator())
+        .thenReturn(platformViewsControllerDelegator);
+    when(flutterEngine.getDartExecutor()).thenReturn(mock(DartExecutor.class));
+    when(flutterEngine.getRenderer()).thenReturn(mock(FlutterRenderer.class));
+    FlutterEngineConnectionRegistry registry =
+        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader, null);
+
+    when(flutterLoader.getSofwareRenderingEnabledViaManifest()).thenReturn(false);
+    when(appComponent.getAppComponent()).thenReturn(activity);
+    Intent intent = mock(Intent.class);
+    when(intent.getBooleanExtra(FlutterShellArgs.ARG_KEY_ENABLE_SOFTWARE_RENDERING, false))
+        .thenReturn(false);
+    when(activity.getIntent()).thenReturn(intent);
+
+    registry.attachToActivity(appComponent, lifecycle);
+
+    verify(platformViewsController).setSoftwareRendering(false);
   }
 
   private static class FakeFlutterPlugin implements FlutterPlugin {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
@@ -196,7 +196,7 @@ public class FlutterEngineConnectionRegistryTest {
     when(flutterLoader.getSofwareRenderingEnabledViaManifest()).thenReturn(false);
     when(appComponent.getAppComponent()).thenReturn(activity);
     Intent intent = mock(Intent.class);
-    when(intent.getBooleanExtra(FlutterShellArgs.ARG_KEY_ENABLE_SOFTWARE_RENDERING, false))
+    when(intent.getBooleanExtra("enable-software-rendering", false))
         .thenReturn(true);
     when(activity.getIntent()).thenReturn(intent);
 
@@ -228,7 +228,7 @@ public class FlutterEngineConnectionRegistryTest {
     when(flutterLoader.getSofwareRenderingEnabledViaManifest()).thenReturn(false);
     when(appComponent.getAppComponent()).thenReturn(activity);
     Intent intent = mock(Intent.class);
-    when(intent.getBooleanExtra(FlutterShellArgs.ARG_KEY_ENABLE_SOFTWARE_RENDERING, false))
+    when(intent.getBooleanExtra("enable-software-rendering", false))
         .thenReturn(false);
     when(activity.getIntent()).thenReturn(intent);
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
@@ -196,8 +196,7 @@ public class FlutterEngineConnectionRegistryTest {
     when(flutterLoader.getSofwareRenderingEnabledViaManifest()).thenReturn(false);
     when(appComponent.getAppComponent()).thenReturn(activity);
     Intent intent = mock(Intent.class);
-    when(intent.getBooleanExtra("enable-software-rendering", false))
-        .thenReturn(true);
+    when(intent.getBooleanExtra("enable-software-rendering", false)).thenReturn(true);
     when(activity.getIntent()).thenReturn(intent);
 
     registry.attachToActivity(appComponent, lifecycle);
@@ -228,8 +227,7 @@ public class FlutterEngineConnectionRegistryTest {
     when(flutterLoader.getSofwareRenderingEnabledViaManifest()).thenReturn(false);
     when(appComponent.getAppComponent()).thenReturn(activity);
     Intent intent = mock(Intent.class);
-    when(intent.getBooleanExtra("enable-software-rendering", false))
-        .thenReturn(false);
+    when(intent.getBooleanExtra("enable-software-rendering", false)).thenReturn(false);
     when(activity.getIntent()).thenReturn(intent);
 
     registry.attachToActivity(appComponent, lifecycle);


### PR DESCRIPTION
Fixes regression caused by https://github.com/flutter/flutter/pull/190222 that accidentally stopped respecting the `enable-software-rendering` Intent flag in the Android embedding.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
