### PR TITLE
Fail loudly in debug mode when ParentDataWidget is incompatible

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -6891,32 +6891,26 @@ abstract class RenderObjectElement extends Element {
   }
 
   void _updateParentData(ParentDataWidget<ParentData> parentDataWidget) {
-    var applyParentData = true;
+    // Fails loudly when the ParentDataWidget cannot apply its parent data to
+    // this render object, instead of silently skipping the update and leaving
+    // a latent release-mode type-cast crash behind. This intentionally makes
+    // the incompatible-type case behave like the competing-ParentDataWidgets
+    // case, which also stops the build with a descriptive error.
+    // See https://github.com/flutter/flutter/issues/188272.
     assert(() {
-      try {
-        if (!parentDataWidget.debugIsValidRenderObject(renderObject)) {
-          applyParentData = false;
-          throw FlutterError.fromParts(<DiagnosticsNode>[
-            ErrorSummary('Incorrect use of ParentDataWidget.'),
-            ...parentDataWidget._debugDescribeIncorrectParentDataType(
-              parentData: renderObject.parentData,
-              parentDataCreator: _ancestorRenderObjectElement?.widget as RenderObjectWidget?,
-              ownershipChain: ErrorDescription(debugGetCreatorChain(10)),
-            ),
-          ]);
-        }
-      } on FlutterError catch (e) {
-        // We catch the exception directly to avoid activating the ErrorWidget,
-        // while still allowing debuggers to break on exception. Since the tree
-        // is in a broken state, adding the ErrorWidget would likely cause more
-        // exceptions, which is not good for the debugging experience.
-        _reportException(ErrorSummary('while applying parent data.'), e, e.stackTrace);
+      if (!parentDataWidget.debugIsValidRenderObject(renderObject)) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('Incorrect use of ParentDataWidget.'),
+          ...parentDataWidget._debugDescribeIncorrectParentDataType(
+            parentData: renderObject.parentData,
+            parentDataCreator: _ancestorRenderObjectElement?.widget as RenderObjectWidget?,
+            ownershipChain: ErrorDescription(debugGetCreatorChain(10)),
+          ),
+        ]);
       }
       return true;
     }());
-    if (applyParentData) {
-      parentDataWidget.applyParentData(renderObject);
-    }
+    parentDataWidget.applyParentData(renderObject);
   }
 
   @override

