### PR TITLE
Clamp glow overscroll indicator paint offset to the edge

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -223,12 +223,17 @@ class _GlowingOverscrollIndicatorState extends State<GlowingOverscrollIndicator>
     // before glow disappears, so the current pixels is -190.0,
     // in this case, we should move the glow up 10.0 pixels and should not
     // overflow the scrollable widget's edge. https://github.com/flutter/flutter/issues/64149.
+    // The distance to the edge is clamped to be non-negative: when the scroll
+    // position is outside of the scroll extents (e.g. with a bouncing physics,
+    // or right after the content dimensions shrank) it would otherwise become
+    // negative and move the glow away from the edge it belongs to.
+    // https://github.com/flutter/flutter/issues/191646.
     _leadingController!._paintOffsetScrollPixels = -math.min(
-      notification.metrics.pixels - notification.metrics.minScrollExtent,
+      math.max(notification.metrics.pixels - notification.metrics.minScrollExtent, 0.0),
       _leadingController!._paintOffset,
     );
     _trailingController!._paintOffsetScrollPixels = -math.min(
-      notification.metrics.maxScrollExtent - notification.metrics.pixels,
+      math.max(notification.metrics.maxScrollExtent - notification.metrics.pixels, 0.0),
       _trailingController!._paintOffset,
     );
 

--- a/packages/flutter/test/widgets/overscroll_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_indicator_test.dart
@@ -730,6 +730,108 @@ void main() {
           ..circle(),
       );
     });
+
+    testWidgets('Leading does not invert when the scroll position is out of range', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/191646
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: NotificationListener<OverscrollIndicatorNotification>(
+            onNotification: (OverscrollIndicatorNotification notification) {
+              if (notification.leading) {
+                notification.paintOffset = 50.0;
+              }
+              return false;
+            },
+            child: CustomScrollView(
+              controller: controller,
+              slivers: const <Widget>[SliverToBoxAdapter(child: SizedBox(height: 2000.0))],
+            ),
+          ),
+        ),
+      );
+      final RenderObject painter = tester.renderObject(find.byType(CustomPaint));
+      await slowDrag(tester, const Offset(200.0, 200.0), const Offset(0.0, 5.0));
+      expect(
+        painter,
+        paints
+          ..save()
+          ..translate(y: 50.0)
+          ..scale()
+          ..circle(),
+      );
+      // Move the scroll position before the leading edge, which can happen with
+      // bouncing physics or right after the content dimensions changed.
+      controller.jumpTo(controller.position.minScrollExtent - 480.0);
+      await tester.pump();
+      // The OverscrollIndicator should stay at its paint offset instead of
+      // being pushed away from the leading edge.
+      expect(
+        painter,
+        paints
+          ..save()
+          ..translate(y: 50.0)
+          ..scale()
+          ..circle(),
+      );
+    });
+
+    testWidgets('Trailing does not invert when the scroll position is out of range', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/191646
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: NotificationListener<OverscrollIndicatorNotification>(
+            onNotification: (OverscrollIndicatorNotification notification) {
+              if (!notification.leading) {
+                notification.paintOffset = 50.0;
+              }
+              return false;
+            },
+            child: CustomScrollView(
+              controller: controller,
+              slivers: const <Widget>[SliverToBoxAdapter(child: SizedBox(height: 2000.0))],
+            ),
+          ),
+        ),
+      );
+      final RenderObject painter = tester.renderObject(find.byType(CustomPaint));
+      await tester.dragFrom(const Offset(200.0, 200.0), const Offset(200.0, -10000.0));
+      await tester.pump();
+      await slowDrag(tester, const Offset(200.0, 200.0), const Offset(0.0, -5.0));
+      expect(
+        painter,
+        paints
+          ..scale(y: -1.0)
+          ..save()
+          ..translate(y: 50.0)
+          ..scale()
+          ..circle(),
+      );
+      // Move the scroll position past the trailing edge, which can happen with
+      // bouncing physics or right after the content dimensions changed.
+      controller.jumpTo(controller.position.maxScrollExtent + 480.0);
+      await tester.pump();
+      // The OverscrollIndicator should stay at its paint offset instead of
+      // being pushed away from the trailing edge.
+      expect(
+        painter,
+        paints
+          ..scale(y: -1.0)
+          ..save()
+          ..translate(y: 50.0)
+          ..scale()
+          ..circle(),
+      );
+    });
   });
 
   testWidgets('StretchingOverscrollIndicator does not crash when child is null', (


### PR DESCRIPTION
The glow paint offset was computed with an unbounded `math.min()` of the
distance between the scroll position and the edge. When `pixels` is outside
`[minScrollExtent, maxScrollExtent]` - for example with a bouncing physics,
or right after the content dimensions shrank while `pixels` still holds the
old value - that distance is negative, so `_paintOffsetScrollPixels` became
positive and translated the glow away from the edge it belongs to instead of
toward it. With `paintOffset: 50` and a 480 pixel out of range position the
glow was painted at `y = 530` instead of `y = 50`.

Clamp the distance to the edge to be non-negative, so the paint offset can
never invert. Values inside the extents are unaffected.

Fixes https://github.com/flutter/flutter/issues/191646

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
