### PR TITLE
android_hardware_smoke_test: Improve reliability

### DIFF
--- a/dev/bots/suite_runners/run_android_hardware_smoke_tests.dart
+++ b/dev/bots/suite_runners/run_android_hardware_smoke_tests.dart
@@ -156,7 +156,7 @@ Future<bool> _runRetryLoop(String testDir) async {
     return false;
   }
 
-  return false;
+  throw StateError('Unreachable');
 }
 
 class _InfrastructureException implements Exception {

--- a/dev/bots/suite_runners/run_android_hardware_smoke_tests.dart
+++ b/dev/bots/suite_runners/run_android_hardware_smoke_tests.dart
@@ -51,7 +51,7 @@ Future<void> runAndroidHardwareSmokeTests({
   try {
     _setAndroidManifestBackend(androidManifestXml, androidManifestContents, backend);
 
-    // 1. Run driver tests to generate reference screenshots (with retry loop)
+    // 1. Run driver tests to generate reference screenshots
     final bool success = await _runRetryLoop(testDir);
     if (!success) {
       return;
@@ -100,8 +100,7 @@ void _setAndroidManifestBackend(File file, String contents, ImpellerBackend back
 }
 
 Future<bool> _runRetryLoop(String testDir) async {
-  const maxAttempts = 3;
-  var exitCode = 0;
+  const maxAttempts = 2;
 
   for (var attempt = 1; attempt <= maxAttempts; attempt++) {
     // Clear logcat buffer before running
@@ -119,47 +118,53 @@ Future<bool> _runRetryLoop(String testDir) async {
       driveArgs.add('--no-build');
     }
 
-    final Command command = await startCommand('flutter', driveArgs, workingDirectory: testDir);
-    exitCode = await command.process.exitCode;
-    if (exitCode == 0) {
+    final CommandResult result = await runCommand('flutter', driveArgs, workingDirectory: testDir);
+    if (result.exitCode == 0) {
       return true;
     }
 
     io.stderr.writeln(
-      'flutter drive failed with exit code $exitCode on attempt $attempt/$maxAttempts.',
+      'flutter drive failed with exit code ${result.exitCode} on attempt $attempt/$maxAttempts.',
     );
 
-    // Inspect the process logcat on failure to detect if a transient EGL/graphics context
-    // negotiation error occurred during startup, enabling a safe activity/process level retry.
-    final bool hasEglWarning = await _checkForTransientEglFailure();
-    if (!hasEglWarning) {
-      // Non-retryable error: exit immediately and log specific failure
-      foundError(<String>[
-        'Android Hardware Smoke Tests driver run failed with exit code $exitCode and no transient EGL warning was found in logcat.',
-      ]);
-      return false;
+    final driverOutput = '${result.flattenedStdout}\n${result.flattenedStderr}';
+
+    // Inspect logcat and driver output on failure to detect if an unrecoverable EGL
+    // graphics pipeline collapse occurred (requires both logcat EGL error and blank image failure).
+    final bool hasEglWarning = await _checkForTransientEglFailure(driverOutput);
+    if (hasEglWarning) {
+      if (attempt < maxAttempts) {
+        io.stderr.writeln(
+          'Attempt $attempt failed with EGL/graphics error. Retrying with clean engine cache...',
+        );
+        continue;
+      }
+      io.stderr.writeln(
+        'INFRASTRUCTURE FAILURE: EGL / graphics driver pipeline collapsed on emulator after $maxAttempts attempts.',
+      );
+      io.exit(2);
     }
 
-    // Retryable EGL warning: log progress and continue if attempts remain
-    if (attempt < maxAttempts) {
-      io.stderr.writeln(
-        'attempt $attempt of $maxAttempts: detected retryable EGL initialization warning. Retrying...',
-      );
-    }
+    foundError(<String>[
+      'Android Hardware Smoke Tests driver run failed with exit code ${result.exitCode}.',
+    ]);
+    return false;
   }
 
-  // Loop finished: exhausted all attempts
-  foundError(<String>[
-    'Android Hardware Smoke Tests driver run failed to initialize EGL after $maxAttempts attempts.',
-  ]);
   return false;
 }
 
-Future<bool> _checkForTransientEglFailure() async {
+Future<bool> _checkForTransientEglFailure(String driverOutput) async {
   try {
     final String logcatOutput = await runAndGetStdout('adb', <String>['logcat', '-d']).join('\n');
-    return logcatOutput.contains('Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED') ||
-        logcatOutput.contains('Failed to initialize 101010-2 format');
+    final bool hasEglWarning =
+        logcatOutput.contains('Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED') ||
+        logcatOutput.contains('EGL_NOT_INITIALIZED') ||
+        logcatOutput.contains('EGL_BAD_CONFIG');
+    final bool hasBlankImageError =
+        driverOutput.contains('blank/empty') || driverOutput.contains('BlankScreenshotException');
+
+    return hasEglWarning && hasBlankImageError;
   } catch (e) {
     io.stderr.writeln('Warning: Failed to check logcat for EGL failure: $e');
     return false;

--- a/dev/bots/suite_runners/run_android_hardware_smoke_tests.dart
+++ b/dev/bots/suite_runners/run_android_hardware_smoke_tests.dart
@@ -161,10 +161,12 @@ Future<bool> _checkForTransientEglFailure(String driverOutput) async {
         logcatOutput.contains('Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED') ||
         logcatOutput.contains('EGL_NOT_INITIALIZED') ||
         logcatOutput.contains('EGL_BAD_CONFIG');
-    final bool hasBlankImageError =
-        driverOutput.contains('blank/empty') || driverOutput.contains('BlankScreenshotException');
+    final bool hasRenderingError =
+        driverOutput.contains('blank/empty') ||
+        driverOutput.contains('BlankScreenshotException') ||
+        driverOutput.contains('EglInitializationException');
 
-    return hasEglWarning && hasBlankImageError;
+    return hasEglWarning && hasRenderingError;
   } catch (e) {
     io.stderr.writeln('Warning: Failed to check logcat for EGL failure: $e');
     return false;

--- a/dev/bots/suite_runners/run_android_hardware_smoke_tests.dart
+++ b/dev/bots/suite_runners/run_android_hardware_smoke_tests.dart
@@ -69,6 +69,9 @@ Future<void> runAndroidHardwareSmokeTests({
         '-s',
       ], workingDirectory: androidDir);
     }
+  } on _InfrastructureException catch (e) {
+    foundError(<String>[e.message]);
+    io.exitCode = 2;
   } finally {
     // Restore original contents.
     androidManifestXml.writeAsStringSync(androidManifestContents);
@@ -142,7 +145,9 @@ Future<bool> _runRetryLoop(String testDir) async {
       io.stderr.writeln(
         'INFRASTRUCTURE FAILURE: EGL / graphics driver pipeline collapsed on emulator after $maxAttempts attempts.',
       );
-      io.exit(2);
+      throw _InfrastructureException(
+        'INFRASTRUCTURE FAILURE: EGL / graphics driver pipeline collapsed on emulator after $maxAttempts attempts.',
+      );
     }
 
     foundError(<String>[
@@ -152,6 +157,13 @@ Future<bool> _runRetryLoop(String testDir) async {
   }
 
   return false;
+}
+
+class _InfrastructureException implements Exception {
+  _InfrastructureException(this.message);
+  final String message;
+  @override
+  String toString() => message;
 }
 
 Future<bool> _checkForTransientEglFailure(String driverOutput) async {

--- a/dev/integration_tests/android_hardware_smoke_test/android/app/src/androidTest/java/com/example/android_hardware_smoke_test/FlutterActivityTest.kt
+++ b/dev/integration_tests/android_hardware_smoke_test/android/app/src/androidTest/java/com/example/android_hardware_smoke_test/FlutterActivityTest.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import io.flutter.embedding.engine.FlutterEngineCache
 import org.json.JSONObject
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
@@ -44,16 +43,13 @@ class FlutterActivityTest {
         @JvmStatic
         @AfterClass
         fun tearDownClass() {
-            InstrumentationRegistry.getInstrumentation().runOnMainSync {
-                val engine = FlutterEngineCache.getInstance().get(MainActivity.CACHED_ENGINE_KEY)
-                engine?.destroy()
-                FlutterEngineCache.getInstance().remove(MainActivity.CACHED_ENGINE_KEY)
-            }
+            MainActivity.evictEngineCache()
         }
 
         private fun verifyNoGraphicsPipelineErrors(marker: String) {
             val errors = getGraphicsPipelineErrors(marker)
             if (errors.isNotEmpty()) {
+                MainActivity.evictEngineCache()
                 throw EglInitializationException(
                     "Graphics pipeline/EGL failure detected in process logcat:\n${errors.joinToString("\n")}"
                 )
@@ -319,6 +315,9 @@ class FlutterActivityTest {
                 verifyNoGraphicsPipelineErrors(marker)
 
                 if (cropped == null) {
+                    // Evict engine cache if a screenshot is blank but no logcat EGL error was detected,
+                    // ensuring any subsequent test run attempt starts with a clean engine instance.
+                    MainActivity.evictEngineCache()
                     throw BlankScreenshotException(
                         "Captured screenshot is blank/empty after $maxAttempts attempts."
                     )

--- a/dev/integration_tests/android_hardware_smoke_test/android/app/src/androidTest/java/com/example/android_hardware_smoke_test/FlutterActivityTest.kt
+++ b/dev/integration_tests/android_hardware_smoke_test/android/app/src/androidTest/java/com/example/android_hardware_smoke_test/FlutterActivityTest.kt
@@ -43,13 +43,17 @@ class FlutterActivityTest {
         @JvmStatic
         @AfterClass
         fun tearDownClass() {
-            MainActivity.evictEngineCache()
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                MainActivity.evictEngineCache()
+            }
         }
 
         private fun verifyNoGraphicsPipelineErrors(marker: String) {
             val errors = getGraphicsPipelineErrors(marker)
             if (errors.isNotEmpty()) {
-                MainActivity.evictEngineCache()
+                InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                    MainActivity.evictEngineCache()
+                }
                 throw EglInitializationException(
                     "Graphics pipeline/EGL failure detected in process logcat:\n${errors.joinToString("\n")}"
                 )
@@ -317,7 +321,9 @@ class FlutterActivityTest {
                 if (cropped == null) {
                     // Evict engine cache if a screenshot is blank but no logcat EGL error was detected,
                     // ensuring any subsequent test run attempt starts with a clean engine instance.
-                    MainActivity.evictEngineCache()
+                    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                        MainActivity.evictEngineCache()
+                    }
                     throw BlankScreenshotException(
                         "Captured screenshot is blank/empty after $maxAttempts attempts."
                     )

--- a/dev/integration_tests/android_hardware_smoke_test/android/app/src/main/kotlin/com/example/android_hardware_smoke_test/MainActivity.kt
+++ b/dev/integration_tests/android_hardware_smoke_test/android/app/src/main/kotlin/com/example/android_hardware_smoke_test/MainActivity.kt
@@ -7,8 +7,6 @@ import android.content.pm.PackageManager
 import android.graphics.PixelFormat
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
@@ -32,33 +30,11 @@ class MainActivity : FlutterActivity() {
         private var activeActivity: WeakReference<MainActivity>? = null
 
         // Destroys and removes the cached FlutterEngine and resets lastConfiguredEngine.
-        // Synchronously blocks if called from a background thread to prevent race conditions
-        // where a subsequent test attempt allocates a new engine before eviction finishes.
         fun evictEngineCache() {
-            val action =
-                Runnable {
-                    val engine = FlutterEngineCache.getInstance().get(CACHED_ENGINE_KEY)
-                    engine?.destroy()
-                    FlutterEngineCache.getInstance().remove(CACHED_ENGINE_KEY)
-                    lastConfiguredEngine = null
-                }
-            if (Looper.myLooper() == Looper.getMainLooper()) {
-                action.run()
-            } else {
-                val latch = java.util.concurrent.CountDownLatch(1)
-                Handler(Looper.getMainLooper()).post {
-                    try {
-                        action.run()
-                    } finally {
-                        latch.countDown()
-                    }
-                }
-                try {
-                    latch.await()
-                } catch (e: InterruptedException) {
-                    Thread.currentThread().interrupt()
-                }
-            }
+            val engine = FlutterEngineCache.getInstance().get(CACHED_ENGINE_KEY)
+            engine?.destroy()
+            FlutterEngineCache.getInstance().remove(CACHED_ENGINE_KEY)
+            lastConfiguredEngine = null
         }
     }
 

--- a/dev/integration_tests/android_hardware_smoke_test/android/app/src/main/kotlin/com/example/android_hardware_smoke_test/MainActivity.kt
+++ b/dev/integration_tests/android_hardware_smoke_test/android/app/src/main/kotlin/com/example/android_hardware_smoke_test/MainActivity.kt
@@ -31,6 +31,9 @@ class MainActivity : FlutterActivity() {
         // Tracks the active activity to prevent transition race conditions on the cached engine.
         private var activeActivity: WeakReference<MainActivity>? = null
 
+        // Destroys and removes the cached FlutterEngine and resets lastConfiguredEngine.
+        // Synchronously blocks if called from a background thread to prevent race conditions
+        // where a subsequent test attempt allocates a new engine before eviction finishes.
         fun evictEngineCache() {
             val action =
                 Runnable {
@@ -42,14 +45,28 @@ class MainActivity : FlutterActivity() {
             if (Looper.myLooper() == Looper.getMainLooper()) {
                 action.run()
             } else {
-                Handler(Looper.getMainLooper()).post(action)
+                val latch = java.util.concurrent.CountDownLatch(1)
+                Handler(Looper.getMainLooper()).post {
+                    try {
+                        action.run()
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+                try {
+                    latch.await()
+                } catch (e: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                }
             }
         }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+        // Lock window pixel format to 8-bit sRGB before FlutterActivity initialization
+        // to prevent HWUI 10-bit format negotiation errors on SwiftShader drivers.
         window.setFormat(PixelFormat.RGBA_8888)
+        super.onCreate(savedInstanceState)
     }
 
     // Accessed by FlutterActivityTest to send orchestration messages.

--- a/dev/integration_tests/android_hardware_smoke_test/android/app/src/main/kotlin/com/example/android_hardware_smoke_test/MainActivity.kt
+++ b/dev/integration_tests/android_hardware_smoke_test/android/app/src/main/kotlin/com/example/android_hardware_smoke_test/MainActivity.kt
@@ -4,7 +4,11 @@ package com.example.android_hardware_smoke_test
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.PixelFormat
 import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
@@ -26,6 +30,26 @@ class MainActivity : FlutterActivity() {
 
         // Tracks the active activity to prevent transition race conditions on the cached engine.
         private var activeActivity: WeakReference<MainActivity>? = null
+
+        fun evictEngineCache() {
+            val action =
+                Runnable {
+                    val engine = FlutterEngineCache.getInstance().get(CACHED_ENGINE_KEY)
+                    engine?.destroy()
+                    FlutterEngineCache.getInstance().remove(CACHED_ENGINE_KEY)
+                    lastConfiguredEngine = null
+                }
+            if (Looper.myLooper() == Looper.getMainLooper()) {
+                action.run()
+            } else {
+                Handler(Looper.getMainLooper()).post(action)
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        window.setFormat(PixelFormat.RGBA_8888)
     }
 
     // Accessed by FlutterActivityTest to send orchestration messages.


### PR DESCRIPTION
Issue https://github.com/flutter/flutter/issues/191348 shows that the detection and retry behavior introduced in PR https://github.com/flutter/flutter/pull/190110 did not solve the issue.

Previously, engine cache cleanup was placed solely in `@AfterClass tearDownClass()`. When a test run failed mid-suite on attempt 1, JUnit aborted before `@AfterClass` could run. When attempt 2 launched, `MainActivity` retrieved the corrupted engine from cache, guaranteeing that subsequent attempts failed with blank screenshots, which matches what we see in the run history.

To fix this, we move cache cleanup to `MainActivity.evictEngineCache()`. `FlutterActivityTest.kt` invokes this cleanup during class teardown and whenever an `EglInitializationException` or `BlankScreenshotException` occurs, ensuring any retry starts with a clean engine instance. 

We also reduce the retry cap in `run_android_hardware_smoke_tests.dart` from 3 attempts to 2 to avoid 30-minute LUCI timeouts on broken emulators, which we saw some of in tryjobs. 

I think this should be an infrastructure failure. So if an unrecoverable EGL collapse occurs across both attempts, the runner logs an infrastructure failure and exits with code 2 (`INFRA_FAILURE`)

We also saw some logs which suggest HWUI repeatedly attempted 10-bit color format negotiation (`101010-2`), which fails on SwiftShader CPU drivers. This could contribute to an increased rate of EGL errors, so `MainActivity.onCreate()` now explicitly locks the window pixel format to `PixelFormat.RGBA_8888`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
