### PR TITLE
On iOS 27+ devices, manually process lldb stops

### DIFF
--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -14,6 +14,7 @@ import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/template.dart';
 import '../base/utils.dart';
+import '../base/version.dart';
 import '../build_info.dart';
 import '../convert.dart';
 import '../device.dart';
@@ -42,6 +43,7 @@ class IOSCoreDeviceLauncher {
     required FileSystem fileSystem,
     required ProcessUtils processUtils,
     required XcodeProjectInterpreter xcodeProjectInterpreter,
+    required Version? deviceVersion,
     @visibleForTesting LLDB? lldb,
   }) : _coreDeviceControl = coreDeviceControl,
        _logger = logger,
@@ -53,6 +55,7 @@ class IOSCoreDeviceLauncher {
              logger: logger,
              processUtils: processUtils,
              xcodeProjectInterpreter: xcodeProjectInterpreter,
+             deviceVersion: deviceVersion,
            );
 
   final IOSCoreDeviceControl _coreDeviceControl;

--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -868,7 +868,7 @@ class IOSCoreDeviceControl {
       unawaited(
         launchProcess.exitCode
             .then((int status) async {
-              _logger.printTrace('lldb exited with code $status');
+              _logger.printTrace('devicectl exited with code $status');
               await stdoutSubscription.cancel();
               await stderrSubscription.cancel();
             })

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -12,6 +12,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
+import '../base/version.dart';
 import '../build_info.dart';
 import 'device_support.dart';
 import 'xcodeproj.dart';
@@ -25,13 +26,16 @@ class LLDB {
     required Logger logger,
     required ProcessUtils processUtils,
     required XcodeProjectInterpreter xcodeProjectInterpreter,
+    required Version? deviceVersion,
   }) : _logger = logger,
        _processUtils = processUtils,
-       _xcodeProjectInterpreter = xcodeProjectInterpreter;
+       _xcodeProjectInterpreter = xcodeProjectInterpreter,
+       _deviceVersion = deviceVersion;
 
   final Logger _logger;
   final ProcessUtils _processUtils;
   final XcodeProjectInterpreter _xcodeProjectInterpreter;
+  final Version? _deviceVersion;
 
   _LLDBProcess? _lldbProcess;
 
@@ -110,8 +114,6 @@ if not error.Success():
     print(f'Failed to write into {base}[+{page_len}]', error)
     return
 
-# If the returned value is False, that tells LLDB not to stop at the breakpoint
-return False
 ''';
 
   /// Starts an LLDB process and inputs commands to start debugging the [appProcessId].
@@ -144,9 +146,20 @@ return False
         }
       });
 
+      // iOS 27+ devices sometimes fail to stop at the JIT breakpoint (only used in debug mode)
+      // when `auto-continue` is enabled. This causes the app to crash. To workaround this, we
+      // manually listen for stops and continue the process if the stop is due to the breakpoint.
+      var manualContinue = false;
+      if (mode == BuildMode.debug &&
+          _deviceVersion != null &&
+          _deviceVersion >= Version(27, 0, 0)) {
+        manualContinue = true;
+      }
+
       final bool start = await _startLLDB(
         appProcessId: appProcessId,
         lldbLogForwarder: lldbLogForwarder,
+        manualContinue: manualContinue,
       );
       if (!start) {
         return false;
@@ -155,10 +168,15 @@ return False
       await _addSymbolSearchPaths(deviceSupport);
 
       if (mode == BuildMode.debug) {
-        await _setBreakpoint();
+        await _setBreakpoint(manualContinue);
       }
       await _attachToAppProcess(appProcessId);
-      await _setupStopHooks();
+
+      // Stop hooks should only be used when manualContinue is false. Otherwise, it would run on
+      // every breakpoint stop instead of just crashes.
+      if (!manualContinue) {
+        await _setupStopHooks();
+      }
       await _printDeviceSupportStatus();
       await _resumeProcess(mode);
       _isAttached = true;
@@ -180,6 +198,7 @@ return False
   Future<bool> _startLLDB({
     required int appProcessId,
     required LLDBLogForwarder lldbLogForwarder,
+    required bool manualContinue,
   }) async {
     if (_lldbProcess != null) {
       _logger.printTrace(
@@ -196,18 +215,63 @@ return False
         appProcessId: appProcessId,
         logger: _logger,
       );
+
+      void printLine(String line) {
+        if (_isAttached && !_ignoreLog(line)) {
+          // Only forwards logs after LLDB is attached. All logs before then are part of the
+          // attach process.
+
+          lldbLogForwarder.addLog(line);
+        } else {
+          _logger.printTrace('[lldb]: $line');
+          _logCompleter?.checkForMatch(line);
+        }
+      }
+
+      var processIsStoppedAfterAttaching = false;
+      final List<String> stopLogs = [];
       final StreamSubscription<String> stdoutSubscription = _lldbProcess!.stdout
           .transform(utf8LineDecoder)
-          .listen((String line) {
-            if (_isAttached && !_ignoreLog(line)) {
-              // Only forwards logs after LLDB is attached. All logs before then are part of the
-              // attach process.
-
-              lldbLogForwarder.addLog(line);
-            } else {
-              _logger.printTrace('[lldb]: $line');
-              _logCompleter?.checkForMatch(line);
+          .listen((String line) async {
+            // If not manually handling stops or if not attached yet, print the line directly.
+            if (!manualContinue || !_isAttached) {
+              printLine(line);
+              return;
             }
+
+            // When manually continuing, listen for process stops and then handle the stop by
+            // either continuing the process or detaching.
+            //
+            // When the process stops, collect logs until the target has stopped. Once the target
+            // has stopped, check if it stopped due to a breakpoint. If it has, continue and
+            // process and discard the logs after the process resumes. If the stop is not caused by
+            // a breakpoint, print the collected logs, get the stack trace, and detach.
+            if (line.contains(_lldbProcessStopped)) {
+              processIsStoppedAfterAttaching = true;
+            }
+            if (processIsStoppedAfterAttaching) {
+              stopLogs.add(line);
+            }
+            if (line.contains(RegExp('Target.*stopped'))) {
+              if (stopLogs.any((log) => log.contains('stop reason = breakpoint'))) {
+                await _lldbProcess?.stdinWriteln('process continue');
+              } else {
+                stopLogs.forEach(printLine);
+                await _lldbProcess?.stdinWriteln('thread backtrace all');
+                await _lldbProcess?.stdinWriteln('detach');
+                processIsStoppedAfterAttaching = false;
+              }
+              return;
+            }
+            if (processIsStoppedAfterAttaching) {
+              if (line.contains(_lldbProcessResuming)) {
+                processIsStoppedAfterAttaching = false;
+                stopLogs.clear();
+              }
+              return;
+            }
+
+            printLine(line);
           });
 
       final StreamSubscription<String> stderrSubscription = _lldbProcess!.stderr
@@ -294,14 +358,17 @@ return False
 
   /// Sets a breakpoint, waits for it print the breakpoint id, and adds a python
   /// script command to be executed whenever the breakpoint is hit.
-  Future<void> _setBreakpoint() async {
+  Future<void> _setBreakpoint(bool manualContinue) async {
     final Future<String> futureLog = _startWaitingForLog(
       _breakpointPattern,
     ).then((value) => value, onError: _handleAsyncError);
 
-    await _lldbProcess?.stdinWriteln(
-      r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
-    );
+    final breakpointSetCommand = manualContinue
+        ? r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'"
+        : r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
+
+    await _lldbProcess?.stdinWriteln(breakpointSetCommand);
+
     final String log = await futureLog;
     final Match? match = _breakpointPattern.firstMatch(log);
     final String? breakpointId = match?.group(1);

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -87,10 +87,13 @@ class LLDB {
   /// Example: Target 0: (Flutter Gallery) stopped.
   static final _targetStoppedPattern = RegExp(r'Target .* stopped.');
 
+  /// LLDB command to continue execution of all threads in the current process.
   static const _processContinueCommand = 'process continue';
 
+  /// LLDB command to show backtraces of all thread call stacks.
   static const _threadBacktraceAllCommand = 'thread backtrace all';
 
+  /// LLDB command to detach from the current target process.
   static const _detachCommand = 'detach';
 
   /// A list of log patterns to ignore.

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -100,7 +100,6 @@ class LLDB {
   static final _ignorePatterns = <Pattern>[
     RegExp(r'\d+ location added to breakpoint \d+'),
     _stopHookProcessedPattern,
-    _targetStoppedPattern,
   ];
 
   /// Pattern of lldb log when libobjc.A.dylib is being read from process memory. This indicates

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -82,10 +82,22 @@ class LLDB {
   /// Example: "- Hook 1 (thread backtrace all)"
   static final _stopHookProcessedPattern = RegExp(r'- Hook \d+');
 
+  /// Pattern of lldb log when the application has started.
+  ///
+  /// Example: Target 0: (Flutter Gallery) stopped.
+  static final _targetStoppedPattern = RegExp(r'Target .* stopped.');
+
+  static const _processContinueCommand = 'process continue';
+
+  static const _threadBacktraceAllCommand = 'thread backtrace all';
+
+  static const _detachCommand = 'detach';
+
   /// A list of log patterns to ignore.
   static final _ignorePatterns = <Pattern>[
     RegExp(r'\d+ location added to breakpoint \d+'),
     _stopHookProcessedPattern,
+    _targetStoppedPattern,
   ];
 
   /// Pattern of lldb log when libobjc.A.dylib is being read from process memory. This indicates
@@ -252,13 +264,13 @@ if not error.Success():
             if (processIsStoppedAfterAttaching) {
               stopLogs.add(line);
             }
-            if (line.contains(RegExp('Target.*stopped'))) {
+            if (line.contains(_targetStoppedPattern)) {
               if (stopLogs.any((log) => log.contains('stop reason = breakpoint'))) {
-                await _lldbProcess?.stdinWriteln('process continue');
+                await _lldbProcess?.stdinWriteln(_processContinueCommand);
               } else {
                 stopLogs.forEach(printLine);
-                await _lldbProcess?.stdinWriteln('thread backtrace all');
-                await _lldbProcess?.stdinWriteln('detach');
+                await _lldbProcess?.stdinWriteln(_threadBacktraceAllCommand);
+                await _lldbProcess?.stdinWriteln(_detachCommand);
                 processIsStoppedAfterAttaching = false;
               }
               return;
@@ -397,7 +409,7 @@ if not error.Success():
       mode == BuildMode.debug ? _lldbBreakpointAdded : _lldbProcessResuming,
     ).then((value) => value, onError: _handleAsyncError);
 
-    await _lldbProcess?.stdinWriteln('process continue');
+    await _lldbProcess?.stdinWriteln(_processContinueCommand);
     await futureLog;
   }
 
@@ -409,7 +421,9 @@ if not error.Success():
     final Future<String> futureLog = _startWaitingForLog(
       _stopHookAddedPattern,
     ).then((value) => value, onError: _handleAsyncError);
-    await _lldbProcess?.stdinWriteln('target stop-hook add -o "thread backtrace all" -o "detach"');
+    await _lldbProcess?.stdinWriteln(
+      'target stop-hook add -o "$_threadBacktraceAllCommand" -o "$_detachCommand"',
+    );
     await futureLog;
   }
 

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -657,6 +657,7 @@ class XCDevice {
             fileSystem: globals.fs,
             processUtils: _processUtils,
             xcodeProjectInterpreter: globals.xcodeProjectInterpreter!,
+            deviceVersion: Version.parse(sdkVersionString),
           ),
           xcodeDebug: _xcodeDebug,
           xcode: _xcode,

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/template.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/application_package.dart';
@@ -91,6 +92,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -118,6 +120,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
         );
 
         final bool result = await launcher.launchAppWithoutDebugger(
@@ -147,6 +150,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
         );
 
         final bool result = await launcher.launchAppWithoutDebugger(
@@ -172,6 +176,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
         );
 
         final bool result = await launcher.launchAppWithoutDebugger(
@@ -220,6 +225,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -272,6 +278,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
         final shutdownHooks = FakeShutdownHooks();
@@ -334,6 +341,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
         final shutdownHooks = FakeShutdownHooks();
@@ -401,6 +409,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -455,6 +464,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -502,6 +512,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -555,6 +566,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -602,6 +614,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -651,6 +664,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -702,6 +716,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -740,6 +755,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: FakeLLDB(),
         );
         final bool result = await launcher.launchAppWithXcodeDebugger(
@@ -774,6 +790,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: FakeLLDB(),
         );
         final bool result = await launcher.launchAppWithXcodeDebugger(
@@ -808,6 +825,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: FakeLLDB(),
         );
         final bool result = await launcher.launchAppWithXcodeDebugger(
@@ -842,6 +860,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: FakeLLDB(),
         );
         final bool result = await launcher.launchAppWithXcodeDebugger(
@@ -875,6 +894,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -905,6 +925,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -934,6 +955,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 
@@ -962,6 +984,7 @@ void main() {
           fileSystem: MemoryFileSystem.test(),
           processUtils: processUtils,
           xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          deviceVersion: Version(16, 0, 0),
           lldb: fakeLLDB,
         );
 

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -102,7 +102,7 @@ void main() {
     );
 
     final Map<String, ({Completer<List<int>> completer, String out})?>
-    inputsAndOutputs = processAttach(
+    inputsAndOutputs = buildAttachInputsAndOutputs(
       breakPointMatcher:
           r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
       processResumingOutput: '1 location added to breakpoint 1\n',
@@ -173,7 +173,7 @@ void main() {
     );
 
     final Map<String, ({Completer<List<int>> completer, String out})?>
-    inputsAndOutputs = processAttach(
+    inputsAndOutputs = buildAttachInputsAndOutputs(
       breakPointMatcher:
           r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
       processResumingOutput: 'Process $_appProcessId resuming\n',
@@ -418,7 +418,7 @@ void main() {
     );
 
     final Map<String, ({Completer<List<int>> completer, String out})?>
-    inputsAndOutputs = processAttach(
+    inputsAndOutputs = buildAttachInputsAndOutputs(
       breakPointMatcher:
           r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
       processResumingOutput: '1 location added to breakpoint 1\n',
@@ -587,7 +587,7 @@ void main() {
         );
 
         final Map<String, ({Completer<List<int>> completer, String out})?>
-        inputsAndOutputs = processAttach(
+        inputsAndOutputs = buildAttachInputsAndOutputs(
           breakPointMatcher:
               r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
           processResumingOutput: 'Process $_appProcessId resuming\n',
@@ -683,7 +683,7 @@ void main() {
         );
 
         final Map<String, ({Completer<List<int>> completer, String out})?>
-        inputsAndOutputs = processAttach(
+        inputsAndOutputs = buildAttachInputsAndOutputs(
           breakPointMatcher:
               r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
           processResumingOutput: 'Process $_appProcessId resuming\n',
@@ -811,7 +811,7 @@ void main() {
     const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
     final unexpectedInputs = ['Stop hook #1 added.\n'];
     final Map<String, ({Completer<List<int>> completer, String out})?> inputsAndOutputs =
-        processAttach(
+        buildAttachInputsAndOutputs(
           breakPointMatcher: breakPointMatcher,
           processResumingOutput: '1 location added to breakpoint 1\n',
           breakPointCompleter: breakPointCompleter,
@@ -1122,7 +1122,9 @@ IOSDeviceSupport createDeviceSupport({
   );
 }
 
-Map<String, ({Completer<List<int>> completer, String out})?> processAttach({
+/// Builds a map of expected stdin command inputs sent to LLDB during [LLDB.attachAndStart]
+/// and their corresponding simulated stdout outputs and completers.
+Map<String, ({Completer<List<int>> completer, String out})?> buildAttachInputsAndOutputs({
   required String breakPointMatcher,
   required String processResumingOutput,
   required Completer<List<int>>? breakPointCompleter,
@@ -1133,7 +1135,6 @@ Map<String, ({Completer<List<int>> completer, String out})?> processAttach({
 }) {
   const processAttachMatcher = 'device process attach --pid $_appProcessId';
   const processContinueMatcher = 'process continue';
-  // const process = '1 location added to breakpoint 1\n';
   const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
   const platformStatusMatcher = 'platform status';
   return {
@@ -1146,7 +1147,6 @@ Map<String, ({Completer<List<int>> completer, String out})?> processAttach({
       'breakpoint command add --script-type python $_breakpointId': null,
       'script lldb.debugger.SetAsync(False)': null,
     },
-
     processAttachMatcher: (
       out: '''
 Process 568 stopped

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/ios/device_support.dart';
 import 'package:flutter_tools/src/ios/lldb.dart';
@@ -21,11 +22,12 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 
+const _deviceId = '123';
+const _appProcessId = 5678;
+const _breakpointId = 123;
+
 void main() {
   testWithoutContext('attachAndStart fails if lldb fails', () async {
-    const deviceId = '123';
-    const appProcessId = 5678;
-
     final processCompleter = Completer<void>();
     final lldbCommand = FakeLLDBCommand(
       command: const <String>['xcrun', 'lldb'],
@@ -45,11 +47,12 @@ void main() {
       logger: logger,
       processUtils: processUtils,
       xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+      deviceVersion: Version(16, 0, 0),
     );
 
     final bool success = await lldb.attachAndStart(
-      deviceId: deviceId,
-      appProcessId: appProcessId,
+      deviceId: _deviceId,
+      appProcessId: _appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
       mode: BuildMode.debug,
       deviceSupport: createDeviceSupport(),
@@ -62,22 +65,18 @@ void main() {
   });
 
   testWithoutContext('attachAndStart returns true on success', () async {
-    const deviceId = '123';
-    const appProcessId = 5678;
-    const breakpointId = 123;
-
     final breakPointCompleter = Completer<List<int>>();
     final processAttachCompleter = Completer<List<int>>();
     final setupStopHooksCompleter = Completer<List<int>>();
     final platformStatusCompleter = Completer<List<int>>();
-    final processResumedCompleted = Completer<List<int>>();
+    final processResumedCompleter = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       breakPointCompleter.future,
       processAttachCompleter.future,
       setupStopHooksCompleter.future,
       platformStatusCompleter.future,
-      processResumedCompleted.future,
+      processResumedCompleter.future,
     ]);
 
     final stdinController = StreamController<List<int>>();
@@ -99,88 +98,56 @@ void main() {
       logger: logger,
       processUtils: processUtils,
       xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+      deviceVersion: Version(16, 0, 0),
     );
 
-    const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
-    const processAttachMatcher = 'device process attach --pid $appProcessId';
-    const processResumedMatcher = 'process continue';
-    const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
-    const platformStatusMatcher = 'platform status';
-    final expectedInputs = [
-      'device select $deviceId',
-      breakPointMatcher,
-      'breakpoint command add --script-type python $breakpointId',
-      'script lldb.debugger.SetAsync(False)',
-      processAttachMatcher,
-      setupStopHooksMatcher,
-      platformStatusMatcher,
-      processResumedMatcher,
-    ];
+    final Map<String, ({Completer<List<int>> completer, String out})?>
+    inputsAndOutputs = processAttach(
+      breakPointMatcher:
+          r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
+      processResumingOutput: '1 location added to breakpoint 1\n',
+      breakPointCompleter: breakPointCompleter,
+      processAttachCompleter: processAttachCompleter,
+      setupStopHooksCompleter: setupStopHooksCompleter,
+      platformStatusCompleter: platformStatusCompleter,
+      processResumedCompleter: processResumedCompleter,
+    );
 
     stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
       String line,
     ) {
-      expectedInputs.remove(line);
-      if (line == breakPointMatcher) {
-        breakPointCompleter.complete(
-          utf8.encode('Breakpoint $breakpointId: no locations (pending).\n'),
-        );
-      }
-      if (line == processAttachMatcher) {
-        processAttachCompleter.complete(
-          utf8.encode('''
-Process 568 stopped
-* thread #1, stop reason = signal SIGSTOP
-    frame #0: 0x0000000102c7b240 dyld`_dyld_start
-dyld`_dyld_start:
-->  0x102c7b240 <+0>:  mov    x0, sp
-    0x102c7b244 <+4>:  and    sp, x0, #0xfffffffffffffff0
-    0x102c7b248 <+8>:  mov    x29, #0x0 ; =0
-    0x102c7b24c <+12>: mov    x30, #0x0 ; =0
-Target 0: (Runner) stopped.
-'''),
-        );
-      }
-      if (line == setupStopHooksMatcher) {
-        setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
-      }
-      if (line == platformStatusMatcher) {
-        platformStatusCompleter.complete(utf8.encode('  Platform: remote-ios\n'));
-      }
-      if (line == processResumedMatcher) {
-        processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));
+      final ({Completer<List<int>> completer, String out})? x = inputsAndOutputs.remove(line);
+      if (x != null) {
+        x.completer.complete(utf8.encode(x.out));
       }
     });
 
     final bool success = await lldb.attachAndStart(
-      deviceId: deviceId,
-      appProcessId: appProcessId,
+      deviceId: _deviceId,
+      appProcessId: _appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
       mode: BuildMode.debug,
       deviceSupport: createDeviceSupport(),
     );
     expect(success, isTrue);
     expect(lldb.isRunning, isTrue);
-    expect(lldb.appProcessId, appProcessId);
-    expect(expectedInputs, isEmpty);
+    expect(lldb.appProcessId, _appProcessId);
+    expect(inputsAndOutputs, isEmpty);
     expect(processManager.hasRemainingExpectations, isFalse);
     expect(logger.errorText, isEmpty);
   });
 
   testWithoutContext('attachAndStart returns true on success for profile mode', () async {
-    const deviceId = '123';
-    const appProcessId = 5678;
-
     final processAttachCompleter = Completer<List<int>>();
     final setupStopHooksCompleter = Completer<List<int>>();
     final platformStatusCompleter = Completer<List<int>>();
-    final processResumedCompleted = Completer<List<int>>();
+    final processResumedCompleter = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       processAttachCompleter.future,
       setupStopHooksCompleter.future,
       platformStatusCompleter.future,
-      processResumedCompleted.future,
+      processResumedCompleter.future,
     ]);
 
     final stdinController = StreamController<List<int>>();
