### PR TITLE
Repaint the transform when a skipped subtree becomes a repaint boundary

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3218,7 +3218,16 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
         return;
       }
 
-      if ((!_wasRepaintBoundary || !isRepaintBoundary) && !parent.isRepaintBoundary) {
+      // If this node is a repaint boundary and already was one when it was
+      // last painted, the parent's compositing state cannot be changed by this
+      // update - but only if the parent already knows that it needs
+      // compositing. The parent may still think that it does not need
+      // compositing if it skipped painting this node (e.g. because it is
+      // scaled to zero or fully transparent) while this node was not a repaint
+      // boundary, which leaves `_wasRepaintBoundary` stale. In that case the
+      // update must keep walking up the tree.
+      if ((!_wasRepaintBoundary || !isRepaintBoundary || !parent._needsCompositing) &&
+          !parent.isRepaintBoundary) {
         parent.markNeedsCompositingBitsUpdate();
         return;
       }

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -513,6 +513,62 @@ void main() {
     expect(caughtErrors, isNull);
   });
 
+  test('markNeedsCompositingBitsUpdate reaches ancestors that skipped painting this subtree', () {
+    // Regression test for https://github.com/flutter/flutter/issues/151735.
+    //
+    // A RenderTransform paints nothing when its matrix is singular, which
+    // leaves the `_wasRepaintBoundary` state of the RenderOpacity below it
+    // stale. The compositing bits update that happens when the opacity becomes
+    // visible again must therefore still reach the RenderTransform, so that it
+    // composites its child through a TransformLayer instead of applying the
+    // transform to a canvas that the child no longer paints into.
+    final child = RenderSizedBox(const Size(50.0, 50.0));
+    final opacity = RenderOpacity(opacity: 0.0, child: child);
+    final transform = RenderTransform(
+      transform: Matrix4.diagonal3Values(0.0, 0.0, 1.0),
+      alignment: Alignment.center,
+      child: opacity,
+    );
+
+    // The transform applied to the layer of `opacity` by all the layers between
+    // it and the layer of the render view (exclusive).
+    double scaleOfOpacityLayer() {
+      final ContainerLayer root = TestRenderingFlutterBinding.instance.renderView.debugLayer!;
+      final layers = <Layer>[opacity.debugLayer!];
+      for (ContainerLayer? ancestor = layers.last.parent; ancestor != root; ancestor = ancestor.parent) {
+        layers.add(ancestor!);
+      }
+      final result = Matrix4.identity();
+      for (int index = layers.length - 1; index > 0; index -= 1) {
+        (layers[index] as ContainerLayer).applyTransform(layers[index - 1], result);
+      }
+      return result.getMaxScaleOnAxis();
+    }
+
+    layout(transform, phase: EnginePhase.composite);
+
+    // Run the "animation" once: the scale and the opacity both become visible.
+    transform.transform = Matrix4.diagonal3Values(2.0, 2.0, 1.0);
+    opacity.opacity = 1.0;
+    pumpFrame(phase: EnginePhase.composite);
+    expect(transform.needsCompositing, isTrue);
+    expect(scaleOfOpacityLayer(), 2.0);
+
+    // Restart the "animation": the transform is singular again, so it paints
+    // nothing at all and the opacity below it is not painted either.
+    transform.transform = Matrix4.diagonal3Values(0.0, 0.0, 1.0);
+    opacity.opacity = 0.0;
+    pumpFrame(phase: EnginePhase.composite);
+    expect(transform.needsCompositing, isFalse);
+
+    // The second run of the "animation" must be scaled just like the first one.
+    transform.transform = Matrix4.diagonal3Values(2.0, 2.0, 1.0);
+    opacity.opacity = 1.0;
+    pumpFrame(phase: EnginePhase.composite);
+    expect(transform.needsCompositing, isTrue);
+    expect(scaleOfOpacityLayer(), 2.0);
+  });
+
   test('ContainerParentDataMixin asserts parentData type', () {
     final TestRenderObject renderObject = TestRenderObjectWithoutSetupParentData();
     final child = TestRenderObject();


### PR DESCRIPTION
A RenderObject that regains repaint boundary status short-circuits
markNeedsCompositingBitsUpdate when _wasRepaintBoundary is also true,
assuming its ancestors already need compositing. That flag is only
refreshed while the node is painted, so it stays stale whenever an
ancestor skips painting the subtree, for example a RenderTransform with
a singular matrix (Transform.scale(scale: 0)) or a fully transparent
RenderOpacity. The ancestors then keep needsCompositing == false and
apply their transform to a canvas the child no longer paints into: the
child's own layer is appended to the enclosing container layer instead,
so a repeated scale animation renders unscaled while opacity still
animates.

The update now keeps walking up the tree unless the parent is already
known to need compositing, which restores the invariant that an ancestor
of a repaint boundary composites its child through a layer.

Fixes https://github.com/flutter/flutter/issues/151735

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
