### PR TITLE
[flutter_tools] Ignore build directories when scanning repo packages

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -565,6 +565,8 @@ class FlutterCommandRunner extends CommandRunner<void> {
         .toList();
   }
 
+  /// Directory names to skip when scanning repository packages to avoid
+  /// traversing build caches and generated artifacts.
   static const _ignoredDirectoryNames = <String>{'.dart_tool', 'build'};
 
   static List<String> _gatherProjectPaths(FileSystem fs, String rootPath) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -565,6 +565,8 @@ class FlutterCommandRunner extends CommandRunner<void> {
         .toList();
   }
 
+  static const _ignoredDirectoryNames = <String>{'.dart_tool', 'build'};
+
   static List<String> _gatherProjectPaths(FileSystem fs, String rootPath) {
     if (fs.isFileSync(fs.path.join(rootPath, '.dartignore'))) {
       return <String>[];
@@ -577,7 +579,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
     final List<String> projectPaths = directory.listSync(followLinks: false).expand((
       FileSystemEntity entity,
     ) {
-      if (entity is Directory && fs.path.basename(entity.path) != '.dart_tool') {
+      if (entity is Directory && !_ignoredDirectoryNames.contains(fs.path.basename(entity.path))) {
         return _gatherProjectPaths(fs, entity.path);
       }
       return <String>[];

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -297,8 +297,55 @@ void main() {
         });
 
         testUsingContext(
-          '',
+          'returns all packages in dev, examples, and packages',
           () {
+            final runner = createTestCommandRunner(DummyFlutterCommand()) as FlutterCommandRunner;
+            final List<String> packagePaths = runner
+                .getRepoPackages()
+                .map((Directory d) => d.path)
+                .toList();
+            expect(packagePaths, <String>[
+              fileSystem
+                  .directory(fileSystem.path.join(_kFlutterRoot, 'dev', 'tools', 'aatool'))
+                  .path,
+              fileSystem.directory(fileSystem.path.join(_kFlutterRoot, 'dev', 'tools')).path,
+            ]);
+          },
+          overrides: <Type, Generator>{
+            FileSystem: () => fileSystem,
+            ProcessManager: () => FakeProcessManager.any(),
+            Platform: () => platform,
+            FlutterVersion: () => FakeFlutterVersion(),
+            OutputPreferences: () => OutputPreferences.test(),
+          },
+        );
+
+        testUsingContext(
+          'ignores .dart_tool and build directories',
+          () {
+            fileSystem
+                .file(fileSystem.path.join(_kFlutterRoot, 'dev', 'tools', 'build', 'pubspec.yaml'))
+                .createSync(recursive: true);
+            fileSystem
+                .file(
+                  fileSystem.path.join(
+                    _kFlutterRoot,
+                    'dev',
+                    'tools',
+                    'build',
+                    'ios',
+                    'SourcePackages',
+                    'pkg',
+                    'pubspec.yaml',
+                  ),
+                )
+                .createSync(recursive: true);
+            fileSystem
+                .file(
+                  fileSystem.path.join(_kFlutterRoot, 'dev', 'tools', '.dart_tool', 'pubspec.yaml'),
+                )
+                .createSync(recursive: true);
+
             final runner = createTestCommandRunner(DummyFlutterCommand()) as FlutterCommandRunner;
             final List<String> packagePaths = runner
                 .getRepoPackages()


### PR DESCRIPTION
`flutter update-packages` fails when build output directories (such as `build/ios/SourcePackages/` generated during DeviceLab runs or iOS SPM builds) contain third-party `pubspec.yaml` files without Flutter repo checksums.

Updates `FlutterCommandRunner._gatherProjectPaths` to ignore `build/` directories in addition to `.dart_tool/` directories when discovering repo packages.

Fixes https://github.com/flutter/flutter/issues/191417

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