@@ -202,69 +169,46 @@ Target 0: (Runner) stopped.
       logger: logger,
       processUtils: processUtils,
       xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+      deviceVersion: Version(27, 0, 0),
     );
 
-    const processAttachMatcher = 'device process attach --pid $appProcessId';
-    const processResumedMatcher = 'process continue';
-    const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
-    const platformStatusMatcher = 'platform status';
-    final expectedInputs = [
-      'device select $deviceId',
-      processAttachMatcher,
-      setupStopHooksMatcher,
-      platformStatusMatcher,
-      processResumedMatcher,
-    ];
+    final Map<String, ({Completer<List<int>> completer, String out})?>
+    inputsAndOutputs = processAttach(
+      breakPointMatcher:
+          r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
+      processResumingOutput: 'Process $_appProcessId resuming\n',
+      breakPointCompleter: null,
+      processAttachCompleter: processAttachCompleter,
+      setupStopHooksCompleter: setupStopHooksCompleter,
+      platformStatusCompleter: platformStatusCompleter,
+      processResumedCompleter: processResumedCompleter,
+    );
 
     stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
       String line,
     ) {
-      expectedInputs.remove(line);
-      if (line == processAttachMatcher) {
-        processAttachCompleter.complete(
-          utf8.encode('''
-Process 568 stopped
-* thread #1, stop reason = signal SIGSTOP
-    frame #0: 0x0000000102c7b240 dyld`_dyld_start
-dyld`_dyld_start:
-->  0x102c7b240 <+0>:  mov    x0, sp
-    0x102c7b244 <+4>:  and    sp, x0, #0xfffffffffffffff0
-    0x102c7b248 <+8>:  mov    x29, #0x0 ; =0
-    0x102c7b24c <+12>: mov    x30, #0x0 ; =0
-Target 0: (Runner) stopped.
-'''),
-        );
-      }
-      if (line == setupStopHooksMatcher) {
-        setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
-      }
-      if (line == platformStatusMatcher) {
-        platformStatusCompleter.complete(utf8.encode('  Platform: remote-ios\n'));
-      }
-      if (line == processResumedMatcher) {
-        processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
+      final ({Completer<List<int>> completer, String out})? x = inputsAndOutputs.remove(line);
+      if (x != null) {
+        x.completer.complete(utf8.encode(x.out));
       }
     });
 
     final bool success = await lldb.attachAndStart(
-      deviceId: deviceId,
-      appProcessId: appProcessId,
+      deviceId: _deviceId,
+      appProcessId: _appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
       mode: BuildMode.profile,
       deviceSupport: createDeviceSupport(),
     );
     expect(success, isTrue);
     expect(lldb.isRunning, isTrue);
