### PR TITLE
Fix Scrollbar mouse hover advertising a drag that is rejected

### DIFF
--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -381,8 +381,12 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
   @override
   void handleHover(PointerHoverEvent event) {
     super.handleHover(event);
-    // Check if the position of the pointer falls over the painted scrollbar
-    if (isPointerOverScrollbar(event.position, event.kind, forHover: true)) {
+    // Check if the position of the pointer falls over the painted scrollbar.
+    // The enlarged `forHover` proximity area is deliberately not used here. It
+    // only serves to bring a faded out scrollbar back into view, and it extends
+    // beyond the area that accepts a press. Painting the thumb as hovered there
+    // would advertise an interaction that cannot be started.
+    if (isPointerOverScrollbar(event.position, event.kind)) {
       // Pointer is hovering over the scrollbar
       setState(() {
         _hoverIsActive = true;

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -740,11 +740,13 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
   /// caused by [PointerDeviceKind.touch] to make sure that the region
   /// isn't too small to be interacted with by the user.
   ///
-  /// The hit test area for hovering with [PointerDeviceKind.mouse] over the
-  /// scrollbar also uses this extra padding. This is to make it easier to
-  /// interact with the scrollbar by presenting it to the mouse for interaction
-  /// based on proximity. When `forHover` is true, the larger hit test area will
-  /// be used.
+  /// The hit test area for hovering with [PointerDeviceKind.mouse] over a
+  /// faded out scrollbar also uses this extra padding. This is to bring the
+  /// scrollbar back into view based on proximity, so that the mouse can then
+  /// move onto it. When `forHover` is true, the larger hit test area will be
+  /// used. Since the enlarged area only reveals the scrollbar, it is never used
+  /// to accept a press; once the scrollbar is visible a mouse must be over the
+  /// track to interact with it.
   bool hitTestInteractive(Offset position, PointerDeviceKind kind, {bool forHover = false}) {
     if (_trackRect == null) {
       // We have not computed the scrollbar position yet.
@@ -814,8 +816,25 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
       case PointerDeviceKind.stylus:
       case PointerDeviceKind.invertedStylus:
       case PointerDeviceKind.unknown:
-        return _thumbRect!.contains(position);
+        // The thumb is inset from the edges of the track by crossAxisMargin.
+        // Pointers landing in that inset are still on the scrollbar, so they
+        // should grab the thumb instead of paging the scroll view like a tap
+        // on the track does.
+        return _crossAxisPaddedThumbRect.contains(position);
     }
+  }
+
+  // The thumb rect, expanded on the cross axis to fill the track, which is
+  // wider than the thumb when crossAxisMargin is greater than zero.
+  Rect get _crossAxisPaddedThumbRect {
+    final Rect thumbRect = _thumbRect!;
+    final Rect? trackRect = _trackRect;
+    if (trackRect == null) {
+      return thumbRect;
+    }
+    return _isVertical
+        ? Rect.fromLTRB(trackRect.left, thumbRect.top, trackRect.right, thumbRect.bottom)
+        : Rect.fromLTRB(thumbRect.left, trackRect.top, thumbRect.right, trackRect.bottom);
   }
 
   @override
@@ -2102,17 +2121,18 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   /// Returns true if the provided [Offset] is located over the track or thumb
   /// of the [RawScrollbar].
   ///
-  /// The hit test area for mouse hovering over the scrollbar is larger than
-  /// regular hit testing. This is to make it easier to interact with the
-  /// scrollbar and present it to the mouse for interaction based on proximity.
-  /// When `forHover` is true, the larger hit test area will be used.
+  /// The hit test area for mouse hovering over a faded out scrollbar is larger
+  /// than regular hit testing. This is to bring the scrollbar back into view
+  /// based on proximity. When `forHover` is true, the larger hit test area will
+  /// be used. The enlarged area does not accept presses, so it should not be
+  /// used to decide whether the scrollbar is to be painted as interactive.
   @protected
   bool isPointerOverScrollbar(Offset position, PointerDeviceKind kind, {bool forHover = false}) {
     if (_scrollbarPainterKey.currentContext == null) {
       return false;
     }
     final Offset localOffset = _getLocalOffset(_scrollbarPainterKey, position);
-    return scrollbarPainter.hitTestInteractive(localOffset, kind, forHover: true);
+    return scrollbarPainter.hitTestInteractive(localOffset, kind, forHover: forHover);
   }
 
   /// Cancels the fade out animation so the scrollbar will remain visible for

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1509,6 +1509,156 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.fuchsia}),
   );
 
+  testWidgets(
+    'Mouse can drag the Scrollbar thumb from the part of the track that hovering highlights',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/163464
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: ScrollConfiguration(
+            behavior: const NoScrollbarBehavior(),
+            child: Scrollbar(
+              thumbVisibility: true,
+              controller: scrollController,
+              child: SingleChildScrollView(
+                controller: scrollController,
+                child: const SizedBox(width: 4000.0, height: 4000.0),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(scrollController.offset, 0.0);
+      expect(
+        find.byType(Scrollbar),
+        paints..rrect(
+          rrect: RRect.fromRectAndRadius(
+            getStartingThumbRect(isAndroid: false),
+            _kDefaultThumbRadius,
+          ),
+          color: _kDefaultIdleThumbColor,
+        ),
+      );
+
+      // The Material thumb is painted with a 2 pixel margin to the right edge
+      // of the viewport, but the track it lives in reaches that edge. Hovering
+      // there highlights the thumb, so it must be draggable from there too.
+      final TestGesture gesture = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(const Offset(799.0, 45.0));
+      await tester.pumpAndSettle();
+      expect(
+        find.byType(Scrollbar),
+        paints..rrect(
+          rrect: RRect.fromRectAndRadius(
+            getStartingThumbRect(isAndroid: false),
+            _kDefaultThumbRadius,
+          ),
+          // Hover color.
+          color: const Color(0x80000000),
+        ),
+      );
+
+      const scrollAmount = 10.0;
+      await gesture.down(const Offset(799.0, 45.0));
+      await tester.pumpAndSettle();
+      await gesture.moveBy(const Offset(0.0, scrollAmount));
+      await tester.pumpAndSettle();
+
+      expect(scrollController.offset, greaterThan(0.0));
+      expect(
+        find.byType(Scrollbar),
+        paints..rrect(
+          rrect: RRect.fromRectAndRadius(
+            getStartingThumbRect(isAndroid: false).shift(const Offset(0.0, scrollAmount)),
+            _kDefaultThumbRadius,
+          ),
+        ),
+      );
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+      TargetPlatform.windows,
+    }),
+  );
+
+  testWidgets(
+    'Mouse proximity reveals the Scrollbar without presenting the thumb as interactive',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/163464
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: ScrollConfiguration(
+            behavior: const NoScrollbarBehavior(),
+            child: Scrollbar(
+              controller: scrollController,
+              child: SingleChildScrollView(
+                controller: scrollController,
+                child: const SizedBox(width: 4000.0, height: 4000.0),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      // Scroll so the scrollbar has metrics, then let it fade out again.
+      await tester.dragFrom(const Offset(400.0, 300.0), const Offset(0.0, -20.0), touchSlopY: 0.0);
+      await tester.pumpAndSettle();
+      final double scrolledOffset = scrollController.offset;
+      expect(scrolledOffset, greaterThan(0.0));
+      await tester.pump(_kScrollbarTimeToFade);
+      await tester.pump(_kScrollbarFadeDuration);
+      expect(find.byType(Scrollbar), isNot(paints..rrect()));
+
+      final TestGesture gesture = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+
+      // The proximity area of a faded out scrollbar reaches far past the track.
+      // Moving into it brings the scrollbar back into view, but the thumb must
+      // not be painted as hovered there, since a press that far from the track
+      // is passed on to the scroll view.
+      await gesture.moveTo(const Offset(775.0, 45.0));
+      await tester.pumpAndSettle();
+      expect(find.byType(Scrollbar), paints..rrect(color: _kDefaultIdleThumbColor));
+
+      await gesture.down(const Offset(775.0, 45.0));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0.0, 10.0));
+      await tester.pumpAndSettle();
+      expect(scrollController.offset, scrolledOffset);
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Once the pointer is over the track the thumb is highlighted, and a drag
+      // started from there moves the scroll view.
+      await gesture.moveTo(const Offset(799.0, 45.0));
+      await tester.pumpAndSettle();
+      expect(find.byType(Scrollbar), paints..rrect(color: const Color(0x80000000)));
+
+      await gesture.down(const Offset(799.0, 45.0));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0.0, 10.0));
+      await tester.pumpAndSettle();
+      expect(scrollController.offset, greaterThan(scrolledOffset));
+      await gesture.up();
+      await tester.pumpAndSettle();
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.linux}),
+  );
+
   testWidgets('Scrollbar dragging is disabled by default on Android', (WidgetTester tester) async {
     var tapCount = 0;
     final scrollController = ScrollController();

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1233,6 +1233,126 @@ void main() {
     );
   });
 
