### PR TITLE
macOS: Fix crash on out-of-bounds text input ranges

### DIFF
--- a/engine/src/flutter/shell/platform/common/text_input_model.cc
+++ b/engine/src/flutter/shell/platform/common/text_input_model.cc
@@ -6,7 +6,9 @@
 
 #include <algorithm>
 #include <string>
+#include <utility>
 
+#include "flutter/fml/logging.h"
 #include "flutter/fml/string_conversion.h"
 
 namespace flutter {
@@ -31,12 +33,14 @@ TextInputModel::~TextInputModel() = default;
 bool TextInputModel::SetText(const std::string& text,
                              const TextRange& selection,
                              const TextRange& composing_range) {
-  text_ = fml::Utf8ToUtf16(text);
-  if (!text_range().Contains(selection) ||
-      !text_range().Contains(composing_range)) {
+  std::u16string new_text = fml::Utf8ToUtf16(text);
+  const TextRange new_text_range(0, new_text.length());
+  if (!new_text_range.Contains(selection) ||
+      !new_text_range.Contains(composing_range)) {
     return false;
   }
 
+  text_ = std::move(new_text);
   selection_ = selection;
   composing_range_ = composing_range;
   composing_ = !composing_range.collapsed();
@@ -56,7 +60,8 @@ bool TextInputModel::SetSelection(const TextRange& range) {
 
 bool TextInputModel::SetComposingRange(const TextRange& range,
                                        size_t cursor_offset) {
-  if (!composing_ || !text_range().Contains(range)) {
+  if (!composing_ || !text_range().Contains(range) ||
+      cursor_offset > text_.length() - range.start()) {
     return false;
   }
   composing_range_ = range;
@@ -71,6 +76,12 @@ void TextInputModel::BeginComposing() {
 
 void TextInputModel::UpdateComposingText(const std::u16string& text,
                                          const TextRange& selection) {
+  // Re-clamp current selection and composing range to text.
+  FML_DCHECK(text_range().Contains(selection_) &&
+             text_range().Contains(composing_range_));
+  selection_ = selection_.ClampedTo(text_.length());
+  composing_range_ = composing_range_.ClampedTo(text_.length());
+
   // Preserve selection if we get a no-op update to the composing region.
   if (text.length() == 0 && composing_range_.collapsed()) {
     return;
@@ -79,8 +90,11 @@ void TextInputModel::UpdateComposingText(const std::u16string& text,
       composing_range_.collapsed() ? selection_ : composing_range_;
   text_.replace(rangeToDelete.start(), rangeToDelete.length(), text);
   composing_range_.set_end(composing_range_.start() + text.length());
-  selection_ = TextRange(selection.start() + composing_range_.start(),
-                         selection.extent() + composing_range_.start());
+
+  // Updated |selection| is supplied by the IME. Clamp to text length.
+  const TextRange clamped_selection = selection.ClampedTo(text.length());
+  selection_ = TextRange(clamped_selection.start() + composing_range_.start(),
+                         clamped_selection.extent() + composing_range_.start());
 }
 
 void TextInputModel::UpdateComposingText(const std::u16string& text) {

--- a/engine/src/flutter/shell/platform/common/text_input_model.h
+++ b/engine/src/flutter/shell/platform/common/text_input_model.h
@@ -24,6 +24,11 @@ class TextInputModel {
   //
   // This method is typically used to update the TextInputModel's editing state
   // when the Flutter framework sends its latest text editing state.
+  //
+  // Returns false and leaves the model untouched if |selection| or
+  // |composing_range| does not fit within |text|. Either all three are applied
+  // or none are, so that the model never holds a range that indexes past the
+  // end of its own text.
   bool SetText(const std::string& text,
                const TextRange& selection = TextRange(0),
                const TextRange& composing_range = TextRange(0));

--- a/engine/src/flutter/shell/platform/common/text_input_model_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/text_input_model_unittests.cc
@@ -47,6 +47,53 @@ TEST(TextInputModel, SetTextResetsSelection) {
   EXPECT_EQ(model->selection(), TextRange(0));
 }
 
+TEST(TextInputModel, SetTextRejectingSelectionLeavesModelUnchanged) {
+  auto model = std::make_unique<TextInputModel>();
+  EXPECT_TRUE(model->SetText("ABCDE", TextRange(3), TextRange(0)));
+  // A rejected update must not apply the text either. Applying it alone would
+  // leave the selection pointing past the end of the new text, and every
+  // subsequent edit indexes into the text with that selection.
+  EXPECT_FALSE(model->SetText("AB", TextRange(5), TextRange(0)));
+  EXPECT_STREQ(model->GetText().c_str(), "ABCDE");
+  EXPECT_EQ(model->selection(), TextRange(3));
+  EXPECT_EQ(model->composing_range(), TextRange(0));
+}
+
+TEST(TextInputModel, SetTextRejectingComposingRangeLeavesModelUnchanged) {
+  auto model = std::make_unique<TextInputModel>();
+  EXPECT_TRUE(model->SetText("ABCDE", TextRange(2), TextRange(1, 3)));
+  EXPECT_FALSE(model->SetText("AB", TextRange(2), TextRange(1, 3)));
+  EXPECT_STREQ(model->GetText().c_str(), "ABCDE");
+  EXPECT_EQ(model->selection(), TextRange(2));
+  EXPECT_EQ(model->composing_range(), TextRange(1, 3));
+  EXPECT_TRUE(model->composing());
+}
+
+TEST(TextInputModel, UpdateComposingTextWithSelectionPastComposingText) {
+  auto model = std::make_unique<TextInputModel>();
+  EXPECT_TRUE(model->SetText("ABCDE", TextRange(5), TextRange(0)));
+  model->BeginComposing();
+
+  // The selection accompanying composing text is relative to that text, but an
+  // input method is free to report one that does not fit inside it. The offset
+  // must not reach the text buffer, where a later edit would index out of
+  // bounds and abort the process from inside the standard library.
+  model->UpdateComposingText(u"n", TextRange(99));
+  EXPECT_STREQ(model->GetText().c_str(), "ABCDEn");
+  EXPECT_EQ(model->selection(), TextRange(6));
+  EXPECT_EQ(model->composing_range(), TextRange(5, 6));
+
+  // Clearing the composing text collapses the composing range, which makes the
+  // next update replace the selection instead. This is the point at which an
+  // unclamped offset becomes an out of bounds index into the text.
+  model->UpdateComposingText(u"", TextRange(99));
+  EXPECT_EQ(model->composing_range(), TextRange(5));
+  EXPECT_EQ(model->selection(), TextRange(5));
+  model->UpdateComposingText(u"m", TextRange(1));
+  EXPECT_STREQ(model->GetText().c_str(), "ABCDEm");
+  EXPECT_EQ(model->selection(), TextRange(6));
+}
+
 TEST(TextInputModel, SetSelectionStart) {
   auto model = std::make_unique<TextInputModel>();
   model->SetText("ABCDE");
@@ -215,6 +262,19 @@ TEST(TextInputModel, SetComposingRangeReverseExtent) {
   EXPECT_EQ(model->selection(), TextRange(4));
   EXPECT_EQ(model->composing_range(), TextRange(4, 1));
   EXPECT_STREQ(model->GetText().c_str(), "ABCDE");
+}
+
+TEST(TextInputModel, SetComposingRangeWithOffsetOutsideString) {
+  auto model = std::make_unique<TextInputModel>();
+  model->SetText("ABCDE");
+  model->BeginComposing();
+  // The offset positions the caret relative to the composing range, and reaches
+  // the text as an index. An offset that runs past the end of the text must be
+  // rejected rather than stored as a selection.
+  EXPECT_FALSE(model->SetComposingRange(TextRange(1, 4), 5));
+  EXPECT_EQ(model->selection(), TextRange(0));
+  EXPECT_TRUE(model->SetComposingRange(TextRange(1, 4), 4));
+  EXPECT_EQ(model->selection(), TextRange(5));
 }
 
 TEST(TextInputModel, SetComposingRangeOutsideString) {

--- a/engine/src/flutter/shell/platform/common/text_range.h
+++ b/engine/src/flutter/shell/platform/common/text_range.h
@@ -89,6 +89,13 @@ class TextRange {
     return range.start() >= start() && range.end() <= end();
   }
 
+  // Returns the range with both endpoints clamped to |length|.
+  //
+  // The base/extent ordering is preserved, so a reversed range stays reversed.
+  TextRange ClampedTo(size_t length) const {
+    return TextRange(std::min(base_, length), std::min(extent_, length));
+  }
+
   bool operator==(const TextRange& other) const {
     return base_ == other.base_ && extent_ == other.extent_;
   }

--- a/engine/src/flutter/shell/platform/common/text_range_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/text_range_unittests.cc
@@ -245,4 +245,18 @@ TEST(TextRange, ReversedReversedRange) {
   EXPECT_TRUE(range.reversed());
 }
 
+TEST(TextRange, ClampedToLongerLength) {
+  EXPECT_EQ(TextRange(2, 6).ClampedTo(10), TextRange(2, 6));
+}
+
+TEST(TextRange, ClampedToShorterLength) {
+  EXPECT_EQ(TextRange(2, 6).ClampedTo(4), TextRange(2, 4));
+}
+
+TEST(TextRange, ClampedToShorterLengthReversed) {
+  // A reversed range must stay reversed: callers derive the cursor position
+  // from the extent, not from the lesser endpoint.
+  EXPECT_EQ(TextRange(6, 2).ClampedTo(4), TextRange(4, 2));
+}
+
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <string>
 
 #include "flutter/common/constants.h"
 #include "flutter/fml/platform/darwin/string_range_sanitization.h"
@@ -93,6 +94,19 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
     return flutter::TextRange(0, 0);
   }
   return flutter::TextRange([base unsignedLongValue], [extent unsignedLongValue]);
+}
+
+// Returns |range| as a TextRange clamped to |length|.
+//
+// A selection made backwards is reported as a range whose length is negative
+// when read as a signed value, so the length is interpreted signed and the
+// direction of the range is preserved. A location of NSNotFound clamps to
+// |length|.
+static flutter::TextRange ClampNSRange(NSRange range, size_t length) {
+  const long text_length = static_cast<long>(length);
+  const long signed_length = std::clamp(static_cast<long>(range.length), -text_length, text_length);
+  const long base = std::clamp(static_cast<long>(range.location), 0L, text_length);
+  return flutter::TextRange(base, std::clamp(base + signed_length, 0L, text_length));
 }
 
 // Returns the autofill hint content type, if specified; otherwise nil.
@@ -535,6 +549,9 @@ static char markerKey;
 }
 
 - (void)setEditingState:(NSDictionary*)state {
+  if (_activeModel == nullptr) {
+    return;
+  }
   NSString* selectionAffinity = state[kSelectionAffinityKey];
   if (selectionAffinity != nil) {
     _textAffinity = [selectionAffinity isEqualToString:kTextAffinityUpstream]
@@ -543,13 +560,25 @@ static char markerKey;
   }
 
   NSString* text = state[kTextKey];
+  if (![text isKindOfClass:[NSString class]]) {
+    text = @"";
+  }
 
-  flutter::TextRange selected_range = RangeFromBaseExtent(
-      state[kSelectionBaseKey], state[kSelectionExtentKey], _activeModel->selection());
-  _activeModel->SetSelection(selected_range);
-
-  flutter::TextRange composing_range = RangeFromBaseExtent(
-      state[kComposingBaseKey], state[kComposingExtentKey], _activeModel->composing_range());
+  // The framework computes these ranges against its own copy of the text, which may be a different
+  // revision than the text it sends here, and the ranges are dropped entirely by |SetText| if they
+  // don't fit.
+  //
+  // Clamp them to the incoming text so a stale offset degrades the caret position rather than
+  // discarding the text update.
+  size_t text_length = text.length;
+  flutter::TextRange selected_range =
+      RangeFromBaseExtent(state[kSelectionBaseKey], state[kSelectionExtentKey],
+                          _activeModel->selection())
+          .ClampedTo(text_length);
+  flutter::TextRange composing_range =
+      RangeFromBaseExtent(state[kComposingBaseKey], state[kComposingExtentKey],
+                          _activeModel->composing_range())
+          .ClampedTo(text_length);
 
   const bool wasComposing = _activeModel->composing();
   _activeModel->SetText([text UTF8String], selected_range, composing_range);
@@ -772,17 +801,7 @@ static char markerKey;
   _eventProducedOutput |= true;
 
   if (range.location != NSNotFound) {
-    // The selected range can actually have negative numbers, since it can start
-    // at the end of the range if the user selected the text going backwards.
-    // Cast to a signed type to determine whether or not the selection is reversed.
-    long signedLength = static_cast<long>(range.length);
-    long location = range.location;
-    long textLength = _activeModel->text_range().end();
-
-    size_t base = std::clamp(location, 0L, textLength);
-    size_t extent = std::clamp(location + signedLength, 0L, textLength);
-
-    _activeModel->SetSelection(flutter::TextRange(base, extent));
+    _activeModel->SetSelection(ClampNSRange(range, _activeModel->text_range().end()));
   } else if (_activeModel->composing() &&
              !(_activeModel->composing_range() == _activeModel->selection())) {
     // When confirmed by Japanese IME, string replaces range of composing_range.
@@ -902,10 +921,11 @@ static char markerKey;
     // the case, because in situations where the replacementRange is actually
     // specified (i.e. when switching between characters equivalent after long
     // key press) the replacementRange is provided while there is no composition.
+    //
+    // The range is clamped to the text because SetComposingRange rejects ranges
+    // that don't fit.
     _activeModel->SetComposingRange(
-        flutter::TextRange(replacementRange.location,
-                           replacementRange.location + replacementRange.length),
-        0);
+        ClampNSRange(replacementRange, _activeModel->text_range().end()), 0);
   }
 
   flutter::TextRange composingBeforeChange = _activeModel->composing_range();
@@ -914,12 +934,20 @@ static char markerKey;
   // Input string may be NSString or NSAttributedString.
   BOOL isAttributedString = [string isKindOfClass:[NSAttributedString class]];
   const NSString* rawString = isAttributedString ? [string string] : string;
-  _activeModel->UpdateComposingText(
-      (const char16_t*)[rawString cStringUsingEncoding:NSUTF16StringEncoding],
-      flutter::TextRange(selectedRange.location, selectedRange.location + selectedRange.length));
+
+  // Copy the UTF-16 code units directly. The C string form truncates at an
+  // embedded NUL and returns NULL when the string cannot be converted.
+  std::u16string marked_text_utf16(rawString.length, u'\0');
+  [rawString getCharacters:reinterpret_cast<unichar*>(marked_text_utf16.data())
+                     range:NSMakeRange(0, marked_text_utf16.length())];
+
+  // selectedRange is provided by the IME. Re-clamp to the text.
+  // NSNotFound (no selection), clamps to end of the marked text.
+  _activeModel->UpdateComposingText(marked_text_utf16,
+                                    ClampNSRange(selectedRange, marked_text_utf16.length()));
 
   if (_enableDeltaModel) {
-    std::string marked_text = [rawString UTF8String];
+    std::string marked_text = rawString ? [rawString UTF8String] : "";
     [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange,
                                                              selectionBeforeChange.collapsed()
                                                                  ? composingBeforeChange

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -298,6 +298,185 @@ static const FlutterViewIdentifier kViewId = 1;
   return true;
 }
 
+- (bool)testSetMarkedTextWithSelectedRangeNotFound {
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
+
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
+    @"inputAction" : @"action",
+    @"inputType" : @{@"name" : @"inputName"},
+  };
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                                             arguments:@[ @(1), setClientConfig ]]
+                    result:^(id){
+                    }];
+
+  FlutterMethodCall* call = [FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditingState"
+                                                              arguments:@{
+                                                                @"text" : @"Text",
+                                                                @"selectionBase" : @(4),
+                                                                @"selectionExtent" : @(4),
+                                                                @"composingBase" : @(-1),
+                                                                @"composingExtent" : @(-1),
+                                                              }];
+  [plugin handleMethodCall:call
+                    result:^(id){
+                    }];
+
+  [plugin setMarkedText:@"marked"
+          selectedRange:NSMakeRange(1, 0)
+       replacementRange:NSMakeRange(NSNotFound, 0)];
+
+  // IMEs report no selection within the marked text by passing NSNotFound,
+  // which is not a valid offset. Clearing the marked text and marking again is
+  // the sequence an input method produces when the input source is switched
+  // mid-composing.
+  [plugin setMarkedText:@""
+          selectedRange:NSMakeRange(NSNotFound, 0)
+       replacementRange:NSMakeRange(NSNotFound, 0)];
+  [plugin setMarkedText:@"n"
+          selectedRange:NSMakeRange(NSNotFound, 0)
+       replacementRange:NSMakeRange(NSNotFound, 0)];
+
+  // A missing selection places the caret at the end of the marked text.
+  NSDictionary* editingState = [plugin editingState];
+  EXPECT_STREQ([editingState[@"text"] UTF8String], "Textn");
+  EXPECT_EQ([editingState[@"selectionBase"] intValue], 5);
+  EXPECT_EQ([editingState[@"selectionExtent"] intValue], 5);
+  EXPECT_EQ([editingState[@"composingBase"] intValue], 4);
+  EXPECT_EQ([editingState[@"composingExtent"] intValue], 5);
+  return true;
+}
+
+- (bool)testSetMarkedTextWithOutOfBoundsRanges {
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
+
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
+    @"inputAction" : @"action",
+    @"inputType" : @{@"name" : @"inputName"},
+  };
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                                             arguments:@[ @(1), setClientConfig ]]
+                    result:^(id){
+                    }];
+
+  FlutterMethodCall* call = [FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditingState"
+                                                              arguments:@{
+                                                                @"text" : @"1234",
+                                                                @"selectionBase" : @(3),
+                                                                @"selectionExtent" : @(3),
+                                                                @"composingBase" : @(-1),
+                                                                @"composingExtent" : @(-1),
+                                                              }];
+  [plugin handleMethodCall:call
+                    result:^(id){
+                    }];
+
+  // Both ranges are computed by the input method against its own version of the
+  // text, which can lag behind the engine's. Each is clamped to what actually
+  // exists rather than dropped.
+  [plugin setMarkedText:@"marked"
+          selectedRange:NSMakeRange(100, 20)
+       replacementRange:NSMakeRange(10, 2)];
+
+  NSDictionary* editingState = [plugin editingState];
+  EXPECT_STREQ([editingState[@"text"] UTF8String], "1234marked");
+  EXPECT_EQ([editingState[@"selectionBase"] intValue], 10);
+  EXPECT_EQ([editingState[@"selectionExtent"] intValue], 10);
+  EXPECT_EQ([editingState[@"composingBase"] intValue], 4);
+  EXPECT_EQ([editingState[@"composingExtent"] intValue], 10);
+  return true;
+}
+
+- (bool)testSetEditingStateWithOutOfBoundsSelection {
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
+
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
+    @"inputAction" : @"action",
+    @"inputType" : @{@"name" : @"inputName"},
+  };
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                                             arguments:@[ @(1), setClientConfig ]]
+                    result:^(id){
+                    }];
+
+  // The framework computes the selection against its own copy of the text and
+  // may send one that does not fit the text accompanying it. The text must
+  // still be applied, with the selection clamped to it, because a selection
+  // that outlives the text it was measured against would be carried into the
+  // next edit as an index into the text buffer.
+  FlutterMethodCall* call = [FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditingState"
+                                                              arguments:@{
+                                                                @"text" : @"Te",
+                                                                @"selectionBase" : @(4),
+                                                                @"selectionExtent" : @(4),
+                                                                @"composingBase" : @(-1),
+                                                                @"composingExtent" : @(-1),
+                                                              }];
+  [plugin handleMethodCall:call
+                    result:^(id){
+                    }];
+
+  NSDictionary* editingState = [plugin editingState];
+  EXPECT_STREQ([editingState[@"text"] UTF8String], "Te");
+  EXPECT_EQ([editingState[@"selectionBase"] intValue], 2);
+  EXPECT_EQ([editingState[@"selectionExtent"] intValue], 2);
+
+  [plugin setMarkedText:@"m" selectedRange:NSMakeRange(1, 0)];
+
+  editingState = [plugin editingState];
+  EXPECT_STREQ([editingState[@"text"] UTF8String], "Tem");
+  EXPECT_EQ([editingState[@"selectionBase"] intValue], 3);
+  EXPECT_EQ([editingState[@"selectionExtent"] intValue], 3);
+  EXPECT_EQ([editingState[@"composingBase"] intValue], 2);
+  EXPECT_EQ([editingState[@"composingExtent"] intValue], 3);
+  return true;
+}
+
 - (bool)testComposingRegionRemovedByFramework {
   id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
@@ -2099,6 +2278,18 @@ TEST(FlutterTextInputPluginTest, TestSetMarkedTextWithReplacementRange) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSetMarkedTextWithReplacementRange]);
 }
 
