### PR TITLE
[windows] Fix null-deref in HostWindowPopup::UpdatePosition (Fixes #191478)

### DIFF
--- a/engine/src/flutter/shell/platform/windows/host_window_popup.cc
+++ b/engine/src/flutter/shell/platform/windows/host_window_popup.cc
@@ -98,6 +98,9 @@ void HostWindowPopup::UpdatePosition() {
                      parent_bottom_right.y - parent_top_left.y},
           work_area),
       free);
+  if (!rect) {
+    return;
+  }
   SetWindowPos(window_handle_, HWND_TOP, rect->left, rect->top, rect->width,
                rect->height, SWP_NOACTIVATE | SWP_NOOWNERZORDER);
 

--- a/engine/src/flutter/shell/platform/windows/window_manager_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/window_manager_unittests.cc
@@ -846,6 +846,55 @@ TEST_F(WindowManagerTest, PopupWindowDoesNotStealFocus) {
   EXPECT_NE(focused_after, popup_window_handle);
 }
 
+TEST_F(WindowManagerTest, PopupWindowHandlesNullPositionCallback) {
+  IsolateScope isolate_scope(isolate());
+
+  const int64_t parent_view_id =
+      InternalFlutterWindows_WindowManager_CreateRegularWindow(
+          engine_id(), regular_creation_request());
+  const HWND parent_window_handle =
+      InternalFlutterWindows_WindowManager_GetTopLevelWindowHandle(
+          engine_id(), parent_view_id);
+
+  // Simulates the positioner failing (e.g. its anchor was torn down).
+  auto position_callback =
+      [](const WindowSize& child_size, const WindowRect& parent_rect,
+         const WindowRect& output_rect) -> WindowRect* { return nullptr; };
+
+  PopupWindowCreationRequest creation_request{
+      .preferred_constraints = {.has_view_constraints = true,
+                                .view_min_width = 100,
+                                .view_min_height = 50,
+                                .view_max_width = 300,
+                                .view_max_height = 200},
+      .parent = parent_window_handle,
+      .get_position_callback = position_callback};
+
+  const int64_t popup_view_id =
+      InternalFlutterWindows_WindowManager_CreatePopupWindow(engine_id(),
+                                                             &creation_request);
+  HWND popup_window_handle =
+      InternalFlutterWindows_WindowManager_GetTopLevelWindowHandle(
+          engine_id(), popup_view_id);
+  ASSERT_NE(popup_window_handle, nullptr);
+
+  FlutterWindowsView* view =
+      engine()->GetViewFromTopLevelWindow(popup_window_handle);
+  ASSERT_NE(view, nullptr);
+
+  RECT initial_rect = {};
+  ASSERT_TRUE(GetWindowRect(popup_window_handle, &initial_rect));
+
+  // Triggers UpdatePosition via the null positioner; must not crash.
+  view->OnFrameGenerated(150, 100);
+  engine()->task_runner()->ProcessTasks();
+
+  RECT rect_after_null_callback = {};
+  ASSERT_TRUE(GetWindowRect(popup_window_handle, &rect_after_null_callback));
+  EXPECT_EQ(initial_rect.left, rect_after_null_callback.left);
+  EXPECT_EQ(initial_rect.top, rect_after_null_callback.top);
+}
+
 // TODO(team-windows): Fix flakes. See:
 // https://github.com/flutter/flutter/issues/177172
 TEST_F(WindowManagerTest, DISABLED_PopupWindowUpdatesPositionOnViewSizeChange) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Hi there,

I recently upgraded from `flutter 3.44.9` to `flutter 3.47.0` and noticed that the upgrade introduced a new crash on windows. This surfaced as a EXCEPTION_ACCESS_VIOLATION_READ crash in my application. 

I was able to trace the issue to `HostWindowPopup` and have proposed a fix with this change. This fix is modeled after the [existing code in host window tooltip].

- Guard against a null WindowRect* from the position callback, matching HostWindowTooltip::UpdatePosition's existing check for the same call. Fixes a reproducible access-violation crash when the callback returns null.

Fixes Issue #191478 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
[existing code in host window tooltip]: https://github.com/flutter/flutter/blob/4cf24164269a5ebf0c16a028a00727d0e77bbb05/engine/src/flutter/shell/platform/windows/host_window_tooltip.cc#L99
