### PR TITLE
Fix black window in the subsurface view renderer

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -187,14 +187,17 @@ GLint fl_compositor_opengl_get_frame_format(const FlutterLayer** layers,
                                             size_t layers_count) {
   // Every backing store in a frame is created by the same engine code from
   // context-wide capabilities, so they all share a format and the first one
-  // describes the frame. Layers that aren't backing stores, e.g. platform
-  // views, don't have a format to match.
+  // describes the frame. Layers that aren't OpenGL framebuffer backing stores,
+  // e.g. platform views, don't have a format to match; fl_engine.cc only
+  // creates framebuffers, so there is nothing else to read a format from.
   for (size_t i = 0; i < layers_count; i++) {
     const FlutterLayer* layer = layers[i];
     if (layer == nullptr ||
         layer->type != kFlutterLayerContentTypeBackingStore ||
         layer->backing_store == nullptr ||
-        layer->backing_store->type != kFlutterBackingStoreTypeOpenGL) {
+        layer->backing_store->type != kFlutterBackingStoreTypeOpenGL ||
+        layer->backing_store->open_gl.type !=
+            kFlutterOpenGLTargetTypeFramebuffer) {
       continue;
     }
 

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -182,3 +182,26 @@ void fl_compositor_opengl_composite_layers(FlCompositorOpenGL* self,
   glBlendFuncSeparate(saved_src_rgb, saved_dst_rgb, saved_src_alpha,
                       saved_dst_alpha);
 }
+
+GLint fl_compositor_opengl_get_frame_format(const FlutterLayer** layers,
+                                            size_t layers_count) {
+  // Every backing store in a frame is created by the same engine code from
+  // context-wide capabilities, so they all share a format and the first one
+  // describes the frame. Layers that aren't backing stores, e.g. platform
+  // views, don't have a format to match.
+  for (size_t i = 0; i < layers_count; i++) {
+    const FlutterLayer* layer = layers[i];
+    if (layer == nullptr ||
+        layer->type != kFlutterLayerContentTypeBackingStore ||
+        layer->backing_store == nullptr ||
+        layer->backing_store->type != kFlutterBackingStoreTypeOpenGL) {
+      continue;
+    }
+
+    return layer->backing_store->open_gl.framebuffer.target == GL_BGRA8_EXT
+               ? GL_BGRA_EXT
+               : GL_RGBA;
+  }
+
+  return GL_RGBA;
+}

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.h
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.h
@@ -53,6 +53,20 @@ void fl_compositor_opengl_composite_layers(FlCompositorOpenGL* compositor,
                                            const FlutterLayer** layers,
                                            size_t layers_count);
 
+/**
+ * fl_compositor_opengl_get_frame_format:
+ * @layers: layers the frame is composited from.
+ * @layers_count: number of layers.
+ *
+ * Gets the texture format to composite @layers into. This matches the format
+ * the engine rendered them with, so the composited frame can be read back
+ * correctly. Compositing into a mismatched format produces an empty frame.
+ *
+ * Returns: a texture format, e.g. GL_RGBA or GL_BGRA_EXT.
+ */
+GLint fl_compositor_opengl_get_frame_format(const FlutterLayer** layers,
+                                            size_t layers_count);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_COMPOSITOR_OPENGL_H_

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
@@ -248,3 +248,78 @@ TEST_F(FlCompositorOpenGLTest, BlitFramebufferNvidia) {
     fl_compositor_opengl_composite_layers(compositor, layers, 1);
   }).join();
 }
