### PR TITLE
Use the value getter instead of the cached field in FormFieldState

### DIFF
--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -674,7 +674,7 @@ class FormFieldState<T> extends State<FormField<T>> with RestorationMixin {
   ///  * [validate], which may update [errorText] and [hasError].
   ///
   ///  * [FormField.forceErrorText], which also may update [errorText] and [hasError].
-  bool get isValid => widget.forceErrorText == null && widget.validator?.call(_value) == null;
+  bool get isValid => widget.forceErrorText == null && widget.validator?.call(value) == null;
 
   /// Calls the [FormField]'s onSaved method with the current value.
   void save() {
@@ -734,7 +734,7 @@ class FormFieldState<T> extends State<FormField<T>> with RestorationMixin {
       return;
     }
     if (widget.validator != null) {
-      _errorText.value = widget.validator!(_value);
+      _errorText.value = widget.validator!(value);
     } else {
       _errorText.value = null;
     }


### PR DESCRIPTION
FormFieldState.isValid and FormFieldState.validate() read the validator's
input from the private _value field, bypassing any override of the value
getter. A FormField subclass that overrides value to read from an external
source of truth (for example a TextEditingController) could therefore have
its validator called with a stale cached value instead of the current one,
notably when validation runs before the subclass's own listener has had a
chance to call didChange().

isValid and validate() now read through the value getter like the rest of
FormFieldState already does, so overrides are respected.

Split out of flutter/flutter#191658, which also updated TextFormField and
CupertinoTextFormFieldRow to override value — those are Material/Cupertino
changes blocked by the code freeze (see #188444) and are ported separately
to flutter/packages.