### PR TITLE
[material] Remove unused parameters from constructors of generic classes

### DIFF
--- a/packages/flutter/lib/src/material/autocomplete.dart
+++ b/packages/flutter/lib/src/material/autocomplete.dart
@@ -190,7 +190,6 @@ class _AutocompleteField extends StatelessWidget {
 // The default Material-style Autocomplete options.
 class _AutocompleteOptions<T extends Object> extends StatelessWidget {
   const _AutocompleteOptions({
-    super.key,
     required this.displayStringForOption,
     required this.onSelected,
     required this.openDirection,

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -652,7 +652,6 @@ class _RenderBottomSheetLayoutWithSizeListener extends RenderShiftedBox {
 
 class _ModalBottomSheet<T> extends StatefulWidget {
   const _ModalBottomSheet({
-    super.key,
     required this.route,
     this.backgroundColor,
     this.elevation,

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -110,7 +110,6 @@ class _DropdownMenuPainter extends CustomPainter {
 // The widget that is the button wrapping the menu items.
 class _DropdownMenuItemButton<T> extends StatefulWidget {
   const _DropdownMenuItemButton({
-    super.key,
     this.padding,
     required this.route,
     required this.buttonRect,
@@ -249,7 +248,6 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
 
 class _DropdownMenu<T> extends StatefulWidget {
   const _DropdownMenu({
-    super.key,
     this.padding,
     required this.route,
     required this.buttonRect,
@@ -258,7 +256,6 @@ class _DropdownMenu<T> extends StatefulWidget {
     required this.enableFeedback,
     this.borderRadius,
     required this.scrollController,
-    this.menuWidth,
     this.mouseCursor,
   });
 
@@ -270,7 +267,6 @@ class _DropdownMenu<T> extends StatefulWidget {
   final bool enableFeedback;
   final BorderRadius? borderRadius;
   final ScrollController scrollController;
-  final double? menuWidth;
   final MouseCursor? mouseCursor;
 
   @override
@@ -649,7 +645,6 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
 
 class _DropdownRoutePage<T> extends StatefulWidget {
   const _DropdownRoutePage({
-    super.key,
     required this.route,
     required this.constraints,
     this.items,
@@ -758,7 +753,7 @@ class _DropdownRoutePageState<T> extends State<_DropdownRoutePage<T>> {
 // selected item lines up with the vertical center of the dropdown button,
 // as closely as possible.
 class _MenuItem<T> extends SingleChildRenderObjectWidget {
-  const _MenuItem({super.key, required this.onLayout, required this.item}) : super(child: item);
+  const _MenuItem({required this.onLayout, required this.item}) : super(child: item);
 
   final ValueChanged<Size> onLayout;
   final DropdownMenuItem<T>? item;
@@ -1042,7 +1037,6 @@ class DropdownButton<T> extends StatefulWidget {
        _isEmpty = false;
 
   DropdownButton._formField({
-    super.key,
     required this.items,
     this.selectedItemBuilder,
     this.value,
@@ -1052,7 +1046,6 @@ class DropdownButton<T> extends StatefulWidget {
     this.onTap,
     this.elevation = 8,
     this.style,
-    this.underline,
     this.icon,
     this.iconDisabledColor,
     this.iconEnabledColor,
@@ -1060,7 +1053,6 @@ class DropdownButton<T> extends StatefulWidget {
     this.isDense = false,
     this.isExpanded = false,
     this.itemHeight = kMinInteractiveDimension,
-    this.menuWidth,
     this.focusColor,
     this.focusNode,
     this.autofocus = false,
@@ -1089,6 +1081,8 @@ class DropdownButton<T> extends StatefulWidget {
          'with the same value',
        ),
        assert(itemHeight == null || itemHeight >= kMinInteractiveDimension),
+       underline = null,
+       menuWidth = null,
        _inputDecoration = inputDecoration,
        _isEmpty = isEmpty;
 

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -662,7 +662,6 @@ class _CheckedPopupMenuItemState<T> extends PopupMenuItemState<T, CheckedPopupMe
 
 class _PopupMenu<T> extends StatefulWidget {
   const _PopupMenu({
-    super.key,
     required this.itemKeys,
     required this.route,
     required this.semanticLabel,

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -719,7 +719,6 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
 
 class _SegmentedButtonRenderWidget<T> extends MultiChildRenderObjectWidget {
   const _SegmentedButtonRenderWidget({
-    super.key,
     required this.segments,
     required this.enabledBorder,
     required this.disabledBorder,

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -3882,12 +3882,7 @@ class _GeometryCachePainter extends CustomPainter {
 }
 
 class _CustomPageRoute<T> extends PageRoute<T> {
-  _CustomPageRoute({
-    required this.builder,
-    RouteSettings super.settings = const RouteSettings(),
-    this.maintainState = true,
-    super.fullscreenDialog,
-  });
+  _CustomPageRoute({required this.builder, this.maintainState = true, super.fullscreenDialog});
 
   final WidgetBuilder builder;
 


### PR DESCRIPTION
We already don't allow unused parameters from non-generic classes. There was a bug preventing us from reporting such parameters on generic classes.

This is work towards https://github.com/dart-lang/sdk/issues/47839

This is mirrored at https://github.com/flutter/packages/pull/12458


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
