### PR TITLE
iOS: Improve FlutterEngineGroup tests

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineGroupTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineGroupTest.mm
@@ -5,6 +5,7 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#include "flutter/fml/synchronization/sync_switch.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngineGroup.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine+Test.h"
 
@@ -30,10 +31,42 @@ FLUTTER_ASSERT_ARC
   FlutterEngine* spawner = [group makeEngineWithEntrypoint:nil libraryURI:nil];
   spawner.isGpuDisabled = YES;
   FlutterEngine* spawnee = [group makeEngineWithEntrypoint:nil libraryURI:nil];
+
+  // Verify engines exist.
   XCTAssertNotNil(spawner);
   XCTAssertNotNil(spawnee);
+
+  // Verify engine properties match.
   XCTAssertEqual(&spawner.threadHost, &spawnee.threadHost);
   XCTAssertEqual(spawner.isGpuDisabled, spawnee.isGpuDisabled);
+
+  // Verify the shell came up with GPU disabled.
+  BOOL gpuDisabled = NO;
+  [spawnee shell].GetIsGpuDisabledSyncSwitch()->Execute(
+      fml::SyncSwitch::Handlers().SetIfTrue([&] { gpuDisabled = YES; }));
+  XCTAssertTrue(gpuDisabled);
+}
+
+// Verifies that the Dart VM, isolate group snapshot, and task runners are shared between engines.
+- (void)testSpawnSharesDartVMAndTaskRunners {
+  FlutterEngineGroup* group = [[FlutterEngineGroup alloc] initWithName:@"foo" project:nil];
+  FlutterEngine* spawner = [group makeEngineWithEntrypoint:nil libraryURI:nil];
+  FlutterEngine* spawnee = [group makeEngineWithEntrypoint:nil libraryURI:nil];
+  XCTAssertNotNil(spawner);
+  XCTAssertNotNil(spawnee);
+
+  // A single Dart VM backs every engine in the group.
+  XCTAssertEqual([spawner shell].GetDartVM(), [spawnee shell].GetDartVM());
+
+  // The engine-managed threads are shared; only the Dart isolate differs.
+  const flutter::TaskRunners& spawnerRunners = [spawner shell].GetTaskRunners();
+  const flutter::TaskRunners& spawneeRunners = [spawnee shell].GetTaskRunners();
+  XCTAssertEqual(spawnerRunners.GetRasterTaskRunner(), spawneeRunners.GetRasterTaskRunner());
+  XCTAssertEqual(spawnerRunners.GetIOTaskRunner(), spawneeRunners.GetIOTaskRunner());
+  XCTAssertEqual(spawnerRunners.GetPlatformTaskRunner(), spawneeRunners.GetPlatformTaskRunner());
+
+  // Platform and UI are merged on iOS, so this holds for the spawned engine too.
+  XCTAssertEqual(spawneeRunners.GetUITaskRunner(), spawneeRunners.GetPlatformTaskRunner());
 }
 
 - (void)testDeleteLastEngine {


### PR DESCRIPTION
Adds tests for `[FlutterEngine spawn]` that do checks at the `flutter::Shell` level.

`testSpawn` already verified that a spawned engine shares its spawner's thread host this adds tests that ensure that spawned engines share a single Dart VM, shared task runners, and that the GPU enabled/disabled state is correctly set on the underlying `Shell`, not just on the `FlutterEngine` itself.

This fills in some test coverage gaps before we start moving iOS towards the embedder API.

Issue: https://github.com/flutter/flutter/issues/112232

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
