### PR TITLE
Fix Badge text contrast violation in a11y_assessments

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/badge.dart
+++ b/dev/a11y_assessments/lib/use_cases/badge.dart
@@ -38,12 +38,10 @@ class MainWidgetState extends State<MainWidget> {
       appBar: AppBar(title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo'))),
       body: const Center(
         child: Badge(
-          label: Text(
-            '5',
-            semanticsLabel: '5 new messages',
-            style: TextStyle(color: Colors.white),
-          ),
-          backgroundColor: Colors.green,
+          // Use the badge colors from the theme. The hard coded white on green
+          // combination only reaches a 2.6:1 contrast ratio, below the 4.5:1
+          // required by WCAG AA for normal sized text.
+          label: Text('5', semanticsLabel: '5 new messages'),
           child: Icon(Icons.mail, semanticLabel: 'Messages'),
         ),
       ),

--- a/dev/a11y_assessments/test/badge_test.dart
+++ b/dev/a11y_assessments/test/badge_test.dart
@@ -20,4 +20,16 @@ void main() {
     await tester.pumpAndSettle();
     expect(findHeadingLevelOnes, findsOne);
   });
+
+  // The badge label carries a `semanticsLabel` that differs from the rendered
+  // text, so `textContrastGuideline` cannot locate it and silently skips it.
+  // Check the label explicitly with a finder based guideline instead.
+  // Regression test for https://github.com/flutter/flutter/issues/172993.
+  testWidgets('badge label meets text contrast guideline', (WidgetTester tester) async {
+    await pumpsUseCase(tester, BadgeUseCase());
+    await expectLater(
+      tester,
+      meetsGuideline(CustomMinimumContrastGuideline(finder: find.text('5'))),
+    );
+  });
 }


### PR DESCRIPTION
The Badge use case drew white text on `Colors.green`, a contrast ratio of
about 2.6:1, well below the 4.5:1 WCAG AA minimum for normal sized text.

The app's own guideline test never caught it: the badge label sets
`semanticsLabel: '5 new messages'`, which differs from the rendered text
'5'. `textContrastGuideline` locates the widget to measure by matching the
semantics label against `Text.data`, finds nothing, and silently skips the
label.

Drop the hard coded colors so the badge uses the theme's `error` and
`onError` pair, which meets the minimum ratio in both brightnesses, and add
a regression test that checks the label with `CustomMinimumContrastGuideline`
so this use case is covered by CI regardless of the label mismatch.

Fixes https://github.com/flutter/flutter/issues/172993

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
