### PR TITLE
[flutter_tools] Rebuild asset bundle when generated manifest content changes

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -8,6 +8,7 @@ import 'package:package_config/package_config_types.dart';
 import '../asset.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/utils.dart';
 import '../build_info.dart';
 import '../bundle_builder.dart';
 import '../devfs.dart';
@@ -818,7 +819,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     if (build != 0) {
       throwToolExit('Error: Failed to build asset bundle');
     }
-    if (_needsRebuild(assetBundle.entries, flavor)) {
+    if (await _needsRebuild(assetBundle.entries, flavor)) {
       await writeBundle(
         globals.fs.directory(globals.fs.path.join('build', 'unit_test_assets')),
         assetBundle.entries,
@@ -845,11 +846,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     }
   }
 
-  bool _needsRebuild(Map<String, AssetBundleEntry> entries, String? flavor) {
-    // TODO(andrewkolos): This logic might fail in the future if we change the
-    //  schema of the contents of the asset manifest file and the user does not
-    //  perform a `flutter clean` after upgrading.
-    //  See https://github.com/flutter/flutter/issues/128563.
+  Future<bool> _needsRebuild(Map<String, AssetBundleEntry> entries, String? flavor) async {
     final File manifest = globals.fs.file(
       globals.fs.path.join('build', 'unit_test_assets', 'AssetManifest.bin'),
     );
@@ -868,6 +865,22 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     for (final entry in files) {
       if (entry.isModifiedAfter(lastModified)) {
         return true;
+      }
+    }
+
+    for (final MapEntry<String, AssetBundleEntry> entry in entries.entries) {
+      if (entry.value.content is! DevFSFileContent) {
+        final File file = globals.fs.file(
+          globals.fs.path.join('build', 'unit_test_assets', entry.key),
+        );
+        if (!file.existsSync()) {
+          return true;
+        }
+        final List<int> entryBytes = await entry.value.contentsAsBytes();
+        final List<int> fileBytes = await file.readAsBytes();
+        if (!listEquals(entryBytes, fileBytes)) {
+          return true;
+        }
       }
     }
 

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -877,6 +877,9 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
           return true;
         }
         final List<int> entryBytes = await assetEntry.contentsAsBytes();
+        if (entryBytes.length != await file.length()) {
+          return true;
+        }
         final List<int> fileBytes = await file.readAsBytes();
         if (!listEquals(entryBytes, fileBytes)) {
           return true;

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -868,15 +868,15 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       }
     }
 
-    for (final MapEntry<String, AssetBundleEntry> entry in entries.entries) {
-      if (entry.value.content is! DevFSFileContent) {
+    for (final MapEntry(key: assetPath, value: assetEntry) in entries.entries) {
+      if (assetEntry.content is! DevFSFileContent) {
         final File file = globals.fs.file(
-          globals.fs.path.join('build', 'unit_test_assets', entry.key),
+          globals.fs.path.join('build', 'unit_test_assets', assetPath),
         );
         if (!file.existsSync()) {
           return true;
         }
-        final List<int> entryBytes = await entry.value.contentsAsBytes();
+        final List<int> entryBytes = await assetEntry.contentsAsBytes();
         final List<int> fileBytes = await file.readAsBytes();
         if (!listEquals(entryBytes, fileBytes)) {
           return true;

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -1453,6 +1453,46 @@ dev_dependencies:
     },
   );
 
+  testUsingContext(
+    'Rebuild the asset bundle if the asset manifest on disk does not match the newly generated asset manifest',
+    () async {
+      final testRunner = FakeFlutterTestRunner(0);
+      fs.file('asset.txt').writeAsStringSync('1');
+      fs.file('pubspec.yaml').writeAsStringSync('''
+name: my_app
+flutter:
+  assets:
+    - asset.txt
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter''');
+      final testCommand = TestCommand(testRunner: testRunner);
+      final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+      await commandRunner.run(const <String>['test', '--no-pub']);
+
+      final File manifestFile = fs.file(
+        globals.fs.path.join('build', 'unit_test_assets', 'AssetManifest.bin'),
+      );
+      expect(manifestFile, exists);
+
+      // Simulate a stale manifest on disk (e.g. from an older Flutter version with different schema/contents).
+      manifestFile.writeAsBytesSync(<int>[0, 1, 2, 3]);
+
+      await commandRunner.run(const <String>['test', '--no-pub']);
+
+      final List<int> manifestBytes = manifestFile.readAsBytesSync();
+      expect(manifestBytes, isNot(<int>[0, 1, 2, 3]));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.empty(),
+      DeviceManager: () => _FakeDeviceManager(<Device>[]),
+    },
+  );
+
   group('Fatal Logs', () {
     testUsingContext(
       "doesn't fail when --fatal-warnings is set and no warning output",


### PR DESCRIPTION
In `flutter test`, the tool checks if the unit test asset bundle needs to be rebuilt by comparing the last modified timestamp of `AssetManifest.bin` against `pubspec.yaml` and physical asset files. However, when Flutter changes the schema or generated content of `AssetManifest.bin` or other synthetic asset metadata (such as `FontManifest.json` or `NOTICES`) without changes to `pubspec.yaml` or physical asset timestamps, tests continue using the stale asset bundle on disk unless `flutter clean` is run.

This change enhances `_needsRebuild` to compare the in-memory byte contents of non-`DevFSFileContent` assets against the existing files on disk, triggering an asset bundle rebuild if any generated metadata file is missing or contains different bytes.

Fixes #128563