### PR TITLE
[flutter_tools] Handle null version gracefully in CachedArtifact and MaterialFonts

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -957,17 +957,18 @@ abstract class CachedArtifact extends ArtifactSet {
         );
       }
     }
+    final String? version = this.version;
+    if (version == null) {
+      logger.printWarning(
+        'No known version for the artifact name "$name". '
+        'Flutter can continue, but the artifact may be re-downloaded on '
+        'subsequent invocations until the problem is resolved.',
+      );
+      return;
+    }
     await updateInner(artifactUpdater, fileSystem, operatingSystemUtils);
     try {
-      if (version == null) {
-        logger.printWarning(
-          'No known version for the artifact name "$name". '
-          'Flutter can continue, but the artifact may be re-downloaded on '
-          'subsequent invocations until the problem is resolved.',
-        );
-      } else {
-        cache.setStampFor(stampName, version!);
-      }
+      cache.setStampFor(stampName, version);
     } on FileSystemException catch (err) {
       logger.printWarning(
         'The new artifact "$name" was downloaded, but Flutter failed to update '

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -152,11 +152,7 @@ class MaterialFonts extends CachedArtifact {
     FileSystem fileSystem,
     OperatingSystemUtils operatingSystemUtils,
   ) async {
-    final String? version = this.version;
-    if (version == null) {
-      return;
-    }
-    final Uri archiveUri = _toStorageUri(version);
+    final Uri archiveUri = _toStorageUri(version!);
     return artifactUpdater.downloadZipArchive(displayName, archiveUri, location);
   }
 
@@ -555,11 +551,7 @@ class GradleWrapper extends CachedArtifact {
     FileSystem fileSystem,
     OperatingSystemUtils operatingSystemUtils,
   ) async {
-    final String? version = this.version;
-    if (version == null) {
-      return;
-    }
-    final Uri archiveUri = _toStorageUri(version);
+    final Uri archiveUri = _toStorageUri(version!);
     await artifactUpdater.downloadZippedTarball(displayName, archiveUri, location);
     // Delete property file, allowing templates to provide it.
     // Remove NOTICE file. Should not be part of the template.
@@ -701,12 +693,8 @@ class FlutterRunnerDebugSymbols extends CachedArtifact {
   String? get version => cache.engineRevision;
 
   Future<void> _downloadDebugSymbols(String targetArch, ArtifactUpdater artifactUpdater) async {
-    final String? version = this.version;
-    if (version == null) {
-      return;
-    }
     final packageName = 'fuchsia-debug-symbols-$targetArch';
-    final String url = packageResolver.resolveUrl(packageName, version);
+    final String url = packageResolver.resolveUrl(packageName, version!);
     await artifactUpdater.downloadZipArchive(
       '$displayName - $targetArch',
       Uri.parse(url),

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -152,7 +152,11 @@ class MaterialFonts extends CachedArtifact {
     FileSystem fileSystem,
     OperatingSystemUtils operatingSystemUtils,
   ) async {
-    final Uri archiveUri = _toStorageUri(version!);
+    final String? version = this.version;
+    if (version == null) {
+      return;
+    }
+    final Uri archiveUri = _toStorageUri(version);
     return artifactUpdater.downloadZipArchive(displayName, archiveUri, location);
   }
 
@@ -551,7 +555,11 @@ class GradleWrapper extends CachedArtifact {
     FileSystem fileSystem,
     OperatingSystemUtils operatingSystemUtils,
   ) async {
-    final Uri archiveUri = _toStorageUri(version!);
+    final String? version = this.version;
+    if (version == null) {
+      return;
+    }
+    final Uri archiveUri = _toStorageUri(version);
     await artifactUpdater.downloadZippedTarball(displayName, archiveUri, location);
     // Delete property file, allowing templates to provide it.
     // Remove NOTICE file. Should not be part of the template.
@@ -693,8 +701,12 @@ class FlutterRunnerDebugSymbols extends CachedArtifact {
   String? get version => cache.engineRevision;
 
   Future<void> _downloadDebugSymbols(String targetArch, ArtifactUpdater artifactUpdater) async {
+    final String? version = this.version;
+    if (version == null) {
+      return;
+    }
     final packageName = 'fuchsia-debug-symbols-$targetArch';
-    final String url = packageResolver.resolveUrl(packageName, version!);
+    final String url = packageResolver.resolveUrl(packageName, version);
     await artifactUpdater.downloadZipArchive(
       '$displayName - $targetArch',
       Uri.parse(url),

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -161,6 +161,35 @@ void main() {
       expect(logger.warningText, contains('No known version for the artifact name "fake"'));
     });
 
+    testWithoutContext('MaterialFonts continues on missing version file', () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      final logger = BufferLogger.test();
+      final Directory artifactDir = fileSystem.systemTempDirectory.createTempSync(
+        'flutter_cache_test_artifact.',
+      );
+      final Directory downloadDir = fileSystem.systemTempDirectory.createTempSync(
+        'flutter_cache_test_download.',
+      );
+      final Cache cache = FakeSecondaryCache()
+        ..version =
+            null // version is missing.
+        ..artifactDirectory = artifactDir
+        ..downloadDir = downloadDir;
+
+      final materialFonts = MaterialFonts(cache);
+      await materialFonts.update(
+        FakeArtifactUpdater(),
+        logger,
+        fileSystem,
+        FakeOperatingSystemUtils(),
+      );
+
+      expect(
+        logger.warningText,
+        contains('No known version for the artifact name "material_fonts"'),
+      );
+    });
+
     testWithoutContext(
       'Gradle wrapper should not be up to date, if some cached artifact is not available',
       () {


### PR DESCRIPTION
When artifact version files (such as `bin/internal/material_fonts.version`) are missing or cannot be resolved, `CachedArtifact.version` evaluates to `null`. Previously, `CachedArtifact.update` invoked `updateInner` before checking if `version` was `null`, causing `MaterialFonts.updateInner` (and other artifact subclasses) to evaluate `version!` and throw an unhandled `TypeError` / `_CastError` with `Null check operator used on a null value`.

This change:
1. Returns early with a warning in `CachedArtifact.update` before attempting `updateInner` or writing stamps when `version == null`.
2. Guards against `version == null` in `MaterialFonts`, `GradleWrapper`, and `FlutterRunnerDebugSymbols`.
3. Adds an automated regression test in `cache_test.dart`.

Fixes #90092