### PR TITLE
[opengles]: Implements buffer orphaning

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles.cc
@@ -111,11 +111,6 @@ bool DeviceBufferGLES::BindAndUploadDataIfNecessary(BindingType type) const {
   const auto& gl = reactor_->GetProcTable();
 
   gl.BindBuffer(target_type, buffer.value());
-  if (!initialized_) {
-    gl.BufferData(target_type, backing_store_->GetLength().GetByteSize(),
-                  nullptr, GL_DYNAMIC_DRAW);
-    initialized_ = true;
-  }
 
   // Take and clear the dirty range BEFORE uploading. A Flush() from another
   // thread during the upload then merges into a fresh dirty range that the
@@ -126,6 +121,19 @@ bool DeviceBufferGLES::BindAndUploadDataIfNecessary(BindingType type) const {
     Lock lock(dirty_range_mutex_);
     std::swap(dirty_range_, dirty);
   }
+
+  if (!initialized_) {
+    gl.BufferData(target_type, backing_store_->GetLength().GetByteSize(),
+                  nullptr, GL_DYNAMIC_DRAW);
+    initialized_ = true;
+  } else if (dirty.has_value() && dirty->offset == 0) {
+    // Orphan the buffer by reallocating its storage when uploading from the
+    // start. This prevents the driver from stalling if in-flight GPU commands
+    // are still reading from the previous buffer contents.
+    gl.BufferData(target_type, backing_store_->GetLength().GetByteSize(),
+                  nullptr, GL_DYNAMIC_DRAW);
+  }
+
   if (dirty.has_value()) {
     gl.BufferSubData(target_type, dirty->offset, dirty->length,
                      backing_store_->GetBuffer() + dirty->offset);

--- a/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/device_buffer_gles_unittests.cc
@@ -88,5 +88,62 @@ TEST(DeviceBufferGLESTest, BindUniformData) {
   EXPECT_TRUE(device_buffer.GetHandle().has_value());
 }
 
+TEST(DeviceBufferGLESTest, BufferOrphaningOnRebindAtOffsetZero) {
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+
+  int buffer_data_count = 0;
+  int buffer_sub_data_count = 0;
+  EXPECT_CALL(*mock_gles_impl, BufferData(_, _, _, _))
+      .Times(2)
+      .WillRepeatedly(
+          [&](GLenum target, GLsizeiptr size, const void* data, GLenum usage) {
+            ++buffer_data_count;
+            EXPECT_EQ(data, nullptr);
+            EXPECT_EQ(size, 64);
+            EXPECT_EQ(usage, static_cast<GLenum>(GL_DYNAMIC_DRAW));
+          });
+
+  EXPECT_CALL(*mock_gles_impl, BufferSubData(_, _, _, _))
+      .Times(3)
+      .WillRepeatedly([&](GLenum target, GLintptr offset, GLsizeiptr size,
+                          const void* data) { ++buffer_sub_data_count; });
+
+  std::shared_ptr<MockGLES> mock_gles =
+      MockGLES::Init(std::move(mock_gles_impl));
+  ProcTableGLES::Resolver resolver = kMockResolverGLES;
+  auto proc_table = std::make_unique<ProcTableGLES>(resolver);
+  auto worker = std::make_shared<TestWorker>();
+  auto reactor = std::make_shared<ReactorGLES>(std::move(proc_table));
+  reactor->AddWorker(worker);
+
+  auto backing_store = std::make_unique<Allocation>();
+  ASSERT_TRUE(backing_store->Truncate(Bytes{64}));
+  DeviceBufferGLES device_buffer(DeviceBufferDescriptor{.size = 64}, reactor,
+                                 std::move(backing_store));
+
+  // First upload: initializes buffer with glBufferData, then glBufferSubData.
+  device_buffer.Flush(Range{0, 16});
+  EXPECT_TRUE(device_buffer.BindAndUploadDataIfNecessary(
+      DeviceBufferGLES::BindingType::kArrayBuffer));
+  EXPECT_EQ(buffer_data_count, 1);
+  EXPECT_EQ(buffer_sub_data_count, 1);
+
+  // Subsequent append at non-zero offset: does not orphan, only
+  // glBufferSubData.
+  device_buffer.Flush(Range{16, 16});
+  EXPECT_TRUE(device_buffer.BindAndUploadDataIfNecessary(
+      DeviceBufferGLES::BindingType::kArrayBuffer));
+  EXPECT_EQ(buffer_data_count, 1);
+  EXPECT_EQ(buffer_sub_data_count, 2);
+
+  // Rebind starting at offset 0 (e.g. frame/buffer reset): orphans buffer via
+  // glBufferData.
+  device_buffer.Flush(Range{0, 32});
+  EXPECT_TRUE(device_buffer.BindAndUploadDataIfNecessary(
+      DeviceBufferGLES::BindingType::kArrayBuffer));
+  EXPECT_EQ(buffer_data_count, 2);
+  EXPECT_EQ(buffer_sub_data_count, 3);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -246,6 +246,16 @@ void mockGenBuffers(GLsizei n, GLuint* buffers) {
   CallMockMethod(&IMockGLESImpl::GenBuffers, n, buffers);
 }
 
+void mockBufferData(GLenum target,
+                    GLsizeiptr size,
+                    const void* data,
+                    GLenum usage) {
+  CallMockMethod(&IMockGLESImpl::BufferData, target, size, data, usage);
+}
+
+static_assert(CheckSameSignature<decltype(mockBufferData),  //
+                                 decltype(glBufferData)>::value);
+
 void mockBufferSubData(GLenum target,
                        GLintptr offset,
                        GLsizeiptr size,
@@ -557,6 +567,8 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockObjectLabelKHR);
   } else if (strcmp(name, "glGenBuffers") == 0) {
     return reinterpret_cast<void*>(mockGenBuffers);
+  } else if (strcmp(name, "glBufferData") == 0) {
+    return reinterpret_cast<void*>(mockBufferData);
   } else if (strcmp(name, "glBufferSubData") == 0) {
     return reinterpret_cast<void*>(mockBufferSubData);
   } else if (strcmp(name, "glIsTexture") == 0) {

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -97,6 +97,10 @@ class IMockGLESImpl {
   virtual void DeleteQueriesEXT(GLsizei size, const GLuint* queries) {}
   virtual void GenBuffers(GLsizei n, GLuint* buffers) {}
   virtual void DeleteBuffers(GLsizei n, const GLuint* buffers) {}
+  virtual void BufferData(GLenum target,
+                          GLsizeiptr size,
+                          const void* data,
+                          GLenum usage) {}
   virtual void BufferSubData(GLenum target,
                              GLintptr offset,
                              GLsizeiptr size,
@@ -270,6 +274,10 @@ class MockGLESImpl : public IMockGLESImpl {
   MOCK_METHOD(void,
               DeleteBuffers,
               (GLsizei n, const GLuint* buffers),
+              (override));
+  MOCK_METHOD(void,
+              BufferData,
+              (GLenum target, GLsizeiptr size, const void* data, GLenum usage),
               (override));
   MOCK_METHOD(
       void,


### PR DESCRIPTION
This was an attempt to make ANGLE windows faster for multiple render passes.  It's considered good form to do this technique in order go avoid implicit synchronizations ( https://wikis.khronos.org/opengl/Buffer_Object_Streaming#Buffer_re-specification ).

It did not have a measurable effect on ANGLE window's performance though.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