+
+// The frame must be composited into the format the engine rendered the layers
+// with. Deriving it from anything else (e.g. an extension check) produces an
+// empty frame, which showed up as a black window in the subsurface renderer.
+TEST_F(FlCompositorOpenGLTest, FrameFormatMatchesBackingStore) {
+  FlutterBackingStore bgra_backing_store = {
+      .type = kFlutterBackingStoreTypeOpenGL,
+      .open_gl = {.framebuffer = {.target = GL_BGRA8_EXT}}};
+  FlutterLayer bgra_layer = {.type = kFlutterLayerContentTypeBackingStore,
+                             .backing_store = &bgra_backing_store};
+  const FlutterLayer* bgra_layers[1] = {&bgra_layer};
+  EXPECT_EQ(fl_compositor_opengl_get_frame_format(bgra_layers, 1), GL_BGRA_EXT);
+
+  FlutterBackingStore rgba_backing_store = {
+      .type = kFlutterBackingStoreTypeOpenGL,
+      .open_gl = {.framebuffer = {.target = GL_RGBA8}}};
+  FlutterLayer rgba_layer = {.type = kFlutterLayerContentTypeBackingStore,
+                             .backing_store = &rgba_backing_store};
+  const FlutterLayer* rgba_layers[1] = {&rgba_layer};
+  EXPECT_EQ(fl_compositor_opengl_get_frame_format(rgba_layers, 1), GL_RGBA);
+}
+
+// Frames with nothing to match the format of fall back to RGBA.
+TEST_F(FlCompositorOpenGLTest, FrameFormatDefaultsToRGBA) {
+  EXPECT_EQ(fl_compositor_opengl_get_frame_format(nullptr, 0), GL_RGBA);
+
+  FlutterLayer no_backing_store = {.type = kFlutterLayerContentTypeBackingStore,
+                                   .backing_store = nullptr};
+  const FlutterLayer* no_backing_store_layers[1] = {&no_backing_store};
+  EXPECT_EQ(fl_compositor_opengl_get_frame_format(no_backing_store_layers, 1),
+            GL_RGBA);
+
+  FlutterBackingStore software_backing_store = {
+      .type = kFlutterBackingStoreTypeSoftware};
+  FlutterLayer software_layer = {.type = kFlutterLayerContentTypeBackingStore,
+                                 .backing_store = &software_backing_store};
+  const FlutterLayer* software_layers[1] = {&software_layer};
+  EXPECT_EQ(fl_compositor_opengl_get_frame_format(software_layers, 1), GL_RGBA);
+}
+
+// Platform views have no format of their own, so the format must be taken from
+// the backing stores around them rather than from whichever layer comes first.
+TEST_F(FlCompositorOpenGLTest, FrameFormatSkipsPlatformViews) {
+  FlutterPlatformView platform_view = {.identifier = 1};
+  FlutterLayer platform_view_layer = {
+      .type = kFlutterLayerContentTypePlatformView,
+      .platform_view = &platform_view};
+
+  FlutterBackingStore backing_store = {
+      .type = kFlutterBackingStoreTypeOpenGL,
+      .open_gl = {.framebuffer = {.target = GL_BGRA8_EXT}}};
+  FlutterLayer backing_store_layer = {
+      .type = kFlutterLayerContentTypeBackingStore,
+      .backing_store = &backing_store};
+
+  const FlutterLayer* layers[2] = {&platform_view_layer, &backing_store_layer};
+  EXPECT_EQ(fl_compositor_opengl_get_frame_format(layers, 2), GL_BGRA_EXT);
+}
+
+// Regression test: the format must come from the layers, never from what the
+// driver is capable of. Mesa advertises GL_EXT_texture_format_BGRA8888 while
+// the engine still renders RGBA, so choosing BGRA from the extension gives a
+// framebuffer that doesn't match the frame and composites to nothing.
+TEST_F(FlCompositorOpenGLTest, FrameFormatIgnoresTextureFormatExtension) {
+  ON_CALL(epoxy, epoxy_has_gl_extension(::testing::_))
+      .WillByDefault(::testing::Return(true));
+
+  FlutterBackingStore backing_store = {
+      .type = kFlutterBackingStoreTypeOpenGL,
+      .open_gl = {.framebuffer = {.target = GL_RGBA8}}};
+  FlutterLayer layer = {.type = kFlutterLayerContentTypeBackingStore,
+                        .backing_store = &backing_store};
+  const FlutterLayer* layers[1] = {&layer};
+  EXPECT_EQ(fl_compositor_opengl_get_frame_format(layers, 1), GL_RGBA);
+}

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
@@ -255,7 +255,8 @@ TEST_F(FlCompositorOpenGLTest, BlitFramebufferNvidia) {
 TEST_F(FlCompositorOpenGLTest, FrameFormatMatchesBackingStore) {
   FlutterBackingStore bgra_backing_store = {
       .type = kFlutterBackingStoreTypeOpenGL,
-      .open_gl = {.framebuffer = {.target = GL_BGRA8_EXT}}};
+      .open_gl = {.type = kFlutterOpenGLTargetTypeFramebuffer,
+                  .framebuffer = {.target = GL_BGRA8_EXT}}};
   FlutterLayer bgra_layer = {.type = kFlutterLayerContentTypeBackingStore,
                              .backing_store = &bgra_backing_store};
   const FlutterLayer* bgra_layers[1] = {&bgra_layer};
@@ -263,7 +264,8 @@ TEST_F(FlCompositorOpenGLTest, FrameFormatMatchesBackingStore) {
 
   FlutterBackingStore rgba_backing_store = {
       .type = kFlutterBackingStoreTypeOpenGL,
-      .open_gl = {.framebuffer = {.target = GL_RGBA8}}};
+      .open_gl = {.type = kFlutterOpenGLTargetTypeFramebuffer,
+                  .framebuffer = {.target = GL_RGBA8}}};
   FlutterLayer rgba_layer = {.type = kFlutterLayerContentTypeBackingStore,
                              .backing_store = &rgba_backing_store};
   const FlutterLayer* rgba_layers[1] = {&rgba_layer};
@@ -286,6 +288,18 @@ TEST_F(FlCompositorOpenGLTest, FrameFormatDefaultsToRGBA) {
                                  .backing_store = &software_backing_store};
   const FlutterLayer* software_layers[1] = {&software_layer};
   EXPECT_EQ(fl_compositor_opengl_get_frame_format(software_layers, 1), GL_RGBA);
+
+  // fl_engine.cc only ever creates framebuffer backing stores. A texture
+  // backing store keeps its format in a different member of the same union, so
+  // it must not be read as if it were a framebuffer.
+  FlutterBackingStore texture_backing_store = {
+      .type = kFlutterBackingStoreTypeOpenGL,
+      .open_gl = {.type = kFlutterOpenGLTargetTypeTexture,
+                  .texture = {.target = GL_BGRA8_EXT}}};
+  FlutterLayer texture_layer = {.type = kFlutterLayerContentTypeBackingStore,
+                                .backing_store = &texture_backing_store};
+  const FlutterLayer* texture_layers[1] = {&texture_layer};
+  EXPECT_EQ(fl_compositor_opengl_get_frame_format(texture_layers, 1), GL_RGBA);
 }
 
 // Platform views have no format of their own, so the format must be taken from
