### PR TITLE
[flutter_tools] Prevent crash when stdout is broken and print fails

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -342,7 +342,7 @@ class Stdio {
   void _safePrint(String message) {
     try {
       print(message);
-    } on Object catch (_) {
+    } on Exception catch (_) {
       // If print also throws (e.g. broken pipe on stdout), we ignore it.
     }
   }

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -294,26 +294,28 @@ class Stdio {
   bool get supportsAnsiEscapes => hasTerminal && stdout.supportsAnsiEscapes;
 
   /// Writes [message] to [stderr], falling back on [fallback] if the write
-  /// throws any exception. The default fallback calls [print] on [message].
+  /// throws any exception. The default fallback prints [message] to the console,
+  /// ignoring any errors.
   void stderrWrite(String message, {void Function(String, dynamic, StackTrace)? fallback}) {
     if (!_stderrDone) {
       _stdioWrite(stderr, message, fallback: fallback);
       return;
     }
     fallback == null
-        ? print(message)
+        ? _safePrint(message)
         : fallback(message, const io.StdoutException('stderr is done'), StackTrace.current);
   }
 
   /// Writes [message] to [stdout], falling back on [fallback] if the write
-  /// throws any exception. The default fallback calls [print] on [message].
+  /// throws any exception. The default fallback prints [message] to the console,
+  /// ignoring any errors.
   void stdoutWrite(String message, {void Function(String, dynamic, StackTrace)? fallback}) {
     if (!_stdoutDone) {
       _stdioWrite(stdout, message, fallback: fallback);
       return;
     }
     fallback == null
-        ? print(message)
+        ? _safePrint(message)
         : fallback(message, const io.StdoutException('stdout is done'), StackTrace.current);
   }
 
@@ -329,12 +331,20 @@ class Stdio {
       },
       onError: (Object error, StackTrace stackTrace) {
         if (fallback == null) {
-          print(message);
+          _safePrint(message);
         } else {
           fallback(message, error, stackTrace);
         }
       },
     );
+  }
+
+  void _safePrint(String message) {
+    try {
+      print(message);
+    } on Object catch (_) {
+      // If print also throws (e.g. broken pipe on stdout), we ignore it.
+    }
   }
 
   /// Adds [stream] to [stdout].

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -173,6 +173,75 @@ void main() {
       }, FSGuardIOOverrides());
     }, mockOverrides);
   });
+
+  testWithoutContext(
+    'Stdio.stdoutWrite does not crash if stdout throws FileSystemException',
+    () async {
+      final mockStdout = CrashingStdout(asyncError: true);
+      final stdio = Stdio.test(stdout: mockStdout, stderr: FakeIOSink());
+
+      Object? printed;
+      var crashed = false;
+      await runZonedGuarded(
+        () async {
+          stdio.stdoutWrite('test message');
+          await Future<void>.delayed(Duration.zero);
+        },
+        (Object error, StackTrace stackTrace) {
+          crashed = true;
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (Zone self, ZoneDelegate parent, Zone association, String line) {
+            printed = line;
+            throw const io.FileSystemException(
+              'writeFrom failed',
+              '',
+              io.OSError('Broken pipe', 32),
+            );
+          },
+        ),
+      );
+      expect(printed, 'test message');
+      expect(crashed, false);
+    },
+  );
+
+  testWithoutContext(
+    'Stdio.stdoutWrite does not crash if stdout is already done and print throws',
+    () async {
+      final mockStdout = CrashingStdout(asyncError: false);
+      final stdio = Stdio.test(stdout: mockStdout, stderr: FakeIOSink());
+
+      // Access stdout to register the done listener.
+      stdio.stdout;
+
+      mockStdout.completeDone();
+      await Future<void>.delayed(Duration.zero);
+
+      Object? printed;
+      var crashed = false;
+      runZonedGuarded(
+        () {
+          stdio.stdoutWrite('test message');
+        },
+        (Object error, StackTrace stackTrace) {
+          crashed = true;
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (Zone self, ZoneDelegate parent, Zone association, String line) {
+            printed = line;
+            throw const io.FileSystemException(
+              'writeFrom failed',
+              '',
+              io.OSError('Broken pipe', 32),
+            );
+          },
+        ),
+      );
+      expect(printed, 'test message');
+      expect(crashed, false);
+    },
+  );
 }
 
 class FakeProcessSignal extends Fake implements io.ProcessSignal {
@@ -187,4 +256,35 @@ final class MockSystemTempOverrides extends io.IOOverrides {
   final io.Directory mockTemp;
   @override
   io.Directory getSystemTempDirectory() => mockTemp;
+}
+
+class CrashingStdout extends Fake implements io.Stdout {
+  CrashingStdout({required this.asyncError});
+
+  final bool asyncError;
+  final _completer = Completer<void>();
+
+  @override
+  void write(Object? object) {
+    if (!asyncError) {
+      throw const io.FileSystemException('writeFrom failed', '', io.OSError('Broken pipe', 32));
+    }
+    Zone.current.handleUncaughtError(
+      const io.FileSystemException('writeFrom failed', '', io.OSError('Broken pipe', 32)),
+      StackTrace.current,
+    );
+  }
+
+  @override
+  Future<void> get done => _completer.future;
+
+  void completeDone() {
+    _completer.complete();
+  }
+}
+
+class FakeIOSink extends Fake implements io.IOSink {
+  final _completer = Completer<void>();
+  @override
+  Future<void> get done => _completer.future;
 }


### PR DESCRIPTION
## Description

This PR prevents `flutter_tools` from crashing when standard output/error is broken and the fallback logging with `print` also throws a `FileSystemException` (e.g. Broken pipe).

Specifically:
- In `Stdio`, introduced `_safePrint` which catches and ignores exceptions thrown by `print` when stdout/error streams are broken or closed.
- Replaced fallback `print` invocations in `stdoutWrite`, `stderrWrite`, and `_stdioWrite` with `_safePrint`.
- Added unit tests in `packages/flutter_tools/test/general.shard/base/io_test.dart` verifying that `stdoutWrite` does not crash when writes fail asynchronously or when the stream is already closed.

## Related Issues

* Fixes https://github.com/flutter/flutter/issues/51872

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md