### PR TITLE
Only bind menu traversal shortcuts while the menu is open

### DIFF
--- a/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
+++ b/packages/flutter/lib/src/widgets/raw_menu_anchor.dart
@@ -31,9 +31,19 @@ import 'tap_region.dart';
 
 const bool _kDebugMenus = false;
 
-const Map<ShortcutActivator, Intent> _kMenuTraversalShortcuts = <ShortcutActivator, Intent>{
+// Shortcuts that are bound to the anchor while its menu is closed.
+//
+// Directional traversal shortcuts are omitted so that widgets in the anchor
+// which handle arrow keys themselves, such as text fields, keep receiving them
+// while the menu is closed.
+const Map<ShortcutActivator, Intent> _kClosedMenuShortcuts = <ShortcutActivator, Intent>{
   SingleActivator(LogicalKeyboardKey.gameButtonA): ActivateIntent(),
   SingleActivator(LogicalKeyboardKey.escape): DismissIntent(),
+};
+
+// Shortcuts that are bound to the anchor while its menu is open.
+const Map<ShortcutActivator, Intent> _kMenuTraversalShortcuts = <ShortcutActivator, Intent>{
+  ..._kClosedMenuShortcuts,
   SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(TraversalDirection.down),
   SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(TraversalDirection.up),
   SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(TraversalDirection.left),
@@ -843,7 +853,9 @@ class _RawMenuAnchorState extends State<RawMenuAnchor> with _RawMenuAnchorBaseMi
   Widget buildAnchor(BuildContext context) {
     final Widget child = Shortcuts(
       includeSemantics: false,
-      shortcuts: _kMenuTraversalShortcuts,
+      // Directional traversal shortcuts are only bound while the menu is open,
+      // so that the anchor doesn't swallow arrow keys that its child needs.
+      shortcuts: isOpen ? _kMenuTraversalShortcuts : _kClosedMenuShortcuts,
       child: TapRegion(
         groupId: root.menuController,
         consumeOutsideTaps: root.isOpen && widget.consumeOutsideTaps,

--- a/packages/flutter/test/widgets/raw_menu_anchor_test.dart
+++ b/packages/flutter/test/widgets/raw_menu_anchor_test.dart
@@ -1212,6 +1212,103 @@ void main() {
     );
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/163475.
+  testWidgets('[Default] Arrow keys are not blocked by a closed anchor', (
+    WidgetTester tester,
+  ) async {
+    final textController = TextEditingController(text: 'text');
+    addTearDown(textController.dispose);
+    final textFieldFocusNode = FocusNode(debugLabel: 'EditableText');
+    addTearDown(textFieldFocusNode.dispose);
+
+    await tester.pumpWidget(
+      App(
+        Menu(
+          controller: controller,
+          menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+          child: SizedBox(
+            width: 200,
+            child: EditableText(
+              controller: textController,
+              focusNode: textFieldFocusNode,
+              style: const TextStyle(),
+              cursorColor: const Color(0xFF000000),
+              backgroundCursorColor: const Color(0xFF000000),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    textFieldFocusNode.requestFocus();
+    await tester.pump();
+
+    textController.selection = const TextSelection.collapsed(offset: 4);
+    await tester.pump();
+
+    // The menu is closed, so the anchor should not intercept arrow keys.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pump();
+
+    expect(textController.selection.baseOffset, 3);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+
+    expect(textController.selection.baseOffset, 4);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/163475.
+  testWidgets('[Default] Up and down arrow keys are not blocked by a closed anchor', (
+    WidgetTester tester,
+  ) async {
+    final textController = TextEditingController(text: 'aaaa\nbbbb');
+    addTearDown(textController.dispose);
+    final textFieldFocusNode = FocusNode(debugLabel: 'EditableText');
+    addTearDown(textFieldFocusNode.dispose);
+
+    await tester.pumpWidget(
+      App(
+        Menu(
+          controller: controller,
+          menuPanel: Panel(children: <Widget>[Text(Tag.a.text)]),
+          child: SizedBox(
+            width: 200,
+            child: EditableText(
+              controller: textController,
+              focusNode: textFieldFocusNode,
+              maxLines: 2,
+              style: const TextStyle(),
+              cursorColor: const Color(0xFF000000),
+              backgroundCursorColor: const Color(0xFF000000),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    textFieldFocusNode.requestFocus();
+    await tester.pump();
+
+    // Place the caret on the second line, between the second and third
+    // characters.
+    textController.selection = const TextSelection.collapsed(offset: 7);
+    await tester.pump();
+
+    // The menu is closed, so the anchor should not intercept arrow keys.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+
+    expect(textController.selection.baseOffset, 2);
+    expect(textFieldFocusNode.hasFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+
+    expect(textController.selection.baseOffset, 7);
+    expect(textFieldFocusNode.hasFocus, isTrue);
+  });
+
   testWidgets('[Default] Focus traversal shortcuts are not bound to actions', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
RawMenuAnchor wrapped its anchor child in a Shortcuts widget that always
mapped the arrow keys to DirectionalFocusIntent. Because the intent is
resolved against the primary focus, an arrow key pressed inside a
TextField in the anchor was turned into a DirectionalFocusIntent, handled
by the text field's DirectionalFocusAction.forTextField (which does
nothing), and reported as handled. The key never reached
DefaultTextEditingShortcuts, so the caret could not be moved with the
arrow keys.

The directional traversal shortcuts are only needed to move focus into and
around an open menu, so they are now bound only while the menu is open.
The gameButtonA and escape shortcuts stay bound so that a closed menu can
still be opened with a game controller and escape keeps bubbling as
before.

Also covers vertical arrow keys (arrowUp/arrowDown) in the regression
tests alongside the existing left/right coverage, so a regression that
forgot to un-bind them would be caught.

Split out of flutter/flutter#191688, which also added matching test
coverage to menu_anchor_test.dart — that is a Material change blocked by
the code freeze (see #188444) and is ported separately to flutter/packages.

Fixes https://github.com/flutter/flutter/issues/163475