### PR TITLE
Cover vertical arrow keys in the closed-anchor regression tests

### DIFF
--- a/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
+++ b/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
@@ -31,9 +31,19 @@ import 'tap_region.dart';
 
 const bool _kDebugMenus = false;
 
-const Map<ShortcutActivator, Intent> _kMenuTraversalShortcuts = <ShortcutActivator, Intent>{
+// Shortcuts that are bound to the anchor while its menu is closed.
+//
+// Directional traversal shortcuts are omitted so that widgets in the anchor
+// which handle arrow keys themselves, such as text fields, keep receiving them
+// while the menu is closed.
+const Map<ShortcutActivator, Intent> _kClosedMenuShortcuts = <ShortcutActivator, Intent>{
   SingleActivator(LogicalKeyboardKey.gameButtonA): ActivateIntent(),
   SingleActivator(LogicalKeyboardKey.escape): DismissIntent(),
+};
+
+// Shortcuts that are bound to the anchor while its menu is open.
+const Map<ShortcutActivator, Intent> _kMenuTraversalShortcuts = <ShortcutActivator, Intent>{
+  ..._kClosedMenuShortcuts,
   SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(TraversalDirection.down),
   SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(TraversalDirection.up),
   SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(TraversalDirection.left),
@@ -843,7 +853,9 @@ class _RawMenuAnchorState extends State<RawMenuAnchor> with _RawMenuAnchorBaseMi
   Widget buildAnchor(BuildContext context) {
     final Widget child = Shortcuts(
       includeSemantics: false,
-      shortcuts: _kMenuTraversalShortcuts,
+      // Directional traversal shortcuts are only bound while the menu is open,
+      // so that the anchor doesn't swallow arrow keys that its child needs.
+      shortcuts: isOpen ? _kMenuTraversalShortcuts : _kClosedMenuShortcuts,
       child: TapRegion(
         groupId: root.menuController,
         consumeOutsideTaps: root.isOpen && widget.consumeOutsideTaps,

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2524,6 +2524,61 @@ void main() {
 
       expect(textController.selection.baseOffset, 4);
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/163475.
+    testWidgets(
+      'Up and down arrow keys move the caret of a multiline TextField in the anchor when the menu is closed',
+      (WidgetTester tester) async {
+        final textController = TextEditingController(text: 'aaaa\nbbbb');
+        addTearDown(textController.dispose);
+        final textFieldFocusNode = FocusNode(debugLabel: 'TextField');
+        addTearDown(textFieldFocusNode.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: MenuAnchor(
+                controller: controller,
+                menuChildren: <Widget>[
+                  MenuItemButton(child: Text(TestMenu.subMenu00.label), onPressed: () {}),
+                ],
+                builder: (BuildContext context, MenuController controller, Widget? child) {
+                  return TextField(
+                    controller: textController,
+                    focusNode: textFieldFocusNode,
+                    maxLines: 2,
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(TextField));
+        await tester.pump();
+
+        expect(textFieldFocusNode.hasFocus, isTrue);
+        expect(controller.isOpen, isFalse);
+
+        // Place the caret on the second line, between the second and third
+        // characters.
+        textController.selection = const TextSelection.collapsed(offset: 7);
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pump();
+
+        // The caret moved up to the first line instead of moving the focus.
+        expect(textController.selection.baseOffset, 2);
+        expect(textFieldFocusNode.hasFocus, isTrue);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        expect(textController.selection.baseOffset, 7);
+        expect(textFieldFocusNode.hasFocus, isTrue);
+      },
+    );
   });
 
   group('Accelerators', () {

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2479,6 +2479,51 @@ void main() {
       await tester.pump();
       expect(focusedMenu, equals('MenuItemButton(Text("Submenu item 1"))'));
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/163475.
+    testWidgets('Arrow keys move the caret of a TextField in the anchor when the menu is closed', (
+      WidgetTester tester,
+    ) async {
+      final textController = TextEditingController(text: 'text');
+      addTearDown(textController.dispose);
+      final textFieldFocusNode = FocusNode(debugLabel: 'TextField');
+      addTearDown(textFieldFocusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MenuAnchor(
+              controller: controller,
+              menuChildren: <Widget>[
+                MenuItemButton(child: Text(TestMenu.subMenu00.label), onPressed: () {}),
+              ],
+              builder: (BuildContext context, MenuController controller, Widget? child) {
+                return TextField(controller: textController, focusNode: textFieldFocusNode);
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      expect(textFieldFocusNode.hasFocus, isTrue);
+      expect(controller.isOpen, isFalse);
+
+      textController.selection = const TextSelection.collapsed(offset: 4);
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+
+      expect(textController.selection.baseOffset, 3);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+
+      expect(textController.selection.baseOffset, 4);
+    });
   });
 
   group('Accelerators', () {

--- a/packages/flutter/test/widgets/raw_menu_anchor_test.dart
+++ b/packages/flutter/test/widgets/raw_menu_anchor_test.dart
@@ -1258,6 +1258,57 @@ void main() {
     expect(textController.selection.baseOffset, 4);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/163475.
+  testWidgets('[Default] Up and down arrow keys are not blocked by a closed anchor', (
+    WidgetTester tester,
+  ) async {
+    final textController = TextEditingController(text: 'aaaa\nbbbb');
+    addTearDown(textController.dispose);
+    final textFieldFocusNode = FocusNode(debugLabel: 'EditableText');
+    addTearDown(textFieldFocusNode.dispose);
+
+    await tester.pumpWidget(
+      App(
+        Menu(
+          controller: controller,
+          menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+          child: SizedBox(
+            width: 200,
+            child: EditableText(
+              controller: textController,
+              focusNode: textFieldFocusNode,
+              maxLines: 2,
+              style: const TextStyle(),
+              cursorColor: const Color(0xFF000000),
+              backgroundCursorColor: const Color(0xFF000000),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    textFieldFocusNode.requestFocus();
+    await tester.pump();
+
+    // Place the caret on the second line, between the second and third
+    // characters.
+    textController.selection = const TextSelection.collapsed(offset: 7);
+    await tester.pump();
+
+    // The menu is closed, so the anchor should not intercept arrow keys.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+
+    expect(textController.selection.baseOffset, 2);
+    expect(textFieldFocusNode.hasFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+
+    expect(textController.selection.baseOffset, 7);
+    expect(textFieldFocusNode.hasFocus, isTrue);
+  });
+
   testWidgets('[Default] Focus traversal shortcuts are not bound to actions', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/widgets/raw_menu_anchor_test.dart
+++ b/packages/flutter/test/widgets/raw_menu_anchor_test.dart
@@ -1212,6 +1212,52 @@ void main() {
     );
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/163475.
+  testWidgets('[Default] Arrow keys are not blocked by a closed anchor', (
+    WidgetTester tester,
+  ) async {
+    final textController = TextEditingController(text: 'text');
+    addTearDown(textController.dispose);
+    final textFieldFocusNode = FocusNode(debugLabel: 'EditableText');
+    addTearDown(textFieldFocusNode.dispose);
+
+    await tester.pumpWidget(
+      App(
+        Menu(
+          controller: controller,
+          menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+          child: SizedBox(
+            width: 200,
+            child: EditableText(
+              controller: textController,
+              focusNode: textFieldFocusNode,
+              style: const TextStyle(),
+              cursorColor: const Color(0xFF000000),
+              backgroundCursorColor: const Color(0xFF000000),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    textFieldFocusNode.requestFocus();
+    await tester.pump();
+
+    textController.selection = const TextSelection.collapsed(offset: 4);
+    await tester.pump();
+
+    // The menu is closed, so the anchor should not intercept arrow keys.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pump();
+
+    expect(textController.selection.baseOffset, 3);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+
+    expect(textController.selection.baseOffset, 4);
+  });
+
   testWidgets('[Default] Focus traversal shortcuts are not bound to actions', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
The fix un-binds all four directional keys while the menu is closed, but the
regression tests only asserted the left and right arrow keys. A regression that
forgot to un-bind arrowUp/arrowDown would not have been caught.

Add a test to both menu_anchor_test.dart and raw_menu_anchor_test.dart that puts
a multiline text field with two lines of text in the anchor and asserts that
arrowUp/arrowDown move the caret between the lines instead of moving the focus.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
