### PR TITLE
[flutter_tools] Restrict WebAssetServer source resolution to source map extensions

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -692,6 +692,10 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
     );
   }
 
+  // File extensions that may legitimately be requested from the project and
+  // Flutter SDK roots for source-map resolution.
+  static const Set<String> _sourceMapExtensions = <String>{'.dart', '.map'};
+
   // Attempt to resolve `path` to a dart file.
   File _resolveDartFile(String path) {
     // Return the actual file objects so that local engine changes are automatically picked up.
@@ -706,12 +710,16 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
       return entrypointCacheDirectory.childFile('web_entrypoint.dart');
     }
 
+    final String extension = fileSystem.path.extension(path);
+
     // If this is a dart file, it must be on the local file system and is
     // likely coming from a source map request. The tool doesn't currently
     // consider the case of Dart files as assets.
-    final File dartFile = fileSystem.file(fileSystem.currentDirectory.uri.resolve(path));
-    if (dartFile.existsSync()) {
-      return dartFile;
+    if (_sourceMapExtensions.contains(extension)) {
+      final File dartFile = fileSystem.file(fileSystem.currentDirectory.uri.resolve(path));
+      if (dartFile.existsSync()) {
+        return dartFile;
+      }
     }
 
     final List<String> segments = path.split('/');
@@ -721,7 +729,7 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
 
     // The file might have been a package file which is signaled by a
     // `/packages/<package>/<path>` request.
-    if (segments.first == 'packages') {
+    if (segments.first == 'packages' && _sourceMapExtensions.contains(extension)) {
       final Uri? filePath = _packages.resolve(
         Uri(scheme: 'package', pathSegments: segments.skip(1)),
       );
@@ -733,26 +741,31 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
       }
     }
 
-    // Otherwise it must be a Dart SDK source or a Flutter Web SDK source.
-    final Directory dartSdkParent = fileSystem
-        .directory(
-          globals.artifacts!.getArtifactPath(
-            Artifact.engineDartSdkPath,
-            platform: TargetPlatform.web_javascript,
-          ),
-        )
-        .parent;
-    final File dartSdkFile = fileSystem.file(dartSdkParent.uri.resolve(path));
-    if (dartSdkFile.existsSync()) {
-      return dartSdkFile;
+    if (_sourceMapExtensions.contains(extension)) {
+      // Otherwise it must be a Dart SDK source or a Flutter Web SDK source.
+      final Directory dartSdkParent = fileSystem
+          .directory(
+            globals.artifacts!.getArtifactPath(
+              Artifact.engineDartSdkPath,
+              platform: TargetPlatform.web_javascript,
+            ),
+          )
+          .parent;
+      final File dartSdkFile = fileSystem.file(dartSdkParent.uri.resolve(path));
+      if (dartSdkFile.existsSync()) {
+        return dartSdkFile;
+      }
+
+      final Directory flutterWebSdk = fileSystem.directory(
+        globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk),
+      );
+      final File webSdkFile = fileSystem.file(flutterWebSdk.uri.resolve(path));
+      if (webSdkFile.existsSync()) {
+        return webSdkFile;
+      }
     }
 
-    final Directory flutterWebSdk = fileSystem.directory(
-      globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk),
-    );
-    final File webSdkFile = fileSystem.file(flutterWebSdk.uri.resolve(path));
-
-    return webSdkFile;
+    return fileSystem.file(fileSystem.currentDirectory.childFile('.non_existent_file'));
   }
 
   File get _resolveDartSdkJsFile {

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -693,10 +693,10 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
   }
 
   /// File extensions that may legitimately be requested from the project and
-  // Flutter SDK roots for source-map resolution.
+  /// Flutter SDK roots for source-map resolution.
   static const _sourceMapExtensions = <String>{'.dart', '.map'};
 
