### PR TITLE
Ignore time of day in CupertinoDatePicker date mode bounds

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -342,13 +342,13 @@ class CupertinoDatePicker extends StatefulWidget {
        assert(
          (mode != CupertinoDatePickerMode.date && mode != CupertinoDatePickerMode.monthYear) ||
              minimumDate == null ||
-             !minimumDate.isAfter(initialDateTime ?? DateTime.now()),
+             !_dateOnly(minimumDate).isAfter(_dateOnly(initialDateTime ?? DateTime.now())),
          'initial date ${initialDateTime ?? DateTime.now()} is not greater than or equal to minimumDate $minimumDate',
        ),
        assert(
          (mode != CupertinoDatePickerMode.date && mode != CupertinoDatePickerMode.monthYear) ||
              maximumDate == null ||
-             !maximumDate.isBefore(initialDateTime ?? DateTime.now()),
+             !_dateOnly(maximumDate).isBefore(_dateOnly(initialDateTime ?? DateTime.now())),
          'initial date ${initialDateTime ?? DateTime.now()} is not less than or equal to maximumDate $maximumDate',
        ),
        assert(
@@ -538,6 +538,14 @@ class CupertinoDatePicker extends StatefulWidget {
       CupertinoDatePickerMode.monthYear => _CupertinoDatePickerMonthYearState(dateOrder: dateOrder),
     };
   }
+
+  // Strips the time of day from `date`.
+  //
+  // In [CupertinoDatePickerMode.date] and [CupertinoDatePickerMode.monthYear]
+  // modes the picker only selects a date, and the entire day of [minimumDate]
+  // and [maximumDate] is selectable, so the time of day of these values must be
+  // ignored when they are validated against [initialDateTime].
+  static DateTime _dateOnly(DateTime date) => DateTime(date.year, date.month, date.day);
 
   // Estimate the minimum width that each column needs to layout its content.
   static double _getColumnWidth(

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -407,6 +407,76 @@ void main() {
       }, throwsAssertionError);
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/63196
+    test('date and monthYear modes ignore the time of day of minimumDate & maximumDate', () {
+      for (final mode in <CupertinoDatePickerMode>[
+        CupertinoDatePickerMode.date,
+        CupertinoDatePickerMode.monthYear,
+      ]) {
+        // The whole day of minimumDate/maximumDate is selectable in these modes,
+        // so the time of day must not make the initial date invalid.
+        expect(() {
+          CupertinoDatePicker(
+            mode: mode,
+            onDateTimeChanged: (DateTime d) {},
+            initialDateTime: DateTime(2020, 8, 8),
+            minimumDate: DateTime(2020, 8, 8, 8),
+          );
+        }, returnsNormally);
+
+        expect(() {
+          CupertinoDatePicker(
+            mode: mode,
+            onDateTimeChanged: (DateTime d) {},
+            initialDateTime: DateTime(2020, 8, 8, 12),
+            maximumDate: DateTime(2020, 8, 8, 8),
+          );
+        }, returnsNormally);
+
+        // Bounds that fall on a different day are still validated.
+        expect(() {
+          CupertinoDatePicker(
+            mode: mode,
+            onDateTimeChanged: (DateTime d) {},
+            initialDateTime: DateTime(2020, 8, 8),
+            minimumDate: DateTime(2020, 8, 9),
+          );
+        }, throwsAssertionError);
+
+        expect(() {
+          CupertinoDatePicker(
+            mode: mode,
+            onDateTimeChanged: (DateTime d) {},
+            initialDateTime: DateTime(2020, 8, 8),
+            maximumDate: DateTime(2020, 8, 7, 23, 59),
+          );
+        }, throwsAssertionError);
+      }
+    });
+
+    testWidgets('date mode builds with a minimumDate later in the initial day', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: SizedBox.square(
+              dimension: 400.0,
+              child: CupertinoDatePicker(
+                mode: CupertinoDatePickerMode.date,
+                onDateTimeChanged: (DateTime d) {},
+                initialDateTime: DateTime(2020, 8, 8),
+                minimumDate: DateTime(2020, 8, 8, 8),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('8'), findsOneWidget);
+    });
+
     testWidgets('changing initialDateTime after first build does not do anything', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
In CupertinoDatePickerMode.date and CupertinoDatePickerMode.monthYear the
picker only selects a date, and the whole day of minimumDate/maximumDate is
selectable at runtime. The constructor asserts however compared the full
DateTime values, so a minimumDate such as DateTime(2020, 8, 8, 8) threw an
assertion for an initialDateTime of DateTime(2020, 8, 8), even though that
date is selectable once the picker is built.

The asserts now strip the time of day from initialDateTime, minimumDate and
maximumDate before comparing them, which matches the day granularity used by
_isCurrentDateValid. Bounds that fall on a different day are still rejected.

Fixes https://github.com/flutter/flutter/issues/63196

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
