### PR TITLE
Ignore unattached focus nodes during focus traversal

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -726,11 +726,20 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
 
   /// Returns all descendants which do not have the [skipTraversal] and do have
   /// the [canRequestFocus] flag set.
+  ///
+  /// Descendants that are not attached to the widget tree (i.e. whose [context]
+  /// is null) are also excluded, because focus traversal needs their geometry
+  /// in order to decide where to move the focus. A node can be part of the
+  /// focus tree without being attached to a widget when focus is requested for
+  /// a node that no widget owns, e.g.
+  /// `FocusScope.of(context).requestFocus(FocusNode())`.
   Iterable<FocusNode> get traversalDescendants {
     if (!descendantsAreFocusable) {
       return const Iterable<FocusNode>.empty();
     }
-    return descendants.where((FocusNode node) => !node.skipTraversal && node.canRequestFocus);
+    return descendants.where(
+      (FocusNode node) => !node.skipTraversal && node.canRequestFocus && node.context != null,
+    );
   }
 
   /// An [Iterable] over the ancestors of this node.

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -155,6 +155,20 @@ enum TraversalEdgeBehavior {
   stop,
 }
 
+// Returns the [FocusScopeNode.focusedChild] of `scope`, or null when that node
+// cannot take part in focus traversal because it is not attached to the widget
+// tree.
+//
+// Focus can be requested for a [FocusNode] that no widget owns, for instance
+// with `FocusScope.of(context).requestFocus(FocusNode())`. That adds the node
+// to the focus tree even though it has no context, and therefore no geometry
+// for the traversal policies to work with, so traversal has to start over from
+// the beginning of the scope instead.
+FocusNode? _traversableFocusedChild(FocusScopeNode scope) {
+  final FocusNode? focusedChild = scope.focusedChild;
+  return focusedChild?.context == null ? null : focusedChild;
+}
+
 /// Determines how focusable widgets are traversed within a [FocusTraversalGroup].
 ///
 /// The focus traversal policy is what determines which widget is "next",
