### PR TITLE
Update merge flag of assembleSemanticsNode children

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2957,6 +2957,16 @@ class SemanticsNode with DiagnosticableTreeMixin {
     }
     _isMergedIntoParent = value;
     parent?._markDirty();
+    if (mergeAllDescendantsIntoThisNode) {
+      // No need to update the descendants since they are merged into this node
+      // regardless of whether this node is merged into its parent.
+      return;
+    }
+    // Children that were introduced in RenderObject.assembleSemanticsNode are
+    // not visited when the semantics tree is compiled, so their merge flag is
+    // only updated when they are adopted or when this node's merge flag
+    // changes.
+    _updateChildrenMergeFlags();
   }
 
   /// Whether the user can interact with this node in assistive technologies.
@@ -3226,19 +3236,8 @@ class SemanticsNode with DiagnosticableTreeMixin {
 
   void _updateChildMergeFlagRecursively(SemanticsNode child) {
     assert(child.owner == owner);
-    final bool childShouldMergeToParent = isPartOfNodeMerging;
-
-    if (childShouldMergeToParent == child.isMergedIntoParent) {
-      return;
-    }
-
-    child.isMergedIntoParent = childShouldMergeToParent;
-
-    if (child.mergeAllDescendantsIntoThisNode) {
-      // No need to update the descendants since `child` has the merge flag set.
-    } else {
-      child._updateChildrenMergeFlags();
-    }
+    // The setter propagates the change to the descendants of `child` if needed.
+    child.isMergedIntoParent = isPartOfNodeMerging;
   }
 
   void _updateChildrenMergeFlags() {

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -240,6 +240,95 @@ void main() {
 
     semantics.dispose();
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/79029
+  testWidgets('Semantics nodes added in assembleSemanticsNode update their merge flag', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final GlobalKey paintKey = GlobalKey();
+
+    Widget buildCustomPaint({required String label}) {
+      return CustomPaint(
+        key: paintKey,
+        size: const Size(100.0, 100.0),
+        painter: _PainterWithSemantics(label: label),
+      );
+    }
+
+    // Not merged.
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: buildCustomPaint(label: 'test1'),
+      ),
+    );
+
+    expect(_semanticsChildrenOfCustomPaint(tester).single.isMergedIntoParent, isFalse);
+
+    // Merged. The global key keeps the render object alive, and with it the
+    // semantics nodes that RenderCustomPaint created in assembleSemanticsNode.
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MergeSemantics(child: buildCustomPaint(label: 'test2')),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(_semanticsChildrenOfCustomPaint(tester).single.isMergedIntoParent, isTrue);
+    expect(tester.getSemantics(find.byType(MergeSemantics)).getSemanticsData().label, 'test2');
+
+    // Not merged again.
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: buildCustomPaint(label: 'test3'),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(_semanticsChildrenOfCustomPaint(tester).single.isMergedIntoParent, isFalse);
+
+    semantics.dispose();
+  });
+}
+
+List<SemanticsNode> _semanticsChildrenOfCustomPaint(WidgetTester tester) {
+  final children = <SemanticsNode>[];
+  tester.getSemantics(find.byType(CustomPaint)).visitChildren((SemanticsNode child) {
+    children.add(child);
+    return true;
+  });
+  return children;
+}
+
+class _PainterWithSemantics extends CustomPainter {
+  const _PainterWithSemantics({required this.label});
+
+  final String label;
+
+  @override
+  void paint(Canvas canvas, Size size) {}
+
+  @override
+  SemanticsBuilderCallback get semanticsBuilder {
+    return (Size size) {
+      return <CustomPainterSemantics>[
+        CustomPainterSemantics(
+          key: const ValueKey<int>(1),
+          rect: const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0),
+          properties: SemanticsProperties(label: label, textDirection: TextDirection.ltr),
+        ),
+      ];
+    };
+  }
+
+  @override
+  bool shouldRepaint(_PainterWithSemantics oldDelegate) => oldDelegate.label != label;
+
+  @override
+  bool shouldRebuildSemantics(_PainterWithSemantics oldDelegate) => oldDelegate.label != label;
 }
 
 class TestConfigDelegate extends SingleChildRenderObjectWidget {


### PR DESCRIPTION
SemanticsNode.isMergedIntoParent was applied to the children of a node only
when the children were adopted (SemanticsNode._adoptChild) or when the node
itself started or stopped merging its descendants. Semantics nodes that a
RenderObject creates in assembleSemanticsNode (for example the nodes
RenderCustomPaint builds from CustomPainterSemantics) are not visited while the
semantics tree is compiled, so they kept a stale isMergedIntoParent flag when
their parent later started or stopped being merged into an ancestor, for
instance when the render object is reparented under a MergeSemantics with a
GlobalKey. The stale flag made the node data of a merging subtree incomplete
and tripped the
`node.parent == null || !node.parent!.isPartOfNodeMerging || node.isMergedIntoParent`
assertion in SemanticsOwner.sendSemanticsUpdate.

The isMergedIntoParent setter now propagates the new value down to the children
of the node, unless the node merges all of its descendants, in which case the
children are merged already. _updateChildMergeFlagRecursively defers to the
setter, so the flag is now kept up to date wherever it changes.

Fixes https://github.com/flutter/flutter/issues/79029

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
