### PR TITLE
Let dispose-time callbacks mark other widgets as needing build

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1460,6 +1460,15 @@ mixin WidgetsBinding
       }
       return true;
     }());
+    if (schedulerPhase == SchedulerPhase.persistentCallbacks) {
+      // This callback is never invoked from within BuildOwner.buildScope, so
+      // the build phase of the frame that is currently being produced is
+      // already over. A new frame is needed to build the elements that were
+      // just marked as dirty, for example by a callback that an application
+      // registered on a widget that is being removed from the tree.
+      scheduleFrame();
+      return;
+    }
     ensureVisualUpdate();
   }
 
@@ -1577,6 +1586,12 @@ mixin WidgetsBinding
       super.drawFrame();
       assert(() {
         debugFrameWasSentToEngine = sendFramesToEngine;
+        // Unmounting the elements that are no longer active can invoke
+        // application callbacks, for example the gesture callbacks of a
+        // GestureDetector whose gesture is interrupted because it is being
+        // removed from the tree. Such a callback is allowed to schedule a build
+        // for a subsequent frame, since the build phase of this frame is over.
+        debugBuildingDirtyElements = false;
         return true;
       }());
       buildOwner!.finalizeTree();

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3044,6 +3044,36 @@ class BuildOwner {
     assert(_debugStateLockLevel >= 0);
   }
 
+  // Calls the given `callback` in a scope where the restriction established by
+  // [lockState] is lifted.
+  //
+  // Unmounting a widget can invoke application callbacks (for example the
+  // gesture callbacks of a [GestureDetector] whose gesture is interrupted
+  // because the widget is being removed from the tree). Such a callback is
+  // allowed to mark other, still mounted, widgets as needing to build: the
+  // build phase is over by the time the elements are unmounted, so those
+  // widgets are simply rebuilt during a subsequent frame.
+  //
+  // Marking the widget that is being unmounted itself as needing to build
+  // remains an error, which is caught by [State.setState] and by the checks at
+  // the beginning of [Element.markNeedsBuild].
+  void _unlockState(VoidCallback callback) {
+    int? previousStateLockLevel;
+    assert(() {
+      previousStateLockLevel = _debugStateLockLevel;
+      _debugStateLockLevel = 0;
+      return true;
+    }());
+    try {
+      callback();
+    } finally {
+      assert(() {
+        _debugStateLockLevel = previousStateLockLevel!;
+        return true;
+      }());
+    }
+  }
+
   /// Establishes a scope for updating the widget tree, and calls the given
   /// `callback`, if any. Then, builds all the elements that were marked as
   /// dirty using [scheduleBuildFor], in depth order.
@@ -6043,8 +6073,12 @@ class StatefulElement extends ComponentElement {
 
   @override
   void unmount() {
+    final BuildOwner owner = this.owner!;
     super.unmount();
-    state.dispose();
+    // The callbacks invoked by State.dispose may legitimately mark other
+    // widgets as needing to build, so the state lock that the framework holds
+    // while it unmounts the elements is lifted here.
+    owner._unlockState(state.dispose);
     assert(() {
       if (state._debugLifecycleState == _StateLifecycle.defunct) {
         return true;

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -2169,6 +2169,41 @@ The findRenderObject() method was called for the following element:
       expect(element.debugIsDefunct, true);
     },
   );
+
+  testWidgets('a callback invoked from State.dispose can mark other widgets as needing to build', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/160508
+    late StateSetter setState;
+    var showSpy = true;
+    var buildCount = 0;
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter setter) {
+          setState = setter;
+          buildCount += 1;
+          return showSpy
+              ? StatefulWidgetSpy(onDispose: (_) => setState(() {}), child: const Placeholder())
+              : const Placeholder();
+        },
+      ),
+    );
+    expect(buildCount, 1);
+
+    // The spy is unmounted at the end of this frame, while the widget tree is
+    // locked. Marking the still mounted StatefulBuilder as needing to build is
+    // allowed there: it is simply rebuilt during the next frame.
+    setState(() {
+      showSpy = false;
+    });
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+    expect(buildCount, 2);
+
+    await tester.pump();
+    expect(buildCount, 3);
+  });
 }
 
 class _TestInheritedElement extends InheritedElement {

--- a/packages/flutter/test/widgets/gesture_detector_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_test.dart
@@ -1428,6 +1428,53 @@ void main() {
       expect(log, <String>['double-tap-down']);
     });
   });
+
+  testWidgets('onTapCancel can call setState when the gesture detector is removed', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/160508
+    late StateSetter setState;
+    var visible = true;
+    var cancelCount = 0;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setter) {
+            setState = setter;
+            return Center(
+              child: visible
+                  ? GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTapDown: (TapDownDetails details) {},
+                      onTapCancel: () {
+                        cancelCount += 1;
+                        setState(() {});
+                      },
+                      child: const SizedBox(width: 100.0, height: 100.0),
+                    )
+                  : const SizedBox(width: 100.0, height: 100.0),
+            );
+          },
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(SizedBox)));
+    addTearDown(() => gesture.up());
+
+    // Removing the gesture detector disposes its recognizers, which cancels the
+    // in-progress tap. The callback is invoked while the widget tree is being
+    // unmounted, but is still allowed to mark other widgets as needing build.
+    setState(() {
+      visible = false;
+    });
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(cancelCount, 1);
+  });
 }
 
 class _EmptySemanticsGestureDelegate extends SemanticsGestureDelegate {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -2476,6 +2476,11 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
           }
         }
       }
+      // Unmounting the elements that are no longer active can invoke
+      // application callbacks that schedule a build for a subsequent frame,
+      // which is allowed because the build phase of this frame is over. See
+      // also WidgetsBinding.drawFrame.
+      debugBuildingDirtyElements = false;
       buildOwner!.finalizeTree();
     } finally {
       debugBuildingDirtyElements = false;


### PR DESCRIPTION
A gesture recognizer resolves its gesture as rejected when it is disposed,
which invokes application callbacks such as GestureDetector.onTapCancel.
RawGestureDetectorState disposes its recognizers from State.dispose, so
removing a GestureDetector while a tap is in progress delivered onTapCancel
while the framework was unmounting the elements. Calling setState from there
threw "setState() or markNeedsBuild() called when widget tree was locked",
even when the widget being marked as dirty was a still mounted ancestor.

Elements are unmounted after the build, layout and paint phases of the frame
are over, so marking another, still active, element as dirty at that point is
harmless: it just has to be rebuilt during a subsequent frame. This change
therefore lifts the state lock while State.dispose runs, stops treating a
build scheduled while the elements are unmounted as a build scheduled during
the frame, and schedules a new frame for the elements that are marked as dirty
once the build phase of the current frame is over (previously that request was
dropped, because SchedulerBinding.ensureVisualUpdate does nothing while a
frame is being produced).

Marking the widget that is being disposed itself as needing to build remains
an error, reported by State.setState and by Element.markNeedsBuild.

Fixes https://github.com/flutter/flutter/issues/160508

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
