### PR TITLE
Show InputDecoration.errorText when the field is disabled in M2

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -5863,9 +5863,9 @@ class _InputDecoratorDefaultsM2 extends InputDecorationThemeData {
   @override
   TextStyle? get errorStyle => WidgetStateTextStyle.resolveWith((Set<WidgetState> states) {
     final ThemeData themeData = Theme.of(context);
-    if (states.contains(WidgetState.disabled)) {
-      return themeData.textTheme.bodySmall!.copyWith(color: Colors.transparent);
-    }
+    // The error text is shown even when the field is disabled: the subtext
+    // space is allocated for it in any case, so hiding the text would only
+    // leave an unexplained gap below the field.
     return themeData.textTheme.bodySmall!.copyWith(color: themeData.colorScheme.error);
   });
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -12066,6 +12066,19 @@ void main() {
       expect(find.text('errorText'), findsOneWidget);
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/67409.
+    testWidgets('InputDecorator shows error text when disabled', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildInputDecoratorM2(
+          decoration: const InputDecoration(enabled: false, errorText: errorText),
+        ),
+      );
+
+      final ThemeData theme = Theme.of(tester.element(findDecorator()));
+      expect(findError(), findsOneWidget);
+      expect(getErrorStyle(tester).color, theme.colorScheme.error);
+    });
+
     testWidgets('InputDecoration shows error border for errorText and error widget', (
       WidgetTester tester,
     ) async {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -7163,7 +7163,8 @@ void main() {
     expect(helperWidget.style!.color, isNot(equals(Colors.transparent)));
     expect(errorWidget.style!.color, isNot(equals(Colors.transparent)));
 
-    // When enabled is false, the helper/error and counter are not visible.
+    // When enabled is false, the helper and counter are not visible, but the
+    // error is still shown, see https://github.com/flutter/flutter/issues/67409.
     await tester.pumpWidget(buildFrame(false, false));
     helperWidget = tester.widget(find.text(helperText));
     counterWidget = tester.widget(find.text(counterText));
@@ -7173,7 +7174,7 @@ void main() {
     errorWidget = tester.widget(find.text(errorText));
     counterWidget = tester.widget(find.text(counterText));
     expect(counterWidget.style!.color, equals(Colors.transparent));
-    expect(errorWidget.style!.color, equals(Colors.transparent));
+    expect(errorWidget.style!.color, isNot(equals(Colors.transparent)));
   });
 
   testWidgets('Disabled text field has default M2 disabled text style for the input text', (

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -625,7 +625,8 @@ void main() {
     expect(helperWidget.style!.color, isNot(equals(Colors.transparent)));
     expect(errorWidget.style!.color, isNot(equals(Colors.transparent)));
 
-    // When enabled is false, the helper/error and counter are not visible.
+    // When enabled is false, the helper and counter are not visible, but the
+    // error is still shown, see https://github.com/flutter/flutter/issues/67409.
     await tester.pumpWidget(buildFrame(false, false));
     helperWidget = tester.widget(find.text(helperText));
     counterWidget = tester.widget(find.text(counterText));
@@ -635,7 +636,7 @@ void main() {
     errorWidget = tester.widget(find.text(errorText));
     counterWidget = tester.widget(find.text(counterText));
     expect(counterWidget.style!.color, equals(Colors.transparent));
-    expect(errorWidget.style!.color, equals(Colors.transparent));
+    expect(errorWidget.style!.color, isNot(equals(Colors.transparent)));
   });
 
   testWidgets('passing a buildCounter shows returned widget', (WidgetTester tester) async {


### PR DESCRIPTION
_InputDecoratorDefaultsM2.errorStyle resolved the error text color to
Colors.transparent for the disabled state. The subtext row is still laid
out for the error, so a disabled field with an errorText reserved space
below the input but painted nothing, leaving an unexplained gap.

The Material 3 defaults already paint the error text with the error
color in every state. This change removes the disabled special case from
the Material 2 defaults so both align, and the space that is reserved
for the error is used by the visible error text.

Fixes https://github.com/flutter/flutter/issues/67409

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
