### PR TITLE
Scroll lazy scrollables during tab focus traversal

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -9,6 +9,8 @@
 library;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'actions.dart';
 import 'basic.dart';
@@ -587,7 +589,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   ///
   /// Returns true if a node requested focus.
   @protected
-  bool _moveFocus(FocusNode currentNode, {required bool forward}) {
+  bool _moveFocus(FocusNode currentNode, {required bool forward, bool allowScroll = true}) {
     final FocusScopeNode nearestScope = currentNode.nearestScope!;
     invalidateScopeData(nearestScope);
     FocusNode? focusedChild = nearestScope.focusedChild;
@@ -608,6 +610,18 @@ abstract class FocusTraversalPolicy with Diagnosticable {
     focusedChild ??= nearestScope;
     final List<FocusNode> sortedNodes = _sortAllDescendants(nearestScope, focusedChild);
     assert(sortedNodes.contains(focusedChild));
+
+    // A lazily built scrollable such as ListView.builder only builds the
+    // children that are inside of its viewport (plus its cache extent), so the
+    // focus tree may not contain a node for the item that comes after the last
+    // built one yet. Scroll the viewport to build it, and retry the traversal
+    // once the new frame has been laid out, rather than immediately applying
+    // the edge behavior of the scope.
+    if (allowScroll &&
+        focusedChild == (forward ? sortedNodes.last : sortedNodes.first) &&
+        _scrollToRevealMoreDescendants(sortedNodes, focusedChild, forward: forward)) {
+      return true;
+    }
 
     if (forward && focusedChild == sortedNodes.last) {
       switch (nearestScope.traversalEdgeBehavior) {
@@ -683,6 +697,102 @@ abstract class FocusTraversalPolicy with Diagnosticable {
       previousNode = node;
     }
     return false;
+  }
+
+  // Scrolls the scrollable that contains `focusedChild` so that the widgets
+  // that come after (or before, when `forward` is false) `focusedChild` in the
+  // traversal order are built, and retries the traversal on the next frame.
+  //
+  // Lazily built scrollables such as ListView.builder only build the children
+  // that are inside of the viewport plus its cache extent, so when the cache
+  // extent is small the focus tree does not contain a node for the next item,
+  // and the traversal would wrongly apply the edge behavior of the scope
+  // instead of moving to that item.
+  //
+  // Returns true if the viewport was scrolled and the traversal was scheduled
+  // to be retried, in which case the caller must not move the focus itself.
+  bool _scrollToRevealMoreDescendants(
+    List<FocusNode> sortedNodes,
+    FocusNode focusedChild, {
+    required bool forward,
+  }) {
+    final BuildContext? context = focusedChild.context;
+    if (context == null) {
+      return false;
+    }
+    final ScrollableState? scrollable = Scrollable.maybeOf(context);
+    final ScrollPosition? position = scrollable?.position;
+    if (position == null || !position.hasPixels || !position.hasContentDimensions) {
+      return false;
+    }
+    final RenderObject? renderObject = context.findRenderObject();
+    if (renderObject == null || !renderObject.attached) {
+      return false;
+    }
+    final RenderAbstractViewport? viewport = RenderAbstractViewport.maybeOf(renderObject);
+    if (viewport == null) {
+      return false;
+    }
+
+    // The scroll offset that puts `renderObject` at the leading edge of the
+    // viewport is the largest offset at which it is still visible, and the
+    // offset for the trailing edge is the smallest one. Whether the traversal
+    // moves towards larger or smaller scroll offsets depends on the axis
+    // direction and on the reading direction, so it is derived from the node
+    // that was traversed just before `focusedChild` instead.
+    final int index = sortedNodes.indexOf(focusedChild);
+    final FocusNode? previous = forward
+        ? (index > 0 ? sortedNodes[index - 1] : null)
+        : (index < sortedNodes.length - 1 ? sortedNodes[index + 1] : null);
+    final RenderObject? previousRenderObject = previous?.context?.findRenderObject();
+    var towardsLargerOffsets = forward;
+    if (previousRenderObject != null &&
+        previousRenderObject.attached &&
+        RenderAbstractViewport.maybeOf(previousRenderObject) == viewport) {
+      final double previousOffset = viewport.getOffsetToReveal(previousRenderObject, 0.0).offset;
+      final double currentOffset = viewport.getOffsetToReveal(renderObject, 0.0).offset;
+      if ((currentOffset - previousOffset).abs() > precisionErrorTolerance) {
+        towardsLargerOffsets = currentOffset > previousOffset;
+      }
+    }
+
+    // Only scroll when `focusedChild` reaches the edge of the viewport that the
+    // traversal is moving towards. Otherwise the scrollable does show what
+    // comes next in the traversal order, and the missing nodes are not simply
+    // waiting to be built.
+    final double edgeOffset = viewport
+        .getOffsetToReveal(renderObject, towardsLargerOffsets ? 1.0 : 0.0)
+        .offset;
+    if (towardsLargerOffsets
+        ? position.pixels > edgeOffset + precisionErrorTolerance
+        : position.pixels < edgeOffset - precisionErrorTolerance) {
+      return false;
+    }
+
+    final double target = clampDouble(
+      viewport.getOffsetToReveal(renderObject, towardsLargerOffsets ? 0.0 : 1.0).offset,
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    if (towardsLargerOffsets
+        ? target <= position.pixels + precisionErrorTolerance
+        : target >= position.pixels - precisionErrorTolerance) {
+      // The viewport is already scrolled as far as it can go in the direction
+      // the traversal is moving towards, so there is nothing left to build.
+      return false;
+    }
+    position.jumpTo(target);
+
+    SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
+      if (focusedChild.context == null || !focusedChild.hasFocus) {
+        return;
+      }
+      // Retry without allowing another scroll, so that a scrollable that has
+      // no more focusable children still falls back to the edge behavior of
+      // the enclosing scope.
+      _moveFocus(focusedChild, forward: forward, allowScroll: false);
+    }, debugLabel: 'FocusTraversalPolicy.retryTraversalAfterScroll');
+    return true;
   }
 }
 

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -1183,6 +1183,131 @@ void main() {
 
       expect(calledCallback, isTrue);
     });
+
+    testWidgets(
+      'Tab traversal scrolls a lazy scrollable to reveal items that are not built yet.',
+      (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/91743.
+        const itemCount = 20;
+        final nodes = List<FocusNode>.generate(
+          itemCount,
+          (int index) => FocusNode(debugLabel: 'Item $index'),
+        );
+        addTearDown(() {
+          for (final node in nodes) {
+            node.dispose();
+          }
+        });
+        final controller = ScrollController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          TestWidgetsApp(
+            home: Center(
+              child: SizedBox(
+                height: 300,
+                width: 200,
+                child: ListView.builder(
+                  controller: controller,
+                  // Without a cache extent, only the items that are visible in
+                  // the viewport are built, so the focus tree has no node after
+                  // the last visible item.
+                  cacheExtent: 0,
+                  itemExtent: 100,
+                  itemCount: itemCount,
+                  itemBuilder: (BuildContext context, int index) {
+                    return Focus(focusNode: nodes[index], child: const SizedBox.expand());
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+
+        nodes[0].requestFocus();
+        await tester.pump();
+        expect(nodes[0].hasPrimaryFocus, isTrue);
+        expect(controller.offset, equals(0.0));
+
+        // Tab forward through more items than fit in the viewport.
+        for (var index = 1; index <= 8; index += 1) {
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+          await tester.pumpAndSettle();
+          expect(nodes[index].hasPrimaryFocus, isTrue, reason: 'Item $index is not focused');
+        }
+        expect(controller.offset, greaterThan(0.0));
+
+        // Tab backwards all the way to the first item.
+        for (var index = 7; index >= 0; index -= 1) {
+          await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+          await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+          await tester.pumpAndSettle();
+          expect(nodes[index].hasPrimaryFocus, isTrue, reason: 'Item $index is not focused');
+        }
+        expect(controller.offset, equals(0.0));
+      },
+      variant: KeySimulatorTransitModeVariant.all(),
+    );
+
+    testWidgets(
+      'Tab traversal does not scroll when the scrollable has no more focusable widgets.',
+      (WidgetTester tester) async {
+        final nodes = List<FocusNode>.generate(
+          3,
+          (int index) => FocusNode(debugLabel: 'Item $index'),
+        );
+        addTearDown(() {
+          for (final node in nodes) {
+            node.dispose();
+          }
+        });
+        final controller = ScrollController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          TestWidgetsApp(
+            home: Center(
+              child: SizedBox(
+                height: 300,
+                width: 200,
+                child: SingleChildScrollView(
+                  controller: controller,
+                  child: Column(
+                    children: <Widget>[
+                      for (final node in nodes)
+                        Focus(focusNode: node, child: const SizedBox(height: 50, width: 200)),
+                      // Scrollable content that contains no focusable widget.
+                      const SizedBox(height: 2000),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        nodes[0].requestFocus();
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pumpAndSettle();
+        expect(nodes[1].hasPrimaryFocus, isTrue);
+        expect(controller.offset, equals(0.0));
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pumpAndSettle();
+        expect(nodes[2].hasPrimaryFocus, isTrue);
+        expect(controller.offset, equals(0.0));
+
+        // The traversal wraps around instead of scrolling the empty space.
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pumpAndSettle();
+        expect(nodes[0].hasPrimaryFocus, isTrue);
+        expect(controller.offset, equals(0.0));
+      },
+      variant: KeySimulatorTransitModeVariant.all(),
+    );
   });
 
   group(OrderedTraversalPolicy, () {


### PR DESCRIPTION
When a lazily built scrollable such as ListView.builder has a small (or
zero) cacheExtent, only the children inside the viewport are built, so the
focus tree has no node after the last visible item. Tab traversal then
treated the last visible item as the edge of the scope and wrapped the
focus around to the first item instead of continuing down the list.

FocusTraversalPolicy now detects that case: when the focused node is the
last (or first, when going backwards) node of the scope, is inside a
scrollable, and reaches the edge of the viewport that the traversal moves
towards, the viewport is scrolled so the missing children get built and the
traversal is retried on the next frame. The retry does not scroll again, so
a scrollable without further focusable children still falls back to the
normal TraversalEdgeBehavior of the scope.

Fixes https://github.com/flutter/flutter/issues/91743

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
