### PR TITLE
[flutter_tools] Compute LSP Content-Length header using UTF-8 byte length

### DIFF
--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -144,7 +144,8 @@ class AnalysisServer {
   Future<int?>? _onExit;
 
   void _writeMessage({required String message}) {
-    _process?.stdin.write('Content-Length: ${message.length}\r\n\r\n$message');
+    final List<int> encodedMessage = utf8.encode(message);
+    _process?.stdin.write('Content-Length: ${encodedMessage.length}\r\n\r\n$message');
   }
 
   Future<Map<String, Object?>?> sendRequest(String method, Map<String, Object?> params) async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/analysis_server_mock.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analysis_server_mock.dart
@@ -24,11 +24,11 @@ class MockLspServerProcess extends test_process_manager.FakeProcess {
     required Completer<void> exitCompleter,
   }) : _exitCompleter = exitCompleter,
        super(completer: exitCompleter) {
-    _stdinController.stream.transform(utf8.decoder).listen(_handleStdinChunk);
+    _stdinController.stream.listen(_handleStdinBytes);
   }
 
   final StreamController<List<int>> _stdinController;
-  final _inputBuffer = StringBuffer();
+  final _inputBuffer = <int>[];
   final _stdoutController = StreamController<List<int>>();
   final Completer<void> _exitCompleter;
 
@@ -85,31 +85,44 @@ class MockLspServerProcess extends test_process_manager.FakeProcess {
     }
   }
 
-  void _handleStdinChunk(String chunk) {
-    _inputBuffer.write(chunk);
-    var input = _inputBuffer.toString();
-    while (true) {
-      final int headerEnd = input.indexOf('\r\n\r\n');
+  static final RegExp _contentLengthRegExp = RegExp(
+    r'content-length:\s*(\d+)',
+    caseSensitive: false,
+  );
+
+  void _handleStdinBytes(List<int> bytes) {
+    _inputBuffer.addAll(bytes);
+    while (_inputBuffer.isNotEmpty) {
+      var headerEnd = -1;
+      for (var i = 0; i < _inputBuffer.length - 3; i++) {
+        if (_inputBuffer[i] == 13 &&
+            _inputBuffer[i + 1] == 10 &&
+            _inputBuffer[i + 2] == 13 &&
+            _inputBuffer[i + 3] == 10) {
+          headerEnd = i;
+          break;
+        }
+      }
       if (headerEnd == -1) {
         break;
       }
-      final String header = input.substring(0, headerEnd);
-      final Match? contentLengthMatch = RegExp(r'Content-Length: (\d+)').firstMatch(header);
+      final String header = utf8.decode(_inputBuffer.sublist(0, headerEnd));
+      final Match? contentLengthMatch = _contentLengthRegExp.firstMatch(header);
       if (contentLengthMatch == null) {
         throw StateError('LSP request is missing a Content-Length header.');
       }
       final int contentLength = int.parse(contentLengthMatch.group(1)!);
-      final int messageEnd = headerEnd + 4 + contentLength;
-      if (input.length < messageEnd) {
+      if (_inputBuffer.length < headerEnd + 4 + contentLength) {
         break;
       }
-      final String message = input.substring(headerEnd + 4, messageEnd);
+      final List<int> messageBytes = _inputBuffer.sublist(
+        headerEnd + 4,
+        headerEnd + 4 + contentLength,
+      );
+      _inputBuffer.removeRange(0, headerEnd + 4 + contentLength);
+      final String message = utf8.decode(messageBytes);
       unawaited(_handleRequest(jsonDecode(message) as Map<String, Object?>));
-      input = input.substring(messageEnd);
     }
-    _inputBuffer
-      ..clear()
-      ..write(input);
   }
 
   void _sendNotification(String method, Map<String, Object?> params) {
@@ -166,7 +179,8 @@ class MockLspServerProcess extends test_process_manager.FakeProcess {
   }
 
   void _writeAsLspToStdout(String message) {
-    _stdoutController.add(utf8.encode('Content-Length: ${message.length}\r\n\r\n$message'));
+    final List<int> bytes = utf8.encode(message);
+    _stdoutController.add(utf8.encode('Content-Length: ${bytes.length}\r\n\r\n$message'));
   }
 
   void _writeRawOutput(String output) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -117,6 +117,52 @@ void main() {
     expect(processManager, hasNoRemainingExpectations);
   });
 
+  testUsingContext('AnalysisServer handles non-ASCII project path', () async {
+    final Directory tempDir = fileSystem.systemTempDirectory.createTempSync(
+      'flutter_analysis_test_’_dir.',
+    );
+    createSampleProject(tempDir);
+
+    final process = MockLspServerProcess();
+    final processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(
+        command: <String>[
+          fileSystem.path.join('Artifact.engineDartSdkPath', 'bin', 'dart'),
+          'language-server',
+          '--dart-sdk',
+          'Artifact.engineDartSdkPath',
+          '--disable-server-feature-completion',
+          '--disable-server-feature-search',
+          '--suppress-analytics',
+        ],
+        process: process,
+      ),
+    ]);
+
+    final server = AnalysisServer(
+      'Artifact.engineDartSdkPath',
+      <String>[tempDir.path],
+      fileSystem: fileSystem,
+      platform: FakePlatform(),
+      processManager: processManager,
+      logger: logger,
+      terminal: terminal,
+      suppressAnalytics: true,
+    );
+
+    var errorCount = 0;
+    server.onErrors.listen((FileAnalysisErrors errors) => errorCount += errors.errors.length);
+
+    await server.start();
+    process.triggerSimulatedAnalysis();
+    await server.waitForAnalysis();
+
+    expect(errorCount, 0);
+
+    await server.dispose();
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
   testUsingContext('AnalysisServer errors', () async {
     final Directory tempDir = fileSystem.systemTempDirectory.createTempSync(
       'flutter_analysis_test.',


### PR DESCRIPTION
## Description

Fixes `flutter analyze` crashing with `FormatException: Unexpected end of input` when analyzing a project whose path contains non-ASCII characters (e.g. `Alexander’s MacBook Pro` with right single quotation mark `’` / U+2019).

In `AnalysisServer._writeMessage`, the `Content-Length` header was being calculated using `message.length` (UTF-16 code units) rather than the UTF-8 encoded byte length required by the LSP specification. When messages contained multibyte Unicode characters (such as in `rootUri` or `workspaceFolders`), the header under-reported the payload length, causing the analysis server's JSON parser to receive a truncated payload and exit prematurely with code 255.

Also updates `MockLspServerProcess` to parse stdin as a stream of raw bytes and compute outgoing message length in bytes to faithfully simulate the LSP transport layer.

## Related Issues
Fixes https://github.com/flutter/flutter/issues/191309

## Tests
- Added `AnalysisServer handles non-ASCII project path` unit test in `packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md