### PR TITLE
Replace Shell::WaitForFirstFrame with an asynchronous API that matches the Shell threading model

### DIFF
--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1445,11 +1445,18 @@ void Shell::OnAnimatorDraw(std::shared_ptr<FramePipeline> pipeline) {
             rasterizer->Draw(pipeline);
           }
 
+          // waiting_for_first_frame is set to true during shell startup, and
+          // after the first frame is drawn it is set fo false and will remain
+          // false.
+          // AddFirstFrameCallback reads waiting_for_first_frame while holding
+          // the waiting_for_first_frame_mutex, and it adds entries to
+          // waiting_for_first_frame_callbacks only if waiting_for_first_frame
+          // is true.
           if (waiting_for_first_frame.load()) {
-            waiting_for_first_frame.store(false);
             std::vector<std::function<void()>> callbacks;
             {
               std::scoped_lock lock(waiting_for_first_frame_mutex);
+              waiting_for_first_frame.store(false);
               std::swap(waiting_for_first_frame_callbacks, callbacks);
             }
             for (const auto& callback : callbacks) {

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1435,7 +1435,8 @@ void Shell::OnAnimatorDraw(std::shared_ptr<FramePipeline> pipeline) {
 
   task_runners_.GetRasterTaskRunner()->PostTask(fml::MakeCopyable(
       [&waiting_for_first_frame = waiting_for_first_frame_,
-       &waiting_for_first_frame_condition = waiting_for_first_frame_condition_,
+       &waiting_for_first_frame_mutex = waiting_for_first_frame_mutex_,
+       &waiting_for_first_frame_callbacks = waiting_for_first_frame_callbacks_,
        rasterizer = rasterizer_->GetWeakPtr(),
        weak_pipeline = std::weak_ptr<FramePipeline>(pipeline)]() mutable {
         if (rasterizer) {
@@ -1446,7 +1447,14 @@ void Shell::OnAnimatorDraw(std::shared_ptr<FramePipeline> pipeline) {
 
           if (waiting_for_first_frame.load()) {
             waiting_for_first_frame.store(false);
-            waiting_for_first_frame_condition.notify_all();
+            std::vector<std::function<void()>> callbacks;
+            {
+              std::scoped_lock lock(waiting_for_first_frame_mutex);
+              std::swap(waiting_for_first_frame_callbacks, callbacks);
+            }
+            for (const auto& callback : callbacks) {
+              callback();
+            }
           }
         }
       }));
@@ -2384,44 +2392,16 @@ Rasterizer::Screenshot Shell::Screenshot(
   return screenshot;
 }
 
-fml::Status Shell::WaitForFirstFrame(fml::TimeDelta timeout) {
-  FML_DCHECK(is_set_up_);
-  if (task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread() ||
-      task_runners_.GetRasterTaskRunner()->RunsTasksOnCurrentThread()) {
-    return fml::Status(fml::StatusCode::kFailedPrecondition,
-                       "WaitForFirstFrame called from thread that can't wait "
-                       "because it is responsible for generating the frame.");
-  }
-
-  // Check for overflow.
-  auto now = std::chrono::steady_clock::now();
-  auto max_duration = std::chrono::steady_clock::time_point::max() - now;
-  auto desired_duration = std::chrono::milliseconds(timeout.ToMilliseconds());
-  auto duration =
-      now + (desired_duration > max_duration ? max_duration : desired_duration);
-
-  std::unique_lock<std::mutex> lock(waiting_for_first_frame_mutex_);
-  bool success = waiting_for_first_frame_condition_.wait_until(
-      lock, duration,
-      [&waiting_for_first_frame = waiting_for_first_frame_,
-       &cancelled = wait_for_first_frame_cancelled_] {
-        return !waiting_for_first_frame.load() || cancelled;
-      });
-  if (wait_for_first_frame_cancelled_) {
-    return fml::Status(fml::StatusCode::kAborted, "Shell is shutting down.");
-  } else if (success) {
-    return fml::Status();
-  } else {
-    return fml::Status(fml::StatusCode::kDeadlineExceeded, "timeout");
-  }
-}
-
-void Shell::CancelWaitForFirstFrame() {
+void Shell::AddFirstFrameCallback(std::function<void()> callback) {
   {
     std::scoped_lock lock(waiting_for_first_frame_mutex_);
-    wait_for_first_frame_cancelled_ = true;
+    if (waiting_for_first_frame_.load()) {
+      waiting_for_first_frame_callbacks_.push_back(std::move(callback));
+      return;
+    }
   }
-  waiting_for_first_frame_condition_.notify_all();
+  // Invoke the callback now because the first frame has already been rendered.
+  callback();
 }
 
 bool Shell::ReloadSystemFonts() {

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -342,26 +342,16 @@ class Shell final : public PlatformView::Delegate,
   /// @brief      Invokes a callback when the first frame has been presented.
   ///
   /// @param[in]  callback  A callback that will be invoked on an arbitrary
-  ///                       thread when the first frame is presented.  If the
-  ///                       first frame has already been presented, then the
-  ///                       callback will be invoked immediately.
+  ///                       thread when the first frame is presented.  The
+  ///                       callback may be run the raster thread, so it should
+  ///                       not do anything expensive.
+  ///
+  ///                       If the first frame has already been presented,
+  ///                       then the callback will be invoked immediately.
+  ///                       If the first frame is never drawn, then the
+  ///                       callback will not be invoked.
   ///
   void AddFirstFrameCallback(std::function<void()> callback);
-
-  //----------------------------------------------------------------------------
-  /// @brief      Unblocks any call to WaitForFirstFrame(), causing it to
-  ///             immediately return 'kAborted' instead of blocking for the
-  ///             full timeout.
-  ///
-  ///             Embedders that pass a reference to the Shell to a thread they
-  ///             do not otherwise synchronize with the shell's destruction
-  ///             must call this, and wait for that thread to finish with the
-  ///             shell, before destroying it. This method only prevents
-  ///             WaitForFirstFrame() from blocking; it does not by itself
-  ///             make it safe to destroy the Shell out from under a caller
-  ///             that has not yet returned from WaitForFirstFrame().
-  ///
-  void CancelWaitForFirstFrame();
 
   //----------------------------------------------------------------------------
   /// @brief      Used by embedders to reload the system fonts in
@@ -522,10 +512,11 @@ class Shell final : public PlatformView::Delegate,
   // True if a first frame has not yet been rendered.
   //
   // This is read and written lock-free on the raster thread, and read under
-  // waiting_for_first_frame_mutex_ in WaitForFirstFrame.
+  // waiting_for_first_frame_mutex_ in AddFirstFrameCallback.
   std::atomic<bool> waiting_for_first_frame_ = true;
 
   std::mutex waiting_for_first_frame_mutex_;
+  // Guarded by waiting_for_first_frame_mutex_.
   std::vector<std::function<void()>> waiting_for_first_frame_callbacks_;
 
   // Written in the UI thread and read from the raster thread. Hence make it

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -339,18 +339,14 @@ class Shell final : public PlatformView::Delegate,
                                     bool base64_encode);
 
   //----------------------------------------------------------------------------
-  /// @brief      Pauses the calling thread until the first frame is presented.
+  /// @brief      Invokes a callback when the first frame has been presented.
   ///
-  /// @param[in]  timeout  The duration to wait before timing out. If this
-  ///                      duration would cause an overflow when added to
-  ///                      std::chrono::steady_clock::now(), this method will
-  ///                      wait indefinitely for the first frame.
+  /// @param[in]  callback  A callback that will be invoked on an arbitrary
+  ///                       thread when the first frame is presented.  If the
+  ///                       first frame has already been presented, then the
+  ///                       callback will be invoked immediately.
   ///
-  /// @return     'kOk' when the first frame has been presented before the
-  ///             timeout successfully, 'kFailedPrecondition' if called from the
-  ///             GPU or UI thread, 'kDeadlineExceeded' if there is a timeout.
-  ///
-  fml::Status WaitForFirstFrame(fml::TimeDelta timeout);
+  void AddFirstFrameCallback(std::function<void()> callback);
 
   //----------------------------------------------------------------------------
   /// @brief      Unblocks any call to WaitForFirstFrame(), causing it to
@@ -529,14 +525,8 @@ class Shell final : public PlatformView::Delegate,
   // waiting_for_first_frame_mutex_ in WaitForFirstFrame.
   std::atomic<bool> waiting_for_first_frame_ = true;
 
-  // True when WaitForFirstFrame has been cancelled because the shell is
-  // shutting down and waiting threads should be unblocked.
-  //
-  // Guarded by waiting_for_first_frame_mutex_.
-  bool wait_for_first_frame_cancelled_ = false;
-
   std::mutex waiting_for_first_frame_mutex_;
-  std::condition_variable waiting_for_first_frame_condition_;
+  std::vector<std::function<void()>> waiting_for_first_frame_callbacks_;
 
   // Written in the UI thread and read from the raster thread. Hence make it
   // atomic.

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -1191,12 +1191,13 @@ TEST_F(ShellTest, OnPlatformViewDestroyDisablesThreadMerger) {
 
   PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
 
-  auto result = shell->WaitForFirstFrame(fml::TimeDelta::Max());
-  // Wait for the rasterizer to process the frame. WaitForFirstFrame only waits
-  // for the Animator, but end_frame_callback is called by the Rasterizer.
+  fml::AutoResetWaitableEvent first_frame_event;
+  shell->AddFirstFrameCallback(
+      [&first_frame_event] { first_frame_event.Signal(); });
+  first_frame_event.Wait();
+  // Wait for the rasterizer to process the frame. AddFirstFrameCallback only
+  // waits for the Animator, but end_frame_callback is called by the Rasterizer.
   PostSync(shell->GetTaskRunners().GetRasterTaskRunner(), [] {});
-  ASSERT_TRUE(result.ok()) << "Result: " << static_cast<int>(result.code())
-                           << ": " << result.message();
 
   ASSERT_TRUE(raster_thread_merger->IsEnabled());
 
@@ -1676,8 +1677,10 @@ TEST_F(ShellTest, WaitForFirstFrame) {
 
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
-  fml::Status result = shell->WaitForFirstFrame(fml::TimeDelta::Max());
-  ASSERT_TRUE(result.ok());
+  fml::AutoResetWaitableEvent first_frame_event;
+  shell->AddFirstFrameCallback(
+      [&first_frame_event] { first_frame_event.Signal(); });
+  first_frame_event.Wait();
 
   DestroyShell(std::move(shell));
 }
@@ -1694,10 +1697,11 @@ TEST_F(ShellTest, WaitForFirstFrameZeroSizeFrame) {
 
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get(), ViewContent::DummyView({1.0, 0.0, 0.0, 22, 0}));
-  fml::Status result = shell->WaitForFirstFrame(fml::TimeDelta::Zero());
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.message(), "timeout");
-  EXPECT_EQ(result.code(), fml::StatusCode::kDeadlineExceeded);
+  fml::AutoResetWaitableEvent first_frame_event;
+  shell->AddFirstFrameCallback(
+      [&first_frame_event] { first_frame_event.Signal(); });
+  bool timeout = first_frame_event.WaitWithTimeout(fml::TimeDelta::Zero());
+  EXPECT_TRUE(timeout);
 
   DestroyShell(std::move(shell));
 }
@@ -1713,72 +1717,12 @@ TEST_F(ShellTest, WaitForFirstFrameTimeout) {
   configuration.SetEntrypoint("emptyMain");
 
   RunEngine(shell.get(), std::move(configuration));
-  fml::Status result = shell->WaitForFirstFrame(fml::TimeDelta::Zero());
-  ASSERT_FALSE(result.ok());
-  ASSERT_EQ(result.code(), fml::StatusCode::kDeadlineExceeded);
+  fml::AutoResetWaitableEvent first_frame_event;
+  shell->AddFirstFrameCallback(
+      [&first_frame_event] { first_frame_event.Signal(); });
+  bool timeout = first_frame_event.WaitWithTimeout(fml::TimeDelta::Zero());
+  EXPECT_TRUE(timeout);
 
-  DestroyShell(std::move(shell));
-}
-
-// Ensure CancelWaitForFirstFrame() correctly causes all tasks blocked on
-// WaitForFirstFrame() to return kAborted.
-//
-// See: b/521830222
-TEST_F(ShellTest, CancelWaitForFirstFrameAllowsSafeShellDestruction) {
-  auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings);
-
-  PlatformViewNotifyCreated(shell.get());
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEntrypoint("emptyMain");
-  RunEngine(shell.get(), std::move(configuration));
-  // No PumpOneFrame: waiting_for_first_frame_ stays true, so
-  // WaitForFirstFrame would otherwise park on the condvar for the full
-  // timeout below.
-
-  fml::AutoResetWaitableEvent bg_has_ref;
-  fml::AutoResetWaitableEvent proceed_with_wait;
-
-  // Background thread holds a raw Shell* obtained while the shell was still
-  // live -- exactly what `strongSelf.shell` (-> `*_shell`) hands the GCD
-  // block in -[FlutterEngine waitForFirstFrame:callback:].
-  Shell* raw_shell = shell.get();
-  fml::Status background_result;
-  std::thread background(
-      [raw_shell, &bg_has_ref, &proceed_with_wait, &background_result] {
-        bg_has_ref.Signal();
-        proceed_with_wait.Wait();
-        // A well-behaved caller must not still be here once the owner has
-        // finished destroying the Shell. CancelWaitForFirstFrame() below makes
-        // sure this call returns promptly instead of blocking for 30 seconds.
-        background_result =
-            raw_shell->WaitForFirstFrame(fml::TimeDelta::FromSeconds(30));
-      });
-
-  bg_has_ref.Wait();
-  proceed_with_wait.Signal();
-
-  // Give the background thread a chance to actually call WaitForFirstFrame()
-  // before it is cancelled below. If it hasn't gotten there yet, cancellation
-  // is still observed safely (and just as fast) the moment it does.
-  std::this_thread::yield();
-
-  fml::TimePoint cancel_start = fml::TimePoint::Now();
-  // Models -[FlutterEngine destroyContext]: cancel any in-flight waiter,
-  // then join it, before freeing the Shell.
-  raw_shell->CancelWaitForFirstFrame();
-  background.join();
-  fml::TimeDelta elapsed = fml::TimePoint::Now() - cancel_start;
-
-  // The whole point of CancelWaitForFirstFrame() is to avoid blocking the
-  // owner for anywhere near the caller's requested timeout.
-  EXPECT_LT(elapsed.ToSecondsF(), 5.0);
-  ASSERT_FALSE(background_result.ok());
-  ASSERT_EQ(background_result.code(), fml::StatusCode::kAborted);
-
-  // Only safe to destroy now that the background thread has been joined,
-  // i.e. is guaranteed to no longer be touching the Shell.
   DestroyShell(std::move(shell));
 }
 
@@ -1794,11 +1738,15 @@ TEST_F(ShellTest, WaitForFirstFrameMultiple) {
 
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
-  fml::Status result = shell->WaitForFirstFrame(fml::TimeDelta::Max());
-  ASSERT_TRUE(result.ok());
+  fml::AutoResetWaitableEvent first_frame_event;
+  shell->AddFirstFrameCallback(
+      [&first_frame_event] { first_frame_event.Signal(); });
+  first_frame_event.Wait();
   for (int i = 0; i < 100; ++i) {
-    result = shell->WaitForFirstFrame(fml::TimeDelta::Zero());
-    ASSERT_TRUE(result.ok());
+    shell->AddFirstFrameCallback(
+        [&first_frame_event] { first_frame_event.Signal(); });
+    bool timeout = first_frame_event.WaitWithTimeout(fml::TimeDelta::Zero());
+    ASSERT_FALSE(timeout);
   }
 
   DestroyShell(std::move(shell));
@@ -1823,10 +1771,7 @@ TEST_F(ShellTest, WaitForFirstFrameInlined) {
   PumpOneFrame(shell.get());
   fml::AutoResetWaitableEvent event;
   task_runner->PostTask([&shell, &event] {
-    fml::Status result = shell->WaitForFirstFrame(fml::TimeDelta::Max());
-    ASSERT_FALSE(result.ok());
-    ASSERT_EQ(result.code(), fml::StatusCode::kFailedPrecondition);
-    event.Signal();
+    shell->AddFirstFrameCallback([&event] { event.Signal(); });
   });
   ASSERT_FALSE(event.WaitWithTimeout(fml::TimeDelta::Max()));
 

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -1778,6 +1778,24 @@ TEST_F(ShellTest, WaitForFirstFrameInlined) {
   DestroyShell(std::move(shell), task_runners);
 }
 
+TEST_F(ShellTest, AddFirstFrameCallbackSkippedIfNoFrame) {
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+
+  // Check that a first frame callback is never invoked if the shell is
+  // destroyed before any frames are rendered.
+  RunEngine(shell.get(), std::move(configuration));
+  shell->AddFirstFrameCallback([] { ASSERT_TRUE(false); });
+
+  DestroyShell(std::move(shell));
+}
+
 static size_t GetRasterizerResourceCacheBytesSync(const Shell& shell) {
   size_t bytes = 0;
   fml::AutoResetWaitableEvent latch;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -612,10 +612,6 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 }
 
 - (void)destroyContext {
-  // Clear any tasks waiting on first frame prior to destroying _shell.
-  if (_shell) {
-    _shell->CancelWaitForFirstFrame();
-  }
   if (_firstFrameWaiters) {
     dispatch_group_wait(_firstFrameWaiters, DISPATCH_TIME_FOREVER);
   }
@@ -1571,6 +1567,14 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 
 - (void)waitForFirstFrame:(NSTimeInterval)timeout
                  callback:(void (^_Nonnull)(BOOL didTimeout))callback {
+  auto first_frame_event = std::make_shared<fml::AutoResetWaitableEvent>();
+
+  self.shell.AddFirstFrameCallback([weak_event = std::weak_ptr(first_frame_event)] {
+    if (auto event = weak_event.lock()) {
+      event->Signal();
+    }
+  });
+
   dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0);
   dispatch_group_t group = dispatch_group_create();
 
@@ -1583,18 +1587,10 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   dispatch_group_t firstFrameWaiters = _firstFrameWaiters;
   dispatch_group_enter(firstFrameWaiters);
 
-  __weak FlutterEngine* weakSelf = self;
   __block BOOL didTimeout = NO;
   dispatch_group_async(group, queue, ^{
-    FlutterEngine* strongSelf = weakSelf;
-    if (!strongSelf || !strongSelf->_shell) {
-      dispatch_group_leave(firstFrameWaiters);
-      return;
-    }
-
     fml::TimeDelta waitTime = fml::TimeDelta::FromMilliseconds(timeout * 1000);
-    fml::Status status = strongSelf.shell.WaitForFirstFrame(waitTime);
-    didTimeout = status.code() == fml::StatusCode::kDeadlineExceeded;
+    didTimeout = first_frame_event->WaitWithTimeout(waitTime);
     dispatch_group_leave(firstFrameWaiters);
   });
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -195,10 +195,6 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   std::shared_ptr<flutter::ThreadHost> _threadHost;
   std::unique_ptr<flutter::Shell> _shell;
 
-  // Callers to -waitForFirstFrame:callback: that are currently queued/processing.
-  // -destroyContext must wait for this group to drain before it is safe to free _shell.
-  dispatch_group_t _firstFrameWaiters;
-
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   FlutterBinaryMessengerRelay* _binaryMessenger;
@@ -612,9 +608,6 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 }
 
 - (void)destroyContext {
-  if (_firstFrameWaiters) {
-    dispatch_group_wait(_firstFrameWaiters, DISPATCH_TIME_FOREVER);
-  }
   [self resetChannels];
   self.isolateId = nil;
   _shell.reset();
@@ -1567,50 +1560,37 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 
 - (void)waitForFirstFrame:(NSTimeInterval)timeout
                  callback:(void (^_Nonnull)(BOOL didTimeout))callback {
-  auto first_frame_event = std::make_shared<fml::AutoResetWaitableEvent>();
-
-  self.shell.AddFirstFrameCallback([weak_event = std::weak_ptr(first_frame_event)] {
-    if (auto event = weak_event.lock()) {
-      event->Signal();
+  // Set up a completion handler that will nil itself out when it fires.
+  __block void (^completion)(BOOL) = [callback copy];
+  void (^complete)(BOOL) = ^(BOOL didTimeout) {
+    if (completion) {
+      void (^cb)(BOOL) = completion;
+      completion = nil;
+      cb(didTimeout);
     }
-  });
+  };
 
-  dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0);
-  dispatch_group_t group = dispatch_group_create();
-
-  // Increment count of tasks waiting for first frame callback. Decrement below
-  // on completion or timeout. In -destroyContext we block until all pending
-  // first frame waiter tasks are cancelled.
-  if (!_firstFrameWaiters) {
-    _firstFrameWaiters = dispatch_group_create();
+  if (!_shell) {
+    // No shell. Bail out since there'll never be a first frame.
+    dispatch_async(dispatch_get_main_queue(), ^{
+      complete(YES);
+    });
+    return;
   }
-  dispatch_group_t firstFrameWaiters = _firstFrameWaiters;
-  dispatch_group_enter(firstFrameWaiters);
 
-  __block BOOL didTimeout = NO;
-  dispatch_group_async(group, queue, ^{
-    fml::TimeDelta waitTime = fml::TimeDelta::FromMilliseconds(timeout * 1000);
-    didTimeout = first_frame_event->WaitWithTimeout(waitTime);
-    dispatch_group_leave(firstFrameWaiters);
+  // Register the first-frame callback and fire the timeout completion handler.
+  // Both are scheduled on the main thread to guarantee ordering.
+  // The winner nils out the completion handler so the loser is a no-op.
+  _shell->AddFirstFrameCallback([complete] {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      complete(NO);
+    });
   });
 
-  // Only execute the main queue task once the background task has completely finished executing.
-  dispatch_group_notify(group, dispatch_get_main_queue(), ^{
-    // Strongly capture self on the task dispatched to the main thread.
-    //
-    // When we capture weakSelf strongly in the above block on a background thread, we risk the
-    // possibility that all other strong references to FlutterEngine go out of scope while the block
-    // executes and that the engine is dealloc'ed at the end of the above block on a background
-    // thread. FlutterEngine is not safe to release on any thread other than the main thread.
-    //
-    // self is never nil here since it's a strong reference that's verified non-nil above, but we
-    // use a conditional check to avoid an unused expression compiler warning.
-    FlutterEngine* strongSelf = self;
-    if (!strongSelf) {
-      return;
-    }
-    callback(didTimeout);
-  });
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC)),
+                 dispatch_get_main_queue(), ^{
+                   complete(YES);
+                 });
 }
 
 - (FlutterEngine*)spawnWithEntrypoint:(/*nullable*/ NSString*)entrypoint


### PR DESCRIPTION
The Shell::WaitForFirstFrame API would block until the engine renders the first frame.  This could potentially cause issues if the shell is destroyed while a thread is waiting within a call to WaitForFirstFrame.

This PR replaces WaitForFirstFrame with an AddFirstFrameCallback API that invokes a callback when the first frame has been rendered.  If the shell is destroyed before the first frame, then the callback will never be executed.

See https://github.com/flutter/flutter/pull/190132