@@ -298,7 +312,8 @@ TEST_F(FlCompositorOpenGLTest, FrameFormatSkipsPlatformViews) {
 
   FlutterBackingStore backing_store = {
       .type = kFlutterBackingStoreTypeOpenGL,
-      .open_gl = {.framebuffer = {.target = GL_BGRA8_EXT}}};
+      .open_gl = {.type = kFlutterOpenGLTargetTypeFramebuffer,
+                  .framebuffer = {.target = GL_BGRA8_EXT}}};
   FlutterLayer backing_store_layer = {
       .type = kFlutterLayerContentTypeBackingStore,
       .backing_store = &backing_store};
@@ -317,7 +332,8 @@ TEST_F(FlCompositorOpenGLTest, FrameFormatIgnoresTextureFormatExtension) {
 
   FlutterBackingStore backing_store = {
       .type = kFlutterBackingStoreTypeOpenGL,
-      .open_gl = {.framebuffer = {.target = GL_RGBA8}}};
+      .open_gl = {.type = kFlutterOpenGLTargetTypeFramebuffer,
+                  .framebuffer = {.target = GL_RGBA8}}};
   FlutterLayer layer = {.type = kFlutterLayerContentTypeBackingStore,
                         .backing_store = &backing_store};
   const FlutterLayer* layers[1] = {&layer};

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_frame.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_frame.cc
@@ -7,6 +7,7 @@
 #include <epoxy/egl.h>
 #include <epoxy/gl.h>
 
