### PR TITLE
[stable] [flutter_tools] Fix crash when migrating flow-style exclude lists in analysis_options.yaml

### DIFF
--- a/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart
@@ -79,6 +79,15 @@ class AnalysisOptionsMigration extends ProjectMigrator {
         final exclude = analyzer['exclude'] as Object?;
         if (exclude is! YamlList) {
           editor.update(<String>['analyzer', 'exclude'], missingExcludes);
+        } else if (exclude.style == CollectionStyle.FLOW) {
+          // Workaround for https://github.com/dart-lang/tools/issues/2532.
+          // Appending to a multiline flow-style list with a trailing comma crashes YamlEditor.
+          // Instead, rewrite the entire exclude list as a block list.
+          final newExcludes = <Object?>[
+            ...exclude,
+            ...missingExcludes.where((String item) => !exclude.contains(item)),
+          ];
+          editor.update(<String>['analyzer', 'exclude'], newExcludes);
         } else {
           for (final missingExclude in missingExcludes) {
             if (!exclude.contains(missingExclude)) {

--- a/packages/flutter_tools/test/general.shard/migrations/analysis_options_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrations/analysis_options_migration_test.dart
@@ -204,6 +204,36 @@ analyzer:
       expect(migratedContents, contains('linux/**'));
     });
 
+    testWithoutContext(
+      'migrates and merges excludes when list is in flow style with newlines',
+      () async {
+        final _TestContext context = _createTestContext();
+        const analysisOptionsContents = '''
+analyzer:
+  exclude:
+    [
+      foo/**,
+      build/**,
+    ]
+''';
+
+        context.analysisOptionsFile.writeAsStringSync(analysisOptionsContents);
+
+        final migration = AnalysisOptionsMigration(context.mockProject, context.testLogger);
+        await migration.migrate();
+
+        final String migratedContents = context.analysisOptionsFile.readAsStringSync();
+        expect(migratedContents, contains('foo/**'));
+        expect(migratedContents, contains('build/**'));
+        expect(migratedContents, contains('android/**'));
+        expect(migratedContents, contains('ios/**'));
+        expect(migratedContents, contains('web/**'));
+        expect(migratedContents, contains('windows/**'));
+        expect(migratedContents, contains('macos/**'));
+        expect(migratedContents, contains('linux/**'));
+      },
+    );
+
     testWithoutContext('skipped if exclusions are inherited via relative include', () async {
       final _TestContext context = _createTestContext();
       const analysisOptionsContents = '''


### PR DESCRIPTION
### Issue Link:
https://github.com/flutter/flutter/issues/191060

### Impact Description:
When `analysis_options.yaml` uses YAML flow-style lists for `analyzer: { exclude: [...] }`, `flutter pub get` or `dart fix` crashes with a `_YamlAssertionError` when attempting to migrate and append platform exclusions. This completely blocks project preparation and tooling execution for projects using flow-style YAML syntax.

### Changelog Description:
[flutter/191060] When `analysis_options.yaml` contains flow-style `exclude:` sequences, `AnalysisOptionsMigration` converts the node to block style before appending to avoid `YamlEditor` assertion crashes.

### Workaround:
Manually edit `analysis_options.yaml` to convert the `exclude:` list from flow style (`[a, b]`) to standard block style (`- a\n- b`).

### Risk:
- [x] Low
- [ ] Medium
- [ ] High

### Test Coverage:
- [x] Yes
- [ ] No

### Validation Steps:
1. Create a Flutter project with `analysis_options.yaml` containing a flow-style `exclude:` list (e.g. `analyzer:\n  exclude: [build/**]`).
2. Run `flutter pub get`.
3. Verify that `flutter pub get` succeeds without a `_YamlAssertionError` crash and correctly migrates the excluded directories.