--- a/packages/flutter/test/widgets/parent_data_test.dart
+++ b/packages/flutter/test/widgets/parent_data_test.dart
@@ -339,6 +339,7 @@ void main() {
 
     final List<Object> exceptions = <Object>[];
     final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    addTearDown(() => FlutterError.onError = oldHandler);
     FlutterError.onError = (FlutterErrorDetails details) {
       exceptions.add(details.exception);
     };
@@ -436,6 +437,7 @@ void main() {
   testWidgets('Parent data invalid ancestor', (WidgetTester tester) async {
     final List<Object> exceptions = <Object>[];
     final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    addTearDown(() => FlutterError.onError = oldHandler);
     FlutterError.onError = (FlutterErrorDetails details) {
       exceptions.add(details.exception);
     };
@@ -481,6 +483,7 @@ void main() {
   ) async {
     final List<Object> exceptions = <Object>[];
     final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    addTearDown(() => FlutterError.onError = oldHandler);
     FlutterError.onError = (FlutterErrorDetails details) {
       exceptions.add(details.exception);
     };
@@ -518,6 +521,7 @@ void main() {
     (WidgetTester tester) async {
       final List<Object> exceptions = <Object>[];
       final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+      addTearDown(() => FlutterError.onError = oldHandler);
       FlutterError.onError = (FlutterErrorDetails details) {
         exceptions.add(details.exception);
       };

--- a/packages/flutter/test/widgets/parent_data_test.dart
+++ b/packages/flutter/test/widgets/parent_data_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -336,6 +337,12 @@ void main() {
     await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr));
     checkTree(tester, <TestParentData>[]);
 
+    final List<Object> exceptions = <Object>[];
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      exceptions.add(details.exception);
+    };
+
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -349,20 +356,24 @@ void main() {
       ),
     );
 
-    exception = tester.takeException();
-    expect(exception, isFlutterError);
+    FlutterError.onError = oldHandler;
+
+    // Mounting stops on the first error, and follow-on errors are reported
+    // while the tree unwinds, so match against all captured exceptions.
     expect(
-      exception.toString(),
-      startsWith(
-        'Incorrect use of ParentDataWidget.\n'
-        'The ParentDataWidget Positioned(left: 7.0, top: 6.0) wants to apply ParentData of type '
-        'StackParentData to a RenderObject, which has been set up to accept ParentData of '
-        'incompatible type FlexParentData.\n'
-        'Usually, this means that the Positioned widget has the wrong ancestor RenderObjectWidget. '
-        'Typically, Positioned widgets are placed directly inside Stack widgets.\n'
-        'The offending Positioned is currently placed inside a Row widget.\n'
-        'The ownership chain for the RenderObject that received the incompatible parent data was:\n'
-        '  DecoratedBox ← Positioned ← Row ← DummyWidget ← Directionality ← ', // End of chain omitted, not relevant for test.
+      exceptions.map((Object exception) => exception.toString()),
+      contains(
+        startsWith(
+          'Incorrect use of ParentDataWidget.\n'
+          'The ParentDataWidget Positioned(left: 7.0, top: 6.0) wants to apply ParentData of type '
+          'StackParentData to a RenderObject, which has been set up to accept ParentData of '
+          'incompatible type FlexParentData.\n'
+          'Usually, this means that the Positioned widget has the wrong ancestor RenderObjectWidget. '
+          'Typically, Positioned widgets are placed directly inside Stack widgets.\n'
+          'The offending Positioned is currently placed inside a Row widget.\n'
+          'The ownership chain for the RenderObject that received the incompatible parent data was:\n'
+          '  DecoratedBox ← Positioned ← Row ← DummyWidget ← Directionality ← ', // End of chain omitted, not relevant for test.
+        ),
       ),
     );
 
@@ -423,6 +434,12 @@ void main() {
   });
 
   testWidgets('Parent data invalid ancestor', (WidgetTester tester) async {
+    final List<Object> exceptions = <Object>[];
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      exceptions.add(details.exception);
+    };
+
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -437,23 +454,90 @@ void main() {
       ),
     );
 
-    final dynamic exception = tester.takeException();
+    FlutterError.onError = oldHandler;
+
+    // Mounting stops on the first error, and follow-on errors are reported
+    // while the tree unwinds, so match against all captured exceptions.
+    expect(
+      exceptions.map((Object exception) => exception.toString()),
+      contains(
+        startsWith(
+          'Incorrect use of ParentDataWidget.\n'
+          'The ParentDataWidget Expanded(flex: 1) wants to apply ParentData of type '
+          'FlexParentData to a RenderObject, which has been set up to accept ParentData of '
+          'incompatible type StackParentData.\n'
+          'Usually, this means that the Expanded widget has the wrong ancestor RenderObjectWidget. '
+          'Typically, Expanded widgets are placed directly inside Flex widgets.\n'
+          'The offending Expanded is currently placed inside a Stack widget.\n'
+          'The ownership chain for the RenderObject that received the incompatible parent data was:\n'
+          '  LimitedBox ← Container ← Expanded ← Stack ← Row ← Directionality ← ', // Omitted end of debugCreator chain because it's irrelevant for test.
+        ),
+      ),
+    );
+  });
+
+  testWidgets('Spacer inside an OverflowBar stops the build with a descriptive error', (
+    WidgetTester tester,
+  ) async {
+    final List<Object> exceptions = <Object>[];
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      exceptions.add(details.exception);
+    };
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: OverflowBar(children: <Widget>[Text('A'), Spacer(), Text('B')]),
+      ),
+    );
+
+    FlutterError.onError = oldHandler;
+
+    // Mounting the OverflowBar stops on the first error; follow-on errors
+    // reported while the tree unwinds are not part of this assertion.
+    final dynamic exception = exceptions.first;
     expect(exception, isFlutterError);
     expect(
       exception.toString(),
       startsWith(
         'Incorrect use of ParentDataWidget.\n'
-        'The ParentDataWidget Expanded(flex: 1) wants to apply ParentData of type '
-        'FlexParentData to a RenderObject, which has been set up to accept ParentData of '
-        'incompatible type StackParentData.\n'
-        'Usually, this means that the Expanded widget has the wrong ancestor RenderObjectWidget. '
-        'Typically, Expanded widgets are placed directly inside Flex widgets.\n'
-        'The offending Expanded is currently placed inside a Stack widget.\n'
-        'The ownership chain for the RenderObject that received the incompatible parent data was:\n'
-        '  LimitedBox ← Container ← Expanded ← Stack ← Row ← Directionality ← ', // Omitted end of debugCreator chain because it's irrelevant for test.
+        'The ParentDataWidget Expanded(flex: 1) wants to apply ParentData of '
+        'type FlexParentData to a RenderObject, which has been set up to '
+        'accept ParentData of incompatible type _OverflowBarParentData.\n'
+        'Usually, this means that the Expanded widget has the wrong ancestor '
+        'RenderObjectWidget. Typically, Expanded widgets are placed directly '
+        'inside Flex widgets.\n'
+        'The offending Expanded is currently placed inside a OverflowBar widget.\n',
       ),
     );
   });
