### PR TITLE
Record throttled undo history entry before undo or redo

### DIFF
--- a/packages/flutter/lib/src/widgets/undo_history.dart
+++ b/packages/flutter/lib/src/widgets/undo_history.dart
@@ -123,19 +123,33 @@ class UndoHistoryState<T> extends State<UndoHistory<T>> with UndoManagerClient {
       // throttling delay is pending), the initial push should not be canceled.
       return;
     }
-    if (_throttleTimer?.isActive ?? false) {
-      _throttleTimer?.cancel(); // Cancel ongoing push, if any.
-      _update(_stack.currentValue);
-    } else {
-      _update(_stack.undo());
-    }
+    _flushPendingPush();
+    _update(_stack.undo());
     _updateState();
   }
 
   @override
   void redo() {
+    _flushPendingPush();
     _update(_stack.redo());
     _updateState();
+  }
+
+  // Records the latest value immediately instead of waiting for the throttling
+  // delay to elapse.
+  //
+  // Undo and redo operate on the stack, so a change that is still waiting to be
+  // pushed has to be recorded first. Otherwise it would be dropped, which would
+  // make it impossible to redo it after an undo, and would make a redo revert
+  // it even though there is nothing to redo.
+  void _flushPendingPush() {
+    if (!(_throttleTimer?.isActive ?? false)) {
+      return;
+    }
+    _throttleTimer!.cancel();
+    _throttleTimer = null;
+    // _lastValue is the value that the pending push would have recorded.
+    _stack.push(_lastValue as T);
   }
 
   @override

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -14043,6 +14043,69 @@ void main() {
       skip: kIsWeb, // [intended]
     );
 
+    // Regression test for https://github.com/flutter/flutter/issues/99186.
+    testWidgets(
+      'Can redo a change that was undone before the throttling delay',
+      (WidgetTester tester) async {
+        // Initialize the controller with a non empty text.
+        controller.text = textA;
+        await tester.pumpWidget(boilerplate());
+
+        // Focus the field and wait for throttling delay to get the initial
+        // state saved in text editing history.
+        focusNode.requestFocus();
+        await tester.pump();
+        await waitForThrottling(tester);
+        expect(controller.value, isDesktop() ? textASelected : textACollapsedAtEnd);
+
+        // Insert some text and undo it without waiting for the throttling delay.
+        await tester.enterText(find.byType(EditableText), textAB);
+        expect(controller.value, textABCollapsedAtEnd);
+        await sendUndo(tester);
+        expect(controller.value, isDesktop() ? textASelected : textACollapsedAtEnd);
+
+        // The insertion is still on the history, so it can be redone.
+        await sendRedo(tester);
+        expect(controller.value, textABCollapsedAtEnd);
+
+        // On web, these keyboard shortcuts are handled by the browser.
+      },
+      variant: TargetPlatformVariant.all(),
+      skip: kIsWeb, // [intended]
+    );
+
+    // Regression test for https://github.com/flutter/flutter/issues/99186.
+    testWidgets(
+      'Redo does not revert a change that is still waiting for the throttling delay',
+      (WidgetTester tester) async {
+        // Initialize the controller with a non empty text.
+        controller.text = textA;
+        await tester.pumpWidget(boilerplate());
+
+        // Focus the field and wait for throttling delay to get the initial
+        // state saved in text editing history.
+        focusNode.requestFocus();
+        await tester.pump();
+        await waitForThrottling(tester);
+        expect(controller.value, isDesktop() ? textASelected : textACollapsedAtEnd);
+
+        // Insert some text and redo without waiting for the throttling delay.
+        // There is nothing to redo, so the insertion must be left alone.
+        await tester.enterText(find.byType(EditableText), textAB);
+        expect(controller.value, textABCollapsedAtEnd);
+        await sendRedo(tester);
+        expect(controller.value, textABCollapsedAtEnd);
+
+        // The insertion can still be undone.
+        await sendUndo(tester);
+        expect(controller.value, isDesktop() ? textASelected : textACollapsedAtEnd);
+
+        // On web, these keyboard shortcuts are handled by the browser.
+      },
+      variant: TargetPlatformVariant.all(),
+      skip: kIsWeb, // [intended]
+    );
+
     testWidgets(
       'Can make changes in the middle of the history',
       (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/undo_history_test.dart
+++ b/packages/flutter/test/widgets/undo_history_test.dart
@@ -383,6 +383,59 @@ void main() {
       expect(controller.value.canRedo, true);
     }, variant: TargetPlatformVariant.all());
 
+    // Regression test for https://github.com/flutter/flutter/issues/99186.
+    testWidgets('a change that is still throttled is recorded before an undo or a redo', (
+      WidgetTester tester,
+    ) async {
+      final value = ValueNotifier<int>(0);
+      addTearDown(value.dispose);
+      final controller = UndoHistoryController();
+      addTearDown(controller.dispose);
+      final key = GlobalKey<UndoHistoryState<int>>();
+
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: UndoHistory<int>(
+            key: key,
+            controller: controller,
+            value: value,
+            onTriggered: (int newValue) {
+              value.value = newValue;
+            },
+            focusNode: _focusNode,
+            child: Container(),
+          ),
+        ),
+      );
+
+      _focusNode.requestFocus();
+
+      // Wait for the throttling so that the initial value is recorded.
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // A redo before the throttling delay has elapsed must not revert the
+      // change, because there is nothing to redo.
+      value.value = 1;
+      await tester.pump();
+      key.currentState!.redo();
+      expect(value.value, 1);
+      expect(controller.value.canUndo, true);
+      expect(controller.value.canRedo, false);
+
+      // The change can be undone and redone even though it was undone before
+      // the throttling delay had elapsed.
+      value.value = 2;
+      await tester.pump();
+      key.currentState!.undo();
+      expect(value.value, 1);
+      expect(controller.value.canUndo, true);
+      expect(controller.value.canRedo, true);
+      key.currentState!.redo();
+      expect(value.value, 2);
+      expect(controller.value.canUndo, true);
+      expect(controller.value.canRedo, false);
+    }, variant: TargetPlatformVariant.all());
+
     testWidgets('ignores value changes pushed during onTriggered', (WidgetTester tester) async {
       final value = ValueNotifier<int>(0);
       addTearDown(value.dispose);


### PR DESCRIPTION
Undo history coalesces changes with a throttle timer, so a change can still
be waiting to be pushed onto the stack when an undo or a redo arrives.
Undo used to cancel that pending push and simply restore the top of the
stack, which dropped the pending change: it could never be redone. Redo did
not look at the pending push at all, so a redo with nothing to redo reverted
text that had just been typed.

Both now flush the pending push onto the stack first, so the pending change
is recorded and the undo and redo operations act on a complete history.

Fixes https://github.com/flutter/flutter/issues/99186

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
