### PR TITLE
Fix selection edge scrolling for touch drags at the screen edge

### DIFF
--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -7,6 +7,7 @@
 library;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:vector_math/vector_math_64.dart';
 
 import 'layer.dart';
@@ -520,9 +521,13 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   ///
   /// The [granularity] contains the granularity which the selection edge should move by.
   /// This value defaults to [TextGranularity.character].
+  ///
+  /// The [deviceKind] contains the kind of the pointer device that is updating
+  /// the selection edge, if any.
   const SelectionEdgeUpdateEvent.forStart({
     required this.globalPosition,
     TextGranularity? granularity,
+    this.deviceKind,
   }) : granularity = granularity ?? TextGranularity.character,
        super._(SelectionEventType.startEdgeUpdate);
 
@@ -532,9 +537,13 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   ///
   /// The [granularity] contains the granularity which the selection edge should move by.
   /// This value defaults to [TextGranularity.character].
+  ///
+  /// The [deviceKind] contains the kind of the pointer device that is updating
+  /// the selection edge, if any.
   const SelectionEdgeUpdateEvent.forEnd({
     required this.globalPosition,
     TextGranularity? granularity,
+    this.deviceKind,
   }) : granularity = granularity ?? TextGranularity.character,
        super._(SelectionEventType.endEdgeUpdate);
 
@@ -547,6 +556,12 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   ///
   /// Defaults to [TextGranularity.character].
   final TextGranularity granularity;
+
+  /// The kind of the pointer device that is updating the selection edge.
+  ///
+  /// This is null when the selection edge is not updated by a pointer device,
+  /// for example when the selection is updated programmatically.
+  final PointerDeviceKind? deviceKind;
 }
 
 /// Extends the start or end of the selection by a given [TextGranularity].

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1181,6 +1181,15 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
   // Pointer drag is a single point, it should not have a size.
   static const double _kDefaultDragTargetSize = 0;
 
+  // Pointer devices that are bound to the screen, such as a finger, cannot be
+  // dragged past the bounds of the screen, so a drag with those devices cannot
+  // reach the edge of a scrollable that is flush against the edge of the
+  // screen. Giving the drag target a size makes edge scrolling possible in that
+  // case. This is an eye-balled value that leaves enough room for the size of a
+  // finger and for the offset between a selection handle and the pointer that
+  // drags it.
+  static const double _kTouchDragTargetSize = 100;
+
   // An eye-balled value for a smooth scrolling speed.
   static const double _kDefaultSelectToScrollVelocityScalar = 30;
 
@@ -1192,6 +1201,14 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
 
   // The scrollable only auto scrolls if the selection starts in the scrollable.
   bool _selectionStartsInScrollable = false;
+
+  // The device kind of the pointer that is driving the current selection.
+  //
+  // Some selection edge updates are synthesized, for example when a selectable
+  // is added while the scrollable is auto scrolling, and they do not carry a
+  // device kind. The last known device kind is used for those updates so the
+  // drag target keeps its size for the duration of the drag.
+  PointerDeviceKind? _currentDragDeviceKind;
 
   ScrollPosition get position => _position;
   ScrollPosition _position;
@@ -1258,6 +1275,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
     _currentDragStartRelatedToOrigin = null;
     _currentDragEndRelatedToOrigin = null;
     _selectionStartsInScrollable = false;
+    _currentDragDeviceKind = null;
     return super.handleClearSelection(event);
   }
 
@@ -1267,6 +1285,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       assert(!_selectionStartsInScrollable);
       _selectionStartsInScrollable = _globalPositionInScrollable(event.globalPosition);
     }
+    _currentDragDeviceKind = event.deviceKind ?? _currentDragDeviceKind;
     final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
     if (event.type == SelectionEventType.endEdgeUpdate) {
       _currentDragEndRelatedToOrigin = _inferPositionRelatedToOrigin(event.globalPosition);
@@ -1277,6 +1296,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       event = SelectionEdgeUpdateEvent.forEnd(
         globalPosition: endOffset,
         granularity: event.granularity,
+        deviceKind: event.deviceKind,
       );
     } else {
       _currentDragStartRelatedToOrigin = _inferPositionRelatedToOrigin(event.globalPosition);
@@ -1287,6 +1307,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       event = SelectionEdgeUpdateEvent.forStart(
         globalPosition: startOffset,
         granularity: event.granularity,
+        deviceKind: event.deviceKind,
       );
     }
     final SelectionResult result = super.handleSelectionEdgeUpdate(event);
