### PR TITLE
Fix GridTile

### DIFF
--- a/packages/flutter/lib/src/material/grid_tile.dart
+++ b/packages/flutter/lib/src/material/grid_tile.dart
@@ -46,9 +46,14 @@ class GridTile extends StatelessWidget {
       return child;
     }
 
+    // The tile sizes itself to its child so that it can be used where the
+    // incoming constraints are unbounded, e.g. in a horizontally scrolling
+    // ListView. A Stack whose children are all positioned would try to expand
+    // to the biggest allowed size, which is infinite in that case.
     return Stack(
+      fit: StackFit.passthrough,
       children: <Widget>[
-        Positioned.fill(child: child),
+        child,
         if (header != null) Positioned(top: 0.0, left: 0.0, right: 0.0, child: header!),
         if (footer != null) Positioned(left: 0.0, bottom: 0.0, right: 0.0, child: footer!),
       ],

--- a/packages/flutter/test/material/grid_title_test.dart
+++ b/packages/flutter/test/material/grid_title_test.dart
@@ -59,6 +59,62 @@ void main() {
     expect(tester.getSize(find.byType(GridTile)), Size.zero);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/82055
+  testWidgets('GridTile with header and footer sizes itself to its child when unconstrained', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            height: 100.0,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              itemCount: 1,
+              itemBuilder: (BuildContext context, int index) {
+                return GridTile(
+                  header: const Text('Header'),
+                  footer: const Text('Footer'),
+                  child: Container(height: 100.0, width: 80.0, color: Colors.red),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(tester.getSize(find.byType(GridTile)), const Size(80.0, 100.0));
+    expect(find.text('Header'), findsOneWidget);
+    expect(find.text('Footer'), findsOneWidget);
+  });
+
+  testWidgets('GridTile child fills the tile when the constraints are tight', (
+    WidgetTester tester,
+  ) async {
+    final Key childKey = UniqueKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 200.0,
+            height: 150.0,
+            child: GridTile(
+              header: const Text('Header'),
+              footer: const Text('Footer'),
+              child: ColoredBox(key: childKey, color: Colors.red),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(GridTile)), const Size(200.0, 150.0));
+    expect(tester.getSize(find.byKey(childKey)), const Size(200.0, 150.0));
+  });
+
   testWidgets('GridTileBar does not crash at zero area', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(


### PR DESCRIPTION
GridTile placed every child of its Stack in a Positioned widget, including the tile content. A Stack without any non-positioned child sizes itself to the biggest allowed size, which is infinite along the main axis of an unbounded parent such as a horizontally scrolling ListView. RenderStack then failed its `size.isFinite` assertion.

The tile content is now a non-positioned child of the Stack, and the Stack uses StackFit.passthrough so the content still receives the constraints the tile receives. The tile keeps filling the available space when the incoming constraints are tight (the GridView case), and shrink-wraps its content when they are unbounded instead of crashing.

Fixes https://github.com/flutter/flutter/issues/82055

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
