### PR TITLE
iOS,macOS: Check viewType before creating a platform view

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -288,7 +288,16 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
   NSDictionary<NSString*, id>* args = [call arguments];
 
   int64_t viewId = [args[@"id"] longLongValue];
+  // A missing argument arrives as nil and an explicit Dart null as NSNull, neither of which can be
+  // converted to a view type.
   NSString* viewTypeString = args[@"viewType"];
+  if (![viewTypeString isKindOfClass:[NSString class]]) {
+    result([FlutterError
+        errorWithCode:@"unknown_view"
+              message:@"'viewType' argument must be a string to create a platform view."
+              details:nil]);
+    return;
+  }
   std::string viewType(viewTypeString.UTF8String);
 
   if (self.platformViews.count(viewId) != 0) {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -370,6 +370,33 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
   return nil;
 }
 
+// Verifies that a create call whose viewType is not a string returns an error rather than raising.
+// An omitted argument arrives as nil and an explicit Dart null as NSNull, and neither can be
+// converted to the view type the factory lookup needs.
+- (void)testCreateWithInvalidViewTypeReturnsError {
+  FlutterPlatformViewsController* flutterPlatformViewsController =
+      CreateTestPlatformViewsController(self.name);
+
+  NSArray<NSDictionary*>* invalidArguments = @[
+    @{@"id" : @2},                               // 'viewType' omitted.
+    @{@"id" : @2, @"viewType" : [NSNull null]},  // 'viewType' explicitly null in Dart.
+    @{@"id" : @2, @"viewType" : @7},             // 'viewType' not a string.
+  ];
+
+  for (NSDictionary* arguments in invalidArguments) {
+    __block BOOL errored = NO;
+    FlutterResult result = ^(id result) {
+      if ([result isKindOfClass:[FlutterError class]]) {
+        errored = YES;
+      }
+    };
+    [flutterPlatformViewsController
+        onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create" arguments:arguments]
+              result:result];
+    XCTAssertTrue(errored, @"arguments: %@", arguments);
+  }
+}
+
 - (void)testFlutterViewOnlyCreateOnceInOneFrame {
   flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
@@ -92,7 +92,16 @@
     NSMutableDictionary<NSString*, id>* args = [call arguments];
     if ([args objectForKey:@"id"]) {
       int64_t viewId = [args[@"id"] longLongValue];
-      NSString* viewType = [NSString stringWithUTF8String:([args[@"viewType"] UTF8String])];
+      // A missing argument arrives as nil and an explicit Dart null as NSNull, neither of which is
+      // a usable factory key.
+      NSString* viewType = args[@"viewType"];
+      if (![viewType isKindOfClass:[NSString class]]) {
+        result([FlutterError
+            errorWithCode:@"unknown_view"
+                  message:@"'viewType' argument must be a string to create a platform view."
+                  details:nil]);
+        return;
+      }
 
       id creationArgs = nil;
       NSObject<FlutterPlatformViewFactory>* factory = _platformViewFactories[viewType];

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
@@ -35,6 +35,37 @@ TEST(FlutterPlatformViewController, TestCreatePlatformViewNoMatchingViewType) {
   EXPECT_TRUE(errored);
 }
 
+// Verifies that a create call whose viewType is not a string returns an error rather than raising.
+// An omitted argument arrives as nil and an explicit Dart null as NSNull, and the factory lookup
+// the argument feeds raises on a nil key.
+TEST(FlutterPlatformViewController, TestCreatePlatformViewInvalidViewType) {
+  // Use id so we can access handleMethodCall method.
+  id platformViewController = [[FlutterPlatformViewController alloc] init];
+
+  NSArray<NSDictionary*>* invalidArguments = @[
+    @{@"id" : @2},  // 'viewType' omitted.
+    @{@"id" : @2,
+      @"viewType" : [NSNull null]},  // 'viewType' explicitly null in Dart.
+    @{@"id" : @2,
+      @"viewType" : @7},  // 'viewType' not a string.
+  ];
+
+  for (NSDictionary* arguments in invalidArguments) {
+    FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"create"
+                                                                      arguments:arguments];
+    __block bool errored = false;
+    FlutterResult result = ^(id result) {
+      if ([result isKindOfClass:[FlutterError class]]) {
+        errored = true;
+      }
+    };
+
+    [platformViewController handleMethodCall:methodCall result:result];
+
+    EXPECT_TRUE(errored) << "arguments: " << arguments.description.UTF8String;
+  }
+}
+
 TEST(FlutterPlatformViewController, TestRegisterPlatformViewFactoryAndCreate) {
   // Use id so we can access handleMethodCall method.
   id platformViewController = [[FlutterPlatformViewController alloc] init];


### PR DESCRIPTION
When creating a platform view, both iOS and macOS converted the platform view `viewType` coming over the method channel into a string without checking whether the incoming value was actually (a) non-null and (b) a string.

In addition to this, macOS was manually converting the `viewType` value to an NSString, but the codec already returns an NSString whenever Dart sent one. Both embedders use `FlutterStandardMethodCodec` for this channel. `FlutterStandardCodecHelper.cc` null to `kCFNull`, which comes out of the channel as `NSNull`, and which doesn't respond to `UTF8String` at all, which causes a crash. Finally if the framework ever mistakenly passed an int, or a bool, or any other non-string type, we'd get a crash. If the parameters omit `viewType` altogether, it arrives as nil:

In any of these cases, we end up with a corrupt or nil viewType string:
  * On macOS, this triggers `NSInvalidArgumentException` from `+stringWithUTF8String:`
  * On iOS, we'd try to construct a `std::string` from NULL and segfault.

We now check that `viewType` is a string, which covers the nil, `NSNull`, and wrong-type cases. They now report a `FlutterError` instead of crashing.

Noticed while working on: https://github.com/flutter/flutter/issues/165904

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
