### PR TITLE
Fixes MSAA on the linux embedder.

### DIFF
--- a/engine/src/flutter/shell/platform/linux/BUILD.gn
+++ b/engine/src/flutter/shell/platform/linux/BUILD.gn
@@ -255,6 +255,7 @@ executable("flutter_linux_unittests") {
     "fl_method_codec_test.cc",
     "fl_method_response_test.cc",
     "fl_mouse_cursor_handler_test.cc",
+    "fl_opengl_frame_test.cc",
     "fl_pixel_buffer_texture_test.cc",
     "fl_platform_channel_test.cc",
     "fl_platform_handler_test.cc",

--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -287,11 +287,15 @@ static bool create_opengl_backing_store(
     return false;
   }
 
-  GLint sized_format = GL_RGBA8;
   GLint general_format = GL_RGBA;
+  GLint sized_format = GL_RGBA8;
+  if (epoxy_has_gl_extension("GL_EXT_texture_format_BGRA8888")) {
+    general_format = GL_BGRA_EXT;
+    sized_format = GL_BGRA8_EXT;
+  }
 
   FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
-      sized_format, general_format, config->size.width, config->size.height,
+      general_format, config->size.width, config->size.height,
       fl_dart_project_get_enable_impeller(self->project));
   if (!framebuffer) {
     g_warning("Failed to create backing store");
@@ -303,7 +307,8 @@ static bool create_opengl_backing_store(
   backing_store_out->open_gl.framebuffer.user_data = framebuffer;
   backing_store_out->open_gl.framebuffer.name =
       fl_framebuffer_get_id(framebuffer);
-  backing_store_out->open_gl.framebuffer.target = sized_format;
+  backing_store_out->open_gl.framebuffer.target =
+      fl_framebuffer_get_texture_id(framebuffer) != 0 ? sized_format : GL_RGBA8;
   backing_store_out->open_gl.framebuffer.destruction_callback = [](void* p) {
     // Backing store destroyed in fl_compositor_opengl_collect_backing_store(),
     // set on FlutterCompositor.collect_backing_store_callback during engine

--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -50,9 +50,6 @@ struct _FlEngine {
   // Type of rendering performed.
   FlutterRendererType renderer_type;
 
-  // Whether Impeller is enabled.
-  gboolean enable_impeller;
-
   // Manages OpenGL contexts.
   FlOpenGLManager* opengl_manager;
 
@@ -295,7 +292,7 @@ static bool create_opengl_backing_store(
 
   FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
       sized_format, general_format, config->size.width, config->size.height,
-      self->enable_impeller);
+      fl_dart_project_get_enable_impeller(self->project));
   if (!framebuffer) {
     g_warning("Failed to create backing store");
     return false;
@@ -691,7 +688,6 @@ static FlEngine* fl_engine_new_full(FlDartProject* project,
   FlEngine* self = FL_ENGINE(g_object_new(fl_engine_get_type(), nullptr));
 
   self->project = FL_DART_PROJECT(g_object_ref(project));
-  self->enable_impeller = fl_dart_project_get_enable_impeller(self->project);
   const gchar* renderer = g_getenv("FLUTTER_LINUX_RENDERER");
   if (g_strcmp0(renderer, "software") == 0) {
     self->renderer_type = kSoftware;
@@ -828,7 +824,6 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
       has_enable_impeller = TRUE;
     }
   }
-  self->enable_impeller = enable_impeller;
 
   g_autoptr(GPtrArray) command_line_args =
       g_ptr_array_new_with_free_func(g_free);

--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -50,6 +50,9 @@ struct _FlEngine {
   // Type of rendering performed.
   FlutterRendererType renderer_type;
 
+  // Whether Impeller is enabled.
+  gboolean enable_impeller;
+
   // Manages OpenGL contexts.
   FlOpenGLManager* opengl_manager;
 
@@ -289,13 +292,10 @@ static bool create_opengl_backing_store(
 
   GLint sized_format = GL_RGBA8;
   GLint general_format = GL_RGBA;
-  if (epoxy_has_gl_extension("GL_EXT_texture_format_BGRA8888")) {
-    sized_format = GL_BGRA8_EXT;
-    general_format = GL_BGRA_EXT;
-  }
 
-  FlFramebuffer* framebuffer = fl_framebuffer_new(
-      general_format, config->size.width, config->size.height, FALSE);
+  FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
+      sized_format, general_format, config->size.width, config->size.height,
+      self->enable_impeller);
   if (!framebuffer) {
     g_warning("Failed to create backing store");
     return false;
@@ -691,6 +691,7 @@ static FlEngine* fl_engine_new_full(FlDartProject* project,
   FlEngine* self = FL_ENGINE(g_object_new(fl_engine_get_type(), nullptr));
 
   self->project = FL_DART_PROJECT(g_object_ref(project));
+  self->enable_impeller = fl_dart_project_get_enable_impeller(self->project);
   const gchar* renderer = g_getenv("FLUTTER_LINUX_RENDERER");
   if (g_strcmp0(renderer, "software") == 0) {
     self->renderer_type = kSoftware;
@@ -827,6 +828,7 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
       has_enable_impeller = TRUE;
     }
   }
+  self->enable_impeller = enable_impeller;
 
   g_autoptr(GPtrArray) command_line_args =
       g_ptr_array_new_with_free_func(g_free);

--- a/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
@@ -1062,28 +1062,14 @@ TEST_F(FlEngineTest, EnableFlutterGpu) {
   EXPECT_TRUE(called);
 }
 
-TEST_F(FlEngineTest, CreateOpenGLBackingStoreWithImpellerMSAA) {
-  ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
-  ON_CALL(epoxy, epoxy_gl_version).WillByDefault(::testing::Return(30));
-  ON_CALL(epoxy, epoxy_has_gl_extension(::testing::_))
-      .WillByDefault(::testing::Return(false));
-  ON_CALL(epoxy, glGetIntegerv(GL_MAX_SAMPLES, ::testing::_))
-      .WillByDefault(::testing::SetArgPointee<1>(4));
+namespace {
 
-  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4,
-                                                      GL_RGBA8, 800, 600));
-  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(
-                         GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, 800, 600));
-  EXPECT_CALL(epoxy,
-              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                                        GL_RENDERBUFFER, ::testing::_));
-  EXPECT_CALL(epoxy,
-              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                                        GL_RENDERBUFFER, ::testing::_));
-  EXPECT_CALL(epoxy,
-              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
-                                        GL_RENDERBUFFER, ::testing::_));
-
+// Helper to start the engine with Impeller enabled, create an OpenGL backing
+// store, verify its target and texture presence, and collect it.
+void test_impeller_backing_store(FlEngine* engine,
+                                 FlDartProject* project,
+                                 uint32_t expected_target,
+                                 bool expect_texture) {
   FlutterCompositor compositor = {};
   fl_engine_get_embedder_api(engine)->Initialize = MOCK_ENGINE_PROC(
       Initialize,
@@ -1107,23 +1093,93 @@ TEST_F(FlEngineTest, CreateOpenGLBackingStoreWithImpellerMSAA) {
 
   FlutterBackingStoreConfig config = {
       .struct_size = sizeof(FlutterBackingStoreConfig),
-      .size = {.width = 800, .height = 600},
+      .size = {.width = 800.0, .height = 600.0},
   };
   FlutterBackingStore backing_store = {};
   EXPECT_TRUE(compositor.create_backing_store_callback(&config, &backing_store,
                                                        compositor.user_data));
   EXPECT_EQ(backing_store.type, kFlutterBackingStoreTypeOpenGL);
   EXPECT_EQ(backing_store.open_gl.type, kFlutterOpenGLTargetTypeFramebuffer);
-  EXPECT_EQ(backing_store.open_gl.framebuffer.target,
-            static_cast<uint32_t>(GL_RGBA8));
+  EXPECT_EQ(backing_store.open_gl.framebuffer.target, expected_target);
 
   FlFramebuffer* fb =
       FL_FRAMEBUFFER(backing_store.open_gl.framebuffer.user_data);
   EXPECT_NE(fb, nullptr);
-  EXPECT_EQ(fl_framebuffer_get_texture_id(fb), 0u);
+  if (expect_texture) {
+    EXPECT_NE(fl_framebuffer_get_texture_id(fb), 0u);
+  } else {
+    EXPECT_EQ(fl_framebuffer_get_texture_id(fb), 0u);
+  }
 
   EXPECT_TRUE(compositor.collect_backing_store_callback(&backing_store,
                                                         compositor.user_data));
+}
+
+}  // namespace
+
+TEST_F(FlEngineTest, CreateOpenGLBackingStoreWithImpellerMSAA) {
+  ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
+  ON_CALL(epoxy, epoxy_gl_version).WillByDefault(::testing::Return(30));
+  ON_CALL(epoxy, epoxy_has_gl_extension(::testing::_))
+      .WillByDefault(::testing::Return(false));
+  ON_CALL(epoxy, glGetIntegerv(GL_MAX_SAMPLES, ::testing::_))
+      .WillByDefault(::testing::SetArgPointee<1>(4));
+
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4,
+                                                      GL_RGBA8, 800, 600));
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(
+                         GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, 800, 600));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                        GL_RENDERBUFFER, ::testing::_));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                        GL_RENDERBUFFER, ::testing::_));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                        GL_RENDERBUFFER, ::testing::_));
+
+  test_impeller_backing_store(engine, project, GL_RGBA8,
+                              /*expect_texture=*/false);
+}
+
+TEST_F(FlEngineTest, CreateOpenGLBackingStoreWithImpellerMSAAAndBgraExtension) {
+  ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
+  ON_CALL(epoxy, epoxy_gl_version).WillByDefault(::testing::Return(30));
+  ON_CALL(epoxy, epoxy_has_gl_extension(::testing::_))
+      .WillByDefault(::testing::Return(false));
+  ON_CALL(epoxy, epoxy_has_gl_extension(
+                     ::testing::StrEq("GL_EXT_texture_format_BGRA8888")))
+      .WillByDefault(::testing::Return(true));
+  ON_CALL(epoxy, glGetIntegerv(GL_MAX_SAMPLES, ::testing::_))
+      .WillByDefault(::testing::SetArgPointee<1>(4));
+
+  // GL_EXT_texture_format_BGRA8888 only defines BGRA for textures, not
+  // renderbuffers. When explicit offscreen MSAA is used without
+  // GL_EXT_multisampled_render_to_texture, a multisample renderbuffer is
+  // created which must use GL_RGBA8.
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4,
+                                                      GL_RGBA8, 800, 600));
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(
+                         GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, 800, 600));
+
+  test_impeller_backing_store(engine, project, GL_RGBA8,
+                              /*expect_texture=*/false);
+}
+
+TEST_F(FlEngineTest, CreateOpenGLBackingStoreWithImplicitMSAAAndBgraExtension) {
+  ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
+  ON_CALL(epoxy, epoxy_has_gl_extension(::testing::_))
+      .WillByDefault(::testing::Return(false));
+  ON_CALL(epoxy, epoxy_has_gl_extension(
+                     ::testing::StrEq("GL_EXT_texture_format_BGRA8888")))
+      .WillByDefault(::testing::Return(true));
+  ON_CALL(epoxy, epoxy_has_gl_extension(
+                     ::testing::StrEq("GL_EXT_multisampled_render_to_texture")))
+      .WillByDefault(::testing::Return(true));
+
+  test_impeller_backing_store(engine, project, GL_BGRA8_EXT,
+                              /*expect_texture=*/true);
 }
 
 TEST_F(FlEngineTest, ChildObjects) {

--- a/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
@@ -8,9 +8,11 @@
 
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
+#include "flutter/shell/platform/linux/fl_framebuffer.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_string_codec.h"
+#include "flutter/shell/platform/linux/testing/mock_epoxy.h"
 #include "flutter/shell/platform/linux/testing/mock_renderable.h"
 
 // MOCK_ENGINE_PROC is leaky by design
@@ -1058,6 +1060,70 @@ TEST_F(FlEngineTest, EnableFlutterGpu) {
   EXPECT_TRUE(fl_engine_start(engine, &error));
   EXPECT_EQ(error, nullptr);
   EXPECT_TRUE(called);
+}
+
+TEST_F(FlEngineTest, CreateOpenGLBackingStoreWithImpellerMSAA) {
+  ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
+  ON_CALL(epoxy, epoxy_gl_version).WillByDefault(::testing::Return(30));
+  ON_CALL(epoxy, epoxy_has_gl_extension(::testing::_))
+      .WillByDefault(::testing::Return(false));
+  ON_CALL(epoxy, glGetIntegerv(GL_MAX_SAMPLES, ::testing::_))
+      .WillByDefault(::testing::SetArgPointee<1>(4));
+
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4,
+                                                      GL_RGBA8, 800, 600));
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(
+                         GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, 800, 600));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                        GL_RENDERBUFFER, ::testing::_));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                        GL_RENDERBUFFER, ::testing::_));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                        GL_RENDERBUFFER, ::testing::_));
+
+  FlutterCompositor compositor = {};
+  fl_engine_get_embedder_api(engine)->Initialize = MOCK_ENGINE_PROC(
+      Initialize,
+      ([&compositor](size_t version, const FlutterRendererConfig* config,
+                     const FlutterProjectArgs* args, void* user_data,
+                     FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+        if (args->compositor != nullptr) {
+          compositor = *args->compositor;
+        }
+        return kSuccess;
+      }));
+  fl_engine_get_embedder_api(engine)->RunInitialized =
+      MOCK_ENGINE_PROC(RunInitialized, ([](auto engine) { return kSuccess; }));
+
+  fl_dart_project_set_enable_impeller(project, TRUE);
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+  ASSERT_NE(compositor.create_backing_store_callback, nullptr);
+
+  FlutterBackingStoreConfig config = {
+      .struct_size = sizeof(FlutterBackingStoreConfig),
+      .size = {.width = 800, .height = 600},
+  };
+  FlutterBackingStore backing_store = {};
+  EXPECT_TRUE(compositor.create_backing_store_callback(&config, &backing_store,
+                                                       compositor.user_data));
+  EXPECT_EQ(backing_store.type, kFlutterBackingStoreTypeOpenGL);
+  EXPECT_EQ(backing_store.open_gl.type, kFlutterOpenGLTargetTypeFramebuffer);
+  EXPECT_EQ(backing_store.open_gl.framebuffer.target,
+            static_cast<uint32_t>(GL_RGBA8));
+
+  FlFramebuffer* fb =
+      FL_FRAMEBUFFER(backing_store.open_gl.framebuffer.user_data);
+  EXPECT_NE(fb, nullptr);
+  EXPECT_EQ(fl_framebuffer_get_texture_id(fb), 0u);
+
+  EXPECT_TRUE(compositor.collect_backing_store_callback(&backing_store,
+                                                        compositor.user_data));
 }
 
 TEST_F(FlEngineTest, ChildObjects) {

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -24,7 +24,10 @@ struct _FlFramebuffer {
   // Texture backing framebuffer.
   GLuint texture_id;
 
-  // Stencil buffer associated with this framebuffer.
+  // Color renderbuffer backing framebuffer (if using offscreen MSAA).
+  GLuint color_renderbuffer;
+
+  // Depth and stencil renderbuffer associated with this framebuffer.
   GLuint depth_stencil;
 
   // EGL image for this texture.
@@ -36,9 +39,18 @@ G_DEFINE_TYPE(FlFramebuffer, fl_framebuffer, G_TYPE_OBJECT)
 static void fl_framebuffer_dispose(GObject* object) {
   FlFramebuffer* self = FL_FRAMEBUFFER(object);
 
-  glDeleteFramebuffers(1, &self->framebuffer_id);
-  glDeleteTextures(1, &self->texture_id);
-  glDeleteRenderbuffers(1, &self->depth_stencil);
+  if (self->framebuffer_id != 0) {
+    glDeleteFramebuffers(1, &self->framebuffer_id);
+  }
+  if (self->texture_id != 0) {
+    glDeleteTextures(1, &self->texture_id);
+  }
+  if (self->color_renderbuffer != 0) {
+    glDeleteRenderbuffers(1, &self->color_renderbuffer);
+  }
+  if (self->depth_stencil != 0) {
+    glDeleteRenderbuffers(1, &self->depth_stencil);
+  }
   g_clear_object(&self->image);
 
   G_OBJECT_CLASS(fl_framebuffer_parent_class)->dispose(object);
@@ -50,6 +62,47 @@ static void fl_framebuffer_class_init(FlFramebufferClass* klass) {
 
 static void fl_framebuffer_init(FlFramebuffer* self) {}
 
+static bool check_supports_implicit_msaa() {
+  return epoxy_has_gl_extension("GL_EXT_multisampled_render_to_texture");
+}
+
+static bool check_supports_offscreen_msaa() {
+  if (epoxy_gl_version() >= 30 ||
+      epoxy_has_gl_extension("GL_ANGLE_framebuffer_multisample") ||
+      epoxy_has_gl_extension("GL_EXT_framebuffer_multisample")) {
+    GLint max_samples = 0;
+    glGetIntegerv(GL_MAX_SAMPLES, &max_samples);
+    return max_samples >= 4;
+  }
+  if (epoxy_has_gl_extension("GL_EXT_multisampled_render_to_texture2")) {
+    GLint max_samples = 0;
+    glGetIntegerv(GL_MAX_SAMPLES_EXT, &max_samples);
+    return max_samples >= 4;
+  }
+  return false;
+}
+
+static GLuint create_texture(GLint format, size_t width, size_t height) {
+  GLuint texture_id;
+  glGenTextures(1, &texture_id);
+  glBindTexture(GL_TEXTURE_2D, texture_id);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, format,
+               GL_UNSIGNED_BYTE, nullptr);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  return texture_id;
+}
+
+static void attach_depth_stencil(GLuint framebuffer_id, GLuint depth_stencil) {
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                            GL_RENDERBUFFER, depth_stencil);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                            GL_RENDERBUFFER, depth_stencil);
+}
+
 FlFramebuffer* fl_framebuffer_new(GLint format,
                                   size_t width,
                                   size_t height,
@@ -60,19 +113,10 @@ FlFramebuffer* fl_framebuffer_new(GLint format,
   self->width = width;
   self->height = height;
 
-  glGenTextures(1, &self->texture_id);
   glGenFramebuffers(1, &self->framebuffer_id);
-
   glBindFramebuffer(GL_FRAMEBUFFER, self->framebuffer_id);
 
-  glBindTexture(GL_TEXTURE_2D, self->texture_id);
-  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, format,
-               GL_UNSIGNED_BYTE, NULL);
-  glBindTexture(GL_TEXTURE_2D, 0);
+  self->texture_id = create_texture(format, width, height);
 
   if (shareable) {
     self->image = fl_egl_image_new(self->texture_id);
@@ -83,15 +127,79 @@ FlFramebuffer* fl_framebuffer_new(GLint format,
 
   glGenRenderbuffers(1, &self->depth_stencil);
   glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
-  glRenderbufferStorage(GL_RENDERBUFFER,      // target
-                        GL_DEPTH24_STENCIL8,  // internal format
-                        width,                // width
-                        height                // height
-  );
-  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                            GL_RENDERBUFFER, self->depth_stencil);
-  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
-                            GL_RENDERBUFFER, self->depth_stencil);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+  attach_depth_stencil(self->framebuffer_id, self->depth_stencil);
+
+  return self;
+}
+
+FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
+                                              GLint general_format,
+                                              size_t width,
+                                              size_t height,
+                                              gboolean enable_impeller) {
+  FlFramebuffer* self =
+      FL_FRAMEBUFFER(g_object_new(fl_framebuffer_get_type(), nullptr));
+
+  self->width = width;
+  self->height = height;
+
+  glGenFramebuffers(1, &self->framebuffer_id);
+  glBindFramebuffer(GL_FRAMEBUFFER, self->framebuffer_id);
+
+  if (enable_impeller) {
+    if (check_supports_implicit_msaa()) {
+      // Implicit MSAA uses GL_EXT_multisampled_render_to_texture, where the
+      // OpenGL driver automatically resolves multisamples into the attached
+      // texture when rendering is completed.
+      self->texture_id = create_texture(general_format, width, height);
+      glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                           GL_TEXTURE_2D, self->texture_id, 0,
+                                           4);
+
+      glGenRenderbuffers(1, &self->depth_stencil);
+      glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
+      glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, 4,
+                                          GL_DEPTH24_STENCIL8, width, height);
+      attach_depth_stencil(self->framebuffer_id, self->depth_stencil);
+    } else if (check_supports_offscreen_msaa()) {
+      // Offscreen MSAA uses a multisample renderbuffer instead of a texture.
+      // The multisample resolve occurs in fl_compositor_opengl_composite_layers
+      // via glBlitFramebuffer (or composite_layer) into the compositor's
+      // single-sample framebuffer texture.
+      glGenRenderbuffers(1, &self->color_renderbuffer);
+      glBindRenderbuffer(GL_RENDERBUFFER, self->color_renderbuffer);
+      glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, sized_format, width,
+                                       height);
+      glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                GL_RENDERBUFFER, self->color_renderbuffer);
+
+      glGenRenderbuffers(1, &self->depth_stencil);
+      glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
+      glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8,
+                                       width, height);
+      attach_depth_stencil(self->framebuffer_id, self->depth_stencil);
+    } else {
+      self->texture_id = create_texture(general_format, width, height);
+      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                             GL_TEXTURE_2D, self->texture_id, 0);
+
+      glGenRenderbuffers(1, &self->depth_stencil);
+      glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
+      glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width,
+                            height);
+      attach_depth_stencil(self->framebuffer_id, self->depth_stencil);
+    }
+  } else {
+    self->texture_id = create_texture(general_format, width, height);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                           self->texture_id, 0);
+
+    glGenRenderbuffers(1, &self->depth_stencil);
+    glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+    attach_depth_stencil(self->framebuffer_id, self->depth_stencil);
+  }
 
   return self;
 }

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -41,15 +41,19 @@ static void fl_framebuffer_dispose(GObject* object) {
 
   if (self->framebuffer_id != 0) {
     glDeleteFramebuffers(1, &self->framebuffer_id);
+    self->framebuffer_id = 0;
   }
   if (self->texture_id != 0) {
     glDeleteTextures(1, &self->texture_id);
+    self->texture_id = 0;
   }
   if (self->color_renderbuffer != 0) {
     glDeleteRenderbuffers(1, &self->color_renderbuffer);
+    self->color_renderbuffer = 0;
   }
   if (self->depth_stencil != 0) {
     glDeleteRenderbuffers(1, &self->depth_stencil);
+    self->depth_stencil = 0;
   }
   g_clear_object(&self->image);
 

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -137,8 +137,7 @@ FlFramebuffer* fl_framebuffer_new(GLint format,
   return self;
 }
 
-FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
-                                              GLint general_format,
+FlFramebuffer* fl_framebuffer_new_multisample(GLint format,
                                               size_t width,
                                               size_t height,
                                               gboolean use_msaa) {
@@ -156,7 +155,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
       // Implicit MSAA uses GL_EXT_multisampled_render_to_texture, where the
       // OpenGL driver automatically resolves multisamples into the attached
       // texture when rendering is completed.
-      self->texture_id = create_texture(general_format, width, height);
+      self->texture_id = create_texture(format, width, height);
       glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                                            GL_TEXTURE_2D, self->texture_id, 0,
                                            4);
@@ -173,7 +172,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
       // single-sample framebuffer texture.
       glGenRenderbuffers(1, &self->color_renderbuffer);
       glBindRenderbuffer(GL_RENDERBUFFER, self->color_renderbuffer);
-      glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, sized_format, width,
+      glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_RGBA8, width,
                                        height);
       glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                                 GL_RENDERBUFFER, self->color_renderbuffer);
