### PR TITLE
Honor ThemeData.hintColor for Material 3 hint text

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2206,7 +2206,28 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
             : themeData.textTheme.titleMedium!)
         .merge(widget.baseStyle)
         .merge(defaultStyle)
+        .merge(_getThemeHintColorStyle(themeData))
         .merge(style);
+  }
+
+  // ThemeData.hintColor is a Material 2 property, but it is still honored for
+  // Material 3 when it has been set by the application, for backward
+  // compatibility. It is ignored when the input is disabled because the
+  // disabled color takes precedence, as it does for Material 2.
+  //
+  // ThemeData always resolves hintColor to a non-null value, so the only way to
+  // know whether it has been set is to compare it with the value that the
+  // ThemeData constructor defaults to.
+  // See https://github.com/flutter/flutter/issues/153219.
+  TextStyle? _getThemeHintColorStyle(ThemeData themeData) {
+    if (!themeData.useMaterial3 || widgetState.contains(WidgetState.disabled)) {
+      return null;
+    }
+    final Color defaultHintColor = switch (themeData.brightness) {
+      Brightness.dark => Colors.white60,
+      Brightness.light => Colors.black.withOpacity(0.6),
+    };
+    return themeData.hintColor == defaultHintColor ? null : TextStyle(color: themeData.hintColor);
   }
 
   TextStyle _getFloatingLabelStyle(ThemeData themeData, InputDecorationThemeData defaults) {

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -5387,6 +5387,78 @@ void main() {
       );
       expect(getHintRect(tester).right, expectedHintRight);
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/153219.
+    group('ThemeData.hintColor', () {
+      testWidgets('is used when it is set', (WidgetTester tester) async {
+        const hintColor = Color(0xFFFF0000);
+        await tester.pumpWidget(
+          buildInputDecorator(
+            isEmpty: true,
+            theme: ThemeData(hintColor: hintColor),
+            decoration: const InputDecoration(hintText: hintText),
+          ),
+        );
+
+        expect(getHintStyle(tester).color, hintColor);
+      });
+
+      testWidgets('is used when it is set on a dark theme', (WidgetTester tester) async {
+        const hintColor = Color(0xFFFF0000);
+        await tester.pumpWidget(
+          buildInputDecorator(
+            isEmpty: true,
+            theme: ThemeData(brightness: Brightness.dark, hintColor: hintColor),
+            decoration: const InputDecoration(hintText: hintText),
+          ),
+        );
+
+        expect(getHintStyle(tester).color, hintColor);
+      });
+
+      testWidgets('is ignored when it is not set', (WidgetTester tester) async {
+        final theme = ThemeData();
+        await tester.pumpWidget(
+          buildInputDecorator(
+            isEmpty: true,
+            theme: theme,
+            decoration: const InputDecoration(hintText: hintText),
+          ),
+        );
+
+        expect(getHintStyle(tester).color, theme.colorScheme.onSurfaceVariant);
+      });
+
+      testWidgets('is ignored when the field is disabled', (WidgetTester tester) async {
+        const hintColor = Color(0xFFFF0000);
+        final theme = ThemeData(hintColor: hintColor);
+        await tester.pumpWidget(
+          buildInputDecorator(
+            isEmpty: true,
+            theme: theme,
+            decoration: const InputDecoration(enabled: false, hintText: hintText),
+          ),
+        );
+
+        expect(getHintStyle(tester).color, theme.colorScheme.onSurface.withOpacity(0.38));
+      });
+
+      testWidgets('is overridden by InputDecoration.hintStyle', (WidgetTester tester) async {
+        const hintStyleColor = Color(0xFF00FF00);
+        await tester.pumpWidget(
+          buildInputDecorator(
+            isEmpty: true,
+            theme: ThemeData(hintColor: const Color(0xFFFF0000)),
+            decoration: const InputDecoration(
+              hintText: hintText,
+              hintStyle: TextStyle(color: hintStyleColor),
+            ),
+          ),
+        );
+
+        expect(getHintStyle(tester).color, hintStyleColor);
+      });
+    });
   });
 
   group('Material3 - InputDecoration helper/counter/error', () {


### PR DESCRIPTION
Since https://github.com/flutter/flutter/pull/150278, InputDecorator uses the
Material 3 default hint color (ColorScheme.onSurfaceVariant) and ignores
ThemeData.hintColor. Apps that customized ThemeData.hintColor lost their hint
text color when they migrated to Flutter 3.24.

ThemeData resolves hintColor to a non-null default in its constructor, so the
only way to know whether an app has set it is to compare it with that default.
_InputDecoratorState now merges a TextStyle built from ThemeData.hintColor into
the inline hint style when the theme uses Material 3 and hintColor differs from
the ThemeData default. The Material 3 default is unchanged when hintColor is not
customized, the disabled color still takes precedence (as for Material 2), and
InputDecoration.hintStyle still overrides the theme.

Fixes https://github.com/flutter/flutter/issues/153219

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
