### PR TITLE
[Widget Preview] Isolate PageStorage scope in widget preview group expansion tile

### DIFF
--- a/dev/integration_tests/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/dev/integration_tests/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -217,7 +217,7 @@ class PreviewWidgetElement extends StatelessElement {
   PreviewWidgetElement(super.widget);
 }
 
-class WidgetPreviewGroupWidget extends StatelessWidget {
+class WidgetPreviewGroupWidget extends StatefulWidget {
   const WidgetPreviewGroupWidget({
     super.key,
     required this.controller,
@@ -235,6 +235,14 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
   // TODO(bkonyi): inherit this from the theme.
   static const _kCardRadius = Radius.circular(12);
 
+  @override
+  State<WidgetPreviewGroupWidget> createState() =>
+      _WidgetPreviewGroupWidgetState();
+}
+
+class _WidgetPreviewGroupWidgetState extends State<WidgetPreviewGroupWidget> {
+  final _bucket = PageStorageBucket();
+
   Widget _buildGridViewFlex(List<WidgetPreview> previews) {
     return Wrap(
       spacing: WidgetPreviewGroupWidget._gridSpacing,
@@ -242,7 +250,7 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
       alignment: WrapAlignment.start,
       children: [
         for (final WidgetPreview preview in previews)
-          WidgetPreviewWidget(controller: controller, preview: preview),
+          WidgetPreviewWidget(controller: widget.controller, preview: preview),
       ],
     );
   }
@@ -253,7 +261,7 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
         for (final preview in previews)
           Center(
             child: WidgetPreviewWidget(
-              controller: controller,
+              controller: widget.controller,
               preview: preview,
             ),
           ),
@@ -269,7 +277,9 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
         data: ListTileTheme.of(context).copyWith(
           dense: true,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(_kCardRadius),
+            borderRadius: BorderRadius.all(
+              WidgetPreviewGroupWidget._kCardRadius,
+            ),
           ),
         ),
         child: Theme(
@@ -277,8 +287,8 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
           // expanded ExpansionTile.
           data: theme.copyWith(dividerColor: Colors.transparent),
           child: ExpansionTile(
-            key: PageStorageKey(group.name),
-            title: Text(group.name),
+            key: PageStorageKey(widget.group.name),
+            title: Text(widget.group.name),
             initiallyExpanded: true,
             children: [
               // Wrap children in a PageStorage to create a storage boundary.
@@ -288,14 +298,16 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
               // to read the ExpansionTile's boolean expansion state as a double,
               // throwing a TypeError (see https://github.com/flutter/flutter/issues/191242).
               PageStorage(
-                bucket: PageStorageBucket(),
+                bucket: _bucket,
                 child: ValueListenableBuilder<LayoutType>(
-                  valueListenable: controller.layoutTypeListenable,
+                  valueListenable: widget.controller.layoutTypeListenable,
                   builder: (context, selectedLayout, _) {
                     return switch (selectedLayout) {
-                      LayoutType.gridView => _buildGridViewFlex(group.previews),
+                      LayoutType.gridView => _buildGridViewFlex(
+                        widget.group.previews,
+                      ),
                       LayoutType.listView => _buildVerticalListView(
-                        group.previews,
+                        widget.group.previews,
                       ),
                     };
                   },

--- a/dev/integration_tests/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/dev/integration_tests/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -281,16 +281,25 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
             title: Text(group.name),
             initiallyExpanded: true,
             children: [
-              ValueListenableBuilder<LayoutType>(
-                valueListenable: controller.layoutTypeListenable,
-                builder: (context, selectedLayout, _) {
-                  return switch (selectedLayout) {
-                    LayoutType.gridView => _buildGridViewFlex(group.previews),
-                    LayoutType.listView => _buildVerticalListView(
-                      group.previews,
-                    ),
-                  };
-                },
+              // Wrap children in a PageStorage to create a storage boundary.
+              // Without this, descendant scrollables (which search ancestor
+              // elements for a PageStorageKey when restoring scroll offset)
+              // inherit the PageStorageKey from the ExpansionTile and attempt
+              // to read the ExpansionTile's boolean expansion state as a double,
+              // throwing a TypeError (see https://github.com/flutter/flutter/issues/191242).
+              PageStorage(
+                bucket: PageStorageBucket(),
+                child: ValueListenableBuilder<LayoutType>(
+                  valueListenable: controller.layoutTypeListenable,
+                  builder: (context, selectedLayout, _) {
+                    return switch (selectedLayout) {
+                      LayoutType.gridView => _buildGridViewFlex(group.previews),
+                      LayoutType.listView => _buildVerticalListView(
+                        group.previews,
+                      ),
+                    };
+                  },
+                ),
               ),
             ],
           ),

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -217,7 +217,7 @@ class PreviewWidgetElement extends StatelessElement {
   PreviewWidgetElement(super.widget);
 }
 
-class WidgetPreviewGroupWidget extends StatelessWidget {
+class WidgetPreviewGroupWidget extends StatefulWidget {
   const WidgetPreviewGroupWidget({
     super.key,
     required this.controller,
@@ -235,6 +235,14 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
   // TODO(bkonyi): inherit this from the theme.
   static const _kCardRadius = Radius.circular(12);
 
+  @override
+  State<WidgetPreviewGroupWidget> createState() =>
+      _WidgetPreviewGroupWidgetState();
+}
+
+class _WidgetPreviewGroupWidgetState extends State<WidgetPreviewGroupWidget> {
+  final _bucket = PageStorageBucket();
+
   Widget _buildGridViewFlex(List<WidgetPreview> previews) {
     return Wrap(
       spacing: WidgetPreviewGroupWidget._gridSpacing,
@@ -242,7 +250,7 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
       alignment: WrapAlignment.start,
       children: [
         for (final WidgetPreview preview in previews)
-          WidgetPreviewWidget(controller: controller, preview: preview),
+          WidgetPreviewWidget(controller: widget.controller, preview: preview),
       ],
     );
   }
@@ -253,7 +261,7 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
         for (final preview in previews)
           Center(
             child: WidgetPreviewWidget(
-              controller: controller,
+              controller: widget.controller,
               preview: preview,
             ),
           ),
@@ -269,7 +277,7 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
         data: ListTileTheme.of(context).copyWith(
           dense: true,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(_kCardRadius),
+            borderRadius: BorderRadius.all(WidgetPreviewGroupWidget._kCardRadius),
           ),
         ),
         child: Theme(
@@ -277,8 +285,8 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
           // expanded ExpansionTile.
           data: theme.copyWith(dividerColor: Colors.transparent),
           child: ExpansionTile(
-            key: PageStorageKey(group.name),
-            title: Text(group.name),
+            key: PageStorageKey(widget.group.name),
+            title: Text(widget.group.name),
             initiallyExpanded: true,
             children: [
               // Wrap children in a PageStorage to create a storage boundary.
@@ -288,14 +296,14 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
               // to read the ExpansionTile's boolean expansion state as a double,
               // throwing a TypeError (see https://github.com/flutter/flutter/issues/191242).
               PageStorage(
-                bucket: PageStorageBucket(),
+                bucket: _bucket,
                 child: ValueListenableBuilder<LayoutType>(
-                  valueListenable: controller.layoutTypeListenable,
+                  valueListenable: widget.controller.layoutTypeListenable,
                   builder: (context, selectedLayout, _) {
                     return switch (selectedLayout) {
-                      LayoutType.gridView => _buildGridViewFlex(group.previews),
+                      LayoutType.gridView => _buildGridViewFlex(widget.group.previews),
                       LayoutType.listView => _buildVerticalListView(
-                        group.previews,
+                        widget.group.previews,
                       ),
                     };
                   },
@@ -308,6 +316,7 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
     );
   }
 }
+
 
 class WidgetPreviewWidget extends StatefulWidget {
   const WidgetPreviewWidget({

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -281,16 +281,25 @@ class WidgetPreviewGroupWidget extends StatelessWidget {
             title: Text(group.name),
             initiallyExpanded: true,
             children: [
-              ValueListenableBuilder<LayoutType>(
-                valueListenable: controller.layoutTypeListenable,
-                builder: (context, selectedLayout, _) {
-                  return switch (selectedLayout) {
-                    LayoutType.gridView => _buildGridViewFlex(group.previews),
-                    LayoutType.listView => _buildVerticalListView(
-                      group.previews,
-                    ),
-                  };
-                },
+              // Wrap children in a PageStorage to create a storage boundary.
+              // Without this, descendant scrollables (which search ancestor
+              // elements for a PageStorageKey when restoring scroll offset)
+              // inherit the PageStorageKey from the ExpansionTile and attempt
+              // to read the ExpansionTile's boolean expansion state as a double,
+              // throwing a TypeError (see https://github.com/flutter/flutter/issues/191242).
+              PageStorage(
+                bucket: PageStorageBucket(),
+                child: ValueListenableBuilder<LayoutType>(
+                  valueListenable: controller.layoutTypeListenable,
+                  builder: (context, selectedLayout, _) {
+                    return switch (selectedLayout) {
+                      LayoutType.gridView => _buildGridViewFlex(group.previews),
+                      LayoutType.listView => _buildVerticalListView(
+                        group.previews,
+                      ),
+                    };
+                  },
+                ),
               ),
             ],
           ),

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -277,7 +277,9 @@ class _WidgetPreviewGroupWidgetState extends State<WidgetPreviewGroupWidget> {
         data: ListTileTheme.of(context).copyWith(
           dense: true,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(WidgetPreviewGroupWidget._kCardRadius),
+            borderRadius: BorderRadius.all(
+              WidgetPreviewGroupWidget._kCardRadius,
+            ),
           ),
         ),
         child: Theme(
@@ -301,7 +303,9 @@ class _WidgetPreviewGroupWidgetState extends State<WidgetPreviewGroupWidget> {
                   valueListenable: widget.controller.layoutTypeListenable,
                   builder: (context, selectedLayout, _) {
                     return switch (selectedLayout) {
-                      LayoutType.gridView => _buildGridViewFlex(widget.group.previews),
+                      LayoutType.gridView => _buildGridViewFlex(
+                        widget.group.previews,
+                      ),
                       LayoutType.listView => _buildVerticalListView(
                         widget.group.previews,
                       ),
@@ -316,7 +320,6 @@ class _WidgetPreviewGroupWidgetState extends State<WidgetPreviewGroupWidget> {
     );
   }
 }
-
 
 class WidgetPreviewWidget extends StatefulWidget {
   const WidgetPreviewWidget({


### PR DESCRIPTION
## Description

When a preview group is collapsed and re-expanded in the Widget Previewer, descendant scrollables (which search ancestor elements for a `PageStorageKey` when restoring scroll offset) inherit the `PageStorageKey` from the `ExpansionTile`. They then attempt to read the `ExpansionTile`'s boolean expansion state as a double, throwing a `TypeError: true: type 'bool' is not a subtype of type 'double?'`.

This PR wraps the `ExpansionTile` children in a `PageStorage` widget with a new `PageStorageBucket`, preventing descendant scrollable widgets from inheriting the `ExpansionTile`'s `PageStorageKey`.

## Related Issues
Fixes https://github.com/flutter/flutter/issues/191242

## Tests
- Tested in widget preview scaffold template.