@@ -184,7 +183,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
                                        width, height);
       attach_depth_stencil(self->depth_stencil);
     } else {
-      self->texture_id = create_texture(general_format, width, height);
+      self->texture_id = create_texture(format, width, height);
       glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                              GL_TEXTURE_2D, self->texture_id, 0);
 
@@ -195,7 +194,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
       attach_depth_stencil(self->depth_stencil);
     }
   } else {
-    self->texture_id = create_texture(general_format, width, height);
+    self->texture_id = create_texture(format, width, height);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                            self->texture_id, 0);
 

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -137,7 +137,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
                                               GLint general_format,
                                               size_t width,
                                               size_t height,
-                                              gboolean enable_impeller) {
+                                              gboolean use_msaa) {
   FlFramebuffer* self =
       FL_FRAMEBUFFER(g_object_new(fl_framebuffer_get_type(), nullptr));
 
@@ -147,7 +147,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
   glGenFramebuffers(1, &self->framebuffer_id);
   glBindFramebuffer(GL_FRAMEBUFFER, self->framebuffer_id);
 
-  if (enable_impeller) {
+  if (use_msaa) {
     if (check_supports_implicit_msaa()) {
       // Implicit MSAA uses GL_EXT_multisampled_render_to_texture, where the
       // OpenGL driver automatically resolves multisamples into the attached

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -71,16 +71,9 @@ static bool check_supports_implicit_msaa() {
 }
 
 static bool check_supports_offscreen_msaa() {
-  if (epoxy_gl_version() >= 30 ||
-      epoxy_has_gl_extension("GL_ANGLE_framebuffer_multisample") ||
-      epoxy_has_gl_extension("GL_EXT_framebuffer_multisample")) {
+  if (epoxy_gl_version() >= 30) {
     GLint max_samples = 0;
     glGetIntegerv(GL_MAX_SAMPLES, &max_samples);
-    return max_samples >= 4;
-  }
-  if (epoxy_has_gl_extension("GL_EXT_multisampled_render_to_texture2")) {
-    GLint max_samples = 0;
-    glGetIntegerv(GL_MAX_SAMPLES_EXT, &max_samples);
     return max_samples >= 4;
   }
   return false;

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -96,7 +96,7 @@ static GLuint create_texture(GLint format, size_t width, size_t height) {
   return texture_id;
 }
 
-static void attach_depth_stencil(GLuint framebuffer_id, GLuint depth_stencil) {
+static void attach_depth_stencil(GLuint depth_stencil) {
   glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
                             GL_RENDERBUFFER, depth_stencil);
   glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
@@ -128,7 +128,7 @@ FlFramebuffer* fl_framebuffer_new(GLint format,
   glGenRenderbuffers(1, &self->depth_stencil);
   glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
   glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
-  attach_depth_stencil(self->framebuffer_id, self->depth_stencil);
+  attach_depth_stencil(self->depth_stencil);
 
   return self;
 }
@@ -161,7 +161,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
       glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
       glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, 4,
                                           GL_DEPTH24_STENCIL8, width, height);
-      attach_depth_stencil(self->framebuffer_id, self->depth_stencil);
+      attach_depth_stencil(self->depth_stencil);
     } else if (check_supports_offscreen_msaa()) {
       // Offscreen MSAA uses a multisample renderbuffer instead of a texture.
       // The multisample resolve occurs in fl_compositor_opengl_composite_layers
@@ -178,7 +178,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
       glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
       glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8,
                                        width, height);
-      attach_depth_stencil(self->framebuffer_id, self->depth_stencil);
+      attach_depth_stencil(self->depth_stencil);
     } else {
       self->texture_id = create_texture(general_format, width, height);
       glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
@@ -188,7 +188,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
       glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
       glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width,
                             height);
-      attach_depth_stencil(self->framebuffer_id, self->depth_stencil);
+      attach_depth_stencil(self->depth_stencil);
     }
   } else {
     self->texture_id = create_texture(general_format, width, height);
@@ -198,7 +198,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
     glGenRenderbuffers(1, &self->depth_stencil);
     glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
-    attach_depth_stencil(self->framebuffer_id, self->depth_stencil);
+    attach_depth_stencil(self->depth_stencil);
   }
 
   return self;

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.h
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.h
@@ -38,8 +38,7 @@ FlFramebuffer* fl_framebuffer_new(GLint format,
 
 /**
  * fl_framebuffer_new_multisample:
- * @sized_format: sized format, e.g. GL_RGBA8, GL_BGRA8_EXT.
- * @general_format: general format, e.g. GL_RGBA, GL_BGRA_EXT.
+ * @format: texture format, e.g. GL_RGBA, GL_BGRA_EXT.
  * @width: width of framebuffer in pixels.
  * @height: height of framebuffer in pixels.
  * @use_msaa: %TRUE to enable multisample anti-aliasing (MSAA) attachments.
@@ -49,18 +48,19 @@ FlFramebuffer* fl_framebuffer_new(GLint format,
  *
  * When @use_msaa is %TRUE, the framebuffer will configure 4x MSAA attachments
  * using either implicit MSAA (multisampled texture via
- * GL_EXT_multisampled_render_to_texture) or offscreen MSAA (multisample color
- * renderbuffer). If offscreen MSAA is used, the framebuffer is not backed by a
- * texture (fl_framebuffer_get_texture_id() returns 0) and must be resolved
- * into a single-sample texture via glBlitFramebuffer before compositing.
+ * GL_EXT_multisampled_render_to_texture) with the requested @format or
+ * offscreen MSAA (multisample color renderbuffer). If offscreen MSAA is used,
+ * the framebuffer is backed by a GL_RGBA8 renderbuffer instead of a texture
+ * (fl_framebuffer_get_texture_id() returns 0) and must be resolved into a
+ * single-sample texture via glBlitFramebuffer before compositing.
  *
  * If @use_msaa is %FALSE or MSAA is not supported by the OpenGL context, a
- * standard single-sample texture and depth/stencil renderbuffer are created.
+ * standard single-sample texture with @format and depth/stencil renderbuffer
+ * are created.
  *
  * Returns: a new #FlFramebuffer.
  */
-FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
-                                              GLint general_format,
+FlFramebuffer* fl_framebuffer_new_multisample(GLint format,
                                               size_t width,
                                               size_t height,
                                               gboolean use_msaa);

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.h
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.h
@@ -42,10 +42,20 @@ FlFramebuffer* fl_framebuffer_new(GLint format,
  * @general_format: general format, e.g. GL_RGBA, GL_BGRA_EXT.
  * @width: width of framebuffer in pixels.
  * @height: height of framebuffer in pixels.
- * @enable_impeller: %TRUE if Impeller is enabled.
+ * @use_msaa: %TRUE to enable multisample anti-aliasing (MSAA) attachments.
  *
  * Creates a new frame buffer, configuring MSAA attachments if supported and
- * Impeller is enabled. Requires a valid OpenGL context to create.
+ * @use_msaa is %TRUE.
+ *
+ * When @use_msaa is %TRUE, the framebuffer will configure 4x MSAA attachments
+ * using either implicit MSAA (multisampled texture via
+ * GL_EXT_multisampled_render_to_texture) or offscreen MSAA (multisample color
+ * renderbuffer). If offscreen MSAA is used, the framebuffer is not backed by a
+ * texture (fl_framebuffer_get_texture_id() returns 0) and must be resolved
+ * into a single-sample texture via glBlitFramebuffer before compositing.
+ *
+ * If @use_msaa is %FALSE or MSAA is not supported by the OpenGL context, a
+ * standard single-sample texture and depth/stencil renderbuffer are created.
  *
  * Returns: a new #FlFramebuffer.
  */
@@ -53,7 +63,7 @@ FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
                                               GLint general_format,
                                               size_t width,
                                               size_t height,
-                                              gboolean enable_impeller);
+                                              gboolean use_msaa);
 
 /**
  * fl_framebuffer_get_shareable:

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.h
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.h
@@ -37,6 +37,25 @@ FlFramebuffer* fl_framebuffer_new(GLint format,
                                   gboolean shareable);
 
 /**
+ * fl_framebuffer_new_multisample:
+ * @sized_format: sized format, e.g. GL_RGBA8, GL_BGRA8_EXT.
+ * @general_format: general format, e.g. GL_RGBA, GL_BGRA_EXT.
+ * @width: width of framebuffer in pixels.
+ * @height: height of framebuffer in pixels.
+ * @enable_impeller: %TRUE if Impeller is enabled.
+ *
+ * Creates a new frame buffer, configuring MSAA attachments if supported and
+ * Impeller is enabled. Requires a valid OpenGL context to create.
+ *
+ * Returns: a new #FlFramebuffer.
+ */
+FlFramebuffer* fl_framebuffer_new_multisample(GLint sized_format,
+                                              GLint general_format,
+                                              size_t width,
+                                              size_t height,
+                                              gboolean enable_impeller);
+
+/**
  * fl_framebuffer_get_shareable:
  * @framebuffer: an #FlFramebuffer.
  *

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
@@ -71,7 +71,7 @@ TEST_F(FlFramebufferTest, ImpellerOffscreenMSAA) {
                                         GL_RENDERBUFFER, ::testing::_));
 
   FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
-      GL_RGBA8, GL_RGBA, 100, 100, /*enable_impeller=*/TRUE);
+      GL_RGBA8, GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
   EXPECT_EQ(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
@@ -93,7 +93,7 @@ TEST_F(FlFramebufferTest, ImpellerImplicitMSAA) {
                          GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, 100, 100));
 
   FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
-      GL_RGBA8, GL_RGBA, 100, 100, /*enable_impeller=*/TRUE);
+      GL_RGBA8, GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
   EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
