### PR TITLE
Extract a handleThumbPressCancel hook in RawScrollbarState

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1886,6 +1886,30 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     _cachedController = null;
   }
 
+  /// Handler called when a press on the scrollbar thumb is canceled before it
+  /// turns into a drag, for example when the thumb drag gesture loses the
+  /// gesture arena.
+  ///
+  /// Subclasses that react to [handleThumbPress] must override this to undo
+  /// that reaction, since [handleThumbPressEnd] is not called for a canceled
+  /// gesture.
+  @protected
+  @mustCallSuper
+  void handleThumbPressCancel() {
+    // _thumbHold might be null if the drag started.
+    // _thumbDrag might be null if the drag activity ended and called _disposeThumbDrag.
+    assert(_thumbHold == null || _thumbDrag == null);
+    _thumbHold?.cancel();
+    _thumbDrag?.cancel();
+    assert(_thumbHold == null);
+    assert(_thumbDrag == null);
+    _thumbDragPointerKind = null;
+    if (_dragIsActive) {
+      _dragIsActive = false;
+      updateMouseCursor();
+    }
+  }
+
   /// Handler called when the track is tapped in order to page in the tapped
   /// direction.
   @protected
@@ -2104,18 +2128,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       // any work.
       return;
     }
-    // _thumbHold might be null if the drag started.
-    // _thumbDrag might be null if the drag activity ended and called _disposeThumbDrag.
-    assert(_thumbHold == null || _thumbDrag == null);
-    _thumbHold?.cancel();
-    _thumbDrag?.cancel();
-    assert(_thumbHold == null);
-    assert(_thumbDrag == null);
-    _thumbDragPointerKind = null;
-    if (_dragIsActive) {
-      _dragIsActive = false;
-      updateMouseCursor();
-    }
+    handleThumbPressCancel();
   }
 
   void _initThumbDragGestureRecognizer(DragGestureRecognizer instance) {


### PR DESCRIPTION
When a touch lands inside the scrollbar thumb's padded hit test area but
outside the scrollbar track, the thumb drag gesture recognizer and the
scrollable's own drag gesture recognizer both join the gesture arena. If
the pointer is lifted before the thumb drag is accepted, the thumb drag
loses the arena and is canceled instead of ended. RawScrollbar handled
that in the private _handleThumbDragCancel, which only cleaned up the
hold/drag activities, giving subclasses no hook to undo a reaction they
started in handleThumbPress (as CupertinoScrollbar does for its thickness
animation) when the drag never gets that far.

_handleThumbDragCancel now delegates to a new protected, mustCallSuper
handleThumbPressCancel() method that subclasses can override, mirroring
the existing handleThumbPressEnd. The default implementation keeps the
previous cleanup behavior unchanged, so this is behavior preserving on
its own.

Split out of flutter/flutter#191691, which also overrides this hook in
CupertinoScrollbar to reverse its thickness animation — that is a
Cupertino change blocked by the code freeze (see #188444) and is ported
separately to flutter/packages, where it is the only regression coverage
for the fix.

Fixes https://github.com/flutter/flutter/issues/162747