### PR TITLE
Fix pinned slivers inside SliverCrossAxisGroup being covered

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -40,7 +40,20 @@ class RenderSliverCrossAxisGroup extends RenderSliver
   }
 
   @override
-  double childMainAxisPosition(RenderSliver child) => 0.0;
+  double childMainAxisPosition(RenderSliver child) {
+    final childParentData = child.parentData! as SliverPhysicalParentData;
+    return switch (applyGrowthDirectionToAxisDirection(
+      constraints.axisDirection,
+      constraints.growthDirection,
+    )) {
+      AxisDirection.down => childParentData.paintOffset.dy,
+      AxisDirection.right => childParentData.paintOffset.dx,
+      AxisDirection.up =>
+        geometry!.paintExtent - child.geometry!.paintExtent - childParentData.paintOffset.dy,
+      AxisDirection.left =>
+        geometry!.paintExtent - child.geometry!.paintExtent - childParentData.paintOffset.dx,
+    };
+  }
 
   @override
   double childCrossAxisPosition(RenderSliver child) {
@@ -112,17 +125,34 @@ class RenderSliverCrossAxisGroup extends RenderSliver
     while (child != null) {
       final childParentData = child.parentData! as SliverPhysicalParentData;
       final SliverGeometry childLayoutGeometry = child.geometry!;
-      final double remainingExtent = geometry!.scrollExtent - constraints.scrollOffset;
-      final double paintCorrection = childLayoutGeometry.paintExtent > remainingExtent
-          ? childLayoutGeometry.paintExtent - remainingExtent
+      // A child such as a pinned SliverPersistentHeader moves itself away from
+      // the leading edge of this group by its paint origin, so that it is not
+      // covered by the preceding pinned slivers (SliverConstraints.overlap).
+      // The paint origin of the group itself is already applied by the parent,
+      // so only the difference has to be accounted for here.
+      final double childPaintOrigin = childLayoutGeometry.paintOrigin - geometry!.paintOrigin;
+      final double childPaintEnd = childPaintOrigin + childLayoutGeometry.paintExtent;
+      final double paintCorrection = childPaintEnd > geometry!.paintExtent
+          ? childPaintEnd - geometry!.paintExtent
           : 0.0;
       final double childExtent =
           child.geometry!.crossAxisExtent ??
           extentPerFlexValue * (childParentData.crossAxisFlex ?? 0);
+      // The offset of the child from the leading edge of this group, along the
+      // main axis and in the growth direction.
+      final double mainAxisOffset = childPaintOrigin - paintCorrection;
+      final double mainAxisPaintOffset = switch (applyGrowthDirectionToAxisDirection(
+        constraints.axisDirection,
+        constraints.growthDirection,
+      )) {
+        AxisDirection.down || AxisDirection.right => mainAxisOffset,
+        AxisDirection.up || AxisDirection.left =>
+          geometry!.paintExtent - childLayoutGeometry.paintExtent - mainAxisOffset,
+      };
       // Set child parent data.
       childParentData.paintOffset = switch (constraints.axis) {
-        Axis.vertical => Offset(offset, -paintCorrection),
-        Axis.horizontal => Offset(-paintCorrection, offset),
+        Axis.vertical => Offset(offset, mainAxisPaintOffset),
+        Axis.horizontal => Offset(mainAxisPaintOffset, offset),
       };
       offset += childExtent;
       child = childAfter(child);

--- a/packages/flutter/test/widgets/sliver_cross_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_cross_axis_group_test.dart
@@ -715,6 +715,126 @@ void main() {
     expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(-20.0));
   });
 