@@ -1506,10 +1527,23 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
   }
 
   Rect _dragTargetFromEvent(SelectionEdgeUpdateEvent event) {
+    final double dragTargetSize = switch (_currentDragDeviceKind) {
+      PointerDeviceKind.touch ||
+      PointerDeviceKind.stylus ||
+      PointerDeviceKind.invertedStylus => _kTouchDragTargetSize,
+      PointerDeviceKind.mouse ||
+      PointerDeviceKind.trackpad ||
+      PointerDeviceKind.unknown ||
+      null => _kDefaultDragTargetSize,
+    };
+    // The drag target is clamped to half of the scrollable so that the auto
+    // scroll areas of the leading and the trailing edge never overlap,
+    // otherwise the auto scroller bounces between the two edges.
+    final box = state.context.findRenderObject()! as RenderBox;
     return Rect.fromCenter(
       center: event.globalPosition,
-      width: _kDefaultDragTargetSize,
-      height: _kDefaultDragTargetSize,
+      width: math.min(dragTargetSize, box.size.width / 2),
+      height: math.min(dragTargetSize, box.size.height / 2),
     );
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1024,7 +1024,13 @@ class SelectableRegionState extends State<SelectableRegion>
   }
 
   void _handleTouchLongPressMoveUpdate(LongPressMoveUpdateDetails details) {
-    _selectEndTo(offset: details.globalPosition, textGranularity: TextGranularity.word);
+    // The update is continuous so the selection keeps auto scrolling when the
+    // drag position rests at the edge of a scrollable.
+    _selectEndTo(
+      offset: details.globalPosition,
+      continuous: true,
+      textGranularity: TextGranularity.word,
+    );
     _selectionStatusNotifier.value = SelectableRegionSelectionStatus.changing;
     _updateSelectedContentIfNeeded();
   }
@@ -1129,6 +1135,7 @@ class SelectableRegionState extends State<SelectableRegion>
           SelectionEdgeUpdateEvent.forEnd(
             globalPosition: _selectionEndPosition!,
             granularity: textGranularity,
+            deviceKind: _lastPointerDeviceKind,
           ),
         ) ==
         SelectionResult.pending) {
@@ -1183,6 +1190,7 @@ class SelectableRegionState extends State<SelectableRegion>
           SelectionEdgeUpdateEvent.forStart(
             globalPosition: _selectionStartPosition!,
             granularity: textGranularity,
+            deviceKind: _lastPointerDeviceKind,
           ),
         ) ==
         SelectionResult.pending) {
@@ -1436,7 +1444,11 @@ class SelectableRegionState extends State<SelectableRegion>
   }) {
     if (!continuous) {
       _selectable?.dispatchSelectionEvent(
-        SelectionEdgeUpdateEvent.forEnd(globalPosition: offset, granularity: textGranularity),
+        SelectionEdgeUpdateEvent.forEnd(
+          globalPosition: offset,
+          granularity: textGranularity,
+          deviceKind: _lastPointerDeviceKind,
+        ),
       );
       return;
     }
@@ -1483,7 +1495,11 @@ class SelectableRegionState extends State<SelectableRegion>
   }) {
     if (!continuous) {
       _selectable?.dispatchSelectionEvent(
-        SelectionEdgeUpdateEvent.forStart(globalPosition: offset, granularity: textGranularity),
+        SelectionEdgeUpdateEvent.forStart(
+          globalPosition: offset,
+          granularity: textGranularity,
+          deviceKind: _lastPointerDeviceKind,
+        ),
       );
       return;
     }

--- a/packages/flutter/test/widgets/scrollable_selection_test.dart
+++ b/packages/flutter/test/widgets/scrollable_selection_test.dart
@@ -952,11 +952,10 @@ void main() {
 
     // Release handle should stop scrolling.
     await gesture.up();
-    // Last scheduled scroll.
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
-    previousOffset = controller.offset;
+    // Let the scrolls that were already scheduled before the release finish.
     await tester.pumpAndSettle();
+    previousOffset = controller.offset;
+    await tester.pump(const Duration(seconds: 1));
     expect(controller.offset, previousOffset);
   });
 
@@ -1013,11 +1012,10 @@ void main() {
 
     // Release handle should stop scrolling.
     await gesture.up();
-    // Last scheduled scroll.
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
-    previousOffset = controller.offset;
+    // Let the scrolls that were already scheduled before the release finish.
     await tester.pumpAndSettle();
+    previousOffset = controller.offset;
+    await tester.pump(const Duration(seconds: 1));
     expect(controller.offset, previousOffset);
   });
 