@@ -234,12 +248,13 @@ abstract class FocusTraversalPolicy with Diagnosticable {
     required bool forward,
   }) {
     if (node is FocusScopeNode) {
-      if (node.focusedChild != null) {
+      final FocusNode? focusedChild = _traversableFocusedChild(node);
+      if (focusedChild != null) {
         // Can't stop here as the `focusedChild` may be a focus scope node
         // without a first focus. The first focus will be picked in the
         // next iteration.
         return _requestTabTraversalFocus(
-          node.focusedChild!,
+          focusedChild,
           alignmentPolicy: alignmentPolicy,
           alignment: alignment,
           duration: duration,
@@ -330,7 +345,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
     bool ignoreCurrentFocus = false,
   }) {
     final FocusScopeNode scope = currentNode.nearestScope!;
-    FocusNode? candidate = scope.focusedChild;
+    FocusNode? candidate = _traversableFocusedChild(scope);
     if (ignoreCurrentFocus || candidate == null && scope.descendants.isNotEmpty) {
       final Iterable<FocusNode> sorted = _sortAllDescendants(
         scope,
@@ -435,7 +450,9 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants, FocusNode currentNode);
 
   static bool _canRequestTraversalFocus(FocusNode node) {
-    return node.canRequestFocus && !node.skipTraversal;
+    // A node that is not attached to the widget tree has no geometry, so the
+    // traversal policies can neither sort it nor move the focus to it.
+    return node.canRequestFocus && !node.skipTraversal && node.context != null;
   }
 
   static Iterable<FocusNode> _getDescendantsWithoutExpandingScope(FocusNode node) {
@@ -485,7 +502,8 @@ abstract class FocusTraversalPolicy with Diagnosticable {
       //
       // Current focused node needs to be in the group so that the caller can
       // find the next traversable node from the current focused node.
-      if (node == currentNode || (node.canRequestFocus && !node.skipTraversal)) {
+      if (node.context != null &&
+          (node == currentNode || (node.canRequestFocus && !node.skipTraversal))) {
         groups[groupNode] ??= _FocusTraversalGroupInfo(
           groupNode,
           members: <FocusNode>[],
@@ -590,7 +608,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   bool _moveFocus(FocusNode currentNode, {required bool forward}) {
     final FocusScopeNode nearestScope = currentNode.nearestScope!;
     invalidateScopeData(nearestScope);
-    FocusNode? focusedChild = nearestScope.focusedChild;
+    FocusNode? focusedChild = _traversableFocusedChild(nearestScope);
     if (focusedChild == null) {
       final FocusNode? firstFocus = forward
           ? findFirstFocus(currentNode)
@@ -1218,10 +1236,11 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     _FocusTraversalGroupNode? groupNode,
   ) {
     if (node is FocusScopeNode) {
-      if (node.focusedChild != null) {
+      final FocusNode? focusedChild = _traversableFocusedChild(node);
+      if (focusedChild != null) {
         return _requestTraversalFocusInDirection(
           currentNode,
-          node.focusedChild!,
+          focusedChild,
           node,
           direction,
           groupNode,
@@ -1369,7 +1388,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
   bool inDirection(FocusNode currentNode, TraversalDirection direction) {
     final _FocusTraversalGroupNode? groupNode = FocusTraversalGroup._getGroupNode(currentNode);
     final FocusScopeNode nearestScope = currentNode.nearestScope!;
-    final FocusNode? focusedChild = nearestScope.focusedChild;
+    final FocusNode? focusedChild = _traversableFocusedChild(nearestScope);
     if (focusedChild == null) {
       final FocusNode firstFocus = findFirstFocusInDirection(currentNode, direction) ?? currentNode;
       switch (direction) {

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -4206,6 +4206,58 @@ void main() {
       expect(enabledButton2Node.hasPrimaryFocus, isTrue);
     },
   );
+  testWidgets('Focus traversal ignores nodes that are not attached to the widget tree', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/66106
+    final detachedNode1 = FocusNode(debugLabel: 'detached 1');
+    addTearDown(detachedNode1.dispose);
+    final detachedNode2 = FocusNode(debugLabel: 'detached 2');
+    addTearDown(detachedNode2.dispose);
+    final node1 = FocusNode(debugLabel: '1');
+    addTearDown(node1.dispose);
+    final node2 = FocusNode(debugLabel: '2');
+    addTearDown(node2.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: FocusScope(
+          child: Column(
+            children: <Widget>[
+              Focus(focusNode: node1, child: const SizedBox(width: 100, height: 100)),
+              Focus(focusNode: node2, child: const SizedBox(width: 100, height: 100)),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final FocusScopeNode scope = FocusScope.of(node1.context!);
+    // Requesting focus for a node that no widget owns, as
+    // `FocusScope.of(context).requestFocus(FocusNode())` does, adds the node to
+    // the focus tree even though it has no context, and therefore no geometry.
+    scope.requestFocus(detachedNode1);
+    scope.requestFocus(detachedNode2);
+    await tester.pump();
+    expect(detachedNode2.hasPrimaryFocus, isTrue);
+
+    // Traversal starts over from the beginning of the scope, because the
+    // currently focused node cannot take part in traversal.
+    expect(node1.nextFocus(), isTrue);
+    await tester.pump();
+    expect(node1.hasPrimaryFocus, isTrue);
+
+    expect(node1.nextFocus(), isTrue);
+    await tester.pump();
+    expect(node2.hasPrimaryFocus, isTrue);
+
+    expect(node2.previousFocus(), isTrue);
+    await tester.pump();
+    expect(node1.hasPrimaryFocus, isTrue);
+
+    expect(scope.traversalDescendants, <FocusNode>[node1, node2]);
+  });
 }
 
 class TestPage<T> extends Page<T> {


### PR DESCRIPTION
Requesting focus for a FocusNode that no widget owns, for example
FocusScope.of(context).requestFocus(FocusNode()), reparents that node
into the focus tree even though it has no BuildContext, and the node
stays there for the rest of the scope's life. Focus traversal then tried
to sort that node together with the real ones, and reading its geometry
(FocusNode.rect) asserted 'Tried to get the bounds of a focus node that
didn't have its context set yet'.

A node that is not attached to the widget tree has no geometry and can
neither be sorted nor be focused by traversal, so it is now filtered out
everywhere traversal collects candidates: FocusNode.traversalDescendants,
FocusTraversalPolicy._canRequestTraversalFocus and
FocusTraversalPolicy._findGroups. In addition, when the focused child of
a scope is such a node, traversal now ignores it and starts over from the
first/last node of the scope instead of using it as the starting point.

Split out of flutter/flutter#191661, which also added a TextFormField
regression test exercising this through TextInputAction.next — that is a
Material change blocked by the code freeze (see #188444) and is ported
separately to flutter/packages.

Fixes https://github.com/flutter/flutter/issues/66106