### PR TITLE
fix: InteractiveViewer jumping back to the start when panning against the boundary of a large child

### DIFF
--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -1268,7 +1268,40 @@ Offset _exceedsBy(Quad boundary, Quad viewport) {
     }
   }
 
-  return _round(largestExcess);
+  return _snapToZero(_round(largestExcess), _precisionTolerance(boundary));
+}
+
+/// The distance from zero below which an excess computed by _exceedsBy is
+/// considered to be zero.
+///
+/// The floating point error in that excess grows with the magnitude of the
+/// coordinates it was computed from, so rounding to a fixed number of decimal
+/// places is not enough on its own: against a boundary that is tens of thousands
+/// of pixels away from the origin, an excess that should have been zero survives
+/// the rounding, and a viewport resting on the boundary is mistaken for one that
+/// lies outside of it.
+double _precisionTolerance(Quad boundary) {
+  // Spelled out rather than looped over a list of the points because this runs
+  // on every frame of a pan or a scale.
+  final double largestCoordinate = math.max(
+    math.max(
+      math.max(boundary.point0.x.abs(), boundary.point0.y.abs()),
+      math.max(boundary.point1.x.abs(), boundary.point1.y.abs()),
+    ),
+    math.max(
+      math.max(boundary.point2.x.abs(), boundary.point2.y.abs()),
+      math.max(boundary.point3.x.abs(), boundary.point3.y.abs()),
+    ),
+  );
+  return math.max(1e-9, largestCoordinate * 1e-11);
+}
+
+/// Snap the components that are nearer to zero than tolerance to exactly zero.
+Offset _snapToZero(Offset offset, double tolerance) {
+  return Offset(
+    offset.dx.abs() < tolerance ? 0.0 : offset.dx,
+    offset.dy.abs() < tolerance ? 0.0 : offset.dy,
+  );
 }
 
 // Round the output values. This works around a precision problem where

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -1736,6 +1736,72 @@ void main() {
       );
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/191482.
+    //
+    // Panning against the boundary of a very tall child used to reset the
+    // vertical translation to zero and jump back to the top of the child.
+    testWidgets('panning against the boundary of a very tall child stays put', (
+      WidgetTester tester,
+    ) async {
+      const viewportSize = Size(400.0, 800.0);
+      const childSize = Size(400.0, 100000.0);
+
+      tester.view.physicalSize = viewportSize;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: InteractiveViewer(
+            maxScale: 3.0,
+            constrained: false,
+            transformationController: transformationController,
+            child: SizedBox.fromSize(size: childSize),
+          ),
+        ),
+      );
+
+      // Each of these rests the viewport against the bottom boundary of the
+      // child at a scale where the boundary check loses enough precision to
+      // report a viewport that fits as being out of bounds.
+      const scales = <double>[2.145201113317985, 1.7979785028542963, 2.950856552791457];
+      const translations = <Offset>[
+        Offset(-303.85748524857473, -213719.76437227987),
+        Offset(-245.2719722233261, -178997.25040212198),
+        Offset(-321.06128323928294, -294285.0304163624),
+      ];
+      const pans = <Offset>[
+        Offset(-0.4154332278286821, -2.4227759928953208),
+        Offset(2.6030588056390362, -1.7826952272598977),
+        Offset(-1.5147411641287807, -1.810529420888404),
+      ];
+
+      for (var i = 0; i < scales.length; i++) {
+        transformationController.value = Matrix4.identity()
+          ..scaleByDouble(scales[i], scales[i], scales[i], 1)
+          ..setTranslation(Vector3(translations[i].dx, translations[i].dy, 0.0));
+        await tester.pump();
+
+        final TestGesture gesture = await tester.startGesture(
+          Offset(viewportSize.width / 2, viewportSize.height / 2),
+        );
+        await tester.pump();
+        await gesture.moveBy(pans[i]);
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+
+        // The pan is clamped to the boundary, so the viewport stays where it
+        // was instead of snapping back to the top of the child.
+        expect(
+          transformationController.value.getTranslation().y,
+          moreOrLessEquals(translations[i].dy, epsilon: 4.0),
+          reason: 'case $i jumped back to the top of the child',
+        );
+      }
+    });
+
     testWidgets('does not accumulate listeners', (WidgetTester tester) async {
       await tester.pumpWidget(
         InteractiveViewer(


### PR DESCRIPTION
This PR fixes `InteractiveViewer` jumping back to the start of its child when panning against the boundary of a large child.

`_exceedsBy` rounds its result to nine decimal places to discard floating point error, but the size of that error grows with the magnitude of the coordinates it is computed from. Against a boundary that is tens of thousands of pixels from the origin the error survives that rounding, so a viewport resting exactly on the boundary is reported as being out of bounds. `_matrixTranslate` then treats the corrected translation as not fitting and resets the translation on that axis to `0.0`, jumping the view back to the start of the child.

This scales the amount of error that is discarded with the magnitude of the boundary coordinates, leaving the behaviour for small children unchanged.

Fixes: https://github.com/flutter/flutter/issues/191482

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
