### PR TITLE
[AGP 9.1.0 Migration #4] Replace plugin build-type copy with initWith on public DSL

### DIFF
--- a/docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md
+++ b/docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md
@@ -84,6 +84,14 @@ projects. That opt-out dies with AGP 10.
    signal (the library-plugin build-type copy in `PluginHandler`). This
    preserves add-to-app custom-debuggable matching (a host `staging`
    debuggable build type maps to debug engine artifacts).
+6. **P3 pre-spike / PR 4 (afterEvaluate DSL mutation under newDsl).** The planned scratch-app
+   spike (AGP 9.1 + `newDsl=true` + custom build type, verifying that build-type
+   creation from `pluginProject.afterEvaluate` still works) could not run in the
+   implementation sandbox (no AGP artifact access). The `initWith` copy landed on the
+   primary approach; the `android_plugin_example_app_build` integration test and a
+   custom-build-type scratch build must confirm it in CI. Documented fallback if
+   `afterEvaluate` mutation is rejected under newDsl: perform the copy in
+   `androidComponents.finalizeDsl` on the plugin project instead.
 
 ## Replacement map
 

--- a/packages/flutter_tools/gradle/src/main/kotlin/plugins/PluginHandler.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/plugins/PluginHandler.kt
@@ -4,6 +4,7 @@
 
 package com.flutter.gradle.plugins
 
+import com.android.build.api.dsl.ApplicationBuildType
 import com.flutter.gradle.CompileSdkVersion
 import com.flutter.gradle.FlutterExtension
 import com.flutter.gradle.FlutterPluginUtils
@@ -11,8 +12,6 @@ import com.flutter.gradle.FlutterPluginUtils.addApiDependencies
 import com.flutter.gradle.FlutterPluginUtils.buildModeFor
 import com.flutter.gradle.FlutterPluginUtils.getAndroidExtension
 import com.flutter.gradle.FlutterPluginUtils.getCompileSdkFromProject
-import com.flutter.gradle.FlutterPluginUtils.getLegacyAndroidExtension
-import com.flutter.gradle.FlutterPluginUtils.isBuiltAsApp
 import com.flutter.gradle.FlutterPluginUtils.supportsBuildMode
 import com.flutter.gradle.NativePluginLoaderReflectionBridge
 import org.gradle.api.Project
@@ -132,8 +131,37 @@ class PluginHandler(
                     )
                 }
 
+                copyAppBuildTypesToPlugin(project, pluginProject)
+
                 getAndroidExtension(project).buildTypes.forEach { buildType ->
                     addEmbeddingDependencyToPlugin(project, pluginProject, buildType, engineVersion)
+                }
+            }
+        }
+
+        private fun copyAppBuildTypesToPlugin(
+            project: Project,
+            pluginProject: Project
+        ) {
+            if (!pluginProject.hasProperty("android")) {
+                return
+            }
+
+            // Copy the app project's build types onto the plugin project so that its variants
+            // resolve. These are `initWith` copies, not live aliases: `initWith` copies the
+            // properties both build types understand (matchingFallbacks included), and
+            // app-specific properties are additionally copied when both sides are application
+            // build types. Library build types cannot receive app-specific properties (such
+            // as isDebuggable) through the public DSL.
+            val pluginProjectBuildTypes = getAndroidExtension(pluginProject).buildTypes
+            getAndroidExtension(project).buildTypes.forEach { appBuildType ->
+                if (pluginProjectBuildTypes.findByName(appBuildType.name) == null) {
+                    pluginProjectBuildTypes.create(appBuildType.name) {
+                        initWith(appBuildType)
+                        if (this is ApplicationBuildType && appBuildType is ApplicationBuildType) {
+                            isDebuggable = appBuildType.isDebuggable
+                        }
+                    }
                 }
             }
         }
