### PR TITLE
Remove octant_offset_c uniform from ubersdf, reorder/document ubersdf uniforms

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -80,7 +80,6 @@ bool UberSDFContents::Render(const ContentContext& renderer,
   frag_info.aa_pixels = UberSDFParameters::kAntialiasPixels;
   frag_info.superellipse_degree = params_.superellipse_degree;
   frag_info.angle_span = params_.angle_span;
-  frag_info.octant_offset_c = params_.octant_offset_c;
   frag_info.circle_center_top = params_.circle_center_top;
   frag_info.circle_center_right = params_.circle_center_right;
   frag_info.radii = params_.radii;

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_parameters.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_parameters.cc
@@ -105,7 +105,6 @@ std::optional<UberSDFParameters> UberSDFParameters::MakeRoundedSuperellipse(
       .superellipse_degree = Point(top_right.top.se_n, top_right.right.se_n),
       .angle_span = Point(top_right.top.circle_max_angle.radians,
                           top_right.right.circle_max_angle.radians),
-      .octant_offset_c = top_right.top.se_a - top_right.right.se_a,
       .circle_center_top = top_right.top.circle_center,
       .circle_center_right = top_right.right.circle_center,
       .radii = Vector4(top_right.top.circle_radius,

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_parameters.h
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_parameters.h
@@ -86,9 +86,6 @@ struct UberSDFParameters {
   /// The angular span of the circular cap for the top and right octants.
   Point angle_span;
 
-  /// The geometric offset 'c' used to connect the two octants of each quadrant.
-  float octant_offset_c;
-
   /// The circular cap center for the top octant of each
   /// quadrant.
   Point circle_center_top;

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_parameters_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_parameters_unittests.cc
@@ -169,10 +169,6 @@ TEST(UberSDFParametersTest, MakeRoundedSuperellipse) {
         params.angle_span.y,
         round_superellipse_params.top_right.right.circle_max_angle.radians);
 
-    EXPECT_EQ(params.octant_offset_c,
-              round_superellipse_params.top_right.top.se_a -
-                  round_superellipse_params.top_right.right.se_a);
-
     EXPECT_EQ(params.circle_center_top,
               round_superellipse_params.top_right.top.circle_center);
     EXPECT_EQ(params.circle_center_right,
@@ -204,8 +200,6 @@ TEST(UberSDFParametersTest, MakeRectangularRoundedSuperellipse) {
     EXPECT_EQ(params.center, Point(60, 120));
     EXPECT_EQ(params.size, Point(50, 100));
     EXPECT_FALSE(params.stroke.has_value());
-
-    EXPECT_EQ(params.octant_offset_c, -50.0f);
   }
 }
 

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -12,20 +12,68 @@ precision mediump float;
 #include "sdf_utils.glsl"
 
 uniform FragInfo {
+  // FragInfo fields are sorted by size (vec4 -> vec2 -> float) to optimize
+  // uniform register usage.
+
+  // ===========================================================================
+  // vec4 fields
+  // ===========================================================================
+
+  /// The RGBA color of the shape.
   vec4 color;
-  vec2 center;
-  vec2 size;
-  float stroke_width;
-  float stroke_join;
-  float aa_pixels;
-  float stroked;
-  float type;
-  vec2 superellipse_degree;
-  vec2 angle_span;
-  float octant_offset_c;
-  vec2 circle_center_top;
-  vec2 circle_center_right;
+  /// Corner radii for rounded rects (top-left, top-right, bottom-left,
+  /// bottom-right), or the circular cap radii for rounded superellipses in
+  /// radii.xy (top octant in x, right octant in y).
   vec4 radii;
+
+  // ===========================================================================
+  // vec2 fields
+  // ===========================================================================
+
+  // --- General Shape Geometry ---
+  /// The center position of the shape in local coordinates.
+  vec2 center;
+  /// The half-dimensions of the shape (half-width, half-height).
+  vec2 size;
+
+  // --- Superellipse Parameters ---
+  /// The exponent degree (n_x, n_y) of the superellipse curvature.
+  vec2 superellipse_degree;
+  /// The angular span of the corner circular arc transitions for rounded
+  /// superellipses.
+  vec2 angle_span;
+  /// The center of the corner transition circle for the top octant of a
+  /// rounded superellipse.
+  vec2 circle_center_top;
+  /// The center of the corner transition circle for the right octant of a
+  /// rounded superellipse.
+  vec2 circle_center_right;
+
+  // ===========================================================================
+  // float fields
+  // ===========================================================================
+
+  // --- General Configuration ---
+  /// The shape type:
+  ///   0: Circle
+  ///   1: Rect
+  ///   2: Oval
+  ///   3: RoundRect
+  ///   4: Rounded Superellipse (must have uniform circular corner radii)
+  float type;
+  /// The width in device pixels over which to apply antialiasing.
+  float aa_pixels;
+
+  // --- Stroke Parameters ---
+  /// Whether the shape is stroked (1.0) or filled (0.0).
+  float stroked;
+  /// The width of the stroke.
+  float stroke_width;
+  /// The join style for the stroke:
+  ///   0: Miter
+  ///   1: Bevel
+  ///   2: Round
+  float stroke_join;
 }
 frag_info;
 
@@ -77,10 +125,12 @@ float distanceFromRoundedSuperellipse(vec2 p,
                                       vec2 radii,
                                       vec2 angle_span,
                                       vec2 circle_center_top,
-                                      vec2 circle_center_right,
-                                      float c) {
+                                      vec2 circle_center_right) {
   // Do work in the first quadrant to simply things.
   p = abs(p);
+
+  // Transition line offset dividing top and right octants.
+  float c = size.x - size.y;
 
   // Declare all RSE params for a single octant.
   float se_degree, span, radius, axis_length;
@@ -195,7 +245,7 @@ vec2 filledSDF(vec2 p) {
     sdf = distanceFromRoundedSuperellipse(
         p, frag_info.superellipse_degree, frag_info.size, frag_info.radii.xy,
         frag_info.angle_span, frag_info.circle_center_top,
-        frag_info.circle_center_right, frag_info.octant_offset_c);
+        frag_info.circle_center_right);
     pixel_size = pixelSize(sdf);
   }
   return vec2(sdf, pixel_size);

--- a/engine/src/flutter/impeller/tools/malioc.json
+++ b/engine/src/flutter/impeller/tools/malioc.json
@@ -8642,7 +8642,7 @@
             "total_cycles": [
               13.625,
               13.625,
-              4.53125,
+              4.5,
               13.4375,
               0.0,
               0.25,
@@ -8669,7 +8669,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              43.88999938964844,
+              44.220001220703125,
               3.0,
               4.0
             ],
@@ -8690,13 +8690,13 @@
               "arithmetic"
             ],
             "total_cycles": [
-              105.66666412353516,
+              106.0,
               3.0,
               24.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 5,
+          "uniform_registers_used": 6,
           "work_registers_used": 4
         }
       }
@@ -11833,7 +11833,7 @@
             "longest_path_cycles": [
               4.0,
               3.387500047683716,
-              1.9375,
+              1.9249999523162842,
               4.0,
               0.0,
               0.25,
@@ -11868,7 +11868,7 @@
             "total_cycles": [
               13.4375,
               12.4375,
-              4.875,
+              4.84375,
               13.4375,
               0.0,
               0.25,
@@ -11877,7 +11877,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 48,
+          "uniform_registers_used": 46,
           "work_registers_used": 32
         }
       }


### PR DESCRIPTION
Followup to https://github.com/flutter/flutter/pull/191235 (Move more RSE rendering cases to complex_rse.frag).

In that PR, there was some discussion about whether removing the `octant_offset_c` uniform would have an affect on the registers used reported by malioc. We decided that we didn't need to remove `octant_offset_c`.

But from testing out the ubesdf gradient changes (https://github.com/flutter/flutter/pull/190874) after merging with https://github.com/flutter/flutter/pull/191235, the Mali-G78 registers used on Vulkan (flutter/impeller/entity/uber_sdf.frag.vkspv) is still 66.

Removing `octant_offset_c` brings the registers used down by 2, as seen in the malioc changes in this PR. So this is needed to bring down the registers used to 64 when the gradient changes are included.

This PR also incorporates the reordering and adding of comments to uber_sdf's uniforms. This way the upcoming gradient change is scoped to only adding the new gradient functionality for easier review.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
