### PR TITLE
Fix Scrollbar mouse hover advertising a drag that is rejected

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -740,11 +740,13 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
   /// caused by [PointerDeviceKind.touch] to make sure that the region
   /// isn't too small to be interacted with by the user.
   ///
-  /// The hit test area for hovering with [PointerDeviceKind.mouse] over the
-  /// scrollbar also uses this extra padding. This is to make it easier to
-  /// interact with the scrollbar by presenting it to the mouse for interaction
-  /// based on proximity. When `forHover` is true, the larger hit test area will
-  /// be used.
+  /// The hit test area for hovering with [PointerDeviceKind.mouse] over a
+  /// faded out scrollbar also uses this extra padding. This is to bring the
+  /// scrollbar back into view based on proximity, so that the mouse can then
+  /// move onto it. When `forHover` is true, the larger hit test area will be
+  /// used. Since the enlarged area only reveals the scrollbar, it is never used
+  /// to accept a press; once the scrollbar is visible a mouse must be over the
+  /// track to interact with it.
   bool hitTestInteractive(Offset position, PointerDeviceKind kind, {bool forHover = false}) {
     if (_trackRect == null) {
       // We have not computed the scrollbar position yet.
@@ -814,8 +816,25 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
       case PointerDeviceKind.stylus:
       case PointerDeviceKind.invertedStylus:
       case PointerDeviceKind.unknown:
-        return _thumbRect!.contains(position);
+        // The thumb is inset from the edges of the track by crossAxisMargin.
+        // Pointers landing in that inset are still on the scrollbar, so they
+        // should grab the thumb instead of paging the scroll view like a tap
+        // on the track does.
+        return _crossAxisPaddedThumbRect.contains(position);
     }
+  }
+
+  // The thumb rect, expanded on the cross axis to fill the track, which is
+  // wider than the thumb when crossAxisMargin is greater than zero.
+  Rect get _crossAxisPaddedThumbRect {
+    final Rect thumbRect = _thumbRect!;
+    final Rect? trackRect = _trackRect;
+    if (trackRect == null) {
+      return thumbRect;
+    }
+    return _isVertical
+        ? Rect.fromLTRB(trackRect.left, thumbRect.top, trackRect.right, thumbRect.bottom)
+        : Rect.fromLTRB(thumbRect.left, trackRect.top, thumbRect.right, trackRect.bottom);
   }
 
   @override
@@ -2102,17 +2121,18 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   /// Returns true if the provided [Offset] is located over the track or thumb
   /// of the [RawScrollbar].
   ///
-  /// The hit test area for mouse hovering over the scrollbar is larger than
-  /// regular hit testing. This is to make it easier to interact with the
-  /// scrollbar and present it to the mouse for interaction based on proximity.
-  /// When `forHover` is true, the larger hit test area will be used.
+  /// The hit test area for mouse hovering over a faded out scrollbar is larger
+  /// than regular hit testing. This is to bring the scrollbar back into view
+  /// based on proximity. When `forHover` is true, the larger hit test area will
+  /// be used. The enlarged area does not accept presses, so it should not be
+  /// used to decide whether the scrollbar is to be painted as interactive.
   @protected
   bool isPointerOverScrollbar(Offset position, PointerDeviceKind kind, {bool forHover = false}) {
     if (_scrollbarPainterKey.currentContext == null) {
       return false;
     }
     final Offset localOffset = _getLocalOffset(_scrollbarPainterKey, position);
-    return scrollbarPainter.hitTestInteractive(localOffset, kind, forHover: true);
+    return scrollbarPainter.hitTestInteractive(localOffset, kind, forHover: forHover);
   }
 
   /// Cancels the fade out animation so the scrollbar will remain visible for

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1233,6 +1233,126 @@ void main() {
     );
   });
 
