### PR TITLE
Use leading scroll offset instead of infinite offset to reveal pinned slivers

### DIFF
--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -1192,31 +1192,32 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     Rect targetRect = MatrixUtils.transformRect(transform, rect);
     final double extentOfPinnedSlivers = maxScrollObstructionExtentBefore(sliver);
 
-    switch (sliver.constraints.growthDirection) {
-      case GrowthDirection.forward:
-        if (isPinned && alignment <= 0) {
-          return RevealedOffset(offset: double.infinity, rect: targetRect);
-        }
-        leadingScrollOffset -= extentOfPinnedSlivers;
-      case GrowthDirection.reverse:
-        if (isPinned && alignment >= 1) {
-          return RevealedOffset(offset: double.negativeInfinity, rect: targetRect);
-        }
-        // If child's growth direction is reverse, when viewport.offset is
-        // `leadingScrollOffset`, it is positioned just outside of the leading
-        // edge of the viewport.
-        leadingScrollOffset -= switch (axis) {
-          Axis.vertical => targetRect.height,
-          Axis.horizontal => targetRect.width,
-        };
-    }
-
     final double mainAxisExtentDifference = switch (axis) {
       Axis.horizontal => size.width - extentOfPinnedSlivers - rectLocal.width,
       Axis.vertical => size.height - extentOfPinnedSlivers - rectLocal.height,
     };
+    final double targetOffset;
+    switch (sliver.constraints.growthDirection) {
+      case GrowthDirection.forward:
+        leadingScrollOffset -= extentOfPinnedSlivers;
+        targetOffset = isPinned && alignment <= 0
+            ? math.max(offset.pixels, leadingScrollOffset)
+            : leadingScrollOffset - mainAxisExtentDifference * alignment;
+      case GrowthDirection.reverse:
+        if (isPinned && alignment >= 1) {
+          targetOffset = math.min(offset.pixels, leadingScrollOffset);
+        } else {
+          // If child's growth direction is reverse, when viewport.offset is
+          // `leadingScrollOffset`, it is positioned just outside of the leading
+          // edge of the viewport.
+          leadingScrollOffset -= switch (axis) {
+            Axis.vertical => targetRect.height,
+            Axis.horizontal => targetRect.width,
+          };
+          targetOffset = leadingScrollOffset - mainAxisExtentDifference * alignment;
+        }
+    }
 
-    final double targetOffset = leadingScrollOffset - mainAxisExtentDifference * alignment;
     final double offsetDifference = offset.pixels - targetOffset;
 
     targetRect = switch (axisDirection) {

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -615,6 +615,373 @@ void main() {
     expect(revealed.offset, -200 + 6 * (100 + 22 + 23) - 22 - 1);
   });
 
