### PR TITLE
Announce PopupMenuButton with a child as a button

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1761,16 +1761,26 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
       );
       final MaterialTapTargetSize tapTargetSize =
           widget.style?.tapTargetSize ?? MaterialTapTargetSize.shrinkWrap;
+      var result = child;
       if (tapTargetSize == MaterialTapTargetSize.padded) {
-        return ConstrainedBox(
+        result = ConstrainedBox(
           constraints: const BoxConstraints(
             minWidth: kMinInteractiveDimension,
             minHeight: kMinInteractiveDimension,
           ),
-          child: child,
+          child: result,
         );
       }
-      return Semantics(expanded: _isMenuExpanded, child: child);
+      // The button semantics are added here rather than by the [InkWell] so
+      // that assistive technologies describe the popup menu button the same way
+      // regardless of whether it is built from [child] or from [icon], in which
+      // case the semantics come from the [IconButton].
+      return Semantics(
+        button: true,
+        enabled: widget.enabled,
+        expanded: _isMenuExpanded,
+        child: result,
+      );
     }
 
     return Semantics(

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -1408,8 +1408,12 @@ void main() {
     expect(
       tester.getSemantics(find.byType(PopupMenuButton<int>)),
       matchesSemantics(
+        isButton: true,
+        hasEnabledState: true,
+        isEnabled: true,
         hasExpandedState: true,
         label: 'XXX',
+        tooltip: 'Show menu',
         hasTapAction: true,
         hasFocusAction: true,
         isFocusable: true,
@@ -1441,8 +1445,107 @@ void main() {
     expect(
       tester.getSemantics(find.byType(PopupMenuButton<int>)),
       matchesSemantics(
+        isButton: true,
+        hasEnabledState: true,
+        isEnabled: true,
         hasExpandedState: true,
         label: 'XXX',
+        tooltip: 'Show menu',
+        hasTapAction: true,
+        hasFocusAction: true,
+        isFocusable: true,
+      ),
+    );
+  });
+
+  testWidgets('PopupMenuButton with a child has button semantics', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/147043
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: PopupMenuButton<int>(
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuItem<int>>[const PopupMenuItem<int>(value: 1, child: Text('Item 1'))];
+            },
+            child: const Text('XXX'),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getSemantics(find.byType(PopupMenuButton<int>)),
+      matchesSemantics(
+        isButton: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        hasExpandedState: true,
+        label: 'XXX',
+        tooltip: 'Show menu',
+        hasTapAction: true,
+        hasFocusAction: true,
+        isFocusable: true,
+      ),
+    );
+  });
+
+  testWidgets('Disabled PopupMenuButton with a child has button semantics', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/147043
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: PopupMenuButton<int>(
+            enabled: false,
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuItem<int>>[const PopupMenuItem<int>(value: 1, child: Text('Item 1'))];
+            },
+            child: const Text('XXX'),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getSemantics(find.byType(PopupMenuButton<int>)),
+      matchesSemantics(
+        isButton: true,
+        hasEnabledState: true,
+        hasExpandedState: true,
+        label: 'XXX',
+        tooltip: 'Show menu',
+      ),
+    );
+  });
+
+  testWidgets('PopupMenuButton with a padded tap target has button semantics', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/147043
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: PopupMenuButton<int>(
+            style: const ButtonStyle(tapTargetSize: MaterialTapTargetSize.padded),
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuItem<int>>[const PopupMenuItem<int>(value: 1, child: Text('Item 1'))];
+            },
+            child: const Text('XXX'),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getSemantics(find.byType(PopupMenuButton<int>)),
+      matchesSemantics(
+        isButton: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        hasExpandedState: true,
+        label: 'XXX',
+        tooltip: 'Show menu',
         hasTapAction: true,
         hasFocusAction: true,
         isFocusable: true,


### PR DESCRIPTION
PopupMenuButton only exposed button semantics when it built its own
IconButton. When a `child` was supplied, the widget just wrapped the
child in a Tooltip and an InkWell, so the semantics node had a tap
action but no button flag and no enabled state. Assistive technologies
therefore did not announce it as a button, and disabled buttons looked
enabled. The `expanded` state was also dropped entirely when
`ButtonStyle.tapTargetSize` was `MaterialTapTargetSize.padded`, because
that branch returned early before the `Semantics` wrapper was added.

The `child` branch now always wraps the result in a single `Semantics`
widget that marks the popup menu button as a button, reports the enabled
state and keeps the expanded state, for both tap target sizes.

Fixes https://github.com/flutter/flutter/issues/147043

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md