+  testWidgets('Scrollbar thumb can be dragged with a mouse within the crossAxisMargin', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/163464
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: PrimaryScrollController(
+            controller: scrollController,
+            child: RawScrollbar(
+              thumbVisibility: true,
+              crossAxisMargin: 2.0,
+              controller: scrollController,
+              child: const SingleChildScrollView(child: SizedBox(width: 4000.0, height: 4000.0)),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 0.0);
+    expect(
+      find.byType(RawScrollbar),
+      paints
+        ..rect(rect: const Rect.fromLTRB(790.0, 0.0, 800.0, 600.0))
+        ..rect(rect: const Rect.fromLTRB(792.0, 0.0, 798.0, 90.0), color: const Color(0x66BCBCBC)),
+    );
+
+    // The pointer is within the crossAxisMargin of the track, next to the
+    // painted thumb. This is part of the scrollbar, so it should drag the
+    // thumb instead of paging the scroll view like a tap on the track.
+    const scrollAmount = 10.0;
+    final TestGesture gesture = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    await gesture.down(const Offset(799.0, 45.0));
+    await tester.pumpAndSettle();
+    await gesture.moveBy(const Offset(0.0, scrollAmount));
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, greaterThan(0.0));
+    expect(
+      find.byType(RawScrollbar),
+      paints
+        ..rect(rect: const Rect.fromLTRB(790.0, 0.0, 800.0, 600.0))
+        ..rect(
+          rect: const Rect.fromLTRB(792.0, 10.0, 798.0, 100.0),
+          color: const Color(0x66BCBCBC),
+        ),
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+    'Horizontal scrollbar thumb can be dragged with a mouse within the crossAxisMargin',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/163464
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: RawScrollbar(
+              thumbVisibility: true,
+              crossAxisMargin: 2.0,
+              controller: scrollController,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                controller: scrollController,
+                child: const SizedBox(width: 4000.0, height: 4000.0),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(scrollController.offset, 0.0);
+      expect(
+        find.byType(RawScrollbar),
+        paints
+          ..rect(rect: const Rect.fromLTRB(0.0, 590.0, 800.0, 600.0))
+          ..rect(rect: const Rect.fromLTRB(0.0, 592.0, 160.0, 598.0), color: const Color(0x66BCBCBC)),
+      );
+
+      // The pointer is within the crossAxisMargin of the track, next to the
+      // painted thumb. This is part of the scrollbar, so it should drag the
+      // thumb instead of paging the scroll view like a tap on the track.
+      const scrollAmount = 10.0;
+      final TestGesture gesture = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await gesture.down(const Offset(45.0, 599.0));
+      await tester.pumpAndSettle();
+      await gesture.moveBy(const Offset(scrollAmount, 0.0));
+      await tester.pumpAndSettle();
+
+      expect(scrollController.offset, greaterThan(0.0));
+      expect(
+        find.byType(RawScrollbar),
+        paints
+          ..rect(rect: const Rect.fromLTRB(0.0, 590.0, 800.0, 600.0))
+          ..rect(
+            rect: const Rect.fromLTRB(10.0, 592.0, 170.0, 598.0),
+            color: const Color(0x66BCBCBC),
+          ),
+      );
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    },
+  );
+
   testWidgets('hit test', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/99324
     final scrollController = ScrollController();


### PR DESCRIPTION
A mouse could highlight the Scrollbar thumb without being able to drag
it. Two separate gaps caused this.

1. ScrollbarPainter.hitTestOnlyThumbInteractive used the painted thumb
   rect for precise pointers, but the thumb is inset from the edges of
   the track by crossAxisMargin. A press in that inset highlighted the
   thumb on hover, yet started no drag. The thumb hit region for precise
   pointers is now expanded across the track on the cross axis. This
   applies to vertical and horizontal scrollbars alike.

2. RawScrollbarState.isPointerOverScrollbar always forwarded
   `forHover: true`, so a caller could not ask for the plain interactive
   region. The Material Scrollbar used it for its hovered visual state,
   so a faded out scrollbar that a nearby mouse had revealed was painted
   as hovered up to 24 logical pixels away from the track, where a press
   is passed on to the scroll view instead. The argument is now honoured
   and Material asks for the plain region. The enlarged proximity region
   keeps its single purpose: revealing a faded out scrollbar so that the
   mouse can then move onto it.

The other option, letting a mouse press start a thumb drag anywhere in
the proximity region, was rejected. It would swallow mouse clicks that
land up to 24 logical pixels away from a scrollbar the user never
touched, and it contradicts the existing assertion in 'Scrollbar hit
test area adjusts for PointerDeviceKind', which requires a mouse drag
from Offset(790.0, 45.0) to leave the scroll view alone. That assertion
records the deliberate decision that a mouse is precise and needs no
touch padding, so it encodes intended behaviour, not the bug. It is
kept unchanged. The bug is the mismatch between the region that is
presented as interactive and the region that accepts a press, and both
ends of that mismatch are now aligned on the track.

Fixes https://github.com/flutter/flutter/issues/163464

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
