### PR TITLE
[stable] [flutter_tools] Handle HttpException during VM service connection

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -146,9 +146,7 @@ Future<io.WebSocket> _defaultOpenChannel(
     attempts += 1;
     try {
       socket = await constructor(url, compression: compression, logger: logger);
-    } on io.WebSocketException catch (e) {
-      await handleError(e);
-    } on io.SocketException catch (e) {
+    } on io.IOException catch (e) {
       await handleError(e);
     }
   }

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -108,6 +108,37 @@ void main() {
     });
   }, overrides: <Type, Generator>{WebSocketConnector: () => failingWebSocketConnector});
 
+  testUsingContext(
+    'VM Service prints messages for HttpException connection failures and retries',
+    () {
+      final logger = BufferLogger.test();
+      FakeAsync().run((FakeAsync time) {
+        final Uri uri = Uri.parse('ws://127.0.0.1:12345/QqL7EFEDNG0=/ws');
+        unawaited(connectToVmService(uri, logger: logger));
+
+        time.elapse(const Duration(seconds: 5));
+        expect(logger.statusText, isEmpty);
+
+        time.elapse(const Duration(minutes: 2));
+
+        final String statusText = logger.statusText;
+        expect(
+          statusText,
+          containsIgnoringWhitespace(
+            'Connecting to the VM Service is taking longer than expected...',
+          ),
+        );
+        expect(statusText, containsIgnoringWhitespace('try re-running with --host-vmservice-port'));
+        expect(
+          statusText,
+          containsIgnoringWhitespace('Exception attempting to connect to the VM Service:'),
+        );
+        expect(statusText, containsIgnoringWhitespace('This was attempt #50. Will retry'));
+      });
+    },
+    overrides: <Type, Generator>{WebSocketConnector: () => httpFailingWebSocketConnector},
+  );
+
   testWithoutContext('setAssetDirectory forwards arguments correctly', () async {
     final mockVMService = FakeVMService();
     final flutterVmService = FlutterVmService(mockVMService);
@@ -737,4 +768,15 @@ Future<io.WebSocket> failingWebSocketConnector(
   Logger? logger,
 }) {
   throw const io.SocketException('Failed WebSocket connection');
+}
+
+/// A [WebSocketConnector] that always throws an [io.HttpException].
+Future<io.WebSocket> httpFailingWebSocketConnector(
+  String url, {
+  io.CompressionOptions? compression,
+  Logger? logger,
+}) {
+  throw const io.HttpException(
+    'Connection closed before full header was received, uri = http://127.0.0.1:63745/TjwUKCgX5S8=/ws',
+  );
 }


### PR DESCRIPTION
### Issue Link:
https://github.com/flutter/flutter/issues/191178

### Impact Description:
During application launch or debugger attach (`flutter run` / `flutter attach`), transient socket resets before HTTP headers complete cause `dart:io` to throw `HttpException`. The connection error was formatted as a raw `String` and passed to `Completer.completeError()`, which bypassed `on Exception` catch blocks in `ColdRunner` and `HotRunner` and resulted in unhandled crashes. This is a top-10 crash signature in Flutter 3.47.0 telemetry.

### Changelog Description:
[flutter/191178] Handle `HttpException` during VM service connection retries and ensure typed exceptions are passed to error completers.

### Workaround:
Rerun `flutter run` or `flutter attach` to re-attempt connection.

### Risk:
- [x] Low
- [ ] Medium
- [ ] High

### Test Coverage:
- [x] Yes
- [ ] No

### Validation Steps:
1. Run unit tests in `packages/flutter_tools/test/general.shard/vmservice_test.dart` and `packages/flutter_tools/test/general.shard/resident_runner_test.dart`.
2. Launch a Flutter app and verify that transient VM service connection resets are retried and caught cleanly without crashing the CLI with an unhandled `String` exception.