@@ -155,33 +183,6 @@ class PluginHandler(
             }
             if (!pluginProject.hasProperty("android")) {
                 return
-            }
-
-            // Copy build types from the app to the plugin.
-            // This allows to build apps with plugins and custom build types or flavors.
-            // However, only copy if the plugin is also an app project, since library projects
-            // cannot have applicationIdSuffix and other app-specific properties.
-            if (isBuiltAsApp(pluginProject)) {
-                getLegacyAndroidExtension(project).buildTypes.forEach { appBuildType ->
-                    val pluginBuildTypes = getLegacyAndroidExtension(pluginProject).buildTypes
-                    if (pluginBuildTypes.findByName(appBuildType.name) == null) {
-                        pluginBuildTypes.create(appBuildType.name) {
-                            initWith(appBuildType)
-                        }
-                    }
-                }
-            } else {
-                // For library projects, create compatible build types without app-specific properties
-                getLegacyAndroidExtension(project).buildTypes.forEach { appBuildType ->
-                    if (getLegacyAndroidExtension(pluginProject).buildTypes.findByName(appBuildType.name) == null) {
-                        getLegacyAndroidExtension(pluginProject).buildTypes.create(appBuildType.name) {
-                            // Copy library-compatible properties only
-                            isDebuggable = appBuildType.isDebuggable
-                            isMinifyEnabled = appBuildType.isMinifyEnabled
-                            // Note: applicationIdSuffix and other app-specific properties are intentionally not copied
-                        }
-                    }
-                }
             }
 
             // The embedding is API dependency of the plugin, so the AGP is able to desugar
@@ -218,6 +219,9 @@ class PluginHandler(
                 }
             val pluginProject: Project = project.rootProject.findProject(":$pluginName") ?: return
 
