### PR TITLE
Expose includeHash on usePathUrlStrategy()

### DIFF
--- a/packages/flutter_web_plugins/lib/src/navigation/url_strategy.dart
+++ b/packages/flutter_web_plugins/lib/src/navigation/url_strategy.dart
@@ -23,8 +23,12 @@ void setUrlStrategy(ui_web.UrlStrategy? strategy) {
 }
 
 /// Use the [PathUrlStrategy] to handle the browser URL.
-void usePathUrlStrategy() {
-  setUrlStrategy(PathUrlStrategy());
+///
+/// Set [includeHash] to preserve the URL fragment (e.g. `/#access_token=...`,
+/// as used by some auth provider redirects) instead of having it stripped on
+/// the very first load. See [PathUrlStrategy.includeHash] for details.
+void usePathUrlStrategy({bool includeHash = false}) {
+  setUrlStrategy(PathUrlStrategy(const ui_web.BrowserPlatformLocation(), includeHash));
 }
 
 /// Uses the browser URL's pathname to represent Flutter's route name.

--- a/packages/flutter_web_plugins/lib/src/navigation_non_web/url_strategy.dart
+++ b/packages/flutter_web_plugins/lib/src/navigation_non_web/url_strategy.dart
@@ -84,7 +84,7 @@ void setUrlStrategy(UrlStrategy? strategy) {
 }
 
 /// Use the [PathUrlStrategy] to handle the browser URL.
-void usePathUrlStrategy() {
+void usePathUrlStrategy({bool includeHash = false}) {
   // No-op in non-web platforms.
 }
 

--- a/packages/flutter_web_plugins/test/navigation/non_web_url_strategy_test.dart
+++ b/packages/flutter_web_plugins/test/navigation/non_web_url_strategy_test.dart
@@ -37,5 +37,11 @@ void main() {
         usePathUrlStrategy();
       }, returnsNormally);
     });
+
+    test('Can usePathUrlStrategy with includeHash: true', () {
+      expect(() {
+        usePathUrlStrategy(includeHash: true);
+      }, returnsNormally);
+    });
   });
 }

--- a/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
+++ b/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
@@ -139,12 +139,19 @@ void main() {
 
     test('can usePathUrlStrategy with the default includeHash', () {
       expect(() => usePathUrlStrategy(), returnsNormally);
-      expect(urlStrategy, isA<PathUrlStrategy>());
+      final UrlStrategy? strategy = urlStrategy;
+      expect(strategy, isA<PathUrlStrategy>());
+      // Dynamic access is needed because `PathUrlStrategy.includeHash` isn't
+      // declared on the non-web stub that the conditional export statically
+      // resolves to outside of a web build.
+      expect((strategy as dynamic).includeHash, isFalse);
     });
 
     test('can usePathUrlStrategy with includeHash: true', () {
       expect(() => usePathUrlStrategy(includeHash: true), returnsNormally);
-      expect(urlStrategy, isA<PathUrlStrategy>());
+      final UrlStrategy? strategy = urlStrategy;
+      expect(strategy, isA<PathUrlStrategy>());
+      expect((strategy as dynamic).includeHash, isTrue);
     });
   });
 }

--- a/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
+++ b/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
@@ -131,4 +131,20 @@ void main() {
       expect(strategy.prepareExternalUrl('/bar/'), '/foo/bar/');
     });
   });
+
+  group('usePathUrlStrategy', () {
+    tearDown(() {
+      setUrlStrategy(null);
+    });
+
+    test('can usePathUrlStrategy with the default includeHash', () {
+      expect(() => usePathUrlStrategy(), returnsNormally);
+      expect(urlStrategy, isA<PathUrlStrategy>());
+    });
+
+    test('can usePathUrlStrategy with includeHash: true', () {
+      expect(() => usePathUrlStrategy(includeHash: true), returnsNormally);
+      expect(urlStrategy, isA<PathUrlStrategy>());
+    });
+  });
 }


### PR DESCRIPTION
## Summary

`usePathUrlStrategy()` always constructed `PathUrlStrategy()` with the default `includeHash: false`, with no way to opt in short of bypassing the convenience function entirely and calling `setUrlStrategy(PathUrlStrategy(location, true))` directly.

`PathUrlStrategy.includeHash` already exists specifically to preserve a URL fragment across the very first load (its doc comment: *"solves the edge cases when using auth provider which redirects back to the app with token in redirect URL as `/#access_token=bla_bla_bla`"*) — which is exactly the symptom reported: the hash is stripped as soon as the engine initializes, because `usePathUrlStrategy()` never gave callers a way to reach that existing flag.

This threads an optional `includeHash` parameter through `usePathUrlStrategy()` in both the real web implementation and the non-web no-op stub, so the conditional-export barrel stays consistent.

Fixes #191724

## Test plan

- [x] `flutter test packages/flutter_web_plugins/test/navigation/non_web_url_strategy_test.dart` — 4/4 passing (VM-based, runs in this environment)
- [x] Added a `@TestOn('chrome')` regression test in `url_strategy_test.dart` asserting `includeHash` actually reaches the constructed `PathUrlStrategy` (via a dynamic-cast read-back, since the field isn't declared on the non-web stub the conditional export statically resolves to outside a web build) — **could not execute this locally**: this sandbox's `dart2js` fails to compile any file that transitively imports `package:flutter`, confirmed by running the pre-existing, unmodified test file and observing the identical failure signature before touching anything. CI's web test shard will cover it.
- [x] `dart analyze packages/flutter_web_plugins/` — no issues
- [x] Verified the new `BrowserPlatformLocation()` passed explicitly is bit-for-bit the same default `HashUrlStrategy` already used internally — no behavior change for existing zero-arg callers

---
### Review-Before-PR
- Tier: T1
- Languages: Dart
- Repo health: 5 test files / 8 source files (flutter_web_plugins)
- Reviewers: correctness, tests
- Findings: 1 total · 1 fixed in-session · 0 deferred · 0 rejected · 0 rejected-critical
- Scorer dropped: 0 · Critical verifier dropped: N/A (T1, no critical findings)
- Skipped: no