### PR TITLE
[iOS][a11y] Opt FlutterSemanticsScrollView out of the status bar scroll-to-top gesture

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSemanticsScrollView.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSemanticsScrollView.mm
@@ -17,6 +17,12 @@ FLUTTER_ASSERT_ARC
     _semanticsObject = semanticsObject;
     _isDoingSystemScrolling = NO;
     self.delegate = self;
+    // This scroll view only mirrors the Flutter scrollable for accessibility; it must not take part
+    // in the system's status bar scroll-to-top gesture. Otherwise, once the user scrolls, UIKit can
+    // pick this view over the FlutterViewController's dedicated scroll view and the framework never
+    // receives the tap. Accessibility scrolling goes through accessibilityScroll: instead, so
+    // opting out here does not affect assistive technologies.
+    self.scrollsToTop = NO;
   }
   return self;
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -196,6 +196,30 @@ const float kFloatCompareEpsilon = 0.001;
   XCTAssertFalse(scrollView.isAccessibilityElement);
 }
 
+- (void)testFlutterScrollableSemanticsObjectDoesNotParticipateInScrollsToTop {
+  fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
+      new flutter::testing::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+
+  flutter::SemanticsNode node;
+  node.flags.hasImplicitScrolling = true;
+  node.actions = flutter::kVerticalScrollSemanticsActions;
+  node.rect = SkRect::MakeXYWH(0, 0, 100, 200);
+  node.scrollExtentMax = 100.0;
+  node.scrollPosition = 0.0;
+
+  FlutterScrollableSemanticsObject* scrollable =
+      [[FlutterScrollableSemanticsObject alloc] initWithBridge:bridge uid:0];
+  [scrollable setSemanticsNode:&node];
+  [scrollable accessibilityBridgeDidFinishUpdate];
+
+  UIScrollView* scrollView = [scrollable nativeAccessibility];
+
+  // The semantics scroll view must opt out of the system status bar scroll-to-top gesture so that
+  // it never competes with the FlutterViewController's dedicated scroll view.
+  XCTAssertFalse(scrollView.scrollsToTop);
+}
+
 - (void)testAccessibilityScrollToVisibleWithChild {
   fml::WeakPtrFactory<flutter::testing::MockAccessibilityBridge> factory(
       new flutter::testing::MockAccessibilityBridge());


### PR DESCRIPTION
On iOS, tapping the status bar should scroll the primary scrollable back to the top. When the
engine's accessibility bridge is active (VoiceOver, Speak Screen, Switch Control, or the simulator,
which always enables it) and the scrollable extends behind the status bar, the first tap does
nothing; only a later tap works.

`FlutterSemanticsScrollView` is the hidden `UIScrollView` the engine creates for each scrollable
semantics node. It was initialized without disabling `scrollsToTop`, so it kept the `UIScrollView`
default of `YES`. Because `accessibilityBridgeDidFinishUpdate` keeps its `contentOffset` in sync
with the Flutter scroll position, it becomes an eligible scroll-to-top receiver as soon as the user
scrolls, competing with the dedicated scroll view `FlutterViewController` installs for this gesture.
When the scrollable covers the status bar area, UIKit asks the semantics scroll view first; it is
its own delegate and does not implement `scrollViewShouldScrollToTop:`, so UIKit gets the default
`YES`, natively scrolls the hidden view, and never asks `FlutterViewController` — the framework
never sees the tap. Once the hidden view's offset is back at zero it stops being eligible, which is
why a subsequent tap appears to work.

This PR sets `scrollsToTop = NO` in `initWithSemanticsObject:` so the semantics scroll view no
longer participates in the gesture. Assistive technologies are unaffected: semantics scrolling is
performed through the forwarded `accessibilityScroll:` action, which does not rely on the native
scroll-to-top mechanism.

Fixes https://github.com/flutter/flutter/issues/191565

Tests: added `testFlutterScrollableSemanticsObjectDoesNotParticipateInScrollsToTop` to
`SemanticsObjectTest.mm`, asserting that the scroll view exposed by
`FlutterScrollableSemanticsObject` has `scrollsToTop == NO` after a semantics update. Locally
`testing/run_tests.py --type=objc` passes (706 tests, 9 skipped, 0 failures) against
`ios_debug_sim_unopt_arm64`, and reverting the one-line change makes the new test — and only the
new test — fail, so it does catch the regression.

I also checked the fix end to end against the reproduction case from the issue: running that app on
a simulator with a locally built engine, the first status bar tap now scrolls the list to the top,
and enumerating the eligible receivers shows a single `UIScrollView` (the one
`FlutterViewController` installs) instead of two. Opening as a draft while the rest of CI runs.

## Before / after

Both clips run the same automated steps on a simulator (scroll down, then a single status bar tap).
The banner and the ripple are debug instrumentation I added to the sample app, not engine behavior:
they log which object UIKit asked via `scrollViewShouldScrollToTop:` and where the tap landed.

**Before** (stock engine): the tap is answered by `FlutterSemanticsScrollView`, the hidden view
scrolls instead, and the list stays where it was.

https://github.com/user-attachments/assets/4a22c2bd-6116-4e3b-a577-3d77c163c103

**After** (this change): the tap reaches `FlutterViewController`, and the list scrolls to the top on
the first tap.

https://github.com/user-attachments/assets/f4cb9196-a3d8-4dd8-9026-34be08e7bb0a

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
