### PR TITLE
Fix predictive back direction after popping onto a non-transitioning route

### DIFF
--- a/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
+++ b/packages/flutter/lib/src/material/predictive_back_page_transitions_builder.dart
@@ -492,7 +492,18 @@ class _PredictiveBackSharedElementPageTransitionState
     if (widget.animation != oldWidget.animation) {
       _updateCurvedAnimations();
     }
-    if (widget.phase != oldWidget.phase && widget.phase == _PredictiveBackPhase.commit) {
+    // The horizontal direction of _positionAnimation is baked into its tween, so
+    // the animations must also be updated when the swipe edge changes. This
+    // state can outlive a gesture, for example when the route below is not
+    // rebuilt after the route above it is popped, so the swipe edge of the
+    // previous gesture must not leak into the next one. Only do this while a
+    // gesture is active (widget.currentBackEvent != null): when a gesture is
+    // canceled, currentBackEvent is cleared to null without changing the swipe
+    // edge of the ongoing rebound, so refreshing here would incorrectly reset
+    // the tween to the default left-edge direction mid-rebound.
+    if ((widget.phase != oldWidget.phase && widget.phase == _PredictiveBackPhase.commit) ||
+        (widget.currentBackEvent != null &&
+            widget.currentBackEvent?.swipeEdge != oldWidget.currentBackEvent?.swipeEdge)) {
       _updateAnimations(MediaQuery.sizeOf(context));
     }
   }

--- a/packages/flutter/test/material/predictive_back_page_transitions_builder_test.dart
+++ b/packages/flutter/test/material/predictive_back_page_transitions_builder_test.dart
@@ -677,6 +677,199 @@ void main() {
     });
   }
 
