### PR TITLE
Add opt-in AOT snapshot support for flutter_tools

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -56,10 +56,6 @@ SET shared_bin=%FLUTTER_ROOT%\bin\internal\shared.bat
 CALL "%shared_bin%"
 
 SET flutter_tools_dir=%FLUTTER_ROOT%\packages\flutter_tools
-SET cache_dir=%FLUTTER_ROOT%\bin\cache
-SET snapshot_path=%cache_dir%\flutter_tools.snapshot
-SET dart_sdk_path=%cache_dir%\dart-sdk
-SET dart=%dart_sdk_path%\bin\dart.exe
 
 SET exit_with_errorlevel=%FLUTTER_ROOT%/bin/internal/exit_with_errorlevel.bat
 
@@ -71,4 +67,4 @@ REM
 REM Do not use the CALL command in the next line to execute Dart. CALL causes
 REM Windows to re-read the line from disk after the CALL command has finished
 REM regardless of the ampersand chain.
-"%dart%" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" %FLUTTER_TOOL_ARGS% "%snapshot_path%" %* & "%exit_with_errorlevel%"
+"%flutter_tool_runtime%" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" %FLUTTER_TOOL_ARGS% "%flutter_tool_snapshot_path%" %* & "%exit_with_errorlevel%"

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -26,9 +26,23 @@ IF "%PROCESSOR_ARCHITECTURE%"=="x86" (
 
 SET flutter_tools_dir=%FLUTTER_ROOT%\packages\flutter_tools
 SET cache_dir=%FLUTTER_ROOT%\bin\cache
+SET use_aot_snapshot=false
+IF "%FLUTTER_TOOLS_USE_AOT_SNAPSHOT%"=="1" SET use_aot_snapshot=true
+IF /I "%FLUTTER_TOOLS_USE_AOT_SNAPSHOT%"=="true" SET use_aot_snapshot=true
+REM FLUTTER_TOOL_ARGS may contain VM options that the AOT runtime does not support.
+IF DEFINED FLUTTER_TOOL_ARGS SET use_aot_snapshot=false
+SET snapshot_kind=app-jit
 SET snapshot_path=%cache_dir%\flutter_tools.snapshot
 SET snapshot_path_old=%cache_dir%\flutter_tools.snapshot.old
 SET stamp_path=%cache_dir%\flutter_tools.stamp
+SET flutter_tool_runtime=%cache_dir%\dart-sdk\bin\dart.exe
+IF "%use_aot_snapshot%"=="true" (
+  SET snapshot_kind=aot
+  SET snapshot_path=%cache_dir%\flutter_tools.aot_snapshot
+  SET snapshot_path_old=%cache_dir%\flutter_tools.aot_snapshot.old
+  SET stamp_path=%cache_dir%\flutter_tools.aot_stamp
+  SET flutter_tool_runtime=%cache_dir%\dart-sdk\bin\dartaotruntime.exe
+)
 SET script_path=%flutter_tools_dir%\bin\flutter_tools.dart
 SET dart_sdk_path=%cache_dir%\dart-sdk
 SET engine_stamp=%cache_dir%\engine-dart-sdk.stamp
@@ -76,7 +90,7 @@ GOTO :after_subroutine
       SET revision=%%r
     )
   )
-  SET compilekey="%revision%:%FLUTTER_TOOL_ARGS%"
+  SET compilekey="%revision%:%FLUTTER_TOOL_ARGS%:%snapshot_kind%"
 
   REM Invalidate cache if:
   REM  * SNAPSHOT_PATH is not a file, or
@@ -216,10 +230,14 @@ GOTO :after_subroutine
         )
       )
 
