### PR TITLE
Respect MediaQuery accessibility features in Material showMenu

### DIFF
--- a/packages/flutter/lib/src/cupertino/menu_anchor.dart
+++ b/packages/flutter/lib/src/cupertino/menu_anchor.dart
@@ -903,16 +903,25 @@ class _MenuOverlayState extends State<_MenuOverlay>
     // Behavior of reduce motion is based on iOS 18.5 simulator. Because the
     // disableAnimations accessibility feature is not present on iOS, all
     // animations are disabled when disableAnimations is enabled.
+    //
+    // These settings are read from the ambient MediaQuery (falling back to the
+    // platform values when there is no MediaQuery) so that they can be
+    // overridden for a subtree, like every other accessibility feature exposed
+    // by MediaQueryData.
     final ui.AccessibilityFeatures accessibilityFeatures = View.of(
       context,
     ).platformDispatcher.accessibilityFeatures;
+    final bool disableAnimations =
+        MediaQuery.maybeDisableAnimationsOf(context) ?? accessibilityFeatures.disableAnimations;
+    final bool reduceMotion =
+        MediaQuery.maybeReduceMotionOf(context) ?? accessibilityFeatures.reduceMotion;
 
-    switch (accessibilityFeatures) {
-      case ui.AccessibilityFeatures(disableAnimations: true):
+    switch ((disableAnimations, reduceMotion)) {
+      case (true, _):
         _scaleAnimation.parent = kAlwaysCompleteAnimation;
         _fadeAnimation.parent = kAlwaysCompleteAnimation;
         _sizeAnimation.parent = kAlwaysCompleteAnimation;
-      case ui.AccessibilityFeatures(reduceMotion: true):
+      case (_, true):
         // Swipe scaling works with reduced motion.
         _scaleAnimation.parent = _swipeAnimationController.view.drive(
           Tween<double>(begin: 0.8, end: 1),

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -949,6 +949,8 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
     super.settings,
     super.requestFocus,
     this.popUpAnimationStyle,
+    this.disableAnimations = false,
+    this.reduceMotion = false,
   }) : assert(
          (position != null) != (positionBuilder != null),
          'Either position or positionBuilder must be provided.',
@@ -976,6 +978,14 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   final Clip clipBehavior;
   final AnimationStyle? popUpAnimationStyle;
 
+  // Whether MediaQueryData.disableAnimations/reduceMotion (or, absent an
+  // override, the platform's AccessibilityFeatures) request that the menu's
+  // open/close animation be skipped or shortened. Resolved once in [showMenu]
+  // from the ambient MediaQuery so it stays consistent for the lifetime of
+  // this route.
+  final bool disableAnimations;
+  final bool reduceMotion;
+
   CurvedAnimation? _animation;
 
   @override
@@ -1000,7 +1010,21 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   }
 
   @override
-  Duration get transitionDuration => popUpAnimationStyle?.duration ?? _kMenuDuration;
+  Duration get transitionDuration {
+    // Disabling animations entirely means the menu should pop open and
+    // closed instantly, so a zero duration is used instead of skipping the
+    // AnimationController's forward()/reverse() calls: this keeps the
+    // controller-driven status changes (and therefore route finalization)
+    // intact while making the transition imperceptible.
+    if (disableAnimations) {
+      return Duration.zero;
+    }
+    final Duration duration = popUpAnimationStyle?.duration ?? _kMenuDuration;
+    if (reduceMotion) {
+      return duration ~/ 3;
+    }
+    return duration;
+  }
 
   @override
   bool get barrierDismissible => true;
@@ -1202,6 +1226,20 @@ Future<T?> showMenu<T>({
 
   final menuItemKeys = List<GlobalKey>.generate(items.length, (int index) => GlobalKey());
   final NavigatorState navigator = Navigator.of(context, rootNavigator: useRootNavigator);
+
+  // These settings are read from the ambient MediaQuery (falling back to the
+  // platform values when there is no MediaQuery) so that they can be
+  // overridden for a subtree, like every other accessibility feature exposed
+  // by MediaQueryData. They are resolved here, from the calling context,
+  // because the route itself may need them before its own subtree (and
+  // therefore its own MediaQuery) has been built.
+  final AccessibilityFeatures accessibilityFeatures =
+      View.of(context).platformDispatcher.accessibilityFeatures;
+  final bool disableAnimations =
+      MediaQuery.maybeDisableAnimationsOf(context) ?? accessibilityFeatures.disableAnimations;
+  final bool reduceMotion =
+      MediaQuery.maybeReduceMotionOf(context) ?? accessibilityFeatures.reduceMotion;
+
   return navigator.push(
     _PopupMenuRoute<T>(
       position: position,
@@ -1223,6 +1261,8 @@ Future<T?> showMenu<T>({
       settings: routeSettings,
       popUpAnimationStyle: popUpAnimationStyle,
       requestFocus: requestFocus,
+      disableAnimations: disableAnimations,
+      reduceMotion: reduceMotion,
     ),
   );
 }

--- a/packages/flutter/test/cupertino/menu_anchor_test.dart
+++ b/packages/flutter/test/cupertino/menu_anchor_test.dart
@@ -1649,6 +1649,54 @@ void main() {
     expect(disabledFade.opacity.value, moreOrLessEquals(1, epsilon: 0.01));
   });
 
+  testWidgets('Menu animations respect MediaQueryData.disableAnimations', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(disableAnimations: true),
+        child: App(
+          CupertinoMenuAnchor(
+            controller: controller,
+            menuChildren: <Widget>[CupertinoMenuItem(onPressed: () {}, child: Text(Tag.a.text))],
+            child: const AnchorButton(Tag.anchor),
+          ),
+        ),
+      ),
+    );
+
+    controller.open();
+    await tester.pump();
+
+    final FadeTransition fade = tester.widget<FadeTransition>(
+      find.ancestor(of: find.byType(ClipRSuperellipse), matching: find.byType(FadeTransition)),
+    );
+    expect(fade.opacity.value, moreOrLessEquals(1, epsilon: 0.01));
+    expect(getScale(tester), moreOrLessEquals(1, epsilon: 0.01));
+  });
+
+  testWidgets('Menu scale animation respects MediaQueryData.reduceMotion', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(reduceMotion: true),
+        child: App(
+          CupertinoMenuAnchor(
+            controller: controller,
+            menuChildren: <Widget>[CupertinoMenuItem(onPressed: () {}, child: Text(Tag.a.text))],
+            child: const AnchorButton(Tag.anchor),
+          ),
+        ),
+      ),
+    );
+
+    controller.open();
+    await tester.pump();
+
+    expect(getScale(tester), moreOrLessEquals(1, epsilon: 0.01));
+  });
+
   group('Focus', () {
     testWidgets(
       '[Browser] Focus wraps on all platforms',

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -4391,6 +4391,79 @@ void main() {
     );
   });
 
+
+  testWidgets('showMenu skips its open animation when MediaQueryData.disableAnimations is true', (
+    WidgetTester tester,
+  ) async {
+    List<PopupMenuItem<int>> menuItems() => const <PopupMenuItem<int>>[
+      PopupMenuItem<int>(value: 1, child: Text('One')),
+      PopupMenuItem<int>(value: 2, child: Text('Two')),
+      PopupMenuItem<int>(value: 3, child: Text('Three')),
+    ];
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(disableAnimations: true),
+        child: MaterialApp(
+          home: Material(
+            child: Center(child: ElevatedButton(onPressed: null, child: Text('Go'))),
+          ),
+        ),
+      ),
+    );
+
+    final BuildContext context = tester.element(find.text('Go'));
+    showMenu<int>(context: context, position: RelativeRect.fill, items: menuItems());
+
+    // Even with only a single, near-instant pump (no time advanced beyond a
+    // single millisecond), the menu should already be fully open because its
+    // open animation duration is reduced to zero when
+    // MediaQueryData.disableAnimations is true.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+
+    expect(
+      tester.getSize(find.byType(Material).last),
+      within(distance: 0.1, from: const Size(112.0, 160.0)),
+    );
+  });
+
+  testWidgets('showMenu shortens its open animation when MediaQueryData.reduceMotion is true', (
+    WidgetTester tester,
+  ) async {
+    List<PopupMenuItem<int>> menuItems() => const <PopupMenuItem<int>>[
+      PopupMenuItem<int>(value: 1, child: Text('One')),
+      PopupMenuItem<int>(value: 2, child: Text('Two')),
+      PopupMenuItem<int>(value: 3, child: Text('Three')),
+    ];
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(reduceMotion: true),
+        child: MaterialApp(
+          home: Material(
+            child: Center(child: ElevatedButton(onPressed: null, child: Text('Go'))),
+          ),
+        ),
+      ),
+    );
+
+    final BuildContext context = tester.element(find.text('Go'));
+    showMenu<int>(context: context, position: RelativeRect.fill, items: menuItems());
+
+    await tester.pump();
+    // The default menu open animation takes 300ms. With reduceMotion the
+    // duration is shortened to a third of that (100ms), so by 100ms the menu
+    // should already be fully open, whereas without the fix it would still
+    // be only a third of the way through its default 300ms animation.
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(
+      tester.getSize(find.byType(Material).last),
+      within(distance: 0.1, from: const Size(112.0, 160.0)),
+    );
+  });
+
   testWidgets('PopupMenuButton scrolls initial value/selected value to visible', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
The actual repro for this issue is showMenu()/PopupMenuButton, the Material
popup menu shown by _PopupMenuRoute. Its transitionDuration was a fixed
300ms (or the caller's AnimationStyle), and it never consulted
MediaQueryData.disableAnimations or MediaQueryData.reduceMotion, so
overriding those flags in the ambient MediaQuery had no effect on the
menu's open/close animation, unlike every other accessibility feature
consumed by the framework widget layer.

showMenu() now resolves disableAnimations and reduceMotion from the calling
context's MediaQuery (falling back to the platform's AccessibilityFeatures
when there is no MediaQuery ancestor, matching the previous CupertinoMenuAnchor
fix) and passes them to _PopupMenuRoute. When disableAnimations is true the
route's transitionDuration becomes Duration.zero so the AnimationController
completes synchronously (status changes, and therefore route finalization on
pop, still fire normally). When only reduceMotion is true the duration is
shortened to a third of its normal value instead of being skipped entirely.

This keeps the previous CupertinoMenuAnchor fix in place; both menu
implementations now honor MediaQueryData overrides for these flags.

Fixes https://github.com/flutter/flutter/issues/106499

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
