### PR TITLE
[iOS] Restore Flutter text focus after native responder recovery

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -1296,6 +1296,11 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   });
 }
 
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+    didRestoreFirstResponderWithTextInputClient:(int)client {
+  [self.textInputChannel invokeMethod:@"TextInputClient.onFocusReceived" arguments:@[ @(client) ]];
+}
+
 #pragma mark - Undo Manager Delegate
 
 - (void)handleUndoWithDirection:(FlutterUndoRedoDirection)direction {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -424,6 +424,19 @@ class TestPlatformMessageResponse : public flutter::PlatformMessageResponse {
   OCMVerify([mockBinaryMessenger sendOnChannel:@"flutter/textinput" message:encodedMethodCall]);
 }
 
+- (void)testFlutterTextInputViewDidRestoreFirstResponderWillCallTextInputClientOnFocusReceived {
+  id mockBinaryMessenger = OCMClassMock([FlutterBinaryMessengerRelay class]);
+  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  [engine setBinaryMessenger:mockBinaryMessenger];
+  [engine runWithEntrypoint:FlutterDefaultDartEntrypoint initialRoute:@"test"];
+  [engine flutterTextInputView:nil didRestoreFirstResponderWithTextInputClient:123];
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"TextInputClient.onFocusReceived"
+                                        arguments:@[ @(123) ]];
+  NSData* encodedMethodCall = [[FlutterJSONMethodCodec sharedInstance] encodeMethodCall:methodCall];
+  OCMVerify([mockBinaryMessenger sendOnChannel:@"flutter/textinput" message:encodedMethodCall]);
+}
+
 - (void)testFlutterEngineUpdatesDisplays {
   FlutterEngine* engine = [[FlutterEngine alloc] init];
   id mockEngine = OCMPartialMock(engine);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -66,6 +66,8 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView
     didResignFirstResponderWithTextInputClient:(int)client;
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+    didRestoreFirstResponderWithTextInputClient:(int)client;
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
     willDismissEditMenuWithTextInputClient:(int)client;
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView
            shareSelectedText:(NSString*)selectedText;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -808,6 +808,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 @property(nonatomic, strong) NSArray<NSDictionary*>* editMenuItems;
 
 - (void)setEditableTransform:(NSArray*)matrix;
+- (BOOL)becomeFirstResponderFromFramework;
+- (BOOL)resignFirstResponderFromFramework;
 @end
 
 @implementation FlutterTextInputView {
@@ -825,6 +827,12 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   bool _isFloatingCursorActive;
   CGPoint _floatingCursorOffset;
   bool _enableInteractiveSelection;
+  BOOL _isResigningFirstResponderFromFramework;
+  // A non-framework resign arms a one-shot notification for this exact view. The responder API
+  // does not reveal which object, if any, takes focus next, so a handoff to a native input can arm
+  // it too. Framework responder calls and client updates cancel it before UIKit can restore stale
+  // input state.
+  BOOL _shouldNotifyFrameworkOnFirstResponderRestore;
   UITextInteraction* _textInteraction API_AVAILABLE(ios(13.0));
 }
 
@@ -1168,6 +1176,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 }
 
 - (void)setTextInputClient:(int)client {
+  _shouldNotifyFrameworkOnFirstResponderRestore = NO;
   _textInputClient = client;
   _hasPlaceholder = NO;
 }
@@ -1336,14 +1345,43 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   return _textInputClient != 0;
 }
 