+TEST(FlutterTextInputPluginTest, TestSetMarkedTextWithSelectedRangeNotFound) {
+  ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSetMarkedTextWithSelectedRangeNotFound]);
+}
+
+TEST(FlutterTextInputPluginTest, TestSetMarkedTextWithOutOfBoundsRanges) {
+  ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSetMarkedTextWithOutOfBoundsRanges]);
+}
+
+TEST(FlutterTextInputPluginTest, TestSetEditingStateWithOutOfBoundsSelection) {
+  ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSetEditingStateWithOutOfBoundsSelection]);
+}
+
 TEST(FlutterTextInputPluginTest, TestComposingRegionRemovedByFramework) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testComposingRegionRemovedByFramework]);
 }
@@ -2521,6 +2712,55 @@ TEST(FlutterTextInputPluginTest, InsertTextHandlesNSAttributedString) {
   EXPECT_STREQ([editingState[@"text"] UTF8String], "attributed text");
   EXPECT_EQ([editingState[@"selectionBase"] intValue], 15);
   EXPECT_EQ([editingState[@"selectionExtent"] intValue], 15);
+}
+
+TEST(FlutterTextInputPluginTest, InsertTextWithReversedReplacementRange) {
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+
+  FlutterTextInputPluginTestDelegate* delegate =
+      [[FlutterTextInputPluginTestDelegate alloc] initWithBinaryMessenger:binaryMessengerMock
+                                                           viewController:viewController];
+
+  FlutterTextInputPlugin* plugin = [[FlutterTextInputPlugin alloc] initWithDelegate:delegate];
+
+  NSDictionary* setClientConfig = @{
+    @"viewId" : @(kViewId),
+    @"inputAction" : @"action",
+    @"inputType" : @{@"name" : @"inputName"},
+  };
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                                             arguments:@[ @(1), setClientConfig ]]
+                    result:^(id){
+                    }];
+
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditingState"
+                                                             arguments:@{
+                                                               @"text" : @"12345",
+                                                               @"selectionBase" : @(5),
+                                                               @"selectionExtent" : @(5),
+                                                               @"composingBase" : @(-1),
+                                                               @"composingExtent" : @(-1),
+                                                             }]
+                    result:^(id){
+                    }];
+
+  // A selection made backwards arrives as a range whose length is negative when
+  // read as a signed value. The two characters before the location are the ones
+  // replaced; read unsigned, the range would instead cover the text after it.
+  [plugin insertText:@"X" replacementRange:NSMakeRange(4, static_cast<NSUInteger>(-2))];
+
+  NSDictionary* editingState = [plugin editingState];
+  EXPECT_STREQ([editingState[@"text"] UTF8String], "12X5");
+  EXPECT_EQ([editingState[@"selectionBase"] intValue], 3);
+  EXPECT_EQ([editingState[@"selectionExtent"] intValue], 3);
 }
 
 TEST(FlutterTextInputPluginTest, InsertTextHandlesEmptyAttributedString) {


### PR DESCRIPTION
`TextInputModel` assumes its selection and composing range fall within its text, but nothing in the text input plugin enforced that. When they don't, we index past the end of `text_` which triggers an abort due to out of range access.

Previously, `setMarkedText:selectedRange:replacementRange:` passed `selectedRange` unvalidated. IMEs report `NSNotFound` to indicate no selection within the mark text. That maps to `NSIntegerMax` rather than an offset, and we incorrectly stored that as the selection. Clearing the marked text collapses the composing range, so the next update replaces the selection instead and calls `replace` with a position `NSIntegerMax`. Clear and re-mark is what an input method emits when the input source is switched mid-composition.

`SetText` was also unsafe: it assigned `text_` before validating the ranges, so a rejected update left us with the new text but the old (now out-of-bounds) ranges still pointing into it.

This fixes that by clamping both ranges before any operation that indexes the text, applying either all of `SetText`'s fields or none, and clamping `selectedRange` and `replacementRange` in the plugin. `setMarkedText:` also null-checks the UTF-16 buffer, which `cStringUsingEncoding:` can return as nullptr.

Fixes: https://github.com/flutter/flutter/issues/190704

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
