### PR TITLE
iOS,macOS: Compile Swift with opt flags in opt builds

### DIFF
--- a/engine/src/build/config/compiler/BUILD.gn
+++ b/engine/src/build/config/compiler/BUILD.gn
@@ -1016,6 +1016,7 @@ config("optimize") {
     cflags = [ "/O1" ] + common_optimize_on_cflags + [ "/Oi" ]
   } else if (is_ios) {
     cflags = [ "-Os" ] + common_optimize_on_cflags  # Favor size over speed.
+    swiftflags = [ "-Osize" ]
   } else if (is_android || is_fuchsia) {
     cflags = [ "-Oz" ] + common_optimize_on_cflags  # Favor size over speed.
   } else if (is_wasm) {
@@ -1027,8 +1028,10 @@ config("optimize") {
   } else {
     if (optimize_for_size) {
       cflags = [ "-Os" ] + common_optimize_on_cflags
+      swiftflags = [ "-Osize" ]
     } else {
       cflags = [ "-O2" ] + common_optimize_on_cflags
+      swiftflags = [ "-O" ]
     }
   }
 
@@ -1070,6 +1073,7 @@ config("no_optimize") {
     ldflags = common_optimize_on_ldflags
   } else {
     cflags = [ "-O0" ]
+    swiftflags = [ "-Onone" ]
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterRunLoop.swift
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterRunLoop.swift
@@ -92,7 +92,7 @@ import Foundation
   // Ensures that the `FlutterRunLoop` for main thread is initialized. Only
   // needs to be called once and must be called on the main thread.
   @objc static func ensureMainLoopInitialized() {
-    assert(Thread.isMainThread, "Must be called on the main thread.")
+    precondition(Thread.isMainThread, "Must be called on the main thread.")
     if _mainRunLoop == nil {
       _mainRunLoop = FlutterRunLoop()
     }


### PR DESCRIPTION
We never passed optimisation flags to `swiftc`, and the compiler's default is `-Onone`, so all of the Darwin embedders' Swift shipped unoptimised in profile and release, and `assert()`s triggered in shipping binaries, as seen in flutter/flutter#190909.

This updates our optimisation gn configs to set equivalent `swiftflags` alongside the `cflags` we already set. For iOS that means `-Osize` (to match `-Os` for Obj-C/C++). For macOS, that means `-O` (to match `-O2` for Obj-C/C++, Swift just has -O, no -O2, -O3). For both, we set and `-Onone` for `:no_optimize`.

When `is_debug` is true, we default to unopt. Swift `assert()` behaves like `FML_DCHECK` (active in unopt, compiled out in opt builds) and we should use `precondition()` where we'd use `FML_CHECK` -- i.e. cases we want to assert even in release builds.

The following dev-specific asserts are now compiled out from shipped engines:
* `DisplayLinkManager.shared` main-thread check
* `KeyboardInsetManager` vsync client internal-state check
* `FlutterRunLoop.mainRunLoop` the guard check already triggers
* `TraceScope.deinit` ensure `end()` was called

This also moves the main-thread check in
`FlutterRunLoop.ensureMainLoopInitialized` to a `precondition`. Binding the main run loop to the wrong thread silently leaves everything later scheduled on it running on the wrong thread so we should continue to blow up in all modes.

This change chops 130272 bytes (0.79%) off `Flutter.framework` on `ios_release`.

Issue: https://github.com/flutter/flutter/issues/191616
Related: https://github.com/flutter/flutter/issues/190909 (demonstrates existing behaviour)

No new tests, since this is a compile config change: the build *is* the test, along with not breaking the existing tests.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
