### PR TITLE
Add agent rule to prevent using material and cupertino in widget tests

### DIFF
--- a/.agents/rules/dart-editing.md
+++ b/.agents/rules/dart-editing.md
@@ -7,3 +7,8 @@ Before declaring a task done:
    files. Run `dart analyze --fatal-infos <files>` or use the MCP server.
 2. Run `dart format` on the modified files. Run `dart format <files>` or use the
    MCP server.
+
+## Layer Dependency Rules
+
+* `material` (`package:flutter/material.dart` or `packages/flutter/lib/src/material/`) can only be used in `material` code and tests (`packages/flutter/lib/src/material/` and `packages/flutter/test/material/`).
+* `cupertino` (`package:flutter/cupertino.dart` or `packages/flutter/lib/src/cupertino/`) can only be used in `cupertino` code and tests (`packages/flutter/lib/src/cupertino/` and `packages/flutter/test/cupertino/`).

--- a/packages/flutter/AGENTS.md
+++ b/packages/flutter/AGENTS.md
@@ -1,6 +1,0 @@
-# Flutter Framework Rules
-
-## Layer Dependency Rules
-
-* `material` (`package:flutter/material.dart` or `src/material/`) can only be used in `material` code and tests (`packages/flutter/lib/src/material/` and `packages/flutter/test/material/`).
-* `cupertino` (`package:flutter/cupertino.dart` or `src/cupertino/`) can only be used in `cupertino` code and tests (`packages/flutter/lib/src/cupertino/` and `packages/flutter/test/cupertino/`).

--- a/packages/flutter/AGENTS.md
+++ b/packages/flutter/AGENTS.md
@@ -1,0 +1,6 @@
+# Flutter Framework Rules
+
+## Layer Dependency Rules
+
+* `material` (`package:flutter/material.dart` or `src/material/`) can only be used in `material` code and tests (`packages/flutter/lib/src/material/` and `packages/flutter/test/material/`).
+* `cupertino` (`package:flutter/cupertino.dart` or `src/cupertino/`) can only be used in `cupertino` code and tests (`packages/flutter/lib/src/cupertino/` and `packages/flutter/test/cupertino/`).


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

seeing a lot of bad agent behavior, I think it warrant a rule

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
