### PR TITLE
Fix Draggable feedback placement under a transformed ancestor

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -492,6 +492,28 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
     _recognizer = null;
   }
 
+  /// Converts a drag anchor, which [DragAnchorStrategy] reports in the local
+  /// coordinate space of this draggable, to the coordinate space of the overlay
+  /// that hosts the feedback.
+  ///
+  /// Without this conversion a transform between the draggable and the overlay
+  /// (such as a [Transform.scale]) would offset the feedback by an amount that
+  /// grows with the distance between the drag anchor and the origin of the
+  /// draggable, which makes the feedback land in a different place depending on
+  /// where the drag started.
+  Offset _dragAnchorToOverlaySpace(Offset anchor, OverlayState overlayState) {
+    if (anchor == Offset.zero) {
+      return anchor;
+    }
+    final RenderObject? draggableBox = context.findRenderObject();
+    final RenderObject? overlayBox = overlayState.context.findRenderObject();
+    if (draggableBox is! RenderBox || overlayBox is! RenderBox) {
+      return anchor;
+    }
+    final Offset origin = overlayBox.globalToLocal(draggableBox.localToGlobal(Offset.zero));
+    return overlayBox.globalToLocal(draggableBox.localToGlobal(anchor)) - origin;
+  }
+
   void _routePointer(PointerDownEvent event) {
     if (widget.maxSimultaneousDrags != null && _activeCount >= widget.maxSimultaneousDrags!) {
       return;
@@ -503,13 +525,20 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
     if (widget.maxSimultaneousDrags != null && _activeCount >= widget.maxSimultaneousDrags!) {
       return null;
     }
-    final Offset dragStartPoint;
-    dragStartPoint = widget.dragAnchorStrategy(widget, context, position);
+    final OverlayState overlayState = Overlay.of(
+      context,
+      debugRequiredFor: widget,
+      rootOverlay: widget.rootOverlay,
+    );
+    final Offset dragStartPoint = _dragAnchorToOverlaySpace(
+      widget.dragAnchorStrategy(widget, context, position),
+      overlayState,
+    );
     setState(() {
       _activeCount += 1;
     });
     final avatar = _DragAvatar<T>(
-      overlayState: Overlay.of(context, debugRequiredFor: widget, rootOverlay: widget.rootOverlay),
+      overlayState: overlayState,
       data: widget.data,
       axis: widget.axis,
       initialPosition: position,

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -3804,6 +3804,60 @@ void main() {
     await tester.pump();
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/147000
+  testWidgets('Drag and drop - childDragAnchorStrategy works when the draggable is scaled', (
+    WidgetTester tester,
+  ) async {
+    final Key sourceKey = UniqueKey();
+    final Key feedbackKey = UniqueKey();
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Align(
+          alignment: Alignment.topLeft,
+          child: Transform.scale(
+            scale: 0.5,
+            alignment: Alignment.topLeft,
+            child: LongPressDraggable<int>(
+              data: 42,
+              feedback: Container(
+                key: feedbackKey,
+                width: 40.0,
+                height: 20.0,
+                color: const Color(0xFFFF0000),
+              ),
+              child: Container(
+                key: sourceKey,
+                width: 300.0,
+                height: 200.0,
+                color: const Color(0xFF0000FF),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    final Finder source = find.byKey(sourceKey);
+    final Finder feedback = find.byKey(feedbackKey);
+    final Offset sourceTopLeft = tester.getTopLeft(source);
+
+    // The feedback must be anchored to the top left of the child no matter
+    // where inside the child the drag was started.
+    for (final startLocation in <Offset>[
+      tester.getTopLeft(source) + const Offset(1.0, 1.0),
+      tester.getCenter(source),
+      tester.getBottomRight(source) - const Offset(1.0, 1.0),
+    ]) {
+      final TestGesture gesture = await tester.startGesture(startLocation);
+      await tester.pump(kLongPressTimeout);
+      expect(feedback, findsOneWidget);
+      expect(tester.getTopLeft(feedback), sourceTopLeft);
+
+      // Finish gesture to release resources.
+      await gesture.up();
+      await tester.pump();
+    }
+  });
+
   testWidgets('Drag and drop - feedback matches pointer in rotated WidgetsApp', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
DragAnchorStrategy reports the drag anchor in the local coordinate space of
the draggable, but _DragAvatar subtracts that anchor from a position that is
expressed in the coordinate space of the overlay that hosts the feedback.
When a transform sits between the draggable and the overlay (for example a
Transform.scale), the two spaces disagree, so the feedback is shifted by an
error that grows with the distance between the drag anchor and the origin of
the draggable. The feedback therefore lands in a different place depending on
where inside the child the drag started, and can end up nowhere near the
pointer.

Convert the anchor returned by the drag anchor strategy from the local space
of the draggable into the space of the overlay before handing it to the drag
avatar. The conversion is the identity when there is no transform between the
draggable and the overlay, so the common case is unchanged.

Fixes https://github.com/flutter/flutter/issues/147000

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