+  testWidgets(
+    'Pinned SliverPersistentHeader in SliverCrossAxisGroup is not covered by a preceding pinned sliver',
+    (WidgetTester tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      var tapCount = 0;
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              height: VIEWPORT_HEIGHT,
+              width: VIEWPORT_WIDTH,
+              child: CustomScrollView(
+                controller: controller,
+                slivers: <Widget>[
+                  SliverPersistentHeader(
+                    delegate: TestDelegate(minExtent: 50.0, maxExtent: 50.0),
+                    pinned: true,
+                  ),
+                  SliverCrossAxisGroup(
+                    slivers: <Widget>[
+                      SliverPersistentHeader(
+                        delegate: TestDelegate(
+                          minExtent: 30.0,
+                          maxExtent: 30.0,
+                          onTap: () => tapCount += 1,
+                        ),
+                        pinned: true,
+                      ),
+                      const SliverToBoxAdapter(child: SizedBox(height: 2400)),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      controller.jumpTo(500.0);
+      await tester.pumpAndSettle();
+
+      final List<RenderSliverPersistentHeader> headers = tester
+          .renderObjectList<RenderSliverPersistentHeader>(find.byType(SliverPersistentHeader))
+          .toList();
+      final RenderSliverPersistentHeader header = headers.last;
+      // The preceding pinned sliver takes up 50.0 of overlap, so the pinned
+      // header inside the group has to be painted below it.
+      expect(header.geometry!.paintOrigin, equals(50.0));
+      expect(header.geometry!.paintExtent, equals(30.0));
+      expect((header.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(50.0));
+      expect(tester.getTopLeft(find.byType(Container).last).dy, equals(50.0));
+
+      // The header is hit testable where it is painted, and not where the
+      // preceding pinned sliver is painted.
+      await tester.tapAt(const Offset(50.0, 60.0));
+      await tester.pump();
+      expect(tapCount, equals(1));
+      await tester.tapAt(const Offset(50.0, 20.0));
+      await tester.pump();
+      expect(tapCount, equals(1));
+    },
+  );
+
+  testWidgets(
+    'Pinned SliverPersistentHeader in SliverCrossAxisGroup is not covered by a preceding pinned sliver when reversed',
+    (WidgetTester tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              height: VIEWPORT_HEIGHT,
+              width: VIEWPORT_WIDTH,
+              child: CustomScrollView(
+                controller: controller,
+                reverse: true,
+                slivers: <Widget>[
+                  SliverPersistentHeader(
+                    delegate: TestDelegate(minExtent: 50.0, maxExtent: 50.0),
+                    pinned: true,
+                  ),
+                  SliverCrossAxisGroup(
+                    slivers: <Widget>[
+                      SliverPersistentHeader(
+                        delegate: TestDelegate(minExtent: 30.0, maxExtent: 30.0),
+                        pinned: true,
+                      ),
+                      const SliverToBoxAdapter(child: SizedBox(height: 2400)),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      controller.jumpTo(500.0);
+      await tester.pumpAndSettle();
+
+      final List<RenderSliverPersistentHeader> headers = tester
+          .renderObjectList<RenderSliverPersistentHeader>(find.byType(SliverPersistentHeader))
+          .toList();
+      final RenderSliverPersistentHeader header = headers.last;
+      expect(header.geometry!.paintOrigin, equals(50.0));
+      // The pinned sliver is pinned to the bottom of the viewport, so the
+      // header inside the group sits right above it.
+      expect(
+        (header.parentData! as SliverPhysicalParentData).paintOffset.dy,
+        equals(VIEWPORT_HEIGHT - 50.0 - 30.0),
+      );
+      expect(
+        tester.getTopLeft(find.byType(Container).last).dy,
+        equals(VIEWPORT_HEIGHT - 50.0 - 30.0),
+      );
+    },
+  );
+
   testWidgets('SliverFloatingPersistentHeader is painted within bounds of SliverCrossAxisGroup', (
     WidgetTester tester,
   ) async {
@@ -1212,7 +1332,7 @@ Widget _buildSliverCrossAxisGroup({
 }
 
 class TestDelegate extends SliverPersistentHeaderDelegate {
-  TestDelegate({this.maxExtent = 60.0, this.minExtent = 60.0});
+  TestDelegate({this.maxExtent = 60.0, this.minExtent = 60.0, this.onTap});
 
   @override
   final double maxExtent;
@@ -1220,9 +1340,15 @@ class TestDelegate extends SliverPersistentHeaderDelegate {
   @override
   final double minExtent;
 
+  final VoidCallback? onTap;
+
   @override
   Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
-    return Container(height: maxExtent);
+    final Widget child = Container(height: maxExtent);
+    if (onTap == null) {
+      return child;
+    }
+    return GestureDetector(behavior: HitTestBehavior.opaque, onTap: onTap, child: child);
   }
 
   @override


### PR DESCRIPTION
RenderSliverCrossAxisGroup positioned its children only by the cross axis
offset and ignored SliverGeometry.paintOrigin. A child such as a pinned
SliverPersistentHeader moves itself past the preceding pinned slivers by
setting its paint origin to SliverConstraints.overlap, so the group painted
it underneath the pinned SliverAppBar instead of below it, which made the
header look like it was not pinned at all. Hit testing had the same problem
because childMainAxisPosition always returned 0.0.

The group now offsets each child along the main axis by its paint origin
(relative to the paint origin of the group itself, which the parent already
applies), clamps that offset so the child still paints within the paint
extent of the group, and reports the resulting main axis position for hit
testing. The offset is mirrored for reversed axis directions, the same way
RenderSliverMainAxisGroup does it.

Fixes https://github.com/flutter/flutter/issues/147704

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