-  // Attempt to resolve `path` to a dart file.
+  /// Attempts to resolve [path] to a dart file.
   File _resolveDartFile(String path) {
     // Return the actual file objects so that local engine changes are automatically picked up.
     switch (path) {

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -692,7 +692,7 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
     );
   }
 
-  // File extensions that may legitimately be requested from the project and
+  /// File extensions that may legitimately be requested from the project and
   // Flutter SDK roots for source-map resolution.
   static const _sourceMapExtensions = <String>{'.dart', '.map'};
 
@@ -704,10 +704,8 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
         return _resolveDartSdkJsFile;
       case 'dart_sdk.js.map':
         return _resolveDartSdkJsMapFile;
-    }
-    // This is the special generated entrypoint.
-    if (path == 'web_entrypoint.dart') {
-      return entrypointCacheDirectory.childFile('web_entrypoint.dart');
+      case 'web_entrypoint.dart':
+        return entrypointCacheDirectory.childFile('web_entrypoint.dart');
     }
 
     final String extension = fileSystem.path.extension(path);
@@ -762,7 +760,7 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
       }
     }
 
-    return fileSystem.file(fileSystem.currentDirectory.childFile('.non_existent_file'));
+    return fileSystem.currentDirectory.childFile('.non_existent_file');
   }
 
   File get _resolveDartSdkJsFile {

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -694,7 +694,7 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
 
   // File extensions that may legitimately be requested from the project and
   // Flutter SDK roots for source-map resolution.
-  static const Set<String> _sourceMapExtensions = <String>{'.dart', '.map'};
+  static const _sourceMapExtensions = <String>{'.dart', '.map'};
 
   // Attempt to resolve `path` to a dart file.
   File _resolveDartFile(String path) {
@@ -711,37 +711,34 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
     }
 
     final String extension = fileSystem.path.extension(path);
-
-    // If this is a dart file, it must be on the local file system and is
-    // likely coming from a source map request. The tool doesn't currently
-    // consider the case of Dart files as assets.
     if (_sourceMapExtensions.contains(extension)) {
+      // If this is a dart file, it must be on the local file system and is
+      // likely coming from a source map request. The tool doesn't currently
+      // consider the case of Dart files as assets.
       final File dartFile = fileSystem.file(fileSystem.currentDirectory.uri.resolve(path));
       if (dartFile.existsSync()) {
         return dartFile;
       }
-    }
 
-    final List<String> segments = path.split('/');
-    if (segments.first.isEmpty) {
-      segments.removeAt(0);
-    }
+      final List<String> segments = path.split('/');
+      if (segments.first.isEmpty) {
+        segments.removeAt(0);
+      }
 
-    // The file might have been a package file which is signaled by a
-    // `/packages/<package>/<path>` request.
-    if (segments.first == 'packages' && _sourceMapExtensions.contains(extension)) {
-      final Uri? filePath = _packages.resolve(
-        Uri(scheme: 'package', pathSegments: segments.skip(1)),
-      );
-      if (filePath != null) {
-        final File packageFile = fileSystem.file(filePath);
-        if (packageFile.existsSync()) {
-          return packageFile;
+      // The file might have been a package file which is signaled by a
+      // `/packages/<package>/<path>` request.
+      if (segments.first == 'packages') {
+        final Uri? filePath = _packages.resolve(
+          Uri(scheme: 'package', pathSegments: segments.skip(1)),
+        );
+        if (filePath != null) {
+          final File packageFile = fileSystem.file(filePath);
+          if (packageFile.existsSync()) {
+            return packageFile;
+          }
         }
       }
-    }
 
-    if (_sourceMapExtensions.contains(extension)) {
       // Otherwise it must be a Dart SDK source or a Flutter Web SDK source.
       final Directory dartSdkParent = fileSystem
           .directory(

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -526,7 +526,7 @@ class WebAssetServer implements AssetReader {
     // Try and resolve the path relative to the built asset directory.
     if (!file.existsSync()) {
       final Uri potential = fileSystem
-          .directory(getAssetBuildDirectory())
+          .directory(getAssetBuildDirectory(null, fileSystem))
           .uri
           .resolve(requestPath.replaceFirst('assets/', ''));
       file = fileSystem.file(potential);

--- a/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:dwds/dwds.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -17,6 +18,7 @@ import 'package:flutter_tools/src/web/web_constants.dart';
 import 'package:shelf/shelf.dart';
 
 import '../../src/common.dart';
+import '../../src/context.dart';
 
 const kTransparentImage = <int>[
   0x89,
@@ -509,5 +511,56 @@ void main() {
 
       expect(server.basePath, isEmpty);
     });
+
+    testUsingContext(
+      'serves assets with exact key and does not serve non-source project files as assets',
+      () async {
+        final WebAssetServer server = await WebAssetServer.start(
+          null,
+          null,
+          false,
+          false,
+          false,
+          BuildInfo.debug,
+          false,
+          const DartDevelopmentServiceConfiguration(enable: false),
+          Uri.base,
+          null,
+          crossOriginIsolation: false,
+          webDevServerConfig: const WebDevServerConfig(host: 'localhost'),
+          webRenderer: WebRendererMode.canvaskit,
+          isWasm: false,
+          useLocalCanvasKit: false,
+          testMode: true,
+          fileSystem: fileSystem,
+          logger: BufferLogger.test(),
+          platform: platform,
+        );
+
+        // Project source file exists in assets/ directory.
+        fileSystem.file('assets/my_asset.txt')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('project file');
+
+        // Built asset exists in build/flutter_assets/assets/my_asset.txt.
+        fileSystem.file('build/flutter_assets/assets/my_asset.txt')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('built asset');
+
+        // Correct key 'assets/my_asset.txt' (URL /assets/assets/my_asset.txt) succeeds.
+        final Response validResponse = await server.handleRequest(
+          Request('GET', Uri.parse('http://localhost:8080/assets/assets/my_asset.txt')),
+        );
+        expect(validResponse.statusCode, HttpStatus.ok);
+        expect(await validResponse.readAsString(), 'built asset');
+
+        // Incorrect key 'my_asset.txt' (URL /assets/my_asset.txt) must return 404.
+        final Response invalidResponse = await server.handleRequest(
+          Request('GET', Uri.parse('http://localhost:8080/assets/my_asset.txt')),
+        );
+        expect(invalidResponse.statusCode, HttpStatus.notFound);
+      },
+      overrides: <Type, Generator>{Artifacts: () => Artifacts.test()},
+    );
   });
 }

--- a/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
@@ -575,11 +575,13 @@ void main() {
       },
     );
 
-    testUsingContext(
-      'serves assets with exact key on Windows filesystem',
-      () async {
-        final windowsFileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
-        final windowsPlatform = FakePlatform(
+    group('on Windows', () {
+      late FileSystem windowsFileSystem;
+      late Platform windowsPlatform;
+
+      setUp(() {
+        windowsFileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+        windowsPlatform = FakePlatform(
           operatingSystem: 'windows',
           environment: <String, String>{'HOME': r'C:\Users\test'},
         );
@@ -587,56 +589,63 @@ void main() {
         windowsFileSystem.file('web/index.html')
           ..createSync(recursive: true)
           ..writeAsStringSync('hello');
+      });
 
-        final WebAssetServer server = await WebAssetServer.start(
-          null,
-          null,
-          false,
-          false,
-          false,
-          BuildInfo.debug,
-          false,
-          const DartDevelopmentServiceConfiguration(enable: false),
-          Uri.base,
-          null,
-          crossOriginIsolation: false,
-          webDevServerConfig: const WebDevServerConfig(host: 'localhost'),
-          webRenderer: WebRendererMode.canvaskit,
-          isWasm: false,
-          useLocalCanvasKit: false,
-          testMode: true,
-          fileSystem: windowsFileSystem,
-          logger: BufferLogger.test(),
-          platform: windowsPlatform,
-        );
+      testUsingContext(
+        'serves assets with exact key on Windows filesystem',
+        () async {
+          final WebAssetServer server = await WebAssetServer.start(
+            null,
+            null,
+            false,
+            false,
+            false,
+            BuildInfo.debug,
+            false,
+            const DartDevelopmentServiceConfiguration(enable: false),
+            Uri.base,
+            null,
+            crossOriginIsolation: false,
+            webDevServerConfig: const WebDevServerConfig(host: 'localhost'),
+            webRenderer: WebRendererMode.canvaskit,
+            isWasm: false,
+            useLocalCanvasKit: false,
+            testMode: true,
+            fileSystem: windowsFileSystem,
+            logger: BufferLogger.test(),
+            platform: windowsPlatform,
+          );
 
-        // Project source file exists in assets/ directory.
-        windowsFileSystem.file(r'assets\my_asset.txt')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('project file');
+          // Project source file exists in assets/ directory.
+          windowsFileSystem.file(r'assets\my_asset.txt')
+            ..createSync(recursive: true)
+            ..writeAsStringSync('project file');
 
-        // Built asset exists in build/flutter_assets/assets/my_asset.txt.
-        windowsFileSystem.file(r'build\flutter_assets\assets\my_asset.txt')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('built asset');
+          // Built asset exists in build/flutter_assets/assets/my_asset.txt.
+          windowsFileSystem.file(r'build\flutter_assets\assets\my_asset.txt')
+            ..createSync(recursive: true)
+            ..writeAsStringSync('built asset');
 
-        // Correct key 'assets/my_asset.txt' (URL /assets/assets/my_asset.txt) succeeds.
-        final Response validResponse = await server.handleRequest(
-          Request('GET', Uri.parse('http://localhost:8080/assets/assets/my_asset.txt')),
-        );
-        expect(validResponse.statusCode, HttpStatus.ok);
-        expect(await validResponse.readAsString(), 'built asset');
+          // Correct key 'assets/my_asset.txt' (URL /assets/assets/my_asset.txt) succeeds.
+          final Response validResponse = await server.handleRequest(
+            Request('GET', Uri.parse('http://localhost:8080/assets/assets/my_asset.txt')),
+          );
+          expect(validResponse.statusCode, HttpStatus.ok);
+          expect(await validResponse.readAsString(), 'built asset');
 
-        // Incorrect key 'my_asset.txt' (URL /assets/my_asset.txt) must return 404.
-        final Response invalidResponse = await server.handleRequest(
-          Request('GET', Uri.parse('http://localhost:8080/assets/my_asset.txt')),
-        );
-        expect(invalidResponse.statusCode, HttpStatus.notFound);
-      },
-      overrides: <Type, Generator>{
-        Artifacts: () => Artifacts.test(),
-        ProcessManager: () => FakeProcessManager.any(),
-      },
-    );
+          // Incorrect key 'my_asset.txt' (URL /assets/my_asset.txt) must return 404.
+          final Response invalidResponse = await server.handleRequest(
+            Request('GET', Uri.parse('http://localhost:8080/assets/my_asset.txt')),
+          );
+          expect(invalidResponse.statusCode, HttpStatus.notFound);
+        },
+        overrides: <Type, Generator>{
+          Artifacts: () => Artifacts.test(),
+          FileSystem: () => windowsFileSystem,
+          Platform: () => windowsPlatform,
+          ProcessManager: () => FakeProcessManager.any(),
+        },
+      );
+    });
   });
 }

--- a/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
@@ -559,6 +559,14 @@ void main() {
           Request('GET', Uri.parse('http://localhost:8080/assets/my_asset.txt')),
         );
         expect(invalidResponse.statusCode, HttpStatus.notFound);
+
+        // Legitimate source files (e.g. lib/main.dart) are served for debugging.
+        fileSystem.file('lib/main.dart').writeAsStringSync('void main() {}');
+        final Response dartSourceResponse = await server.handleRequest(
+          Request('GET', Uri.parse('http://localhost:8080/lib/main.dart')),
+        );
+        expect(dartSourceResponse.statusCode, HttpStatus.ok);
+        expect(await dartSourceResponse.readAsString(), 'void main() {}');
       },
       overrides: <Type, Generator>{Artifacts: () => Artifacts.test()},
     );

