### PR TITLE
iOS: Add null check for touch rate correction task runner

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1324,12 +1324,22 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     return;
   }
 
+  FlutterFMLTaskRunner* platformTaskRunner = self.engine.platformTaskRunner;
+  if (platformTaskRunner == nil) {
+    // The engine has no platform task runner until its shell is created, and the vsync client
+    // dereferences the task runner we hand it. Losing the smoothing the correction client provides
+    // is better than dereferencing null.
+    [FlutterLogger logWarning:@"Unable to correct touch rate: the engine has no platform task "
+                              @"runner."];
+    return;
+  }
+
   void (^callback)(CFTimeInterval, CFTimeInterval) =
       ^(CFTimeInterval startTime, CFTimeInterval targetTime) {
         // Do nothing in this block. Just trigger system to callback touch events with correct rate.
       };
   _touchRateCorrectionVSyncClient = [[FlutterVSyncClient alloc]
-                initWithTaskRunner:self.engine.platformTaskRunner
+                initWithTaskRunner:platformTaskRunner
       isVariableRefreshRateEnabled:self.displayLinkManager.maxRefreshRateEnabledOnIPhone
                     maxRefreshRate:self.displayLinkManager.displayRefreshRate
                           callback:callback];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -2887,6 +2887,33 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   XCTAssertTrue(clientBefore == clientAfter);
 }
 
+// Verifies that no touch rate correction vsync client is created when the engine has no platform
+// task runner. The task runner is nil before the engine's shell is created and after its context is
+// destroyed, and the vsync client dereferences the task runner it is given.
+//
+// A view controller cannot attach to an engine that has no shell, so the engine is run and its
+// context destroyed afterwards rather than simply left uninitialized.
+- (void)testCreateTouchRateCorrectionVSyncClientWillNotCreateVsyncClientWithoutTaskRunner {
+  id mockDisplayLinkManager = OCMPartialMock([FlutterDisplayLinkManager shared]);
+  [self addTeardownBlock:^{
+    [mockDisplayLinkManager stopMocking];
+  }];
+  double maxFrameRate = 120;
+  (void)[[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
+
+  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  [engine runWithEntrypoint:nil];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
+  [engine destroyContext];
+  XCTAssertNil(engine.platformTaskRunner);
+
+  // Verify the client is nil, and we don't crash.
+  [viewController createTouchRateCorrectionVSyncClientIfNeeded];
+  XCTAssertNil(viewController.touchRateCorrectionVSyncClient);
+}
+
 - (void)testCreateTouchRateCorrectionVSyncClientWillNotCreateVsyncClientWhenRefreshRateIs60HZ {
   id mockDisplayLinkManager = OCMPartialMock([FlutterDisplayLinkManager shared]);
   [self addTeardownBlock:^{


### PR DESCRIPTION
`FlutterViewController.viewDidLoad` creates a vsync client to correct the rate at which touch events are delivered on ProMotion displays, and passes it `self.engine.platformTaskRunner`. That property is nullable and only set once the engine's shell is created, then cleared again in `destroyContext`. `FlutterVSyncClient` requires a non-null task runner and dereferences it. A view controller whose engine is nil would dereference null and takes the app down with it, at launch. We now bail out when there's no task runner.

The argument is that losing whatever smoothing effect this has while we have no running egnine has no effect, and either way it's better than a null deref.

There's the separate argument detailed in #191199 that this entire client isn't really doing anything positive and should be deleted. This simply prevents the null deref until that work can land.

Also worth noting that `platformTaskRunner` is declared `nullable` and the Swift-generated `initWithTaskRunner:` takes a `_Nonnull` task runner, so clang spotted this issue when I enabled `-Wnullable-to-nonnull-conversion`:

```
FlutterViewController.mm:1332:36: warning: implicit conversion from nullable
pointer 'FlutterFMLTaskRunner * _Nullable' to non-nullable pointer type
'FlutterFMLTaskRunner * _Nonnull' [-Wnullable-to-nonnull-conversion]
```

I'll follow up with a patch that enables that warning, but it requires a few other cleanups first.

Issue: https://github.com/flutter/flutter/issues/190030

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
