### PR TITLE
macOS: Don't stall window resize on frames with no layers

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterCompositor.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterCompositor.mm
@@ -110,23 +110,27 @@ bool FlutterCompositor::Present(FlutterViewIdentifier view_id,
   // the layer information instead of passing the original pointers from embedder.
   auto layers_copy = std::make_shared<std::vector<LayerVariant>>(CopyLayers(layers, layers_count));
 
-  [view.surfaceManager presentSurfaces:surfaces
-                                atTime:presentation_time
-                                notify:^{
-                                  // Accessing presenters_ here does not need a
-                                  // lock to avoid race condition against
-                                  // AddView and RemoveView, since all three
-                                  // take place on the platform thread. (The
-                                  // macOS API requires platform view presenting
-                                  // to take place on the platform thread,
-                                  // enforced by `FlutterThreadSynchronizer`.)
-                                  dispatch_assert_queue(dispatch_get_main_queue());
-                                  auto found_presenter = presenters_.find(view_id);
-                                  if (found_presenter != presenters_.end()) {
-                                    found_presenter->second.PresentPlatformViews(
-                                        view, *layers_copy, platform_view_controller_);
-                                  }
-                                }];
+  dispatch_block_t notify_block = ^{
+    // Accessing presenters_ here does not need a
+    // lock to avoid race condition against
+    // AddView and RemoveView, since all three
+    // take place on the platform thread. (The
+    // macOS API requires platform view presenting
+    // to take place on the platform thread,
+    // enforced by `FlutterThreadSynchronizer`.)
+    dispatch_assert_queue(dispatch_get_main_queue());
+    auto found_presenter = presenters_.find(view_id);
+    if (found_presenter != presenters_.end()) {
+      found_presenter->second.PresentPlatformViews(view, *layers_copy, platform_view_controller_);
+    }
+  };
+
+  if (layers_count == 0) {
+    // A frame with no layers displays nothing, and so has no frame size to commit.
+    [view.surfaceManager presentEmptyFrameAtTime:presentation_time notify:notify_block];
+  } else {
+    [view.surfaceManager presentSurfaces:surfaces atTime:presentation_time notify:notify_block];
+  }
 
   return true;
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
@@ -35,6 +35,14 @@
         withBlock:(nonnull dispatch_block_t)block
             delay:(NSTimeInterval)delay;
 
+/*
+ * Schedules the block on the platform thread for a frame that has no layers.
+ *
+ * Such a frame displays no contents and has no frame size, so it unblocks the platform thread no
+ * matter which frame size that thread is waiting for during a resize.
+ */
+- (void)onPresentEmptyFrameWithBlock:(nonnull dispatch_block_t)block delay:(NSTimeInterval)delay;
+
 @end
 
 /**
@@ -83,6 +91,17 @@
 - (void)presentSurfaces:(nonnull NSArray<FlutterSurfacePresentInfo*>*)surfaces
                  atTime:(CFTimeInterval)presentationTime
                  notify:(nullable dispatch_block_t)notify;
+
+/**
+ * Presents a frame that has no layers, removing all sublayers.
+ *
+ * Called instead of `presentSurfaces:atTime:notify:` when the frame being presented has no layers
+ * at all, and thus nothing on screen that a window resize could be out of sync with.
+ *
+ * Must be called on raster thread, and behaves like `presentSurfaces:atTime:notify:` otherwise.
+ */
+- (void)presentEmptyFrameAtTime:(CFTimeInterval)presentationTime
+                         notify:(nullable dispatch_block_t)notify;
 
 @end
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -44,6 +44,15 @@
  */
 - (void)commit:(NSArray<FlutterSurfacePresentInfo*>*)surfaces;
 
+/**
+ * Presents the given surfaces, reporting the frame to the delegate as an empty frame if
+ * `emptyFrame` is set.
+ */
+- (void)presentSurfaces:(NSArray<FlutterSurfacePresentInfo*>*)surfaces
+             emptyFrame:(BOOL)emptyFrame
+                 atTime:(CFTimeInterval)presentationTime
+                 notify:(nullable dispatch_block_t)notify;
+
 @end
 
 static NSColor* GetBorderColorForLayer(int layer) {
@@ -242,11 +251,20 @@ static CGSize GetRequiredFrameSize(NSArray<FlutterSurfacePresentInfo*>* surfaces
 - (void)presentSurfaces:(NSArray<FlutterSurfacePresentInfo*>*)surfaces
                  atTime:(CFTimeInterval)presentationTime
                  notify:(dispatch_block_t)notify {
+  [self presentSurfaces:surfaces emptyFrame:NO atTime:presentationTime notify:notify];
+}
+
+- (void)presentEmptyFrameAtTime:(CFTimeInterval)presentationTime notify:(dispatch_block_t)notify {
+  [self presentSurfaces:@[] emptyFrame:YES atTime:presentationTime notify:notify];
+}
+
+- (void)presentSurfaces:(NSArray<FlutterSurfacePresentInfo*>*)surfaces
+             emptyFrame:(BOOL)emptyFrame
+                 atTime:(CFTimeInterval)presentationTime
+                 notify:(dispatch_block_t)notify {
   id<MTLCommandBuffer> commandBuffer = [_commandQueue commandBuffer];
   [commandBuffer commit];
   [commandBuffer waitUntilScheduled];
-
-  CGSize size = GetRequiredFrameSize(surfaces);
 
   CFTimeInterval delay = 0;
 
@@ -266,18 +284,23 @@ static CGSize GetRequiredFrameSize(NSArray<FlutterSurfacePresentInfo*>* surfaces
     CFTimeInterval now = CACurrentMediaTime();
     delay = std::max(minPresentationTime - now, 0.0);
   }
-  [_delegate onPresent:size
-             withBlock:^{
-               _lastPresentationTime = presentationTime;
-               [CATransaction begin];
-               [CATransaction setDisableActions:YES];
-               [self commit:surfaces];
-               if (notify != nil) {
-                 notify();
-               }
-               [CATransaction commit];
-             }
-                 delay:delay];
+
+  dispatch_block_t commitBlock = ^{
+    _lastPresentationTime = presentationTime;
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    [self commit:surfaces];
+    if (notify != nil) {
+      notify();
+    }
+    [CATransaction commit];
+  };
+
+  if (emptyFrame) {
+    [_delegate onPresentEmptyFrameWithBlock:commitBlock delay:delay];
+  } else {
+    [_delegate onPresent:GetRequiredFrameSize(surfaces) withBlock:commitBlock delay:delay];
+  }
 }
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
@@ -14,6 +14,7 @@
 @interface TestView : NSView <FlutterSurfaceManagerDelegate>
 
 @property(readwrite, nonatomic) CGSize presentedFrameSize;
+@property(readwrite, nonatomic) BOOL didPresentEmptyFrame;
 - (nonnull instancetype)init;
 
 @end
@@ -33,6 +34,11 @@
         withBlock:(nonnull dispatch_block_t)block
             delay:(NSTimeInterval)delay {
   self.presentedFrameSize = frameSize;
+  block();
+}
+
+- (void)onPresentEmptyFrameWithBlock:(nonnull dispatch_block_t)block delay:(NSTimeInterval)delay {
+  self.didPresentEmptyFrame = YES;
   block();
 }
 
@@ -297,6 +303,27 @@ TEST(FlutterSurfaceManager, LayerManagement) {
   [surfaceManager presentSurfaces:@[] atTime:0 notify:nil];
   EXPECT_EQ(testView.layer.sublayers.count, 0ul);
   EXPECT_TRUE(CGSizeEqualToSize(testView.presentedFrameSize, CGSizeMake(0, 0)));
+}
+
+// Regression test for https://github.com/flutter/flutter/issues/190075: a frame size of zero never
+// matches the size the platform thread waits for during a window resize.
+TEST(FlutterSurfaceManager, PresentingEmptyFrameReportsNoFrameSize) {
+  TestView* testView = [[TestView alloc] init];
+  FlutterSurfaceManager* surfaceManager = CreateSurfaceManager(testView);
+
+  auto surface = [surfaceManager surfaceForSize:CGSizeMake(100, 50)];
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface) ] atTime:0 notify:nil];
+
+  EXPECT_EQ(testView.layer.sublayers.count, 1ul);
+  EXPECT_FALSE(testView.didPresentEmptyFrame);
+  EXPECT_TRUE(CGSizeEqualToSize(testView.presentedFrameSize, CGSizeMake(100, 50)));
+
+  [surfaceManager presentEmptyFrameAtTime:0 notify:nil];
+
+  EXPECT_EQ(testView.layer.sublayers.count, 0ul);
+  EXPECT_TRUE(testView.didPresentEmptyFrame);
+  // The last committed frame size is left unchanged.
+  EXPECT_TRUE(CGSizeEqualToSize(testView.presentedFrameSize, CGSizeMake(100, 50)));
 }
 
 TEST(FlutterSurfaceManager, WideGamutSurfaceHasCorrectPixelFormat) {

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -55,6 +55,16 @@
   [_resizeSynchronizer performCommitForSize:frameSize afterDelay:delay notify:notifyBlock];
 }
 
