### PR TITLE
Make adaptive dialog and search bar constructors return their public type

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -350,7 +350,7 @@ class AboutDialog extends StatelessWidget {
     this.applicationIcon,
     this.applicationLegalese,
     this.children,
-  });
+  }) : _isAdaptive = false;
 
   /// Creates an adaptive [AboutDialog] based on whether the target platform is
   /// iOS or macOS, following Material design's
@@ -365,14 +365,18 @@ class AboutDialog extends StatelessWidget {
   /// [applicationLegalese], and additional [children] that appear in the dialog.
   ///
   /// The target platform is based on the current [Theme]: [ThemeData.platform].
-  const factory AboutDialog.adaptive({
-    Key? key,
-    String? applicationName,
-    String? applicationVersion,
-    Widget? applicationIcon,
-    String? applicationLegalese,
-    List<Widget>? children,
-  }) = _AdaptiveAboutDialog;
+  const AboutDialog.adaptive({
+    super.key,
+    this.applicationName,
+    this.applicationVersion,
+    this.applicationIcon,
+    this.applicationLegalese,
+    this.children,
+  }) : _isAdaptive = true;
+
+  // Whether this dialog was created with [AboutDialog.adaptive]. When true, an
+  // [AlertDialog.adaptive] with platform specific actions is built.
+  final bool _isAdaptive;
 
   /// The name of the application.
   ///
@@ -410,6 +414,50 @@ class AboutDialog extends StatelessWidget {
   /// Defaults to nothing.
   final List<Widget>? children;
 
+  List<Widget> _actions(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+    final String viewLicensesLabel = themeData.useMaterial3
+        ? localizations.viewLicensesButtonLabel
+        : localizations.viewLicensesButtonLabel.toUpperCase();
+    final String closeLabel = themeData.useMaterial3
+        ? localizations.closeButtonLabel
+        : localizations.closeButtonLabel.toUpperCase();
+    void showLicenses() {
+      showLicensePage(
+        context: context,
+        applicationName: applicationName,
+        applicationVersion: applicationVersion,
+        applicationIcon: applicationIcon,
+        applicationLegalese: applicationLegalese,
+      );
+    }
+
+    void close() {
+      Navigator.pop(context);
+    }
+
+    if (_isAdaptive) {
+      switch (themeData.platform) {
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          return <Widget>[
+            CupertinoDialogAction(onPressed: showLicenses, child: Text(viewLicensesLabel)),
+            CupertinoDialogAction(onPressed: close, child: Text(closeLabel)),
+          ];
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          break;
+      }
+    }
+    return <Widget>[
+      TextButton(onPressed: showLicenses, child: Text(viewLicensesLabel)),
+      TextButton(onPressed: close, child: Text(closeLabel)),
+    ];
+  }
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
@@ -417,183 +465,35 @@ class AboutDialog extends StatelessWidget {
     final String version = applicationVersion ?? _defaultApplicationVersion(context);
     final Widget? icon = applicationIcon ?? _defaultApplicationIcon(context);
     final ThemeData themeData = Theme.of(context);
-    final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    return AlertDialog(
-      content: ListBody(
-        children: <Widget>[
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              if (icon != null) IconTheme(data: themeData.iconTheme, child: icon),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                  child: ListBody(
-                    children: <Widget>[
-                      Text(name, style: themeData.textTheme.headlineSmall),
-                      Text(version, style: themeData.textTheme.bodyMedium),
-                      const SizedBox(height: _textVerticalSeparation),
-                      Text(applicationLegalese ?? '', style: themeData.textTheme.bodySmall),
-                    ],
-                  ),
+    final Widget content = ListBody(
+      children: <Widget>[
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            if (icon != null) IconTheme(data: themeData.iconTheme, child: icon),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                child: ListBody(
+                  children: <Widget>[
+                    Text(name, style: themeData.textTheme.headlineSmall),
+                    Text(version, style: themeData.textTheme.bodyMedium),
+                    const SizedBox(height: _textVerticalSeparation),
+                    Text(applicationLegalese ?? '', style: themeData.textTheme.bodySmall),
+                  ],
                 ),
               ),
-            ],
-          ),
-          ...?children,
-        ],
-      ),
-      actions: <Widget>[
-        TextButton(
-          child: Text(
-            themeData.useMaterial3
-                ? localizations.viewLicensesButtonLabel
-                : localizations.viewLicensesButtonLabel.toUpperCase(),
-          ),
-          onPressed: () {
-            showLicensePage(
-              context: context,
-              applicationName: applicationName,
-              applicationVersion: applicationVersion,
-              applicationIcon: applicationIcon,
-              applicationLegalese: applicationLegalese,
-            );
-          },
+            ),
+          ],
         ),
-        TextButton(
-          child: Text(
-            themeData.useMaterial3
-                ? localizations.closeButtonLabel
-                : localizations.closeButtonLabel.toUpperCase(),
-          ),
-          onPressed: () {
-            Navigator.pop(context);
-          },
-        ),
+        ...?children,
       ],
-      scrollable: true,
     );
