### PR TITLE
Disable more Windows tests that have been causing CI flakes

### DIFF
--- a/engine/src/flutter/shell/platform/windows/window_manager_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/window_manager_unittests.cc
@@ -949,7 +949,10 @@ TEST_F(WindowManagerTest, CreateRegularWindowSizedToContent) {
   EXPECT_GE(view_id, 0);
 }
 
-TEST_F(WindowManagerTest, RegularWindowSizedToContentResizesToContent) {
+// TODO(team-windows): Fix flakes. See:
+// https://github.com/flutter/flutter/issues/177172
+TEST_F(WindowManagerTest,
+       DISABLED_RegularWindowSizedToContentResizesToContent) {
   IsolateScope isolate_scope(isolate());
 
   RegularWindowCreationRequest creation_request{
@@ -1023,8 +1026,11 @@ TEST_F(WindowManagerTest, RegularWindowSizedToContentResizableHasThickFrame) {
   EXPECT_NE(style & WS_MAXIMIZEBOX, 0L);
 }
 
-TEST_F(WindowManagerTest,
-       RegularWindowSizedToContentResizableStopsTrackingAfterFirstFrame) {
+// TODO(team-windows): Fix flakes. See:
+// https://github.com/flutter/flutter/issues/177172
+TEST_F(
+    WindowManagerTest,
+    DISABLED_RegularWindowSizedToContentResizableStopsTrackingAfterFirstFrame) {
   IsolateScope isolate_scope(isolate());
 
   RegularWindowCreationRequest creation_request{
@@ -1091,7 +1097,9 @@ TEST_F(WindowManagerTest, CreateModalDialogSizedToContent) {
   EXPECT_GE(view_id, 0);
 }
 
-TEST_F(WindowManagerTest, DialogWindowSizedToContentResizesToContent) {
+// TODO(team-windows): Fix flakes. See:
+// https://github.com/flutter/flutter/issues/177172
+TEST_F(WindowManagerTest, DISABLED_DialogWindowSizedToContentResizesToContent) {
   IsolateScope isolate_scope(isolate());
 
   DialogWindowCreationRequest creation_request{


### PR DESCRIPTION
These test cases have been flaking repeatedly on the Windows LUCI bots:
* WindowManagerTest.DialogWindowSizedToContentResizesToContent
* WindowManagerTest.RegularWindowSizedToContentResizableStopsTrackingAfterFirstFrame
* WindowManagerTest.RegularWindowSizedToContentResizesToContent

Previously some other Windows tests involving resizing had been disabled due to similar flakiness (see https://github.com/flutter/flutter/pull/189477)

See https://github.com/flutter/flutter/issues/177172