-    IF "%FLUTTER_TOOL_ARGS%" == "" (
-      "%dart%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" --no-enable-mirrors "%script_path%" > NUL
+    IF "%snapshot_kind%"=="aot" (
+      "%dart%" compile aot-snapshot --verbosity=error --output="%snapshot_path%" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" "%script_path%" > NUL
     ) else (
-      "%dart%" "%FLUTTER_TOOL_ARGS%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" "%script_path%" > NUL
+      IF "%FLUTTER_TOOL_ARGS%" == "" (
+        "%dart%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" --no-enable-mirrors "%script_path%" > NUL
+      ) else (
+        "%dart%" "%FLUTTER_TOOL_ARGS%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" "%script_path%" > NUL
+      )
     )
     IF "%ERRORLEVEL%" NEQ "0" (
       ECHO Error: Unable to create dart snapshot for flutter tool. 1>&2
@@ -237,4 +255,4 @@ GOTO :after_subroutine
 :after_subroutine
 
 :final_exit
-  EXIT /B %exit_code%
+  ENDLOCAL & SET "flutter_tool_runtime=%flutter_tool_runtime%" & SET "flutter_tool_snapshot_path=%snapshot_path%" & EXIT /B %exit_code%

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -122,7 +122,7 @@ function upgrade_flutter () (
   "$FLUTTER_ROOT/bin/internal/update_engine_version.sh"
 
   local revision="$(git -C "$FLUTTER_ROOT" rev-parse HEAD)"
-  local compilekey="$revision:$FLUTTER_TOOL_ARGS"
+  local compilekey="$revision:$FLUTTER_TOOL_ARGS:$SNAPSHOT_KIND"
 
   # Invalidate cache if:
   #  * SNAPSHOT_PATH is not a file, or
@@ -176,7 +176,11 @@ function upgrade_flutter () (
     fi
 
     # Compile...
-    "$DART" --verbosity=error $FLUTTER_TOOL_ARGS --snapshot="$SNAPSHOT_PATH" --snapshot-kind="app-jit" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" --no-enable-mirrors "$SCRIPT_PATH" > /dev/null
+    if [[ "$SNAPSHOT_KIND" == "aot" ]]; then
+      "$DART" compile aot-snapshot --verbosity=error --output="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" "$SCRIPT_PATH" > /dev/null
+    else
+      "$DART" --verbosity=error $FLUTTER_TOOL_ARGS --snapshot="$SNAPSHOT_PATH" --snapshot-kind="app-jit" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" --no-enable-mirrors "$SCRIPT_PATH" > /dev/null
+    fi
     echo "$compilekey" > "$STAMP_PATH"
 
     # Delete any temporary snapshot path.
@@ -203,18 +207,27 @@ function shared::execute() {
   fi
 
   FLUTTER_TOOLS_DIR="$FLUTTER_ROOT/packages/flutter_tools"
+  SNAPSHOT_KIND="app-jit"
   SNAPSHOT_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.snapshot"
   STAMP_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.stamp"
+  # FLUTTER_TOOL_ARGS may contain VM options that the AOT runtime does not support.
+  if [[ -z "$FLUTTER_TOOL_ARGS" && ( "$FLUTTER_TOOLS_USE_AOT_SNAPSHOT" == "1" || "$FLUTTER_TOOLS_USE_AOT_SNAPSHOT" == "true" ) ]]; then
+    SNAPSHOT_KIND="aot"
+    SNAPSHOT_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.aot_snapshot"
+    STAMP_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.aot_stamp"
+  fi
   SCRIPT_PATH="$FLUTTER_TOOLS_DIR/bin/flutter_tools.dart"
   DART_SDK_PATH="$FLUTTER_ROOT/bin/cache/dart-sdk"
 
   DART="$DART_SDK_PATH/bin/dart"
+  DART_AOT_RUNTIME="$DART_SDK_PATH/bin/dartaotruntime"
 
   # If running over git-bash, overrides the default UNIX executables with win32
   # executables
   case "$(uname -s)" in
     MINGW* | MSYS* )
       DART="$DART.exe"
+      DART_AOT_RUNTIME="$DART_AOT_RUNTIME.exe"
       ;;
   esac
 
@@ -270,7 +283,11 @@ function shared::execute() {
     flutter*)
       # FLUTTER_TOOL_ARGS aren't quoted below, because it is meant to be
       # considered as separate space-separated args.
-      exec "$DART" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" $FLUTTER_TOOL_ARGS "$SNAPSHOT_PATH" "$@"
+      if [[ "$SNAPSHOT_KIND" == "aot" ]]; then
+        exec "$DART_AOT_RUNTIME" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" $FLUTTER_TOOL_ARGS "$SNAPSHOT_PATH" "$@"
+      else
+        exec "$DART" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" $FLUTTER_TOOL_ARGS "$SNAPSHOT_PATH" "$@"
+      fi
       ;;
     dart*)
       exec "$DART" "$@"

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -45,6 +45,7 @@ const kFlutterRootEnvironmentVariableName =
 const kFlutterEngineEnvironmentVariableName =
     'FLUTTER_ENGINE'; // should point to //engine/src/ (root of flutter/engine repo)
 const kSnapshotFileName = 'flutter_tools.snapshot'; // in //flutter/bin/cache/
+const kAotSnapshotFileName = 'flutter_tools.aot_snapshot'; // in //flutter/bin/cache/
 const kFlutterToolsScriptFileName =
     'flutter_tools.dart'; // in //flutter/packages/flutter_tools/bin/
 const kFlutterEnginePackageName = 'sky_engine';
@@ -303,7 +304,10 @@ class Cache {
 
       if (platform.script.scheme == 'file') {
         final String script = platform.script.toFilePath(windows: platform.isWindows);
-        if (fileSystem.path.basename(script) == kSnapshotFileName) {
+        if (<String>{
+          kSnapshotFileName,
+          kAotSnapshotFileName,
+        }.contains(fileSystem.path.basename(script))) {
           return normalize(dirname(dirname(fileSystem.path.dirname(script))));
         }
         if (fileSystem.path.basename(script) == kFlutterToolsScriptFileName) {

--- a/packages/flutter_tools/test/general.shard/commands/flutter_root_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/flutter_root_test.dart
@@ -69,6 +69,20 @@ void main() {
     expect(defaultFlutterRoot, '/flutter');
   });
 
+  testWithoutContext('Cache can initialize flutter root from AOT snapshot location', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final String defaultFlutterRoot = Cache.defaultFlutterRoot(
+      fileSystem: fileSystem,
+      userMessages: UserMessages(),
+      platform: FakePlatform(
+        environment: <String, String>{},
+        script: Uri.parse('file:///flutter/bin/cache/flutter_tools.aot_snapshot'),
+      ),
+    );
+
+    expect(defaultFlutterRoot, '/flutter');
+  });
+
   testWithoutContext('Cache can initialize flutter root from script file', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final String defaultFlutterRoot = Cache.defaultFlutterRoot(

--- a/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
@@ -148,6 +148,27 @@ echo executed dart binary
     result = await processManager.run(<String>[flutterBash.path, '--version']);
     expect(result.stderr, isNot(contains('Building flutter tool...')));
   });
+
+  test('shared.sh builds and reuses the AOT flutter tool snapshot', () async {
+    setupToolsEntrypointNewerPubpsec();
+    const environment = <String, String>{'FLUTTER_TOOLS_USE_AOT_SNAPSHOT': '1'};
+
+    ProcessResult result = await processManager.run(<String>[
+      flutterBash.path,
+      '--version',
+    ], environment: environment);
+    expect(result, const ProcessResultMatcher());
+    expect(result.stderr, contains('Building flutter tool'));
+    expect(aotSnapshot.existsSync(), isTrue);
+    expect(aotStamp.existsSync(), isTrue);
+
+    result = await processManager.run(<String>[
+      flutterBash.path,
+      '--version',
+    ], environment: environment);
+    expect(result, const ProcessResultMatcher());
+    expect(result.stderr, isNot(contains('Building flutter tool...')));
+  });
 }
 
 // A test Dart app that will run until it receives SIGTERM
@@ -170,6 +191,20 @@ File get dartBash {
 // The executable bash entrypoint for the Flutter binary.
 File get flutterBash {
   return flutterRoot.childDirectory('bin').childFile('flutter').absolute;
+}
+
+File get aotSnapshot {
+  return flutterRoot
+      .childDirectory('bin')
+      .childDirectory('cache')
+      .childFile('flutter_tools.aot_snapshot');
+}
+
+File get aotStamp {
+  return flutterRoot
+      .childDirectory('bin')
+      .childDirectory('cache')
+      .childFile('flutter_tools.aot_stamp');
 }
 
 void makeExecutable(File file) {

--- a/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
@@ -70,6 +70,27 @@ Future<void> main() async {
     result = await processManager.run(<String>[flutterBatch.path, '--version']);
     expect(result.stderr, isNot(contains('Building flutter tool...')));
   });
+
+  test('shared.bat builds and reuses the AOT flutter tool snapshot', () async {
+    setupToolsEntrypointNewerPubpsec();
+    const environment = <String, String>{'FLUTTER_TOOLS_USE_AOT_SNAPSHOT': '1'};
+
+    ProcessResult result = await processManager.run(<String>[
+      flutterBatch.path,
+      '--version',
+    ], environment: environment);
+    expect(result, const ProcessResultMatcher());
+    expect(result.stderr, contains('Building flutter tool'));
+    expect(aotSnapshot.existsSync(), isTrue);
+    expect(aotStamp.existsSync(), isTrue);
+
+    result = await processManager.run(<String>[
+      flutterBatch.path,
+      '--version',
+    ], environment: environment);
+    expect(result, const ProcessResultMatcher());
+    expect(result.stderr, isNot(contains('Building flutter tool...')));
+  });
 }
 
 Future<String> runDartBatch() async {
@@ -112,6 +133,20 @@ File get dartBatch {
 // The executable batch entrypoint for the Flutter binary.
 File get flutterBatch {
   return flutterRoot.childDirectory('bin').childFile('flutter.bat').absolute;
+}
+
+File get aotSnapshot {
+  return flutterRoot
+      .childDirectory('bin')
+      .childDirectory('cache')
+      .childFile('flutter_tools.aot_snapshot');
+}
+
+File get aotStamp {
+  return flutterRoot
+      .childDirectory('bin')
+      .childDirectory('cache')
+      .childFile('flutter_tools.aot_stamp');
 }
 
 // The Dart SDK's stamp file.


### PR DESCRIPTION
This PR adds opt-in support for compiling and running `flutter_tools` as an AOT snapshot:

```sh
FLUTTER_TOOLS_USE_AOT_SNAPSHOT=1 flutter <command>
```

App-JIT remains the default. AOT uses separate snapshot and stamp files to avoid stale cache reuse when switching modes. The implementation supports POSIX, Git Bash, and Windows entrypoints, and includes Flutter root detection and integration tests.

When `FLUTTER_TOOL_ARGS` is set, the launcher keeps using App-JIT because it may contain VM options unsupported by `dartaotruntime`.

This follows up on #170488.

Fixes #170486.

## Performance

The benchmark used the synthetic `flutter-test-concurrency-benchmark` package, which contains generated widget tests. The measured command ran one generated test with a controlled 20 ms body:

```sh
flutter test --no-pub test/generated/short_0000_test.dart
```

Both snapshots were built before measurement. The benchmark used 3 warm-up runs and 20 measured runs per mode, alternating the App-JIT/AOT execution order.

| Metric | App-JIT | AOT | Difference |
|---|---:|---:|---:|
| Mean wall time | 2.18 s | 1.81 s | -16.9% |
| Median wall time | 2.14 s | 1.71 s | -20.1% |
| Mean user CPU | 1.78 s | 1.41 s | -20.9% |
| CPU cycles | 1.91B | 0.41B | -78.2% |

The AOT snapshot was 30.1 MiB compared with 71.6 MiB for App-JIT. Initial compilation is excluded and is expected to be slower, which is why AOT remains opt-in.

## Testing

- Dart analyzer and Flutter root unit test
- POSIX entrypoint integration tests
- Manual App-JIT/AOT build, reuse, and mode-switching checks
- Windows entrypoint integration test added for CI

## Pre-launch Checklist

- [x] I read the Contributor Guide and followed the submission process.
- [x] I read the AI contribution guidelines and understand my responsibilities.
- [x] I read the Tree Hygiene guidance.
- [x] I read and followed the Flutter Style Guide.
- [x] I signed the CLA.
- [x] I listed at least one issue that this PR fixes.
- [x] I added tests for this change.
- [x] All existing and new tests are passing.
