### PR TITLE
Fix NaN crash in FixedExtentScrollPhysics ballistics

### DIFF
--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -513,16 +513,23 @@ class FixedExtentScrollPhysics extends ScrollPhysics {
     // If it was going to end up past the scroll extent, defer back to the
     // parent physics' ballistics again which should put us on the scrollable's
     // boundary.
-    if (testFrictionSimulation != null &&
-        (testFrictionSimulation.x(double.infinity) == metrics.minScrollExtent ||
-            testFrictionSimulation.x(double.infinity) == metrics.maxScrollExtent)) {
+    //
+    // A non-finite natural end position means the parent simulation springs
+    // back to one of the boundaries but never mathematically settles on it (for
+    // instance a critically damped or an underdamped spring), so it belongs to
+    // this scenario as well.
+    final double? naturalEndPosition = testFrictionSimulation?.x(double.infinity);
+    if (naturalEndPosition != null &&
+        (!naturalEndPosition.isFinite ||
+            naturalEndPosition == metrics.minScrollExtent ||
+            naturalEndPosition == metrics.maxScrollExtent)) {
       return super.createBallisticSimulation(metrics, velocity);
     }
 
     // From the natural final position, find the nearest item it should have
     // settled to.
     final int settlingItemIndex = _getItemFromOffset(
-      offset: testFrictionSimulation?.x(double.infinity) ?? metrics.pixels,
+      offset: naturalEndPosition ?? metrics.pixels,
       itemExtent: metrics.itemExtent,
       minScrollExtent: metrics.minScrollExtent,
       maxScrollExtent: metrics.maxScrollExtent,

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -1639,6 +1639,40 @@ void main() {
       expect(scrolledPositions.last, moreOrLessEquals(40 * 1000.0, epsilon: 0.2));
     });
 
+    testWidgets('does not throw when the parent physics uses a critically damped spring', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/149657.
+      final controller = FixedExtentScrollController(initialItem: 95);
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListWheelScrollView(
+            controller: controller,
+            physics: const FixedExtentScrollPhysics(
+              parent: _CriticallyDampedBouncingScrollPhysics(),
+            ),
+            itemExtent: 100.0,
+            children: List<Widget>.generate(100, (int index) {
+              return const Placeholder();
+            }),
+          ),
+        ),
+      );
+
+      // Fling hard enough towards the end of the list that the parent
+      // ballistic simulation overshoots maxScrollExtent and has to spring
+      // back to it.
+      await tester.fling(find.byType(ListWheelScrollView), const Offset(0.0, -300.0), 5000.0);
+      expect(tester.takeException(), isNull);
+
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(controller.selectedItem, 99);
+    });
+
     testWidgets(
       'high fling velocities lands exactly on items',
       (WidgetTester tester) async {
@@ -2061,4 +2095,20 @@ void main() {
       expect(tester.getSize(find.byType(ListWheelViewport)), Size.zero);
     },
   );
+}
+
+/// A [BouncingScrollPhysics] whose spring is exactly critically damped, so that
+/// its [SpringSimulation] never mathematically settles in finite time.
+class _CriticallyDampedBouncingScrollPhysics extends BouncingScrollPhysics {
+  const _CriticallyDampedBouncingScrollPhysics({super.parent});
+
+  @override
+  _CriticallyDampedBouncingScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return _CriticallyDampedBouncingScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  SpringDescription get spring =>
+      // `withDampingRatio` defaults to a ratio of 1.0, i.e. critical damping.
+      SpringDescription.withDampingRatio(mass: 0.4, stiffness: 75.0);
 }


### PR DESCRIPTION
FixedExtentScrollPhysics asks the parent physics for a test ballistic
simulation and uses `simulation.x(double.infinity)` as the natural
resting position of the fling, then rounds that offset to the nearest
item.

When the parent is a BouncingScrollPhysics whose spring is critically
damped or underdamped, and the fling overshoots the scroll extent, the
BouncingScrollSimulation hands over to a SpringSimulation whose
`x(double.infinity)` evaluates to NaN (`(c1 + c2 * t) * e^(r * t)` and
`e^(r * t) * (c1 * cos(w * t) + c2 * sin(w * t))` are both `0 * infinity`
at `t == infinity`). The NaN offset then reached `double.round()` and
threw `Unsupported operation: Infinity or NaN toInt` from inside the drag
end handler, which also left ScrollableState._drag dangling and made the
next drag fail the `'_drag == null': is not true` assertion.

Such a simulation always springs back to minScrollExtent or
maxScrollExtent, which is exactly the case that is already deferred to
the parent physics, so a non-finite natural end position is now handled
by that same branch.

Fixes https://github.com/flutter/flutter/issues/149657

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