+  testWidgets('Scrollbar thumb can be dragged with a mouse within the crossAxisMargin', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/163464
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: PrimaryScrollController(
+            controller: scrollController,
+            child: RawScrollbar(
+              thumbVisibility: true,
+              crossAxisMargin: 2.0,
+              controller: scrollController,
+              child: const SingleChildScrollView(child: SizedBox(width: 4000.0, height: 4000.0)),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 0.0);
+    expect(
+      find.byType(RawScrollbar),
+      paints
+        ..rect(rect: const Rect.fromLTRB(790.0, 0.0, 800.0, 600.0))
+        ..rect(rect: const Rect.fromLTRB(792.0, 0.0, 798.0, 90.0), color: const Color(0x66BCBCBC)),
+    );
+
+    // The pointer is within the crossAxisMargin of the track, next to the
+    // painted thumb. This is part of the scrollbar, so it should drag the
+    // thumb instead of paging the scroll view like a tap on the track.
+    const scrollAmount = 10.0;
+    final TestGesture gesture = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    await gesture.down(const Offset(799.0, 45.0));
+    await tester.pumpAndSettle();
+    await gesture.moveBy(const Offset(0.0, scrollAmount));
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, greaterThan(0.0));
+    expect(
+      find.byType(RawScrollbar),
+      paints
+        ..rect(rect: const Rect.fromLTRB(790.0, 0.0, 800.0, 600.0))
+        ..rect(
+          rect: const Rect.fromLTRB(792.0, 10.0, 798.0, 100.0),
+          color: const Color(0x66BCBCBC),
+        ),
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+    'Horizontal scrollbar thumb can be dragged with a mouse within the crossAxisMargin',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/163464
+      final scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: RawScrollbar(
+              thumbVisibility: true,
+              crossAxisMargin: 2.0,
+              controller: scrollController,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                controller: scrollController,
+                child: const SizedBox(width: 4000.0, height: 4000.0),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(scrollController.offset, 0.0);
+      expect(
+        find.byType(RawScrollbar),
+        paints
+          ..rect(rect: const Rect.fromLTRB(0.0, 590.0, 800.0, 600.0))
+          ..rect(rect: const Rect.fromLTRB(0.0, 592.0, 160.0, 598.0), color: const Color(0x66BCBCBC)),
+      );
+
+      // The pointer is within the crossAxisMargin of the track, next to the
+      // painted thumb. This is part of the scrollbar, so it should drag the
+      // thumb instead of paging the scroll view like a tap on the track.
+      const scrollAmount = 10.0;
+      final TestGesture gesture = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await gesture.down(const Offset(45.0, 599.0));
+      await tester.pumpAndSettle();
+      await gesture.moveBy(const Offset(scrollAmount, 0.0));
+      await tester.pumpAndSettle();
+
+      expect(scrollController.offset, greaterThan(0.0));
+      expect(
+        find.byType(RawScrollbar),
+        paints
+          ..rect(rect: const Rect.fromLTRB(0.0, 590.0, 800.0, 600.0))
+          ..rect(
+            rect: const Rect.fromLTRB(10.0, 592.0, 170.0, 598.0),
+            color: const Color(0x66BCBCBC),
+          ),
+      );
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    },
+  );
+
   testWidgets('hit test', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/99324
     final scrollController = ScrollController();


### PR DESCRIPTION
A mouse could highlight the Scrollbar thumb without being able to drag it.
Two separate gaps caused this.

1. ScrollbarPainter.hitTestOnlyThumbInteractive used the painted thumb
   rect for precise pointers, but the thumb is inset from the edges of
   the track by crossAxisMargin. A press in that inset highlighted the
   thumb on hover, yet started no drag. The thumb hit region for precise
   pointers is now expanded across the track on the cross axis. This
   applies to vertical and horizontal scrollbars alike.

2. RawScrollbarState.isPointerOverScrollbar always forwarded
   forHover: true, so a caller could not ask for the plain interactive
   region. The enlarged proximity region keeps its single purpose:
   revealing a faded out scrollbar so that the mouse can then move onto
   it. The argument is now honoured by the base class.

Split out of flutter/flutter#191689, which also updated the Material
Scrollbar's hover handler to stop passing forHover: true (so it now asks
for the plain interactive region) — that is a Material change blocked by
the code freeze (see #188444) and is ported separately to flutter/packages.
That companion change is what makes gap 2 observable for MaterialScrollbar;
this base-class fix is a prerequisite for it and is behavior preserving on
its own for any caller that does not yet pass forHover: false explicitly.

Fixes https://github.com/flutter/flutter/issues/163464