### PR TITLE
[flutter_tools] Deprecate --build and --no-build flags on flutter run

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -489,7 +489,13 @@ class RunCommand extends RunCommandBase {
             'a test using "flutter run" for debugging purposes. This flag is '
             'only available when running in debug mode.',
       )
-      ..addFlag('build', defaultsTo: true, help: 'If necessary, build the app before running.')
+      ..addFlag(
+        'build',
+        defaultsTo: true,
+        help:
+            '(deprecated) If necessary, build the app before running. To use an existing app, pass the "--${FlutterOptions.kUseApplicationBinary}" '
+            'flag with an existing application artifact.',
+      )
       ..addOption('project-root', hide: !verboseHelp, help: 'Specify the project root directory.')
       ..addFlag(
         'hot',
@@ -749,6 +755,13 @@ class RunCommand extends RunCommandBase {
         '--flavor is only supported for Android, Linux, macOS, iOS, and Windows devices. '
         'Flavor-related features may not function properly and could '
         'behave differently in a future release.',
+      );
+    }
+
+    if (argResults!.wasParsed('build')) {
+      globals.printWarning(
+        'The "--build" and "--no-build" flags are deprecated and will be removed in a future release. '
+        'To use a prebuilt application, pass "--${FlutterOptions.kUseApplicationBinary}".',
       );
     }
   }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -760,10 +760,17 @@ class RunCommand extends RunCommandBase {
     }
 
     if (argResults!.wasParsed('build')) {
-      globals.printWarning(
-        'The "--build" and "--no-build" flags are deprecated and will be removed in a future release. '
-        'To use a prebuilt application, pass "--${FlutterOptions.kUseApplicationBinary}".',
-      );
+      if (boolArg('build')) {
+        globals.printWarning(
+          'The "--build" flag is deprecated and will be removed in a future release. '
+          'Building is the default behavior, so this flag can be safely removed.',
+        );
+      } else {
+        globals.printWarning(
+          'The "--no-build" flag is deprecated and will be removed in a future release. '
+          'To use a prebuilt application, pass "--${FlutterOptions.kUseApplicationBinary}".',
+        );
+      }
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -492,6 +492,7 @@ class RunCommand extends RunCommandBase {
       ..addFlag(
         'build',
         defaultsTo: true,
+        hide: !verboseHelp,
         help:
             '(deprecated) If necessary, build the app before running. To use an existing app, pass the "--${FlutterOptions.kUseApplicationBinary}" '
             'flag with an existing application artifact.',

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1913,6 +1913,78 @@ server:
       // https://github.com/flutter/flutter/issues/142060
       skip: true,
     );
+
+    testUsingContext(
+      'warning triggered when --build flag is passed',
+      () async {
+        final CommandRunner<void> runner = createTestCommandRunner(
+          TestRunCommandThatOnlyValidates(),
+        );
+        await runner.run(<String>['run', '--build']);
+
+        expect(
+          testLogger.warningText,
+          contains(
+            'The "--build" and "--no-build" flags are deprecated and will be removed in a future release. '
+            'To use a prebuilt application, pass "--${FlutterOptions.kUseApplicationBinary}".',
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
+      },
+      initializeFlutterRoot: false,
+    );
+
+    testUsingContext(
+      'warning triggered when --no-build flag is passed',
+      () async {
+        final CommandRunner<void> runner = createTestCommandRunner(
+          TestRunCommandThatOnlyValidates(),
+        );
+        await runner.run(<String>['run', '--no-build']);
+
+        expect(
+          testLogger.warningText,
+          contains(
+            'The "--build" and "--no-build" flags are deprecated and will be removed in a future release. '
+            'To use a prebuilt application, pass "--${FlutterOptions.kUseApplicationBinary}".',
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
+      },
+      initializeFlutterRoot: false,
+    );
+
+    testUsingContext(
+      'no warning triggered when --build or --no-build flag is not passed',
+      () async {
+        final CommandRunner<void> runner = createTestCommandRunner(
+          TestRunCommandThatOnlyValidates(),
+        );
+        await runner.run(<String>['run']);
+
+        expect(
+          testLogger.warningText,
+          isNot(contains('The "--build" and "--no-build" flags are deprecated')),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
+      },
+      initializeFlutterRoot: false,
+    );
   });
 }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1925,8 +1925,8 @@ server:
         expect(
           testLogger.warningText,
           contains(
-            'The "--build" and "--no-build" flags are deprecated and will be removed in a future release. '
-            'To use a prebuilt application, pass "--${FlutterOptions.kUseApplicationBinary}".',
+            'The "--build" flag is deprecated and will be removed in a future release. '
+            'Building is the default behavior, so this flag can be safely removed.',
           ),
         );
       },
@@ -1950,7 +1950,7 @@ server:
         expect(
           testLogger.warningText,
           contains(
-            'The "--build" and "--no-build" flags are deprecated and will be removed in a future release. '
+            'The "--no-build" flag is deprecated and will be removed in a future release. '
             'To use a prebuilt application, pass "--${FlutterOptions.kUseApplicationBinary}".',
           ),
         );
@@ -1974,7 +1974,7 @@ server:
 
         expect(
           testLogger.warningText,
-          isNot(contains('The "--build" and "--no-build" flags are deprecated')),
+          isNot(contains('is deprecated')),
         );
       },
       overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

This PR formally deprecates the \`--build\` and \`--no-build\` flags on \`flutter run\` in favor of \`--use-application-binary\`, aligning \`flutter run\` with \`flutter drive\` (which previously deprecated \`--build\`).

### Context & Changes
* In 2019 ([#37735](https://github.com/flutter/flutter/pull/37735)), \`flutter run\` stopped handling the \`build\` flag when \`--use-application-binary\` was added, but the flag definition was unintentionally left on \`argParser\`, causing it to remain in \`--help\` as a silent no-op.
* Rather than restoring implicit build-skipping behavior (which introduces ambiguity regarding which derived artifact to run across build flavors, split APKs, and schemes), we deprecate \`--[no-]build\` and direct users to \`--use-application-binary\`.
* Hides \`--build\` from standard \`flutter run -h\` output (\`hide: !verboseHelp\`).
* Emits a deprecation warning when \`--build\` or \`--no-build\` is passed.
* Adds hermetic unit tests in \`run_test.dart\` for the deprecation warnings.

## Related Issues
Fixes #68529

## Tests
- Added hermetic unit tests in \`packages/flutter_tools/test/commands.shard/hermetic/run_test.dart\` verifying warning triggers and default execution.
- Verified \`packages/flutter_tools/test/general.shard/args_test.dart\` passes.