-    expect(lldb.appProcessId, appProcessId);
-    expect(expectedInputs, isEmpty);
+    expect(lldb.appProcessId, _appProcessId);
+    expect(inputsAndOutputs, isEmpty);
     expect(processManager.hasRemainingExpectations, isFalse);
     expect(logger.errorText, isEmpty);
   });
 
   testWithoutContext('attachAndStart returns false when stderr during log waiter', () async {
-    const deviceId = '123';
-    const appProcessId = 5678;
-
     final breakPointCompleter = Completer<List<int>>();
     final errorCompleter = Completer<List<int>>();
 
@@ -291,10 +235,12 @@ Target 0: (Runner) stopped.
       logger: logger,
       processUtils: processUtils,
       xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+      deviceVersion: Version(16, 0, 0),
     );
 
-    const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
-    final expectedInputs = ['device select $deviceId', breakPointMatcher];
+    const breakPointMatcher =
+        r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
+    final expectedInputs = ['device select $_deviceId', breakPointMatcher];
     const errorText = "error: 'device' is not a valid command.\n";
 
     stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
@@ -307,8 +253,8 @@ Target 0: (Runner) stopped.
     });
 
     final bool success = await lldb.attachAndStart(
-      deviceId: deviceId,
-      appProcessId: appProcessId,
+      deviceId: _deviceId,
+      appProcessId: _appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
       mode: BuildMode.debug,
       deviceSupport: createDeviceSupport(),
@@ -322,9 +268,6 @@ Target 0: (Runner) stopped.
   });
 
   testWithoutContext('attachAndStart returns false when stderr not during log waiter', () async {
-    const deviceId = '123';
-    const appProcessId = 5678;
-
     final breakPointCompleter = Completer<List<int>>();
     final errorCompleter = Completer<List<int>>();
 
@@ -351,10 +294,11 @@ Target 0: (Runner) stopped.
       logger: logger,
       processUtils: processUtils,
       xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+      deviceVersion: Version(16, 0, 0),
     );
     final expectedInputs = [
-      'device select $deviceId',
-      r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
+      'device select $_deviceId',
+      r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
     ];
     const errorText = "error: 'device' is not a valid command.\n";
 
@@ -368,8 +312,8 @@ Target 0: (Runner) stopped.
     });
 
     final bool success = await lldb.attachAndStart(
-      deviceId: deviceId,
-      appProcessId: appProcessId,
+      deviceId: _deviceId,
+      appProcessId: _appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
       mode: BuildMode.debug,
       deviceSupport: createDeviceSupport(),
@@ -383,9 +327,6 @@ Target 0: (Runner) stopped.
   });
 
   testWithoutContext('attachAndStart prints warning if takes too long', () async {
-    const deviceId = '123';
-    const appProcessId = 5678;
-
     final stdinController = StreamController<List<int>>();
 
     final processCompleter = Completer<void>();
@@ -405,6 +346,7 @@ Target 0: (Runner) stopped.
       logger: logger,
       processUtils: processUtils,
       xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+      deviceVersion: Version(16, 0, 0),
     );
 
     final completer = Completer<void>();
@@ -419,8 +361,8 @@ Target 0: (Runner) stopped.
 
     await FakeAsync().run((FakeAsync time) {
       lldb.attachAndStart(
-        deviceId: deviceId,
-        appProcessId: appProcessId,
+        deviceId: _deviceId,
+        appProcessId: _appProcessId,
         lldbLogForwarder: FakeLLDBLogForwarder(),
         mode: BuildMode.debug,
         deviceSupport: createDeviceSupport(),
@@ -437,15 +379,11 @@ Target 0: (Runner) stopped.
   });
 
   testWithoutContext('attachAndStart streams logs to LLDBLogForwarder', () async {
-    const deviceId = '123';
-    const appProcessId = 5678;
-    const breakpointId = 123;
-
     final breakPointCompleter = Completer<List<int>>();
     final processAttachCompleter = Completer<List<int>>();
     final setupStopHooksCompleter = Completer<List<int>>();
     final platformStatusCompleter = Completer<List<int>>();
-    final processResumedCompleted = Completer<List<int>>();
+    final processResumedCompleter = Completer<List<int>>();
     final logAfterAttachCompleter = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
@@ -453,7 +391,7 @@ Target 0: (Runner) stopped.
       processAttachCompleter.future,
       setupStopHooksCompleter.future,
       platformStatusCompleter.future,
-      processResumedCompleted.future,
+      processResumedCompleter.future,
       logAfterAttachCompleter.future,
     ]);
 
@@ -476,56 +414,27 @@ Target 0: (Runner) stopped.
       logger: logger,
       processUtils: processUtils,
       xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+      deviceVersion: Version(16, 0, 0),
     );
 
-    const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
-    const processAttachMatcher = 'device process attach --pid $appProcessId';
-    const processResumedMatcher = 'process continue';
-    const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
-    const platformStatusMatcher = 'platform status';
-    final expectedInputs = [
-      'device select $deviceId',
-      breakPointMatcher,
-      'breakpoint command add --script-type python $breakpointId',
-      'script lldb.debugger.SetAsync(False)',
-      processAttachMatcher,
-      setupStopHooksMatcher,
-      platformStatusMatcher,
-      processResumedMatcher,
-    ];
+    final Map<String, ({Completer<List<int>> completer, String out})?>
+    inputsAndOutputs = processAttach(
+      breakPointMatcher:
+          r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
+      processResumingOutput: '1 location added to breakpoint 1\n',
+      breakPointCompleter: breakPointCompleter,
+      processAttachCompleter: processAttachCompleter,
+      setupStopHooksCompleter: setupStopHooksCompleter,
+      platformStatusCompleter: platformStatusCompleter,
+      processResumedCompleter: processResumedCompleter,
+    );
 
     stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
       String line,
     ) {
-      expectedInputs.remove(line);
-      if (line == breakPointMatcher) {
-        breakPointCompleter.complete(
-          utf8.encode('Breakpoint $breakpointId: no locations (pending).\n'),
-        );
-      }
-      if (line == processAttachMatcher) {
-        processAttachCompleter.complete(
-          utf8.encode('''
-Process 568 stopped
-* thread #1, stop reason = signal SIGSTOP
-    frame #0: 0x0000000102c7b240 dyld`_dyld_start
-dyld`_dyld_start:
-->  0x102c7b240 <+0>:  mov    x0, sp
-    0x102c7b244 <+4>:  and    sp, x0, #0xfffffffffffffff0
-    0x102c7b248 <+8>:  mov    x29, #0x0 ; =0
-    0x102c7b24c <+12>: mov    x30, #0x0 ; =0
-Target 0: (Runner) stopped.
-'''),
-        );
-      }
-      if (line == setupStopHooksMatcher) {
-        setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
-      }
-      if (line == platformStatusMatcher) {
-        platformStatusCompleter.complete(utf8.encode('  Platform: remote-ios\n'));
-      }
-      if (line == processResumedMatcher) {
-        processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));
+      final ({Completer<List<int>> completer, String out})? x = inputsAndOutputs.remove(line);
+      if (x != null) {
+        x.completer.complete(utf8.encode(x.out));
       }
     });
 
