### PR TITLE
Use input entry mode by default in landscape date picker

### DIFF
--- a/packages/flutter/examples/api/test/material/date_picker/date_picker_theme_day_shape.0_test.dart
+++ b/packages/flutter/examples/api/test/material/date_picker/date_picker_theme_day_shape.0_test.dart
@@ -28,6 +28,12 @@ void main() {
             as ShapeDecoration?;
       }
 
+      // The date picker defaults to the calendar entry mode in portrait
+      // orientation only.
+      tester.view.physicalSize = const Size(1080.0, 2400.0);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
       await tester.pumpWidget(const example.DatePickerApp());
 
       await tester.tap(find.text('Open Date Picker'));

--- a/packages/flutter/examples/api/test/material/date_picker/show_date_picker.1_test.dart
+++ b/packages/flutter/examples/api/test/material/date_picker/show_date_picker.1_test.dart
@@ -12,6 +12,12 @@ void main() {
     const String datePickerTitle = 'Select date';
     const String initialDate = 'Sun, Jul 25';
 
+    // The date picker defaults to the calendar entry mode in portrait
+    // orientation only.
+    tester.view.physicalSize = const Size(1080.0, 2400.0);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+
     await tester.pumpWidget(const example.DatePickerApp());
 
     // The date picker is not shown initially.

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -98,7 +98,11 @@ const double _fontSizeToScale = 14.0;
 /// An optional [initialEntryMode] argument can be used to display the date
 /// picker in the [DatePickerEntryMode.calendar] (a calendar month grid)
 /// or [DatePickerEntryMode.input] (a text input field) mode.
-/// It defaults to [DatePickerEntryMode.calendar].
+/// If it is null, [DatePickerEntryMode.calendar] is used in portrait
+/// orientation and [DatePickerEntryMode.input] is used in landscape
+/// orientation. This is because the calendar grid can't respect the minimum
+/// touch target size recommended by the accessibility guidelines when the
+/// available height is as small as it is in landscape orientation.
 ///
 /// {@template flutter.material.date_picker.switchToInputEntryModeIcon}
 /// An optional [switchToInputEntryModeIcon] argument can be used to
@@ -199,7 +203,7 @@ Future<DateTime?> showDatePicker({
   required DateTime firstDate,
   required DateTime lastDate,
   DateTime? currentDate,
-  DatePickerEntryMode initialEntryMode = DatePickerEntryMode.calendar,
+  DatePickerEntryMode? initialEntryMode,
   SelectableDayPredicate? selectableDayPredicate,
   String? helpText,
   String? cancelText,
@@ -245,12 +249,25 @@ Future<DateTime?> showDatePicker({
   );
   assert(debugCheckHasMaterialLocalizations(context));
 
+  // The calendar day grid can't respect the minimum touch target size
+  // recommended by the accessibility guidelines in landscape orientation,
+  // because the dialog height is too small to lay out 7 rows of 48 logical
+  // pixels. The input entry mode is used instead, as recommended by the
+  // Material Design guidelines for constrained viewports. The user can still
+  // switch to the calendar entry mode with the entry mode button.
+  final DatePickerEntryMode effectiveInitialEntryMode =
+      initialEntryMode ??
+      switch (MediaQuery.orientationOf(context)) {
+        Orientation.portrait => DatePickerEntryMode.calendar,
+        Orientation.landscape => DatePickerEntryMode.input,
+      };
+
   Widget dialog = DatePickerDialog(
     initialDate: initialDate,
     firstDate: firstDate,
     lastDate: lastDate,
     currentDate: currentDate,
-    initialEntryMode: initialEntryMode,
+    initialEntryMode: effectiveInitialEntryMode,
     selectableDayPredicate: selectableDayPredicate,
     helpText: helpText,
     cancelText: cancelText,

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -176,6 +176,67 @@ void main() {
       expect(dialogContainerSize, calendarPortraitDialogSizeM3);
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/170786.
+    testWidgets('Default entry mode depends on the orientation', (WidgetTester tester) async {
+      Future<void> showPicker(Size size) async {
+        tester.view.physicalSize = size;
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+        late BuildContext buttonContext;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    onPressed: () {
+                      buttonContext = context;
+                    },
+                    child: const Text('Go'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.tap(find.text('Go'));
+        showDatePicker(
+          context: buttonContext,
+          initialDate: initialDate,
+          firstDate: firstDate,
+          lastDate: lastDate,
+        );
+        await tester.pumpAndSettle();
+      }
+
+      // In portrait, the calendar day grid has enough room to respect the
+      // minimum touch target size, so the calendar entry mode is used.
+      await showPicker(narrowWindowSize);
+      expect(find.byType(CalendarDatePicker), findsOneWidget);
+      expect(find.byType(InputDatePickerFormField), findsNothing);
+
+      // Close the dialog.
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      // In landscape, the calendar day grid can't respect the minimum touch
+      // target size, so the input entry mode is used.
+      await showPicker(wideWindowSize);
+      expect(find.byType(CalendarDatePicker), findsNothing);
+      expect(find.byType(InputDatePickerFormField), findsOneWidget);
+    });
+
+    testWidgets('Explicit initialEntryMode is not overridden by the orientation', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = wideWindowSize;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        expect(find.byType(CalendarDatePicker), findsOneWidget);
+      }, useMaterial3: true);
+    });
+
     testWidgets('Default dialog properties', (WidgetTester tester) async {
       final theme = ThemeData();
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
@@ -741,6 +802,7 @@ void main() {
                       firstDate: DateTime(2018),
                       lastDate: DateTime(2030),
                       switchToInputEntryModeIcon: switchToInputEntryModeIcon,
+                      initialEntryMode: DatePickerEntryMode.calendar,
                     );
                   },
                 );

--- a/packages/flutter_localizations/test/material/date_picker_test.dart
+++ b/packages/flutter_localizations/test/material/date_picker_test.dart
@@ -125,6 +125,7 @@ void main() {
                     firstDate: firstDate,
                     lastDate: lastDate,
                     locale: const Locale('fr', 'CA'),
+                    initialEntryMode: DatePickerEntryMode.calendar,
                   );
                 },
                 child: const Text('X'),
@@ -164,6 +165,7 @@ void main() {
                     firstDate: firstDate,
                     lastDate: lastDate,
                     locale: const Locale('fr', 'CA'),
+                    initialEntryMode: DatePickerEntryMode.calendar,
                   );
                 },
                 child: const Text('X'),
@@ -204,6 +206,7 @@ void main() {
                     firstDate: firstDate,
                     lastDate: lastDate,
                     textDirection: TextDirection.rtl,
+                    initialEntryMode: DatePickerEntryMode.calendar,
                   );
                 },
                 child: const Text('X'),
@@ -242,6 +245,7 @@ void main() {
                     firstDate: firstDate,
                     lastDate: lastDate,
                     textDirection: TextDirection.rtl,
+                    initialEntryMode: DatePickerEntryMode.calendar,
                   );
                 },
                 child: const Text('X'),
