### PR TITLE
Fix ConstrainedBox intrinsics ignoring its own constraints

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -8,6 +8,7 @@
 /// @docImport 'sliver.dart';
 library;
 
+import 'dart:math' as math;
 import 'dart:ui' as ui show Color, Gradient, Image, ImageFilter;
 
 import 'package:flutter/animation.dart';
@@ -246,12 +247,21 @@ class RenderConstrainedBox extends RenderProxyBox {
     markNeedsLayout();
   }
 
+  // The incoming intrinsic dimension describes the space available to this
+  // render box. Since [performLayout] additionally constrains the child with
+  // [additionalConstraints], the child never gets more space than
+  // min(incoming, additionalConstraints.max), so the child's intrinsics have to
+  // be evaluated at that reduced extent. Forwarding the unreduced incoming
+  // value instead underestimates the intrinsics of children whose size depends
+  // on the extent in the other axis, such as wrapping text.
   @override
   double computeMinIntrinsicWidth(double height) {
     if (_additionalConstraints.hasBoundedWidth && _additionalConstraints.hasTightWidth) {
       return _additionalConstraints.minWidth;
     }
-    final double width = super.computeMinIntrinsicWidth(height);
+    final double width = super.computeMinIntrinsicWidth(
+      math.min(height, _additionalConstraints.maxHeight),
+    );
     assert(width.isFinite);
     if (!_additionalConstraints.hasInfiniteWidth) {
       return _additionalConstraints.constrainWidth(width);
@@ -264,7 +274,9 @@ class RenderConstrainedBox extends RenderProxyBox {
     if (_additionalConstraints.hasBoundedWidth && _additionalConstraints.hasTightWidth) {
       return _additionalConstraints.minWidth;
     }
-    final double width = super.computeMaxIntrinsicWidth(height);
+    final double width = super.computeMaxIntrinsicWidth(
+      math.min(height, _additionalConstraints.maxHeight),
+    );
     assert(width.isFinite);
     if (!_additionalConstraints.hasInfiniteWidth) {
       return _additionalConstraints.constrainWidth(width);
@@ -277,7 +289,9 @@ class RenderConstrainedBox extends RenderProxyBox {
     if (_additionalConstraints.hasBoundedHeight && _additionalConstraints.hasTightHeight) {
       return _additionalConstraints.minHeight;
     }
-    final double height = super.computeMinIntrinsicHeight(width);
+    final double height = super.computeMinIntrinsicHeight(
+      math.min(width, _additionalConstraints.maxWidth),
+    );
     assert(height.isFinite);
     if (!_additionalConstraints.hasInfiniteHeight) {
       return _additionalConstraints.constrainHeight(height);
@@ -290,7 +304,9 @@ class RenderConstrainedBox extends RenderProxyBox {
     if (_additionalConstraints.hasBoundedHeight && _additionalConstraints.hasTightHeight) {
       return _additionalConstraints.minHeight;
     }
-    final double height = super.computeMaxIntrinsicHeight(width);
+    final double height = super.computeMaxIntrinsicHeight(
+      math.min(width, _additionalConstraints.maxWidth),
+    );
     assert(height.isFinite);
     if (!_additionalConstraints.hasInfiniteHeight) {
       return _additionalConstraints.constrainHeight(height);

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -935,6 +935,29 @@ void main() {
     expect(opacity.paintsChild(sliver), false);
   });
 
+  test('RenderConstrainedBox intrinsics take the additional constraints into account', () {
+    // Regression test for https://github.com/flutter/flutter/issues/177740
+    // The child is only ever as wide as `additionalConstraints` allows, so its
+    // intrinsic height has to be measured at that reduced width.
+    final RenderBox squareChild = RenderAspectRatio(aspectRatio: 1.0);
+    final constrainedBox = RenderConstrainedBox(
+      additionalConstraints: const BoxConstraints.tightFor(width: 50.0),
+      child: squareChild,
+    );
+    expect(constrainedBox.getMinIntrinsicHeight(200.0), 50.0);
+    expect(constrainedBox.getMaxIntrinsicHeight(200.0), 50.0);
+    // A smaller incoming extent still wins over the additional constraints.
+    expect(constrainedBox.getMaxIntrinsicHeight(20.0), 20.0);
+
+    final RenderBox otherSquareChild = RenderAspectRatio(aspectRatio: 1.0);
+    final heightConstrainedBox = RenderConstrainedBox(
+      additionalConstraints: const BoxConstraints(maxHeight: 50.0),
+      child: otherSquareChild,
+    );
+    expect(heightConstrainedBox.getMinIntrinsicWidth(200.0), 50.0);
+    expect(heightConstrainedBox.getMaxIntrinsicWidth(200.0), 50.0);
+  });
+
   test('RenderCustomClip extenders respect clipBehavior when asked to describeApproximateClip', () {
     final RenderBox child = RenderConstrainedBox(
       additionalConstraints: const BoxConstraints.tightFor(width: 200, height: 200),

--- a/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
@@ -1324,4 +1324,58 @@ void main() {
       });
     });
   });
+
+  testWidgets('SliverFillRemaining does not overflow when a width constrained child wraps text', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/177740
+    // The extent of a SliverFillRemaining with hasScrollBody set to false is
+    // derived from the max intrinsic height of its child. That intrinsic height
+    // used to be measured while ignoring the width constraint imposed by the
+    // SizedBox below, which made the text report fewer lines than it needs.
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(size: Size(400.0, 600.0)),
+          child: CustomScrollView(
+            slivers: <Widget>[
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Column(
+                  children: <Widget>[
+                    const Expanded(
+                      child: Padding(
+                        padding: EdgeInsets.all(32.0),
+                        child: Center(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: <Widget>[
+                              SizedBox(
+                                width: 240.0,
+                                child: Text(
+                                  'Show this QR Code to the cashier to get your discount of 42% ',
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                    ...List<Widget>.generate(
+                      50,
+                      (int index) => SizedBox(height: 30.0, child: Text('Item $index')),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
 }


### PR DESCRIPTION
RenderConstrainedBox forwarded the incoming intrinsic extent to its child
unchanged, even though performLayout enforces additionalConstraints on that
child. For a Container/SizedBox with a fixed width, the child's intrinsic
height was therefore measured at the full available width instead of the
narrower width the child actually gets, so wrapping text reported fewer lines
than it needs.

SliverFillRemaining with hasScrollBody: false sizes itself from the max
intrinsic height of its child, so the underestimated intrinsic height made the
sliver too short and the content overflowed.

The intrinsic getters now clamp the incoming extent with the matching maximum
of additionalConstraints before querying the child, which matches the
constraints the child receives during layout.

Fixes https://github.com/flutter/flutter/issues/177740

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
