### PR TITLE
WIP: Make touch to present latency on iOS match UIKit

### DIFF
--- a/engine/src/flutter/shell/common/animator.cc
+++ b/engine/src/flutter/shell/common/animator.cc
@@ -253,20 +253,7 @@ void Animator::RequestFrame(bool regenerate_layer_trees) {
     return;
   }
 
-  // The AwaitVSync is going to call us back at the next VSync. However, we want
-  // to be reasonably certain that the UI thread is not in the middle of a
-  // particularly expensive callout. We post the AwaitVSync to run right after
-  // an idle. This does NOT provide a guarantee that the UI thread has not
-  // started an expensive operation right after posting this message however.
-  // To support that, we need edge triggered wakes on VSync.
-
-  task_runners_.GetUITaskRunner()->PostTask(
-      [self = weak_factory_.GetWeakPtr()]() {
-        if (!self) {
-          return;
-        }
-        self->AwaitVSync();
-      });
+  AwaitVSync();
   frame_scheduled_ = true;
 }
 
@@ -300,6 +287,9 @@ void Animator::ScheduleSecondaryVsyncCallback(uintptr_t id,
 }
 
 void Animator::ScheduleMaybeClearTraceFlowIds() {
+  // Don't schedule the secondary callback nonsense, just to not get
+  // confused while debugging the vsync client.
+#if 0
   waiter_->ScheduleSecondaryCallback(
       reinterpret_cast<uintptr_t>(this), [self = weak_factory_.GetWeakPtr()] {
         if (!self) {
@@ -324,6 +314,7 @@ void Animator::ScheduleMaybeClearTraceFlowIds() {
           }
         }
       });
+#endif
 }
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1231,7 +1231,10 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
   FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
