### PR TITLE
[stable] [flutter_tools] Gracefully handle ping timeouts for custom devices

### DIFF
--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -490,7 +490,7 @@ class CustomDevice extends Device {
   ///
   /// If [timeout] is not null and the process doesn't finish in time,
   /// it will be killed with a SIGTERM, false will be returned and the timeout
-  /// will be reported in the log using [Logger.printError]. If [timeout]
+  /// will be reported in the log using [Logger.printTrace]. If [timeout]
   /// is null, it's treated as if it's an infinite timeout.
   Future<bool> tryPing({
     Duration? timeout,
@@ -498,7 +498,13 @@ class CustomDevice extends Device {
   }) async {
     final List<String> interpolated = interpolateCommand(_config.pingCommand, replacementValues);
 
-    final RunResult result = await _processUtils.run(interpolated, timeout: timeout);
+    final RunResult result;
+    try {
+      result = await _processUtils.run(interpolated, timeout: timeout);
+    } on ProcessException catch (e) {
+      _logger.printTrace('Error pinging custom device $id: $e');
+      return false;
+    }
 
     if (result.exitCode != 0) {
       return false;

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -8,6 +8,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
@@ -294,6 +295,58 @@ void main() {
       );
 
       expect(await discovery.discoverDevices(), hasLength(0));
+    },
+  );
+
+  testWithoutContext(
+    "CustomDevices.discoverDevices doesn't report device and does not throw when ping command times out",
+    () async {
+      final fs = MemoryFileSystem.test();
+      final Directory dir = fs.directory('custom_devices_config_dir');
+
+      _writeCustomDevicesConfigFile(dir, <CustomDeviceConfig>[testConfig]);
+
+      final logger = BufferLogger.test();
+      final discovery = CustomDevices(
+        featureFlags: TestFeatureFlags(areCustomDevicesEnabled: true),
+        logger: logger,
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: testConfig.pingCommand,
+            exception: const ProcessException('testping', <String>[], 'Process timed out'),
+          ),
+        ]),
+        config: CustomDevicesConfig.test(fileSystem: fs, directory: dir, logger: logger),
+      );
+
+      expect(await discovery.discoverDevices(), hasLength(0));
+      expect(
+        logger.traceText,
+        contains('Error pinging custom device testid: ProcessException: Process timed out'),
+      );
+    },
+  );
+
+  testWithoutContext(
+    'CustomDevice.tryPing returns false and logs trace when ping command times out',
+    () async {
+      final logger = BufferLogger.test();
+      final device = CustomDevice(
+        config: testConfig,
+        logger: logger,
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: testConfig.pingCommand,
+            exception: const ProcessException('testping', <String>[], 'Process timed out'),
+          ),
+        ]),
+      );
+
+      expect(await device.tryPing(), isFalse);
+      expect(
+        logger.traceText,
+        contains('Error pinging custom device testid: ProcessException: Process timed out'),
+      );
     },
   );
 


### PR DESCRIPTION
### Issue Link:
https://github.com/flutter/flutter/issues/191177

### Impact Description:
In Flutter 3.47.0, an unhandled `ProcessException` during background custom device polling causes the Flutter CLI tool to crash when custom devices are configured and a ping timeout occurs. This impacts developers using custom devices.

### Changelog Description:
[flutter/191177] The Flutter tool crashes if a configured custom device ping times out.

### Workaround:
Remove offline or unreachable custom devices from `.flutter_custom_devices.json`.

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
1. Configure a custom device in `.flutter_custom_devices.json` with a ping command that will timeout or fail with a ProcessException (e.g., pinging an unreachable IP with a short timeout).
2. Run any flutter command that triggers device discovery (e.g., `flutter devices`).
3. Verify that the tool does not crash and instead logs the timeout trace (visible in verbose mode).