+- (void)onPresentEmptyFrameWithBlock:(dispatch_block_t)block delay:(NSTimeInterval)delay {
+  // Such a frame has no contents, and thus no content size of its own. Report the current view
+  // size, which is the size a view sized to its contents is already laid out for.
+  auto notifyBlock = ^{
+    [self.sizingDelegate viewDidUpdateContents:self withSize:self.bounds.size];
+    block();
+  };
+  [_resizeSynchronizer performCommitForEmptyFrameAfterDelay:delay notify:notifyBlock];
+}
+
 - (FlutterSurfaceManager*)surfaceManager {
   return _surfaceManager;
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
@@ -6,7 +6,9 @@
 
 #import <Metal/Metal.h>
 
-#import "flutter/testing/testing.h"
+#import "flutter/shell/platform/darwin/macos/InternalFlutterSwift/InternalFlutterSwift.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h"
+#include "flutter/testing/testing.h"
 
 constexpr int64_t kImplicitViewId = 0ll;
 
@@ -24,6 +26,63 @@ constexpr int64_t kImplicitViewId = 0ll;
 }
 
 @end
+
+@interface TestFlutterViewSizingDelegate : NSObject <FlutterViewSizingDelegate>
+
+@property(readwrite, nonatomic) NSSize updatedContentsSize;
+@property(readwrite, nonatomic) BOOL didUpdateContents;
+
+@end
+
+@implementation TestFlutterViewSizingDelegate
+
+- (std::optional<NSSize>)minimumViewSize:(nonnull FlutterView*)view {
+  return std::nullopt;
+}
+
+- (std::optional<NSSize>)maximumViewSize:(nonnull FlutterView*)view {
+  return std::nullopt;
+}
+
+- (void)viewDidUpdateContents:(nonnull FlutterView*)view withSize:(NSSize)newSize {
+  self.didUpdateContents = YES;
+  self.updatedContentsSize = newSize;
+}
+
+@end
+
+// Regression test for https://github.com/flutter/flutter/issues/190075. A frame with no layers has
+// no size of its own, so it must not report a content size of zero, which is neither a size the
+// sizing delegate can lay out for nor a size a pending resize can ever match.
+TEST(FlutterView, EmptyFramePresentReportsViewSize) {
+  [FlutterRunLoop ensureMainLoopInitialized];
+
+  id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+  id<MTLCommandQueue> queue = [device newCommandQueue];
+  TestFlutterViewDelegate* delegate = [[TestFlutterViewDelegate alloc] init];
+  FlutterView* view = [[FlutterView alloc] initWithMTLDevice:device
+                                                commandQueue:queue
+                                                    delegate:delegate
+                                              viewIdentifier:kImplicitViewId
+                                             enableWideGamut:NO];
+  [view setFrameSize:NSMakeSize(80, 60)];
+  TestFlutterViewSizingDelegate* sizingDelegate = [[TestFlutterViewSizingDelegate alloc] init];
+  view.sizingDelegate = sizingDelegate;
+
+  // FlutterView conforms to FlutterSurfaceManagerDelegate privately.
+  id surfaceManagerDelegate = view;
+  __block BOOL didCommit = NO;
+  [surfaceManagerDelegate
+      onPresentEmptyFrameWithBlock:^{
+        didCommit = YES;
+      }
+                             delay:0];
+  [FlutterRunLoop.mainRunLoop pollFlutterMessagesOnce];
+
+  EXPECT_TRUE(didCommit);
+  EXPECT_TRUE(sizingDelegate.didUpdateContents);
+  EXPECT_TRUE(NSEqualSizes(sizingDelegate.updatedContentsSize, NSMakeSize(80, 60)));
+}
 
 TEST(FlutterView, ShouldInheritContentsScaleReturnsYes) {
   id<MTLDevice> device = MTLCreateSystemDefaultDevice();

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/ResizeSynchronizer.swift
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/ResizeSynchronizer.swift
@@ -25,11 +25,13 @@ import Foundation
 ///
 /// 2.  Commit (Raster Thread): As the engine renders frames, the raster thread, upon presenting a
 ///     new frame, calls `performCommit(forSize:afterDelay:notify:)`, providing the size of the
-///     frame just rendered.
+///     frame just rendered. A frame with no layers displays nothing and has no size, and is
+///     committed with `performCommitForEmptyFrame(afterDelay:notify:)` instead.
 ///
 /// 3.  Unblocking: If the size of the committed frame matches the target size that `beginResize()`
 ///     is waiting for, `beginResize()` unblocks. This allows the native resize operation to
-///     complete, now that Flutter's content is synchronized with the new window dimensions.
+///     complete, now that Flutter's content is synchronized with the new window dimensions. A
+///     frame with no layers unblocks `beginResize()` whatever target size it waits for.
 ///
 /// Safeguards:
 ///   - Timeout: `beginResize()` includes a timeout mechanism to prevent indefinite blocking if a
@@ -42,7 +44,24 @@ import Foundation
 ///     actions between the platform thread and the raster thread.
 @objc(FlutterResizeSynchronizer)
 final class ResizeSynchronizer: NSObject {
-  private static let invalidSize = CGSize(width: -1, height: -1)
+  /// A frame committed by the raster thread.
+  private enum CommittedFrame {
+    /// A frame with no layers. Such a frame has no size, and displays nothing that could be out
+    /// of sync with the window.
+    case empty
+    /// A frame with contents of the given size, in physical pixels.
+    case contents(CGSize)
+
+    /// Whether a resize to `size` may complete with this frame on screen.
+    func satisfiesResize(toSize size: CGSize) -> Bool {
+      switch self {
+      case .empty:
+        return true
+      case .contents(let contentsSize):
+        return contentsSize == size
+      }
+    }
+  }
 
   // Synchronizes access to _isInResize_unsafe: isInResize is accessed from multiple threads and
   // thus requires synchronized access to the underlying storage.
@@ -67,8 +86,9 @@ final class ResizeSynchronizer: NSObject {
   // True if at least one frame has been presented. Must be set on platform thread.
   private var didReceiveFrame: Bool = false
 
-  // The updated view surface size. Must be set on platform thread.
-  private var contentSize: CGSize = ResizeSynchronizer.invalidSize
+  // The frame most recently committed during the current resize, if any. Must be set on platform
+  // thread.
+  private var committedFrame: CommittedFrame?
 
   /// Begins window resize operation to the specified size.
   ///
@@ -86,9 +106,9 @@ final class ResizeSynchronizer: NSObject {
       return
     }
 
-    // Mark that we're in a resize and set the content size to a sentinel value.
+    // Mark that we're in a resize and forget any previously committed frame.
     isInResize = true
-    contentSize = ResizeSynchronizer.invalidSize
+    committedFrame = nil
 
     // Call the notify callback.
     notify()
@@ -97,8 +117,8 @@ final class ResizeSynchronizer: NSObject {
     let startTime = CFAbsoluteTimeGetCurrent()
     let timeoutDuration: TimeInterval = 1.0
     while true {
-      // If no change to size, or we got a shutdown notice, bail out.
-      if contentSize == size || isShuttingDown {
+      // If a committed frame satisfies the requested size, or we got a shutdown notice, bail out.
+      if (committedFrame?.satisfiesResize(toSize: size) ?? false) || isShuttingDown {
         break
       }
 
@@ -108,7 +128,7 @@ final class ResizeSynchronizer: NSObject {
         break
       }
 
-      // Process platform thread messages to pick up any updates to contentSize, didReceiveFrame,
+      // Process platform thread messages to pick up any updates to committedFrame, didReceiveFrame,
       // isShuttingDown made in performCommit and shutdown methods.
       FlutterRunLoop.mainRunLoop.pollFlutterMessagesOnce()
     }
@@ -126,6 +146,26 @@ final class ResizeSynchronizer: NSObject {
     afterDelay delay: TimeInterval,
     notify: @escaping () -> Void
   ) {
+    commit(.contents(size), afterDelay: delay, notify: notify)
+  }
+
+  /// Commit a frame with no layers.
+  ///
+  /// Such a frame has no size, and unblocks `beginResize` whatever size it waits for.
+  ///
+  /// Called from the raster thread on frame present.
+  @objc func performCommitForEmptyFrame(
+    afterDelay delay: TimeInterval,
+    notify: @escaping () -> Void
+  ) {
+    commit(.empty, afterDelay: delay, notify: notify)
+  }
+
+  private func commit(
+    _ frame: CommittedFrame,
+    afterDelay delay: TimeInterval,
+    notify: @escaping () -> Void
+  ) {
     var effectiveDelay = delay
 
     // If we're currently resizing, process immediately.
@@ -135,7 +175,7 @@ final class ResizeSynchronizer: NSObject {
 
     FlutterRunLoop.mainRunLoop.perform(afterDelay: effectiveDelay) {
       self.didReceiveFrame = true
-      self.contentSize = size
+      self.committedFrame = frame
       notify()
     }
   }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/ResizeSynchronizerTests.swift
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/ResizeSynchronizerTests.swift
@@ -97,6 +97,56 @@ struct ResizeSynchronizerTests {
   }
 
   @MainActor
+  @Test("beginResize does not invoke onTimeout if a frame with nothing to rasterize is committed")
+  func testBeginResizeDoesNotTimeOutWithEmptyFrameCommit() async {
+    FlutterRunLoop.ensureMainLoopInitialized()
+
+    // Resize synchronizer must have presented a frame in order to block.
+    let synchronizer = ResizeSynchronizer()
+    var didReceiveFrame = false
+    synchronizer.performCommit(forSize: CGSize(width: 10, height: 10), afterDelay: 0) {
+      didReceiveFrame = true
+    }
+    do {
+      try await waitForCondition("didReceiveFrame to be true", timeout: 1.0) { didReceiveFrame }
+    } catch {
+      // Record the timeout and bail out of the test.
+      Issue.record("\(error)")
+      return
+    }
+
+    var didCommit = false
+    var didTimeout = false
+    let latch = DispatchSemaphore(value: 0)
+
+    // Call performCommitForEmptyFrame from raster thread during frame present.
+    Thread.detachNewThread {
+      // Block until `beginResize` has been called.
+      latch.wait()
+
+      synchronizer.performCommitForEmptyFrame(afterDelay: 0) {
+        didCommit = true
+      }
+    }
+
+    // This call blocks until a frame is committed, or times out.
+    synchronizer.beginResize(forSize: CGSize(width: 100, height: 100)) {
+      // Unblock the raster thread by signaling the latch.
+      latch.signal()
+    } onTimeout: {
+      didTimeout = true
+    }
+
+    // Verify beginResize did not timeout.
+    #expect(
+      didTimeout == false,
+      "onTimeout was called even though a frame with nothing to rasterize was committed")
+
+    // Verify performCommitForEmptyFrame callback was invoked.
+    #expect(didCommit == true)
+  }
+
+  @MainActor
   @Test("beginResize invokes onTimeout if performCommit not called with matching frame size")
   func testBeginResizeDoesTimeOutWithoutMatchingPerformCommit() async {
     FlutterRunLoop.ensureMainLoopInitialized()


### PR DESCRIPTION
`FlutterSurfaceManager` derives the committed frame size from the presented surfaces, starting at `CGSizeZero` ([`GetRequiredFrameSize`](https://github.com/flutter/flutter/blob/58cc1b845dfa7035182336861288b662904350ca/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm#L233-L240)). A frame with nothing to rasterize has no layers at all, because the embedder's layer builder only adds a backing store layer when [`HasEngineRenderedContents()`](https://github.com/flutter/flutter/blob/58cc1b845dfa7035182336861288b662904350ca/engine/src/flutter/shell/platform/embedder/embedder_external_view_embedder.cc#L416-L424) is true. The committed size is then `(0, 0)`, which never matches the size `ResizeSynchronizer.beginResize` waits for, so every resize step blocked the platform thread for the full one second timeout and logged `Resize timed out`.

Such a frame displays nothing that could be out of sync with the window, so `FlutterCompositor` now presents it with a new `presentEmptyFrameAtTime:notify:`, which reaches `ResizeSynchronizer` as an empty frame and unblocks a pending resize whatever size that resize waits for. Windows does the same in [`OnEmptyFrameGenerated`](https://github.com/flutter/flutter/blob/58cc1b845dfa7035182336861288b662904350ca/engine/src/flutter/shell/platform/windows/flutter_windows_view.cc#L143-L163), covered there by [`TestEmptyFrameResizes`](https://github.com/flutter/flutter/blob/58cc1b845dfa7035182336861288b662904350ca/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc#L1024).

The empty frame is keyed on the frame having no layers, not on it presenting no surfaces. A frame whose only layer is a platform view also presents no surfaces, but that platform view is on screen and is positioned from the frame being committed, so unblocking on it would leave the platform view at the pre-resize geometry. Those frames keep their existing behavior and still stall, measured at 1017.10 ms per resize step with this PR versus 1019.15 ms without it. That case needs the frame's real size to synchronize against, which the embedder does not currently give the macOS compositor, so I left it out of this PR and filed https://github.com/flutter/flutter/issues/191865 for it.

An empty frame reports the view's current size to `FlutterViewSizingDelegate`, since it has no content size of its own. Reporting zero, as the old code did, would shrink a window sized to its contents to nothing, and would leave a positioner window hidden, since `viewDidUpdateContents:withSize:` is the only automatic path that reveals it.

`FlutterSurfaceManagerDelegate` is not a public framework header, so its new required method is not an API change for embedders.

### Verification

Sample and probe from the issue, 20 resize steps through `-[FlutterView setFrameSize:]`, local `mac_debug_unopt_arm64` engine, macOS 26.5.2 arm64:

| scene | mean per resize step | `Resize timed out` |
|---|---|---|
| before | 1020.30 ms | 20 / 20 |
| after | 8.82 ms | 0 / 20 |

`flutter_desktop_darwin_unittests` (235 tests) and `flutter_desktop_darwin_swift_unittests` (5 tests) pass, and clang-tidy is clean. Each new test was confirmed to fail with the corresponding part of the fix reverted.

Fixes https://github.com/flutter/flutter/issues/190075

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