@@ -534,8 +443,8 @@ Target 0: (Runner) stopped.
     final lldbLogForwarder = FakeLLDBLogForwarder(expectedLog: expectedForwardedLog);
 
     final bool success = await lldb.attachAndStart(
-      deviceId: deviceId,
-      appProcessId: appProcessId,
+      deviceId: _deviceId,
+      appProcessId: _appProcessId,
       lldbLogForwarder: lldbLogForwarder,
       mode: BuildMode.debug,
       deviceSupport: createDeviceSupport(),
@@ -546,8 +455,8 @@ Target 0: (Runner) stopped.
 
     expect(success, isTrue);
     expect(lldb.isRunning, isTrue);
-    expect(lldb.appProcessId, appProcessId);
-    expect(expectedInputs, isEmpty);
+    expect(lldb.appProcessId, _appProcessId);
+    expect(inputsAndOutputs, isEmpty);
     expect(processManager.hasRemainingExpectations, isFalse);
     expect(logger.errorText, isEmpty);
     expect(lldbLogForwarder.logs.length, 1);
@@ -555,9 +464,6 @@ Target 0: (Runner) stopped.
   });
 
   testWithoutContext('exit returns true and kills process', () async {
-    const deviceId = '123';
-    const appProcessId = 5678;
-
     final stdinController = StreamController<List<int>>();
 
     final processCompleter = Completer<void>();
@@ -577,6 +483,7 @@ Target 0: (Runner) stopped.
       logger: logger,
       processUtils: processUtils,
       xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+      deviceVersion: Version(16, 0, 0),
     );
 
     final lldbStarted = Completer<void>();
@@ -591,8 +498,8 @@ Target 0: (Runner) stopped.
 
     unawaited(
       lldb.attachAndStart(
-        deviceId: deviceId,
-        appProcessId: appProcessId,
+        deviceId: _deviceId,
+        appProcessId: _appProcessId,
         lldbLogForwarder: FakeLLDBLogForwarder(),
         mode: BuildMode.debug,
         deviceSupport: createDeviceSupport(),
@@ -617,6 +524,7 @@ Target 0: (Runner) stopped.
       logger: logger,
       processUtils: processUtils,
       xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+      deviceVersion: Version(16, 0, 0),
     );
     expect(lldb.isRunning, isFalse);
     final bool exitStatus = lldb.exit();
@@ -642,21 +550,18 @@ Target 0: (Runner) stopped.
                 .childDirectory('Symbols')
               ..createSync(recursive: true);
 
-        const deviceId = '123';
-        const appProcessId = 5678;
-
         final platformSelectCompleter = Completer<List<int>>();
         final processAttachCompleter = Completer<List<int>>();
         final setupStopHooksCompleter = Completer<List<int>>();
         final platformStatusCompleter = Completer<List<int>>();
-        final processResumedCompleted = Completer<List<int>>();
+        final processResumedCompleter = Completer<List<int>>();
 
         final stdoutStream = Stream<List<int>>.fromFutures([
           platformSelectCompleter.future,
           processAttachCompleter.future,
           setupStopHooksCompleter.future,
           platformStatusCompleter.future,
-          processResumedCompleted.future,
+          processResumedCompleter.future,
         ]);
 
         final stdinController = StreamController<List<int>>();
@@ -678,49 +583,39 @@ Target 0: (Runner) stopped.
           logger: logger,
           processUtils: processUtils,
           xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+          deviceVersion: Version(16, 0, 0),
         );
 
-        final platformSelectMatcher = 'platform select remote-ios --sysroot "${archSymbols.path}"';
-        const processAttachMatcher = 'device process attach --pid $appProcessId';
-        const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
-        const processResumedMatcher = 'process continue';
-        const platformStatusMatcher = 'platform status';
-        final expectedInputs = [
-          'device select $deviceId',
-          platformSelectMatcher,
-          processAttachMatcher,
-          setupStopHooksMatcher,
-          platformStatusMatcher,
-          processResumedMatcher,
-        ];
+        final Map<String, ({Completer<List<int>> completer, String out})?>
+        inputsAndOutputs = processAttach(
+          breakPointMatcher:
+              r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
+          processResumingOutput: 'Process $_appProcessId resuming\n',
+          breakPointCompleter: null,
+          processAttachCompleter: processAttachCompleter,
+          setupStopHooksCompleter: setupStopHooksCompleter,
+          platformStatusCompleter: platformStatusCompleter,
+          processResumedCompleter: processResumedCompleter,
+        );
+        inputsAndOutputs.addAll({
+          'platform select remote-ios --sysroot "${archSymbols.path}"': null,
+        });
 
         stdinController.stream
             .transform<String>(utf8.decoder)
             .transform(const LineSplitter())
             .listen((String line) {
-              expectedInputs.remove(line);
-              if (line == platformSelectMatcher) {
-                platformSelectCompleter.complete(utf8.encode('\n'));
-              }
-              if (line == processAttachMatcher) {
-                processAttachCompleter.complete(
-                  utf8.encode('Process 568 stopped\nTarget 0: (Runner) stopped.\n'),
-                );
-              }
-              if (line == setupStopHooksMatcher) {
-                setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
-              }
-              if (line == platformStatusMatcher) {
-                platformStatusCompleter.complete(utf8.encode('  Platform: remote-ios\n'));
-              }
-              if (line == processResumedMatcher) {
-                processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
+              final ({Completer<List<int>> completer, String out})? x = inputsAndOutputs.remove(
+                line,
+              );
+              if (x != null) {
+                x.completer.complete(utf8.encode(x.out));
               }
             });
 
         final bool success = await lldb.attachAndStart(
-          deviceId: deviceId,
-          appProcessId: appProcessId,
+          deviceId: _deviceId,
+          appProcessId: _appProcessId,
           lldbLogForwarder: FakeLLDBLogForwarder(),
           mode: BuildMode.profile,
           deviceSupport: createDeviceSupport(
@@ -732,7 +627,7 @@ Target 0: (Runner) stopped.
         );
 
         expect(success, isTrue);
-        expect(expectedInputs, isEmpty);
+        expect(inputsAndOutputs, isEmpty);
       },
     );
 
@@ -751,21 +646,18 @@ Target 0: (Runner) stopped.
                 .childDirectory('Symbols')
               ..createSync(recursive: true);
 
-        const deviceId = '123';
-        const appProcessId = 5678;
-
         final platformSelectCompleter = Completer<List<int>>();
         final processAttachCompleter = Completer<List<int>>();
         final setupStopHooksCompleter = Completer<List<int>>();
         final platformStatusCompleter = Completer<List<int>>();
-        final processResumedCompleted = Completer<List<int>>();
+        final processResumedCompleter = Completer<List<int>>();
 
         final stdoutStream = Stream<List<int>>.fromFutures([
           platformSelectCompleter.future,
           processAttachCompleter.future,
           setupStopHooksCompleter.future,
           platformStatusCompleter.future,
-          processResumedCompleted.future,
+          processResumedCompleter.future,
         ]);
 
         final stdinController = StreamController<List<int>>();
@@ -787,49 +679,37 @@ Target 0: (Runner) stopped.
           logger: logger,
           processUtils: processUtils,
           xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+          deviceVersion: Version(16, 0, 0),
         );
 
