### PR TITLE
[beta] Only exclude platform directories that actually exist in analysis_options.yaml

### DIFF
--- a/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart
@@ -12,13 +12,23 @@ import '../project.dart';
 /// Migrates analysis_options.yaml to exclude build and platform directories.
 class AnalysisOptionsMigration extends ProjectMigrator {
   AnalysisOptionsMigration(FlutterProject project, super.logger)
-    : _analysisOptionsFile = project.directory.childFile('analysis_options.yaml');
+    : _project = project,
+      _analysisOptionsFile = project.directory.childFile('analysis_options.yaml');
 
+  final FlutterProject _project;
   final File _analysisOptionsFile;
 
   @override
   Future<void> migrate() async {
     if (!_analysisOptionsFile.existsSync()) {
+      return;
+    }
+
+    // A pure Dart package (no `flutter` dependency) has no platform scaffold
+    // directories, so `web/`, `android/`, etc. are ordinary source or asset
+    // directories rather than generated platform code. Excluding them here
+    // would silently drop them from analysis.
+    if (!_project.manifest.dependencies.contains('flutter')) {
       return;
     }
 
@@ -36,14 +46,14 @@ class AnalysisOptionsMigration extends ProjectMigrator {
       return;
     }
 
-    const excludesToExclude = <String>[
+    final excludesToExclude = <String>[
       'build/**',
-      'android/**',
-      'ios/**',
-      'web/**',
-      'windows/**',
-      'macos/**',
-      'linux/**',
+      if (_project.android.existsSync()) 'android/**',
+      if (_project.ios.existsSync()) 'ios/**',
+      if (_project.web.existsSync()) 'web/**',
+      if (_project.windows.existsSync()) 'windows/**',
+      if (_project.macos.existsSync()) 'macos/**',
+      if (_project.linux.existsSync()) 'linux/**',
     ];
 
     var needsMigration = false;

--- a/packages/flutter_tools/templates/app/analysis_options.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/analysis_options.yaml.tmpl
@@ -14,12 +14,24 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - build/**
+{{#android}}
     - android/**
+{{/android}}
+{{#ios}}
     - ios/**
+{{/ios}}
+{{#web}}
     - web/**
+{{/web}}
+{{#windows}}
     - windows/**
+{{/windows}}
+{{#macos}}
     - macos/**
+{{/macos}}
+{{#linux}}
     - linux/**
+{{/linux}}
 {{^withEmptyMain}}
 
 linter:

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -4205,6 +4205,23 @@ void main() {
     },
   );
 
+  testUsingContext('analysis_options.yaml only excludes platforms that were generated', () async {
+    await _createProject(
+      projectDir,
+      <String>['--no-pub', '--platforms', 'android,ios'],
+      <String>['analysis_options.yaml'],
+    );
+
+    final String analysisOptions = projectDir.childFile('analysis_options.yaml').readAsStringSync();
+    expect(analysisOptions, contains('- build/**'));
+    expect(analysisOptions, contains('- android/**'));
+    expect(analysisOptions, contains('- ios/**'));
+    expect(analysisOptions, isNot(contains('- web/**')));
+    expect(analysisOptions, isNot(contains('- windows/**')));
+    expect(analysisOptions, isNot(contains('- macos/**')));
+    expect(analysisOptions, isNot(contains('- linux/**')));
+  });
+
   testUsingContext('should escape ":" in project description', () async {
     await _createProject(
       projectDir,

--- a/packages/flutter_tools/test/general.shard/migrations/analysis_options_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrations/analysis_options_migration_test.dart
@@ -12,6 +12,8 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 
+const _allPlatforms = <String>['android', 'ios', 'web', 'windows', 'macos', 'linux'];
+
 void main() {
   group('Analysis options migration', () {
     testWithoutContext('skipped if analysis_options.yaml file is missing', () async {
@@ -160,6 +162,47 @@ analyzer:
       expect(migratedContents, contains('- linux/**'));
     });
 
+    testWithoutContext(
+      'skipped entirely for a Dart-only package (no flutter dependency)',
+      () async {
+        final _TestContext context = _createTestContext(
+          isFlutterProject: false,
+          platforms: <String>['web'],
+        );
+        const analysisOptionsContents = '''
+include: package:lints/recommended.yaml
+''';
+        context.analysisOptionsFile.writeAsStringSync(analysisOptionsContents);
+
+        final migration = AnalysisOptionsMigration(context.mockProject, context.testLogger);
+        await migration.migrate();
+
+        expect(context.analysisOptionsFile.readAsStringSync(), analysisOptionsContents);
+        expect(context.testLogger.statusText, isEmpty);
+      },
+    );
+
+    testWithoutContext('only excludes platform directories that actually exist', () async {
+      final _TestContext context = _createTestContext(platforms: <String>['android', 'ios']);
+      const analysisOptionsContents = '''
+include: package:flutter_lints/flutter.yaml
+''';
+
+      context.analysisOptionsFile.writeAsStringSync(analysisOptionsContents);
+
+      final migration = AnalysisOptionsMigration(context.mockProject, context.testLogger);
+      await migration.migrate();
+
+      final String migratedContents = context.analysisOptionsFile.readAsStringSync();
+      expect(migratedContents, contains('- build/**'));
+      expect(migratedContents, contains('- android/**'));
+      expect(migratedContents, contains('- ios/**'));
+      expect(migratedContents, isNot(contains('- web/**')));
+      expect(migratedContents, isNot(contains('- windows/**')));
+      expect(migratedContents, isNot(contains('- macos/**')));
+      expect(migratedContents, isNot(contains('- linux/**')));
+    });
+
     testWithoutContext('migrates and preserves comments inside exclude list', () async {
       final _TestContext context = _createTestContext();
       const analysisOptionsContents = '''
@@ -209,28 +252,67 @@ typedef _TestContext = ({
   MemoryFileSystem memoryFileSystem,
   File analysisOptionsFile,
   BufferLogger testLogger,
-  FakeFlutterProject mockProject,
+  FlutterProject mockProject,
 });
 
-_TestContext _createTestContext() {
+/// Builds a test context backed by a real [FlutterProject] view of an
+/// in-memory directory, so that platform existence checks (`android.existsSync()`,
+/// etc.) reflect the directories actually created here, matching production
+/// behavior instead of being separately mocked.
+_TestContext _createTestContext({
+  bool isFlutterProject = true,
+  List<String> platforms = _allPlatforms,
+}) {
   final memoryFileSystem = MemoryFileSystem.test();
-  final File analysisOptionsFile = memoryFileSystem.file('analysis_options.yaml');
+  final Directory projectDirectory = memoryFileSystem.currentDirectory;
+  final File analysisOptionsFile = projectDirectory.childFile('analysis_options.yaml');
   final testLogger = BufferLogger(
     terminal: Terminal.test(),
     outputPreferences: OutputPreferences.test(),
   );
-  final mockProject = FakeFlutterProject(directory: memoryFileSystem.currentDirectory);
+
+  projectDirectory
+      .childFile('pubspec.yaml')
+      .writeAsStringSync(
+        isFlutterProject
+            ? '''
+name: test_project
+dependencies:
+  flutter:
+    sdk: flutter
+'''
+            : '''
+name: test_project
+''',
+      );
+
+  if (platforms.contains('android')) {
+    projectDirectory.childDirectory('android').createSync(recursive: true);
+  }
+  if (platforms.contains('ios')) {
+    projectDirectory.childDirectory('ios').createSync(recursive: true);
+  }
+  if (platforms.contains('web')) {
+    projectDirectory.childDirectory('web').childFile('index.html').createSync(recursive: true);
+  }
+  if (platforms.contains('windows')) {
+    projectDirectory
+        .childDirectory('windows')
+        .childFile('CMakeLists.txt')
+        .createSync(recursive: true);
+  }
+  if (platforms.contains('macos')) {
+    projectDirectory.childDirectory('macos').createSync(recursive: true);
+  }
+  if (platforms.contains('linux')) {
+    projectDirectory.childDirectory('linux').createSync(recursive: true);
+  }
+
+  final FlutterProject mockProject = FlutterProject.fromDirectoryTest(projectDirectory);
   return (
     memoryFileSystem: memoryFileSystem,
     analysisOptionsFile: analysisOptionsFile,
     testLogger: testLogger,
     mockProject: mockProject,
   );
-}
-
-class FakeFlutterProject extends Fake implements FlutterProject {
-  FakeFlutterProject({required this.directory});
-
-  @override
-  final Directory directory;
 }


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:

https://github.com/flutter/flutter/issues/191131

### Impact Description:

`AnalysisOptionsMigration` writes a fixed seven-entry `exclude` list (`android/**`, `ios/**`, `web/**`, `windows/**`, `macos/**`, `linux/**`, `build/**`) into `analysis_options.yaml` on every `flutter pub get` / `analyze` / `run` / `build`, regardless of which directories the project actually contains. A Dart-only package (e.g. `dart create -t web`) that uses `web/` as a source directory gets it silently excluded from analysis the first time any Flutter command touches the package, and there is no opt-out — the entries are restored on every command.

### Changelog Description:

[flutter/191131] Only exclude platform directories that actually exist, so `web/**` sources in Dart web packages are no longer silently dropped from analysis.

### Workaround:

None — every Flutter command that reaches `ensureReadyForPlatformSpecificTooling` restores the full exclude list; the only way to keep the entries out is to not run Flutter tooling in the package.

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:

1. `dart create -t web repro && cd repro && flutter pub get` — confirm `web/**` is not added to the `exclude` list and `dart analyze` still reports errors in `web/main.dart`.
2. `flutter create --platforms=android,ios app` — confirm `analysis_options.yaml` only excludes `build/**`, `android/**`, and `ios/**`.
3. Run `packages/flutter_tools/test/general.shard/migrations/analysis_options_migration_test.dart` and `packages/flutter_tools/test/commands.shard/permeable/create_test.dart`.

### Conflict Resolution:

The automatic cherry-pick failed; conflicts were resolved manually:

- `analysis_options_migration_test.dart`: removed `FakeFlutterProject` (deleted upstream in favor of a real `FlutterProject` view). The adjacent `FakePackageConfig` block only appears as upstream context from #191082, which is not on this branch, so it was not carried over.
- `analysis_options_migration.dart`: the patch applied cleanly but referenced `_project`, a field introduced on master by #191082; added the minimal `_project` field and initializer without the rest of #191082.

Verified locally with `flutter test packages/flutter_tools/test/general.shard/migrations/analysis_options_migration_test.dart` — all 11 tests pass.
