### PR TITLE
iOS: Ensure engine is run on the main thread

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -56,6 +56,11 @@ extern NSString* const FlutterDefaultInitialRoute;
  * A newly initialized FlutterEngine will not actually run a Dart Isolate until
  * either `-runWithEntrypoint:` or `-runWithEntrypoint:libraryURI` is invoked.
  * One of these methods must be invoked before calling `-setViewController:`.
+ *
+ * `FlutterEngine` instances must be created and run on the main thread. The engine adopts the
+ * thread that runs it as its platform thread, which is also used for executing application UI code
+ * written in Dart. Running an engine on a background queue is not supported, apps and app
+ * extensions must dispatch to the main queue.
  */
 FLUTTER_DARWIN_EXPORT
 @interface FlutterEngine : NSObject <FlutterPluginRegistry>
@@ -76,7 +81,7 @@ FLUTTER_DARWIN_EXPORT
  * This means that the engine will continue to run regardless of whether a `FlutterViewController`
  * is attached to it or not, until `-destroyContext:` is called or the process finishes.
  */
-- (instancetype)init;
+- (instancetype)init NS_SWIFT_UI_ACTOR;
 
 /**
  * Initialize this FlutterEngine.
@@ -95,7 +100,7 @@ FLUTTER_DARWIN_EXPORT
  *   be unique across FlutterEngine instances, and is used in instrumentation to label
  *   the threads used by this FlutterEngine.
  */
-- (instancetype)initWithName:(NSString*)labelPrefix;
+- (instancetype)initWithName:(NSString*)labelPrefix NS_SWIFT_UI_ACTOR;
 
 /**
  * Initialize this FlutterEngine with a `FlutterDartProject`.
@@ -116,7 +121,8 @@ FLUTTER_DARWIN_EXPORT
  *   the threads used by this FlutterEngine.
  * @param project The `FlutterDartProject` to run.
  */
-- (instancetype)initWithName:(NSString*)labelPrefix project:(nullable FlutterDartProject*)project;
+- (instancetype)initWithName:(NSString*)labelPrefix
+                     project:(nullable FlutterDartProject*)project NS_SWIFT_UI_ACTOR;
 
 /**
  * Initialize this FlutterEngine with a `FlutterDartProject`.
@@ -137,7 +143,7 @@ FLUTTER_DARWIN_EXPORT
  */
 - (instancetype)initWithName:(NSString*)labelPrefix
                      project:(nullable FlutterDartProject*)project
-      allowHeadlessExecution:(BOOL)allowHeadlessExecution;
+      allowHeadlessExecution:(BOOL)allowHeadlessExecution NS_SWIFT_UI_ACTOR;
 
 /**
  * Initialize this FlutterEngine with a `FlutterDartProject`.
@@ -161,7 +167,7 @@ FLUTTER_DARWIN_EXPORT
 - (instancetype)initWithName:(NSString*)labelPrefix
                      project:(nullable FlutterDartProject*)project
       allowHeadlessExecution:(BOOL)allowHeadlessExecution
-          restorationEnabled:(BOOL)restorationEnabled NS_DESIGNATED_INITIALIZER;
+          restorationEnabled:(BOOL)restorationEnabled NS_DESIGNATED_INITIALIZER NS_SWIFT_UI_ACTOR;
 
 /**
  * Runs a Dart program on an Isolate from the main Dart library (i.e. the library that
@@ -171,9 +177,11 @@ FLUTTER_DARWIN_EXPORT
  * The first call to this method will create a new Isolate. Subsequent calls will return
  * immediately and have no effect.
  *
+ * This method must be called on the main thread. See the `FlutterEngine` class documentation.
+ *
  * @return YES if the call succeeds in creating and running a Flutter Engine instance; NO otherwise.
  */
-- (BOOL)run;
+- (BOOL)run NS_SWIFT_UI_ACTOR;
 
 /**
  * Runs a Dart program on an Isolate from the main Dart library (i.e. the library that
@@ -182,6 +190,8 @@ FLUTTER_DARWIN_EXPORT
  * The first call to this method will create a new Isolate. Subsequent calls will return
  * immediately and have no effect.
  *
+ * This method must be called on the main thread. See the `FlutterEngine` class documentation.
+ *
  * @param entrypoint The name of a top-level function from the same Dart
  *   library that contains the app's main() function.  If this is FlutterDefaultDartEntrypoint (or
  *   nil) it will default to `main()`.  If it is not the app's main() function, that function must
@@ -189,7 +199,7 @@ FLUTTER_DARWIN_EXPORT
  *   compiler.
  * @return YES if the call succeeds in creating and running a Flutter Engine instance; NO otherwise.
  */