+
+  testWidgets(
+    'Spacer inside an OverflowBar surfaces an ErrorWidget instead of being ignored silently',
+    (WidgetTester tester) async {
+      final List<Object> exceptions = <Object>[];
+      final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+      FlutterError.onError = (FlutterErrorDetails details) {
+        exceptions.add(details.exception);
+      };
+
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: OverflowBar(children: <Widget>[Text('A'), Spacer(), Text('B')]),
+        ),
+      );
+
+      FlutterError.onError = oldHandler;
+
+      expect(
+        exceptions.map((Object exception) => exception.toString()),
+        contains(startsWith('Incorrect use of ParentDataWidget.')),
+      );
+      expect(find.byType(ErrorWidget), findsOneWidget);
+    },
+  );
 
   testWidgets('ParentDataWidget can be used with different ancestor RenderObjectWidgets', (
     WidgetTester tester,


### PR DESCRIPTION
This PR fixes a debug/release behavioral inconsistency reported in #188272:
a `Spacer` placed inside `AlertDialog.actions` (which lays its actions out via
`OverflowBar`) rendered fine in debug mode but crashed release mode with:

```
type '_OverflowBarParentData' is not a subtype of type 'FlexParentData'
in type cast
#0 Flexible.applyParentData (package:flutter/src/widgets/basic.dart)
```

`RenderObjectElement._updateParentData` previously caught the `FlutterError`
thrown when a `ParentDataWidget` was applied to a render object with an
incompatible parent-data type, reported it via `_reportException`, and then
silently skipped applying the parent data. Debug builds therefore appeared to
work while release builds crashed.

The debug assert now lets the descriptive `FlutterError` propagate (matching
how competing-ParentDataWidget errors already behave), so misuse stops the
build loudly in debug mode with an error naming the offending widget and its
ownership chain, and can never slip through to release unnoticed.

Release-mode behavior is unchanged (asserts never run there); only debug mode
changes from "silently ignored" to "descriptive build-stopping error". This is
not a breaking change: no contributed-test-facing APIs or behaviors changed,
so no migration guide or [Data Driven Fixes] are needed.

Fixes https://github.com/flutter/flutter/issues/188272

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`). No public API surface changed; the new error message is self-documenting via existing `_debugDescribeIncorrectParentDataType` output.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.