### PR TITLE
Skip layout-dirty children during semantics compilation

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -5946,6 +5946,15 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
   List<_RenderObjectSemantics> _getNonBlockedChildren() {
     final result = <_RenderObjectSemantics>[];
     renderObject.visitChildrenForSemantics((RenderObject renderChild) {
+      // A child that still needs layout was skipped during the layout phase, so
+      // it has no up-to-date geometry and cannot contribute to semantics. Skip
+      // it here as well, mirroring what the paint phase does in
+      // `_paintWithContext`. Laying the child out again marks the semantics
+      // dirty (see `RenderObject.layout`), so it rejoins the semantics tree once
+      // it has valid geometry.
+      if (renderChild._needsLayout) {
+        return;
+      }
       if (renderChild._semantics.isBlockingPreviousSibling) {
         result.clear();
       }
@@ -6014,7 +6023,6 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
       effectiveChildParentData = childParentData;
     }
     for (final _RenderObjectSemantics childSemantics in _getNonBlockedChildren()) {
-      assert(!childSemantics.renderObject._needsLayout);
       childSemantics._didUpdateParentData(effectiveChildParentData);
       for (final _SemanticsFragment fragment in childSemantics.mergeUp) {
         if (hasChildConfigurationsDelegate && fragment.configToMergeUp != null) {

--- a/packages/flutter/test/widgets/semantics_layout_dirty_test.dart
+++ b/packages/flutter/test/widgets/semantics_layout_dirty_test.dart
@@ -1,0 +1,184 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Regression tests for https://github.com/flutter/flutter/issues/191188.
+//
+// Semantics compilation used to assert that every child reachable through
+// `visitChildrenForSemantics` had already been laid out. A render object that
+// skips laying its child out (but still visits it for semantics) violated that
+// assumption and crashed the framework with an assertion that had no message.
+// The semantics phase now skips layout-dirty children, mirroring the paint
+// phase; the subtree rejoins the semantics tree once it is laid out again.
+
+/// A render object that independently controls whether it lays its child out
+/// and whether it exposes the child via [visitChildrenForSemantics].
+class Gate extends SingleChildRenderObjectWidget {
+  const Gate({
+    super.key,
+    required this.layoutChild,
+    this.includeInSemantics = true,
+    this.boundary = false,
+    required super.child,
+  });
+
+  final bool layoutChild;
+  final bool includeInSemantics;
+  final bool boundary;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) => RenderGate(
+    layoutChild: layoutChild,
+    includeInSemantics: includeInSemantics,
+    boundary: boundary,
+  );
+
+  @override
+  void updateRenderObject(BuildContext context, RenderGate renderObject) {
+    renderObject
+      ..layoutChild = layoutChild
+      ..includeInSemantics = includeInSemantics;
+  }
+}
+
+class RenderGate extends RenderBox with RenderObjectWithChildMixin<RenderBox> {
+  RenderGate({required bool layoutChild, required bool includeInSemantics, required bool boundary})
+    : _layoutChild = layoutChild,
+      _includeInSemantics = includeInSemantics,
+      _boundary = boundary;
+
+  bool _layoutChild;
+  bool _includeInSemantics;
+  final bool _boundary;
+
+  bool get layoutChild => _layoutChild;
+  set layoutChild(bool value) {
+    if (_layoutChild == value) {
+      return;
+    }
+    _layoutChild = value;
+    markNeedsLayout();
+  }
+
+  bool get includeInSemantics => _includeInSemantics;
+  set includeInSemantics(bool value) {
+    if (_includeInSemantics == value) {
+      return;
+    }
+    _includeInSemantics = value;
+    markNeedsSemanticsUpdate();
+  }
+
+  @override
+  void performLayout() {
+    size = constraints.biggest;
+    final RenderBox? child = this.child;
+    if (_layoutChild && child != null) {
+      child.layout(BoxConstraints.loose(constraints.biggest), parentUsesSize: true);
+    }
+  }
+
+  @override
+  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
+    final RenderBox? child = this.child;
+    if (_includeInSemantics && child != null) {
+      visitor(child);
+    }
+  }
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    config.isSemanticBoundary = _boundary;
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {}
+}
+
+void main() {
+  testWidgets('semantics does not assert when a visited child stops being laid out', (
+    WidgetTester tester,
+  ) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+
+    Widget app({required bool layoutChild}) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Gate(
+          layoutChild: layoutChild,
+          child: Semantics(container: true, child: const SizedBox(width: 100, height: 100)),
+        ),
+      );
+    }
+
+    // 1. Everything is laid out and part of the semantics tree.
+    await tester.pumpWidget(app(layoutChild: true));
+    final RenderGate gate = tester.renderObject<RenderGate>(find.byType(Gate));
+    final RenderBox child = gate.child!;
+
+    // 2. The gate stops laying its child out, and the child is marked as needing
+    //    layout. Nothing lays it out again, but it is still visited by
+    //    `visitChildrenForSemantics`. This used to assert.
+    await tester.pumpWidget(app(layoutChild: false));
+    expect(gate.layoutChild, isFalse);
+    child.markNeedsLayout();
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(child.debugNeedsLayout, isTrue);
+    handle.dispose();
+  });
+
+  testWidgets('semantics does not assert when a layout-dirty subtree is newly admitted', (
+    WidgetTester tester,
+  ) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+
+    Widget app({required bool layoutMid, required bool includeLeaf}) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Gate(
+          layoutChild: layoutMid,
+          boundary: true,
+          child: Gate(
+            layoutChild: true,
+            includeInSemantics: includeLeaf,
+            child: Semantics(container: true, child: const SizedBox(width: 100, height: 100)),
+          ),
+        ),
+      );
+    }
+
+    // 1. Everything is laid out; the leaf is kept out of the semantics tree.
+    await tester.pumpWidget(app(layoutMid: true, includeLeaf: false));
+
+    final List<RenderGate> gates = tester.renderObjectList<RenderGate>(find.byType(Gate)).toList();
+    final RenderGate boundary = gates.first;
+    final RenderGate mid = gates.last;
+    final RenderBox leaf = mid.child!;
+
+    // 2. The outer gate stops laying the middle gate out, then both the middle
+    //    gate and the leaf are marked as needing layout.
+    await tester.pumpWidget(app(layoutMid: false, includeLeaf: false));
+    mid.markNeedsLayout();
+    leaf.markNeedsLayout();
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(boundary.debugNeedsLayout, isFalse);
+    expect(mid.debugNeedsLayout, isTrue);
+    expect(leaf.debugNeedsLayout, isTrue);
+
+    // 3. The middle gate exposes the layout-dirty leaf to the semantics tree.
+    await tester.pumpWidget(app(layoutMid: false, includeLeaf: true));
+    expect(mid.includeInSemantics, isTrue);
+
+    expect(tester.takeException(), isNull);
+    handle.dispose();
+  });
+}