-  }
-}
-
-class _AdaptiveAboutDialog extends AboutDialog {
-  const _AdaptiveAboutDialog({
-    super.key,
-    super.applicationName,
-    super.applicationVersion,
-    super.applicationIcon,
-    super.applicationLegalese,
-    super.children,
-  });
-
-  List<Widget>? _actions(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
-    final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-
-    switch (themeData.platform) {
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        return <Widget>[
-          CupertinoDialogAction(
-            child: Text(
-              themeData.useMaterial3
-                  ? localizations.viewLicensesButtonLabel
-                  : localizations.viewLicensesButtonLabel.toUpperCase(),
-            ),
-            onPressed: () {
-              showLicensePage(
-                context: context,
-                applicationName: applicationName,
-                applicationVersion: applicationVersion,
-                applicationIcon: applicationIcon,
-                applicationLegalese: applicationLegalese,
-              );
-            },
-          ),
-          CupertinoDialogAction(
-            child: Text(
-              themeData.useMaterial3
-                  ? localizations.closeButtonLabel
-                  : localizations.closeButtonLabel.toUpperCase(),
-            ),
-            onPressed: () {
-              Navigator.pop(context);
-            },
-          ),
-        ];
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return <Widget>[
-          TextButton(
-            child: Text(
-              themeData.useMaterial3
-                  ? localizations.viewLicensesButtonLabel
-                  : localizations.viewLicensesButtonLabel.toUpperCase(),
-            ),
-            onPressed: () {
-              showLicensePage(
-                context: context,
-                applicationName: applicationName,
-                applicationVersion: applicationVersion,
-                applicationIcon: applicationIcon,
-                applicationLegalese: applicationLegalese,
-              );
-            },
-          ),
-          TextButton(
-            child: Text(
-              themeData.useMaterial3
-                  ? localizations.closeButtonLabel
-                  : localizations.closeButtonLabel.toUpperCase(),
-            ),
-            onPressed: () {
-              Navigator.pop(context);
-            },
-          ),
-        ];
+    final List<Widget> actions = _actions(context);
+    if (_isAdaptive) {
+      return AlertDialog.adaptive(content: content, actions: actions, scrollable: true);
     }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    super.build(context);
-
-    final String name = applicationName ?? _defaultApplicationName(context);
-    final String version = applicationVersion ?? _defaultApplicationVersion(context);
-    final Widget? icon = applicationIcon ?? _defaultApplicationIcon(context);
-    final ThemeData themeData = Theme.of(context);
-    final List<Widget>? actions = _actions(context);
-
-    return AlertDialog.adaptive(
-      content: ListBody(
-        children: <Widget>[
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              if (icon != null) IconTheme(data: themeData.iconTheme, child: icon),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                  child: ListBody(
-                    children: <Widget>[
-                      Text(name, style: themeData.textTheme.headlineSmall),
-                      Text(version, style: themeData.textTheme.bodyMedium),
-                      const SizedBox(height: _textVerticalSeparation),
-                      Text(applicationLegalese ?? '', style: themeData.textTheme.bodySmall),
-                    ],
-                  ),
-                ),
-              ),
-            ],
-          ),
-          ...?children,
-        ],
-      ),
-      actions: actions,
-      scrollable: true,
-    );
+    return AlertDialog(content: content, actions: actions, scrollable: true);
   }
 }
 

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -451,7 +451,11 @@ class AlertDialog extends StatelessWidget {
     this.alignment,
     this.constraints,
     this.scrollable = false,
-  });
+  }) : _isAdaptive = false,
+       _scrollController = null,
+       _actionScrollController = null,
+       _insetAnimationDuration = const Duration(milliseconds: 100),
+       _insetAnimationCurve = Curves.decelerate;
 
   /// Creates an adaptive [AlertDialog] based on whether the target platform is
   /// iOS or macOS, following Material design's