@@ -115,7 +115,7 @@ TEST_F(FlFramebufferTest, ImpellerNoMSAA) {
                                            100, 100));
 
   FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
-      GL_RGBA8, GL_RGBA, 100, 100, /*enable_impeller=*/TRUE);
+      GL_RGBA8, GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
   EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
@@ -137,7 +137,7 @@ TEST_F(FlFramebufferTest, SkiaNoMSAA) {
                                            100, 100));
 
   FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
-      GL_RGBA8, GL_RGBA, 100, 100, /*enable_impeller=*/FALSE);
+      GL_RGBA8, GL_RGBA, 100, 100, /*use_msaa=*/FALSE);
   EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
@@ -48,3 +48,100 @@ TEST_F(FlFramebufferTest, Sibling) {
       fl_framebuffer_new(GL_RGB, 100, 100, TRUE);
   g_autoptr(FlFramebuffer) sibling = fl_framebuffer_create_sibling(framebuffer);
 }
+
+TEST_F(FlFramebufferTest, ImpellerOffscreenMSAA) {
+  ON_CALL(epoxy, epoxy_gl_version).WillByDefault(::testing::Return(30));
+  ON_CALL(epoxy, epoxy_has_gl_extension(::testing::_))
+      .WillByDefault(::testing::Return(false));
+  ON_CALL(epoxy, glGetIntegerv(GL_MAX_SAMPLES, ::testing::_))
+      .WillByDefault(::testing::SetArgPointee<1>(4));
+
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4,
+                                                      GL_RGBA8, 100, 100));
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(
+                         GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, 100, 100));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                        GL_RENDERBUFFER, ::testing::_));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                        GL_RENDERBUFFER, ::testing::_));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                        GL_RENDERBUFFER, ::testing::_));
+
+  FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
+      GL_RGBA8, GL_RGBA, 100, 100, /*enable_impeller=*/TRUE);
+  EXPECT_EQ(fl_framebuffer_get_texture_id(framebuffer), 0u);
+
+  EXPECT_CALL(epoxy, glDeleteFramebuffers);
+  EXPECT_CALL(epoxy, glDeleteTextures).Times(0);
+  EXPECT_CALL(epoxy, glDeleteRenderbuffers).Times(2);
+  g_object_unref(framebuffer);
+}
+
+TEST_F(FlFramebufferTest, ImpellerImplicitMSAA) {
+  ON_CALL(epoxy, epoxy_has_gl_extension(
+                     ::testing::StrEq("GL_EXT_multisampled_render_to_texture")))
+      .WillByDefault(::testing::Return(true));
+
+  EXPECT_CALL(epoxy, glGenTextures);
+  EXPECT_CALL(epoxy, glFramebufferTexture2DMultisampleEXT(
+                         GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         ::testing::_, 0, 4));
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisampleEXT(
+                         GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, 100, 100));
+
+  FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
+      GL_RGBA8, GL_RGBA, 100, 100, /*enable_impeller=*/TRUE);
+  EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
+
+  EXPECT_CALL(epoxy, glDeleteFramebuffers);
+  EXPECT_CALL(epoxy, glDeleteTextures);
+  EXPECT_CALL(epoxy, glDeleteRenderbuffers);
+  g_object_unref(framebuffer);
+}
+
+TEST_F(FlFramebufferTest, ImpellerNoMSAA) {
+  ON_CALL(epoxy, epoxy_gl_version).WillByDefault(::testing::Return(20));
+  ON_CALL(epoxy, epoxy_has_gl_extension(::testing::_))
+      .WillByDefault(::testing::Return(false));
+
+  EXPECT_CALL(epoxy, glGenTextures);
+  EXPECT_CALL(epoxy,
+              glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                     GL_TEXTURE_2D, ::testing::_, 0));
+  EXPECT_CALL(epoxy, glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8,
+                                           100, 100));
+
+  FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
+      GL_RGBA8, GL_RGBA, 100, 100, /*enable_impeller=*/TRUE);
+  EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
+
+  EXPECT_CALL(epoxy, glDeleteFramebuffers);
+  EXPECT_CALL(epoxy, glDeleteTextures);
+  EXPECT_CALL(epoxy, glDeleteRenderbuffers);
+  g_object_unref(framebuffer);
+}
+
+TEST_F(FlFramebufferTest, SkiaNoMSAA) {
+  ON_CALL(epoxy, epoxy_gl_version).WillByDefault(::testing::Return(30));
+  ON_CALL(epoxy, glGetIntegerv(GL_MAX_SAMPLES, ::testing::_))
+      .WillByDefault(::testing::SetArgPointee<1>(4));
+
+  EXPECT_CALL(epoxy, glGenTextures);
+  EXPECT_CALL(epoxy,
+              glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                     GL_TEXTURE_2D, ::testing::_, 0));
+  EXPECT_CALL(epoxy, glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8,
+                                           100, 100));
+
+  FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
+      GL_RGBA8, GL_RGBA, 100, 100, /*enable_impeller=*/FALSE);
+  EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
+
+  EXPECT_CALL(epoxy, glDeleteFramebuffers);
+  EXPECT_CALL(epoxy, glDeleteTextures);
+  EXPECT_CALL(epoxy, glDeleteRenderbuffers);
+  g_object_unref(framebuffer);
+}

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
@@ -70,8 +70,8 @@ TEST_F(FlFramebufferTest, ImpellerOffscreenMSAA) {
               glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
                                         GL_RENDERBUFFER, ::testing::_));
 
