### PR TITLE
[stable] fix: limit render size of custom elements

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart
@@ -56,6 +56,9 @@ class CustomElementDimensionsProvider extends DimensionsProvider {
     _hostElementResizeObserver?.observe(_hostElement);
   }
 
+  /// Limit size of canvas to render into. Anything larger than 16384 breaks rendering
+  static const double _maxElementSize = 16384.0;
+
   // The host element that will be used to retrieve (and observe) app size measurements.
   final DomElement _hostElement;
 
@@ -84,10 +87,12 @@ class CustomElementDimensionsProvider extends DimensionsProvider {
   @override
   ui.Size computePhysicalSize() {
     final double devicePixelRatio = EngineFlutterDisplay.instance.devicePixelRatio;
-    return ui.Size(
-      _hostElement.clientWidth * devicePixelRatio,
-      _hostElement.clientHeight * devicePixelRatio,
+    final double width = (_hostElement.clientWidth * devicePixelRatio).clamp(0.0, _maxElementSize);
+    final double height = (_hostElement.clientHeight * devicePixelRatio).clamp(
+      0.0,
+      _maxElementSize,
     );
+    return ui.Size(width, height);
   }
 
   @override

--- a/engine/src/flutter/lib/web_ui/test/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider_test.dart
@@ -30,6 +30,7 @@ void doTests() {
     tearDown(() {
       provider.close(); // cleanup
       sizeSource.remove();
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(null);
     });
 
     test('returns physical size of element (width * dpr)', () {
@@ -43,6 +44,86 @@ void doTests() {
         ..style.height = '${logicalHeight}px';
 
       const expected = ui.Size(logicalWidth * dpr, logicalHeight * dpr);
+
+      final ui.Size computed = provider.computePhysicalSize();
+
+      expect(computed, expected);
+    });
+
+    test('limits physical height of element', () {
+      const double logicalWidth = 50;
+      const double logicalHeight = 20000;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
+
+      sizeSource
+        ..style.width = '${logicalWidth}px'
+        ..style.height = '${logicalHeight}px';
+
+      const expected = ui.Size(logicalWidth, 16384);
+
+      final ui.Size computed = provider.computePhysicalSize();
+
+      expect(computed, expected);
+    });
+
+    test('limits physical width of element', () {
+      const double logicalWidth = 20000;
+      const double logicalHeight = 50;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
+
+      sizeSource
+        ..style.width = '${logicalWidth}px'
+        ..style.height = '${logicalHeight}px';
+
+      const expected = ui.Size(16384, logicalHeight);
+
+      final ui.Size computed = provider.computePhysicalSize();
+
+      expect(computed, expected);
+    });
+
+    test('limits physical size of element', () {
+      const double logicalWidth = 20000;
+      const double logicalHeight = 20000;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
+
+      sizeSource
+        ..style.width = '${logicalWidth}px'
+        ..style.height = '${logicalHeight}px';
+
+      const expected = ui.Size(16384, 16384);
+
+      final ui.Size computed = provider.computePhysicalSize();
+
+      expect(computed, expected);
+    });
+
+    test('limits physical width of element given custom dpr', () {
+      const double logicalWidth = 10000;
+      const double logicalHeight = 5000;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(2.0);
+
+      sizeSource
+        ..style.width = '${logicalWidth}px'
+        ..style.height = '${logicalHeight}px';
+
+      const expected = ui.Size(16384, 10000);
+
+      final ui.Size computed = provider.computePhysicalSize();
+
+      expect(computed, expected);
+    });
+
+    test('limits physical height of element given custom dpr', () {
+      const double logicalWidth = 5000;
+      const double logicalHeight = 10000;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(2.0);
+
+      sizeSource
+        ..style.width = '${logicalWidth}px'
+        ..style.height = '${logicalHeight}px';
+
+      const expected = ui.Size(10000, 16384);
 
       final ui.Size computed = provider.computePhysicalSize();
 


### PR DESCRIPTION
This is a CP request for https://github.com/flutter/flutter/pull/184961

- **Impacted Users**: Users of flutter web, using resizable custom host elements
- **Impact Description**: See linked PR, flutter renderer crashes if the custom host element gets too large
- **Workaround**: Limit size of host element via css. But that's not always possible. In the original issue, the problem was chrome resizing the host element automatically when moving it to a document pip window.
- **Risk**: Low, real-live scenarios wont render 16k x 16k Pixel host elements
- **Test Coverage**: Existing tests pass, new test covers newly handled edge case
- **Validation Steps**: Run repro example linked in https://github.com/flutter/flutter/pull/184961#issuecomment-4236116134

Our production app is currently stuck on 3.38, where this was not an issue.