### PR TITLE
Read TextFormField value from its controller

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -298,6 +298,16 @@ class _CupertinoTextFormFieldRowState extends FormFieldState<String> {
   CupertinoTextFormFieldRow get _cupertinoTextFormFieldRow =>
       super.widget as CupertinoTextFormFieldRow;
 
+  // The text editing controller is the source of truth for this field's value.
+  //
+  // Reading the value from the controller rather than from the value cached by
+  // [FormFieldState] guarantees that validators (and [FormField.onSaved]) see
+  // the current text even when they run before this state has been notified of
+  // a controller change, for example when [FormState.validate] is called from
+  // a controller listener that was registered before this field's own listener.
+  @override
+  String? get value => _effectiveController.text;
+
   @override
   void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
     super.restoreState(oldBucket, initialRestore);
@@ -391,7 +401,7 @@ class _CupertinoTextFormFieldRowState extends FormFieldState<String> {
     // notifications for changes originating from within this class -- for
     // example, the reset() method. In such cases, the FormField value will
     // already have been set.
-    if (_effectiveController.text != value) {
+    if (_effectiveController.text != super.value) {
       didChange(_effectiveController.text);
     }
   }

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -351,6 +351,16 @@ class _TextFormFieldState extends FormFieldState<String> {
 
   TextFormField get _textFormField => super.widget as TextFormField;
 
+  // The text editing controller is the source of truth for this field's value.
+  //
+  // Reading the value from the controller rather than from the value cached by
+  // [FormFieldState] guarantees that validators (and [FormField.onSaved]) see
+  // the current text even when they run before this state has been notified of
+  // a controller change, for example when [FormState.validate] is called from
+  // a controller listener that was registered before this field's own listener.
+  @override
+  String? get value => _effectiveController.text;
+
   @override
   void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
     super.restoreState(oldBucket, initialRestore);
@@ -445,7 +455,7 @@ class _TextFormFieldState extends FormFieldState<String> {
     // notifications for changes originating from within this class -- for
     // example, the reset() method. In such cases, the FormField value will
     // already have been set.
-    if (_effectiveController.text != value) {
+    if (_effectiveController.text != super.value) {
       didChange(_effectiveController.text);
     }
   }

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -674,7 +674,7 @@ class FormFieldState<T> extends State<FormField<T>> with RestorationMixin {
   ///  * [validate], which may update [errorText] and [hasError].
   ///
   ///  * [FormField.forceErrorText], which also may update [errorText] and [hasError].
-  bool get isValid => widget.forceErrorText == null && widget.validator?.call(_value) == null;
+  bool get isValid => widget.forceErrorText == null && widget.validator?.call(value) == null;
 
   /// Calls the [FormField]'s onSaved method with the current value.
   void save() {
@@ -734,7 +734,7 @@ class FormFieldState<T> extends State<FormField<T>> with RestorationMixin {
       return;
     }
     if (widget.validator != null) {
-      _errorText.value = widget.validator!(_value);
+      _errorText.value = widget.validator!(value);
     } else {
       _errorText.value = null;
     }

--- a/packages/flutter/test/cupertino/text_form_field_row_test.dart
+++ b/packages/flutter/test/cupertino/text_form_field_row_test.dart
@@ -667,4 +667,58 @@ void main() {
     controller.selection = const TextSelection.collapsed(offset: 0);
     await tester.pump();
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/40494.
+  testWidgets(
+    'validator receives the up-to-date value when validate() is called from a controller listener',
+    (WidgetTester tester) async {
+      final formKey = GlobalKey<FormState>();
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      final controllerTexts = <String>[];
+      final validatedValues = <String?>[];
+      final fieldValues = <String?>[];
+
+      // This listener is added before the CupertinoTextFormFieldRow adds its
+      // own listener, so it is notified first, while the row has not had a
+      // chance to update its value yet.
+      controller.addListener(() {
+        final FormState? formState = formKey.currentState;
+        if (formState == null) {
+          return;
+        }
+        controllerTexts.add(controller.text);
+        formState.validate();
+        fieldValues.add(formState.fields.single.value as String?);
+      });
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: Form(
+              key: formKey,
+              child: CupertinoTextFormFieldRow(
+                controller: controller,
+                validator: (String? value) {
+                  validatedValues.add(value);
+                  return null;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(CupertinoTextFormFieldRow), 'a');
+      await tester.pump();
+
+      expect(controller.text, 'a');
+      expect(controllerTexts, contains('a'));
+      // The validator and the field value must always agree with the value the
+      // controller is notifying about.
+      expect(validatedValues, controllerTexts);
+      expect(fieldValues, controllerTexts);
+    },
+  );
 }

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -1942,4 +1942,58 @@ void main() {
 
     expect(controller.text, 'Initial Value');
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/40494.
+  testWidgets(
+    'validator receives the up-to-date value when validate() is called from a controller listener',
+    (WidgetTester tester) async {
+      final formKey = GlobalKey<FormState>();
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      final controllerTexts = <String>[];
+      final validatedValues = <String?>[];
+      final fieldValues = <String?>[];
+
+      // This listener is added before the TextFormField adds its own listener,
+      // so it is notified first, while the TextFormField has not had a chance
+      // to update its value yet.
+      controller.addListener(() {
+        final FormState? formState = formKey.currentState;
+        if (formState == null) {
+          return;
+        }
+        controllerTexts.add(controller.text);
+        formState.validate();
+        fieldValues.add(formState.fields.single.value as String?);
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Form(
+              key: formKey,
+              child: TextFormField(
+                controller: controller,
+                validator: (String? value) {
+                  validatedValues.add(value);
+                  return null;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'a');
+      await tester.pump();
+
+      expect(controller.text, 'a');
+      expect(controllerTexts, contains('a'));
+      // The validator and the field value must always agree with the value the
+      // controller is notifying about.
+      expect(validatedValues, controllerTexts);
+      expect(fieldValues, controllerTexts);
+    },
+  );
 }


### PR DESCRIPTION
FormFieldState cached the field value and only refreshed it after the
TextEditingController had already notified its listeners. A listener that
was registered before the field's own listener (for example one added in
the enclosing State.initState) therefore saw a stale FormFieldState.value,
and FormState.validate() called from such a listener passed the previous
text to the validators.

_TextFormFieldState and _CupertinoTextFormFieldRowState now expose the
controller text as their value, so the value can no longer lag behind the
controller regardless of listener order. FormFieldState.validate/isValid
now read the public value getter instead of the cached field so that these
overrides are honored. The internal cached value is still used to suppress
the controller notifications that originate from within the field itself.

Fixes https://github.com/flutter/flutter/issues/40494

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