-- (BOOL)resignFirstResponder {
-  BOOL success = [super resignFirstResponder];
-  if (success) {
-    if (!_preventCursorDismissWhenResignFirstResponder) {
-      [self.textInputDelegate flutterTextInputView:self
-          didResignFirstResponderWithTextInputClient:_textInputClient];
-    }
+- (BOOL)becomeFirstResponder {
+  BOOL wasFirstResponder = self.isFirstResponder;
+  BOOL success = [super becomeFirstResponder];
+  if (success && !wasFirstResponder && self.isFirstResponder &&
+      _shouldNotifyFrameworkOnFirstResponderRestore) {
+    _shouldNotifyFrameworkOnFirstResponderRestore = NO;
+    // Existing framework client and FocusNode guards decide whether to accept the restored focus.
+    [self.textInputDelegate flutterTextInputView:self
+        didRestoreFirstResponderWithTextInputClient:_textInputClient];
   }
+  return success;
+}
+
+- (BOOL)resignFirstResponder {
+  BOOL wasFirstResponder = self.isFirstResponder;
+  BOOL success = [super resignFirstResponder];
+  if (success && !_preventCursorDismissWhenResignFirstResponder) {
+    if (wasFirstResponder) {
+      _shouldNotifyFrameworkOnFirstResponderRestore =
+          !_isResigningFirstResponderFromFramework && _textInputClient != 0;
+    }
+    [self.textInputDelegate flutterTextInputView:self
+        didResignFirstResponderWithTextInputClient:_textInputClient];
+  }
+  return success;
+}
+
+- (BOOL)becomeFirstResponderFromFramework {
+  _shouldNotifyFrameworkOnFirstResponderRestore = NO;
+  return [self becomeFirstResponder];
+}
+
+- (BOOL)resignFirstResponderFromFramework {
+  _shouldNotifyFrameworkOnFirstResponderRestore = NO;
+  _isResigningFirstResponderFromFramework = YES;
+  BOOL success = [self resignFirstResponder];
+  _isResigningFirstResponderFromFramework = NO;
   return success;
 }
 
@@ -2853,7 +2891,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 - (void)showTextInput {
   _activeView.viewResponder = _viewResponder;
   [self addToInputParentViewIfNeeded:_activeView];
-  [_activeView becomeFirstResponder];
+  [_activeView becomeFirstResponderFromFramework];
 }
 
 - (void)enableActiveViewAccessibility {
@@ -2864,7 +2902,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 }
 
 - (void)hideTextInput {
-  [_activeView resignFirstResponder];
+  [_activeView resignFirstResponderFromFramework];
 
   // Remove the input view from the view hierarchy after resigning first responder.
   // This flag is set by clearTextInputClient when autofillContext is empty.
@@ -2878,7 +2916,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 }
 
 - (void)triggerAutofillSave:(BOOL)saveEntries {
-  [_activeView resignFirstResponder];
+  [_activeView resignFirstResponderFromFramework];
 
   if (saveEntries) {
     // Make all the input fields in the autofill context visible,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -22,6 +22,7 @@ FLUTTER_ASSERT_ARC
 
 @interface FlutterTextInputView ()
 @property(nonatomic, copy) NSString* autofillId;
+@property(nonatomic, assign) BOOL preventCursorDismissWhenResignFirstResponder;
 - (void)setEditableTransform:(NSArray*)matrix;
 - (void)setTextInputClient:(int)client;
 - (void)setTextInputState:(NSDictionary*)state;
@@ -33,6 +34,8 @@ FLUTTER_ASSERT_ARC
 - (void)handleSearchWebAction;
 - (void)handleLookUpAction;
 - (void)handleShareAction;
+- (BOOL)becomeFirstResponderFromFramework;
+- (BOOL)resignFirstResponderFromFramework;
 @end
 
 @interface FlutterTextInputViewSpy : FlutterTextInputView
@@ -1696,6 +1699,138 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
                                  return ([state[@"selectionBase"] intValue]) == 9 &&
                                         ([state[@"selectionExtent"] intValue] == 9);
                                }]]);
