### PR TITLE
Clip text selection highlight to the bounds of the text

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -3634,8 +3634,22 @@ class _SelectableFragment
       final selectionPaint = Paint()
         ..style = PaintingStyle.fill
         ..color = paragraph.selectionColor!;
+      // Selection boxes can extend past the bounds of the text, for instance
+      // when the selection contains trailing whitespace, which is never
+      // wrapped. Clip the highlight so that it is never painted outside of the
+      // text, the same way RenderEditable does.
+      final textBounds = Rect.fromLTWH(
+        0.0,
+        0.0,
+        paragraph._textPainter.width,
+        paragraph._textPainter.height,
+      );
       for (final TextBox textBox in paragraph.getBoxesForSelection(selection)) {
-        context.canvas.drawRect(textBox.toRect().shift(offset), selectionPaint);
+        final Rect rect = textBox.toRect().intersect(textBounds);
+        if (rect.isEmpty) {
+          continue;
+        }
+        context.canvas.drawRect(rect.shift(offset), selectionPaint);
       }
     }
   }

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1121,6 +1121,30 @@ void main() {
       expect(paintingContext.pushedLayers.whereType<LeaderLayer>(), hasLength(2));
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/99139.
+    test('does not paint selection highlight outside of the text bounds', () async {
+      final registrar = TestSelectionRegistrar();
+      const selectionColor = Color(0xAF6694e8);
+      // Trailing whitespace is never wrapped, so the selection boxes for the
+      // whitespace extend past the width the paragraph was laid out with.
+      final paragraph = RenderParagraph(
+        const TextSpan(text: '12       '),
+        textDirection: TextDirection.ltr,
+        registrar: registrar,
+        selectionColor: selectionColor,
+      );
+      layout(paragraph, constraints: const BoxConstraints(maxWidth: 50.0));
+      expect(paragraph.size.width, 50.0);
+      for (final Selectable selectable in registrar.selectables) {
+        selectable.dispatchSelectionEvent(const SelectAllSelectionEvent());
+      }
+
+      final paintingContext = MockPaintingContext();
+      paragraph.paint(paintingContext, Offset.zero);
+      expect(paintingContext.canvas.drawnRect, isNotNull);
+      expect(paintingContext.canvas.drawnRect!.right, lessThanOrEqualTo(50.0));
+    });
+
     // Regression test for https://github.com/flutter/flutter/issues/126652.
     test('paints selection when tap at chinese character', () async {
       final registrar = TestSelectionRegistrar();


### PR DESCRIPTION
Trailing whitespace is never wrapped, so the selection boxes returned for a
selection that ends with whitespace can extend far past the width the
paragraph was laid out with. _SelectableFragment.paintSelection drew those
boxes as-is, so selecting text that ends with a long run of spaces painted the
highlight outside of the widget, on top of whatever is next to it.

RenderParagraph only clips while painting when it detects visual overflow, and
that check is based on the line box sizes, which exclude trailing whitespace,
so no clip was applied in this case.

Intersect every selection box with the bounds of the laid out text before
painting it, which is what RenderEditable's selection painter already does.

Fixes https://github.com/flutter/flutter/issues/99139

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
