### PR TITLE
Repaint ink features when an Expansible changes size

### DIFF
--- a/packages/flutter/lib/src/widgets/expansible.dart
+++ b/packages/flutter/lib/src/widgets/expansible.dart
@@ -8,6 +8,7 @@ library;
 import 'basic.dart';
 import 'framework.dart';
 import 'page_storage.dart';
+import 'size_changed_layout_notifier.dart';
 import 'ticker_provider.dart';
 import 'transitions.dart';
 
@@ -461,16 +462,22 @@ class _ExpansibleState extends State<Expansible> with SingleTickerProviderStateM
       child: TickerMode(enabled: !closed, child: widget.bodyBuilder(context, _animationController)),
     );
 
-    return AnimatedBuilder(
-      animation: _animationController.view,
-      builder: (BuildContext context, Widget? child) {
-        final Widget header = widget.headerBuilder(context, _animationController);
-        final Widget body = ClipRect(
-          child: Align(heightFactor: _heightFactor.value, child: child),
-        );
-        return widget.expansibleBuilder(context, header, body, _animationController);
-      },
-      child: shouldRemoveBody ? null : result,
+    // Expanding and collapsing moves the widgets that follow this one. Ancestors
+    // that paint relative to the position of their descendants, such as the ink
+    // effects painted by Material, only repaint when they are notified of a
+    // layout change, so dispatch one whenever this widget resizes.
+    return SizeChangedLayoutNotifier(
+      child: AnimatedBuilder(
+        animation: _animationController.view,
+        builder: (BuildContext context, Widget? child) {
+          final Widget header = widget.headerBuilder(context, _animationController);
+          final Widget body = ClipRect(
+            child: Align(heightFactor: _heightFactor.value, child: child),
+          );
+          return widget.expansibleBuilder(context, header, body, _animationController);
+        },
+        child: shouldRemoveBody ? null : result,
+      ),
     );
   }
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -8,6 +8,7 @@
 library;
 
 import 'dart:ui';
+import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -2319,4 +2320,84 @@ void main() {
     final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
     expect(listTile.statesController, isNull);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/84201.
+  testWidgets('ListTile tileColor is repainted when an ExpansionTile above it expands', (
+    WidgetTester tester,
+  ) async {
+    const boundaryKey = Key('boundary');
+    const tileKey = Key('tile');
+    const tileColor = Color(0xFFFFFFFF);
+    final controller = ExpansibleController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      RepaintBoundary(
+        key: boundaryKey,
+        child: MaterialApp(
+          home: Material(
+            color: const Color(0xFF000000),
+            child: ListView(
+              children: <Widget>[
+                ExpansionTile(
+                  controller: controller,
+                  title: const Text('Expansion'),
+                  children: const <Widget>[SizedBox(height: 150.0)],
+                ),
+                const ListTile(key: tileKey, tileColor: tileColor, title: Text('Tile')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Returns the vertical bounds of the tile color as it was actually painted.
+    Future<Rect> paintedTileColorBounds() async {
+      final RenderRepaintBoundary boundary = tester.renderObject<RenderRepaintBoundary>(
+        find.byKey(boundaryKey),
+      );
+      ByteData? data;
+      var width = 0;
+      var height = 0;
+      await tester.runAsync(() async {
+        final ui.Image image = await boundary.toImage();
+        width = image.width;
+        height = image.height;
+        data = await image.toByteData();
+        image.dispose();
+      });
+      double? top;
+      double? bottom;
+      for (var y = 0; y < height; y += 1) {
+        final int offset = (y * width + width ~/ 2) * 4;
+        final int pixel = Color.fromARGB(
+          data!.getUint8(offset + 3),
+          data!.getUint8(offset),
+          data!.getUint8(offset + 1),
+          data!.getUint8(offset + 2),
+        ).toARGB32();
+        if (pixel == tileColor.toARGB32()) {
+          top ??= y.toDouble();
+          bottom = y + 1.0;
+        }
+      }
+      return Rect.fromLTRB(0.0, top!, 0.0, bottom!);
+    }
+
+    Rect tileRect = tester.getRect(find.byKey(tileKey));
+    Rect paintedRect = await paintedTileColorBounds();
+    expect(paintedRect.top, tileRect.top);
+    expect(paintedRect.bottom, tileRect.bottom);
+
+    // Expanding the tile above moves the ListTile down. Its tile color must
+    // move with it.
+    controller.expand();
+    await tester.pumpAndSettle();
+
+    tileRect = tester.getRect(find.byKey(tileKey));
+    paintedRect = await paintedTileColorBounds();
+    expect(paintedRect.top, tileRect.top);
+    expect(paintedRect.bottom, tileRect.bottom);
+  }, skip: isBrowser); // [intended] The test uses RenderRepaintBoundary.toImage.
 }

--- a/packages/flutter/test/widgets/expansible_test.dart
+++ b/packages/flutter/test/widgets/expansible_test.dart
@@ -533,4 +533,43 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Body'), findsOneWidget);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/84201.
+  testWidgets('Dispatches a SizeChangedLayoutNotification when expanded and collapsed', (
+    WidgetTester tester,
+  ) async {
+    final controller = ExpansibleController();
+    addTearDown(controller.dispose);
+    final notifications = <SizeChangedLayoutNotification>[];
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: NotificationListener<SizeChangedLayoutNotification>(
+          onNotification: (SizeChangedLayoutNotification notification) {
+            notifications.add(notification);
+            return false;
+          },
+          child: Center(
+            child: Expansible(
+              controller: controller,
+              headerBuilder: (BuildContext context, Animation<double> animation) =>
+                  const Text('Header'),
+              bodyBuilder: (BuildContext context, Animation<double> animation) =>
+                  const SizedBox(height: 100.0),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(notifications, isEmpty);
+
+    controller.expand();
+    await tester.pumpAndSettle();
+    expect(notifications, isNotEmpty);
+
+    notifications.clear();
+    controller.collapse();
+    await tester.pumpAndSettle();
+    expect(notifications, isNotEmpty);
+  });
 }


### PR DESCRIPTION
Expansible animates its size when it expands and collapses, which moves
the widgets that follow it. Ancestors that paint relative to the position
of their descendants, such as the ink effects painted by Material, only
repaint when a LayoutChangedNotification is dispatched. Nothing dispatched
one, and the viewport of a ListView is a repaint boundary, so a ListTile
that an ExpansionTile moved kept painting its tileColor at the old
position.

Wrap the Expansible in a SizeChangedLayoutNotifier so that a
SizeChangedLayoutNotification is dispatched whenever it resizes.

Fixes https://github.com/flutter/flutter/issues/84201

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