+#include "flutter/shell/platform/linux/fl_compositor_opengl.h"
 #include "flutter/shell/platform/linux/fl_framebuffer.h"
 
 struct _FlOpenGLFrame {
@@ -82,13 +83,8 @@ void fl_opengl_frame_composite(FlOpenGLFrame* self,
   if (self->framebuffer == nullptr ||
       fl_framebuffer_get_width(self->framebuffer) != width ||
       fl_framebuffer_get_height(self->framebuffer) != height) {
-    GLint general_format = GL_RGBA;
-    if (layers[0]->type == kFlutterLayerContentTypeBackingStore &&
-        layers[0]->backing_store != nullptr &&
-        layers[0]->backing_store->type == kFlutterBackingStoreTypeOpenGL &&
-        layers[0]->backing_store->open_gl.framebuffer.target == GL_BGRA8_EXT) {
-      general_format = GL_BGRA_EXT;
-    }
+    GLint general_format =
+        fl_compositor_opengl_get_frame_format(layers, layers_count);
     g_clear_object(&self->framebuffer);
     self->framebuffer =
         fl_framebuffer_new(general_format, width, height, self->shareable);

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_frame_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_frame_test.cc
@@ -49,6 +49,7 @@ TEST_F(FlOpenGLFrameTest, CompositeRGBA) {
   FlutterBackingStore backing_store = {
       .type = kFlutterBackingStoreTypeOpenGL,
       .open_gl = {
+          .type = kFlutterOpenGLTargetTypeFramebuffer,
           .framebuffer = {.target = GL_RGBA8, .user_data = framebuffer}}};
   FlutterLayer layer = {.type = kFlutterLayerContentTypeBackingStore,
                         .backing_store = &backing_store,
@@ -78,6 +79,7 @@ TEST_F(FlOpenGLFrameTest, CompositeBGRA) {
   FlutterBackingStore backing_store = {
       .type = kFlutterBackingStoreTypeOpenGL,
       .open_gl = {
+          .type = kFlutterOpenGLTargetTypeFramebuffer,
           .framebuffer = {.target = GL_BGRA8_EXT, .user_data = framebuffer}}};
   FlutterLayer layer = {.type = kFlutterLayerContentTypeBackingStore,
                         .backing_store = &backing_store,
@@ -107,6 +109,7 @@ TEST_F(FlOpenGLFrameTest, ZeroSizeClearsFrame) {
   FlutterBackingStore backing_store = {
       .type = kFlutterBackingStoreTypeOpenGL,
       .open_gl = {
+          .type = kFlutterOpenGLTargetTypeFramebuffer,
           .framebuffer = {.target = GL_RGBA8, .user_data = framebuffer}}};
   FlutterLayer layer = {.type = kFlutterLayerContentTypeBackingStore,
                         .backing_store = &backing_store,

--- a/engine/src/flutter/shell/platform/linux/fl_view_renderer_subsurface.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view_renderer_subsurface.cc
@@ -289,10 +289,8 @@ static void fl_view_renderer_subsurface_present_layers(
   if (self->framebuffer == nullptr ||
       fl_framebuffer_get_width(self->framebuffer) != width ||
       fl_framebuffer_get_height(self->framebuffer) != height) {
-    GLint general_format = GL_RGBA;
-    if (epoxy_has_gl_extension("GL_EXT_texture_format_BGRA8888")) {
-      general_format = GL_BGRA_EXT;
-    }
+    GLint general_format =
+        fl_compositor_opengl_get_frame_format(layers, layers_count);
     g_clear_object(&self->framebuffer);
     self->framebuffer =
         fl_framebuffer_new(general_format, width, height, FALSE);


### PR DESCRIPTION
FlViewRendererSubsurface is the default renderer on Wayland, so Flutter apps running with Impeller on Mesa drivers currently show nothing but a black window.

It picked its framebuffer format from
epoxy_has_gl_extension("GL_EXT_texture_format_BGRA8888"), which asks what the driver is capable of rather than what the engine actually rendered. The frame was composited into a BGRA framebuffer while the engine had rendered RGBA, so nothing reached the screen. The failure is silent: the framebuffer is complete, no GL errors are raised, and the Wayland surface is committed as normal.

That check used to be correct, and was invalidated by 5f97c7f836b ("Fixes MSAA on the linux embedder", #191379) in two ways:

- It replaced the identical check in fl_opengl_frame.cc with one that reads the format the engine reported in the layer's backing store, making the extension check the stale copy of a rule that had moved on.
- It made the engine render RGBA even where the extension is advertised. With Impeller the backing store is now allocated by fl_framebuffer_new_multisample(), whose offscreen MSAA path attaches a multisample renderbuffer of GL_RGBA8 and no texture, and fl_engine.cc reports GL_RGBA8 for those. Driver capability and rendered format are therefore no longer the same question.

FlViewRendererSubsurface was written before that landed and merged cleanly after it, in 706edcdc32f ("Add FlViewRendererSubsurface", #191389), because the two changes touch different files and so never conflicted textually.

Move the rule into fl_compositor_opengl_get_frame_format() and use it from both paths so they cannot disagree again. fl_engine.cc remains the only place that chooses a format; both consumers now follow what it reports. Every backing store in a frame is created from context-wide capabilities, so they all share a format, and the first one describes the frame. Take it from the first backing store rather than the first layer, as platform views carry no format and would otherwise decide it by being drawn first.

The bug is not reachable from a unit test, as presenting a frame requires a realized Wayland subsurface and the tests run on X11, so test the shared function directly, including that an advertised extension does not change its result.
