### PR TITLE
[flutter_tools] Move plugin validation out of asserts

### DIFF
--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -126,7 +126,7 @@ class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
     FileSystem fileSystem,
   ) {
     if (!validate(yaml)) {
-      throwToolExit('Invalid "android" plugin specification.');
+      throwToolExit('Invalid "android" plugin specification for plugin "$name".');
     }
 
     final dartPluginClass = yaml[kDartPluginClass] as String?;
@@ -321,7 +321,7 @@ class IOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlug
 
   factory IOSPlugin.fromYaml(String name, YamlMap yaml) {
     if (!validate(yaml)) {
-      throwToolExit('Invalid "ios" plugin specification.');
+      throwToolExit('Invalid "ios" plugin specification for plugin "$name".');
     }
 
     final dartPluginClass = yaml[kDartPluginClass] as String?;
@@ -436,7 +436,7 @@ class MacOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPl
 
   factory MacOSPlugin.fromYaml(String name, YamlMap yaml) {
     if (!validate(yaml)) {
-      throwToolExit('Invalid "macos" plugin specification.');
+      throwToolExit('Invalid "macos" plugin specification for plugin "$name".');
     }
 
     final dartPluginClass = yaml[kDartPluginClass] as String?;
@@ -548,7 +548,7 @@ class WindowsPlugin extends PluginPlatform implements NativeOrDartPlugin, Varian
 
   factory WindowsPlugin.fromYaml(String name, YamlMap yaml) {
     if (!validate(yaml)) {
-      throwToolExit('Invalid "windows" plugin specification.');
+      throwToolExit('Invalid "windows" plugin specification for plugin "$name".');
     }
     final pluginClass = yaml[kPluginClass] as String?;
     final variants = <PluginPlatformVariant>{};
@@ -673,7 +673,7 @@ class LinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
 
   factory LinuxPlugin.fromYaml(String name, YamlMap yaml) {
     if (!validate(yaml)) {
-      throwToolExit('Invalid "linux" plugin specification.');
+      throwToolExit('Invalid "linux" plugin specification for plugin "$name".');
     }
 
     final dartPluginClass = yaml[kDartPluginClass] as String?;

--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -125,7 +125,9 @@ class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
     String pluginPath,
     FileSystem fileSystem,
   ) {
-    assert(validate(yaml));
+    if (!validate(yaml)) {
+      throwToolExit('Invalid "android" plugin specification.');
+    }
 
     final dartPluginClass = yaml[kDartPluginClass] as String?;
     final dartFileName = yaml[kDartFileName] as String?;
@@ -318,7 +320,9 @@ class IOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlug
        sharedDarwinSource = sharedDarwinSource ?? false;
 
   factory IOSPlugin.fromYaml(String name, YamlMap yaml) {
-    assert(validate(yaml)); // TODO(zanderso): https://github.com/flutter/flutter/issues/67241
+    if (!validate(yaml)) {
+      throwToolExit('Invalid "ios" plugin specification.');
+    }
 
     final dartPluginClass = yaml[kDartPluginClass] as String?;
     final dartFileName = yaml[kDartFileName] as String?;
@@ -431,7 +435,9 @@ class MacOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPl
        sharedDarwinSource = sharedDarwinSource ?? false;
 
   factory MacOSPlugin.fromYaml(String name, YamlMap yaml) {
-    assert(validate(yaml));
+    if (!validate(yaml)) {
+      throwToolExit('Invalid "macos" plugin specification.');
+    }
 
     final dartPluginClass = yaml[kDartPluginClass] as String?;
     final dartFileName = yaml[kDartFileName] as String?;
@@ -541,7 +547,9 @@ class WindowsPlugin extends PluginPlatform implements NativeOrDartPlugin, Varian
        );
 
   factory WindowsPlugin.fromYaml(String name, YamlMap yaml) {
-    assert(validate(yaml));
+    if (!validate(yaml)) {
+      throwToolExit('Invalid "windows" plugin specification.');
+    }
     final pluginClass = yaml[kPluginClass] as String?;
     final variants = <PluginPlatformVariant>{};
     final variantList = yaml[kSupportedVariants] as YamlList?;
@@ -664,7 +672,9 @@ class LinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
        );
 
   factory LinuxPlugin.fromYaml(String name, YamlMap yaml) {
-    assert(validate(yaml));
+    if (!validate(yaml)) {
+      throwToolExit('Invalid "linux" plugin specification.');
+    }
 
     final dartPluginClass = yaml[kDartPluginClass] as String?;
     final dartFileName = yaml[kDartFileName] as String?;

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -2227,6 +2227,29 @@ iosPrefix: FLT
         final YamlMap map = Plugin.createPlatformsYamlMap(<String>[], 'foo', 'bar');
         expect(map.isEmpty, true);
       });
+
+      testUsingContext('Platform plugin fromYaml factories perform validation', () async {
+        expect(
+          () => AndroidPlugin.fromYaml('foo', YamlMap.wrap(<String, dynamic>{}), '', globals.fs),
+          throwsToolExit(),
+        );
+        expect(
+          () => IOSPlugin.fromYaml('foo', YamlMap.wrap(<String, dynamic>{})),
+          throwsToolExit(),
+        );
+        expect(
+          () => MacOSPlugin.fromYaml('foo', YamlMap.wrap(<String, dynamic>{})),
+          throwsToolExit(),
+        );
+        expect(
+          () => WindowsPlugin.fromYaml('foo', YamlMap.wrap(<String, dynamic>{})),
+          throwsToolExit(),
+        );
+        expect(
+          () => LinuxPlugin.fromYaml('foo', YamlMap.wrap(<String, dynamic>{})),
+          throwsToolExit(),
+        );
+      });
     });
 
     group('Plugin files', () {

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -2231,23 +2231,23 @@ iosPrefix: FLT
       testUsingContext('Platform plugin fromYaml factories perform validation', () async {
         expect(
           () => AndroidPlugin.fromYaml('foo', YamlMap.wrap(<String, dynamic>{}), '', globals.fs),
-          throwsToolExit(),
+          throwsToolExit(message: 'Invalid "android" plugin specification for plugin "foo".'),
         );
         expect(
           () => IOSPlugin.fromYaml('foo', YamlMap.wrap(<String, dynamic>{})),
-          throwsToolExit(),
+          throwsToolExit(message: 'Invalid "ios" plugin specification for plugin "foo".'),
         );
         expect(
           () => MacOSPlugin.fromYaml('foo', YamlMap.wrap(<String, dynamic>{})),
-          throwsToolExit(),
+          throwsToolExit(message: 'Invalid "macos" plugin specification for plugin "foo".'),
         );
         expect(
           () => WindowsPlugin.fromYaml('foo', YamlMap.wrap(<String, dynamic>{})),
-          throwsToolExit(),
+          throwsToolExit(message: 'Invalid "windows" plugin specification for plugin "foo".'),
         );
         expect(
           () => LinuxPlugin.fromYaml('foo', YamlMap.wrap(<String, dynamic>{})),
-          throwsToolExit(),
+          throwsToolExit(message: 'Invalid "linux" plugin specification for plugin "foo".'),
         );
       });
     });


### PR DESCRIPTION
## Description

Platform plugin `fromYaml` factories in `platform_plugins.dart` (`AndroidPlugin`, `IOSPlugin`, `MacOSPlugin`, `WindowsPlugin`, and `LinuxPlugin`) previously performed validation inside `assert` statements. When Flutter tools runs in release mode (assertions disabled), calling these factories directly could bypass validation and return invalid plugin instances rather than surfacing a clean tool exit.

This PR:
1. Replaces `assert(validate(yaml))` in all platform plugin `fromYaml` factories with explicit validation checks that call `throwToolExit`.
2. Includes the plugin name in the exit error message (e.g. `Invalid "android" plugin specification for plugin "$name".`).
3. Adds automated unit tests in `plugins_test.dart` verifying that `fromYaml` throws `ToolExit` when passed invalid YAML.

Fixes https://github.com/flutter/flutter/issues/67241

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to provide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to provide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-provide
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://discord.gg/flutterdev
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests