### PR TITLE
iOS: Key the platform view factory registries by NSString

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -105,12 +105,12 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 @property(nonatomic, readonly) FlutterClippingMaskViewPool* maskViewPool;
 
 @property(nonatomic, readonly)
-    std::unordered_map<std::string, NSObject<FlutterPlatformViewFactory>*>& factories;
+    NSMutableDictionary<NSString*, NSObject<FlutterPlatformViewFactory>*>* factories;
 
-// The FlutterPlatformViewGestureRecognizersBlockingPolicy for each type of platform view.
+// The FlutterPlatformViewGestureRecognizersBlockingPolicy for each type of platform view, boxed in
+// an NSNumber.
 @property(nonatomic, readonly)
-    std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>&
-        gestureRecognizersBlockingPoliciesByType;
+    NSMutableDictionary<NSString*, NSNumber*>* gestureRecognizersBlockingPoliciesByType;
 
 /// The size of the current onscreen surface in physical pixels.
 @property(nonatomic, assign) DlISize frameSize;
@@ -238,9 +238,8 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
   // `self.slices[viewId] = x`.
   std::unique_ptr<flutter::OverlayLayerPool> _layerPool;
   std::unordered_map<int64_t, std::unique_ptr<flutter::EmbedderViewSlice>> _slices;
-  std::unordered_map<std::string, NSObject<FlutterPlatformViewFactory>*> _factories;
-  std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>
-      _gestureRecognizersBlockingPoliciesByType;
+  NSMutableDictionary<NSString*, NSObject<FlutterPlatformViewFactory>*>* _factories;
+  NSMutableDictionary<NSString*, NSNumber*>* _gestureRecognizersBlockingPoliciesByType;
   FlutterFMLTaskRunner* _platformTaskRunner;
   std::unordered_map<int64_t, PlatformViewData> _platformViews;
   std::unordered_map<int64_t, flutter::EmbeddedViewParams> _currentCompositionParams;
@@ -254,6 +253,8 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 - (id)init {
   if (self = [super init]) {
     _layerPool = std::make_unique<flutter::OverlayLayerPool>();
+    _factories = [[NSMutableDictionary alloc] init];
+    _gestureRecognizersBlockingPoliciesByType = [[NSMutableDictionary alloc] init];
     _maskViewPool =
         [[FlutterClippingMaskViewPool alloc] initWithCapacity:kFlutterClippingMaskViewPoolCapacity];
     _hadPlatformViews = NO;
@@ -298,8 +299,6 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
               details:nil]);
     return;
   }
-  std::string viewType(viewTypeString.UTF8String);
-
   if (self.platformViews.count(viewId) != 0) {
     result([FlutterError errorWithCode:@"recreating_view"
                                message:@"trying to create an already created view"
@@ -307,7 +306,7 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
     return;
   }
 
-  NSObject<FlutterPlatformViewFactory>* factory = self.factories[viewType];
+  NSObject<FlutterPlatformViewFactory>* factory = self.factories[viewTypeString];
   if (factory == nil) {
     result([FlutterError
         errorWithCode:@"unregistered_view_type"
@@ -352,7 +351,8 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
         FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded;
   } else if ([gestureBlockingPolicyValue
                  isEqualToString:kGestureBlockingPolicyFallbackToPluginDefault]) {
-    gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
+    gestureBlockingPolicy = static_cast<FlutterPlatformViewGestureRecognizersBlockingPolicy>(
+        self.gestureRecognizersBlockingPoliciesByType[viewTypeString].integerValue);
   } else {
     result([FlutterError
         errorWithCode:@"unknown_gesture_blocking_policy"
@@ -431,10 +431,9 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
                               withId:(NSString*)factoryId
     gestureRecognizersBlockingPolicy:
         (FlutterPlatformViewGestureRecognizersBlockingPolicy)gestureRecognizerBlockingPolicy {
-  std::string idString([factoryId UTF8String]);
-  FML_CHECK(self.factories.count(idString) == 0);
-  self.factories[idString] = factory;
-  self.gestureRecognizersBlockingPoliciesByType[idString] = gestureRecognizerBlockingPolicy;
+  FML_CHECK(self.factories[factoryId] == nil);
+  self.factories[factoryId] = factory;
+  self.gestureRecognizersBlockingPoliciesByType[factoryId] = @(gestureRecognizerBlockingPolicy);
 }
 
 - (void)beginFrameWithSize:(DlISize)frameSize {
@@ -1103,15 +1102,6 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 
 - (std::unordered_map<int64_t, std::unique_ptr<flutter::EmbedderViewSlice>>&)slices {
   return _slices;
-}
-
-- (std::unordered_map<std::string, NSObject<FlutterPlatformViewFactory>*>&)factories {
-  return _factories;
-}
-
-- (std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>&)
-    gestureRecognizersBlockingPoliciesByType {
-  return _gestureRecognizersBlockingPoliciesByType;
 }
 
 - (std::unordered_map<int64_t, PlatformViewData>&)platformViews {


### PR DESCRIPTION
`FlutterPlatformViewsController` was holding its view factories and their gesture blocking policies in `std::unordered_map`s keyed by `std::string`, so both the registration path and the create path converted an `NSString` to a `std::string` first. But all the mapped values are Obj-C types so we can migrate to na `NSMutableDictionary`. This matches how we do it in the macOS embedder.

This removes the last of the `UTF8String` conversions in this file. As noted in #191853 and #191854 `std::string`'s `const char*` constructor determines the length using `strlen`, so it truncates at an embedded NUL and dereferences null if `UTF8String` ever returns NULL, which it does for a nil receiver.

Spotted while working on: https://github.com/flutter/flutter/issues/191616

No new tests since this just changes the implementation without changing any semantics.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
