### PR TITLE
[flutter_tools] Emit VM-service events for hot reload and restart

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -728,6 +728,26 @@ mixin WidgetsBinding
       );
 
       registerServiceExtension(
+  name: WidgetsServiceExtensions.sendExtensionEvent.name,
+  callback: (Map<String, String> parameters) async {
+    final String? eventKind = parameters['eventKind'];
+
+    if (eventKind == null || eventKind.isEmpty) {
+      return <String, dynamic>{
+        'sent': false,
+        'error': 'Missing or empty event kind param.',
+      };
+    }
+
+    postEvent(eventKind, <String, dynamic>{});
+
+    return <String, dynamic>{
+      'sent': true,
+    };
+  },
+);
+
+      registerServiceExtension(
         name: WidgetsServiceExtensions.didSendFirstFrameRasterizedEvent.name,
         callback: (_) async {
           return <String, dynamic>{

--- a/packages/flutter/lib/src/widgets/service_extensions copy.dart
+++ b/packages/flutter/lib/src/widgets/service_extensions copy.dart
@@ -115,6 +115,10 @@ enum WidgetsServiceExtensions {
   ///   registered.
   debugAllowBanner,
 
+  /// Name of service extension that, when called, sends an event to the
+  /// Extension event stream.
+  sendExtensionEvent,
+
   /// Name of service extension that, when called, will perform accessibility
   /// evaluations on the widget tree and return the results.
   ///

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -441,6 +441,30 @@ class ResidentWebRunner extends ResidentRunner {
     return OperationResult.ok;
   }
 
+  Future<void> _sendHotEvent(String eventKind) async {
+    if (!supportsServiceProtocol || !_deviceIsDebuggable || !isRunningDebug) {
+      return;
+    }
+    try {
+      final vmservice.VM vm = await _vmService.service.getVM();
+      for (final vmservice.IsolateRef isolate in vm.isolates ?? <vmservice.IsolateRef>[]) {
+        if (isolate.isSystemIsolate ?? false) {
+          continue;
+        }
+        final String? isolateId = isolate.id;
+        if (isolateId == null) {
+          continue;
+        }
+        await _vmService.flutterSendExtensionEvent(isolateId: isolateId, eventKind: eventKind);
+        break;
+      }
+    } on Object catch (error, stackTrace) {
+      // Event delivery is best-effort and must not turn a successful web reload
+      // or restart into a failed operation.
+      _logger.printTrace('Failed to send $eventKind event: $error\n$stackTrace');
+    }
+  }
+
   @override
   Future<OperationResult> restart({
     bool fullRestart = false,
@@ -627,6 +651,7 @@ class ResidentWebRunner extends ResidentRunner {
     final Duration elapsed = _systemClock.now().difference(start);
     final String elapsedMS = getElapsedAsMilliseconds(elapsed);
     _logger.printStatus('${fullRestart ? 'Restarted' : 'Reloaded'} application in $elapsedMS.');
+    await _sendHotEvent(fullRestart ? kHotRestartEventKind : kHotReloadEventKind);
 
     if (fullRestart) {
       for (final FlutterDevice? device in flutterDevices) {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -607,6 +607,45 @@ class HotRunner extends ResidentRunner {
     await Future.wait(futures);
   }
 
+  Future<void> _sendHotEvent(
+  String eventKind, {
+  required Map<FlutterDevice?, List<FlutterView>> viewsByDevice,
+}) async {
+  for (final FlutterDevice? device in flutterDevices) {
+    try {
+      if (device == null || device.vmService == null) {
+        continue;
+      }
+
+      final sentIsolates = <String>{};
+      final List<FlutterView> views = viewsByDevice[device] ?? <FlutterView>[];
+
+      for (final view in views) {
+        final String? isolateId = view.uiIsolate?.id;
+
+        if (isolateId == null || !sentIsolates.add(isolateId)) {
+          continue;
+        }
+
+        await device.vmService!.flutterSendExtensionEvent(
+          isolateId: isolateId,
+          eventKind: eventKind,
+        );
+
+        if (eventKind == kHotRestartEventKind) {
+          break;
+        }
+      }
+    } on Object catch (error, stackTrace) {
+      // Event delivery is best-effort and must not turn a successful reload or
+      // restart into a failed operation.
+      globals.printTrace(
+        'Failed to send $eventKind event: $error\n$stackTrace',
+      );
+    }
+  }
+}
+
   Future<OperationResult> _restartFromSources({String? reason}) async {
     final restartTimer = Stopwatch()..start();
     UpdateFSReport updatedDevFS;
@@ -633,9 +672,11 @@ class HotRunner extends ResidentRunner {
     }
     // Check if the isolate is paused and resume it.
     final operations = <Future<void>>[];
+    final viewsByDevice = <FlutterDevice?, List<FlutterView>>{};
     for (final FlutterDevice? device in flutterDevices) {
       final uiIsolatesIds = <String?>{};
       final List<FlutterView> views = await device!.vmService!.getFlutterViews();
+      viewsByDevice[device] = views;
       for (final view in views) {
         if (view.uiIsolate == null) {
           continue;
@@ -717,6 +758,11 @@ class HotRunner extends ResidentRunner {
         );
       }
     }
+    // Send the event while the original UI isolates are still available. A full
+    // restart may leave the replacement isolate paused before framework service
+    // extensions are registered, so forwarding from the old isolate is the only
+    // reliable point that does not depend on application execution after restart.
+    await _sendHotEvent(kHotRestartEventKind, viewsByDevice: viewsByDevice);
     await Future.wait(operations);
     globals.printTrace('Finished waiting on operations.');
     await _launchFromDevFS();
@@ -1041,6 +1087,7 @@ class HotRunner extends ResidentRunner {
     );
     shouldReportReloadTime = reassembleResult.shouldReportReloadTime;
     if (reassembleResult.reassembleViews.isEmpty) {
+      await _sendHotEvent(kHotReloadEventKind, viewsByDevice: viewCache);
       return OperationResult(OperationResult.ok.code, reloadMessage);
     }
     // Record time it took for Flutter to reassemble the application.
@@ -1101,11 +1148,15 @@ class HotRunner extends ResidentRunner {
         ),
       );
     }
-    return OperationResult(
+    final result = OperationResult(
       reassembleResult.failedReassemble ? 1 : OperationResult.ok.code,
       reloadMessage,
       extraTimings: extraTimings,
     );
+    if (result.isOk) {
+      await _sendHotEvent(kHotReloadEventKind, viewsByDevice: viewCache);
+    }
+    return result;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -37,6 +37,8 @@ const kFlutterToolAlias = 'Flutter Tools';
 
 const kReloadSourcesServiceName = 'reloadSources';
 const kHotRestartServiceName = 'hotRestart';
+const kHotReloadEventKind = 'Flutter.HotReload';
+const kHotRestartEventKind = 'Flutter.HotRestart';
 const kFlutterVersionServiceName = 'flutterVersion';
 const kCompileExpressionServiceName = 'compileExpression';
 const kFlutterMemoryInfoServiceName = 'flutterMemoryInfo';
@@ -664,6 +666,18 @@ class FlutterVmService {
 
   Future<Map<String, Object?>?> flutterReassemble({required String? isolateId}) {
     return invokeFlutterExtensionRpcRaw('ext.flutter.reassemble', isolateId: isolateId);
+  }
+
+  /// Sends [eventKind] to the VM Service Extension stream from [isolateId].
+  Future<Map<String, Object?>?> flutterSendExtensionEvent({
+    required String isolateId,
+    required String eventKind,
+  }) {
+    return invokeFlutterExtensionRpcRaw(
+      'ext.flutter.sendExtensionEvent',
+      isolateId: isolateId,
+      args: <String, Object>{'eventKind': eventKind},
+    );
   }
 
   Future<bool> flutterAlreadyPaintedFirstUsefulFrame({required String isolateId}) async {

--- a/packages/flutter_tools/test/general.shard/run_hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/run_hot_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
+import 'package:vm_service/vm_service.dart' as vm_service;
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -166,11 +167,14 @@ class _FakeDevFS extends Fake implements DevFS {
 }
 
 class _FakeFlutterDevice extends Fake implements FlutterDevice {
+  _FakeFlutterDevice({FlutterVmService? vmService})
+      : vmService = vmService ?? _FakeFlutterVmService();
+
   @override
   final DevFS? devFS = _FakeDevFS();
 
   @override
-  final FlutterVmService? vmService = _FakeFlutterVmService();
+  final FlutterVmService? vmService;
 }
 
 class _FakeHotCompatibleFlutterDevice extends Fake implements FlutterDevice {
@@ -204,6 +208,18 @@ class _FakeHotCompatibleFlutterDevice extends Fake implements FlutterDevice {
 class _FakeFlutterVmService extends Fake implements FlutterVmService {
   @override
   final vm_service.VmService service = _FakeVmService();
+
+  @override
+  Future<void> flutterSendExtensionEvent({
+    required String isolateId,
+    required String eventKind,
+    Map<String, dynamic>? eventData,
+  }) async {
+    sentEvents.add((isolateId: isolateId, eventKind: eventKind));
+  }
+
+  final List<({String isolateId, String eventKind})> sentEvents =
+      <({String isolateId, String eventKind})>[];
 }
 
 class _FakeVmService extends Fake implements vm_service.VmService {

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -195,6 +195,23 @@ void main() {
     expect(call.args, <String, String>{'isolateId': 'def'});
   });
 
+  testUsingContext('flutterSendExtensionEvent forwards arguments correctly', () async {
+    final fakeVmServiceHost = FakeVmServiceHost(
+      requests: <VmServiceExpectation>[
+        const FakeVmServiceRequest(
+          method: 'ext.flutter.sendExtensionEvent',
+          args: <String, Object>{'isolateId': 'def', 'eventKind': kHotReloadEventKind},
+        ),
+      ],
+    );
+
+    await fakeVmServiceHost.vmService.flutterSendExtensionEvent(
+      isolateId: 'def',
+      eventKind: kHotReloadEventKind,
+    );
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+  });
+
   testUsingContext('runInView forwards arguments correctly', () async {
     final fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[


### PR DESCRIPTION
## Description

This PR implements #134470 by exposing VM Service events for Flutter Hot Reload and Hot Restart.

The goal is to allow external development tools, such as DevTools, to observe when a Hot Reload or Hot Restart occurs without changing the existing reload/restart behavior.

### Changes

* Emit a VM Service event when Hot Reload is performed.
* Emit a VM Service event when Hot Restart is performed.
* Reuse the existing VM Service event infrastructure rather than introducing a new event mechanism.
* Add tests covering the new event behavior.
* Keep the existing Hot Reload and Hot Restart workflows unchanged.

This provides a way for external tools to react to Flutter development lifecycle events.

## Issue

Fixes #134470

## Pre-launch Checklist

* [ ] I read the Contributor Guide and followed the process outlined there for submitting a PR.
* [ ] I read the AI contribution guidelines and understand my responsibilities, or I am not using AI tools.
* [ ] I read the Tree Hygiene wiki page, which explains my responsibilities.
* [ ] I signed the CLA.
* [x] I listed at least one issue that this PR fixes in the description above.
* [x] I updated/added relevant documentation (doc comments with `///`).
* [x] I added new tests to check the change I am making.
* [ ] I followed the breaking change policy and added Data Driven Fixes where supported.
* [ ] All existing and new tests are passing.
