### PR TITLE
Fix focus trapped in a scope with no focusable descendants

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -595,7 +595,11 @@ abstract class FocusTraversalPolicy with Diagnosticable {
       final FocusNode? firstFocus = forward
           ? findFirstFocus(currentNode)
           : findLastFocus(currentNode);
-      if (firstFocus != null) {
+      // If the scope has nothing that can be focused, findFirstFocus/findLastFocus
+      // falls back to the current node, which would leave the focus where it is.
+      // Fall through instead, so that the traversal continues in the enclosing
+      // scope according to the edge behavior of this scope.
+      if (firstFocus != null && nearestScope.traversalDescendants.isNotEmpty) {
         return _requestTabTraversalFocus(
           firstFocus,
           alignmentPolicy: forward
@@ -607,6 +611,29 @@ abstract class FocusTraversalPolicy with Diagnosticable {
     }
     focusedChild ??= nearestScope;
     final List<FocusNode> sortedNodes = _sortAllDescendants(nearestScope, focusedChild);
+    if (sortedNodes.isEmpty) {
+      // There is nothing to move the focus to in this scope, so the focus would
+      // be trapped here. This happens, for instance, when a nested Navigator
+      // shows a route that has no focusable widget in it: the route scope takes
+      // the focus, but the traversal can never leave it.
+      switch (nearestScope.traversalEdgeBehavior) {
+        case TraversalEdgeBehavior.parentScope:
+          final FocusScopeNode? parentScope = nearestScope.enclosingScope;
+          if (parentScope != null && parentScope != FocusManager.instance.rootScope) {
+            // The empty scope is deliberately not unfocused here, because the
+            // parent scope needs it as its focused child to know where the
+            // traversal left off.
+            return forward ? parentScope.nextFocus() : parentScope.previousFocus();
+          }
+          return false;
+        case TraversalEdgeBehavior.leaveFlutterView:
+          focusedChild.unfocus();
+          return false;
+        case TraversalEdgeBehavior.closedLoop:
+        case TraversalEdgeBehavior.stop:
+          return false;
+      }
+    }
     assert(sortedNodes.contains(focusedChild));
 
     if (forward && focusedChild == sortedNodes.last) {

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -638,6 +638,65 @@ void main() {
     expect(node3.hasFocus, isFalse);
   });
 
+  testWidgets('Nested navigator with no focusable widget does not trap focus', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/151061.
+    final node1 = FocusNode();
+    addTearDown(node1.dispose);
+    final node2 = FocusNode();
+    addTearDown(node2.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: FocusTraversalGroup(
+          policy: ReadingOrderTraversalPolicy(),
+          child: FocusScope(
+            child: Column(
+              children: <Widget>[
+                Focus(focusNode: node1, child: const SizedBox.square(dimension: 100.0)),
+                SizedBox.square(
+                  dimension: 100.0,
+                  child: Navigator(
+                    pages: const <Page<void>>[
+                      TestPage<void>(child: SizedBox.square(dimension: 100.0)),
+                    ],
+                    onPopPage: (_, _) => false,
+                  ),
+                ),
+                Focus(focusNode: node2, child: const SizedBox.square(dimension: 100.0)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // The route of the nested navigator takes the focus when it is pushed, even
+    // though it has no focusable widget in it.
+    expect(primaryFocus, isA<FocusScopeNode>());
+    expect(node1.hasFocus, isFalse);
+    expect(node2.hasFocus, isFalse);
+
+    // Moving forward from the empty route continues in the enclosing scope.
+    primaryFocus!.nextFocus();
+    await tester.pump();
+    expect(node1.hasFocus, isFalse);
+    expect(node2.hasPrimaryFocus, isTrue);
+
+    node2.previousFocus();
+    await tester.pump();
+    expect(node1.hasFocus, isFalse);
+    expect(node2.hasFocus, isFalse);
+
+    // Moving backwards from the empty route continues in the enclosing scope.
+    primaryFocus!.previousFocus();
+    await tester.pump();
+    expect(node1.hasPrimaryFocus, isTrue);
+    expect(node2.hasFocus, isFalse);
+  });
+
   group(ReadingOrderTraversalPolicy, () {
     testWidgets('Find the initial focus if there is none yet.', (WidgetTester tester) async {
       final GlobalKey key1 = GlobalKey(debugLabel: '1');


### PR DESCRIPTION
FocusTraversalPolicy._moveFocus returned early when the nearest scope had no
focused child, because findFirstFocus/findLastFocus falls back to the current
node when the scope has nothing that can be focused. The focus therefore never
left that scope. This happens with a nested Navigator whose route has no
focusable widget (for example a Scaffold with an empty AppBar): the route scope
takes the primary focus when the route is pushed, and pressing Tab afterwards
did nothing at all.

The traversal now detects that the nearest scope has no traversable descendant
and applies the traversal edge behavior of that scope, which by default hands
the traversal over to the enclosing scope, so the focus can leave the empty
route.

Fixes https://github.com/flutter/flutter/issues/151061

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
