### PR TITLE
[flutter_tools] Add --force flag to flutter channel

### DIFF
--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -27,6 +27,12 @@ class ChannelCommand extends FlutterCommand {
           'This is the equivalent of running "flutter precache" with the "--all-platforms" flag.',
       defaultsTo: true,
     );
+    argParser.addFlag(
+      'force',
+      abbr: 'f',
+      help: 'Force switch channels, potentially discarding local changes.',
+      negatable: false,
+    );
   }
 
   @override
@@ -164,7 +170,7 @@ class ChannelCommand extends FlutterCommand {
         'This is not an official channel. For a list of available channels, try "flutter channel".',
       );
     }
-    await _checkout(branchName);
+    await _checkout(branchName, force: boolArg('force'));
     if (boolArg('cache-artifacts')) {
       await precacheArtifacts(Cache.flutterRoot);
     }
@@ -183,7 +189,7 @@ class ChannelCommand extends FlutterCommand {
     }
   }
 
-  static Future<void> _checkout(String branchName) async {
+  static Future<void> _checkout(String branchName, {bool force = false}) async {
     // Get latest refs from upstream.
     RunResult runResult = await globals.git.run(<String>[
       'fetch',
@@ -200,6 +206,7 @@ class ChannelCommand extends FlutterCommand {
         // branch already exists, try just switching to it
         runResult = await globals.git.run(<String>[
           'checkout',
+          if (force) '-f',
           branchName,
           '--',
         ], workingDirectory: Cache.flutterRoot);
@@ -207,6 +214,7 @@ class ChannelCommand extends FlutterCommand {
         // branch does not exist, we have to create it
         runResult = await globals.git.run(<String>[
           'checkout',
+          if (force) '-f',
           '--track',
           '-b',
           branchName,

--- a/packages/flutter_tools/test/general.shard/channel_test.dart
+++ b/packages/flutter_tools/test/general.shard/channel_test.dart
@@ -349,6 +349,71 @@ void main() {
     );
 
     testUsingContext(
+      'can switch channels with --force',
+      () async {
+        fakeProcessManager.addCommands(const <FakeCommand>[
+          FakeCommand(command: <String>['git', 'fetch']),
+          FakeCommand(
+            command: <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
+          ),
+          FakeCommand(command: <String>['git', 'checkout', '-f', 'beta', '--']),
+          FakeCommand(
+            command: <String>['bin/flutter', '--no-color', '--no-version-check', 'precache'],
+          ),
+        ]);
+
+        final command = ChannelCommand();
+        final CommandRunner<void> runner = createTestCommandRunner(command);
+        await runner.run(<String>['channel', '--force', 'beta']);
+
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+        expect(
+          testLogger.statusText,
+          containsIgnoringWhitespace("Switching to flutter channel 'beta'..."),
+        );
+        expect(testLogger.errorText, hasLength(0));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => MemoryFileSystem.test(),
+        ProcessManager: () => fakeProcessManager,
+      },
+    );
+
+    testUsingContext(
+      'can switch channels with -f when branch does not exist locally',
+      () async {
+        fakeProcessManager.addCommands(const <FakeCommand>[
+          FakeCommand(command: <String>['git', 'fetch']),
+          FakeCommand(
+            command: <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
+            exitCode: 1,
+          ),
+          FakeCommand(
+            command: <String>['git', 'checkout', '-f', '--track', '-b', 'beta', 'origin/beta'],
+          ),
+          FakeCommand(
+            command: <String>['bin/flutter', '--no-color', '--no-version-check', 'precache'],
+          ),
+        ]);
+
+        final command = ChannelCommand();
+        final CommandRunner<void> runner = createTestCommandRunner(command);
+        await runner.run(<String>['channel', '-f', 'beta']);
+
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+        expect(
+          testLogger.statusText,
+          containsIgnoringWhitespace("Switching to flutter channel 'beta'..."),
+        );
+        expect(testLogger.errorText, hasLength(0));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => MemoryFileSystem.test(),
+        ProcessManager: () => fakeProcessManager,
+      },
+    );
+
+    testUsingContext(
       'switching channels prompts to run flutter upgrade',
       () async {
         fakeProcessManager.addCommands(const <FakeCommand>[


### PR DESCRIPTION
Adds a `--force` (`-f`) flag to `flutter channel` to allow switching channels even when local SDK modifications or untracked changes exist, matching `flutter upgrade` behavior.

Fixes https://github.com/flutter/flutter/issues/191262

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://discord.gg/rflutter
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
