### PR TITLE
[Windows] Don't set message callbacks after the engine is destroyed

### DIFF
--- a/engine/src/flutter/shell/platform/common/client_wrapper/core_implementations.cc
+++ b/engine/src/flutter/shell/platform/common/client_wrapper/core_implementations.cc
@@ -130,6 +130,7 @@ void BinaryMessengerImpl::SetMessageHandler(const std::string& channel,
     return;
   }
   if (!engine_available) {
+    handlers_.erase(channel);
     return;
   }
   // Save the handler, to keep it alive.

--- a/engine/src/flutter/shell/platform/common/client_wrapper/core_implementations.cc
+++ b/engine/src/flutter/shell/platform/common/client_wrapper/core_implementations.cc
@@ -115,10 +115,21 @@ void BinaryMessengerImpl::Send(const std::string& channel,
 
 void BinaryMessengerImpl::SetMessageHandler(const std::string& channel,
                                             BinaryMessageHandler handler) {
+  // Setting a callback requires a running engine, so there is nothing to
+  // register or unregister once the engine is gone. Handlers are commonly
+  // cleared from plugin destructors, which run while the engine is being torn
+  // down, so this is a normal call rather than a client error.
+  const bool engine_available =
+      FlutterDesktopMessengerIsAvailable(messenger_);
   if (!handler) {
     handlers_.erase(channel);
-    FlutterDesktopMessengerSetCallback(messenger_, channel.c_str(), nullptr,
-                                       nullptr);
+    if (engine_available) {
+      FlutterDesktopMessengerSetCallback(messenger_, channel.c_str(), nullptr,
+                                         nullptr);
+    }
+    return;
+  }
+  if (!engine_available) {
     return;
   }
   // Save the handler, to keep it alive.

--- a/engine/src/flutter/shell/platform/common/client_wrapper/plugin_registrar_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/client_wrapper/plugin_registrar_unittests.cc
@@ -40,9 +40,15 @@ class TestApi : public testing::StubFlutterApi {
     last_message_callback_set_ = callback;
   }
 
+  bool MessengerIsAvailable() override { return messenger_available_; }
+
   void PluginRegistrarSetDestructionHandler(
       FlutterDesktopOnPluginRegistrarDestroyed callback) override {
     last_destruction_callback_set_ = callback;
+  }
+
+  void set_messenger_available(bool available) {
+    messenger_available_ = available;
   }
 
   const uint8_t* last_data_sent() { return last_data_sent_; }
@@ -54,6 +60,7 @@ class TestApi : public testing::StubFlutterApi {
   }
 
  private:
+  bool messenger_available_ = true;
   const uint8_t* last_data_sent_ = nullptr;
   FlutterDesktopMessageCallback last_message_callback_set_ = nullptr;
   FlutterDesktopOnPluginRegistrarDestroyed last_destruction_callback_set_ =
@@ -153,6 +160,32 @@ TEST(PluginRegistrarTest, MessengerSetMessageHandler) {
   // Unregister.
   messenger->SetMessageHandler(channel_name, nullptr);
   EXPECT_EQ(test_api->last_message_callback_set(), nullptr);
+}
+
+// Tests that a messenger doesn't call into the C API to unregister a handler
+// once the engine is gone, since setting a callback requires a running engine.
+// Handlers are commonly cleared from plugin destructors, which run while the
+// engine is being torn down.
+TEST(PluginRegistrarTest, MessengerSetMessageHandlerWithoutEngine) {
+  testing::ScopedStubFlutterApi scoped_api_stub(std::make_unique<TestApi>());
+  auto test_api = static_cast<TestApi*>(scoped_api_stub.stub());
+
+  auto dummy_registrar_handle =
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1);
+  PluginRegistrar registrar(dummy_registrar_handle);
+  BinaryMessenger* messenger = registrar.messenger();
+  const std::string channel_name("foo");
+
+  BinaryMessageHandler binary_handler = [](const uint8_t* message,
+                                           const size_t message_size,
+                                           const BinaryReply& reply) {};
+  messenger->SetMessageHandler(channel_name, std::move(binary_handler));
+  ASSERT_NE(test_api->last_message_callback_set(), nullptr);
+
+  // The engine is gone; clearing the handler must not reach the C API.
+  test_api->set_messenger_available(false);
+  messenger->SetMessageHandler(channel_name, nullptr);
+  EXPECT_NE(test_api->last_message_callback_set(), nullptr);
 }
 
 // Tests that the registrar manager returns the same instance when getting

--- a/engine/src/flutter/shell/platform/common/client_wrapper/testing/stub_flutter_api.cc
+++ b/engine/src/flutter/shell/platform/common/client_wrapper/testing/stub_flutter_api.cc
@@ -106,8 +106,10 @@ void FlutterDesktopMessengerRelease(FlutterDesktopMessengerRef messenger) {
 }
 
 bool FlutterDesktopMessengerIsAvailable(FlutterDesktopMessengerRef messenger) {
-  assert(false);  // not implemented
-  return false;
+  if (s_stub_implementation) {
+    return s_stub_implementation->MessengerIsAvailable();
+  }
+  return true;
 }
 
 FlutterDesktopMessengerRef FlutterDesktopMessengerLock(

--- a/engine/src/flutter/shell/platform/common/client_wrapper/testing/stub_flutter_api.h
+++ b/engine/src/flutter/shell/platform/common/client_wrapper/testing/stub_flutter_api.h
@@ -65,6 +65,9 @@ class StubFlutterApi {
                                     FlutterDesktopMessageCallback callback,
                                     void* user_data) {}
 
+  // Called for FlutterDesktopMessengerIsAvailable.
+  virtual bool MessengerIsAvailable() { return true; }
+
   // Called for FlutterDesktopTextureRegistrarRegisterExternalTexture.
   virtual int64_t TextureRegistrarRegisterExternalTexture(
       const FlutterDesktopTextureInfo* info) {


### PR DESCRIPTION
`BinaryMessengerImpl::SetMessageHandler` calls `FlutterDesktopMessengerSetCallback` unconditionally, but that API requires a running engine — the Windows implementation states the precondition explicitly:

```cpp
void FlutterDesktopMessengerSetCallback(FlutterDesktopMessengerRef messenger, ...) {
  FML_DCHECK(FlutterDesktopMessengerIsAvailable(messenger))
      << "Messenger must reference a running engine to set a callback";
```

Clearing a handler after the engine is gone is not a client error, though: plugins commonly own channels and clear their handlers from their destructors, and plugin destructors run while the engine is being torn down. In a release build (no `DCHECK`) the call reaches the destroyed engine and dereferences it.

On Windows this crashes the process on exit for an app whose plugins clear handlers in their destructors. From a minidump of such a shutdown — an access violation reading `0x1e8` inside `flutter_windows.dll`, which then escapes the window procedure and is reported as `0xc000041d`:

```
flutter::BinaryMessengerImpl::SetMessageHandler
  <- ~EventChannelProxyImpl        (channel_->SetStreamHandler(nullptr))
  <- ~PluginBase
  <- ~Plugin
  <- std::default_delete<flutter::Plugin>    (PluginRegistrar tearing down plugins)
```

The reply handler in `ForwardToHandler` already handles the same situation ("Drop reply if it comes in after the engine is destroyed") by checking `FlutterDesktopMessengerIsAvailable`. This applies the same check to `SetMessageHandler`, for both the register and unregister paths, so a handler that outlives the engine is dropped instead of reaching a destroyed engine.

Verified on Windows: with the plugin left unchanged — still clearing its handler from its destructor — applying only this guard stops the crash on exit, and removing the guard brings it back.

`FlutterDesktopMessengerIsAvailable` was `assert(false); // not implemented` in the client-wrapper test stub, so the stub now delegates to `StubFlutterApi` (defaulting to available), which lets the wrapper tests exercise the new path.

## Tests

- Adds `PluginRegistrarTest.MessengerSetMessageHandlerWithoutEngine`: clearing a handler while the messenger reports unavailable must not call into the C API.
- Existing `client_wrapper` tests continue to cover the normal register/unregister paths through the same stub.

## Notes

- No issue is filed for this; happy to open one if that is preferred.
- The same missing check applies to `BinaryMessengerImpl::Send`. I left it out to keep this change reviewable, since dropping outgoing messages silently deserves its own discussion.
