### PR TITLE
Add tick count customization to CupertinoActivityIndicator

### DIFF
--- a/packages/flutter/examples/api/lib/cupertino/activity_indicator/cupertino_activity_indicator.0.dart
+++ b/packages/flutter/examples/api/lib/cupertino/activity_indicator/cupertino_activity_indicator.0.dart
@@ -45,14 +45,16 @@ class CupertinoIndicatorExample extends StatelessWidget {
             Column(
               mainAxisAlignment: .center,
               children: <Widget>[
-                // Cupertino activity indicator with custom radius and color.
+                // Cupertino activity indicator with custom radius, color, and
+                // tick count.
                 CupertinoActivityIndicator(
                   radius: 20.0,
                   color: CupertinoColors.activeBlue,
+                  tickCount: 12,
                 ),
                 SizedBox(height: 10),
                 Text(
-                  'radius: 20.0\ncolor: CupertinoColors.activeBlue',
+                  'radius: 20.0\ncolor: CupertinoColors.activeBlue\ntickCount: 12',
                   textAlign: .center,
                 ),
               ],
@@ -62,9 +64,16 @@ class CupertinoIndicatorExample extends StatelessWidget {
               children: <Widget>[
                 // Cupertino activity indicator with custom radius and disabled
                 // animation.
-                CupertinoActivityIndicator(radius: 20.0, animating: false),
+                CupertinoActivityIndicator(
+                  radius: 20.0,
+                  animating: false,
+                  tickCount: 16,
+                ),
                 SizedBox(height: 10),
-                Text('radius: 20.0\nanimating: false', textAlign: .center),
+                Text(
+                  'radius: 20.0\nanimating: false\ntickCount: 16',
+                  textAlign: .center,
+                ),
               ],
             ),
           ],

--- a/packages/flutter/examples/api/test/cupertino/activity_indicator/cupertino_activity_indicator.0_test.dart
+++ b/packages/flutter/examples/api/test/cupertino/activity_indicator/cupertino_activity_indicator.0_test.dart
@@ -23,8 +23,12 @@ void main() {
       tester.widget<CupertinoActivityIndicator>(firstIndicator).radius,
       10.0,
     );
+    expect(
+      tester.widget<CupertinoActivityIndicator>(firstIndicator).tickCount,
+      8,
+    );
 
-    // Cupertino activity indicator with custom radius and color.
+    // Cupertino activity indicator with custom radius, color, and tick count.
     final Finder secondIndicator = find
         .byType(CupertinoActivityIndicator)
         .at(1);
@@ -40,6 +44,10 @@ void main() {
       tester.widget<CupertinoActivityIndicator>(secondIndicator).color,
       CupertinoColors.activeBlue,
     );
+    expect(
+      tester.widget<CupertinoActivityIndicator>(secondIndicator).tickCount,
+      12,
+    );
 
     // Cupertino activity indicator with custom radius and disabled animation.
     final Finder thirdIndicator = find.byType(CupertinoActivityIndicator).at(2);
@@ -50,6 +58,10 @@ void main() {
     expect(
       tester.widget<CupertinoActivityIndicator>(thirdIndicator).radius,
       20.0,
+    );
+    expect(
+      tester.widget<CupertinoActivityIndicator>(thirdIndicator).tickCount,
+      16,
     );
   });
 }

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -10,6 +10,7 @@ import 'package:flutter/widgets.dart';
 import 'colors.dart';
 
 const double _kDefaultIndicatorRadius = 10.0;
+const int _kDefaultIndicatorTickCount = 8;
 
 // Extracted from iOS 13.2 Beta.
 const Color _kActiveTickColor = CupertinoDynamicColor.withBrightness(
@@ -38,7 +39,9 @@ class CupertinoActivityIndicator extends StatefulWidget {
     this.color,
     this.animating = true,
     this.radius = _kDefaultIndicatorRadius,
+    this.tickCount = _kDefaultIndicatorTickCount,
   }) : assert(radius > 0.0),
+       assert(tickCount > 0),
        progress = 1.0;
 
   /// Creates a non-animated iOS-style activity indicator that displays
@@ -52,9 +55,11 @@ class CupertinoActivityIndicator extends StatefulWidget {
     this.color,
     this.radius = _kDefaultIndicatorRadius,
     this.progress = 1.0,
+    this.tickCount = _kDefaultIndicatorTickCount,
   }) : assert(radius > 0.0),
        assert(progress >= 0.0),
        assert(progress <= 1.0),
+       assert(tickCount > 0),
        animating = false;
 
   /// Color of the activity indicator.
@@ -71,6 +76,11 @@ class CupertinoActivityIndicator extends StatefulWidget {
   ///
   /// Defaults to 10 pixels. Must be positive.
   final double radius;
+
+  /// The number of ticks drawn around the indicator.
+  ///
+  /// Defaults to 8. Must be positive.
+  final int tickCount;
 
   /// Determines the percentage of spinner ticks that will be shown. Typical usage would
   /// display all ticks, however, this allows for more fine-grained control such as
@@ -126,6 +136,7 @@ class _CupertinoActivityIndicatorState extends State<CupertinoActivityIndicator>
           activeColor: widget.color ?? CupertinoDynamicColor.resolve(_kActiveTickColor, context),
           radius: widget.radius,
           progress: widget.progress,
+          tickCount: widget.tickCount,
         ),
       ),
     );
@@ -134,12 +145,11 @@ class _CupertinoActivityIndicatorState extends State<CupertinoActivityIndicator>
 
 const double _kTwoPI = math.pi * 2.0;
 
