### PR TITLE
Fix null check crash when reorderable drop target is off screen

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -941,6 +941,11 @@ class SliverReorderableListState extends State<SliverReorderableList>
 
   void _dragEnd(_DragInfo item) {
     setState(() {
+      // The drop position is derived from the geometry of the item occupying
+      // the insert position. That item may not be laid out anymore, e.g. when
+      // the list has been auto scrolled far away from it. In that case the
+      // drop position stays null and the item is dropped where it is instead
+      // of animating to a position that cannot be computed.
       if (_insertIndex! - item.index == 1) {
         // When returning to original position from below, _insertIndex equals
         // item.index + 1 because insertion index is calculated with the dragged
@@ -952,23 +957,33 @@ class SliverReorderableListState extends State<SliverReorderableList>
       } else if (_reverse) {
         if (_insertIndex! >= _items.length) {
           // Drop at the starting position of the last element and offset its own extent
-          _finalDropPosition =
-              _itemOffsetAt(_items.length - 1) - _extentOffset(item.itemExtent, _scrollDirection);
+          final Offset? offset = _itemOffsetAt(_items.length - 1);
+          _finalDropPosition = offset == null
+              ? null
+              : offset - _extentOffset(item.itemExtent, _scrollDirection);
         } else {
           // Drop at the end of the current element occupying the insert position
-          _finalDropPosition =
-              _itemOffsetAt(_insertIndex!) +
-              _extentOffset(_itemExtentAt(_insertIndex!), _scrollDirection);
+          final Offset? offset = _itemOffsetAt(_insertIndex!);
+          final double? extent = _itemExtentAt(_insertIndex!);
+          _finalDropPosition = offset == null || extent == null
+              ? null
+              : offset + _extentOffset(extent, _scrollDirection);
         }
       } else {
         if (_insertIndex! == 0) {
           // Drop at the starting position of the first element and offset its own extent
-          _finalDropPosition = _itemOffsetAt(0) - _extentOffset(item.itemExtent, _scrollDirection);
+          final Offset? offset = _itemOffsetAt(0);
+          _finalDropPosition = offset == null
+              ? null
+              : offset - _extentOffset(item.itemExtent, _scrollDirection);
         } else {
           // Drop at the end of the previous element occupying the insert position
           final int atIndex = _insertIndex! - 1;
-          _finalDropPosition =
-              _itemOffsetAt(atIndex) + _extentOffset(_itemExtentAt(atIndex), _scrollDirection);
+          final Offset? offset = _itemOffsetAt(atIndex);
+          final double? extent = _itemExtentAt(atIndex);
+          _finalDropPosition = offset == null || extent == null
+              ? null
+              : offset + _extentOffset(extent, _scrollDirection);
         }
       }
     });
@@ -1128,12 +1143,15 @@ class SliverReorderableListState extends State<SliverReorderableList>
     );
   }
 
-  Offset _itemOffsetAt(int index) {
-    return _items[index]!.targetGeometry().topLeft;
+  // Returns null when the item at [index] is not currently laid out, e.g. when
+  // it has been scrolled out of the viewport and out of the cache extent.
+  Offset? _itemOffsetAt(int index) {
+    return _items[index]?.targetGeometry().topLeft;
   }
 
-  double _itemExtentAt(int index) {
-    return _sizeExtent(_items[index]!.targetGeometry().size, _scrollDirection);
+  double? _itemExtentAt(int index) {
+    final Size? size = _items[index]?.targetGeometry().size;
+    return size == null ? null : _sizeExtent(size, _scrollDirection);
   }
 
   Widget _itemBuilder(BuildContext context, int index) {

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -2171,6 +2171,54 @@ void main() {
     );
     expect(tester.getSize(find.byType(ReorderableDelayedDragStartListener)), Size.zero);
   });
+
+  testWidgets('SliverReorderableList does not crash when the drop target is not laid out', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/87093
+    const itemHeights = <double>[100, 2000];
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: CustomScrollView(
+          controller: scrollController,
+          cacheExtent: 0,
+          slivers: <Widget>[
+            SliverReorderableList(
+              itemBuilder: (BuildContext context, int index) {
+                return ReorderableDragStartListener(
+                  key: ValueKey<int>(index),
+                  index: index,
+                  child: SizedBox(height: itemHeights[index], child: Text('item $index')),
+                );
+              },
+              itemCount: itemHeights.length,
+              onReorderItem: (_, _) {},
+              autoScrollerVelocityScalar: 50,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final TestGesture drag = await tester.startGesture(tester.getCenter(find.text('item 0')));
+    await tester.pump(kLongPressTimeout);
+
+    // Drag the first item down to the bottom edge so the auto scroller kicks
+    // in and scrolls the first item out of the (zero extent) cache area.
+    await drag.moveBy(const Offset(0, 560));
+    for (var i = 0; i < 20; i += 1) {
+      await tester.pump(const Duration(milliseconds: 51));
+      await tester.idle();
+    }
+    expect(scrollController.offset, greaterThan(itemHeights[0]));
+
+    await drag.up();
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class TestList extends StatelessWidget {


### PR DESCRIPTION
SliverReorderableListState._dragEnd computed the drop animation target with
_items[index]!, assuming the item occupying the insert position is still laid
out. When the list auto scrolls far enough during a drag (easy to hit when an
item is taller than the viewport, or with a small cacheExtent) that item is
disposed and removed from _items, so the null check operator threw.

_itemOffsetAt and _itemExtentAt now return null for items that are not laid
out, and _dragEnd leaves _finalDropPosition null in that case. A null
_finalDropPosition is already handled by the drag proxy: the item is simply
dropped where it is instead of animating to an unknown position.

Fixes https://github.com/flutter/flutter/issues/87093

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
