### PR TITLE
iOS: Deprecate FlutterEngine.isGpuDisabled

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -443,7 +443,8 @@ FLUTTER_DARWIN_EXPORT
  *
  * Typically this is set when the app is backgrounded and foregrounded.
  */
-@property(nonatomic, assign) BOOL isGpuDisabled;
+@property(nonatomic, assign) BOOL isGpuDisabled FLUTTER_DEPRECATED(
+    "This property is managed by the engine and will be removed from the public API.");
 
 @end
 


### PR DESCRIPTION
`FlutterEngine.isGpuDisabled` is currently exposed as a public read/write property on `FlutterEngine` in the iOS framework API (`FlutterEngine.h`).

This property is used internally by the engine to track whether the app currently has access to the GPU. We update it on lifecycle transitions between foreground and background, as well as on startup and when the view is mounted/unmounted from the view hierarchy. 

This state management was originally added to prevent GPU work from running on the IO thread pool when the application loses access to the GPU. While we do need to expose a read/write property for tests, there was no clear need for it to be exposed as public API, and should have been exposed on `FlutterEngine_Internal.h`.

Issue: https://github.com/flutter/flutter/issues/191347

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