-        final platformSelectMatcher = 'platform select remote-ios --sysroot "${symbols.path}"';
-        const processAttachMatcher = 'device process attach --pid $appProcessId';
-        const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
-        const processResumedMatcher = 'process continue';
-        const platformStatusMatcher = 'platform status';
-        final expectedInputs = [
-          'device select $deviceId',
-          platformSelectMatcher,
-          processAttachMatcher,
-          setupStopHooksMatcher,
-          platformStatusMatcher,
-          processResumedMatcher,
-        ];
+        final Map<String, ({Completer<List<int>> completer, String out})?>
+        inputsAndOutputs = processAttach(
+          breakPointMatcher:
+              r"breakpoint set --auto-continue true --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'",
+          processResumingOutput: 'Process $_appProcessId resuming\n',
+          breakPointCompleter: null,
+          processAttachCompleter: processAttachCompleter,
+          setupStopHooksCompleter: setupStopHooksCompleter,
+          platformStatusCompleter: platformStatusCompleter,
+          processResumedCompleter: processResumedCompleter,
+        );
+        inputsAndOutputs.addAll({'platform select remote-ios --sysroot "${symbols.path}"': null});
 
         stdinController.stream
             .transform<String>(utf8.decoder)
             .transform(const LineSplitter())
             .listen((String line) {
-              expectedInputs.remove(line);
-              if (line == platformSelectMatcher) {
-                platformSelectCompleter.complete(utf8.encode('\n'));
-              }
-              if (line == processAttachMatcher) {
-                processAttachCompleter.complete(
-                  utf8.encode('Process 568 stopped\nTarget 0: (Runner) stopped.\n'),
-                );
-              }
-              if (line == setupStopHooksMatcher) {
-                setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
-              }
-              if (line == platformStatusMatcher) {
-                platformStatusCompleter.complete(utf8.encode('  Platform: remote-ios\n'));
-              }
-              if (line == processResumedMatcher) {
-                processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
+              final ({Completer<List<int>> completer, String out})? x = inputsAndOutputs.remove(
+                line,
+              );
+              if (x != null) {
+                x.completer.complete(utf8.encode(x.out));
               }
             });
 
         final bool success = await lldb.attachAndStart(
-          deviceId: deviceId,
-          appProcessId: appProcessId,
+          deviceId: _deviceId,
+          appProcessId: _appProcessId,
           lldbLogForwarder: FakeLLDBLogForwarder(),
           mode: BuildMode.profile,
           deviceSupport: createDeviceSupport(
@@ -841,7 +721,7 @@ Target 0: (Runner) stopped.
         );
 
         expect(success, isTrue);
-        expect(expectedInputs, isEmpty);
+        expect(inputsAndOutputs, isEmpty);
       },
     );
   });
