### PR TITLE
Reattach a Focus node stolen by a duplicated Focus widget

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -615,9 +615,30 @@ class _FocusState extends State<Focus> {
     super.dispose();
   }
 
+  // Reattaches [focusNode] when this widget is no longer the attachment point
+  // of the node.
+  //
+  // A [FocusNode] is meant to be hosted by a single [Focus] widget, but a
+  // subtree can be temporarily duplicated during a transition, which is what
+  // the Cupertino navigation bars do during their Hero flights. The duplicated
+  // [Focus] widget takes over the attachment of the shared node, and removes
+  // the node from the focus tree once it is disposed. Reattaching the node here
+  // keeps it usable: without this, the node would be left with no place in the
+  // focus tree and could never be focused again.
+  void _reattachIfNeeded() {
+    if (!_focusAttachment!.isAttached) {
+      _focusAttachment = focusNode.attach(
+        context,
+        onKeyEvent: widget.onKeyEvent,
+        onKey: widget.onKey,
+      );
+    }
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _reattachIfNeeded();
     _focusAttachment?.reparent();
     _handleAutofocus();
   }
@@ -713,6 +734,7 @@ class _FocusState extends State<Focus> {
 
   @override
   Widget build(BuildContext context) {
+    _reattachIfNeeded();
     _focusAttachment!.reparent(parent: widget.parentNode);
     Widget child = widget.child;
     if (widget.includeSemantics) {
@@ -896,6 +918,7 @@ class _FocusScopeState extends _FocusState {
 
   @override
   Widget build(BuildContext context) {
+    _reattachIfNeeded();
     _focusAttachment!.reparent(parent: widget.parentNode);
     Widget result = _FocusInheritedScope(node: focusNode, child: widget.child);
     if (widget.includeSemantics) {

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1901,6 +1901,38 @@ void main() {
       focusNode.requestFocus();
       await tester.pump();
     });
+
+    testWidgets(
+      'Focus re-attaches its node when another Focus widget with the same node is removed',
+      (WidgetTester tester) async {
+        final focusNode = FocusNode();
+        addTearDown(focusNode.dispose);
+
+        Widget build({required bool duplicated}) {
+          return Directionality(
+            textDirection: TextDirection.ltr,
+            child: Column(
+              children: <Widget>[
+                Focus(focusNode: focusNode, child: const SizedBox(height: 10)),
+                // A second Focus widget hosting the same node, which is what
+                // happens when a subtree is duplicated for the duration of a
+                // transition, e.g. by the Cupertino navigation bar heroes.
+                if (duplicated) Focus(focusNode: focusNode, child: const SizedBox(height: 10)),
+              ],
+            ),
+          );
+        }
+
+        await tester.pumpWidget(build(duplicated: false));
+        await tester.pumpWidget(build(duplicated: true));
+        await tester.pumpWidget(build(duplicated: false));
+
+        // The remaining Focus widget still hosts the node, so it can be focused.
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(focusNode.hasFocus, isTrue);
+      },
+    );
   });
 
   group('ExcludeFocus', () {


### PR DESCRIPTION
CupertinoNavigationBar rebuilds the user provided nav bar components inside
the Hero flight overlay while the original components are kept alive in the
hidden hero launch pad. A CupertinoTextField with a user provided focus node
is therefore hosted by two Focus widgets at the same time: the copy in the
flight takes over the attachment of the node, and when the flight ends and the
copy is disposed it removes the node from the focus tree. The original Focus
widget kept a stale attachment, whose reparent() calls are no-ops, so the node
stayed out of the focus tree and the text field could never be focused again.

_FocusState now reattaches its focus node when the node is no longer attached
at its own attachment point, which restores the node's place in the focus tree
the next time the widget is rebuilt.

Split out of flutter/flutter#191664, which also added a CupertinoNavigationBar
regression test — that is a Cupertino change blocked by the code freeze
(see #188444) and is ported separately to flutter/packages.

Fixes https://github.com/flutter/flutter/issues/81976