### PR TITLE
Reset CupertinoScrollbar thumb thickness on canceled thumb drag

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -216,6 +216,14 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
   }
 
   @override
+  void handleThumbPressCancel() {
+    // handleThumbPressEnd is not called when the gesture is canceled, so the
+    // thickness animation started by handleThumbPress has to be reverted here.
+    _thicknessAnimationController.reverse();
+    super.handleThumbPressCancel();
+  }
+
+  @override
   void handleTrackTapDown(TapDownDetails details) {
     // On iOS, tapping the track does not page towards the position of the tap.
     if (ScrollConfiguration.of(context).getPlatform(context) != TargetPlatform.iOS) {

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1843,6 +1843,25 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     _cachedController = null;
   }
 
+  /// Handler called when a press on the scrollbar thumb is canceled before it
+  /// turns into a drag, for example when the thumb drag gesture loses the
+  /// gesture arena.
+  ///
+  /// Subclasses that react to [handleThumbPress] must override this to undo
+  /// that reaction, since [handleThumbPressEnd] is not called for a canceled
+  /// gesture.
+  @protected
+  @mustCallSuper
+  void handleThumbPressCancel() {
+    // _thumbHold might be null if the drag started.
+    // _thumbDrag might be null if the drag activity ended and called _disposeThumbDrag.
+    assert(_thumbHold == null || _thumbDrag == null);
+    _thumbHold?.cancel();
+    _thumbDrag?.cancel();
+    assert(_thumbHold == null);
+    assert(_thumbDrag == null);
+  }
+
   /// Handler called when the track is tapped in order to page in the tapped
   /// direction.
   @protected
@@ -2007,13 +2026,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       // any work.
       return;
     }
-    // _thumbHold might be null if the drag started.
-    // _thumbDrag might be null if the drag activity ended and called _disposeThumbDrag.
-    assert(_thumbHold == null || _thumbDrag == null);
-    _thumbHold?.cancel();
-    _thumbDrag?.cancel();
-    assert(_thumbHold == null);
-    assert(_thumbDrag == null);
+    handleThumbPressCancel();
   }
 
   void _initThumbDragGestureRecognizer(DragGestureRecognizer instance) {

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -1358,4 +1358,60 @@ void main() {
     );
     expect(tester.getSize(find.byType(CupertinoScrollbar)), Size.zero);
   });
+
+  testWidgets('CupertinoScrollbar thumb thickness is restored when the thumb drag is canceled', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/162747
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: PrimaryScrollController(
+          controller: scrollController,
+          child: CupertinoScrollbar(
+            thumbVisibility: true,
+            controller: scrollController,
+            child: ListView.builder(
+              controller: scrollController,
+              itemCount: 50,
+              itemBuilder: (BuildContext context, int index) =>
+                  const SizedBox(height: 50.0, child: Text('Item')),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    double thumbThickness() {
+      final CustomPaint customPaint = tester
+          .widgetList<CustomPaint>(
+            find.descendant(
+              of: find.byType(CupertinoScrollbar),
+              matching: find.byType(CustomPaint),
+            ),
+          )
+          .firstWhere((CustomPaint paint) => paint.foregroundPainter is ScrollbarPainter);
+      return (customPaint.foregroundPainter! as ScrollbarPainter).thickness;
+    }
+
+    expect(thumbThickness(), CupertinoScrollbar.defaultThickness);
+
+    // Touch the thumb close to, but not directly on top of, the scrollbar
+    // track. The touch is still within the thumb's padded hit test area, so
+    // the thumb drag gesture recognizer is notified, but the scrollable's own
+    // drag gesture recognizer also joins the gesture arena. Lifting the finger
+    // without moving it makes the thumb drag lose the arena, which cancels the
+    // gesture instead of ending it.
+    final TestGesture gesture = await tester.startGesture(const Offset(780.0, 74.0));
+    await tester.pump();
+    await tester.pump(kScrollbarResizeDuration);
+    expect(thumbThickness(), CupertinoScrollbar.defaultThicknessWhileDragging);
+
+    await gesture.up();
+    await tester.pump();
+    await tester.pump(kScrollbarResizeDuration);
+    expect(thumbThickness(), CupertinoScrollbar.defaultThickness);
+  });
 }


### PR DESCRIPTION
When a touch lands inside the scrollbar thumb's padded hit test area but
outside the scrollbar track, the thumb drag gesture recognizer and the
scrollable's own drag gesture recognizer both join the gesture arena. If the
pointer is lifted before the thumb drag is accepted, the thumb drag loses the
arena and is canceled instead of ended. RawScrollbar handled that in the
private _handleThumbDragCancel, which only cleaned up the hold/drag activities,
so CupertinoScrollbar never got a chance to revert the thickness and radius
animation it starts in handleThumbPress. The thumb stayed stuck at
thicknessWhileDragging until the next thumb drag ended normally.

RawScrollbarState now exposes a protected handleThumbPressCancel hook that
_handleThumbDragCancel delegates to, and CupertinoScrollbar overrides it to
reverse the thickness animation controller, the same way handleThumbPressEnd
already does. The default implementation keeps the previous cleanup behavior,
so nothing changes for existing subclasses.

Fixes https://github.com/flutter/flutter/issues/162747

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