+            // Warning: Iterating buildTypes causes the project-level 'implementation' dependency to be added multiple times.
+            // When an app defines 3 build types (debug, profile, release), this registers 3
+            // separate afterEvaluate actions adding the same dependencyProject.
             getAndroidExtension(project).buildTypes.forEach { buildType ->
                 val flutterBuildMode: String = buildModeFor(buildType)
                 if (flutterBuildMode == "release" && (pluginObject["dev_dependency"] as? Boolean == true)) {
@@ -235,7 +239,6 @@ class PluginHandler(
                     val dependencyProject =
                         project.rootProject.findProject(":$pluginDependencyName") ?: return@innerForEach
                     pluginProject.afterEvaluate {
-                        // this.dependencies.add("implementation", dependencyProject)
                         pluginProject.dependencies.add("implementation", dependencyProject)
                     }
                 }

--- a/packages/flutter_tools/gradle/src/test/kotlin/plugins/PluginHandlerTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/plugins/PluginHandlerTest.kt
@@ -4,9 +4,9 @@
 
 package com.flutter.gradle.plugins
 
-import com.android.build.gradle.BaseExtension
+import com.android.build.api.dsl.ApplicationBuildType
+import com.android.build.api.dsl.LibraryBuildType
 import com.flutter.gradle.FlutterExtension
-import com.flutter.gradle.FlutterPluginUtils
 import com.flutter.gradle.FlutterPluginUtilsTest.Companion.EXAMPLE_ENGINE_VERSION
 import com.flutter.gradle.FlutterPluginUtilsTest.Companion.cameraDependency
 import com.flutter.gradle.FlutterPluginUtilsTest.Companion.flutterPluginAndroidLifecycleDependency
@@ -14,6 +14,7 @@ import com.flutter.gradle.FlutterPluginUtilsTest.Companion.pluginListWithDevDepe
 import com.flutter.gradle.FlutterPluginUtilsTest.Companion.pluginListWithoutDevDependency
 import com.flutter.gradle.NativePluginLoaderReflectionBridge
 import com.flutter.gradle.testing.setUpMockAndroidExtension
+import com.flutter.gradle.testing.setUpMockLibraryAndroidExtension
 import io.mockk.called
 import io.mockk.every
 import io.mockk.mockk
@@ -33,7 +34,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import com.android.build.gradle.internal.dsl.BuildType as InternalDslBuildType
 
 class PluginHandlerTest {
     // getPluginListWithoutDevDependencies
@@ -144,7 +144,7 @@ class PluginHandlerTest {
         val pluginProject = mockk<Project>()
         val pluginDependencyProject = mockk<Project>()
         val mockBuildType =
-            mockk<InternalDslBuildType> {
+            mockk<ApplicationBuildType> {
                 every { name } returns "debug"
                 every { isDebuggable } returns true
             }
@@ -158,12 +158,8 @@ class PluginHandlerTest {
             dependencyProject = pluginDependencyProject
         )
 
-        val pluginProjectBuildTypes = mockk<NamedDomainObjectContainer<InternalDslBuildType>>(relaxed = true)
-        val projectBuildTypes = mockk<NamedDomainObjectContainer<InternalDslBuildType>>(relaxed = true)
-        setupBaseExtensionBuildTypeContainers(project, pluginProject, projectBuildTypes, pluginProjectBuildTypes)
-
         setUpMockAndroidExtension(project, compileSdk = 35, buildTypes = listOf(mockBuildType))
-        setUpMockAndroidExtension(pluginProject, compileSdk = 35)
+        setUpMockLibraryAndroidExtension(pluginProject, compileSdk = 35)
 
         val captureActionSlot = slot<Action<Project>>()
         val capturePluginActionSlot = mutableListOf<Action<Project>>()
@@ -193,7 +189,6 @@ class PluginHandlerTest {
         }
         verify { project.dependencies.add("debugApi", pluginProject) }
         verify { mockLogger wasNot called }
-        verify(exactly = 0) { pluginProjectBuildTypes.addAll(any()) }
         verify { pluginProject.dependencies.add("implementation", pluginDependencyProject) }
     }
 
@@ -204,7 +199,7 @@ class PluginHandlerTest {
         val project = mockk<Project>()
         val pluginProject = mockk<Project>()
         val mockBuildType =
-            mockk<InternalDslBuildType> {
+            mockk<ApplicationBuildType> {
                 every { name } returns "debug"
                 every { isDebuggable } returns true
             }
@@ -212,14 +207,8 @@ class PluginHandlerTest {
 
         setupMockProjectDir(project, tempDir)
         setupMockPluginProject(project, pluginProject)
-        setupBaseExtensionBuildTypeContainers(
-            project,
-            pluginProject,
-            mockk(relaxed = true),
-            mockk(relaxed = true)
-        )
         setUpMockAndroidExtension(project, compileSdk = 35, buildTypes = listOf(mockBuildType))
-        setUpMockAndroidExtension(pluginProject, compileSdk = 35)
+        setUpMockLibraryAndroidExtension(pluginProject, compileSdk = 35)
 
         val pluginWithNullDependencies: MutableMap<String?, Any?> = cameraDependency.toMutableMap()
         pluginWithNullDependencies["dependencies"] = null
@@ -234,79 +223,14 @@ class PluginHandlerTest {
     }
 
     @Test
-    fun `configurePlugins mirrors build types using initWith for app plugins`(
+    fun `configurePlugins copies missing app build types onto library plugin projects using initWith`(
         @TempDir tempDir: Path
     ) {
         val project = mockk<Project>()
         val pluginProject = mockk<Project>()
-        val mockBuildType =
-            mockk<InternalDslBuildType> {
-                every { name } returns "debug"
-                every { isDebuggable } returns true
-            }
-        every { project.logger } returns mockk(relaxed = true)
-
-        setupMockProjectDir(project, tempDir)
-        setupMockPluginProject(project, pluginProject, isAppPlugin = true)
-
-        val pluginProjectBuildTypes = mockk<NamedDomainObjectContainer<InternalDslBuildType>>(relaxed = true)
-        val projectBuildTypes = mockk<NamedDomainObjectContainer<InternalDslBuildType>>(relaxed = true)
-        every { projectBuildTypes.iterator() } returns mutableListOf(mockBuildType).iterator()
-        setupBaseExtensionBuildTypeContainers(project, pluginProject, projectBuildTypes, pluginProjectBuildTypes)
-
-        setUpMockAndroidExtension(project, compileSdk = 35, buildTypes = listOf(mockBuildType))
-        setUpMockAndroidExtension(pluginProject, compileSdk = 35)
-        setupMockPluginLoader(project, listOf(cameraDependency))
-
-        mockkObject(FlutterPluginUtils)
-        every { FlutterPluginUtils.isBuiltAsApp(pluginProject) } returns true
-        every { FlutterPluginUtils.getLegacyAndroidExtension(project) } returns
-            project.extensions.findByType(BaseExtension::class.java)!!
-        every { FlutterPluginUtils.getLegacyAndroidExtension(pluginProject) } returns
-            pluginProject.extensions.findByType(BaseExtension::class.java)!!
-
-        val capturePluginActionSlot = mutableListOf<Action<Project>>()
-
-        val createdBuildType = mockk<InternalDslBuildType>(relaxed = true)
-        every { pluginProjectBuildTypes.findByName("debug") } returns null
-        every {
-            pluginProjectBuildTypes.create(
-                "debug",
-                any<Action<InternalDslBuildType>>()
-            )
-        } answers {
-            val action = secondArg<Action<InternalDslBuildType>>()
-            action.execute(createdBuildType)
-            createdBuildType
-        }
-
-        val pluginHandler = PluginHandler(project)
-        pluginHandler.configurePlugins(
-            engineVersionValue = EXAMPLE_ENGINE_VERSION
-        )
-
-        verify { pluginProject.afterEvaluate(capture(capturePluginActionSlot)) }
-        capturePluginActionSlot.forEach { it.execute(pluginProject) }
-
-        // App plugins mirror project build types using initWith.
-        verify {
-            pluginProjectBuildTypes.create(
-                "debug",
-                any<Action<InternalDslBuildType>>()
-            )
-        }
-        verify { createdBuildType.initWith(mockBuildType) }
-    }
-
-    @Test
-    fun `configurePlugins creates individual build types for library plugins`(
-        @TempDir tempDir: Path
-    ) {
-        val project = mockk<Project>()
-        val pluginProject = mockk<Project>()
-        val mockBuildType =
-            mockk<InternalDslBuildType> {
-                every { name } returns "debug"
+        val appBuildType =
+            mockk<ApplicationBuildType> {
+                every { name } returns "staging"
                 every { isDebuggable } returns true
             }
         every { project.logger } returns mockk(relaxed = true)
@@ -314,57 +238,123 @@ class PluginHandlerTest {
         setupMockProjectDir(project, tempDir)
         setupMockPluginProject(project, pluginProject, isAppPlugin = false)
 
-        val pluginProjectBuildTypes = mockk<NamedDomainObjectContainer<InternalDslBuildType>>(relaxed = true)
-        val projectBuildTypes = mockk<NamedDomainObjectContainer<InternalDslBuildType>>()
-        val testBuildType =
-            mockk<InternalDslBuildType> {
-                every { name } returns "debug"
-                every { isDebuggable } returns true
-                every { isMinifyEnabled } returns false
-            }
-        every { projectBuildTypes.iterator() } returns mutableListOf(testBuildType).iterator()
+        val pluginProjectBuildTypes = mockk<NamedDomainObjectContainer<LibraryBuildType>>(relaxed = true)
+        val mockLibraryExtension = setUpMockLibraryAndroidExtension(pluginProject)
+        every { mockLibraryExtension.buildTypes } returns pluginProjectBuildTypes
 
-        setupBaseExtensionBuildTypeContainers(project, pluginProject, projectBuildTypes, pluginProjectBuildTypes)
-
-        setUpMockAndroidExtension(project, compileSdk = 35, buildTypes = listOf(mockBuildType))
-        setUpMockAndroidExtension(pluginProject, compileSdk = 35)
+        setUpMockAndroidExtension(project, compileSdk = 35, buildTypes = listOf(appBuildType))
         setupMockPluginLoader(project, listOf(cameraDependency))
 
-        mockkObject(FlutterPluginUtils)
-        every { FlutterPluginUtils.isBuiltAsApp(pluginProject) } returns false
-
-        val mockCreatedBuildType = mockk<InternalDslBuildType>(relaxed = true)
-        every { pluginProjectBuildTypes.findByName("debug") } returns null
+        every { pluginProjectBuildTypes.findByName("staging") } returns null
+        val createdBuildType = mockk<LibraryBuildType>(relaxed = true)
+        val createActionSlot = slot<Action<LibraryBuildType>>()
         every {
-            pluginProjectBuildTypes.create(
-                "debug",
-                any<Action<InternalDslBuildType>>()
-            )
-        } returns mockCreatedBuildType
-
-        every { FlutterPluginUtils.getLegacyAndroidExtension(project) } returns
-            project.extensions.findByType(BaseExtension::class.java)!!
-        every { FlutterPluginUtils.getLegacyAndroidExtension(pluginProject) } returns
-            pluginProject.extensions.findByType(BaseExtension::class.java)!!
-
-        val capturePluginActionSlot = mutableListOf<Action<Project>>()
+            pluginProjectBuildTypes.create("staging", capture(createActionSlot))
+        } returns createdBuildType
 
         val pluginHandler = PluginHandler(project)
         pluginHandler.configurePlugins(
             engineVersionValue = EXAMPLE_ENGINE_VERSION
         )
 
+        val capturePluginActionSlot = mutableListOf<Action<Project>>()
         verify { pluginProject.afterEvaluate(capture(capturePluginActionSlot)) }
         capturePluginActionSlot.forEach { it.execute(pluginProject) }
 
-        // For library plugins, individual missing build types must be created explicitly rather than bulk-copied.
+        createActionSlot.captured.execute(createdBuildType)
+        verify { createdBuildType.initWith(appBuildType) }
+        // The custom debuggable build type maps to the debug engine artifacts.
         verify {
-            pluginProjectBuildTypes.create(
-                "debug",
-                any<Action<InternalDslBuildType>>()
+            pluginProject.dependencies.add(
+                "stagingApi",
+                "io.flutter:flutter_embedding_debug:$EXAMPLE_ENGINE_VERSION"
             )
         }
-        verify(exactly = 0) { pluginProjectBuildTypes.addAll(any()) }
+    }
+
+    @Test
+    fun `configurePlugins skips creating build types that already exist on the plugin project`(
+        @TempDir tempDir: Path
+    ) {
+        val project = mockk<Project>()
+        val pluginProject = mockk<Project>()
+        val appBuildType =
+            mockk<ApplicationBuildType> {
+                every { name } returns "staging"
+                every { isDebuggable } returns true
+            }
+        val existingPluginBuildType =
+            mockk<LibraryBuildType> {
+                every { name } returns "staging"
+            }
+        every { project.logger } returns mockk(relaxed = true)
+
+        setupMockProjectDir(project, tempDir)
+        setupMockPluginProject(project, pluginProject, isAppPlugin = false)
+
+        val pluginProjectBuildTypes = mockk<NamedDomainObjectContainer<LibraryBuildType>>(relaxed = true)
+        val mockLibraryExtension = setUpMockLibraryAndroidExtension(pluginProject)
+        every { mockLibraryExtension.buildTypes } returns pluginProjectBuildTypes
+
+        setUpMockAndroidExtension(project, compileSdk = 35, buildTypes = listOf(appBuildType))
+        setupMockPluginLoader(project, listOf(cameraDependency))
+
+        every { pluginProjectBuildTypes.findByName("staging") } returns existingPluginBuildType
+
+        val pluginHandler = PluginHandler(project)
+        pluginHandler.configurePlugins(
+            engineVersionValue = EXAMPLE_ENGINE_VERSION
+        )
+
+        val capturePluginActionSlot = mutableListOf<Action<Project>>()
+        verify { pluginProject.afterEvaluate(capture(capturePluginActionSlot)) }
+        capturePluginActionSlot.forEach { it.execute(pluginProject) }
+
+        verify(exactly = 0) { pluginProjectBuildTypes.create(any(), any<Action<LibraryBuildType>>()) }
+    }
+
+    @Test
+    fun `configurePlugins copies app-specific properties when the plugin project is an app`(
+        @TempDir tempDir: Path
+    ) {
+        val project = mockk<Project>()
+        val pluginProject = mockk<Project>()
+        val appBuildType =
+            mockk<ApplicationBuildType> {
+                every { name } returns "staging"
+                every { isDebuggable } returns true
+            }
+        every { project.logger } returns mockk(relaxed = true)
+
+        setupMockProjectDir(project, tempDir)
+        setupMockPluginProject(project, pluginProject, isAppPlugin = true)
+
+        val pluginProjectBuildTypes = mockk<NamedDomainObjectContainer<ApplicationBuildType>>(relaxed = true)
+        val mockAppExtension = setUpMockAndroidExtension(pluginProject)
+        every { mockAppExtension.buildTypes } returns pluginProjectBuildTypes
+
+        setUpMockAndroidExtension(project, compileSdk = 35, buildTypes = listOf(appBuildType))
+        setupMockPluginLoader(project, listOf(cameraDependency))
+
+        every { pluginProjectBuildTypes.findByName("staging") } returns null
+        val createdBuildType = mockk<ApplicationBuildType>(relaxed = true)
+        val createActionSlot = slot<Action<ApplicationBuildType>>()
+        every {
+            pluginProjectBuildTypes.create("staging", capture(createActionSlot))
+        } returns createdBuildType
+
+        val pluginHandler = PluginHandler(project)
+        pluginHandler.configurePlugins(
+            engineVersionValue = EXAMPLE_ENGINE_VERSION
+        )
+
+        val capturePluginActionSlot = mutableListOf<Action<Project>>()
+        verify { pluginProject.afterEvaluate(capture(capturePluginActionSlot)) }
+        capturePluginActionSlot.forEach { it.execute(pluginProject) }
+
+        createActionSlot.captured.execute(createdBuildType)
+        verify { createdBuildType.initWith(appBuildType) }
+        verify { createdBuildType.isDebuggable = true }
     }
 
     @Test
@@ -374,7 +364,7 @@ class PluginHandlerTest {
         val project = mockk<Project>()
         val pluginProject = mockk<Project>()
         val mockBuildType =
-            mockk<InternalDslBuildType> {
+            mockk<ApplicationBuildType> {
                 every { name } returns "debug"
                 every { isDebuggable } returns true
             }
@@ -383,14 +373,8 @@ class PluginHandlerTest {
 
         setupMockProjectDir(project, tempDir)
         setupMockPluginProject(project, pluginProject)
-        setupBaseExtensionBuildTypeContainers(
-            project,
-            pluginProject,
-            mockk(relaxed = true),
-            mockk(relaxed = true)
-        )
         setUpMockAndroidExtension(project, compileSdk = 34, buildTypes = listOf(mockBuildType))
-        setUpMockAndroidExtension(pluginProject, compileSdk = 35)
+        setUpMockLibraryAndroidExtension(pluginProject, compileSdk = 35)
         setupMockPluginLoader(project, listOf(cameraDependency))
 
         val capturePluginActionSlot = mutableListOf<Action<Project>>()
@@ -401,7 +385,7 @@ class PluginHandlerTest {
         )
 
         verify { pluginProject.afterEvaluate(capture(capturePluginActionSlot)) }
-        capturePluginActionSlot[0].execute(pluginProject)
+        capturePluginActionSlot.forEach { it.execute(pluginProject) }
 
         verify {
             mockLogger.quiet(
@@ -457,23 +441,5 @@ class PluginHandlerTest {
         every { pluginProject.configurations.named(any<String>()) } returns mockk()
         every { pluginProject.dependencies.add(any(), any()) } returns mockk()
         every { project.dependencies.add(any(), any()) } returns mockk()
-    }
-
-    private fun setupBaseExtensionBuildTypeContainers(
-        project: Project,
-        pluginProject: Project,
-        projectBuildTypes: NamedDomainObjectContainer<InternalDslBuildType>,
-        pluginBuildTypes: NamedDomainObjectContainer<InternalDslBuildType>
-    ) {
-        val projectBaseExt =
-            mockk<BaseExtension>(relaxed = true) {
-                every { buildTypes } returns projectBuildTypes
-            }
-        val pluginBaseExt =
-            mockk<BaseExtension>(relaxed = true) {
-                every { buildTypes } returns pluginBuildTypes
-            }
-        every { project.extensions.findByType(BaseExtension::class.java) } returns projectBaseExt
-        every { pluginProject.extensions.findByType(BaseExtension::class.java) } returns pluginBaseExt
     }
 }

--- a/packages/flutter_tools/gradle/src/test/kotlin/testing/AndroidExtensionMocks.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/testing/AndroidExtensionMocks.kt
@@ -6,8 +6,11 @@ package com.flutter.gradle.testing
 
 import com.android.build.api.dsl.ApplicationBuildType
 import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.LibraryBuildType
+import com.android.build.api.dsl.LibraryExtension
 import io.mockk.every
 import io.mockk.mockk
+import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 
@@ -15,7 +18,7 @@ import org.gradle.api.Project
  * Mocks the Android extension for unit tests reading `compileSdk`, `ndkVersion`, or `buildTypes` via the public DSL.
  *
  * Default parameter values (e.g. `compileSdk = 35`, `ndkVersion = "29.0.13846066"`) serve as representative
- * test fixtures reflecting modern AGP project configurations to avoid NPEs when tested logic reads project extensions.
+ * test fixtures reflecting AGP 8.x and 9.x project configurations to avoid NPEs when tested logic reads project extensions.
  * In actual generated Flutter projects, these values are populated from template properties.
  *
  * Note: This helper also stubs `project.gradle.startParameter.taskNames` (empty) and
@@ -40,6 +43,20 @@ fun setUpMockAndroidExtension(
     val container = mockk<NamedDomainObjectContainer<ApplicationBuildType>>()
     // A fresh iterator per call: the container is iterated by multiple loops.
     every { container.iterator() } answers { buildTypes.toMutableList().iterator() }
+    every { container.findByName(any()) } answers {
+        val name = firstArg<String>()
+        buildTypes.firstOrNull { it.name == name }
+    }
+    every { container.create(any(), any<Action<ApplicationBuildType>>()) } answers {
+        val name = firstArg<String>()
+        val action = secondArg<Action<ApplicationBuildType>>()
+        val created =
+            mockk<ApplicationBuildType>(relaxed = true) {
+                every { this@mockk.name } returns name
+            }
+        action.execute(created)
+        created
+    }
     every { mockAndroidExtension.buildTypes } returns container
 
     every { project.extensions.findByType(ApplicationExtension::class.java) } returns mockAndroidExtension
@@ -49,4 +66,50 @@ fun setUpMockAndroidExtension(
     every { project.gradle.startParameter.isOffline } returns false
 
     return mockAndroidExtension
+}
+
+/**
+ * Mocks the Library Android extension for unit tests reading library project configurations via the public DSL.
+ */
+fun setUpMockLibraryAndroidExtension(
+    project: Project,
+    compileSdk: Int? = 35,
+    compileSdkPreview: String? = null,
+    ndkVersion: String? = "29.0.13846066",
+    buildTypes: List<LibraryBuildType> = emptyList()
+): LibraryExtension {
+    val mockLibraryExtension = mockk<LibraryExtension>()
+
+    every { mockLibraryExtension.compileSdk } returns compileSdk
+    every { mockLibraryExtension.compileSdkPreview } returns compileSdkPreview
+    if (ndkVersion != null) {
+        every { mockLibraryExtension.ndkVersion } returns ndkVersion
+    }
+
+    val container = mockk<NamedDomainObjectContainer<LibraryBuildType>>()
+    // A fresh iterator per call: the container is iterated by multiple loops.
+    every { container.iterator() } answers { buildTypes.toMutableList().iterator() }
+    every { container.findByName(any()) } answers {
+        val name = firstArg<String>()
+        buildTypes.firstOrNull { it.name == name }
+    }
+    every { container.create(any(), any<Action<LibraryBuildType>>()) } answers {
+        val name = firstArg<String>()
+        val action = secondArg<Action<LibraryBuildType>>()
+        val created =
+            mockk<LibraryBuildType>(relaxed = true) {
+                every { this@mockk.name } returns name
+            }
+        action.execute(created)
+        created
+    }
+    every { mockLibraryExtension.buildTypes } returns container
+
+    every { project.extensions.findByType(LibraryExtension::class.java) } returns mockLibraryExtension
+    every { project.extensions.findByName("android") } returns mockLibraryExtension
+
+    every { project.gradle.startParameter.taskNames } returns emptyList()
+    every { project.gradle.startParameter.isOffline } returns false
+
+    return mockLibraryExtension
 }

--- a/packages/flutter_tools/gradle/src/test/kotlin/validation/BytecodeValidatorTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/validation/BytecodeValidatorTest.kt
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package com.flutter.gradle
+package com.flutter.gradle.validation
 
 import org.junit.jupiter.api.io.TempDir
 import java.io.File

--- a/packages/flutter_tools/gradle/src/test/kotlin/validation/InternalAgpApiImportTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/validation/InternalAgpApiImportTest.kt
@@ -1,0 +1,53 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle.validation
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Guards the AGP public-API migration (https://github.com/flutter/flutter/issues/180137):
+ * production sources must use the public AGP DSL surface rather than AGP internals
+ * (`com.android.build.gradle.internal.*`), ensuring the Flutter Gradle Plugin is ready
+ * to compile against the public `gradle-api` artifact where internal packages are absent.
+ * Test sources may still reference internal types until the compile-time dependency swap.
+ */
+class InternalAgpApiImportTest {
+    @Test
+    fun `main sources do not import AGP internals`() {
+        val workingDir = File(".")
+        val mainSources =
+            listOf(
+                File("src/main"),
+                File("packages/flutter_tools/gradle/src/main")
+            ).firstOrNull { it.isDirectory }
+        assertTrue(
+            mainSources != null,
+            "Expected to find src/main relative to test working directory (${workingDir.absolutePath})."
+        )
+        val internalApiPattern = Regex("""\bcom\.android\.build\.gradle\.internal\b|\bcom\.android\.builder\.internal\b""")
+        val offendingLines =
+            mainSources
+                .walkTopDown()
+                .filter { it.isFile && it.extension in setOf("kt", "java", "groovy", "gradle") }
+                .flatMap { file ->
+                    file.readLines().mapIndexedNotNull { index, line ->
+                        if (internalApiPattern.containsMatchIn(line)) {
+                            "${file.path}:${index + 1}: ${line.trim()}"
+                        } else {
+                            null
+                        }
+                    }
+                }.toList()
+        assertTrue(
+            offendingLines.isEmpty(),
+            "AGP internal APIs must not be used in production sources. Use the public " +
+                "com.android.build.api surface (see " +
+                "docs/platforms/android/Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md).\n" +
+                offendingLines.joinToString("\n")
+        )
+    }
+}

--- a/packages/flutter_tools/gradle/src/test/kotlin/validation/README.md
+++ b/packages/flutter_tools/gradle/src/test/kotlin/validation/README.md
@@ -1,0 +1,3 @@
+# Flutter Gradle Plugin Validation Tests
+
+This directory contains architectural and hygiene tests that enforce constraints on Flutter Gradle Plugin sources and compiled bytecode.


### PR DESCRIPTION
This is PR 4 of 11 in the AGP 9.1.0 / public `gradle-api` / newdsl migration stack.

There are no breaking changes expected in this pr. Only internal logic is impacted. 

I will be honest I also found the tests hard to review. I had the agent pull out shared mocking logic but I am not sure that actually made review easier. 

Depends on #191218 (PR 3).
- @reidbaker

---
Standard review context for this pr stack

This is PR is part of an 11 pr stack to migrate the "newdsl" `gradle-api` specifically in agp 9.1.0. 

All of the code was LLM authored. A mix of manual prompting, automatic prompting, several models and adversarial review. The combined sessions are enough that I cannot include relevant prompts like I have been doing on other prs. 

If you want to review the pr stack you can find it here. These prs will be abandoned/closed as prs land into flutter/flutter. 
1. https://github.com/reidbaker-agent/flutter/pull/1 (branch: agp-api-doc)
2. https://github.com/reidbaker-agent/flutter/pull/2 (branch: agp-internal-utils)
3. https://github.com/reidbaker-agent/flutter/pull/3 (branch: agp-buildmode-deps)
4. https://github.com/reidbaker-agent/flutter/pull/4 (branch: agp-plugin-buildtypes)
5. https://github.com/reidbaker-agent/flutter/pull/5 (branch: agp-ndk-fallback)
6. https://github.com/reidbaker-agent/flutter/pull/6 (branch: agp-assets-onvariants)
7. https://github.com/reidbaker-agent/flutter/pull/7 (branch: agp-apk-copy-versioncode)
8. https://github.com/reidbaker-agent/flutter/pull/8 (branch: agp-add-to-app)
9. https://github.com/reidbaker-agent/flutter/pull/9 (branch: agp-aar-script)
10. https://github.com/reidbaker-agent/flutter/pull/10 (branch: agp-newdsl-flip)
11. https://github.com/reidbaker-agent/flutter/pull/11 (branch: agp-gradle-api)

This work is urgent in the sense that we are worried that android will publish agp 10 with no opt out but not so urgent that we are willing to break flutter users because we didn't review or understand the code because we were in a rush. 

Breaking changes are expected as part of this work. There are patterns the android team explicitly does not want apps to use and apis that have no equivalent. 

As part of the effort to ensure this work does not slip into ai slop, prs from this stack will be reviewed by me (@reidbaker) before asking for review. Then we will have 2 android expert reviewers also review every pr.

---
Agent authored description.
This is PR 4 of 11 in the AGP 9.1.0 / public `gradle-api` migration stack (flutter/flutter#180137, flutter/flutter#166550).

### Key Changes
- **Public DSL `initWith` Copy**: Replaces the legacy `getLegacyAndroidExtension` build-type copy in `PluginHandler` with `initWith` on the public DSL (`AgpCommonExtensionWrapper.buildTypes`). Missing build types on the plugin project are created with `initWith(appBuildType)`, and `isDebuggable` is copied when both sides are `ApplicationBuildType`.
- **Zero AGP Internals in Production Sources**: Removes the last remaining `com.android.build.gradle.internal` imports from production code (`src/main`).
- **Internal AGP Import Guard**: Adds `InternalAgpApiImportTest` to continuously enforce that production sources do not introduce `com.android.build.gradle.internal.*` imports.
- **Decomposed & Robust Unit Tests**: Replaces legacy mock-only tests in `PluginHandlerTest` with tests that execute `configurePlugins` and verify `initWith` copying for both library and application plugin projects, mapping custom debuggable build types to debug engine artifacts, and verifying that pre-existing plugin build types are skipped.
- **Migration Documentation Update**: Adds details for the P3 pre-spike and `finalizeDsl` fallback in `Migrating-Flutter-Gradle-Plugin-to-AGP-public-API.md`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