-  task_runners_.GetUITaskRunner()->PostTask(
+  // Dispatch the event synchronously if possible, there is no need to increase
+  // latency by scheduling a new run loop turn.
+  fml::TaskRunner::RunNowOrPostTask(
+      task_runners_.GetUITaskRunner(),
       fml::MakeCopyable([engine = weak_engine_, packet = std::move(packet),
                          flow_id = next_pointer_flow_id_]() mutable {
         if (engine) {

--- a/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
@@ -166,6 +166,7 @@ source_set("InternalFlutterSwiftCommon") {
   configs += [ ":config" ]
   bridge_header = "InternalFlutterSwiftCommon-Bridging-Header.h"
   sources = [
+    "framework/Source/FlutterRunLoop.swift",
     "framework/Source/Logger.swift",
     "framework/Source/Tracing+TraceScope.swift",
   ]

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterRunLoop.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterRunLoop.swift
@@ -11,7 +11,7 @@ import Foundation
 /// schedules the task in both common run loop mode and a private run loop mode,
 /// which allows it to run in a mode where it only processes Flutter messages
 /// (`pollFlutterMessagesOnce()`).
-@objc final class FlutterRunLoop: NSObject {
+@objc public final class FlutterRunLoop: NSObject {
   private static let flutterRunLoopMode = CFRunLoopMode("FlutterRunLoopMode" as CFString)
 
   private static var _mainRunLoop: FlutterRunLoop?
@@ -91,7 +91,7 @@ import Foundation
 
   // Ensures that the `FlutterRunLoop` for main thread is initialized. Only
   // needs to be called once and must be called on the main thread.
-  @objc static func ensureMainLoopInitialized() {
+  @objc public static func ensureMainLoopInitialized() {
     assert(Thread.isMainThread, "Must be called on the main thread.")
     if _mainRunLoop == nil {
       _mainRunLoop = FlutterRunLoop()
@@ -99,7 +99,7 @@ import Foundation
   }
 
   // The `FlutterRunLoop` for the main thread.
-  @objc static var mainRunLoop: FlutterRunLoop {
+  @objc public static var mainRunLoop: FlutterRunLoop {
     assert(
       _mainRunLoop != nil,
       "Main run loop has not been initialized. Call ensureMainLoopInitialized() first."
@@ -108,7 +108,7 @@ import Foundation
   }
 
   // Schedules a block to be executed on the main thread.
-  @objc func perform(afterDelay delay: TimeInterval, block: @escaping () -> Void) {
+  @objc public func perform(afterDelay delay: TimeInterval, block: @escaping () -> Void) {
     tasksLock.lock()
     defer { tasksLock.unlock() }
 
@@ -123,7 +123,7 @@ import Foundation
 
   // Schedules a block to be executed on the main thread after a delay.
   @objc(performBlock:)
-  func perform(_ block: @escaping () -> Void) {
+  public func perform(_ block: @escaping () -> Void) {
     perform(afterDelay: 0, block: block)
   }
 
@@ -158,7 +158,7 @@ import Foundation
 
   /// Executes single iteration of the run loop in the mode where only Flutter
   /// messages are processed.
-  @objc func pollFlutterMessagesOnce() {
+  @objc public func pollFlutterMessagesOnce() {
     CFRunLoopRunInMode(Self.flutterRunLoopMode, 0.1, true)
   }
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -41,7 +41,22 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/profiler_metrics_ios.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
+#import "flutter/shell/platform/embedder/embedder_task_runner.h"
 #include "flutter/shell/profiling/sampling_profiler.h"
+
+static void PostTask(flutter::EmbedderTaskRunner* task_runner,
+                     uint64_t task_baton,
+                     fml::TimePoint target_time) {
+  [FlutterRunLoop.mainRunLoop
+      performAfterDelay:std::max(0.0, (target_time - fml::TimePoint::Now()).ToSecondsF())
+                  block:^{
+                    task_runner->PostTask(task_baton);
+                  }];
+}
+
+static bool RunsTaskOnCurrentThread() {
+  return [NSThread isMainThread];
+}
 
 FLUTTER_ASSERT_ARC
 
@@ -240,6 +255,8 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
   NSAssert(labelPrefix, @"labelPrefix is required");
+
+  [FlutterRunLoop ensureMainLoopInitialized];
 
   _restorationEnabled = restorationEnabled;
   _allowHeadlessExecution = allowHeadlessExecution;
@@ -960,7 +977,17 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 
   // The platform and UI threads are always merged on iOS, so the UI task runner is the platform
   // thread's task runner.
-  fml::RefPtr<fml::TaskRunner> platform_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+  fml::RefPtr<fml::TaskRunner> platform_runner = fml::MakeRefCounted<flutter::EmbedderTaskRunner>(
+      flutter::EmbedderTaskRunner::DispatchTable{
+          .post_task_callback =
+              [](flutter::EmbedderTaskRunner* task_runner, uint64_t task_baton,
+                 fml::TimePoint target_time) { PostTask(task_runner, task_baton, target_time); },
+          .runs_task_on_current_thread_callback = []() { return RunsTaskOnCurrentThread(); },
+          .destruction_callback = []() {},
+      },
+
+      0);
+  //  fml::MessageLoop::GetCurrent().GetTaskRunner();
   flutter::TaskRunners task_runners(threadLabel.UTF8String,                       // label
                                     platform_runner,                              // platform
                                     _threadHost->raster_thread->GetTaskRunner(),  // raster

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -20,6 +20,8 @@ FLUTTER_ASSERT_ARC
 
 extern CFTimeInterval display_link_target;
 
+bool FlutterDidPresentSurface;
+
 @interface FlutterMetalLayer () {
   id<MTLDevice> _preferredDevice;
   CGSize _drawableSize;
@@ -439,9 +441,10 @@ extern CFTimeInterval display_link_target;
       [self presentOnMainThread:texture];
     } else {
       // Core animation layers can only be updated on main thread.
-      dispatch_async(dispatch_get_main_queue(), ^{
+      [FlutterRunLoop.mainRunLoop performBlock:^{
         [self presentOnMainThread:texture];
-      });
+        FlutterDidPresentSurface = true;
+      }];
     }
   }
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -39,7 +39,6 @@
 #import "flutter/third_party/spring_animation/spring_animation.h"
 
 bool FlutterDispatchingTouches;
-dispatch_block_t FlutterAfterDispatchingTouchesBlock;
 
 FLUTTER_ASSERT_ARC
 
@@ -1283,10 +1282,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   FlutterDispatchingTouches = true;
   [self.engine dispatchPointerDataPacket:std::move(packet)];
   FlutterDispatchingTouches = false;
-  if (FlutterAfterDispatchingTouchesBlock != nullptr) {
-    FlutterAfterDispatchingTouchesBlock();
-    FlutterAfterDispatchingTouchesBlock = nullptr;
-  }
 }
 
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
@@ -1294,6 +1289,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
+  NSLog(@"Touches moved %f", CACurrentMediaTime());
   [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -38,6 +38,9 @@
 #import "flutter/shell/platform/embedder/embedder.h"
 #import "flutter/third_party/spring_animation/spring_animation.h"
 
+bool FlutterDispatchingTouches;
+dispatch_block_t FlutterAfterDispatchingTouchesBlock;
+
 FLUTTER_ASSERT_ARC
 
 static constexpr int kMicrosecondsPerSecond = 1000 * 1000;
@@ -1277,7 +1280,13 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     }
   }
 
+  FlutterDispatchingTouches = true;
   [self.engine dispatchPointerDataPacket:std::move(packet)];
+  FlutterDispatchingTouches = false;
+  if (FlutterAfterDispatchingTouchesBlock != nullptr) {
+    FlutterAfterDispatchingTouchesBlock();
+    FlutterAfterDispatchingTouchesBlock = nullptr;
+  }
 }
 
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1337,6 +1337,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)triggerTouchRateCorrectionIfNeeded:(NSSet*)touches {
+  // This is not needed now that we're running CADisplayLink on main thread.
+#if 0
   if (_touchRateCorrectionVSyncClient == nil) {
     // If the _touchRateCorrectionVSyncClient is not created, means current devices doesn't
     // need to correct the touch rate. So just return.
@@ -1358,6 +1360,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   } else {
     [_touchRateCorrectionVSyncClient pause];
   }
+#endif
 }
 
 - (void)invalidateTouchRateCorrectionVSyncClient {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -48,6 +48,7 @@ class VsyncWaiterIOS final : public VsyncWaiter, public VariableRefreshRateRepor
   FlutterVSyncClient* client_;
   FlutterDisplayLinkManager* display_link_manager_;
   double max_refresh_rate_;
+  bool waiting_for_vsync_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiterIOS);
 };

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -49,6 +49,8 @@ class VsyncWaiterIOS final : public VsyncWaiter, public VariableRefreshRateRepor
   FlutterDisplayLinkManager* display_link_manager_;
   double max_refresh_rate_;
   bool waiting_for_vsync_ = false;
+  bool block_until_frame_available_ = false;
+  int idle_countdown_ = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiterIOS);
 };

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -16,7 +16,6 @@ const static double kRefreshRateDiffToIgnore = 0.1;
 
 extern bool FlutterDispatchingTouches;
 extern bool FlutterDidPresentSurface;
-extern dispatch_block_t FlutterAfterDispatchingTouchesBlock;
 
 namespace flutter {
 
@@ -26,10 +25,13 @@ VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners,
   FML_DCHECK(display_link_manager);
   auto vsyncCallback = ^(CFTimeInterval startTime, CFTimeInterval targetTime) {
     if (!waiting_for_vsync_) {
-      [client_ pause];
+      if (--idle_countdown_ == 0) {
+        [client_ pause];
+      }
       return;
     }
     waiting_for_vsync_ = false;
+    idle_countdown_ = 10;
 
     // Compute delay using the same CACurrentMediaTime() clock.
     CFTimeInterval delay = CACurrentMediaTime() - startTime;
@@ -47,6 +49,15 @@ VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners,
     // Align target time to the C++ steady_clock used by fml::TimePoint.
     fml::TimePoint target_time = start_time + fml::TimeDelta::FromSecondsF(duration);
     FireCallback(start_time, target_time, true);
+
+    if (block_until_frame_available_) {
+      block_until_frame_available_ = false;
+      FlutterDidPresentSurface = false;
+      CFTimeInterval startTime = CACurrentMediaTime();
+      while (!FlutterDidPresentSurface && CACurrentMediaTime() - startTime < 0.5) {
+        [FlutterRunLoop.mainRunLoop pollFlutterMessagesOnce];
+      }
+    }
   };
   FlutterFMLTaskRunner* uiTaskRunner =
       [[FlutterFMLTaskRunner alloc] initWithTaskRunner:task_runners_.GetUITaskRunner()];
@@ -72,25 +83,14 @@ void VsyncWaiterIOS::AwaitVSync() {
     [client_ setMaxRefreshRate:max_refresh_rate_];
   }
 
-  // When dispatching touches, start rendering the frame immediately and then
-  // hold the main thred inside touches Dispatch until the frame is presented.
-  if (FlutterDispatchingTouches) {
-    FireCallback(fml::TimePoint::Now(), fml::TimePoint::Now(), false);
-    FlutterAfterDispatchingTouchesBlock = ^{
-      FlutterDidPresentSurface = false;
-      CFTimeInterval startTime = CACurrentMediaTime();
-      while (!FlutterDidPresentSurface && CACurrentMediaTime() - startTime < 0.5) {
-        [FlutterRunLoop.mainRunLoop pollFlutterMessagesOnce];
-      }
-    };
-    return;
-  }
-
   if (client_.displayLink.paused) {
     [client_ await];
     FireCallback(fml::TimePoint::Now(), fml::TimePoint::Now(), false);
   } else {
     waiting_for_vsync_ = true;
+    if (FlutterDispatchingTouches) {
+      block_until_frame_available_ = true;
+    }
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
 
+#import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/InternalFlutterSwift/InternalFlutterSwift.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFMLTaskRunner+FML.h"
@@ -12,6 +13,10 @@ FLUTTER_ASSERT_ARC
 
 // When calculating refresh rate diffrence, anything within 0.1 fps is ignored.
 const static double kRefreshRateDiffToIgnore = 0.1;
+
+extern bool FlutterDispatchingTouches;
+extern bool FlutterDidPresentSurface;
+extern dispatch_block_t FlutterAfterDispatchingTouchesBlock;
 
 namespace flutter {
 
@@ -65,6 +70,20 @@ void VsyncWaiterIOS::AwaitVSync() {
   if (fabs(new_max_refresh_rate - max_refresh_rate_) > kRefreshRateDiffToIgnore) {
     max_refresh_rate_ = new_max_refresh_rate;
     [client_ setMaxRefreshRate:max_refresh_rate_];
+  }
+
+  // When dispatching touches, start rendering the frame immediately and then
+  // hold the main thred inside touches Dispatch until the frame is presented.
+  if (FlutterDispatchingTouches) {
+    FireCallback(fml::TimePoint::Now(), fml::TimePoint::Now(), false);
+    FlutterAfterDispatchingTouchesBlock = ^{
+      FlutterDidPresentSurface = false;
+      CFTimeInterval startTime = CACurrentMediaTime();
+      while (!FlutterDidPresentSurface && CACurrentMediaTime() - startTime < 0.5) {
+        [FlutterRunLoop.mainRunLoop pollFlutterMessagesOnce];
+      }
+    };
+    return;
   }
 
   if (client_.displayLink.paused) {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -20,6 +20,12 @@ VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners,
     : VsyncWaiter(task_runners), display_link_manager_(display_link_manager) {
   FML_DCHECK(display_link_manager);
   auto vsyncCallback = ^(CFTimeInterval startTime, CFTimeInterval targetTime) {
+    if (!waiting_for_vsync_) {
+      [client_ pause];
+      return;
+    }
+    waiting_for_vsync_ = false;
+
     // Compute delay using the same CACurrentMediaTime() clock.
     CFTimeInterval delay = CACurrentMediaTime() - startTime;
     if (delay < 0.0) {
@@ -44,6 +50,7 @@ VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners,
       isVariableRefreshRateEnabled:display_link_manager_.maxRefreshRateEnabledOnIPhone
                     maxRefreshRate:display_link_manager_.displayRefreshRate
                           callback:vsyncCallback];
+  client_.allowPauseAfterVsync = false;
   max_refresh_rate_ = display_link_manager_.displayRefreshRate;
 }
 
@@ -59,7 +66,13 @@ void VsyncWaiterIOS::AwaitVSync() {
     max_refresh_rate_ = new_max_refresh_rate;
     [client_ setMaxRefreshRate:max_refresh_rate_];
   }
-  [client_ await];
+
+  if (client_.displayLink.paused) {
+    [client_ await];
+    FireCallback(fml::TimePoint::Now(), fml::TimePoint::Now(), false);
+  } else {
+    waiting_for_vsync_ = true;
+  }
 }
 
 // |VariableRefreshRateReporter|

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios.mm
@@ -101,7 +101,7 @@ void PlatformViewIOS::attachView() {
 
 PointerDataDispatcherMaker PlatformViewIOS::GetDispatcherMaker() {
   return [](DefaultPointerDataDispatcher::Delegate& delegate) {
-    return std::make_unique<SmoothPointerDataDispatcher>(delegate);
+    return std::make_unique<DefaultPointerDataDispatcher>(delegate);
   };
 }
 

--- a/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
@@ -62,10 +62,7 @@ source_set("InternalFlutterSwift") {
     "//flutter/shell/platform/darwin/macos/framework",  # For module.modulemap
   ]
   bridge_header = "InternalFlutterSwift-Bridging-Header.h"
-  sources = [
-    "framework/Source/FlutterRunLoop.swift",
-    "framework/Source/ResizeSynchronizer.swift",
-  ]
+  sources = [ "framework/Source/ResizeSynchronizer.swift" ]
   deps = [ "//flutter/shell/platform/darwin/common:framework_common" ]
   public = _flutter_framework_headers + framework_common_headers
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterDisplayLink.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterDisplayLink.mm
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "flutter/fml/logging.h"
+#import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #import "flutter/shell/platform/darwin/macos/InternalFlutterSwift/InternalFlutterSwift.h"
 
 @class _FlutterDisplayLinkView;

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterDisplayLinkTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterDisplayLinkTest.mm
@@ -9,6 +9,7 @@
 #include <numeric>
 
 #include "flutter/fml/synchronization/waitable_event.h"
+#import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #import "flutter/shell/platform/darwin/macos/InternalFlutterSwift/InternalFlutterSwift.h"
 #include "flutter/testing/testing.h"
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiterTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiterTest.mm
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDisplayLink.h"
 
+#import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #import "flutter/shell/platform/darwin/macos/InternalFlutterSwift/InternalFlutterSwift.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiter.h"
 #import "flutter/testing/testing.h"

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/ResizeSynchronizer.swift
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/ResizeSynchronizer.swift
@@ -4,6 +4,7 @@
 
 import CoreGraphics
 import Foundation
+import InternalFlutterSwiftCommon
 
 /// Coordinates Flutter view content updates with macOS window resizing.
 ///

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/ResizeSynchronizerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/ResizeSynchronizerTests.swift
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @testable import InternalFlutterSwift
+import InternalFlutterSwiftCommon
 import Testing
 
 // Tests for `ResizeSynchronizer`.


### PR DESCRIPTION
This PR builds on top of https://github.com/flutter/flutter/pull/191368 to fix the last remaining issue - delaying CA commit until we have frame available. This gets rid of the second frame of latency.

This is a very hacky proof of concept PR that is cutting a lot of corners. But it works.

(Note that we can match UIKit while gesture is in progress, but the gesture starts slower because of recognizer logic differences. Also there is some weirdness in `ScrollDragController._adjustForScrollStartThreshold` that maybe need a look.)

https://github.com/user-attachments/assets/d29194f6-7d69-4025-97da-e4ffafe31d02

---

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
