### PR TITLE
Keep driven scroll animations alive on curve overshoot

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -702,7 +702,9 @@ class DrivenScrollActivity extends ScrollActivity {
     required Duration duration,
     required Curve curve,
     required TickerProvider vsync,
-  }) : assert(duration > Duration.zero) {
+  }) : assert(duration > Duration.zero),
+       _lowerBound = math.min(from, to),
+       _upperBound = math.max(from, to) {
     _completer = Completer<void>();
     _controller =
         AnimationController.unbounded(
@@ -724,7 +726,8 @@ class DrivenScrollActivity extends ScrollActivity {
     super.delegate,
     Simulation simulation, {
     required TickerProvider vsync,
-  }) {
+  }) : _lowerBound = null,
+       _upperBound = null {
     _completer = Completer<void>();
     _controller =
         AnimationController.unbounded(
@@ -740,6 +743,11 @@ class DrivenScrollActivity extends ScrollActivity {
   late final Completer<void> _completer;
   late final AnimationController _controller;
 
+  // The range spanned by the animation, or null if the activity is driven by a
+  // simulation, in which case the range is not known ahead of time.
+  final double? _lowerBound;
+  final double? _upperBound;
+
   /// A [Future] that completes when the activity stops.
   ///
   /// For example, this [Future] will complete if the animation reaches the end
@@ -748,7 +756,17 @@ class DrivenScrollActivity extends ScrollActivity {
   Future<void> get done => _completer.future;
 
   void _tick() {
-    if (!applyMoveTo(_controller.value)) {
+    final double value = _controller.value;
+    if (applyMoveTo(value)) {
+      return;
+    }
+    // The position could not be fully applied. If the animation is currently
+    // overshooting the range it was asked to animate over (as curves such as
+    // Curves.elasticInOut do), the overflow is only transient: the animation
+    // still ends within that range, so the activity keeps going instead of
+    // being cancelled. Otherwise the requested range itself is out of the
+    // scrollable's bounds and there is no point in continuing.
+    if (_lowerBound == null || (value >= _lowerBound && value <= _upperBound!)) {
       delegate.goIdle();
     }
   }

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -447,6 +447,42 @@ void main() {
     expect(previousPageCompleted, true);
   });
 
+  testWidgets('PageController nextPage animates to the next page with an overshooting curve', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/160880
+    final controller = PageController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: PageView(
+          controller: controller,
+          physics: const NeverScrollableScrollPhysics(),
+          children: kStates.map<Widget>((String state) => Text(state)).toList(),
+        ),
+      ),
+    );
+
+    expect(controller.page, 0.0);
+
+    // Curves.elasticInOut moves outside of the animated range, which
+    // overscrolls the page view that is still resting on its first page.
+    controller.nextPage(duration: const Duration(milliseconds: 500), curve: Curves.elasticInOut);
+    await tester.pumpAndSettle();
+    expect(controller.page, 1.0);
+    expect(find.text('Alaska'), findsOneWidget);
+
+    controller.previousPage(
+      duration: const Duration(milliseconds: 500),
+      curve: Curves.elasticInOut,
+    );
+    await tester.pumpAndSettle();
+    expect(controller.page, 0.0);
+    expect(find.text('Alabama'), findsOneWidget);
+  });
+
   testWidgets('PageView in zero-size container', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(

--- a/packages/flutter/test/widgets/scroll_activity_test.dart
+++ b/packages/flutter/test/widgets/scroll_activity_test.dart
@@ -71,6 +71,33 @@ void main() {
     expect(controller.position.pixels, thirty + 100.0); // and ends up at the end
   });
 
+  testWidgets(
+    'DrivenScrollActivity keeps animating when the curve overshoots the scroll extent',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/160880
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView(controller: controller, children: children(10)),
+        ),
+      );
+      expect(controller.offset, 0.0);
+
+      // Curves.elasticInOut goes below its start value at the beginning of the
+      // animation, which overscrolls the position that is already at the
+      // minimum scroll extent. The animation must not be cancelled by it.
+      controller.animateTo(
+        100.0,
+        duration: const Duration(milliseconds: 500),
+        curve: Curves.elasticInOut,
+      );
+      await tester.pumpAndSettle();
+      expect(controller.offset, 100.0);
+    },
+  );
+
   testWidgets('DrivenScrollActivity allows overriding applyMoveTo', (WidgetTester tester) async {
     final controller = ScrollController();
     addTearDown(controller.dispose);


### PR DESCRIPTION
DrivenScrollActivity stopped the animation and went idle as soon as
ScrollPosition.setPixels reported any overscroll. Curves that leave the
[0, 1] range, such as Curves.elasticInOut, drive the position slightly
outside of the animated range, so with clamping physics an animation
that starts or ends at a scroll extent edge (for example
PageController.nextPage on the first page) was cancelled on its very
first frame and the scroll view snapped back.

The activity now only gives up when the overflowing value is inside the
range it was asked to animate over, which means the requested target
itself is unreachable. A transient overshoot outside of that range is
ignored, so the animation runs to completion.

Fixes https://github.com/flutter/flutter/issues/160880

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
