### PR TITLE
[tool] Report an actionable error for unsupported JDK Gradle crashes

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -482,6 +482,25 @@ To fix this, you can either:
     }
   }
 
+  /// Prints the suggestion of the first known Gradle error found in [output],
+  /// if there is one.
+  ///
+  /// Unlike app builds, AAR builds do not stream the Gradle output through
+  /// [_runGradleTask], so the known error handlers are applied to the captured
+  /// output instead. Only the suggestion is reported, the AAR build is never
+  /// retried.
+  Future<void> _reportKnownGradleError(FlutterProject project, String output) async {
+    final bool usesAndroidX = isAppUsingAndroidX(project.android.hostAppGradleRoot);
+    for (final String line in LineSplitter.split(output)) {
+      for (final GradleHandledError gradleError in gradleErrors) {
+        if (gradleError.test(line)) {
+          await gradleError.handler(line: line, project: project, usesAndroidX: usesAndroidX);
+          return;
+        }
+      }
+    }
+  }
+
   /// Builds an app.
   ///
   /// * [project] is typically [FlutterProject.current()].
@@ -957,6 +976,7 @@ To fix this, you can either:
       _logger.printStatus(result.stdout, wrap: false);
       _logger.printError(result.stderr, wrap: false);
       await _checkJavaAndGradleCompatibility(project, androidBuildInfo.buildInfo);
+      await _reportKnownGradleError(project, '${result.stdout}\n${result.stderr}');
       throwToolExit(
         'Gradle task $aarTask failed with exit code ${result.exitCode}.',
         exitCode: result.exitCode,

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -8,6 +8,7 @@ import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
 import '../base/process.dart';
 import '../base/terminal.dart';
+import '../base/version.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import 'gradle_utils.dart' as utils;
@@ -78,6 +79,7 @@ final gradleErrors = <GradleHandledError>[
   sslExceptionHandler,
   zipExceptionHandler,
   incompatibleJavaAndGradleVersionsHandler,
+  unsupportedJavaVersionHandler,
   remoteTerminatedHandshakeHandler,
   couldNotOpenCacheDirectoryHandler,
   incompatibleCompileSdk35AndAgpVersionHandler,
@@ -541,6 +543,43 @@ final incompatibleJavaAndGradleVersionsHandler = GradleHandledError(
         return GradleBuildStatus.exit;
       },
   eventLabel: 'incompatible-java-gradle-version',
+);
+
+/// When the JDK that Gradle runs on is newer than the Java version that the
+/// build tooling (Gradle, the Android Gradle plugin, or the Kotlin Gradle
+/// plugin) knows how to parse, the build crashes while parsing the version
+/// string, for example:
+///
+///     java.lang.IllegalArgumentException: 25.0.2
+///         at org.jetbrains.kotlin.com.intellij.util.lang.JavaVersion.parse(JavaVersion.java:245)
+///
+/// The stack frame is matched instead of the exception message because the
+/// message is only the Java version, which is too generic to match on its own.
+/// The class is repackaged by some plugins, so only the end of the class name
+/// is matched.
+@visibleForTesting
+final unsupportedJavaVersionHandler = GradleHandledError(
+  test: _lineMatcher(const <String>['com.intellij.util.lang.JavaVersion.parse']),
+  handler:
+      ({required String line, required FlutterProject project, required bool usesAndroidX}) async {
+        final Version? javaVersion = globals.java?.version;
+        final javaVersionText = javaVersion == null ? '' : ' ($javaVersion)';
+        globals.printBox(
+          '${globals.logger.terminal.warningMark} The Java version used by Flutter'
+          '$javaVersionText is not supported by the Gradle, Android Gradle plugin, '
+          'or Kotlin Gradle plugin versions used by this project.\n\n'
+          'To fix this issue, either select a supported Java version by running\n'
+          '`flutter config --jdk-dir=</path/to/jdk>`\n'
+          'or upgrade the Gradle, Android Gradle plugin, and Kotlin Gradle plugin '
+          'versions used by this project.\n\n'
+          'To check the Java version used by Flutter, run `flutter doctor --verbose`.\n'
+          'See the link below for more information on compatible Java/Gradle versions:\n'
+          '${AndroidProject.javaGradleCompatUrl}\n\n',
+          title: _boxTitle,
+        );
+        return GradleBuildStatus.exit;
+      },
+  eventLabel: 'unsupported-java-version',
 );
 
 @visibleForTesting

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -2456,6 +2456,97 @@ Gradle Crashed
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{AndroidStudio: () => FakeAndroidStudio()});
 
