### PR TITLE
WIP: Reduce touch to present latency on iOS

### DIFF
--- a/engine/src/flutter/shell/common/animator.cc
+++ b/engine/src/flutter/shell/common/animator.cc
@@ -253,20 +253,7 @@ void Animator::RequestFrame(bool regenerate_layer_trees) {
     return;
   }
 
-  // The AwaitVSync is going to call us back at the next VSync. However, we want
-  // to be reasonably certain that the UI thread is not in the middle of a
-  // particularly expensive callout. We post the AwaitVSync to run right after
-  // an idle. This does NOT provide a guarantee that the UI thread has not
-  // started an expensive operation right after posting this message however.
-  // To support that, we need edge triggered wakes on VSync.
-
-  task_runners_.GetUITaskRunner()->PostTask(
-      [self = weak_factory_.GetWeakPtr()]() {
-        if (!self) {
-          return;
-        }
-        self->AwaitVSync();
-      });
+  AwaitVSync();
   frame_scheduled_ = true;
 }
 
@@ -300,6 +287,9 @@ void Animator::ScheduleSecondaryVsyncCallback(uintptr_t id,
 }
 
 void Animator::ScheduleMaybeClearTraceFlowIds() {
+  // Don't schedule the secondary callback nonsense, just to not get
+  // confused while debugging the vsync client.
+#if 0
   waiter_->ScheduleSecondaryCallback(
       reinterpret_cast<uintptr_t>(this), [self = weak_factory_.GetWeakPtr()] {
         if (!self) {
@@ -324,6 +314,7 @@ void Animator::ScheduleMaybeClearTraceFlowIds() {
           }
         }
       });
+#endif
 }
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1231,7 +1231,10 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
   FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
-  task_runners_.GetUITaskRunner()->PostTask(
+  // Dispatch the event synchronously if possible, there is no need to increase
+  // latency by scheduling a new run loop turn.
+  fml::TaskRunner::RunNowOrPostTask(
+      task_runners_.GetUITaskRunner(),
       fml::MakeCopyable([engine = weak_engine_, packet = std::move(packet),
                          flow_id = next_pointer_flow_id_]() mutable {
         if (engine) {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1337,6 +1337,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)triggerTouchRateCorrectionIfNeeded:(NSSet*)touches {
+  // This is not needed now that we're running CADisplayLink on main thread.
+#if 0
   if (_touchRateCorrectionVSyncClient == nil) {
     // If the _touchRateCorrectionVSyncClient is not created, means current devices doesn't
     // need to correct the touch rate. So just return.
@@ -1358,6 +1360,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   } else {
     [_touchRateCorrectionVSyncClient pause];
   }
+#endif
 }
 
 - (void)invalidateTouchRateCorrectionVSyncClient {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -48,6 +48,7 @@ class VsyncWaiterIOS final : public VsyncWaiter, public VariableRefreshRateRepor
   FlutterVSyncClient* client_;
   FlutterDisplayLinkManager* display_link_manager_;
   double max_refresh_rate_;
+  bool waiting_for_vsync_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiterIOS);
 };

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -20,6 +20,12 @@ VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners,
     : VsyncWaiter(task_runners), display_link_manager_(display_link_manager) {
   FML_DCHECK(display_link_manager);
   auto vsyncCallback = ^(CFTimeInterval startTime, CFTimeInterval targetTime) {
+    if (!waiting_for_vsync_) {
+      [client_ pause];
+      return;
+    }
+    waiting_for_vsync_ = false;
+
     // Compute delay using the same CACurrentMediaTime() clock.
     CFTimeInterval delay = CACurrentMediaTime() - startTime;
     if (delay < 0.0) {
@@ -44,6 +50,7 @@ VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners,
       isVariableRefreshRateEnabled:display_link_manager_.maxRefreshRateEnabledOnIPhone
                     maxRefreshRate:display_link_manager_.displayRefreshRate
                           callback:vsyncCallback];
+  client_.allowPauseAfterVsync = false;
   max_refresh_rate_ = display_link_manager_.displayRefreshRate;
 }
 
@@ -59,7 +66,13 @@ void VsyncWaiterIOS::AwaitVSync() {
     max_refresh_rate_ = new_max_refresh_rate;
     [client_ setMaxRefreshRate:max_refresh_rate_];
   }
-  [client_ await];
+
+  if (client_.displayLink.paused) {
+    [client_ await];
+    FireCallback(fml::TimePoint::Now(), fml::TimePoint::Now(), false);
+  } else {
+    waiting_for_vsync_ = true;
+  }
 }
 
 // |VariableRefreshRateReporter|

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios.mm
@@ -101,7 +101,7 @@ void PlatformViewIOS::attachView() {
 
 PointerDataDispatcherMaker PlatformViewIOS::GetDispatcherMaker() {
   return [](DefaultPointerDataDispatcher::Delegate& delegate) {
-    return std::make_unique<SmoothPointerDataDispatcher>(delegate);
+    return std::make_unique<DefaultPointerDataDispatcher>(delegate);
   };
 }
 


### PR DESCRIPTION
This is a reasonably minimal change required to reduce the touch to present latency on iOS by one frame.

- Replaces `SmoothPointerDataDispatcher` with `DefaultPointerDataDispatcher`.
- Ensures that the path from `touchesMoved` all the way to `VSyncWaiter::AwaitVSync` is completely synchronous without scheduling unnecessary event loop turns. This is required so that `CADisplayLink` callback is always called after `AwaitVSync`. Other embedders will likely benefit from this change too.
- Modifies `vsync_waiter_ios` to not waste time when scheduling the first frame and does not pause the display link after each tick.

With this PR, this is the flow for each frame during tracking on iOS (and other platform with merged threads):
```
                        +-  touchesMoved:
                        |        \/
synchronous operation --+   pointer processing in framework requests new frame
 (same runloop turn)    |        \/
                        +-  vsync request
                                 \/
                            display link callback
```

Note that UIKit phases are [well defined](https://developer.apple.com/documentation/uikit/uiupdateactionphase?language=objc) and event dispatch is guaranteed to come before display link callback.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