@@ -879,6 +759,145 @@ Target 0: (Runner) stopped.
       await exitCompleter.future;
       lldbLogForwarder.addLog('hello world');
     });
+  });
+
+  testWithoutContext('Stops are handled manually for iOS 27+', () async {
+    final breakPointCompleter = Completer<List<int>>();
+    final processAttachCompleter = Completer<List<int>>();
+    final platformStatusCompleter = Completer<List<int>>();
+    final processResumedCompleter = Completer<List<int>>();
+    final breakpointStopCompleter = Completer<List<int>>();
+    final breakpointContinueCompleter = Completer<List<int>>();
+    final normalLogCompleter = Completer<List<int>>();
+    final crashCompleter = Completer<List<int>>();
+    final backtraceCompleter = Completer<void>();
+    final detachCompleter = Completer<void>();
+
+    var isAttached = false;
+
+    final stdoutStream = Stream<List<int>>.fromFutures([
+      breakPointCompleter.future,
+      processAttachCompleter.future,
+      platformStatusCompleter.future,
+      processResumedCompleter.future.whenComplete(() => isAttached = true),
+      breakpointStopCompleter.future,
+      breakpointContinueCompleter.future,
+      normalLogCompleter.future,
+      crashCompleter.future,
+    ]);
+
+    final stdinController = StreamController<List<int>>();
+
+    final processCompleter = Completer<void>();
+    final lldbCommand = FakeLLDBCommand(
+      command: const <String>['xcrun', 'lldb'],
+      completer: processCompleter,
+      stdin: io.IOSink(stdinController.sink),
+      stdout: stdoutStream,
+      stderr: const Stream.empty(),
+    );
+
+    final logger = BufferLogger.test();
+
+    final processManager = FakeLLDBProcessManager([lldbCommand]);
+    final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+    final lldb = LLDB(
+      logger: logger,
+      processUtils: processUtils,
+      xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+      deviceVersion: Version(27, 0, 0),
+    );
+
+    const breakPointMatcher = r"breakpoint set --func-regex '^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$'";
+    final unexpectedInputs = ['Stop hook #1 added.\n'];
+    final Map<String, ({Completer<List<int>> completer, String out})?> inputsAndOutputs =
+        processAttach(
+          breakPointMatcher: breakPointMatcher,
+          processResumingOutput: '1 location added to breakpoint 1\n',
+          breakPointCompleter: breakPointCompleter,
+          processAttachCompleter: processAttachCompleter,
+          platformStatusCompleter: platformStatusCompleter,
+          processResumedCompleter: processResumedCompleter,
+          setupStopHooksCompleter: null,
+        );
+
+    stdinController.stream.transform<String>(utf8.decoder).transform(const LineSplitter()).listen((
+      String line,
+    ) {
+      final ({Completer<List<int>> completer, String out})? x = inputsAndOutputs.remove(line);
+      if (x != null) {
+        x.completer.complete(utf8.encode(x.out));
+      }
+      expect(unexpectedInputs.contains(line), isFalse);
+      if (isAttached && line == 'process continue') {
+        breakpointContinueCompleter.complete(utf8.encode('Process $_appProcessId resuming\n'));
+      }
+      if (line == 'thread backtrace all') {
+        backtraceCompleter.complete();
+      }
+      if (line == 'detach') {
+        detachCompleter.complete();
+      }
+    });
+
+    final lldbLogForwarder = FakeLLDBLogForwarder();
+    final bool success = await lldb.attachAndStart(
+      deviceId: _deviceId,
+      appProcessId: _appProcessId,
+      lldbLogForwarder: lldbLogForwarder,
+      mode: BuildMode.debug,
+      deviceSupport: createDeviceSupport(),
+    );
+    expect(success, isTrue);
+    expect(inputsAndOutputs, isEmpty);
+
+    // Simulate a breakpoint stop after attached.
+    breakpointStopCompleter.complete(
+      utf8.encode('''
+Process $_appProcessId stopped
+* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
+    frame #0: 0x0000000107996d18 Flutter`NOTIFY_DEBUGGER_ABOUT_RX_PAGES
+Flutter`NOTIFY_DEBUGGER_ABOUT_RX_PAGES:
+->  0x107996d18 <+0>: ret
+
+Flutter`dart::VirtualMemory::AllocateAligned:
+    0x107996d1c <+0>: stp    x28, x27, [sp, #-0x50]!
+    0x107996d20 <+4>: stp    x24, x23, [sp, #0x10]
+    0x107996d24 <+8>: stp    x22, x21, [sp, #0x20]
+Target 0: (Flutter Gallery) stopped.
+'''),
+    );
+    await breakpointContinueCompleter.future;
+
+    // Verify Breakpoint stop logs should not be printed.
+    expect(lldbLogForwarder.logs, isEmpty);
+    expect(logger.traceText, isNot(contains('NOTIFY_DEBUGGER_ABOUT_RX_PAGES')));
+
+    // Verify normal logs are printed
+    normalLogCompleter.complete(utf8.encode('Hello World\n'));
+    await pumpEventQueue();
+    expect(lldbLogForwarder.logs, contains('Hello World'));
+
+    // Simulate a crash stop while attached.
+    crashCompleter.complete(
+      utf8.encode('''
+Process $_appProcessId stopped
+* thread #1, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
+    frame #0: 0x0000000102c7b240 my_crashed_code
+Target 0: (Runner) stopped.
+'''),
+    );
+
+    await backtraceCompleter.future;
+    await detachCompleter.future;
+
+    // Verify crash logs are printed
+    expect(lldbLogForwarder.logs, contains('Process $_appProcessId stopped'));
+    expect(
+      lldbLogForwarder.logs,
+      contains('* thread #1, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)'),
+    );
+    expect(lldbLogForwarder.logs, contains('Target 0: (Runner) stopped.'));
   });
 }
 
