### PR TITLE
Make AlignmentGeometryTween a Tween<AlignmentGeometry>

### DIFF
--- a/packages/flutter/lib/src/rendering/tweens.dart
+++ b/packages/flutter/lib/src/rendering/tweens.dart
@@ -60,7 +60,7 @@ class AlignmentTween extends Tween<Alignment> {
 /// See also:
 ///
 ///  * [AlignmentTween], which interpolates between two [Alignment] objects.
-class AlignmentGeometryTween extends Tween<AlignmentGeometry?> {
+class AlignmentGeometryTween extends Tween<AlignmentGeometry> {
   /// Creates a fractional offset geometry tween.
   ///
   /// The [begin] and [end] properties may be null; the null value
@@ -69,5 +69,5 @@ class AlignmentGeometryTween extends Tween<AlignmentGeometry?> {
 
   /// Returns the value this variable has at the given animation clock value.
   @override
-  AlignmentGeometry? lerp(double t) => AlignmentGeometry.lerp(begin, end, t);
+  AlignmentGeometry lerp(double t) => AlignmentGeometry.lerp(begin, end, t)!;
 }

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1086,7 +1086,7 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
   @override
   Widget build(BuildContext context) {
     return Align(
-      alignment: _alignment!.evaluate(animation)!,
+      alignment: _alignment!.evaluate(animation),
       heightFactor: _heightFactorTween?.evaluate(animation),
       widthFactor: _widthFactorTween?.evaluate(animation),
       child: widget.child,
@@ -2413,7 +2413,7 @@ class _AnimatedFractionallySizedBoxState
   @override
   Widget build(BuildContext context) {
     return FractionallySizedBox(
-      alignment: _alignment!.evaluate(animation)!,
+      alignment: _alignment!.evaluate(animation),
       heightFactor: _heightFactorTween?.evaluate(animation),
       widthFactor: _widthFactorTween?.evaluate(animation),
       child: widget.child,

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -184,6 +184,30 @@ void main() {
       expect(actualAlignment, const Alignment(0.0, 0.5));
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/82320
+    testWidgets('animates an AlignmentGeometryTween', (WidgetTester tester) async {
+      final controller = AnimationController(vsync: const TestVSync());
+      addTearDown(controller.dispose);
+      final Animation<AlignmentGeometry> alignmentTween = AlignmentGeometryTween(
+        begin: AlignmentDirectional.centerStart,
+        end: AlignmentDirectional.bottomEnd,
+      ).animate(controller);
+      final Widget widget = Directionality(
+        textDirection: TextDirection.rtl,
+        child: AlignTransition(alignment: alignmentTween, child: const Text('Ready')),
+      );
+
+      await tester.pumpWidget(widget);
+
+      final RenderPositionedBox actualPositionedBox = tester.renderObject(find.byType(Align));
+
+      expect(actualPositionedBox.alignment, AlignmentDirectional.centerStart);
+
+      controller.value = 0.5;
+      await tester.pump();
+      expect(actualPositionedBox.alignment, const AlignmentDirectional(0.0, 0.5));
+    });
+
     testWidgets('keeps width and height factors', (WidgetTester tester) async {
       final controller = AnimationController(vsync: const TestVSync());
       addTearDown(controller.dispose);


### PR DESCRIPTION
`AlignmentGeometryTween` extended `Tween<AlignmentGeometry?>`, so
`AlignmentGeometryTween(...).animate(...)` produced an
`Animation<AlignmentGeometry?>`. Widgets such as `AlignTransition` take an
`Animation<AlignmentGeometry>`, so after the null safety migration the tween
could no longer be used with them and the code failed to compile.

`AlignmentGeometry.lerp` only returns null when both `begin` and `end` are
null, which is the same situation in which the already non-nullable
`AlignmentTween` throws. This change makes `AlignmentGeometryTween` extend
`Tween<AlignmentGeometry>` and adds `!` to the `lerp` call, exactly matching
`AlignmentTween`. The now redundant `!` on the `evaluate` calls in
`_AnimatedAlignState` and `_AnimatedFractionallySizedBoxState` is removed.

Fixes https://github.com/flutter/flutter/issues/82320

---

## Reviewer context — this is a source-breaking change

`AlignmentGeometryTween` moves from `Tween<AlignmentGeometry?>` to `Tween<AlignmentGeometry>`.
That is exactly what issue #82320 asks for, and it mirrors the already non-nullable `AlignmentTween`,
but it **is source-breaking**: code that explicitly declared `Tween<AlignmentGeometry?>` or
`Animation<AlignmentGeometry?>` for this tween must drop the `?`.

Per the Flutter breaking change policy this PR needs:
* a breaking-change announcement / migration guide entry, and
* a check against the `flutter/tests` registry.

I have not filed those, because they need a maintainer decision on whether to accept the break at all.
If the team prefers a non-breaking route, the alternative is to leave the tween as-is and instead make
`AlignTransition` accept `Animation<AlignmentGeometry?>`, which is additive but arguably papers over
the real problem.

Rationale for the break: `AlignmentGeometry.lerp` only returns null when *both* `begin` and `end` are
null, so the nullable type never carried real information for a configured tween; it just made the
tween unusable with `AlignTransition` after null safety.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
