### PR TITLE
Include spacing in RenderWrap max intrinsic main axis extent

### DIFF
--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -528,7 +528,9 @@ class RenderWrap extends RenderBox
   double computeMaxIntrinsicWidth(double height) {
     switch (direction) {
       case Axis.horizontal:
-        var width = 0.0;
+        // The maximum intrinsic width is reached when every child is laid out
+        // in a single run, which also includes the spacing between them.
+        double width = math.max(childCount - 1, 0) * spacing;
         RenderBox? child = firstChild;
         while (child != null) {
           width += child.getMaxIntrinsicWidth(double.infinity);
@@ -562,7 +564,9 @@ class RenderWrap extends RenderBox
       case Axis.horizontal:
         return getDryLayout(BoxConstraints(maxWidth: width)).height;
       case Axis.vertical:
-        var height = 0.0;
+        // The maximum intrinsic height is reached when every child is laid out
+        // in a single run, which also includes the spacing between them.
+        double height = math.max(childCount - 1, 0) * spacing;
         RenderBox? child = firstChild;
         while (child != null) {
           height += child.getMaxIntrinsicHeight(double.infinity);

--- a/packages/flutter/test/rendering/wrap_test.dart
+++ b/packages/flutter/test/rendering/wrap_test.dart
@@ -180,6 +180,78 @@ void main() {
     expect(renderWrap.computeMinIntrinsicWidth(80), 80);
   });
 
+  test('Compute max intrinsic width includes spacing', () {
+    final children = <RenderBox>[
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints(minWidth: 80, minHeight: 80),
+      ),
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints(minWidth: 80, minHeight: 80),
+      ),
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints(minWidth: 80, minHeight: 80),
+      ),
+    ];
+
+    final renderWrap = RenderWrap();
+
+    children.forEach(renderWrap.add);
+
+    renderWrap.spacing = 5;
+    renderWrap.runSpacing = 5;
+    renderWrap.direction = Axis.horizontal;
+
+    // Laying the children out in a single run needs 3 * 80 for the children and
+    // 2 * 5 for the spacing between them.
+    expect(renderWrap.computeMaxIntrinsicWidth(double.infinity), 250);
+    // Every child can be placed in its own run, so the spacing does not
+    // contribute to the minimum intrinsic width.
+    expect(renderWrap.computeMinIntrinsicWidth(double.infinity), 80);
+  });
+
+  test('Compute max intrinsic height includes spacing', () {
+    final children = <RenderBox>[
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints(minWidth: 80, minHeight: 80),
+      ),
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints(minWidth: 80, minHeight: 80),
+      ),
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints(minWidth: 80, minHeight: 80),
+      ),
+    ];
+
+    final renderWrap = RenderWrap();
+
+    children.forEach(renderWrap.add);
+
+    renderWrap.spacing = 5;
+    renderWrap.runSpacing = 5;
+    renderWrap.direction = Axis.vertical;
+
+    expect(renderWrap.computeMaxIntrinsicHeight(double.infinity), 250);
+    expect(renderWrap.computeMinIntrinsicHeight(double.infinity), 80);
+  });
+
+  test('Compute max intrinsic extent does not add spacing for a single child', () {
+    final renderWrap = RenderWrap();
+    renderWrap.add(
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints(minWidth: 80, minHeight: 80),
+      ),
+    );
+
+    renderWrap.spacing = 5;
+    renderWrap.runSpacing = 5;
+
+    renderWrap.direction = Axis.horizontal;
+    expect(renderWrap.computeMaxIntrinsicWidth(double.infinity), 80);
+
+    renderWrap.direction = Axis.vertical;
+    expect(renderWrap.computeMaxIntrinsicHeight(double.infinity), 80);
+  });
+
   test('Wrap respects clipBehavior', () {
     const viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
     final context = TestClipPaintingContext();


### PR DESCRIPTION
RenderWrap.computeMaxIntrinsicWidth (horizontal) and
computeMaxIntrinsicHeight (vertical) only summed the max intrinsic extents
of the children. The maximum intrinsic main axis extent is reached when all
children sit in a single run, so the `spacing` between adjacent children is
part of that extent. Ignoring it made the reported intrinsic extent too
small, and widgets such as IntrinsicWidth then constrained the Wrap to a
width that forces an extra run.

The fix seeds the accumulator with `max(childCount - 1, 0) * spacing`, so
an empty Wrap and a Wrap with a single child are unchanged.

Fixes https://github.com/flutter/flutter/issues/82289

---

## Reviewer context (please read)

This fix has a history. PR #82609 (2021) fixed the same root cause and was **merged**, then
reverted by PR #82872. The revert PR gives no reason in its description; per the issue thread the
revert was caused by a **Google-internal test failure**, not by the math being wrong.

So this PR intentionally re-lands the same correction. Points for the reviewer:

* The math: for a `Wrap`, the *max* intrinsic main-axis extent is the single-run case, so it must
  include `spacing * (childCount - 1)`. The current code sums only the children's own max intrinsic
  extents, so `IntrinsicWidth` sizes the `Wrap` too small and forces an extra run.
* Empty and single-child `Wrap`s are unchanged (`math.max(childCount - 1, 0)`).
* If the internal breakage still exists, it is likely a golden/layout expectation that encoded the
  old, too-small intrinsic size. Please run the internal tests before landing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