@@ -1440,6 +1438,102 @@ void main() {
     // If _selectionStartsInScrollable was correctly preserved as TRUE,
     // the scrollable will have started auto-scrolling downwards.
     expect(position.pixels, greaterThan(0.0));
+    await gesture.up();
+  });
+
+  testWidgets('select to scroll forward works when a touch drag reaches the edge of the viewport', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/162856.
+    // A touch pointer cannot be dragged past the physical bounds of the screen,
+    // so the auto scroll must start before the drag position leaves the
+    // scrollable when the scrollable is flush against the edge of the screen.
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SelectionArea(
+          selectionControls: materialTextSelectionControls,
+          child: ListView.builder(
+            controller: controller,
+            itemCount: 100,
+            itemBuilder: (BuildContext context, int index) {
+              return Text('Item $index');
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final RenderParagraph paragraph0 = tester.renderObject<RenderParagraph>(
+      find.descendant(of: find.text('Item 0'), matching: find.byType(RichText)),
+    );
+    final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph0, 2));
+    addTearDown(gesture.removePointer);
+    // Long press to start selecting.
+    await tester.pump(kLongPressTimeout);
+    expect(controller.offset, 0.0);
+
+    // Drag to the bottom of the viewport without leaving its bounds.
+    await gesture.moveTo(tester.getBottomLeft(find.byType(ListView)) - const Offset(0.0, 1.0));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(controller.offset, greaterThan(0.0));
+
+    // Scroll to the end.
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+    expect(controller.offset, 4200.0);
+    await gesture.up();
+  });
+
+  testWidgets('select to scroll works when a selection handle is dragged to the edge of the viewport', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/162856.
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SelectionArea(
+          selectionControls: materialTextSelectionControls,
+          child: ListView.builder(
+            controller: controller,
+            itemCount: 100,
+            itemBuilder: (BuildContext context, int index) {
+              return Text('Item $index');
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Long press to bring up the selection handles.
+    final RenderParagraph paragraph0 = tester.renderObject<RenderParagraph>(
+      find.descendant(of: find.text('Item 0'), matching: find.byType(RichText)),
+    );
+    final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph0, 2));
+    addTearDown(gesture.removePointer);
+    await tester.pump(kLongPressTimeout);
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(paragraph0.selections[0], const TextSelection(baseOffset: 0, extentOffset: 4));
+
+    final List<TextBox> boxes = paragraph0.getBoxesForSelection(paragraph0.selections[0]);
+    expect(boxes.length, 1);
+    // Drag the end handle to the bottom of the viewport without leaving its
+    // bounds.
+    await gesture.down(globalize(boxes[0].toRect().bottomRight, paragraph0));
+    expect(controller.offset, 0.0);
+    await gesture.moveTo(tester.getBottomLeft(find.byType(ListView)) - const Offset(0.0, 1.0));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(controller.offset, greaterThan(0.0));
+
+    // Scroll to the end.
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+    expect(controller.offset, 4200.0);
     await gesture.up();
   });
 


### PR DESCRIPTION
A selection drag only starts auto scrolling once the drag target passes the
bounds of the scrollable. The drag target of a selection drag has a size of
zero, so the drag has to move past the edge of the scrollable to auto scroll.
That is impossible with a touch pointer when the scrollable is flush against
the edge of the screen, because a touch pointer cannot be reported outside of
the screen, so edge scrolling never started on mobile unless the scroll view
was inset, for example by a SafeArea.

Selection edge update events now carry the kind of the pointer device that
drives them. Devices that are bound to the screen, such as a finger or a
stylus, get a drag target with a size instead of a single point, which lets the
auto scroller start while the drag is still inside the scrollable. The drag
target is clamped to half of the scrollable so small scrollables do not bounce
between their leading and trailing edges. Drags with a mouse keep their zero
sized drag target.

Long press drag updates are also made continuous, so the auto scroll keeps
running while the finger rests at the edge instead of stopping as soon as the
finger stops moving.

Fixes https://github.com/flutter/flutter/issues/162856

---

## Reviewer context

This also fixes #110788, a duplicate report of the same root cause (selection edge auto-scroll never
starts for a touch pointer, because the drag target used for edge-scroll detection has zero size and a
touch pointer can never leave the viewport bounds). I commented on #110788 pointing here instead of
opening a second PR for it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
