### PR TITLE
Let SliverCrossAxisGroup collapse flexible children to zero extent

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -87,16 +87,16 @@ class RenderSliverCrossAxisGroup extends RenderSliver
     while (child != null) {
       final childParentData = child.parentData! as SliverPhysicalParentData;
       final int flex = childParentData.crossAxisFlex ?? 0;
-      double childExtent;
       if (flex != 0) {
-        childExtent = extentPerFlexValue * flex;
-        assert(_assertOutOfExtent(childExtent));
+        // Unlike the flex == 0 case above, a flexible child dividing up
+        // extent that has already been exhausted by constrained siblings is
+        // not an error: it degrades gracefully to a zero cross axis extent,
+        // matching how RenderFlex collapses flexible children when there is
+        // no free space (see https://github.com/flutter/flutter/issues/191275).
         child.layout(
           constraints.copyWith(crossAxisExtent: extentPerFlexValue * flex),
           parentUsesSize: true,
         );
-      } else {
-        childExtent = child.geometry!.crossAxisExtent!;
       }
       final SliverGeometry childLayoutGeometry = child.geometry!;
       if (geometry!.scrollExtent < childLayoutGeometry.scrollExtent) {

--- a/packages/flutter/test/widgets/sliver_cross_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_cross_axis_group_test.dart
@@ -625,13 +625,9 @@ void main() {
     );
   });
 
-  testWidgets('Assertion error when expanded widget runs out of cross axis extent', (
-    WidgetTester tester,
-  ) async {
-    final errors = <FlutterErrorDetails>[];
-    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
-    FlutterError.onError = (FlutterErrorDetails error) => errors.add(error);
-
+  // Regression test for https://github.com/flutter/flutter/issues/191275.
+  testWidgets('Expanded widget collapses to zero cross axis extent instead of asserting '
+      'when constrained siblings consume all available extent', (WidgetTester tester) async {
     final items = List<int>.generate(20, (int i) => i);
     await tester.pumpWidget(
       _buildSliverCrossAxisGroup(
@@ -660,14 +656,15 @@ void main() {
         ],
       ),
     );
+    // No assertion error: the third (flexible) sliver gets 0.0 cross axis
+    // extent instead of crashing, matching how RenderFlex collapses
+    // flexible children when there is no free space.
     await tester.pumpAndSettle();
-    FlutterError.onError = oldHandler;
-    expect(errors, isNotEmpty);
-    final error = errors.first.exception as AssertionError;
-    expect(
-      error.toString(),
-      contains('SliverCrossAxisGroup ran out of extent before child could be laid out.'),
-    );
+
+    final RenderSliverList third = tester
+        .renderObjectList<RenderSliverList>(find.byType(SliverList))
+        .last;
+    expect(third.constraints.crossAxisExtent, equals(0.0));
   });
 
   testWidgets('applyPaintTransform is implemented properly', (WidgetTester tester) async {


### PR DESCRIPTION
`RenderSliverCrossAxisGroup.performLayout` lays out `flex == 0` children first (e.g. `SliverConstrainedCrossAxis`, which determines its own cross axis extent), then divides whatever cross axis extent remains among the `flex != 0` children (e.g. `SliverCrossAxisExpanded`) proportionally.

If the `flex == 0` siblings consume all the available extent, `remainingExtent` reaches `0.0`, so every flexible child's share (`extentPerFlexValue * flex`) is also exactly `0.0`. An assertion on that share being strictly positive then throws `SliverCrossAxisGroup ran out of extent before child could be laid out.` — even though a flexible child getting `0.0` extent isn't actually a layout failure, it's the same graceful degradation `RenderFlex` already applies to `Expanded` children when a `Row`/`Column` has no free space left.

Fix: removed the assertion on the flexible branch. `crossAxisFlex` is always a positive int (asserted in `SliverCrossAxisExpanded`'s constructor) and `remainingExtent` is already clamped to `>= 0.0` before division, so the flexible share can be `0.0` but can never be negative there — the assertion was only ever rejecting the valid zero case. The assertion guarding the `flex == 0` branch (a sliver that determines its own required extent) is unchanged, since that's a different, legitimate failure mode.

The existing test `Assertion error when expanded widget runs out of cross axis extent` was asserting the crash as the expected behavior for exactly this scenario; updated it to assert the graceful zero-extent layout instead.

Fixes #191275

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