-- (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint;
+- (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint NS_SWIFT_UI_ACTOR;
 
 /**
  * Runs a Dart program on an Isolate from the main Dart library (i.e. the library that
@@ -197,6 +207,8 @@ FLUTTER_DARWIN_EXPORT
  *
  * The first call to this method will create a new Isolate. Subsequent calls will return
  * immediately and have no effect.
+ *
+ * This method must be called on the main thread. See the `FlutterEngine` class documentation.
  *
  * @param entrypoint The name of a top-level function from the same Dart
  *   library that contains the app's main() function.  If this is FlutterDefaultDartEntrypoint (or
@@ -208,7 +220,7 @@ FLUTTER_DARWIN_EXPORT
  * @return YES if the call succeeds in creating and running a Flutter Engine instance; NO otherwise.
  */
 - (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint
-             initialRoute:(nullable NSString*)initialRoute;
+             initialRoute:(nullable NSString*)initialRoute NS_SWIFT_UI_ACTOR;
 
 /**
  * Runs a Dart program on an Isolate using the specified entrypoint and Dart library,
@@ -216,6 +228,8 @@ FLUTTER_DARWIN_EXPORT
  *
  * The first call to this method will create a new Isolate. Subsequent calls will return
  * immediately and have no effect.
+ *
+ * This method must be called on the main thread. See the `FlutterEngine` class documentation.
  *
  * @param entrypoint The name of a top-level function from a Dart library.  If this is
  *   FlutterDefaultDartEntrypoint (or nil); this will default to `main()`.  If it is not the app's
@@ -226,7 +240,8 @@ FLUTTER_DARWIN_EXPORT
  *   the same library as the `main()` function in the Dart program.
  * @return YES if the call succeeds in creating and running a Flutter Engine instance; NO otherwise.
  */
-- (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint libraryURI:(nullable NSString*)uri;
+- (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint
+               libraryURI:(nullable NSString*)uri NS_SWIFT_UI_ACTOR;
 
 /**
  * Runs a Dart program on an Isolate using the specified entrypoint and Dart library,
@@ -234,6 +249,8 @@ FLUTTER_DARWIN_EXPORT
  *
  * The first call to this method will create a new Isolate. Subsequent calls will return
  * immediately and have no effect.
+ *
+ * This method must be called on the main thread. See the `FlutterEngine` class documentation.
  *
  * @param entrypoint The name of a top-level function from a Dart library.  If this is
  *   FlutterDefaultDartEntrypoint (or nil); this will default to `main()`.  If it is not the app's
@@ -248,7 +265,7 @@ FLUTTER_DARWIN_EXPORT
  */
 - (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint
                libraryURI:(nullable NSString*)libraryURI
-             initialRoute:(nullable NSString*)initialRoute;
+             initialRoute:(nullable NSString*)initialRoute NS_SWIFT_UI_ACTOR;
 
 /**
  * Runs a Dart program on an Isolate using the specified entrypoint and Dart library,
@@ -256,6 +273,8 @@ FLUTTER_DARWIN_EXPORT
  *
  * The first call to this method will create a new Isolate. Subsequent calls will return
  * immediately and have no effect.
+ *
+ * This method must be called on the main thread. See the `FlutterEngine` class documentation.
  *
  * @param entrypoint The name of a top-level function from a Dart library.  If this is
  *   FlutterDefaultDartEntrypoint (or nil); this will default to `main()`.  If it is not the app's
@@ -272,7 +291,7 @@ FLUTTER_DARWIN_EXPORT
 - (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint
                libraryURI:(nullable NSString*)libraryURI
              initialRoute:(nullable NSString*)initialRoute
-           entrypointArgs:(nullable NSArray<NSString*>*)entrypointArgs;
+           entrypointArgs:(nullable NSArray<NSString*>*)entrypointArgs NS_SWIFT_UI_ACTOR;
 
 /**
  * Destroy running context for an engine.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngineGroup.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngineGroup.h
@@ -49,6 +49,10 @@ FLUTTER_DARWIN_EXPORT
  * Deleting a FlutterEngineGroup doesn't invalidate existing FlutterEngines, but
  * it eliminates the possibility to create more FlutterEngines in that group.
  *
+ * Engines in a group share task runners, including the platform thread of the first engine
+ * created in the group. All `-makeEngine*` methods must therefore be called on the main thread.
+ * See `FlutterEngine` class documentation.
+ *
  * @warning This class is a work-in-progress and may change.
  * @see https://github.com/flutter/flutter/issues/72009
  */
@@ -70,6 +74,8 @@ FLUTTER_DARWIN_EXPORT
 /**
  * Creates a running `FlutterEngine` that shares components with this group.
  *
+ * This method must be called on the main thread.
+ *
  * @param entrypoint The name of a top-level function from a Dart library.  If this is
  *   FlutterDefaultDartEntrypoint (or nil); this will default to `main()`.  If it is not the app's
  *   main() function, that function must be decorated with `@pragma(vm:entry-point)` to ensure the
@@ -80,10 +86,12 @@ FLUTTER_DARWIN_EXPORT
  * @see FlutterEngineGroup
  */
 - (FlutterEngine*)makeEngineWithEntrypoint:(nullable NSString*)entrypoint
-                                libraryURI:(nullable NSString*)libraryURI;
+                                libraryURI:(nullable NSString*)libraryURI NS_SWIFT_UI_ACTOR;
 
 /**
  * Creates a running `FlutterEngine` that shares components with this group.
+ *
+ * This method must be called on the main thread.
  *
  * @param entrypoint The name of a top-level function from a Dart library.  If this is
  *   FlutterDefaultDartEntrypoint (or nil); this will default to `main()`.  If it is not the app's
@@ -98,16 +106,19 @@ FLUTTER_DARWIN_EXPORT
  */
 - (FlutterEngine*)makeEngineWithEntrypoint:(nullable NSString*)entrypoint
                                 libraryURI:(nullable NSString*)libraryURI
-                              initialRoute:(nullable NSString*)initialRoute;
+                              initialRoute:(nullable NSString*)initialRoute NS_SWIFT_UI_ACTOR;
 
 /**
  * Creates a running `FlutterEngine` that shares components with this group.
+ *
+ * This method must be called on the main thread.
  *
  * @param options Options that control how a FlutterEngine should be created.
  *
  * @see FlutterEngineGroupOptions
  */
-- (FlutterEngine*)makeEngineWithOptions:(nullable FlutterEngineGroupOptions*)options;
+- (FlutterEngine*)makeEngineWithOptions:(nullable FlutterEngineGroupOptions*)options
+    NS_SWIFT_UI_ACTOR;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterHeadlessDartRunner.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterHeadlessDartRunner.h
@@ -26,6 +26,9 @@ typedef void (^FlutterHeadlessDartRunnerCallback)(BOOL success);
  * and no native drawing surface. It is appropriate for use in running Dart
  * code e.g. in the background from a plugin.
  *
+ * Like any `FlutterEngine`, this class must be created and run on the main thread.
+ * See `FlutterEngine` class documentation.
+ *
  * Most callers should prefer using `FlutterEngine` directly; this interface exists
  * for legacy support.
  */
@@ -46,7 +49,8 @@ FLUTTER_DEPRECATED("FlutterEngine should be used rather than FlutterHeadlessDart
  * be unique across FlutterEngine instances
  * @param projectOrNil The `FlutterDartProject` to run.
  */
-- (instancetype)initWithName:(NSString*)labelPrefix project:(FlutterDartProject*)projectOrNil;
+- (instancetype)initWithName:(NSString*)labelPrefix
+                     project:(FlutterDartProject*)projectOrNil NS_SWIFT_UI_ACTOR;
 
 /**
  * Initialize this FlutterHeadlessDartRunner with a `FlutterDartProject`.
@@ -64,7 +68,7 @@ FLUTTER_DEPRECATED("FlutterEngine should be used rather than FlutterHeadlessDart
  */
 - (instancetype)initWithName:(NSString*)labelPrefix
                      project:(FlutterDartProject*)projectOrNil
-      allowHeadlessExecution:(BOOL)allowHeadlessExecution;
+      allowHeadlessExecution:(BOOL)allowHeadlessExecution NS_SWIFT_UI_ACTOR;
 
 /**
  * Initialize this FlutterHeadlessDartRunner with a `FlutterDartProject`.
@@ -84,13 +88,13 @@ FLUTTER_DEPRECATED("FlutterEngine should be used rather than FlutterHeadlessDart
 - (instancetype)initWithName:(NSString*)labelPrefix
                      project:(FlutterDartProject*)projectOrNil
       allowHeadlessExecution:(BOOL)allowHeadlessExecution
-          restorationEnabled:(BOOL)restorationEnabled NS_DESIGNATED_INITIALIZER;
+          restorationEnabled:(BOOL)restorationEnabled NS_DESIGNATED_INITIALIZER NS_SWIFT_UI_ACTOR;
 
 /**
  * Not recommended for use - will initialize with a default label ("io.flutter.headless")
  * and the default FlutterDartProject.
  */
-- (instancetype)init;
+- (instancetype)init NS_SWIFT_UI_ACTOR;
 
 @end
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine+Test.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine+Test.h
@@ -33,7 +33,8 @@ class ThreadHost;
 - (FlutterEngine*)spawnWithEntrypoint:(/*nullable*/ NSString*)entrypoint
                            libraryURI:(/*nullable*/ NSString*)libraryURI
                          initialRoute:(/*nullable*/ NSString*)initialRoute
-                       entrypointArgs:(/*nullable*/ NSArray<NSString*>*)entrypointArgs;
+                       entrypointArgs:(/*nullable*/ NSArray<NSString*>*)entrypointArgs
+    NS_SWIFT_UI_ACTOR;
 - (const flutter::ThreadHost&)threadHost;
 - (void)updateDisplays;
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -243,8 +243,7 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 
   // Reading the UIApplication lifecycle state and registering for UIKit notifications below both
   // require the main thread, as does running the engine.
-  FML_DCHECK([[NSThread currentThread] isMainThread])
-      << "FlutterEngine must be created on the main thread.";
+  FML_DCHECK(NSThread.isMainThread) << "FlutterEngine must be created on the main thread.";
 
   _restorationEnabled = restorationEnabled;
   _allowHeadlessExecution = allowHeadlessExecution;
@@ -294,7 +293,7 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 }
 
 + (FlutterEngine*)engineForIdentifier:(int64_t)identifier {
-  NSAssert([[NSThread currentThread] isMainThread], @"Must be called on the main thread.");
+  NSAssert(NSThread.isMainThread, @"Must be called on the main thread.");
   return (__bridge FlutterEngine*)reinterpret_cast<void*>(identifier);
 }
 
@@ -930,7 +929,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   //
   // Engines spawned from this one inherit these task runners, so this applies to every engine in a
   // FlutterEngineGroup.
-  FML_CHECK([[NSThread currentThread] isMainThread])
+  FML_CHECK(NSThread.isMainThread)
       << "FlutterEngine must be run on the main thread. The engine adopts the calling thread as "
          "its platform and UI thread, both of which must be the main thread. To start an engine "
          "from a background queue, dispatch to the main queue first.";
@@ -1622,8 +1621,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                            libraryURI:(/*nullable*/ NSString*)libraryURI
                          initialRoute:(/*nullable*/ NSString*)initialRoute
                        entrypointArgs:(/*nullable*/ NSArray<NSString*>*)entrypointArgs {
-  FML_CHECK([[NSThread currentThread] isMainThread])
-      << "FlutterEngine must be spawned on the iOS main thread.";
+  FML_CHECK(NSThread.isMainThread) << "FlutterEngine must be spawned on the iOS main thread.";
 
   NSAssert(_shell, @"Spawning from an engine without a shell (possibly not run).");
   FlutterEngine* result = [[FlutterEngine alloc] initWithName:self.labelPrefix

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -241,6 +241,11 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   NSAssert(self, @"Super init cannot be nil");
   NSAssert(labelPrefix, @"labelPrefix is required");
 
+  // Reading the UIApplication lifecycle state and registering for UIKit notifications below both
+  // require the main thread, as does running the engine.
+  FML_DCHECK([[NSThread currentThread] isMainThread])
+      << "FlutterEngine must be created on the main thread.";
+
   _restorationEnabled = restorationEnabled;
   _allowHeadlessExecution = allowHeadlessExecution;
   _labelPrefix = [labelPrefix copy];
@@ -918,6 +923,18 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 - (BOOL)createShell:(NSString*)entrypoint
          libraryURI:(NSString*)libraryURI
        initialRoute:(NSString*)initialRoute {
+  // MakeThreadHost below adopts the calling thread as this engine's platform/UI thread, which
+  // must be the main thread. The engine relies on UIApplicationMain to pump the platform thread's
+  // run loop, and the platform thread reads UIKit state (UIScreen, CADisplayLink) and runs all
+  // plugin and platform channel callbacks.
+  //
+  // Engines spawned from this one inherit these task runners, so this applies to every engine in a
+  // FlutterEngineGroup.
+  FML_CHECK([[NSThread currentThread] isMainThread])
+      << "FlutterEngine must be run on the main thread. The engine adopts the calling thread as "
+         "its platform and UI thread, both of which must be the main thread. To start an engine "
+         "from a background queue, dispatch to the main queue first.";
+
   if (_shell != nullptr) {
     [FlutterLogger logWarning:@"This FlutterEngine was already invoked."];
     return NO;
@@ -1605,6 +1622,9 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                            libraryURI:(/*nullable*/ NSString*)libraryURI
                          initialRoute:(/*nullable*/ NSString*)initialRoute
                        entrypointArgs:(/*nullable*/ NSArray<NSString*>*)entrypointArgs {
+  FML_CHECK([[NSThread currentThread] isMainThread])
+      << "FlutterEngine must be spawned on the iOS main thread.";
+
   NSAssert(_shell, @"Spawning from an engine without a shell (possibly not run).");
   FlutterEngine* result = [[FlutterEngine alloc] initWithName:self.labelPrefix
                                                       project:self.dartProject

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -59,9 +59,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)launchEngine:(nullable NSString*)entrypoint
           libraryURI:(nullable NSString*)libraryOrNil
       entrypointArgs:(nullable NSArray<NSString*>*)entrypointArgs;
+/**
+ * Creates the shell, adopting the calling thread as this engine's platform thread.
+ *
+ * Must be called on the main thread; see the `FlutterEngine` class documentation.
+ */
 - (BOOL)createShell:(nullable NSString*)entrypoint
          libraryURI:(nullable NSString*)libraryOrNil
-       initialRoute:(nullable NSString*)initialRoute;
+       initialRoute:(nullable NSString*)initialRoute NS_SWIFT_UI_ACTOR;
 - (void)attachView;
 - (void)notifyLowMemory;
 
@@ -74,11 +79,15 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * This results in a faster creation time and a smaller memory footprint engine.
  * This should only be called on a FlutterEngine that is running.
+ *
+ * The spawned engine shares this engine's task runners, so this must be called on this engine's
+ * platform thread, which is always the main thread.
  */
 - (FlutterEngine*)spawnWithEntrypoint:(nullable NSString*)entrypoint
                            libraryURI:(nullable NSString*)libraryURI
                          initialRoute:(nullable NSString*)initialRoute
-                       entrypointArgs:(nullable NSArray<NSString*>*)entrypointArgs;
+                       entrypointArgs:(nullable NSArray<NSString*>*)entrypointArgs
+    NS_SWIFT_UI_ACTOR;
 
 /**
  * Dispatches the given key event data to the framework through the engine.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngine.swift
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/LaunchEngine.swift
@@ -28,6 +28,10 @@ import Foundation
 /// For new application code, application developers should consider conforming to
 /// `FlutterImplicitEngineDelegate` and implementing `didInitializeImplicitFlutterEngine` instead of
 /// relying on `FlutterAppDelegate`'s automatic registration.
+///
+/// This class is main-actor isolated. It creates and runs a `FlutterEngine`, both of which must
+/// happen on the main thread.
+@MainActor
 @objc(FlutterLaunchEngine)
 final class LaunchEngine: NSObject {
 


### PR DESCRIPTION
Previously, running a `FlutterEngine` from a background queue silently gave us an engine whose platform thread was not the main thread. The first symptom an app sees is an assertion deep inside `DisplayLinkManager.shared`, which is accurate but confusing and looks like a bug rather than an intentional precondition.

`MakeThreadHost` adopts the calling thread as the engine's platform/UI thread. That thread is required to be the main thread for several reasons:
* it reads UIKit state and runs every plugin and platform channel callback
* nothing else pumps its run loop

We now assert this via `FML_CHECK` in:
* `createShell:libraryURI:initialRoute:`: covers the `run*` methods and `FlutterViewController`'s implicit engine
* `spawnWithEntrypoint:libraryURI:initialRoute:entrypointArgs:`: covers the second and later engines in a `FlutterEngineGroup`.

A spawned engine inherits its spawner's task runners rather than adopting the calling thread, so the check in `createShell` constrains every engine in a group.

This also adds an `FML_DCHECK` during engine construction since it reads `UIApplication` lifecycle state and registers UIKit observers.

This also annotates the Swift-visible entry points `NS_SWIFT_UI_ACTOR` so that Swift callers get a compile-time error rather than a runtime abort. `FlutterViewController` doesn't need an annotation since, like all view controllers, it already inherits main actor isolation from `UIViewController`.

Issue: https://github.com/flutter/flutter/issues/190909
Related: https://github.com/flutter/flutter/issues/190725
Related: https://github.com/flutter/flutter/issues/165904

No test changes, since these are assertions and unlike GoogleTest, XCUITest and Swift Testing tests have no death-test. This doesn't add any additional runtime aborts since `DisplayLinkManager.shared` already does this; it just pushes them up to where they're actually actionable by the user, and provides better error messages.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
