### PR TITLE
Fix pointer id/coordinate mismatch in Android platform view multi-touch

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -636,9 +636,7 @@ class _AndroidMotionEventConverter {
     // are relative to this order as well.
     // See https://github.com/flutter/flutter/issues/191105.
     final List<int> pointers = pointerPositions.keys.toList()
-      ..sort(
-        (int a, int b) => (pointerProperties[a]?.id ?? 0).compareTo(pointerProperties[b]?.id ?? 0),
-      );
+      ..sort((int a, int b) => pointerProperties[a]!.id.compareTo(pointerProperties[b]!.id));
     final int pointerIdx = pointers.indexOf(event.pointer);
     final int numPointers = pointers.length;
 

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -627,7 +627,18 @@ class _AndroidMotionEventConverter {
   }
 
   AndroidMotionEvent? toAndroidMotionEvent(PointerEvent event) {
-    final List<int> pointers = pointerPositions.keys.toList();
+    // Android orders the pointers within a MotionEvent by Android pointer id, and
+    // the engine pairs the coordinates sent from here with the pointers of the
+    // original MotionEvent by array position. `pointerPositions` is keyed by
+    // Flutter pointer and iterates in insertion order, which stops matching
+    // Android's order as soon as a released Android pointer id is recycled by
+    // [handlePointerDownEvent]. The action index and the batching check below
+    // are relative to this order as well.
+    // See https://github.com/flutter/flutter/issues/191105.
+    final List<int> pointers = pointerPositions.keys.toList()
+      ..sort(
+        (int a, int b) => (pointerProperties[a]?.id ?? 0).compareTo(pointerProperties[b]?.id ?? 0),
+      );
     final int pointerIdx = pointers.indexOf(event.pointer);
     final int numPointers = pointers.length;
 

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -558,13 +558,10 @@ void main() {
         downArgs[kIndexAction],
         AndroidViewController.pointerAction(0, AndroidViewController.kActionPointerDown),
       );
-      expect(
-        downArgs[kIndexPointerProperties],
-        <List<int>>[
-          <int>[0, AndroidPointerProperties.kToolTypeFinger],
-          <int>[1, AndroidPointerProperties.kToolTypeFinger],
-        ],
-      );
+      expect(downArgs[kIndexPointerProperties], <List<int>>[
+        <int>[0, AndroidPointerProperties.kToolTypeFinger],
+        <int>[1, AndroidPointerProperties.kToolTypeFinger],
+      ]);
       // Android pointer id 0 is Flutter pointer 3, id 1 is Flutter pointer 2.
       expect(xOf(downCall), <double>[30, 20]);
 

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -496,6 +496,96 @@ void main() {
       final moveArgs = moveCalls.single.arguments as List<dynamic>;
       expect(moveArgs[kAndroidMotionEventListIndexPointerCount], equals(pointerCount));
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/191105.
+    testWidgets('motion event converter orders pointers by Android pointer id', (
+      WidgetTester tester,
+    ) async {
+      final log = <MethodCall>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform_views,
+        (MethodCall methodCall) async {
+          log.add(methodCall);
+          return null;
+        },
+      );
+
+      final AndroidViewController viewController = PlatformViewsService.initSurfaceAndroidView(
+        id: 7,
+        viewType: 'web',
+        layoutDirection: TextDirection.ltr,
+      );
+      viewController.pointTransformer = (Offset offset) => offset;
+
+      // Indexes in the list returned by AndroidMotionEvent._asList.
+      const kIndexAction = 3;
+      const kIndexPointerCount = 4;
+      const kIndexPointerProperties = 5;
+      const kIndexPointerCoords = 6;
+      // Index of x within the list returned by AndroidPointerCoords._asList.
+      const kCoordsIndexX = 7;
+
+      List<double> xOf(MethodCall call) {
+        final args = call.arguments as List<dynamic>;
+        return (args[kIndexPointerCoords] as List<dynamic>)
+            .map<double>((dynamic coords) => (coords as List<dynamic>)[kCoordsIndexX] as double)
+            .toList();
+      }
+
+      // Flutter pointer 1 takes Android pointer id 0, Flutter pointer 2 takes id 1.
+      await viewController.dispatchPointerEvent(
+        const PointerDownEvent(pointer: 1, position: Offset(10, 10)),
+      );
+      await viewController.dispatchPointerEvent(
+        const PointerDownEvent(pointer: 2, position: Offset(20, 20)),
+      );
+      // Lifting Flutter pointer 1 releases Android pointer id 0 for reuse.
+      await viewController.dispatchPointerEvent(
+        const PointerUpEvent(pointer: 1, position: Offset(10, 10)),
+      );
+      log.clear();
+      // Flutter pointer 3 is assigned the recycled Android pointer id 0, so it is
+      // last in insertion order but first in Android pointer id order.
+      await viewController.dispatchPointerEvent(
+        const PointerDownEvent(pointer: 3, position: Offset(30, 30)),
+      );
+
+      final MethodCall downCall = log.singleWhere((MethodCall call) => call.method == 'touch');
+      final downArgs = downCall.arguments as List<dynamic>;
+      expect(downArgs[kIndexPointerCount], 2);
+      // The action index is the position of the pressed pointer in Android pointer id order.
+      expect(
+        downArgs[kIndexAction],
+        AndroidViewController.pointerAction(0, AndroidViewController.kActionPointerDown),
+      );
+      expect(
+        downArgs[kIndexPointerProperties],
+        <List<int>>[
+          <int>[0, AndroidPointerProperties.kToolTypeFinger],
+          <int>[1, AndroidPointerProperties.kToolTypeFinger],
+        ],
+      );
+      // Android pointer id 0 is Flutter pointer 3, id 1 is Flutter pointer 2.
+      expect(xOf(downCall), <double>[30, 20]);
+
+      // The engine splits one Android move across its pointers in Android pointer
+      // id order, flagging each with the original pointer count. The converter must
+      // send a single MotionEvent once the last of them has arrived.
+      const kPointerDataFlagMultiple = 2;
+      const int platformData = kPointerDataFlagMultiple | (2 << 8);
+      log.clear();
+      await viewController.dispatchPointerEvent(
+        const PointerMoveEvent(pointer: 3, position: Offset(31, 31), platformData: platformData),
+      );
+      await viewController.dispatchPointerEvent(
+        const PointerMoveEvent(pointer: 2, position: Offset(21, 21), platformData: platformData),
+      );
+
+      final MethodCall moveCall = log.singleWhere((MethodCall call) => call.method == 'touch');
+      final moveArgs = moveCall.arguments as List<dynamic>;
+      expect(moveArgs[kIndexAction], AndroidViewController.kActionMove);
+      expect(xOf(moveCall), <double>[31, 21]);
+    });
   });
 
   group('iOS', () {


### PR DESCRIPTION
## Summary
- `_AndroidMotionEventConverter.toAndroidMotionEvent` built its pointer list from `pointerPositions.keys.toList()`, which iterates in Flutter pointer *insertion* order.
- The engine (`PlatformViewsController.toMotionEvent` / `translateMotionEvent`, Java) pairs the coordinates sent from the framework with the original `MotionEvent`'s pointers *by array position*, on the assumption that this order matches ascending Android pointer id.
- Those two orders agree until a released Android pointer id gets recycled by a new touch-down, at which point insertion order and id order diverge — corrupting the derived action index and pairing each pointer with the wrong coordinates (two fingers can end up reporting identical/reflected coordinates).
- Fix: sort the pointer list by `AndroidPointerProperties.id` (the Android pointer id) before deriving the action index and building the `pointerProperties`/`pointerCoords` arrays, so both sides agree on what array order means.

Fixes #191105

## Test plan
- [x] Added a regression test in `packages/flutter/test/services/platform_views_test.dart` that recycles a released Android pointer id and asserts the resulting `MotionEvent`'s pointer order, action index, and coordinates are keyed by Android pointer id, not insertion order.
- [x] Red/green verified: reverting the fix makes the new test fail with a corrupted action-index value; restoring the fix makes it pass.
- [x] `flutter test packages/flutter/test/services/platform_views_test.dart` — 27/27 passing.
- [x] `flutter analyze` on the two changed files — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)