### PR TITLE
Fix AnimatedList.separated assertion when inserting right after a rem…

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -835,9 +835,13 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
     if (index == 0) {
       return index;
     }
-    final int itemsAndSeparatorsCount = _itemsCount;
+    // Children animating out from an earlier removeItem call still count
+    // towards [_itemsCount] until their animation finishes (see
+    // [_indexToItemIndex]), so exclude them here too: [index] is defined
+    // against the settled, post-removal item count.
+    final int itemsAndSeparatorsCount = _itemsCount - _outgoingItemsCount;
     final int separatorsCount = itemsAndSeparatorsCount ~/ 2;
-    final int separatedItemsCount = _itemsCount - separatorsCount;
+    final int separatedItemsCount = itemsAndSeparatorsCount - separatorsCount;
 
     final isNewLastIndex = index == separatedItemsCount;
     final int indexAdjustedForSeparators = index * 2;

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -1279,6 +1279,68 @@ void main() {
     },
   );
 
+  // Regression test for https://github.com/flutter/flutter/issues/179029.
+  testWidgets(
+    'AnimatedList.separated can insert a new last item right after removing the previous one',
+    (WidgetTester tester) async {
+      Widget itemBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 100.0, child: Center(child: Text('item $index')));
+      }
+
+      Widget separatorBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 10.0, child: Center(child: Text('separator $index')));
+      }
+
+      Widget removedSeparatorBuilder(BuildContext context, int index, Animation<double> animation) {
+        return SizedBox(height: 10.0, child: Center(child: Text('removing separator $index')));
+      }
+
+      Widget removedItemBuilder(BuildContext context, Animation<double> animation) {
+        return const SizedBox(height: 100.0, child: Center(child: Text('removing item')));
+      }
+
+      const numItems = 2;
+      final listKey = GlobalKey<AnimatedListState>();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: AnimatedList.separated(
+            key: listKey,
+            initialItemCount: numItems,
+            itemBuilder: itemBuilder,
+            separatorBuilder: separatorBuilder,
+            removedSeparatorBuilder: removedSeparatorBuilder,
+          ),
+        ),
+      );
+
+      // Remove the last item, then immediately (before its removal animation
+      // finishes) insert a new item at the same, now-last, index. Before the
+      // fix this triggered an "itemIndex >= 0 && itemIndex <= _itemsCount"
+      // assertion inside _SliverAnimatedMultiBoxAdaptorState.insertItem,
+      // because _computeItemIndex used the raw sliver child count instead of
+      // the settled (post-removal) item count to place the new item.
+      listKey.currentState!.removeItem(numItems - 1, removedItemBuilder);
+      listKey.currentState!.insertItem(numItems - 1);
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('item 0'), findsOneWidget);
+      expect(find.text('removing item'), findsOneWidget);
+
+      await tester.pumpAndSettle();
+
+      // The removal animation finished and the newly inserted item settled
+      // into place, with exactly one separator between the two items.
+      expect(tester.takeException(), isNull);
+      expect(find.text('item 0'), findsOneWidget);
+      expect(find.text('item 1'), findsOneWidget);
+      expect(find.text('removing item'), findsNothing);
+      expect(find.textContaining('separator'), findsOneWidget);
+    },
+  );
+
   testWidgets('AnimatedList does not crash at zero area', (WidgetTester tester) async {
     tester.view.physicalSize = Size.zero;
     final controller = ScrollController();


### PR DESCRIPTION
…oval

_AnimatedScrollViewState._computeItemIndex derived the underlying sliver index for insertItem/removeItem from the raw _itemsCount, which still includes items whose removal animation is still in flight (_itemsCount only decrements once that animation completes). insertItem's index parameter is defined against the settled, post-removal item count (per the class's own _indexToItemIndex contract), so computing it from the raw count double-counted the still-animating-out items once _indexToItemIndex shifted past them, overshooting _itemsCount and tripping the "itemIndex >= 0 && itemIndex <= _itemsCount" assertion.

This is the same root cause as #186361/#186389, which fixed the "are there enough items for a separator" check in removeItem's wrapper but left _computeItemIndex itself using the raw count. Removing the last item and immediately inserting a new one at the same index (the documented, single-frame remove+insert pattern) hit the gap.

Exclude in-flight outgoing items from _computeItemIndex's count so all of its callers (insertItem, insertAllItems, removeItem) agree with _indexToItemIndex on what "settled item count" means.

Fixes https://github.com/flutter/flutter/issues/179029

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
