### PR TITLE
Scale down ContinuousRectangleBorder radii that overflow the rect

### DIFF
--- a/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
@@ -75,8 +75,14 @@ class ContinuousRectangleBorder extends OutlinedBorder {
     return super.lerpTo(b, t);
   }
 
-  double _clampToShortest(RRect rrect, double value) {
-    return value > rrect.shortestSide ? rrect.shortestSide : value;
+  // Returns `scale`, further reduced if needed so that `radius1 + radius2` fits
+  // within `limit`. Mirrors the scaling that `RRect.scaleRadii` applies.
+  static double _scaleToFit(double scale, double radius1, double radius2, double limit) {
+    final double sum = radius1 + radius2;
+    if (sum > limit && sum > 0.0) {
+      return math.min(scale, limit / sum);
+    }
+    return scale;
   }
 
   Path _getPath(RRect rrect) {
@@ -84,16 +90,50 @@ class ContinuousRectangleBorder extends OutlinedBorder {
     final double right = rrect.right;
     final double top = rrect.top;
     final double bottom = rrect.bottom;
-    //  Radii will be clamped to the value of the shortest side
-    // of rrect to avoid strange tie-fighter shapes.
-    final double tlRadiusX = math.max(0.0, _clampToShortest(rrect, rrect.tlRadiusX));
-    final double tlRadiusY = math.max(0.0, _clampToShortest(rrect, rrect.tlRadiusY));
-    final double trRadiusX = math.max(0.0, _clampToShortest(rrect, rrect.trRadiusX));
-    final double trRadiusY = math.max(0.0, _clampToShortest(rrect, rrect.trRadiusY));
-    final double blRadiusX = math.max(0.0, _clampToShortest(rrect, rrect.blRadiusX));
-    final double blRadiusY = math.max(0.0, _clampToShortest(rrect, rrect.blRadiusY));
-    final double brRadiusX = math.max(0.0, _clampToShortest(rrect, rrect.brRadiusX));
-    final double brRadiusY = math.max(0.0, _clampToShortest(rrect, rrect.brRadiusY));
+
+    // Negative radii are documented to behave like zero radii. Clamp them
+    // before the scaling below rather than after it, because the scaling looks
+    // at the sum of the two radii drawn along a side: a negative radius would
+    // otherwise cancel out part of the radius of the corner it shares that side
+    // with and let an overflowing corner through unscaled.
+    double tlRadiusX = math.max(0.0, rrect.tlRadiusX);
+    double tlRadiusY = math.max(0.0, rrect.tlRadiusY);
+    double trRadiusX = math.max(0.0, rrect.trRadiusX);
+    double trRadiusY = math.max(0.0, rrect.trRadiusY);
+    double blRadiusX = math.max(0.0, rrect.blRadiusX);
+    double blRadiusY = math.max(0.0, rrect.blRadiusY);
+    double brRadiusX = math.max(0.0, rrect.brRadiusX);
+    double brRadiusY = math.max(0.0, rrect.brRadiusY);
+
+    // Every side is shared by two corners, and the curves below consume one
+    // radius worth of that side at each of its ends. When those two radii do
+    // not fit, the curves overshoot and the straight segment between them runs
+    // backwards, so the contour crosses over itself. That stays invisible while
+    // the shape is filled, but it is drawn as a tie-fighter shape as soon as
+    // the shape is stroked. Shrink every radius by the same factor until each
+    // side fits, the way `RRect.scaleRadii` does for rounded rectangles.
+    //
+    // Note that this shape has always spent the x radii along the vertical
+    // sides and the y radii along the horizontal ones, so the pairs below are
+    // matched to the sides the path actually walks rather than to the pairs
+    // `RRect.scaleRadii` would use.
+    final double width = math.max(0.0, right - left);
+    final double height = math.max(0.0, bottom - top);
+    var scale = 1.0;
+    scale = _scaleToFit(scale, tlRadiusY, trRadiusX, width); // Top side.
+    scale = _scaleToFit(scale, trRadiusY, brRadiusX, height); // Right side.
+    scale = _scaleToFit(scale, brRadiusY, blRadiusX, width); // Bottom side.
+    scale = _scaleToFit(scale, blRadiusY, tlRadiusX, height); // Left side.
+    if (scale < 1.0) {
+      tlRadiusX *= scale;
+      tlRadiusY *= scale;
+      trRadiusX *= scale;
+      trRadiusY *= scale;
+      blRadiusX *= scale;
+      blRadiusY *= scale;
+      brRadiusX *= scale;
+      brRadiusY *= scale;
+    }
 
     return Path()
       ..moveTo(left, top + tlRadiusX)

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -2474,6 +2474,49 @@ void main() {
     expect(getCheckboxRenderer(), paints..rrect(color: inactiveBackgroundColor));
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/132947
+  testWidgets('Checkbox outline does not self-intersect with a large ContinuousRectangleBorder radius', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: Checkbox(
+              shape: ContinuousRectangleBorder(borderRadius: BorderRadius.circular(24.0)),
+              value: false,
+              onChanged: (bool? value) {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    Path? outline;
+    expect(
+      tester.renderObject<RenderBox>(find.byType(Checkbox)),
+      paints..something((Symbol method, List<dynamic> arguments) {
+        if (method != #drawPath) {
+          return false;
+        }
+        outline = arguments[0] as Path;
+        return true;
+      }),
+    );
+
+    // The checkbox is painted in an 18x18 box centered in the render box, so
+    // the 24.0 radius has to be scaled down to 9.0 to fit.
+    final Size size = tester.getSize(find.byType(Checkbox));
+    final box = Rect.fromLTWH((size.width - 18.0) / 2.0, (size.height - 18.0) / 2.0, 18.0, 18.0);
+    final Path expected = ContinuousRectangleBorder(
+      borderRadius: BorderRadius.circular(9.0),
+    ).getOuterPath(box);
+
+    expect(outline, isNotNull);
+    expect(outline, coversSameAreaAs(expected, areaToCompare: box.inflate(2.0)));
+  });
+
   testWidgets('Checkbox renders at zero area', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(

--- a/packages/flutter/test/painting/continuous_rectangle_border_test.dart
+++ b/packages/flutter/test/painting/continuous_rectangle_border_test.dart
@@ -7,6 +7,8 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
+import 'dart:ui' show PathMetric;
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -28,6 +30,16 @@ Widget _buildGoldenTest({required Color color, required BorderRadiusGeometry bor
       ),
     ),
   );
+}
+
+// The total length of every contour in [path]. A contour that doubles back over
+// itself is longer than the outline it is supposed to draw.
+double _perimeterOf(Path path) {
+  var length = 0.0;
+  for (final PathMetric metric in path.computeMetrics()) {
+    length += metric.length;
+  }
+  return length;
 }
 
 void main() {
@@ -136,6 +148,106 @@ void main() {
 
     expect(border.getOuterPath(rect, textDirection: TextDirection.rtl), looksLikeRectRtl);
     expect(border.getInnerPath(rect, textDirection: TextDirection.rtl), looksLikeRectRtl);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/132947
+  test('ContinuousRectangleBorder scales down radii that overflow the rect', () {
+    const rect = Rect.fromLTWH(0.0, 0.0, 18.0, 18.0);
+
+    // Two corner radii share each side, so a radius greater than half of the
+    // shortest side has to be scaled down. Otherwise the outline overshoots
+    // and doubles back on itself, which is invisible when the shape is filled
+    // but is drawn as a self-intersecting outline when the shape is stroked.
+    const overflowing = ContinuousRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(24.0)),
+    );
+    const scaled = ContinuousRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(9.0)),
+    );
+
+    expect(
+      overflowing.getOuterPath(rect),
+      coversSameAreaAs(scaled.getOuterPath(rect), areaToCompare: rect.inflate(2.0)),
+    );
+
+    // Radii that already fit are left alone.
+    const fitting = ContinuousRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(4.0)),
+    );
+    expect(
+      fitting.getOuterPath(rect),
+      coversSameAreaAs(
+        ContinuousRectangleBorder(
+          borderRadius: BorderRadius.circular(4.0),
+        ).getOuterPath(rect),
+        areaToCompare: rect.inflate(2.0),
+      ),
+    );
+    expect(
+      fitting.getOuterPath(rect),
+      isNot(coversSameAreaAs(scaled.getOuterPath(rect), areaToCompare: rect.inflate(2.0))),
+    );
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/132947
+  test('ContinuousRectangleBorder scales down elliptical radii that overflow a side', () {
+    // This shape spends the x radii along the vertical sides and the y radii
+    // along the horizontal ones, so an elliptical radius overflows the side it
+    // is actually drawn along. Here the bottom side is 20.0 wide but is asked
+    // for 15.0 from the bottom right corner and 15.0 from the bottom left one.
+    const rect = Rect.fromLTWH(0.0, 0.0, 20.0, 100.0);
+    const overflowing = ContinuousRectangleBorder(
+      borderRadius: BorderRadius.only(
+        bottomRight: Radius.elliptical(0.0, 15.0),
+        bottomLeft: Radius.elliptical(15.0, 0.0),
+      ),
+    );
+    // 20.0 / (15.0 + 15.0) leaves 10.0 for each of the two corners.
+    const scaled = ContinuousRectangleBorder(
+      borderRadius: BorderRadius.only(
+        bottomRight: Radius.elliptical(0.0, 10.0),
+        bottomLeft: Radius.elliptical(10.0, 0.0),
+      ),
+    );
+
+    final Path overflowingPath = overflowing.getOuterPath(rect);
+    expect(
+      overflowingPath,
+      coversSameAreaAs(scaled.getOuterPath(rect), areaToCompare: rect.inflate(2.0)),
+    );
+    // The two curves would otherwise overshoot and the straight segment between
+    // them would run backwards, which covers the same area but makes the
+    // stroked outline double back over itself.
+    expect(_perimeterOf(overflowingPath), moreOrLessEquals(_perimeterOf(scaled.getOuterPath(rect))));
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/132947
+  test('ContinuousRectangleBorder treats a negative radius as zero while scaling', () {
+    // The radii are scaled down by comparing the sum of the two radii drawn
+    // along a side against the length of that side. A negative radius has to be
+    // clamped to zero before that sum is taken, otherwise it cancels out part of
+    // the radius of the corner it shares the side with and lets that corner
+    // overflow.
+    const rect = Rect.fromLTWH(0.0, 0.0, 20.0, 100.0);
+    const mixed = ContinuousRectangleBorder(
+      borderRadius: BorderRadius.only(
+        bottomRight: Radius.elliptical(0.0, 40.0),
+        bottomLeft: Radius.elliptical(-15.0, 0.0),
+      ),
+    );
+    const clamped = ContinuousRectangleBorder(
+      borderRadius: BorderRadius.only(bottomRight: Radius.elliptical(0.0, 40.0)),
+    );
+
+    // A negative radius is documented to behave exactly like a zero radius.
+    final Path mixedPath = mixed.getOuterPath(rect);
+    expect(
+      mixedPath,
+      coversSameAreaAs(clamped.getOuterPath(rect), areaToCompare: rect.inflate(2.0)),
+    );
+    expect(_perimeterOf(mixedPath), moreOrLessEquals(_perimeterOf(clamped.getOuterPath(rect))));
+    // The outline never leaves the rect it was given.
+    expect(mixedPath.getBounds(), rect);
   });
 
   testWidgets('Golden test even radii', (WidgetTester tester) async {


### PR DESCRIPTION
ContinuousRectangleBorder._getPath spends one radius worth of space at each end of every side, but it clamped each radius independently to rrect.shortestSide. Two radii share every side, so two radii that each pass that clamp can still add up to more than the side they are drawn along. When that happens the corner curves overshoot and the straight segment between them runs backwards, so the contour crosses over itself. That is invisible while the shape is filled, which is why it went unnoticed, but it is drawn as a self-intersecting tie-fighter outline as soon as the shape is stroked. An unchecked Checkbox is stroked, so it rendered incorrectly with any radius larger than half of its 18x18 box.

Clamp negative radii to zero first, then shrink every radius by a single common factor until each side fits, which is the rule RRect.scaleRadii applies to rounded rectangles. The negative radii are clamped before the sums are taken rather than after, so that a negative radius cannot cancel out part of the radius of the corner it shares a side with and let an overflowing corner through unscaled.

The sums are paired to the sides this path actually walks. This shape spends the x radii along the vertical sides and the y radii along the horizontal ones, so RRect.scaleRadii cannot be called directly: it pairs the radii by axis and would leave elliptical radii overflowing the side they are really drawn along. For circular radii the two pairings are equivalent.

Two goldens in continuous_rectangle_border_test.dart change on purpose because they use radii that overflow their box. See the PR description for the triage.

Fixes https://github.com/flutter/flutter/issues/132947

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