### PR DESCRIPTION
## Description

Fixes a message-less framework assertion in semantics compilation:

```
'package:flutter/src/rendering/object.dart': Failed assertion:
'!childSemantics.renderObject._needsLayout': is not true.
```

`_RenderObjectSemantics._collectChildMergeUpAndSiblingGroup` assumed that every child reachable through `visitChildrenForSemantics` had already been laid out. Nothing enforces that: `visitChildrenForSemantics` defaults to `visitChildren`, so a render object that skips laying a child out keeps handing it to the semantics phase unless it overrides both. When such a layout-dirty child is reached, the framework crashes with an assertion that has no message and tells the user to file a framework bug.

The rest of the pipeline is already defensive about this exact state: the paint phase skips render objects that still need layout (`_paintWithContext`), and `flushSemantics` already filters layout-dirty nodes out of both its update roots and the geometry pass. This change makes the semantics collection do the same — skip layout-dirty children in `_getNonBlockedChildren()` (so `debugCheckForParentData` walks the same set) and drop the now-redundant assert. Recovery is already in place: `RenderObject.layout` calls `markNeedsSemanticsUpdate()` after `performLayout`, so a subtree that is laid out again rejoins the semantics tree once it has valid geometry.

Thanks to @gfx for the detailed root-cause analysis, the candidate fix, and the reproduction tests in the issue.

## Tests

Adds `packages/flutter/test/widgets/semantics_layout_dirty_test.dart` with two regression tests (no Material/Cupertino dependency), covering both ways the issue describes reaching the assertion:

- a semantics child whose parent stops laying it out, and
- a layout-dirty subtree that is newly admitted to the semantics tree.

Both tests fail without the fix (throwing the `!childSemantics.renderObject._needsLayout` assertion) and pass with it.

Fixes #191188.

I searched the open pull requests for flutter/flutter and did not find an existing PR addressing this issue before opening this one.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
