### PR TITLE
macOS: Record test accessibility notifications in a dictionary

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -20,14 +20,15 @@ class AccessibilityBridgeMacSpy : public AccessibilityBridgeMac {
 
   AccessibilityBridgeMacSpy(__weak FlutterEngine* flutter_engine,
                             __weak FlutterViewController* view_controller)
-      : AccessibilityBridgeMac(flutter_engine, view_controller) {}
+      : AccessibilityBridgeMac(flutter_engine, view_controller),
+        actual_notifications([NSMutableDictionary dictionary]) {}
 
-  std::unordered_map<std::string, gfx::NativeViewAccessible> actual_notifications;
+  NSMutableDictionary<NSAccessibilityNotificationName, id>* actual_notifications;
 
  private:
   void DispatchMacOSNotification(gfx::NativeViewAccessible native_node,
                                  NSAccessibilityNotificationName mac_notification) override {
-    actual_notifications[[mac_notification UTF8String]] = native_node;
+    actual_notifications[mac_notification] = native_node;
   }
 };
 
@@ -133,10 +134,10 @@ TEST_F(AccessibilityBridgeMacWindowTest, SendsAccessibilityCreateNotificationFlu
 
   bridge->OnAccessibilityEvent(targeted_event);
 
-  ASSERT_EQ(bridge->actual_notifications.size(), 1u);
-  auto target = bridge->actual_notifications.find([NSAccessibilityCreatedNotification UTF8String]);
-  ASSERT_NE(target, bridge->actual_notifications.end());
-  EXPECT_EQ(target->second, expectedTarget);
+  ASSERT_EQ(bridge->actual_notifications.count, 1u);
+  id target = bridge->actual_notifications[NSAccessibilityCreatedNotification];
+  ASSERT_NE(target, nil);
+  EXPECT_EQ(target, expectedTarget);
   [engine shutDownEngine];
 }
 
@@ -263,7 +264,7 @@ TEST_F(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhe
   bridge->OnAccessibilityEvent(targeted_event);
 
   // Does not send any notification if the engine is headless.
-  EXPECT_EQ(bridge->actual_notifications.size(), 0u);
+  EXPECT_EQ(bridge->actual_notifications.count, 0u);
   [engine shutDownEngine];
 }
 
@@ -312,7 +313,7 @@ TEST_F(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhe
   bridge->OnAccessibilityEvent(targeted_event);
 
   // Does not send any notification if the flutter view is not attached to a NSWindow.
-  EXPECT_EQ(bridge->actual_notifications.size(), 0u);
+  EXPECT_EQ(bridge->actual_notifications.count, 0u);
   [engine shutDownEngine];
 }
 


### PR DESCRIPTION
`AccessibilityBridgeMacSpy` was recording the notifications it saw in a `std::unordered_map<std::string, gfx::NativeViewAccessible>`, converting the `NSAccessibilityNotificationName` key to a `std::string` on the way in and back again on the way out.

Both the key and value are Obj-C objects, so we can use an `NSMutableDictionary` and avoid all the conversions. Similar to #191853, `std::string` conversions use `strlen` to determine the length, which truncates at any embedded NUL chars, potentially hiding bugs.

Spotted while working on: https://github.com/flutter/flutter/issues/191616

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