@@ -284,6 +288,7 @@ void main() {
                     lastDate: lastDate,
                     locale: const Locale('fr', 'CA'),
                     textDirection: TextDirection.rtl,
+                    initialEntryMode: DatePickerEntryMode.calendar,
                   );
                 },
                 child: const Text('X'),
@@ -327,6 +332,7 @@ void main() {
                     lastDate: lastDate,
                     locale: const Locale('fr', 'CA'),
                     textDirection: TextDirection.rtl,
+                    initialEntryMode: DatePickerEntryMode.calendar,
                   );
                 },
                 child: const Text('X'),
@@ -377,6 +383,7 @@ void main() {
                       initialDate: initialDate,
                       firstDate: firstDate,
                       lastDate: lastDate,
+                      initialEntryMode: DatePickerEntryMode.calendar,
                     );
                   },
                 ),


### PR DESCRIPTION
In landscape orientation the date picker dialog is only 346 logical pixels
high, so the calendar day grid shrinks each day button well below the 48
logical pixel minimum touch target size recommended by the accessibility
guidelines. There is no Material specification for a landscape calendar
layout, and the Material Design guidelines recommend using the input mode
when the viewport is constrained.

`showDatePicker` now takes a nullable `initialEntryMode`. When it is not
provided, the entry mode defaults to `DatePickerEntryMode.calendar` in
portrait orientation and to `DatePickerEntryMode.input` in landscape
orientation. Callers that pass an explicit entry mode are not affected, and
the user can still switch to the calendar with the entry mode button.

Fixes https://github.com/flutter/flutter/issues/170786

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
