### PR TITLE
Keep overlay child semantics when it blocks previously painted nodes

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -5931,6 +5931,20 @@ class _RenderObjectSemantics extends _SemanticsFragment with DiagnosticableTreeM
         config.isBlockingUserActions = blocksUserAction;
       });
     }
+    if (configProvider.effective.traversalChildIdentifier != null && isBlockingPreviousSibling) {
+      // A traversal child is grafted onto the semantics node that provides the
+      // matching traversalParentIdentifier. For example, an OverlayPortal's
+      // overlay child is grafted onto the OverlayPortal itself.
+      //
+      // When this render object also blocks the semantics of previously painted
+      // nodes, the traversal parent is painted before this render object and is
+      // therefore blocked as well, leaving no node to graft onto. Dropping the
+      // identifier keeps this subtree in the semantics tree at its paint order
+      // position instead of removing it from the semantics tree entirely.
+      configProvider.updateConfig((SemanticsConfiguration config) {
+        config.traversalChildIdentifier = null;
+      });
+    }
     if (localeForChildren != configProvider.effective.locale) {
       configProvider.updateConfig((SemanticsConfiguration config) {
         config.locale = localeForChildren;

--- a/packages/flutter/test/widgets/overlay_portal_test.dart
+++ b/packages/flutter/test/widgets/overlay_portal_test.dart
@@ -3046,6 +3046,70 @@ void main() {
       semantics.dispose();
     }, skip: kIsWeb); // [intended] the web traversal order by using ARIA-OWNS.
 
+    // Regression test for https://github.com/flutter/flutter/issues/176533.
+    testWidgets('BlockSemantics in the overlay child blocks the OverlayPortal and its siblings', (
+      WidgetTester tester,
+    ) async {
+      final semantics = SemanticsTester(tester);
+      late final OverlayEntry entry;
+      addTearDown(() {
+        entry.remove();
+        entry.dispose();
+      });
+
+      final Widget widget = Directionality(
+        textDirection: TextDirection.ltr,
+        child: Overlay(
+          initialEntries: <OverlayEntry>[
+            entry = OverlayEntry(
+              builder: (BuildContext context) {
+                return DefaultTextStyle(
+                  style: const TextStyle(fontSize: 10),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      OverlayPortal(
+                        controller: controller1,
+                        overlayChildBuilder: (BuildContext context) => const Positioned(
+                          left: 0.0,
+                          top: 0.0,
+                          child: BlockSemantics(child: Text('BBBB')),
+                        ),
+                        child: const Text('A'),
+                      ),
+                      const Text('CC'),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+
+      // The overlay child paints on top of everything else in the Overlay, so
+      // the BlockSemantics in the overlay child blocks the semantics of the
+      // OverlayPortal (which is the traversal parent of the overlay child) and
+      // its siblings. The overlay child itself must stay in the semantics tree.
+      final expected = TestSemantics.root(
+        children: <TestSemantics>[
+          TestSemantics(
+            children: <TestSemantics>[TestSemantics(label: 'BBBB')],
+          ),
+        ],
+      );
+
+      expect(
+        semantics,
+        hasSemantics(expected, ignoreId: true, ignoreRect: true, ignoreTransform: true),
+      );
+      expect(semantics, isNot(includesNodeWith(label: 'A')));
+      expect(semantics, isNot(includesNodeWith(label: 'CC')));
+      semantics.dispose();
+    }, skip: kIsWeb); // [intended] the web traversal order by using ARIA-OWNS.
+
     testWidgets('OverlayPortal overlay child clipping', (WidgetTester tester) async {
       final semantics = SemanticsTester(tester);
 


### PR DESCRIPTION
An OverlayPortal's overlay child is painted by the Overlay, but its
semantics node is grafted back onto the OverlayPortal using
traversalChildIdentifier / traversalParentIdentifier.

When the overlay child contains a BlockSemantics, the RenderTheater drops
every child that is painted before the overlay child. That includes the
OverlayPortal itself, which is the node that provides the matching
traversalParentIdentifier. With no node left to graft onto, the overlay
child was removed from both the traversal tree and the hit-test tree, so
the whole semantics tree ended up empty: neither the blocked siblings nor
the still visible overlay content could be reached by assistive
technologies.

_RenderObjectSemantics.updateChildren now drops the
traversalChildIdentifier of a render object that also blocks the
semantics of previously painted nodes. Such a render object always blocks
its own traversal parent, so grafting can never succeed. Without the
identifier the subtree simply stays in the semantics tree at its paint
order position, which keeps the overlay child reachable while the blocked
siblings stay blocked.

Fixes https://github.com/flutter/flutter/issues/176533

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
