### PR TITLE
macOS: Compare accessibility strings as NSStrings in tests

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -376,13 +376,11 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   // Verify the accessibility tree is attached to the flutter view.
   EXPECT_EQ([engine.viewController.flutterView.accessibilityChildren count], 1u);
   NSAccessibilityElement* native_root = engine.viewController.flutterView.accessibilityChildren[0];
-  std::string root_label = [native_root.accessibilityLabel UTF8String];
-  EXPECT_TRUE(root_label == "root");
+  EXPECT_TRUE([native_root.accessibilityLabel isEqualToString:@"root"]);
   EXPECT_EQ(native_root.accessibilityRole, NSAccessibilityGroupRole);
   EXPECT_EQ([native_root.accessibilityChildren count], 1u);
   NSAccessibilityElement* native_child1 = native_root.accessibilityChildren[0];
-  std::string child1_value = [native_child1.accessibilityValue UTF8String];
-  EXPECT_TRUE(child1_value == "child 1");
+  EXPECT_TRUE([native_child1.accessibilityValue isEqualToString:@"child 1"]);
   EXPECT_EQ(native_child1.accessibilityRole, NSAccessibilityStaticTextRole);
   EXPECT_EQ([native_child1.accessibilityChildren count], 0u);
   // Disable the semantics.

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -62,8 +62,7 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
   NSAccessibilityElement* native_accessibility =
       root_platform_node_delegate->GetNativeViewAccessible();
   ASSERT_NE(native_accessibility, nil);
-  std::string value = [native_accessibility.accessibilityValue UTF8String];
-  EXPECT_TRUE(value == "accessibility");
+  EXPECT_TRUE([native_accessibility.accessibilityValue isEqualToString:@"accessibility"]);
   EXPECT_TRUE(
       [native_accessibility.accessibilityRole isEqualToString:NSAccessibilityStaticTextRole]);
   EXPECT_EQ([native_accessibility.accessibilityChildren count], 0u);
@@ -104,16 +103,14 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
   NSAccessibilityElement* native_accessibility =
       root_platform_node_delegate->GetNativeViewAccessible();
   ASSERT_NE(native_accessibility, nil);
-  std::string value = [native_accessibility.accessibilityValue UTF8String];
-  EXPECT_EQ(value, "selectable text");
+  EXPECT_TRUE([native_accessibility.accessibilityValue isEqualToString:@"selectable text"]);
   EXPECT_TRUE(
       [native_accessibility.accessibilityRole isEqualToString:NSAccessibilityStaticTextRole]);
   EXPECT_EQ([native_accessibility.accessibilityChildren count], 0u);
   NSRange selection = native_accessibility.accessibilitySelectedTextRange;
   EXPECT_EQ(selection.location, 1u);
   EXPECT_EQ(selection.length, 2u);
-  std::string selected_text = [native_accessibility.accessibilitySelectedText UTF8String];
-  EXPECT_EQ(selected_text, "el");
+  EXPECT_TRUE([native_accessibility.accessibilitySelectedText isEqualToString:@"el"]);
 }
 
 TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRange) {


### PR DESCRIPTION
We were converting `NSString` instances to `std::string`s purely to compare them against C string literals. Comparing the `NSString` directly is shorter, matches the neighbouring role assertions, and drops five `UTF8String` conversions.

Round-tripping these through `std::string` results in any embedded NULs triggering truncation which could, in theory, hide bugs.

Spotted while working on: https://github.com/flutter/flutter/issues/191616

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