-  FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
-      GL_RGBA8, GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
+  FlFramebuffer* framebuffer =
+      fl_framebuffer_new_multisample(GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
   EXPECT_EQ(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
@@ -92,8 +92,8 @@ TEST_F(FlFramebufferTest, ImpellerImplicitMSAA) {
   EXPECT_CALL(epoxy, glRenderbufferStorageMultisampleEXT(
                          GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, 100, 100));
 
-  FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
-      GL_RGBA8, GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
+  FlFramebuffer* framebuffer =
+      fl_framebuffer_new_multisample(GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
   EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
@@ -114,8 +114,8 @@ TEST_F(FlFramebufferTest, ImpellerNoMSAA) {
   EXPECT_CALL(epoxy, glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8,
                                            100, 100));
 
-  FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
-      GL_RGBA8, GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
+  FlFramebuffer* framebuffer =
+      fl_framebuffer_new_multisample(GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
   EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
@@ -136,8 +136,64 @@ TEST_F(FlFramebufferTest, SkiaNoMSAA) {
   EXPECT_CALL(epoxy, glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8,
                                            100, 100));
 
-  FlFramebuffer* framebuffer = fl_framebuffer_new_multisample(
-      GL_RGBA8, GL_RGBA, 100, 100, /*use_msaa=*/FALSE);
+  FlFramebuffer* framebuffer =
+      fl_framebuffer_new_multisample(GL_RGBA, 100, 100, /*use_msaa=*/FALSE);
+  EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
+
+  EXPECT_CALL(epoxy, glDeleteFramebuffers);
+  EXPECT_CALL(epoxy, glDeleteTextures);
+  EXPECT_CALL(epoxy, glDeleteRenderbuffers);
+  g_object_unref(framebuffer);
+}
+
+TEST_F(FlFramebufferTest, ImpellerOffscreenMSAABgra) {
+  ON_CALL(epoxy, epoxy_gl_version).WillByDefault(::testing::Return(30));
+  ON_CALL(epoxy, glGetIntegerv(GL_MAX_SAMPLES, ::testing::_))
+      .WillByDefault(::testing::SetArgPointee<1>(4));
+
+  EXPECT_CALL(epoxy, glGenRenderbuffers).Times(2);
+  // GL_EXT_texture_format_BGRA8888 only defines BGRA for textures, not
+  // renderbuffers. When explicit offscreen MSAA is used without
+  // GL_EXT_multisampled_render_to_texture, a multisample renderbuffer is
+  // created which must use GL_RGBA8.
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4,
+                                                      GL_RGBA8, 100, 100));
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisample(
+                         GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, 100, 100));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                        GL_RENDERBUFFER, ::testing::_));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                        GL_RENDERBUFFER, ::testing::_));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                        GL_RENDERBUFFER, ::testing::_));
+
+  FlFramebuffer* framebuffer =
+      fl_framebuffer_new_multisample(GL_BGRA_EXT, 100, 100, /*use_msaa=*/TRUE);
+  EXPECT_EQ(fl_framebuffer_get_texture_id(framebuffer), 0u);
+
+  EXPECT_CALL(epoxy, glDeleteFramebuffers);
+  EXPECT_CALL(epoxy, glDeleteTextures).Times(0);
+  EXPECT_CALL(epoxy, glDeleteRenderbuffers).Times(2);
+  g_object_unref(framebuffer);
+}
+
+TEST_F(FlFramebufferTest, ImpellerImplicitMSAABgra) {
+  ON_CALL(epoxy, epoxy_has_gl_extension(
+                     ::testing::StrEq("GL_EXT_multisampled_render_to_texture")))
+      .WillByDefault(::testing::Return(true));
+
+  EXPECT_CALL(epoxy, glGenTextures);
+  EXPECT_CALL(epoxy, glFramebufferTexture2DMultisampleEXT(
+                         GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         ::testing::_, 0, 4));
+  EXPECT_CALL(epoxy, glRenderbufferStorageMultisampleEXT(
+                         GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, 100, 100));
+
+  FlFramebuffer* framebuffer =
+      fl_framebuffer_new_multisample(GL_BGRA_EXT, 100, 100, /*use_msaa=*/TRUE);
   EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_frame.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_frame.cc
@@ -83,6 +83,12 @@ void fl_opengl_frame_composite(FlOpenGLFrame* self,
       fl_framebuffer_get_width(self->framebuffer) != width ||
       fl_framebuffer_get_height(self->framebuffer) != height) {
     GLint general_format = GL_RGBA;
+    if (layers[0]->type == kFlutterLayerContentTypeBackingStore &&
+        layers[0]->backing_store != nullptr &&
+        layers[0]->backing_store->type == kFlutterBackingStoreTypeOpenGL &&
+        layers[0]->backing_store->open_gl.framebuffer.target == GL_BGRA8_EXT) {
+      general_format = GL_BGRA_EXT;
+    }
     g_clear_object(&self->framebuffer);
     self->framebuffer =
         fl_framebuffer_new(general_format, width, height, self->shareable);

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_frame.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_frame.cc
@@ -83,9 +83,6 @@ void fl_opengl_frame_composite(FlOpenGLFrame* self,
       fl_framebuffer_get_width(self->framebuffer) != width ||
       fl_framebuffer_get_height(self->framebuffer) != height) {
     GLint general_format = GL_RGBA;
-    if (epoxy_has_gl_extension("GL_EXT_texture_format_BGRA8888")) {
-      general_format = GL_BGRA_EXT;
-    }
     g_clear_object(&self->framebuffer);
     self->framebuffer =
         fl_framebuffer_new(general_format, width, height, self->shareable);

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_frame_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_frame_test.cc
@@ -1,0 +1,135 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/linux/fl_opengl_frame.h"
+
+#include <epoxy/gl.h>
+
+#include "flutter/shell/platform/linux/fl_compositor_opengl.h"
+#include "flutter/shell/platform/linux/fl_framebuffer.h"
+#include "flutter/shell/platform/linux/fl_opengl_manager.h"
+#include "flutter/shell/platform/linux/testing/linux_test.h"
+#include "flutter/shell/platform/linux/testing/mock_epoxy.h"
+#include "gtest/gtest.h"
+
+class FlOpenGLFrameTest : public flutter::testing::LinuxTest {
+ protected:
+  void SetUp() override {
+    opengl_manager = fl_opengl_manager_new();
+    compositor = fl_compositor_opengl_new(opengl_manager);
+  }
+
+  ~FlOpenGLFrameTest() override {
+    g_clear_object(&compositor);
+    g_clear_object(&opengl_manager);
+  }
+
+  ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
+  FlOpenGLManager* opengl_manager = nullptr;
+  FlCompositorOpenGL* compositor = nullptr;
+};
+
+TEST_F(FlOpenGLFrameTest, GetSizeInitiallyZero) {
+  g_autoptr(FlOpenGLFrame) frame = fl_opengl_frame_new(/*shareable=*/TRUE);
+  size_t frame_width = 123;
+  size_t frame_height = 456;
+  fl_opengl_frame_get_size(frame, &frame_width, &frame_height);
+  EXPECT_EQ(frame_width, 0u);
+  EXPECT_EQ(frame_height, 0u);
+}
+
+TEST_F(FlOpenGLFrameTest, CompositeRGBA) {
+  constexpr size_t width = 100;
+  constexpr size_t height = 100;
+
+  g_autoptr(FlOpenGLFrame) frame = fl_opengl_frame_new(/*shareable=*/TRUE);
+  g_autoptr(FlFramebuffer) framebuffer =
+      fl_framebuffer_new(GL_RGBA, width, height, FALSE);
+  FlutterBackingStore backing_store = {
+      .type = kFlutterBackingStoreTypeOpenGL,
+      .open_gl = {
+          .framebuffer = {.target = GL_RGBA8, .user_data = framebuffer}}};
+  FlutterLayer layer = {.type = kFlutterLayerContentTypeBackingStore,
+                        .backing_store = &backing_store,
+                        .offset = {0, 0},
+                        .size = {width, height}};
+  const FlutterLayer* layers[1] = {&layer};
+
+  EXPECT_CALL(epoxy, glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0,
+                                  GL_RGBA, GL_UNSIGNED_BYTE, nullptr));
+
+  fl_opengl_frame_composite(frame, compositor, layers, 1);
+
+  size_t frame_width = 0;
+  size_t frame_height = 0;
+  fl_opengl_frame_get_size(frame, &frame_width, &frame_height);
+  EXPECT_EQ(frame_width, width);
+  EXPECT_EQ(frame_height, height);
+}
+
+TEST_F(FlOpenGLFrameTest, CompositeBGRA) {
+  constexpr size_t width = 100;
+  constexpr size_t height = 100;
+
+  g_autoptr(FlOpenGLFrame) frame = fl_opengl_frame_new(/*shareable=*/TRUE);
+  g_autoptr(FlFramebuffer) framebuffer =
+      fl_framebuffer_new(GL_BGRA_EXT, width, height, FALSE);
+  FlutterBackingStore backing_store = {
+      .type = kFlutterBackingStoreTypeOpenGL,
+      .open_gl = {
+          .framebuffer = {.target = GL_BGRA8_EXT, .user_data = framebuffer}}};
+  FlutterLayer layer = {.type = kFlutterLayerContentTypeBackingStore,
+                        .backing_store = &backing_store,
+                        .offset = {0, 0},
+                        .size = {width, height}};
+  const FlutterLayer* layers[1] = {&layer};
+
+  EXPECT_CALL(epoxy, glTexImage2D(GL_TEXTURE_2D, 0, GL_BGRA_EXT, width, height,
+                                  0, GL_BGRA_EXT, GL_UNSIGNED_BYTE, nullptr));
+
+  fl_opengl_frame_composite(frame, compositor, layers, 1);
+
+  size_t frame_width = 0;
+  size_t frame_height = 0;
+  fl_opengl_frame_get_size(frame, &frame_width, &frame_height);
+  EXPECT_EQ(frame_width, width);
+  EXPECT_EQ(frame_height, height);
+}
+
+TEST_F(FlOpenGLFrameTest, ZeroSizeClearsFrame) {
+  constexpr size_t width = 100;
+  constexpr size_t height = 100;
+
+  g_autoptr(FlOpenGLFrame) frame = fl_opengl_frame_new(/*shareable=*/TRUE);
+  g_autoptr(FlFramebuffer) framebuffer =
+      fl_framebuffer_new(GL_RGBA, width, height, FALSE);
+  FlutterBackingStore backing_store = {
+      .type = kFlutterBackingStoreTypeOpenGL,
+      .open_gl = {
+          .framebuffer = {.target = GL_RGBA8, .user_data = framebuffer}}};
+  FlutterLayer layer = {.type = kFlutterLayerContentTypeBackingStore,
+                        .backing_store = &backing_store,
+                        .offset = {0, 0},
+                        .size = {width, height}};
+  const FlutterLayer* layers[1] = {&layer};
+
+  fl_opengl_frame_composite(frame, compositor, layers, 1);
+
+  size_t frame_width = 0;
+  size_t frame_height = 0;
+  fl_opengl_frame_get_size(frame, &frame_width, &frame_height);
+  EXPECT_EQ(frame_width, width);
+  EXPECT_EQ(frame_height, height);
+
+  FlutterLayer zero_layer = {.type = kFlutterLayerContentTypeBackingStore,
+                             .backing_store = &backing_store,
+                             .offset = {0, 0},
+                             .size = {0, 0}};
+  const FlutterLayer* zero_layers[1] = {&zero_layer};
+  fl_opengl_frame_composite(frame, compositor, zero_layers, 1);
+
+  fl_opengl_frame_get_size(frame, &frame_width, &frame_height);
+  EXPECT_EQ(frame_width, 0u);
+  EXPECT_EQ(frame_height, 0u);
+}

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
@@ -608,9 +608,14 @@ static void _glTexImage2D(GLenum target,
                           GLenum format,
                           GLenum type,
                           const void* pixels) {
+  if (mock) {
+    mock->glTexImage2D(target, level, internalformat, width, height, border,
+                       format, type, pixels);
+  }
   if (pixels != nullptr) {
-    FML_CHECK(internalformat == GL_RGBA || internalformat == GL_RGBA8);
-    FML_CHECK(format == GL_RGBA);
+    FML_CHECK(internalformat == GL_RGBA || internalformat == GL_RGBA8 ||
+              internalformat == GL_BGRA_EXT);
+    FML_CHECK(format == GL_RGBA || format == GL_BGRA_EXT);
     FML_CHECK(type == GL_UNSIGNED_BYTE);
 
     // Simple mock read to detect out-of-bounds reads in tests.

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
@@ -478,17 +478,38 @@ static void _glFramebufferRenderbuffer(GLenum target,
                                        GLenum renderbuffertarget,
                                        GLuint renderbuffer) {
   framebuffer_renderbuffers[attachment] = renderbuffer;
+  if (mock) {
+    mock->glFramebufferRenderbuffer(target, attachment, renderbuffertarget,
+                                    renderbuffer);
+  }
 }
 
 static void _glFramebufferTexture2D(GLenum target,
                                     GLenum attachment,
                                     GLenum textarget,
                                     GLuint texture,
-                                    GLint level) {}
+                                    GLint level) {
+  if (mock) {
+    mock->glFramebufferTexture2D(target, attachment, textarget, texture, level);
+  }
+}
+
+static void _glFramebufferTexture2DMultisampleEXT(GLenum target,
+                                                  GLenum attachment,
+                                                  GLenum textarget,
+                                                  GLuint texture,
+                                                  GLint level,
+                                                  GLsizei samples) {
+  if (mock) {
+    mock->glFramebufferTexture2DMultisampleEXT(target, attachment, textarget,
+                                               texture, level, samples);
+  }
+}
 
 static void _glGenTextures(GLsizei n, GLuint* textures) {
+  static GLuint next_id = 1;
   for (GLsizei i = 0; i < n; i++) {
-    textures[i] = 0;
+    textures[i] = next_id++;
   }
   if (mock) {
     mock->glGenTextures(n, textures);
@@ -496,8 +517,9 @@ static void _glGenTextures(GLsizei n, GLuint* textures) {
 }
 
 static void _glGenFramebuffers(GLsizei n, GLuint* framebuffers) {
+  static GLuint next_id = 1;
   for (GLsizei i = 0; i < n; i++) {
-    framebuffers[i] = 0;
+    framebuffers[i] = next_id++;
   }
   if (mock) {
     mock->glGenFramebuffers(n, framebuffers);
@@ -505,8 +527,9 @@ static void _glGenFramebuffers(GLsizei n, GLuint* framebuffers) {
 }
 
 static void _glGenRenderbuffers(GLsizei n, GLuint* renderbuffers) {
+  static GLuint next_id = 1;
   for (GLsizei i = 0; i < n; i++) {
-    renderbuffers[i] = 0;
+    renderbuffers[i] = next_id++;
   }
   if (mock) {
     mock->glGenRenderbuffers(n, renderbuffers);
@@ -530,6 +553,9 @@ static void _glGetFramebufferAttachmentParameteriv(GLenum target,
 static void _glGetIntegerv(GLenum pname, GLint* data) {
   if (pname == GL_TEXTURE_BINDING_2D) {
     *data = bound_texture_2d;
+  }
+  if (mock) {
+    mock->glGetIntegerv(pname, data);
   }
 }
 
@@ -603,7 +629,33 @@ void _glLinkProgram(GLuint program) {}
 void _glRenderbufferStorage(GLenum target,
                             GLenum internalformat,
                             GLsizei width,
-                            GLsizei height) {}
+                            GLsizei height) {
+  if (mock) {
+    mock->glRenderbufferStorage(target, internalformat, width, height);
+  }
+}
+
+void _glRenderbufferStorageMultisample(GLenum target,
+                                       GLsizei samples,
+                                       GLenum internalformat,
+                                       GLsizei width,
+                                       GLsizei height) {
+  if (mock) {
+    mock->glRenderbufferStorageMultisample(target, samples, internalformat,
+                                           width, height);
+  }
+}
+
+void _glRenderbufferStorageMultisampleEXT(GLenum target,
+                                          GLsizei samples,
+                                          GLenum internalformat,
+                                          GLsizei width,
+                                          GLsizei height) {
+  if (mock) {
+    mock->glRenderbufferStorageMultisampleEXT(target, samples, internalformat,
+                                              width, height);
+  }
+}
 
 void _glShaderSource(GLuint shader,
                      GLsizei count,
@@ -711,17 +763,34 @@ void (*epoxy_glFramebufferTexture2D)(GLenum target,
                                      GLenum textarget,
                                      GLuint texture,
                                      GLint level);
+void (*epoxy_glFramebufferTexture2DMultisampleEXT)(GLenum target,
+                                                   GLenum attachment,
+                                                   GLenum textarget,
+                                                   GLuint texture,
+                                                   GLint level,
+                                                   GLsizei samples);
 void (*epoxy_glGetFramebufferAttachmentParameteriv)(GLenum target,
                                                     GLenum attachment,
                                                     GLenum pname,
                                                     GLint* params);
 void (*epoxy_glGenFramebuffers)(GLsizei n, GLuint* framebuffers);
+void (*epoxy_glGenRenderbuffers)(GLsizei n, GLuint* renderbuffers);
 void (*epoxy_glGenTextures)(GLsizei n, GLuint* textures);
 void (*epoxy_glLinkProgram)(GLuint program);
 void (*epoxy_glRenderbufferStorage)(GLenum target,
                                     GLenum internalformat,
                                     GLsizei width,
                                     GLsizei height);
+void (*epoxy_glRenderbufferStorageMultisample)(GLenum target,
+                                               GLsizei samples,
+                                               GLenum internalformat,
+                                               GLsizei width,
+                                               GLsizei height);
+void (*epoxy_glRenderbufferStorageMultisampleEXT)(GLenum target,
+                                                  GLsizei samples,
+                                                  GLenum internalformat,
+                                                  GLsizei width,
+                                                  GLsizei height);
 void (*epoxy_glShaderSource)(GLuint shader,
                              GLsizei count,
                              const GLchar* const* string,
@@ -776,6 +845,8 @@ static void library_init() {
   epoxy_glEnable = _glEnable;
   epoxy_glFramebufferRenderbuffer = _glFramebufferRenderbuffer;
   epoxy_glFramebufferTexture2D = _glFramebufferTexture2D;
+  epoxy_glFramebufferTexture2DMultisampleEXT =
+      _glFramebufferTexture2DMultisampleEXT;
   epoxy_glGenFramebuffers = _glGenFramebuffers;
   epoxy_glGenRenderbuffers = _glGenRenderbuffers;
   epoxy_glGenTextures = _glGenTextures;
@@ -790,6 +861,9 @@ static void library_init() {
   epoxy_glIsEnabled = _glIsEnabled;
   epoxy_glLinkProgram = _glLinkProgram;
   epoxy_glRenderbufferStorage = _glRenderbufferStorage;
+  epoxy_glRenderbufferStorageMultisample = _glRenderbufferStorageMultisample;
+  epoxy_glRenderbufferStorageMultisampleEXT =
+      _glRenderbufferStorageMultisampleEXT;
   epoxy_glShaderSource = _glShaderSource;
   epoxy_glTexParameterf = _glTexParameterf;
   epoxy_glTexParameteri = _glTexParameteri;

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
@@ -52,7 +52,47 @@ class MockEpoxy {
   MOCK_METHOD(void, glGenFramebuffers, (GLsizei n, GLuint* framebuffers));
   MOCK_METHOD(void, glGenRenderbuffers, (GLsizei n, GLuint* renderbuffers));
   MOCK_METHOD(void, glGenTextures, (GLsizei n, GLuint* textures));
+  MOCK_METHOD(void,
+              glFramebufferRenderbuffer,
+              (GLenum target,
+               GLenum attachment,
+               GLenum renderbuffertarget,
+               GLuint renderbuffer));
+  MOCK_METHOD(void,
+              glFramebufferTexture2D,
+              (GLenum target,
+               GLenum attachment,
+               GLenum textarget,
+               GLuint texture,
+               GLint level));
+  MOCK_METHOD(void,
+              glFramebufferTexture2DMultisampleEXT,
+              (GLenum target,
+               GLenum attachment,
+               GLenum textarget,
+               GLuint texture,
+               GLint level,
+               GLsizei samples));
+  MOCK_METHOD(void, glGetIntegerv, (GLenum pname, GLint* data));
   MOCK_METHOD(const GLubyte*, glGetString, (GLenum pname));
+  MOCK_METHOD(
+      void,
+      glRenderbufferStorage,
+      (GLenum target, GLenum internalformat, GLsizei width, GLsizei height));
+  MOCK_METHOD(void,
+              glRenderbufferStorageMultisample,
+              (GLenum target,
+               GLsizei samples,
+               GLenum internalformat,
+               GLsizei width,
+               GLsizei height));
+  MOCK_METHOD(void,
+              glRenderbufferStorageMultisampleEXT,
+              (GLenum target,
+               GLsizei samples,
+               GLenum internalformat,
+               GLsizei width,
+               GLsizei height));
 };
 
 }  // namespace testing

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
@@ -93,6 +93,17 @@ class MockEpoxy {
                GLenum internalformat,
                GLsizei width,
                GLsizei height));
+  MOCK_METHOD(void,
+              glTexImage2D,
+              (GLenum target,
+               GLint level,
+               GLint internalformat,
+               GLsizei width,
+               GLsizei height,
+               GLint border,
+               GLenum format,
+               GLenum type,
+               const void* pixels));
 };
 
 }  // namespace testing


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/191171

This is the linux equivalent of the windows change: https://github.com/flutter/flutter/pull/190256

On desktop we normally need to have an explicit resolution step for MSAA to work, this adds that explicit step.  On linux we were already blitting from this framebuffer so we didn't need to provide an explicit resolve step, it already existed.

I also removed code about using bgra.  This was impeding our usage of MSAA render buffers, on linux I don't think there is a reason we have to use BGRA.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