+    testUsingContext(
+      'build aar reports an actionable error when the Java version is unsupported',
+      () async {
+        final builder = AndroidGradleBuilder(
+          java: FakeJava(version: const Version.withText(25, 0, 2, '25.0.2')),
+          logger: logger,
+          processManager: processManager,
+          fileSystem: fileSystem,
+          artifacts: Artifacts.test(),
+          analytics: fakeAnalytics,
+          gradleUtils: FakeGradleUtils(),
+          platform: FakePlatform(),
+          androidStudio: FakeAndroidStudio(),
+        );
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'gradlew',
+              '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
+              '-Pflutter-root=/',
+              '-Poutput-dir=build/',
+              '-Pis-plugin=false',
+              '-PbuildNumber=1.0',
+              '-q',
+              '-Pdart-obfuscation=false',
+              '-Ptrack-widget-creation=false',
+              '-Ptree-shake-icons=false',
+              '-Ptarget-platform=android-arm,android-arm64,android-x64',
+              'assembleAarRelease',
+            ],
+            exitCode: 1,
+            stdout: '''
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':flutter:javaDocDebugGeneration'.
+> 25.0.2
+
+* Exception is:
+java.lang.IllegalArgumentException: 25.0.2
+\tat org.jetbrains.kotlin.com.intellij.util.lang.JavaVersion.parse(JavaVersion.java:245)
+''',
+          ),
+        );
+
+        final File manifestFile = fileSystem.file('pubspec.yaml');
+        manifestFile.createSync(recursive: true);
+        manifestFile.writeAsStringSync('''
+        flutter:
+          module:
+            androidPackage: com.example.test
+        ''');
+
+        fileSystem.file('.android/gradlew').createSync(recursive: true);
+        fileSystem.file('.android/gradle.properties').writeAsStringSync('irrelevant');
+        fileSystem.file('.android/build.gradle').createSync(recursive: true);
+        fileSystem.directory('build/outputs/repo').createSync(recursive: true);
+
+        await expectLater(
+          () async => builder.buildGradleAar(
+            androidBuildInfo: const AndroidBuildInfo(
+              BuildInfo(
+                BuildMode.release,
+                null,
+                treeShakeIcons: false,
+                packageConfigPath: '.dart_tool/package_config.json',
+              ),
+            ),
+            project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+            outputDirectory: fileSystem.directory('build/'),
+            target: '',
+            buildNumber: '1.0',
+          ),
+          throwsToolExit(
+            exitCode: 1,
+            message: 'Gradle task assembleAarRelease failed with exit code 1.',
+          ),
+        );
+        expect(
+          testLogger.statusText,
+          contains('The Java version used by Flutter (25.0.2) is not supported'),
+        );
+        expect(testLogger.statusText, contains('flutter config --jdk-dir='));
+        expect(processManager, hasNoRemainingExpectations);
+      },
+      overrides: <Type, Generator>{
+        AndroidStudio: () => FakeAndroidStudio(),
+        Java: () => FakeJava(version: const Version.withText(25, 0, 2, '25.0.2')),
+      },
+    );
+
     testUsingContext('build apk uses selected local engine with arm32 ABI', () async {
       final builder = AndroidGradleBuilder(
         java: FakeJava(),

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
@@ -50,6 +51,7 @@ void main() {
           sslExceptionHandler,
           zipExceptionHandler,
           incompatibleJavaAndGradleVersionsHandler,
+          unsupportedJavaVersionHandler,
           remoteTerminatedHandshakeHandler,
           couldNotOpenCacheDirectoryHandler,
           incompatibleCompileSdk35AndAgpVersionHandler,
@@ -1394,6 +1396,57 @@ Could not compile build file '…/example/android/build.gradle'.
         );
       },
       overrides: <Type, Generator>{
+        GradleUtils: () => FakeGradleUtils(),
+        Platform: () => fakePlatform('android'),
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+  });
+
+  group('unsupported java version error', () {
+    const errorMessage = '''
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':flutter:javaDocDebugGeneration'.
+> 25.0.2
+
+java.lang.IllegalArgumentException: 25.0.2
+\tat org.jetbrains.kotlin.com.intellij.util.lang.JavaVersion.parse(JavaVersion.java:245)
+''';
+
+    testWithoutContext('pattern', () {
+      expect(unsupportedJavaVersionHandler.test(errorMessage), isTrue);
+      // The exception message alone is too generic to be matched.
+      expect(
+        unsupportedJavaVersionHandler.test('java.lang.IllegalArgumentException: 25.0.2'),
+        isFalse,
+      );
+    });
+
+    testUsingContext(
+      'suggestion',
+      () async {
+        final GradleBuildStatus status = await unsupportedJavaVersionHandler.handler(
+          line: errorMessage,
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+          usesAndroidX: true,
+        );
+
+        expect(status, equals(GradleBuildStatus.exit));
+        expect(
+          testLogger.statusText,
+          contains('The Java version used by Flutter (25.0.2) is not supported'),
+        );
+        expect(testLogger.statusText, contains('flutter config --jdk-dir='));
+        expect(
+          testLogger.statusText,
+          contains('https://docs.gradle.org/current/userguide/compatibility.html#java'),
+        );
+      },
+      overrides: <Type, Generator>{
+        Java: () => FakeJava(version: const Version.withText(25, 0, 2, '25.0.2')),
         GradleUtils: () => FakeGradleUtils(),
         Platform: () => fakePlatform('android'),
         FileSystem: () => fileSystem,


### PR DESCRIPTION
`flutter build aar` (and app builds) can fail deep inside Gradle when the JDK
that Gradle runs on is newer than the Java version the build tooling knows how
to parse. The Gradle/AGP/Kotlin copy of `com.intellij.util.lang.JavaVersion`
throws `java.lang.IllegalArgumentException: <java version>`, for example while
running `javaDocDebugGeneration` with the JDK 25 bundled in the Android Studio
release candidate. The tool did not recognize this failure, so it only printed
the raw Java stack trace followed by `Gradle task assembleAarDebug failed with
exit code 1`, which gives the user nothing to act on.

Add `unsupportedJavaVersionHandler`, which detects the `JavaVersion.parse`
stack frame and prints a Flutter Fix box naming the Java version in use and
explaining how to select a different JDK or upgrade the project's Gradle, AGP
and KGP versions. AAR builds do not stream Gradle output through
`_runGradleTask`, so they never ran the known error handlers at all; run them
over the captured output before the generic tool exit so AAR builds report the
suggestion too.

Fixes https://github.com/flutter/flutter/issues/189988

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
