### PR TITLE
Rebuild SliverPersistentHeader when its dependencies change

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -274,12 +274,18 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
   @override
   void update(_SliverPersistentHeaderRenderObjectWidget newWidget) {
     final oldWidget = widget as _SliverPersistentHeaderRenderObjectWidget;
+    // RenderObjectElement.update clears the dirty flag without going through
+    // performRebuild, so a rebuild that was already scheduled for this element
+    // (because an inherited widget the delegate depends on changed, for
+    // instance) would otherwise be silently dropped.
+    final bool needsRebuild = dirty;
     super.update(newWidget);
     final SliverPersistentHeaderDelegate newDelegate = newWidget.delegate;
     final SliverPersistentHeaderDelegate oldDelegate = oldWidget.delegate;
-    if (newDelegate != oldDelegate &&
-        (newDelegate.runtimeType != oldDelegate.runtimeType ||
-            newDelegate.shouldRebuild(oldDelegate))) {
+    if (needsRebuild ||
+        (newDelegate != oldDelegate &&
+            (newDelegate.runtimeType != oldDelegate.runtimeType ||
+                newDelegate.shouldRebuild(oldDelegate)))) {
       final _RenderSliverPersistentHeaderForWidgetsMixin renderObject = this.renderObject;
       _updateChild(newDelegate, renderObject.lastShrinkOffset, renderObject.lastOverlapsContent);
       renderObject.triggerRebuild();

--- a/packages/flutter/test/widgets/sliver_persistent_header_test.dart
+++ b/packages/flutter/test/widgets/sliver_persistent_header_test.dart
@@ -1083,6 +1083,83 @@ void main() {
       handle.dispose();
     });
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/170571
+  testWidgets('SliverPersistentHeader rebuilds when an inherited widget it depends on changes', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const InheritedColorHeaderApp());
+    expect(tester.widget<ColoredBox>(find.byType(ColoredBox)).color, const Color(0xFF00FF00));
+
+    tester.state<InheritedColorHeaderAppState>(find.byType(InheritedColorHeaderApp)).toggle();
+    await tester.pump();
+
+    expect(tester.widget<ColoredBox>(find.byType(ColoredBox)).color, const Color(0xFF0000FF));
+  });
+}
+
+class InheritedColor extends InheritedWidget {
+  const InheritedColor({required this.color, required super.child});
+
+  final Color color;
+
+  static Color of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<InheritedColor>()!.color;
+  }
+
+  @override
+  bool updateShouldNotify(InheritedColor oldWidget) => color != oldWidget.color;
+}
+
+class InheritedColorDelegate extends SliverPersistentHeaderDelegate {
+  @override
+  double get maxExtent => 100.0;
+
+  @override
+  double get minExtent => 100.0;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return ColoredBox(color: InheritedColor.of(context), child: const SizedBox.expand());
+  }
+
+  // The delegate itself has no configuration, so returning false is correct.
+  // The header must still rebuild when the inherited color it depends on changes.
+  @override
+  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) => false;
+}
+
+class InheritedColorHeaderApp extends StatefulWidget {
+  const InheritedColorHeaderApp({super.key});
+
+  @override
+  State<InheritedColorHeaderApp> createState() => InheritedColorHeaderAppState();
+}
+
+class InheritedColorHeaderAppState extends State<InheritedColorHeaderApp> {
+  Color color = const Color(0xFF00FF00);
+
+  void toggle() {
+    setState(() {
+      color = const Color(0xFF0000FF);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return InheritedColor(
+      color: color,
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverPersistentHeader(pinned: true, delegate: InheritedColorDelegate()),
+            const BigSliver(height: 550.0),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class TestDelegate extends SliverPersistentHeaderDelegate {


### PR DESCRIPTION
_SliverPersistentHeaderElement triggers a layout-time rebuild of the
header child from performRebuild(). RenderObjectElement.update() clears
the element's dirty flag without going through performRebuild(), so when
the header was already marked dirty (for example because an inherited
widget its delegate depends on, such as Theme, changed) and its parent
rebuilt it in the same frame, the pending rebuild was silently dropped
and the header kept painting its stale child.

The fix records whether a rebuild was pending before calling
super.update() and triggers the rebuild in that case too, mirroring what
LayoutBuilder's element already does.

Fixes https://github.com/flutter/flutter/issues/170571

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
