### PR TITLE
feat: Add includeRouteSemantics to PageRoute

### DIFF
--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -29,6 +29,7 @@ abstract class PageRoute<T> extends ModalRoute<T> {
     super.directionalTraversalEdgeBehavior,
     this.fullscreenDialog = false,
     this.allowSnapshotting = true,
+    this.includeRouteSemantics = true,
     bool barrierDismissible = false,
   }) : _barrierDismissible = barrierDismissible;
 
@@ -45,6 +46,18 @@ abstract class PageRoute<T> extends ModalRoute<T> {
 
   @override
   final bool allowSnapshotting;
+
+  /// {@template flutter.widgets.PageRoute.includeRouteSemantics}
+  /// Whether this route introduces a route scope in the semantics tree.
+  ///
+  /// Defaults to true. When true, screen readers can treat pushes and pops of
+  /// this route as navigation to a new screen and announce the change to users.
+  ///
+  /// Set this to false for routes that update only part of the screen, such as
+  /// tab or shell content in a nested navigator. This prevents screen readers
+  /// from treating the route as a new screen.
+  /// {@endtemplate}
+  final bool includeRouteSemantics;
 
   @override
   bool get opaque => true;

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -542,6 +542,16 @@ void main() {
     expect(focusNode.hasPrimaryFocus, isTrue);
   });
 
+  group('PageRoute', () {
+    test('includes route semantics by default', () {
+      expect(_TestPageRoute().includeRouteSemantics, isTrue);
+    });
+
+    test('can opt out of route semantics', () {
+      expect(_TestPageRoute(includeRouteSemantics: false).includeRouteSemantics, isFalse);
+    });
+  });
+
   group('PageRouteBuilder', () {
     testWidgets('reverseTransitionDuration defaults to 300ms', (WidgetTester tester) async {
       // Default PageRouteBuilder reverse transition duration should be 300ms.
@@ -3116,6 +3126,31 @@ class _SimulationRoute extends PageRouteBuilder<void> {
     Widget child,
   ) {
     return transitionBuilder(context, animation, child);
+  }
+}
+
+class _TestPageRoute extends PageRoute<void> {
+  _TestPageRoute({super.includeRouteSemantics});
+
+  @override
+  Color? get barrierColor => null;
+
+  @override
+  String? get barrierLabel => null;
+
+  @override
+  bool get maintainState => false;
+
+  @override
+  Duration get transitionDuration => Duration.zero;
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    return const SizedBox.shrink();
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This extracts the Widgets portion of #182556 so the Material and Cupertino
changes can be moved separately to `material_ui` and `cupertino_ui`.

Nested navigators may use routes to update only part of the visible screen.
Material and Cupertino routes currently introduce a semantics route scope,
causing screen readers to treat these updates as navigation to a new screen.

This change adds `PageRoute.includeRouteSemantics`, which defaults to `true`.
Design-system route implementations can use this property to let applications
opt out of the route semantics scope when a route represents partial-screen
content, such as tab or shell content in a nested navigator.

Part of issue #168915.
Extracted from PR #182556.

## Pre-launch Checklist

- [✅] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [✅] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [✅] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [✅] I signed the [CLA].
- [✅] I listed at least one issue that this PR fixes in the description above.
- [✅] I updated/added relevant documentation (doc comments with `///`).
- [✅] I added new tests to check the change I am making, or this PR is [test-exempt].
- [✅] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [✅] All existing and new tests are passing.
