### PR TITLE
Fix duplicate selection handle leaders on repeated paints

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1532,6 +1532,18 @@ class _SelectableFragment
   LayerLink? _startHandleLayerLink;
   LayerLink? _endHandleLayerLink;
 
+  // The [LeaderLayer]s pushed by [paintHandles] for the handle layer links.
+  //
+  // A [LayerLink] can only be linked to a single [LeaderLayer] per frame, but a
+  // [RenderParagraph] can be painted more than once in the same frame. For
+  // example, a [RenderListWheelViewport] paints the item that overlaps the
+  // magnifier twice: once magnified and once cylindrically. These handles are
+  // used to detect that case: while a leader layer of an earlier paint of the
+  // same frame is still attached, pushing another one would leave the link with
+  // more than one leader.
+  final LayerHandle<LeaderLayer> _startHandleLeaderLayer = LayerHandle<LeaderLayer>();
+  final LayerHandle<LeaderLayer> _endHandleLeaderLayer = LayerHandle<LeaderLayer>();
+
   @override
   SelectionGeometry get value => _selectionGeometry;
   late SelectionGeometry _selectionGeometry;
@@ -3550,10 +3562,16 @@ class _SelectableFragment
     }
     if (_startHandleLayerLink != startHandle) {
       _startHandleLayerLink = startHandle;
+      if (startHandle == null) {
+        _startHandleLeaderLayer.layer = null;
+      }
       paragraph.markNeedsPaint();
     }
     if (_endHandleLayerLink != endHandle) {
       _endHandleLayerLink = endHandle;
+      if (endHandle == null) {
+        _endHandleLeaderLayer.layer = null;
+      }
       paragraph.markNeedsPaint();
     }
   }
@@ -3615,6 +3633,13 @@ class _SelectableFragment
   }
 
   @override
+  void dispose() {
+    _startHandleLeaderLayer.layer = null;
+    _endHandleLeaderLayer.layer = null;
+    super.dispose();
+  }
+
+  @override
   int get contentLength => range.end - range.start;
 
   @override
@@ -3644,26 +3669,34 @@ class _SelectableFragment
     if (_textSelectionStart == null || _textSelectionEnd == null) {
       return;
     }
-    if (_startHandleLayerLink != null && value.startSelectionPoint != null) {
-      context.pushLayer(
-        LeaderLayer(
-          link: _startHandleLayerLink!,
-          offset: offset + value.startSelectionPoint!.localPosition,
-        ),
-        (PaintingContext context, Offset offset) {},
-        Offset.zero,
+    if (_startHandleLayerLink != null &&
+        value.startSelectionPoint != null &&
+        !_isLeaderLayerStillInLayerTree(_startHandleLeaderLayer)) {
+      final leaderLayer = LeaderLayer(
+        link: _startHandleLayerLink!,
+        offset: offset + value.startSelectionPoint!.localPosition,
       );
+      _startHandleLeaderLayer.layer = leaderLayer;
+      context.pushLayer(leaderLayer, (PaintingContext context, Offset offset) {}, Offset.zero);
     }
-    if (_endHandleLayerLink != null && value.endSelectionPoint != null) {
-      context.pushLayer(
-        LeaderLayer(
-          link: _endHandleLayerLink!,
-          offset: offset + value.endSelectionPoint!.localPosition,
-        ),
-        (PaintingContext context, Offset offset) {},
-        Offset.zero,
+    if (_endHandleLayerLink != null &&
+        value.endSelectionPoint != null &&
+        !_isLeaderLayerStillInLayerTree(_endHandleLeaderLayer)) {
+      final leaderLayer = LeaderLayer(
+        link: _endHandleLayerLink!,
+        offset: offset + value.endSelectionPoint!.localPosition,
       );
+      _endHandleLeaderLayer.layer = leaderLayer;
+      context.pushLayer(leaderLayer, (PaintingContext context, Offset offset) {}, Offset.zero);
     }
+  }
+
+  // Whether the leader layer pushed by an earlier paint is still part of the
+  // layer tree, which means the paragraph is being painted more than once in
+  // the same frame. The layer tree is torn down and rebuilt before a paint, so
+  // a leader layer that is still attached can only come from the current frame.
+  static bool _isLeaderLayerStillInLayerTree(LayerHandle<LeaderLayer> handle) {
+    return handle.layer?.attached ?? false;
   }
 
   @override

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -938,5 +939,49 @@ void main() {
       ),
     );
     expect(tester.getSize(find.byType(CupertinoPicker)), Size.zero);
+  });
+
+  testWidgets('CupertinoPicker in a SelectableRegion only pushes one selection handle leader layer per link', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/140543.
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: SizedBox(
+            height: 300.0,
+            width: 300.0,
+            child: SelectableRegion(
+              selectionControls: cupertinoTextSelectionControls,
+              child: CupertinoPicker(
+                itemExtent: 50.0,
+                onSelectedItemChanged: (int index) {},
+                children: const <Widget>[Text('Element 1'), Text('Element 2')],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // The item in the center of the wheel is painted twice in the same frame:
+    // once dimmed outside of the center rect and once at full opacity inside of
+    // it. Selecting it used to push a selection handle leader layer for each of
+    // those paints, leaving the handle layer links with more than one leader.
+    final Rect textRect = tester.getRect(find.text('Element 1'));
+    final TestGesture gesture = await tester.startGesture(
+      textRect.centerLeft + const Offset(2.0, 0.0),
+      kind: PointerDeviceKind.mouse,
+    );
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+    await gesture.moveTo(textRect.centerRight - const Offset(2.0, 0.0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    // One leader layer for the toolbar and one for each selection handle.
+    expect(tester.layers.whereType<LeaderLayer>(), hasLength(3));
   });
 }


### PR DESCRIPTION
A `RenderParagraph` can be painted more than once in the same frame. For
example `RenderListWheelViewport`, which backs `CupertinoPicker`, paints
the item that overlaps the center of the wheel twice: once clipped to the
magnifier and once clipped to the dimmed cylindrical part. Every paint of
a selected `_SelectableFragment` pushed a brand new `LeaderLayer` for the
selection handle `LayerLink`s, so a double paint left each link with two
leaders and tripped the `_debugPreviousLeaders!.isEmpty` assertion of
`LayerLink` at the end of the frame.

`_SelectableFragment` now keeps a `LayerHandle` for each handle leader
layer it pushes. The layer tree below a repaint boundary is torn down
before it is repainted, so a leader layer that is still attached can only
come from an earlier paint of the current frame. In that case the handle
layer is already in the tree and pushing another one is skipped.

Fixes https://github.com/flutter/flutter/issues/140543

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