@@ -482,40 +486,55 @@ class AlertDialog extends StatelessWidget {
   ///
   /// ** See code in examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart **
   /// {@end-tool}
-  const factory AlertDialog.adaptive({
-    Key? key,
-    Widget? icon,
-    EdgeInsetsGeometry? iconPadding,
-    Color? iconColor,
-    Widget? title,
-    EdgeInsetsGeometry? titlePadding,
-    TextStyle? titleTextStyle,
-    Widget? content,
-    EdgeInsetsGeometry? contentPadding,
-    TextStyle? contentTextStyle,
-    List<Widget>? actions,
-    EdgeInsetsGeometry? actionsPadding,
-    MainAxisAlignment? actionsAlignment,
-    OverflowBarAlignment? actionsOverflowAlignment,
-    VerticalDirection? actionsOverflowDirection,
-    double? actionsOverflowButtonSpacing,
-    EdgeInsetsGeometry? buttonPadding,
-    Color? backgroundColor,
-    double? elevation,
-    Color? shadowColor,
-    Color? surfaceTintColor,
-    String? semanticLabel,
-    EdgeInsets insetPadding,
-    Clip? clipBehavior,
-    ShapeBorder? shape,
-    AlignmentGeometry? alignment,
-    BoxConstraints? constraints,
-    bool scrollable,
+  const AlertDialog.adaptive({
+    super.key,
+    this.icon,
+    this.iconPadding,
+    this.iconColor,
+    this.title,
+    this.titlePadding,
+    this.titleTextStyle,
+    this.content,
+    this.contentPadding,
+    this.contentTextStyle,
+    this.actions,
+    this.actionsPadding,
+    this.actionsAlignment,
+    this.actionsOverflowAlignment,
+    this.actionsOverflowDirection,
+    this.actionsOverflowButtonSpacing,
+    this.buttonPadding,
+    this.backgroundColor,
+    this.elevation,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.semanticLabel,
+    this.insetPadding,
+    this.clipBehavior,
+    this.shape,
+    this.alignment,
+    this.constraints,
+    this.scrollable = false,
     ScrollController? scrollController,
     ScrollController? actionScrollController,
-    Duration insetAnimationDuration,
-    Curve insetAnimationCurve,
-  }) = _AdaptiveAlertDialog;
+    Duration insetAnimationDuration = const Duration(milliseconds: 100),
+    Curve insetAnimationCurve = Curves.decelerate,
+  }) : _isAdaptive = true,
+       _scrollController = scrollController,
+       _actionScrollController = actionScrollController,
+       _insetAnimationDuration = insetAnimationDuration,
+       _insetAnimationCurve = insetAnimationCurve;
+
+  // Whether this dialog was created with [AlertDialog.adaptive]. When true, a
+  // [CupertinoAlertDialog] is built on iOS and macOS.
+  final bool _isAdaptive;
+
+  // The following fields are only used by [AlertDialog.adaptive] to configure
+  // the [CupertinoAlertDialog] built on iOS and macOS.
+  final ScrollController? _scrollController;
+  final ScrollController? _actionScrollController;
+  final Duration _insetAnimationDuration;
+  final Curve _insetAnimationCurve;
 
   /// An optional icon to display at the top of the dialog.
   ///
@@ -766,6 +785,27 @@ class AlertDialog extends StatelessWidget {
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData theme = Theme.of(context);
 
+    if (_isAdaptive) {
+      switch (theme.platform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          break;
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          return CupertinoAlertDialog(
+            title: title,
+            content: content,
+            actions: actions ?? <Widget>[],
+            scrollController: _scrollController,
+            actionScrollController: _actionScrollController,
+            insetAnimationDuration: _insetAnimationDuration,
+            insetAnimationCurve: _insetAnimationCurve,
+          );
+      }
+    }
+
     final DialogThemeData dialogTheme = DialogTheme.of(context);
     final DialogThemeData defaults = theme.useMaterial3
         ? _DialogDefaultsM3(context)
@@ -953,72 +993,6 @@ class AlertDialog extends StatelessWidget {
       semanticsRole: SemanticsRole.alertDialog,
       child: dialogChild,
     );
-  }
-}
-
-class _AdaptiveAlertDialog extends AlertDialog {
-  const _AdaptiveAlertDialog({
-    super.key,
-    super.icon,
-    super.iconPadding,
-    super.iconColor,
-    super.title,
-    super.titlePadding,
-    super.titleTextStyle,
-    super.content,
-    super.contentPadding,
-    super.contentTextStyle,
-    super.actions,
-    super.actionsPadding,
-    super.actionsAlignment,
-    super.actionsOverflowAlignment,
-    super.actionsOverflowDirection,
-    super.actionsOverflowButtonSpacing,
-    super.buttonPadding,
-    super.backgroundColor,
-    super.elevation,
-    super.shadowColor,
-    super.surfaceTintColor,
-    super.semanticLabel,
-    super.insetPadding,
-    super.clipBehavior,
-    super.shape,
-    super.alignment,
-    super.constraints,
-    super.scrollable = false,
-    this.scrollController,
-    this.actionScrollController,
-    this.insetAnimationDuration = const Duration(milliseconds: 100),
-    this.insetAnimationCurve = Curves.decelerate,
-  });
-
-  final ScrollController? scrollController;
-  final ScrollController? actionScrollController;
-  final Duration insetAnimationDuration;
-  final Curve insetAnimationCurve;
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    switch (theme.platform) {
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        break;
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        return CupertinoAlertDialog(
-          title: title,
-          content: content,
-          actions: actions ?? <Widget>[],
-          scrollController: scrollController,
-          actionScrollController: actionScrollController,
-          insetAnimationDuration: insetAnimationDuration,
-          insetAnimationCurve: insetAnimationCurve,
-        );
-    }
-    return super.build(context);
   }
 }
 

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -168,7 +168,8 @@ class SearchAnchor extends StatefulWidget {
   ///
   /// ** See code in examples/api/lib/material/search_anchor/search_anchor.0.dart **
   /// {@end-tool}
-  factory SearchAnchor.bar({
+  SearchAnchor.bar({
+    Key? key,
     Widget? barLeading,
     Iterable<Widget>? barTrailing,
     String? barHintText,
@@ -203,17 +204,82 @@ class SearchAnchor extends StatefulWidget {
     EdgeInsetsGeometry? viewPadding,
     bool? shrinkWrap,
     bool? isFullScreen,
-    SearchController searchController,
-    TextCapitalization textCapitalization,
+    SearchController? searchController,
+    TextCapitalization? textCapitalization,
     required SuggestionsBuilder suggestionsBuilder,
     TextInputAction? textInputAction,
     TextInputType? keyboardType,
-    EdgeInsets scrollPadding,
-    EditableTextContextMenuBuilder contextMenuBuilder,
-    bool enabled,
+    EdgeInsets scrollPadding = const EdgeInsets.all(20.0),
+    EditableTextContextMenuBuilder contextMenuBuilder = SearchBar._defaultContextMenuBuilder,
+    bool enabled = true,
     SmartDashesType? smartDashesType,
     SmartQuotesType? smartQuotesType,
-  }) = _SearchAnchorWithSearchBar;
+  }) : this(
+         key: key,
+         viewBarPadding: viewBarPadding,
+         viewBuilder: viewBuilder,
+         viewLeading: viewLeading,
+         viewTrailing: viewTrailing,
+         viewHintText: viewHintText ?? barHintText,
+         viewBackgroundColor: viewBackgroundColor,
+         viewElevation: viewElevation,
+         viewSide: viewSide,
+         viewShape: viewShape,
+         headerHeight: viewHeaderHeight,
+         headerTextStyle: viewHeaderTextStyle,
+         headerHintStyle: viewHeaderHintStyle,
+         dividerColor: dividerColor,
+         viewConstraints: viewConstraints,
+         viewPadding: viewPadding,
+         shrinkWrap: shrinkWrap,
+         isFullScreen: isFullScreen,
+         searchController: searchController,
+         textCapitalization: textCapitalization,
+         viewOnSubmitted: onSubmitted,
+         viewOnChanged: onChanged,
+         viewOnClose: onClose,
+         viewOnOpen: onOpen,
+         suggestionsBuilder: suggestionsBuilder,
+         textInputAction: textInputAction,
+         keyboardType: keyboardType,
+         enabled: enabled,
+         smartDashesType: smartDashesType,
+         smartQuotesType: smartQuotesType,
+         builder: (BuildContext context, SearchController controller) {
+           return SearchBar(
+             constraints: constraints,
+             controller: controller,
+             onTap: () {
+               controller.openView();
+               onTap?.call();
+             },
+             onChanged: (String value) {
+               controller.openView();
+             },
+             onSubmitted: onSubmitted,
+             hintText: barHintText,
+             hintStyle: barHintStyle,
+             textStyle: barTextStyle,
+             elevation: barElevation,
+             backgroundColor: barBackgroundColor,
+             overlayColor: barOverlayColor,
+             side: barSide,
+             shape: barShape,
+             padding:
+                 barPadding ??
+                 const MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.symmetric(horizontal: 16.0)),
+             leading: barLeading ?? const Icon(Icons.search),
+             trailing: barTrailing,
+             textCapitalization: textCapitalization,
+             textInputAction: textInputAction,
+             keyboardType: keyboardType,
+             scrollPadding: scrollPadding,
+             contextMenuBuilder: contextMenuBuilder,
+             smartDashesType: smartDashesType,
+             smartQuotesType: smartQuotesType,
+           );
+         },
+       );
 
   /// Whether the search view grows to fill the entire screen when the
   /// [SearchAnchor] is tapped.
@@ -1218,98 +1284,6 @@ class _ViewContentState extends State<_ViewContent> {
       ),
     );
   }
