### PR TITLE
Animate scroll offset for accessibility scroll actions

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -68,6 +68,12 @@ typedef TwoDimensionalViewportBuilder =
 // next potential ancestor Scrollable.
 typedef _EnsureVisibleResults = (List<Future<void>>, ScrollableState);
 
+// The duration and curve used to animate the scroll offset when an assistive
+// technology performs a scroll action on a [Scrollable]. They are chosen to
+// roughly match the animation the native scroll views use for the same action.
+const Duration _kSemanticScrollDuration = Duration(milliseconds: 300);
+const Curve _kSemanticScrollCurve = Curves.easeInOut;
+
 /// A widget that manages scrolling in one dimension and informs the [Viewport]
 /// through which the content is viewed.
 ///
@@ -749,12 +755,35 @@ class ScrollableState extends State<Scrollable>
 
   final GlobalKey _scrollSemanticsKey = GlobalKey();
 
+  late final _semanticsGestureDelegate = _ScrollableSemanticsGestureDelegate(this);
+
   @override
   @protected
   void setSemanticsActions(Set<SemanticsAction> actions) {
     if (_gestureDetectorKey.currentState != null) {
       _gestureDetectorKey.currentState!.replaceSemanticsActions(actions);
     }
+  }
+
+  // Scrolls in response to a scroll action performed by an assistive
+  // technology, e.g. the three finger scroll of VoiceOver on iOS.
+  //
+  // The offset is animated instead of applied at once because the native scroll
+  // views animate accessibility scrolls as well. Without the animation the
+  // content appears to teleport, which makes it hard to keep track of where in
+  // the scrollable the user ended up.
+  void _handleSemanticsScroll(DragUpdateDetails details) {
+    final double delta = details.primaryDelta ?? 0.0;
+    if (delta == 0.0 || !position.hasPixels || !position.hasContentDimensions) {
+      return;
+    }
+    // The delta describes the drag the assistive technology asked for, which
+    // moves the content in the opposite direction of the scroll offset.
+    position.moveTo(
+      position.pixels - delta,
+      duration: _kSemanticScrollDuration,
+      curve: _kSemanticScrollCurve,
+    );
   }
 
   // GESTURE RECOGNITION AND POINTER IGNORING
@@ -1029,6 +1058,7 @@ class ScrollableState extends State<Scrollable>
         child: RawGestureDetector(
           key: _gestureDetectorKey,
           gestures: _gestureRecognizers,
+          semantics: _semanticsGestureDelegate,
           behavior: widget.hitTestBehavior,
           excludeFromSemantics: widget.excludeFromSemantics,
           child: Semantics(
@@ -1641,6 +1671,33 @@ class _ScrollSemantics extends SingleChildRenderObjectWidget {
       ..axis = axis
       ..position = position
       ..semanticChildCount = semanticChildCount;
+  }
+}
+
+// Turns the scroll actions of an assistive technology into an animated scroll
+// of the [Scrollable]'s position.
+//
+// The default semantics delegate of [RawGestureDetector] synthesizes a complete
+// drag gesture for a scroll action, which moves the scroll offset to its
+// destination within a single frame. [Scrollable] animates the offset instead,
+// see [ScrollableState._handleSemanticsScroll].
+class _ScrollableSemanticsGestureDelegate extends SemanticsGestureDelegate {
+  const _ScrollableSemanticsGestureDelegate(this.state);
+
+  final ScrollableState state;
+
+  @override
+  void assignSemantics(RenderSemanticsGestureHandler renderObject) {
+    // Only expose the scroll actions that the installed drag gesture
+    // recognizers would expose, so that scrollables that cannot be dragged
+    // (e.g. because of NeverScrollableScrollPhysics) stay unscrollable for
+    // assistive technologies as well.
+    final Axis? axis = state._gestureRecognizers.isEmpty ? null : state._lastAxisDirection;
+    renderObject
+      ..onTap = null
+      ..onLongPress = null
+      ..onHorizontalDragUpdate = axis == Axis.horizontal ? state._handleSemanticsScroll : null
+      ..onVerticalDragUpdate = axis == Axis.vertical ? state._handleSemanticsScroll : null;
   }
 }
 

--- a/packages/flutter/test/widgets/scrollable_semantics_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_test.dart
@@ -870,6 +870,75 @@ void main() {
       semantics.dispose();
     },
   );
+
+  testWidgets('scrolling by a semantics action animates the scroll offset', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ListView(
+          controller: controller,
+          children: List<Widget>.generate(80, (int i) => Text('$i')),
+        ),
+      ),
+    );
+
+    expect(controller.offset, 0.0);
+
+    // 80% of the 600px tall viewport.
+    const expectedOffset = 480.0;
+
+    final SemanticsNode scrollable = findNodeWithAction(
+      tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!,
+      SemanticsAction.scrollUp,
+    )!;
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(
+      scrollable.id,
+      SemanticsAction.scrollUp,
+    );
+
+    // The scroll offset is animated instead of jumping to its destination.
+    await tester.pump();
+    expect(controller.offset, 0.0);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.offset, greaterThan(0.0));
+    expect(controller.offset, lessThan(expectedOffset));
+
+    await tester.pumpAndSettle();
+    expect(controller.offset, expectedOffset);
+
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(
+      scrollable.id,
+      SemanticsAction.scrollDown,
+    );
+    await tester.pump();
+    expect(controller.offset, expectedOffset);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(controller.offset, lessThan(expectedOffset));
+    expect(controller.offset, greaterThan(0.0));
+
+    await tester.pumpAndSettle();
+    expect(controller.offset, 0.0);
+
+    semantics.dispose();
+  });
+}
+
+SemanticsNode? findNodeWithAction(SemanticsNode node, SemanticsAction action) {
+  if (node.getSemanticsData().hasAction(action)) {
+    return node;
+  }
+  SemanticsNode? result;
+  node.visitChildren((SemanticsNode child) {
+    result ??= findNodeWithAction(child, action);
+    return result == null;
+  });
+  return result;
 }
 
 Future<void> flingUp(WidgetTester tester, {int repetitions = 1}) =>


### PR DESCRIPTION
Scroll actions coming from an assistive technology (for example VoiceOver's
three finger scroll on iOS) were turned into a synthetic drag gesture by the
default semantics delegate of RawGestureDetector. That drag applied the whole
scroll increment in a single frame, so the content jumped to its destination
while native scroll views animate the same action.

Scrollable now installs its own SemanticsGestureDelegate, which animates the
scroll position with ScrollPosition.moveTo instead of synthesizing a drag. The
set of exposed scroll actions is unchanged: the actions are still only offered
when a drag gesture recognizer is installed and they are still filtered by
setSemanticsActions.

Fixes https://github.com/flutter/flutter/issues/64279

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
