### PR TITLE
Constrain the width of the children of a vertical Wrap

### DIFF
--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -620,7 +620,10 @@ class RenderWrap extends RenderBox
     }
     final BoxConstraints childConstraints = switch (direction) {
       Axis.horizontal => BoxConstraints(maxWidth: constraints.maxWidth),
-      Axis.vertical => BoxConstraints(maxHeight: constraints.maxHeight),
+      Axis.vertical => BoxConstraints(
+        maxWidth: constraints.maxWidth,
+        maxHeight: constraints.maxHeight,
+      ),
     };
 
     final (_AxisSize childrenAxisSize, List<_RunMetrics> runMetrics) = _computeRuns(
@@ -659,7 +662,10 @@ class RenderWrap extends RenderBox
   ]) {
     final (BoxConstraints childConstraints, double mainAxisLimit) = switch (direction) {
       Axis.horizontal => (BoxConstraints(maxWidth: constraints.maxWidth), constraints.maxWidth),
-      Axis.vertical => (BoxConstraints(maxHeight: constraints.maxHeight), constraints.maxHeight),
+      Axis.vertical => (
+        BoxConstraints(maxWidth: constraints.maxWidth, maxHeight: constraints.maxHeight),
+        constraints.maxHeight,
+      ),
     };
 
     var mainAxisExtent = 0.0;
@@ -738,7 +744,15 @@ class RenderWrap extends RenderBox
     assert(firstChild != null);
     final (BoxConstraints childConstraints, double mainAxisLimit) = switch (direction) {
       Axis.horizontal => (BoxConstraints(maxWidth: constraints.maxWidth), constraints.maxWidth),
-      Axis.vertical => (BoxConstraints(maxHeight: constraints.maxHeight), constraints.maxHeight),
+      // Unlike the horizontal case, where the main axis limit already bounds
+      // the width of the children, a vertical Wrap must explicitly forward the
+      // incoming width constraint. Otherwise the children are laid out with an
+      // unbounded width, which many widgets (for instance TextField) do not
+      // support.
+      Axis.vertical => (
+        BoxConstraints(maxWidth: constraints.maxWidth, maxHeight: constraints.maxHeight),
+        constraints.maxHeight,
+      ),
     };
 
     final (bool flipMainAxis, _) = _areAxesFlipped;

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -1041,4 +1041,68 @@ void main() {
     );
     verify(tester, <Offset>[const Offset(700.0, 0.0)]);
   });
+
+  testWidgets('Vertical Wrap constrains the width of its children', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/38503
+    late BoxConstraints childConstraints;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 300.0,
+            height: 400.0,
+            child: Wrap(
+              direction: Axis.vertical,
+              children: <Widget>[
+                LayoutBuilder(
+                  builder: (BuildContext context, BoxConstraints constraints) {
+                    childConstraints = constraints;
+                    return const SizedBox(width: 100.0, height: 50.0);
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(childConstraints, const BoxConstraints(maxWidth: 300.0, maxHeight: 400.0));
+  });
+
+  testWidgets('Vertical Wrap lays out its children within the available width', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/38503
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 100.0,
+            child: Wrap(
+              direction: Axis.vertical,
+              children: <Widget>[
+                Text(
+                  'A long line of text that has to wrap',
+                  style: TextStyle(height: 1.0, fontSize: 10.0),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(Text)).width, lessThanOrEqualTo(100.0));
+    expect(tester.getSize(find.byType(Wrap)).width, lessThanOrEqualTo(100.0));
+
+    // The dry layout must agree with the actual layout.
+    final RenderBox wrap = tester.renderObject<RenderBox>(find.byType(Wrap));
+    expect(
+      wrap.getDryLayout(const BoxConstraints(maxWidth: 100.0, maxHeight: 600.0)),
+      wrap.size,
+    );
+  });
 }


### PR DESCRIPTION
A `RenderWrap` only ever constrained its children along the main axis: for
`Axis.vertical` the children were laid out with `BoxConstraints(maxHeight:
constraints.maxHeight)`, leaving their width unbounded. Widgets that require a
bounded width, such as `TextField` (`InputDecorator` asserts that its width is
finite), therefore threw during layout and were not rendered inside a
`Wrap(direction: Axis.vertical)`.

The children of a vertical Wrap now also receive the incoming `maxWidth`
constraint, so they are laid out within the width that is actually available,
just like the children of a horizontal Wrap already are. The same constraint is
used by the layout, the dry layout and the dry baseline code paths so that they
stay consistent. Intrinsic sizing is unaffected: the intrinsic width query
already passes an unbounded `maxWidth`, so the constraint stays unbounded there.

The horizontal case is deliberately left unchanged: bounding the height of the
children of a horizontal Wrap would change the layout of existing apps.

Fixes https://github.com/flutter/flutter/issues/38503

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