-}
-
-class _SearchAnchorWithSearchBar extends SearchAnchor {
-  _SearchAnchorWithSearchBar({
-    Widget? barLeading,
-    Iterable<Widget>? barTrailing,
-    String? barHintText,
-    GestureTapCallback? onTap,
-    WidgetStateProperty<double?>? barElevation,
-    WidgetStateProperty<Color?>? barBackgroundColor,
-    WidgetStateProperty<Color?>? barOverlayColor,
-    WidgetStateProperty<BorderSide?>? barSide,
-    WidgetStateProperty<OutlinedBorder?>? barShape,
-    WidgetStateProperty<EdgeInsetsGeometry?>? barPadding,
-    super.viewBarPadding,
-    WidgetStateProperty<TextStyle?>? barTextStyle,
-    WidgetStateProperty<TextStyle?>? barHintStyle,
-    super.viewBuilder,
-    super.viewLeading,
-    super.viewTrailing,
-    String? viewHintText,
-    super.viewBackgroundColor,
-    super.viewElevation,
-    super.viewSide,
-    super.viewShape,
-    double? viewHeaderHeight,
-    TextStyle? viewHeaderTextStyle,
-    TextStyle? viewHeaderHintStyle,
-    super.dividerColor,
-    BoxConstraints? constraints,
-    super.viewConstraints,
-    super.viewPadding,
-    super.shrinkWrap,
-    super.isFullScreen,
-    super.searchController,
-    super.textCapitalization,
-    ValueChanged<String>? onChanged,
-    ValueChanged<String>? onSubmitted,
-    VoidCallback? onClose,
-    VoidCallback? onOpen,
-    required super.suggestionsBuilder,
-    super.textInputAction,
-    super.keyboardType,
-    EdgeInsets scrollPadding = const EdgeInsets.all(20.0),
-    EditableTextContextMenuBuilder contextMenuBuilder = SearchBar._defaultContextMenuBuilder,
-    super.enabled,
-    super.smartDashesType,
-    super.smartQuotesType,
-  }) : super(
-         viewHintText: viewHintText ?? barHintText,
-         headerHeight: viewHeaderHeight,
-         headerTextStyle: viewHeaderTextStyle,
-         headerHintStyle: viewHeaderHintStyle,
-         viewOnSubmitted: onSubmitted,
-         viewOnChanged: onChanged,
-         viewOnClose: onClose,
-         viewOnOpen: onOpen,
-         builder: (BuildContext context, SearchController controller) {
-           return SearchBar(
-             constraints: constraints,
-             controller: controller,
-             onTap: () {
-               controller.openView();
-               onTap?.call();
-             },
-             onChanged: (String value) {
-               controller.openView();
-             },
-             onSubmitted: onSubmitted,
-             hintText: barHintText,
-             hintStyle: barHintStyle,
-             textStyle: barTextStyle,
-             elevation: barElevation,
-             backgroundColor: barBackgroundColor,
-             overlayColor: barOverlayColor,
-             side: barSide,
-             shape: barShape,
-             padding:
-                 barPadding ??
-                 const MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.symmetric(horizontal: 16.0)),
-             leading: barLeading ?? const Icon(Icons.search),
-             trailing: barTrailing,
-             textCapitalization: textCapitalization,
-             textInputAction: textInputAction,
-             keyboardType: keyboardType,
-             scrollPadding: scrollPadding,
-             contextMenuBuilder: contextMenuBuilder,
-             smartDashesType: smartDashesType,
-             smartQuotesType: smartQuotesType,
-           );
-         },
-       );
 }
 
 /// A controller to manage a search view created by [SearchAnchor].

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -2000,6 +2000,33 @@ void main() {
     final Finder xText = find.text('X');
     expect(tester.getSize(xText).isEmpty, isTrue);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/177089
+  testWidgets('AboutDialog.adaptive can be found by type on each platform', (
+    WidgetTester tester,
+  ) async {
+    for (final TargetPlatform platform in TargetPlatform.values) {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: platform),
+          home: const Material(
+            child: Center(child: ElevatedButton(onPressed: null, child: Text('Go'))),
+          ),
+        ),
+      );
+
+      final BuildContext context = tester.element(find.text('Go'));
+
+      showAdaptiveAboutDialog(context: context, applicationName: 'Test');
+
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.byType(AboutDialog), findsOneWidget, reason: 'platform: $platform');
+
+      Navigator.of(context).pop();
+      await tester.pumpAndSettle();
+    }
+  });
 }
 
 class FakeLicenseEntry extends LicenseEntry {

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -3465,6 +3465,30 @@ void main() {
 
     semantics.dispose();
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/177089
+  testWidgets('AlertDialog.adaptive can be found by type on each platform', (
+    WidgetTester tester,
+  ) async {
+    final dialog = AlertDialog.adaptive(
+      title: const Text('title'),
+      content: const Text('content'),
+      actions: <Widget>[TextButton(onPressed: () {}, child: const Text('OK'))],
+    );
+
+    for (final TargetPlatform platform in TargetPlatform.values) {
+      await tester.pumpWidget(_buildAppWithDialog(dialog, theme: ThemeData(platform: platform)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsOneWidget, reason: 'platform: $platform');
+
+      await tester.tapAt(const Offset(10.0, 10.0));
+      await tester.pumpAndSettle();
+    }
+  });
 }
 
 @pragma('vm:entry-point')

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -4382,6 +4382,23 @@ void main() {
     await tester.pump();
     expect(find.text('X'), findsOne);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/177089
+  testWidgets('SearchAnchor.bar can be found by type', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: SearchAnchor.bar(
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(SearchAnchor), findsOneWidget);
+  });
 }
 
 Future<void> checkSearchBarDefaults(


### PR DESCRIPTION
AlertDialog.adaptive, AboutDialog.adaptive and SearchAnchor.bar were
redirecting factory constructors that returned private subclasses
(_AdaptiveAlertDialog, _AdaptiveAboutDialog and _SearchAnchorWithSearchBar).
Because the widget in the tree is an instance of the private subclass,
find.byType(AlertDialog), find.byType(AboutDialog) and
find.byType(SearchAnchor) never matched them, and users had to fall back to
find.bySubtype. This is the same problem that was fixed for the Material
button .icon constructors.

Each factory is now a real generative constructor of the public class. The
platform specific behaviour of the adaptive dialogs is preserved by private
fields on the public class: AlertDialog stores the CupertinoAlertDialog only
options and builds a CupertinoAlertDialog from build() when the constructor
was AlertDialog.adaptive and the target platform is iOS or macOS, and
AboutDialog picks Cupertino dialog actions the same way. SearchAnchor.bar
redirects to the default SearchAnchor constructor with the SearchBar builder
it used to install through the private subclass, and it now also accepts a
key, which the factory could not.

Fixes https://github.com/flutter/flutter/issues/177089

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
