### PR TITLE
Guard FocusNode.rect/offset/size against an unlaid-out RenderBox

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -851,6 +851,11 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       'Setting the context is typically done with the attach method.',
     );
     final RenderObject object = context!.findRenderObject()!;
+    // A box that hasn't been laid out yet has no size to read, so report zero
+    // until it does.
+    if (object is RenderBox && !object.hasSize) {
+      return Offset.zero;
+    }
     return MatrixUtils.transformPoint(object.getTransformTo(null), object.semanticBounds.topLeft);
   }
 
@@ -866,6 +871,11 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       'Setting the context is typically done with the attach method.',
     );
     final RenderObject object = context!.findRenderObject()!;
+    // A box that hasn't been laid out yet has no size to read, so report zero
+    // until it does.
+    if (object is RenderBox && !object.hasSize) {
+      return Rect.zero;
+    }
     final Offset topLeft = MatrixUtils.transformPoint(
       object.getTransformTo(null),
       object.semanticBounds.topLeft,

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -112,6 +112,27 @@ void main() {
       expect(focusNode2.offset, equals(const Offset(443.0, 194.5)));
     });
 
+    test('rect, offset, and size return zero when the RenderObject is not laid out', () {
+      // Regression test for https://github.com/flutter/flutter/issues/191508.
+      // Reading the bounds of a focus node whose box isn't laid out yet used to
+      // throw "RenderBox was not laid out"; it should report zero instead.
+      final owner = PipelineOwner();
+      addTearDown(() => owner.rootNode = null);
+      final RenderBox box = RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints.tightFor(width: 10, height: 10),
+      );
+      owner.rootNode = box;
+      expect(box.hasSize, isFalse);
+
+      final node = FocusNode();
+      addTearDown(node.dispose);
+      node.attach(_UnlaidOutBuildContext(box));
+
+      expect(node.rect, Rect.zero);
+      expect(node.offset, Offset.zero);
+      expect(node.size, Size.zero);
+    });
+
     testWidgets('descendantsAreFocusable disables focus for descendants.', (
       WidgetTester tester,
     ) async {
@@ -2435,4 +2456,16 @@ class _LoggingTestFocusNode extends FocusNode {
   }) {
     throw StateError("Shouldn't call toStringDeep here");
   }
+}
+
+class _UnlaidOutBuildContext implements BuildContext {
+  _UnlaidOutBuildContext(this._renderObject);
+
+  final RenderObject _renderObject;
+
+  @override
+  RenderObject findRenderObject() => _renderObject;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError();
 }


### PR DESCRIPTION
## Description

Fixes a crash (thrown even in release builds): `Bad state: RenderBox was not laid out: _RenderTheater`.

`FocusNode.rect` and `FocusNode.offset` read the attached render object's `semanticBounds`, which for a `RenderBox` reads its `size`. If the render object is attached to the tree but has not completed layout yet (for example, a just-mounted `Overlay` whose `_RenderTheater` takes focus before the layout phase reaches it), reading its bounds throws `RenderBox was not laid out`. On web this reproduces reliably because the engine services `requestViewFocusChange` synchronously, so the focus node is measured before its first layout.

This change guards the getters: when the attached object is a `RenderBox` that is not yet laid out (`!hasSize`), `rect` returns `Rect.zero` and `offset` returns `Offset.zero` (and `size`, which derives from `rect`, returns `Size.zero`). Once layout runs, the focus node is measured again and reports its real bounds, so this only affects the transient pre-layout window. This matches the reporter's suggested fix. Thanks to @grupoclip for the detailed report, the in-browser measurements, and the stack traces.

## Tests

Adds a regression test in `focus_manager_test.dart` that attaches a `RenderBox` to a `PipelineOwner` without laying it out (mirroring a just-mounted `Overlay`) and asserts `FocusNode.rect`, `offset`, and `size` return zero instead of throwing. The test fails without the fix (throwing `RenderBox was not laid out`) and passes with it.

Fixes #191508.

I searched the open pull requests for flutter/flutter and did not find an existing PR addressing this issue before opening this one.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