--- a/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
@@ -568,7 +568,75 @@ void main() {
         expect(dartSourceResponse.statusCode, HttpStatus.ok);
         expect(await dartSourceResponse.readAsString(), 'void main() {}');
       },
-      overrides: <Type, Generator>{Artifacts: () => Artifacts.test()},
+      overrides: <Type, Generator>{
+        Artifacts: () => Artifacts.test(),
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
+
+    testUsingContext(
+      'serves assets with exact key on Windows filesystem',
+      () async {
+        final windowsFileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+        final windowsPlatform = FakePlatform(
+          operatingSystem: 'windows',
+          environment: <String, String>{'HOME': r'C:\Users\test'},
+        );
+        windowsFileSystem.file('lib/main.dart').createSync(recursive: true);
+        windowsFileSystem.file('web/index.html')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('hello');
+
+        final WebAssetServer server = await WebAssetServer.start(
+          null,
+          null,
+          false,
+          false,
+          false,
+          BuildInfo.debug,
+          false,
+          const DartDevelopmentServiceConfiguration(enable: false),
+          Uri.base,
+          null,
+          crossOriginIsolation: false,
+          webDevServerConfig: const WebDevServerConfig(host: 'localhost'),
+          webRenderer: WebRendererMode.canvaskit,
+          isWasm: false,
+          useLocalCanvasKit: false,
+          testMode: true,
+          fileSystem: windowsFileSystem,
+          logger: BufferLogger.test(),
+          platform: windowsPlatform,
+        );
+
+        // Project source file exists in assets/ directory.
+        windowsFileSystem.file(r'assets\my_asset.txt')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('project file');
+
+        // Built asset exists in build/flutter_assets/assets/my_asset.txt.
+        windowsFileSystem.file(r'build\flutter_assets\assets\my_asset.txt')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('built asset');
+
+        // Correct key 'assets/my_asset.txt' (URL /assets/assets/my_asset.txt) succeeds.
+        final Response validResponse = await server.handleRequest(
+          Request('GET', Uri.parse('http://localhost:8080/assets/assets/my_asset.txt')),
+        );
+        expect(validResponse.statusCode, HttpStatus.ok);
+        expect(await validResponse.readAsString(), 'built asset');
+
+        // Incorrect key 'my_asset.txt' (URL /assets/my_asset.txt) must return 404.
+        final Response invalidResponse = await server.handleRequest(
+          Request('GET', Uri.parse('http://localhost:8080/assets/my_asset.txt')),
+        );
+        expect(invalidResponse.statusCode, HttpStatus.notFound);
+      },
+      overrides: <Type, Generator>{
+        Artifacts: () => Artifacts.test(),
+        ProcessManager: () => FakeProcessManager.any(),
+      },
     );
   });
 }


### PR DESCRIPTION
## Description
Restricts `_resolveDartFile` in `WebAssetServer` to only resolve files with source map extensions (`.dart`, `.map`) from the project root, package, and SDK paths, aligning behavior with `ReleaseAssetServer`.

Previously, `WebAssetServer._resolveDartFile` attempted to resolve any relative path directly against `fileSystem.currentDirectory`, which caused raw project files (such as `<root>/assets/...`) to be served directly with HTTP 200 when requested by debug web runtime asset loaders, masking invalid asset key references that failed on release web and native platforms.

## Issues Fixed
Fixes #84346

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md