### PR TITLE
Do not reload a paused Image when the image cache is cleared

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1153,6 +1153,9 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
   /// true.
   bool _isPaused = false;
 
+  /// The [ImageConfiguration] that [_imageStream] was last resolved against.
+  ImageConfiguration? _resolvedConfiguration;
+
   @override
   void initState() {
     super.initState();
@@ -1174,7 +1177,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
   @override
   void didChangeDependencies() {
     _updateInvertColors();
-    _resolveImage();
+    _resolveImage(onlyIfConfigurationChanged: true);
 
     _isPaused = !TickerMode.of(context) || (MediaQuery.maybeDisableAnimationsOf(context) ?? false);
 
@@ -1222,20 +1225,28 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
         SemanticsBinding.instance.accessibilityFeatures.invertColors;
   }
 
-  void _resolveImage() {
+  void _resolveImage({bool onlyIfConfigurationChanged = false}) {
+    final ImageConfiguration configuration = createLocalImageConfiguration(
+      context,
+      size: widget.width != null && widget.height != null
+          ? Size(widget.width!, widget.height!)
+          : null,
+    );
+    // Resolving asks the image cache for the image again. While the image is
+    // paused this state is not listening to the stream, so the image cache no
+    // longer tracks it as a live image and may start a second, redundant load
+    // of the same image, discarding the frame that is currently displayed.
+    // Only resolve again when the configuration the image is resolved against
+    // has actually changed.
+    if (onlyIfConfigurationChanged && configuration == _resolvedConfiguration) {
+      return;
+    }
+    _resolvedConfiguration = configuration;
     final provider = ScrollAwareImageProvider<Object>(
       context: _scrollAwareContext,
       imageProvider: widget.image,
     );
-    final ImageStream newStream = provider.resolve(
-      createLocalImageConfiguration(
-        context,
-        size: widget.width != null && widget.height != null
-            ? Size(widget.width!, widget.height!)
-            : null,
-      ),
-    );
-    _updateSourceStream(newStream);
+    _updateSourceStream(provider.resolve(configuration));
   }
 
   ImageStreamListener? _imageStreamListener;

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -2807,6 +2807,35 @@ void main() {
     expect(find.byType(Image), findsOneWidget);
   });
 
+  testWidgets('Does not reload the image when the cache is cleared while ticker mode is disabled', (
+    WidgetTester tester,
+  ) async {
+    final provider = _ReloadableTestImageProvider(image10x10);
+
+    Widget buildFrame({required bool enabled}) {
+      return TickerMode(enabled: enabled, child: Image(image: provider));
+    }
+
+    await tester.pumpWidget(buildFrame(enabled: true));
+    expect(provider.loadCallCount, 1);
+    expect(tester.widget<RawImage>(find.byType(RawImage)).image, isNotNull);
+
+    // Pause the image, e.g. because its route was pushed behind another route.
+    await tester.pumpWidget(buildFrame(enabled: false));
+    expect(provider.loadCallCount, 1);
+    expect(tester.widget<RawImage>(find.byType(RawImage)).image, isNotNull);
+
+    // The image cache is cleared while the image is paused, e.g. because the
+    // engine signaled memory pressure while the app was in the background.
+    imageCache.clear();
+
+    // Resuming must neither drop the image that is currently displayed nor
+    // decode it a second time.
+    await tester.pumpWidget(buildFrame(enabled: true));
+    expect(provider.loadCallCount, 1);
+    expect(tester.widget<RawImage>(find.byType(RawImage)).image, isNotNull);
+  });
+
   testWidgets('Keeps stream alive when animations are disabled', (WidgetTester tester) async {
     imageCache.maximumSize = 0;
     final ui.Image image = (await tester.runAsync(() => createTestImage(cache: false)))!;
@@ -3230,6 +3259,30 @@ class _ConfigurationKeyedTestImageProvider extends _TestImageProvider {
   @override
   Future<_ConfigurationAwareKey> obtainKey(ImageConfiguration configuration) {
     return SynchronousFuture<_ConfigurationAwareKey>(_ConfigurationAwareKey(this, configuration));
+  }
+}
+
+/// An [ImageProvider] that creates a new [ImageStreamCompleter] every time it
+/// is loaded, like real image providers do.
+class _ReloadableTestImageProvider extends ImageProvider<_ReloadableTestImageProvider> {
+  _ReloadableTestImageProvider(this.image);
+
+  final ui.Image image;
+
+  int get loadCallCount => _loadCallCount;
+  int _loadCallCount = 0;
+
+  @override
+  Future<_ReloadableTestImageProvider> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<_ReloadableTestImageProvider>(this);
+  }
+
+  @override
+  ImageStreamCompleter loadImage(_ReloadableTestImageProvider key, ImageDecoderCallback decode) {
+    _loadCallCount += 1;
+    return OneFrameImageStreamCompleter(
+      SynchronousFuture<ImageInfo>(ImageInfo(image: image.clone())),
+    );
   }
 }
 


### PR DESCRIPTION
While an Image is paused (TickerMode disabled or
MediaQueryData.disableAnimations), _ImageState removes its listener from
the stream and keeps the completer alive with an ImageStreamCompleterHandle.
Dropping the last listener also makes the image cache stop tracking the
completer as a live image. If the cache is then cleared, for example because
the engine signals memory pressure while the app is in the background, the
next didChangeDependencies re-resolves the image, misses the cache and starts
a second load of the same image. Because gaplessPlayback defaults to false,
the frame that is currently on screen is thrown away, so the image disappears
and flickers back in.

didChangeDependencies now only re-resolves the image when the
ImageConfiguration the image was resolved against has actually changed, so a
TickerMode or MediaQuery change alone no longer discards the already decoded
image. Explicit resolves from didUpdateWidget and reassemble are unaffected.

Fixes https://github.com/flutter/flutter/issues/118709

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