+}
+
+- (void)testRestoringPlatformFirstResponderNotifiesFrameworkOnce {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [UIApplication.sharedApplication.keyWindow addSubview:inputView];
+  [inputView setTextInputClient:123];
+
+  XCTAssertTrue([inputView becomeFirstResponderFromFramework]);
+  OCMVerify(never(), [engine flutterTextInputView:inputView
+                         didRestoreFirstResponderWithTextInputClient:123]);
+
+  XCTAssertTrue([inputView resignFirstResponder]);
+  OCMVerify(times(1), [engine flutterTextInputView:inputView
+                          didResignFirstResponderWithTextInputClient:123]);
+  OCMVerify(never(), [engine flutterTextInputView:inputView
+                         didRestoreFirstResponderWithTextInputClient:123]);
+  XCTAssertTrue([inputView becomeFirstResponder]);
+  OCMVerify(times(1), [engine flutterTextInputView:inputView
+                          didRestoreFirstResponderWithTextInputClient:123]);
+
+  XCTAssertTrue([inputView becomeFirstResponder]);
+  OCMVerify(times(1), [engine flutterTextInputView:inputView
+                          didRestoreFirstResponderWithTextInputClient:123]);
+
+  XCTAssertTrue([inputView resignFirstResponder]);
+  OCMVerify(times(2), [engine flutterTextInputView:inputView
+                          didResignFirstResponderWithTextInputClient:123]);
+  OCMVerify(times(1), [engine flutterTextInputView:inputView
+                          didRestoreFirstResponderWithTextInputClient:123]);
+  XCTAssertTrue([inputView becomeFirstResponder]);
+  OCMVerify(times(2), [engine flutterTextInputView:inputView
+                          didRestoreFirstResponderWithTextInputClient:123]);
+
+  [inputView resignFirstResponderFromFramework];
+  [inputView removeFromSuperview];
+}
+
+- (void)testFrameworkResponderChangesCancelPendingFocusRestore {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [UIApplication.sharedApplication.keyWindow addSubview:inputView];
+  [inputView setTextInputClient:123];
+
+  XCTAssertTrue([inputView becomeFirstResponderFromFramework]);
+  XCTAssertTrue([inputView resignFirstResponderFromFramework]);
+  XCTAssertTrue([inputView becomeFirstResponder]);
+
+  XCTAssertTrue([inputView resignFirstResponder]);
+  XCTAssertTrue([inputView becomeFirstResponderFromFramework]);
+
+  OCMVerify(never(), [engine flutterTextInputView:inputView
+                         didRestoreFirstResponderWithTextInputClient:123]);
+
+  [inputView resignFirstResponderFromFramework];
+  [inputView removeFromSuperview];
+}
+
+- (void)testInteractiveKeyboardResignDoesNotArmFocusRestore {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [UIApplication.sharedApplication.keyWindow addSubview:inputView];
+  [inputView setTextInputClient:123];
+
+  XCTAssertTrue([inputView becomeFirstResponderFromFramework]);
+  inputView.preventCursorDismissWhenResignFirstResponder = YES;
+  XCTAssertTrue([inputView resignFirstResponder]);
+  inputView.preventCursorDismissWhenResignFirstResponder = NO;
+  XCTAssertTrue([inputView becomeFirstResponder]);
+
+  OCMVerify(never(), [engine flutterTextInputView:inputView
+                         didResignFirstResponderWithTextInputClient:123]);
+  OCMVerify(never(), [engine flutterTextInputView:inputView
+                         didRestoreFirstResponderWithTextInputClient:123]);
+
+  [inputView resignFirstResponderFromFramework];
+  [inputView removeFromSuperview];
+}
+
+- (void)testChangingClientCancelsPendingFocusRestore {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [UIApplication.sharedApplication.keyWindow addSubview:inputView];
+  [inputView setTextInputClient:123];
+
+  XCTAssertTrue([inputView becomeFirstResponderFromFramework]);
+  XCTAssertTrue([inputView resignFirstResponder]);
+  [inputView setTextInputClient:456];
+  XCTAssertTrue([inputView becomeFirstResponder]);
+
+  OCMVerify(never(), [engine flutterTextInputView:inputView
+                         didRestoreFirstResponderWithTextInputClient:123]);
+  OCMVerify(never(), [engine flutterTextInputView:inputView
+                         didRestoreFirstResponderWithTextInputClient:456]);
+
+  [inputView resignFirstResponderFromFramework];
+  [inputView removeFromSuperview];
+}
+
+- (void)testResettingSameClientCancelsPendingFocusRestore {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [UIApplication.sharedApplication.keyWindow addSubview:inputView];
+  [inputView setTextInputClient:123];
+
+  XCTAssertTrue([inputView becomeFirstResponderFromFramework]);
+  XCTAssertTrue([inputView resignFirstResponder]);
+  [inputView setTextInputClient:123];
+  XCTAssertTrue([inputView becomeFirstResponder]);
+
+  OCMVerify(never(), [engine flutterTextInputView:inputView
+                         didRestoreFirstResponderWithTextInputClient:123]);
+
+  [inputView resignFirstResponderFromFramework];
+  [inputView removeFromSuperview];
+}
+
+- (void)testPluginUsesFrameworkResponderChangesForExplicitTextInputMethods {
+  [self setClientId:123 configuration:self.mutableTemplateCopy];
+  id mockInputView = OCMPartialMock(textInputPlugin.activeView);
+  OCMStub([mockInputView becomeFirstResponderFromFramework]).andReturn(YES);
+  OCMStub([mockInputView resignFirstResponderFromFramework]).andReturn(YES);
+
+  [self setTextInputShow];
+  OCMVerify(times(1), [mockInputView becomeFirstResponderFromFramework]);
+
+  [self setTextInputHide];
+  OCMVerify(times(1), [mockInputView resignFirstResponderFromFramework]);
+
+  FlutterMethodCall* finishAutofillContextCall =
+      [FlutterMethodCall methodCallWithMethodName:@"TextInput.finishAutofillContext" arguments:@NO];
+  [textInputPlugin handleMethodCall:finishAutofillContextCall
+                             result:^(id _Nullable result){
+                             }];
+
+  OCMVerify(times(2), [mockInputView resignFirstResponderFromFramework]);
+  [mockInputView stopMocking];
 }
 
 - (void)testInputViewsHasNonNilInputDelegate {


### PR DESCRIPTION

Fixes https://github.com/flutter/flutter/issues/189051

On iOS 26, UIKit resigns the native text responder during a quick app switch and restores it on return. The engine reports the resignation to the framework as `onConnectionClosed` but never reports the restoration, so the keyboard comes back while every `FocusNode` stays unfocused and typing goes nowhere.

I filed that issue, [together with a sample app that uses nothing but plain `TextField` widgets.](https://github.com/hoyahozz/ios-keyboard-stuck-after-app-switch) 
### Root cause

Instrumented unpatched engine, iPhone 17 / iOS 26.6 :

```text
18:54:13.415  resignFirstResponder client=1
18:54:13.420  framework focus cleared (onConnectionClosed)
18:54:13.488  AppLifecycleState.paused
18:54:13.783  becomeFirstResponder client=1      <-- UIKit restores the same view
18:54:14.042  AppLifecycleState.resumed
18:54:14.043  all Flutter text fields focus=false
18:54:14.272  viewInsets.bottom=physical=924.0, logical=308.0
```

The `becomeFirstResponder` never reaches Dart. There is no reverse message for "UIKit restored the same view", so only the framework half stays down.

I cannot see UIKit's internals, so I compared behaviour instead. A standalone UIKit app with a single `UITextField` and no Flutter, built once and installed on both devices, produced this sequence only on iOS 26 :

- iPhone 15 Pro / iOS 18.1.1 : the field stays first responder across the switch, with no resignation.
- iPhone 17 / iOS 26.6 : `willResignActive → resignFirstResponder → didEndEditing`, then `willEnterForeground → becomeFirstResponder → didBeginEditing`.

Plain UIKit recovers on its own, because `didBeginEditing` puts the field back into editing. Flutter has no equivalent signal. I cannot say why UIKit does this and Apple does not document it, so I treated it as a behaviour difference observed from **iOS 26** onward and fixed the Flutter side of the boundary, which does not depend on the reason.

### The fix

`FlutterTextInputView` now tracks *why* its responder state changed, and sends the existing `TextInputClient.onFocusReceived` when UIKit restores it.

- A non-framework `resignFirstResponder` on a valid client arms a one-shot restore flag.
- A real `false → true` restoration of the same view consumes the flag and sends one notification, so it fires at most once per cycle.
- `TextInput.show`, `TextInput.hide`, `TextInput.finishAutofillContext` and `TextInput.setClient` cancel it. `showTextInput`, `hideTextInput` and `triggerAutofillSave` now call `becomeFirstResponderFromFramework` / `resignFirstResponderFromFramework`, which is how framework-driven changes are kept out of the classification.
- Interactive keyboard dismissal never arms it.
- `onConnectionClosed` still fires unchanged, so real handoffs to native inputs and system menus are unaffected.
- No framework changes. `TextInput` still matches the client id, and `EditableTextState.onFocusReceived` still checks `mounted`, `_hasFocus` and `canRequestFocus`, so a stale client cannot steal focus.

The guarantee is narrow : *if UIKit restores the same responder before the framework declares a new input state, the existing Dart guards get exactly one chance to accept it.*

### Tests

New Objective-C tests cover :

- one notification per platform `resign → become` cycle
- no notification when either side of the transition came from the framework
- interactive keyboard dismissal never arming
- `setClient` cancelling a pending restoration, for both a new and a repeated id
- `show` / `hide` / `finishAutofillContext` going through the wrappers
- the delegate serialising to `TextInputClient.onFocusReceived`

### Validation on device

iPhone 17 / iOS 26.6, using the sample app from the issue. Same app source and same Flutter revision in both runs. Before, the keyboard returns but no field is focused and typing goes nowhere; after, the same field keeps focus across the switch.

#### Before

https://github.com/user-attachments/assets/b70e4875-7737-46cb-a3db-738817f5b04c

#### After

https://github.com/user-attachments/assets/045efe24-0cfd-458b-a567-7fe8fd9def73 



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