-/// Alpha values extracted from the native component (for both dark and light mode) to
-/// draw the spinning ticks.
-const List<int> _kAlphaValues = <int>[47, 47, 47, 47, 72, 97, 122, 147];
+/// The minimum alpha value used to draw the spinning ticks.
+const int _kMinTickAlpha = 47;
 
-/// The alpha value that is used to draw the partially revealed ticks.
-const int _partiallyRevealedAlpha = 147;
+/// The maximum alpha value used to draw the spinning and partially revealed ticks.
+const int _kMaxTickAlpha = 147;
 
 class _CupertinoActivityIndicatorPainter extends CustomPainter {
   _CupertinoActivityIndicatorPainter({
@@ -147,6 +157,7 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     required this.activeColor,
     required this.radius,
     required this.progress,
+    required this.tickCount,
   }) : tickFundamentalShape = RRect.fromLTRBXY(
          -radius / _kDefaultIndicatorRadius,
          -radius / 3.0,
@@ -161,15 +172,25 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
   final Color activeColor;
   final double radius;
   final double progress;
+  final int tickCount;
 
   // Use a RRect instead of RSuperellipse since this shape is really small
   // and should make little visual difference.
   final RRect tickFundamentalShape;
 
+  int _alphaValueForTick(int tick) {
+    final int fadingTickCount = tickCount - tickCount ~/ 2;
+    final int fadingTick = tick - tickCount ~/ 2;
+    if (fadingTick < 0) {
+      return _kMinTickAlpha;
+    }
+    return _kMinTickAlpha +
+        ((_kMaxTickAlpha - _kMinTickAlpha) * (fadingTick + 1) / fadingTickCount).round();
+  }
+
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint();
-    final int tickCount = _kAlphaValues.length;
 
     canvas.save();
     canvas.translate(size.width / 2.0, size.height / 2.0);
@@ -178,9 +199,7 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
 
     for (var i = 0; i < tickCount * progress; ++i) {
       final int t = (i - activeTick) % tickCount;
-      paint.color = activeColor.withAlpha(
-        progress < 1 ? _partiallyRevealedAlpha : _kAlphaValues[t],
-      );
+      paint.color = activeColor.withAlpha(progress < 1 ? _kMaxTickAlpha : _alphaValueForTick(t));
       canvas.drawRRect(tickFundamentalShape, paint);
       canvas.rotate(_kTwoPI / tickCount);
     }
@@ -192,7 +211,8 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
   bool shouldRepaint(_CupertinoActivityIndicatorPainter oldPainter) {
     return oldPainter.position != position ||
         oldPainter.activeColor != activeColor ||
-        oldPainter.progress != progress;
+        oldPainter.progress != progress ||
+        oldPainter.tickCount != tickCount;
   }
 }
 

--- a/packages/flutter/test/cupertino/activity_indicator_test.dart
+++ b/packages/flutter/test/cupertino/activity_indicator_test.dart
@@ -156,6 +156,47 @@ void main() {
     );
   });
 
+  test('tickCount defaults to 8', () {
+    expect(const CupertinoActivityIndicator().tickCount, 8);
+    expect(const CupertinoActivityIndicator.partiallyRevealed().tickCount, 8);
+  });
+
+  for (final tickCount in <int>[8, 12, 16]) {
+    testWidgets('Can specify $tickCount ticks', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Center(child: CupertinoActivityIndicator(animating: false, tickCount: tickCount)),
+      );
+
+      expect(
+        find.byType(CupertinoActivityIndicator),
+        paintsExactlyCountTimes(#drawRRect, tickCount),
+      );
+      expect(
+        tester
+            .widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator))
+            .tickCount,
+        tickCount,
+      );
+    });
+  }
+
+  testWidgets('Partially revealed activity indicator honors tickCount', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const Center(
+        child: CupertinoActivityIndicator.partiallyRevealed(progress: 0.5, tickCount: 16),
+      ),
+    );
+
+    expect(find.byType(CupertinoActivityIndicator), paintsExactlyCountTimes(#drawRRect, 8));
+  });
+
+  test('tickCount must be positive', () {
+    expect(() => CupertinoActivityIndicator(tickCount: 0), throwsAssertionError);
+    expect(() => CupertinoActivityIndicator.partiallyRevealed(tickCount: 0), throwsAssertionError);
+  });
+
   group('CupertinoLinearActivityIndicator', () {
     testWidgets('draws the linear activity indicator', (WidgetTester tester) async {
       await tester.pumpWidget(const Center(child: CupertinoLinearActivityIndicator(progress: 0.2)));


### PR DESCRIPTION
## Summary

- add an optional positive `tickCount` to both `CupertinoActivityIndicator` constructors, defaulting to 8
- distribute custom tick counts evenly and scale the existing alpha progression across them
- preserve the exact existing 8-tick alpha values, animation duration, dimensions, and geometry
- update the API sample and add coverage for default, 12-tick, 16-tick, partially revealed, and invalid configurations

This is an opt-in customization. Existing applications that omit `tickCount` receive no visual or behavioral change.

- Fixes #191550

## Tests

- `dart format --output=none --set-exit-if-changed` on the four changed files
- `bin/flutter analyze --no-pub` on the four changed files
- `bin/flutter test --no-pub packages/flutter/test/cupertino/activity_indicator_test.dart`
- `bin/flutter test --no-pub packages/flutter/examples/api/test/cupertino/activity_indicator/cupertino_activity_indicator.0_test.dart`

All commands passed. The existing golden comparisons in the framework test were skipped locally because Flutter Gold was inaccessible from this environment; they remain available to CI.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
