### PR TITLE
Repaint ink features when an Expansible changes size

### DIFF
--- a/packages/flutter/lib/src/widgets/expansible.dart
+++ b/packages/flutter/lib/src/widgets/expansible.dart
@@ -8,6 +8,7 @@ library;
 import 'basic.dart';
 import 'framework.dart';
 import 'page_storage.dart';
+import 'size_changed_layout_notifier.dart';
 import 'ticker_provider.dart';
 import 'transitions.dart';
 
@@ -461,16 +462,22 @@ class _ExpansibleState extends State<Expansible> with SingleTickerProviderStateM
       child: TickerMode(enabled: !closed, child: widget.bodyBuilder(context, _animationController)),
     );
 
-    return AnimatedBuilder(
-      animation: _animationController.view,
-      builder: (BuildContext context, Widget? child) {
-        final Widget header = widget.headerBuilder(context, _animationController);
-        final Widget body = ClipRect(
-          child: Align(heightFactor: _heightFactor.value, child: child),
-        );
-        return widget.expansibleBuilder(context, header, body, _animationController);
-      },
-      child: shouldRemoveBody ? null : result,
+    // Expanding and collapsing moves the widgets that follow this one. Ancestors
+    // that paint relative to the position of their descendants, such as the ink
+    // effects painted by Material, only repaint when they are notified of a
+    // layout change, so dispatch one whenever this widget resizes.
+    return SizeChangedLayoutNotifier(
+      child: AnimatedBuilder(
+        animation: _animationController.view,
+        builder: (BuildContext context, Widget? child) {
+          final Widget header = widget.headerBuilder(context, _animationController);
+          final Widget body = ClipRect(
+            child: Align(heightFactor: _heightFactor.value, child: child),
+          );
+          return widget.expansibleBuilder(context, header, body, _animationController);
+        },
+        child: shouldRemoveBody ? null : result,
+      ),
     );
   }
 }

--- a/packages/flutter/test/widgets/expansible_test.dart
+++ b/packages/flutter/test/widgets/expansible_test.dart
@@ -533,4 +533,43 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Body'), findsOneWidget);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/84201.
+  testWidgets('Dispatches a SizeChangedLayoutNotification when expanded and collapsed', (
+    WidgetTester tester,
+  ) async {
+    final controller = ExpansibleController();
+    addTearDown(controller.dispose);
+    final notifications = <SizeChangedLayoutNotification>[];
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: NotificationListener<SizeChangedLayoutNotification>(
+          onNotification: (SizeChangedLayoutNotification notification) {
+            notifications.add(notification);
+            return false;
+          },
+          child: Center(
+            child: Expansible(
+              controller: controller,
+              headerBuilder: (BuildContext context, Animation<double> animation) =>
+                  const Text('Header'),
+              bodyBuilder: (BuildContext context, Animation<double> animation) =>
+                  const SizedBox(height: 100.0),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(notifications, isEmpty);
+
+    controller.expand();
+    await tester.pumpAndSettle();
+    expect(notifications, isNotEmpty);
+
+    notifications.clear();
+    controller.collapse();
+    await tester.pumpAndSettle();
+    expect(notifications, isNotEmpty);
+  });
 }


### PR DESCRIPTION
Expansible animates its size when it expands and collapses, which moves
the widgets that follow it. Ancestors that paint relative to the position
of their descendants, such as the ink effects painted by Material, only
repaint when a LayoutChangedNotification is dispatched. Nothing dispatched
one, and the viewport of a ListView is a repaint boundary, so a ListTile
that an ExpansionTile moved kept painting its tileColor at the old
position.

Wrap the Expansible in a SizeChangedLayoutNotifier so that a
SizeChangedLayoutNotification is dispatched whenever it resizes.

Split out of flutter/flutter#191667, which also added an ExpansionTile
regression test — that is a Material change blocked by the code freeze
(see #188444) and is ported separately to flutter/packages.

Fixes https://github.com/flutter/flutter/issues/84201