+  testWidgets(
+    'PredictiveBackPageTransitionsBuilder uses the swipe edge of the current gesture after popping a route that the route below cannot transition to',
+    (WidgetTester tester) async {
+      const PageTransitionsBuilder pageTransitionsBuilder = PredictiveBackPageTransitionsBuilder();
+
+      Future<void> sendBackGestureMessage(MethodCall methodCall) async {
+        final ByteData message = const StandardMethodCodec().encodeMethodCall(methodCall);
+        await binding.defaultBinaryMessenger.handlePlatformMessage(
+          'flutter/backgesture',
+          message,
+          (ByteData? _) {},
+        );
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            pageTransitionsTheme: const PageTransitionsTheme(
+              builders: <TargetPlatform, PageTransitionsBuilder>{
+                TargetPlatform.android: pageTransitionsBuilder,
+              },
+            ),
+          ),
+          home: Builder(
+            builder: (BuildContext context) => Material(
+              child: TextButton(
+                child: const Text('push b'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    _NoSecondaryAnimationPageRoute<void>(
+                      builder: (BuildContext context) => Material(
+                        child: TextButton(
+                          child: const Text('page b'),
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute<void>(
+                                builder: (BuildContext context) => const Text('page c'),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('push b'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('page b'));
+      await tester.pumpAndSettle();
+      expect(find.text('page c'), findsOneWidget);
+
+      // Pop page c with a predictive back gesture from the right edge.
+      await sendBackGestureMessage(
+        const MethodCall('startBackGesture', <String, dynamic>{
+          'touchOffset': <double>[795.0, 300.0],
+          'progress': 0.0,
+          'swipeEdge': 1, // right
+        }),
+      );
+      await tester.pump();
+      await sendBackGestureMessage(
+        const MethodCall('updateBackGestureProgress', <String, dynamic>{
+          'touchOffset': <double>[700.0, 300.0],
+          'progress': 0.35,
+          'swipeEdge': 1, // right
+        }),
+      );
+      await tester.pump();
+      await sendBackGestureMessage(const MethodCall('commitBackGesture'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('page c'), findsNothing);
+      expect(find.text('page b'), findsOneWidget);
+      final double restingPageBDx = tester.getTopLeft(find.text('page b')).dx;
+
+      // Start another predictive back gesture from the right edge, this time on
+      // page b.
+      await sendBackGestureMessage(
+        const MethodCall('startBackGesture', <String, dynamic>{
+          'touchOffset': <double>[795.0, 300.0],
+          'progress': 0.0,
+          'swipeEdge': 1, // right
+        }),
+      );
+      await tester.pump();
+      await sendBackGestureMessage(
+        const MethodCall('updateBackGestureProgress', <String, dynamic>{
+          'touchOffset': <double>[700.0, 300.0],
+          'progress': 0.35,
+          'swipeEdge': 1, // right
+        }),
+      );
+      await tester.pump();
+
+      // Page b must move to the left, away from the right edge gesture, and not
+      // towards it.
+      expect(tester.getTopLeft(find.text('page b')).dx, lessThan(restingPageBDx));
+
+      await sendBackGestureMessage(const MethodCall('cancelBackGesture'));
+      await tester.pumpAndSettle();
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+
+  testWidgets(
+    'PredictiveBackPageTransitionsBuilder rebounds toward the same edge after canceling a right-edge gesture',
+    (WidgetTester tester) async {
+      const PageTransitionsBuilder pageTransitionsBuilder = PredictiveBackPageTransitionsBuilder();
+
+      Future<void> sendBackGestureMessage(MethodCall methodCall) async {
+        final ByteData message = const StandardMethodCodec().encodeMethodCall(methodCall);
+        await binding.defaultBinaryMessenger.handlePlatformMessage(
+          'flutter/backgesture',
+          message,
+          (ByteData? _) {},
+        );
+      }
+
+      final routes = <String, WidgetBuilder>{
+        '/': (BuildContext context) => Material(
+          child: TextButton(
+            child: const Text('push'),
+            onPressed: () {
+              Navigator.of(context).pushNamed('/b');
+            },
+          ),
+        ),
+        '/b': (BuildContext context) => const Text('page b'),
+      };
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            pageTransitionsTheme: const PageTransitionsTheme(
+              builders: <TargetPlatform, PageTransitionsBuilder>{
+                TargetPlatform.android: pageTransitionsBuilder,
+              },
+            ),
+          ),
+          routes: routes,
+        ),
+      );
+
+      await tester.tap(find.text('push'));
+      await tester.pumpAndSettle();
+      expect(find.text('page b'), findsOneWidget);
+
+      // Start a predictive back gesture from the right edge.
+      await sendBackGestureMessage(
+        const MethodCall('startBackGesture', <String, dynamic>{
+          'touchOffset': <double>[795.0, 300.0],
+          'progress': 0.0,
+          'swipeEdge': 1, // right
+        }),
+      );
+      await tester.pump();
+      await sendBackGestureMessage(
+        const MethodCall('updateBackGestureProgress', <String, dynamic>{
+          'touchOffset': <double>[700.0, 300.0],
+          'progress': 0.35,
+          'swipeEdge': 1, // right
+        }),
+      );
+      await tester.pump();
+
+      final double dxDuringGesture = tester.getTopLeft(find.text('page b')).dx;
+
+      // Cancel the gesture. currentBackEvent is cleared to null at this
+      // point, but the position must not jump: the driving animation's value
+      // has not changed yet on this frame, so the tween must still reflect
+      // the right edge of the gesture that was just canceled. A regression
+      // here shows up as the position suddenly jumping toward the opposite
+      // side, which is what the default left-edge tween would produce.
+      await sendBackGestureMessage(const MethodCall('cancelBackGesture'));
+      await tester.pump();
+      expect(
+        tester.getTopLeft(find.text('page b')).dx,
+        moreOrLessEquals(dxDuringGesture, epsilon: 0.5),
+      );
+
+      await tester.pumpAndSettle();
+      expect(tester.getTopLeft(find.text('page b')).dx, 0.0);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+
+
   testWidgets('PredictiveBackPageTransitionsBuilder uses fallbackColor', (
     WidgetTester tester,
   ) async {
@@ -777,6 +970,15 @@ void main() {
     },
     variant: TargetPlatformVariant.all(),
   );
+}
+
+/// Mimics routing packages whose routes never run a secondary animation for the
+/// route below them.
+class _NoSecondaryAnimationPageRoute<T> extends MaterialPageRoute<T> {
+  _NoSecondaryAnimationPageRoute({required super.builder});
+
+  @override
+  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) => false;
 }
 
 String _getTransitionsString(PageTransitionsBuilder pageTransitionsBuilder) {


### PR DESCRIPTION
_PredictiveBackSharedElementPageTransitionState bakes the horizontal
direction of the gesture into the tween of _positionAnimation, and only
rebuilt that tween in didChangeDependencies and when the gesture was
committed. When the route below cannot transition to the route above it
(canTransitionTo returns false, as done by some routing packages), it is
not rebuilt while the route above it is popped, so its transition state
survives the pop with the swipe edge of that earlier gesture. The next
gesture on that route then reused the stale direction and moved the page
towards the finger instead of away from it.

Update the animations in didUpdateWidget when the swipe edge of the
current back event changes, so a new gesture always animates towards the
correct side. This refresh is now restricted to when a gesture is active
(currentBackEvent != null): handleCancelBackGesture() also clears
currentBackEvent to null, and without this guard that clearing was
mistaken for a swipe edge change, resetting the tween to the default
left-edge direction mid-rebound and making a canceled right-edge gesture
rebound the wrong way.

Fixes https://github.com/flutter/flutter/issues/191101

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