+  group('Viewport getOffsetToReveal Sliver - pinned', () {
+    testWidgets('down, forward growth', (WidgetTester tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      const headerKey = Key('pinned-header');
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              height: 400.0,
+              width: 300.0,
+              child: CustomScrollView(
+                controller: controller,
+                slivers: <Widget>[
+                  const SliverToBoxAdapter(
+                    child: SizedBox(height: 300.0, child: Text('Preceding content')),
+                  ),
+                  SliverPersistentHeader(
+                    pinned: true,
+                    delegate: _TestSliverPersistentHeaderDelegate(
+                      key: headerKey,
+                      minExtent: 50.0,
+                      maxExtent: 50.0,
+                    ),
+                  ),
+                  SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) =>
+                          SizedBox(height: 50.0, child: Text('Tile $index')),
+                      childCount: 20,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final RenderAbstractViewport viewport = tester.allRenderObjects
+          .whereType<RenderAbstractViewport>()
+          .first;
+
+      final RenderObject target = tester.renderObject(find.byKey(headerKey, skipOffstage: false));
+
+      // When the viewport is at offset 0.0 (unpinned):
+      RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+      expect(revealed.offset, 300.0);
+      expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 300.0, 50.0));
+
+      // When the viewport is at offset 500.0 (already pinned at leading edge):
+      controller.jumpTo(500.0);
+      await tester.pumpAndSettle();
+
+      revealed = viewport.getOffsetToReveal(target, 0.0);
+      expect(revealed.offset, 500.0);
+      expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 300.0, 50.0));
+    });
+
+    testWidgets('up, forward growth', (WidgetTester tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      const headerKey = Key('pinned-header');
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              height: 400.0,
+              width: 300.0,
+              child: CustomScrollView(
+                controller: controller,
+                reverse: true,
+                slivers: <Widget>[
+                  const SliverToBoxAdapter(
+                    child: SizedBox(height: 300.0, child: Text('Preceding content')),
+                  ),
+                  SliverPersistentHeader(
+                    pinned: true,
+                    delegate: _TestSliverPersistentHeaderDelegate(
+                      key: headerKey,
+                      minExtent: 50.0,
+                      maxExtent: 50.0,
+                    ),
+                  ),
+                  SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) =>
+                          SizedBox(height: 50.0, child: Text('Tile $index')),
+                      childCount: 20,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final RenderAbstractViewport viewport = tester.allRenderObjects
+          .whereType<RenderAbstractViewport>()
+          .first;
+
+      final RenderObject target = tester.renderObject(find.byKey(headerKey, skipOffstage: false));
+
+      // When the viewport is at offset 0.0 (unpinned):
+      RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+      expect(revealed.offset, 300.0);
+      expect(revealed.rect, const Rect.fromLTWH(0.0, 350.0, 300.0, 50.0));
+
+      // When the viewport is at offset 500.0 (already pinned at leading edge):
+      controller.jumpTo(500.0);
+      await tester.pumpAndSettle();
+
+      revealed = viewport.getOffsetToReveal(target, 0.0);
+      expect(revealed.offset, 500.0);
+      expect(revealed.rect, const Rect.fromLTWH(0.0, 350.0, 300.0, 50.0));
+    });
+
+    testWidgets('right, forward growth', (WidgetTester tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      const headerKey = Key('pinned-header');
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              height: 300.0,
+              width: 400.0,
+              child: CustomScrollView(
+                scrollDirection: Axis.horizontal,
+                controller: controller,
+                slivers: <Widget>[
+                  const SliverToBoxAdapter(
+                    child: SizedBox(width: 300.0, child: Text('Preceding content')),
+                  ),
+                  SliverPersistentHeader(
+                    pinned: true,
+                    delegate: _TestSliverPersistentHeaderDelegate(
+                      key: headerKey,
+                      minExtent: 50.0,
+                      maxExtent: 50.0,
+                    ),
+                  ),
+                  SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) =>
+                          SizedBox(width: 50.0, child: Text('Tile $index')),
+                      childCount: 20,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final RenderAbstractViewport viewport = tester.allRenderObjects
+          .whereType<RenderAbstractViewport>()
+          .first;
+
+      final RenderObject target = tester.renderObject(find.byKey(headerKey, skipOffstage: false));
+
+      // When the viewport is at offset 0.0 (unpinned):
+      RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+      expect(revealed.offset, 300.0);
+      expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 50.0, 300.0));
+
+      // When the viewport is at offset 500.0 (already pinned at leading edge):
+      controller.jumpTo(500.0);
+      await tester.pumpAndSettle();
+
+      revealed = viewport.getOffsetToReveal(target, 0.0);
+      expect(revealed.offset, 500.0);
+      expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 50.0, 300.0));
+    });
+
+    testWidgets('left, forward growth', (WidgetTester tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      const headerKey = Key('pinned-header');
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              height: 300.0,
+              width: 400.0,
+              child: CustomScrollView(
+                scrollDirection: Axis.horizontal,
+                reverse: true,
+                controller: controller,
+                slivers: <Widget>[
+                  const SliverToBoxAdapter(
+                    child: SizedBox(width: 300.0, child: Text('Preceding content')),
+                  ),
+                  SliverPersistentHeader(
+                    pinned: true,
+                    delegate: _TestSliverPersistentHeaderDelegate(
+                      key: headerKey,
+                      minExtent: 50.0,
+                      maxExtent: 50.0,
+                    ),
+                  ),
+                  SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) =>
+                          SizedBox(width: 50.0, child: Text('Tile $index')),
+                      childCount: 20,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final RenderAbstractViewport viewport = tester.allRenderObjects
+          .whereType<RenderAbstractViewport>()
+          .first;
+
+      final RenderObject target = tester.renderObject(find.byKey(headerKey, skipOffstage: false));
+
+      // When the viewport is at offset 0.0 (unpinned):
+      RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+      expect(revealed.offset, 300.0);
+      expect(revealed.rect, const Rect.fromLTWH(350.0, 0.0, 50.0, 300.0));
+
+      // When the viewport is at offset 500.0 (already pinned at leading edge):
+      controller.jumpTo(500.0);
+      await tester.pumpAndSettle();
+
+      revealed = viewport.getOffsetToReveal(target, 0.0);
+      expect(revealed.offset, 500.0);
+      expect(revealed.rect, const Rect.fromLTWH(350.0, 0.0, 50.0, 300.0));
+    });
+
+    testWidgets('up, reverse growth', (WidgetTester tester) async {
+      const Key centerKey = ValueKey<String>('center');
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      const headerKey = Key('pinned-header');
+
+      const Widget centerSliver = SliverToBoxAdapter(
+        key: centerKey,
+        child: SizedBox(height: 100.0, child: Text('Tile center')),
+      );
+      final Widget pinnedHeader = SliverPersistentHeader(
+        pinned: true,
+        delegate: _TestSliverPersistentHeaderDelegate(
+          key: headerKey,
+          minExtent: 50.0,
+          maxExtent: 50.0,
+        ),
+      );
+      const Widget precedingSliver = SliverToBoxAdapter(
+        child: SizedBox(height: 300.0, child: Text('Preceding content')),
+      );
+      const Widget trailingSliver = SliverToBoxAdapter(
+        child: SizedBox(height: 500.0, child: Text('Trailing content')),
+      );
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              height: 400.0,
+              width: 300.0,
+              child: CustomScrollView(
+                controller: controller,
+                center: centerKey,
+                slivers: <Widget>[trailingSliver, pinnedHeader, precedingSliver, centerSliver],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final RenderAbstractViewport viewport = tester.allRenderObjects
+          .whereType<RenderAbstractViewport>()
+          .first;
+
+      final RenderObject target = tester.renderObject(find.byKey(headerKey, skipOffstage: false));
+
+      // When viewport is at offset 0.0 (unpinned):
+      RevealedOffset revealed = viewport.getOffsetToReveal(target, 1.0);
+      expect(revealed.offset, -300.0);
+
+      // When viewport is at offset -500.0 (pinned at reverse leading edge):
+      controller.jumpTo(-500.0);
+      await tester.pumpAndSettle();
+
+      revealed = viewport.getOffsetToReveal(target, 1.0);
+      expect(revealed.offset, -500.0);
+    });
+
+    testWidgets('left, reverse growth', (WidgetTester tester) async {
+      const Key centerKey = ValueKey<String>('center');
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      const headerKey = Key('pinned-header');
+
+      const Widget centerSliver = SliverToBoxAdapter(
+        key: centerKey,
+        child: SizedBox(width: 100.0, child: Text('Tile center')),
+      );
+      final Widget pinnedHeader = SliverPersistentHeader(
+        pinned: true,
+        delegate: _TestSliverPersistentHeaderDelegate(
+          key: headerKey,
+          minExtent: 50.0,
+          maxExtent: 50.0,
+        ),
+      );
+      const Widget precedingSliver = SliverToBoxAdapter(
+        child: SizedBox(width: 300.0, child: Text('Preceding content')),
+      );
+      const Widget trailingSliver = SliverToBoxAdapter(
+        child: SizedBox(width: 500.0, child: Text('Trailing content')),
+      );
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              height: 300.0,
+              width: 400.0,
+              child: CustomScrollView(
+                scrollDirection: Axis.horizontal,
+                controller: controller,
+                center: centerKey,
+                slivers: <Widget>[trailingSliver, pinnedHeader, precedingSliver, centerSliver],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final RenderAbstractViewport viewport = tester.allRenderObjects
+          .whereType<RenderAbstractViewport>()
+          .first;
+
+      final RenderObject target = tester.renderObject(find.byKey(headerKey, skipOffstage: false));
+
+      // When viewport is at offset 0.0 (unpinned):
+      RevealedOffset revealed = viewport.getOffsetToReveal(target, 1.0);
+      expect(revealed.offset, -300.0);
+
+      // When viewport is at offset -500.0 (pinned at reverse leading edge):
+      controller.jumpTo(-500.0);
+      await tester.pumpAndSettle();
+
+      revealed = viewport.getOffsetToReveal(target, 1.0);
+      expect(revealed.offset, -500.0);
+    });
+  });
+
   testWidgets('Nested Viewports showOnScreen', (WidgetTester tester) async {
     final controllersX = List<ScrollController>.generate(
       10,


### PR DESCRIPTION
Applicable only if the target provided to `RenderViewportBase.getOffsetToReveal` (and its callers e.g `Scrollable.ensureVisible`, `scrollUntilVisible` etc.) is a pinned sliver.

(in say `AxisDirection.down`) If the pinned sliver is below the leading edge, scroll the viewport by the minimum offset required to pin the sliver rather than giving it an infinite target offset which just makes it scroll to the end of the viewport. While the header will always remain pinned, other slivers below it do not need to scroll. 

Fixes [When calling Scrollable.ensureVisible to pinned SliverPersistentHeader, the view scrolls too much](https://github.com/flutter/flutter/issues/115964)