@@ -1099,6 +1118,52 @@ IOSDeviceSupport createDeviceSupport({
     modelCode: modelCode,
     operatingSystemVersion: operatingSystemVersion,
     cpuArchitectureString: cpuArchitectureString,
-    deviceId: deviceId,
+    deviceId: _deviceId,
   );
+}
+
+Map<String, ({Completer<List<int>> completer, String out})?> processAttach({
+  required String breakPointMatcher,
+  required String processResumingOutput,
+  required Completer<List<int>>? breakPointCompleter,
+  required Completer<List<int>> processAttachCompleter,
+  required Completer<List<int>> platformStatusCompleter,
+  required Completer<List<int>> processResumedCompleter,
+  required Completer<List<int>>? setupStopHooksCompleter,
+}) {
+  const processAttachMatcher = 'device process attach --pid $_appProcessId';
+  const processContinueMatcher = 'process continue';
+  // const process = '1 location added to breakpoint 1\n';
+  const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
+  const platformStatusMatcher = 'platform status';
+  return {
+    'device select $_deviceId': null,
+    if (breakPointCompleter != null) ...{
+      breakPointMatcher: (
+        out: 'Breakpoint $_breakpointId: no locations (pending).\n',
+        completer: breakPointCompleter,
+      ),
+      'breakpoint command add --script-type python $_breakpointId': null,
+      'script lldb.debugger.SetAsync(False)': null,
+    },
+
+    processAttachMatcher: (
+      out: '''
+Process 568 stopped
+* thread #1, stop reason = signal SIGSTOP
+    frame #0: 0x0000000102c7b240 dyld`_dyld_start
+dyld`_dyld_start:
+->  0x102c7b240 <+0>:  mov    x0, sp
+    0x102c7b244 <+4>:  and    sp, x0, #0xfffffffffffffff0
+    0x102c7b248 <+8>:  mov    x29, #0x0 ; =0
+    0x102c7b24c <+12>: mov    x30, #0x0 ; =0
+Target 0: (Runner) stopped.
+''',
+      completer: processAttachCompleter,
+    ),
+    if (setupStopHooksCompleter != null)
+      setupStopHooksMatcher: (out: 'Stop hook #1 added.\n', completer: setupStopHooksCompleter),
+    platformStatusMatcher: (out: '  Platform: remote-ios\n', completer: platformStatusCompleter),
+    processContinueMatcher: (out: processResumingOutput, completer: processResumedCompleter),
+  };
 }


### PR DESCRIPTION
On iOS 27+ devices, `lldb` sometimes doesn't stop on breakpoints when auto-continue is enabled. To workaround this, we disable auto-continue and manually process stops. If a stop is caused by a breakpoint, we tell the process to continue. Otherwise, we print the backtrace and detach.

Fixes https://github.com/flutter/flutter/issues/190307.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
