### PR TITLE
common: Fix surrogate pair stepping in TextInputModel delete methods

### DIFF
--- a/engine/src/flutter/shell/platform/common/text_input_model.cc
+++ b/engine/src/flutter/shell/platform/common/text_input_model.cc
@@ -24,6 +24,43 @@ bool IsTrailingSurrogate(char32_t code_point) {
   return (code_point & 0xFFFFFC00) == 0xDC00;
 }
 
+// Returns the position one character after |pos|, or |limit| if a whole
+// character does not fit between the two.
+//
+// A surrogate pair that straddles |limit| is not stepped over. We can't end
+// halfway through, and deleting half a character would produce invalid UTF-8.
+//
+// A leading surrogate spans two code units only if |text| pairs it with a
+// trailing one. An unpaired surrogate is a character of its own, so it is
+// stepped over alone rather than swallowing whatever follows it.
+size_t NextCharacterBoundary(const std::u16string& text,
+                             size_t pos,
+                             size_t limit) {
+  if (pos == limit) {
+    return pos;
+  }
+  size_t step = IsLeadingSurrogate(text.at(pos)) && pos + 1 < text.length() &&
+                        IsTrailingSurrogate(text.at(pos + 1))
+                    ? 2
+                    : 1;
+  return limit - pos < step ? pos : pos + step;
+}
+
+// Returns the position one character before |pos|, or |limit| if a whole
+// character does not fit between the two.
+size_t PreviousCharacterBoundary(const std::u16string& text,
+                                 size_t pos,
+                                 size_t limit) {
+  if (pos == limit) {
+    return pos;
+  }
+  size_t step = IsTrailingSurrogate(text.at(pos - 1)) && pos >= 2 &&
+                        IsLeadingSurrogate(text.at(pos - 2))
+                    ? 2
+                    : 1;
+  return pos - limit < step ? pos : pos - step;
+}
+
 }  // namespace
 
 TextInputModel::TextInputModel() = default;
@@ -168,59 +205,74 @@ bool TextInputModel::Backspace() {
   if (DeleteSelected()) {
     return true;
   }
-  // There is no selection. Delete the preceding codepoint.
-  size_t position = selection_.position();
-  if (position != editable_range().start()) {
-    int count = IsTrailingSurrogate(text_.at(position - 1)) ? 2 : 1;
-    text_.erase(position - count, count);
-    selection_ = TextRange(position - count);
-    if (composing_) {
-      composing_range_.set_end(composing_range_.end() - count);
-    }
-    return true;
+  // There is no selection. Delete the preceding character.
+  size_t position = std::clamp(selection_.position(), editable_range().start(),
+                               editable_range().end());
+  size_t start =
+      PreviousCharacterBoundary(text_, position, editable_range().start());
+  if (start == position) {
+    return false;
   }
-  return false;
+  size_t count = position - start;
+  text_.erase(start, count);
+  selection_ = TextRange(start);
+  if (composing_) {
+    composing_range_.set_end(composing_range_.end() - count);
+  }
+  return true;
 }
 
 bool TextInputModel::Delete() {
   if (DeleteSelected()) {
     return true;
   }
-  // There is no selection. Delete the preceding codepoint.
-  size_t position = selection_.position();
-  if (position < editable_range().end()) {
-    int count = IsLeadingSurrogate(text_.at(position)) ? 2 : 1;
-    text_.erase(position, count);
-    if (composing_) {
-      composing_range_.set_end(composing_range_.end() - count);
-    }
-    return true;
+  // There is no selection. Delete the following character.
+  size_t position = std::clamp(selection_.position(), editable_range().start(),
+                               editable_range().end());
+  size_t end = NextCharacterBoundary(text_, position, editable_range().end());
+  if (end == position) {
+    return false;
   }
-  return false;
+  size_t count = end - position;
+  text_.erase(position, count);
+  if (composing_) {
+    composing_range_.set_end(composing_range_.end() - count);
+  }
+  return true;
 }
 
 bool TextInputModel::DeleteSurrounding(int offset_from_cursor, int count) {
+  size_t min_pos = editable_range().start();
   size_t max_pos = editable_range().end();
-  size_t start = selection_.extent();
+  size_t start = std::clamp(selection_.extent(), min_pos, max_pos);
   if (offset_from_cursor < 0) {
     for (int i = 0; i < -offset_from_cursor; i++) {
-      // If requested start is before the available text then reduce the
-      // number of characters to delete.
-      if (start == editable_range().start()) {
+      size_t previous = PreviousCharacterBoundary(text_, start, min_pos);
+      // We hit the start of the editable range. Delete only the characters it
+      // covered.
+      if (previous == start) {
         count = i;
         break;
       }
-      start -= IsTrailingSurrogate(text_.at(start - 1)) ? 2 : 1;
+      start = previous;
     }
   } else {
-    for (int i = 0; i < offset_from_cursor && start != max_pos; i++) {
-      start += IsLeadingSurrogate(text_.at(start)) ? 2 : 1;
+    for (int i = 0; i < offset_from_cursor; i++) {
+      size_t next = NextCharacterBoundary(text_, start, max_pos);
+      if (next == start) {
+        break;
+      }
+      start = next;
     }
   }
 
   auto end = start;
-  for (int i = 0; i < count && end != max_pos; i++) {
-    end += IsLeadingSurrogate(text_.at(start)) ? 2 : 1;
+  for (int i = 0; i < count; i++) {
+    size_t next = NextCharacterBoundary(text_, end, max_pos);
+    if (next == end) {
+      break;
+    }
+    end = next;
   }
 
   if (start == end) {

--- a/engine/src/flutter/shell/platform/common/text_input_model_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/text_input_model_unittests.cc
@@ -616,6 +616,66 @@ TEST(TextInputModel, DeleteWideCharacters) {
   EXPECT_STREQ(model->GetText().c_str(), "😄🙃🧐");
 }
 
+TEST(TextInputModel, DeleteSplitPairAtComposingEnd) {
+  auto model = std::make_unique<TextInputModel>();
+  // The composing range ends between the two halves of U+1F600, and the cursor
+  // sits on the leading one.
+  EXPECT_TRUE(model->SetText("a\U0001F600bcd", TextRange(1), TextRange(1, 2)));
+  // Only half the character is editable. Verify we don't delete the whole
+  // pair, which reaches outside the composing range and leaves its end before
+  // its start.
+  EXPECT_FALSE(model->Delete());
+  EXPECT_STREQ(model->GetText().c_str(), "a\U0001F600bcd");
+  EXPECT_EQ(model->composing_range(), TextRange(1, 2));
+}
+
+TEST(TextInputModel, DeleteUnpairedLeadingSurrogate) {
+  auto model = std::make_unique<TextInputModel>();
+  model->SetText("ab");
+  EXPECT_TRUE(model->SetSelection(TextRange(0)));
+  // Composing text arrives from the input method as UTF-16 and is not required
+  // to be well formed, so a leading surrogate can stand alone.
+  model->AddText(std::u16string(1, 0xD83D));
+  EXPECT_TRUE(model->SetSelection(TextRange(0)));
+  // The surrogate is unpaired, so it is one character on its own. Verify we
+  // don't treat it as half of a pair and take the 'a' after it as well.
+  EXPECT_TRUE(model->Delete());
+  EXPECT_STREQ(model->GetText().c_str(), "ab");
+  EXPECT_EQ(model->selection(), TextRange(0));
+}
+
+TEST(TextInputModel, DeleteUnpairedSurrogateAtEndComposing) {
+  auto model = std::make_unique<TextInputModel>();
+  model->SetText("ab");
+  EXPECT_TRUE(model->SetSelection(TextRange(2)));
+  model->AddText(std::u16string(1, 0xD83D));
+  model->BeginComposing();
+  EXPECT_TRUE(model->SetComposingRange(TextRange(0, 3), 3));
+  EXPECT_TRUE(model->SetSelection(TextRange(2)));
+  // Verify the composing range shrinks by the one code unit deleted. Measuring
+  // the unpaired surrogate as half of a pair shrinks it by two, leaving it
+  // shorter than the text it describes.
+  EXPECT_TRUE(model->Delete());
+  EXPECT_STREQ(model->GetText().c_str(), "ab");
+  EXPECT_EQ(model->composing_range(), TextRange(0, 2));
+}
+
+TEST(TextInputModel, DeleteWithSelectionPastComposingRange) {
+  auto model = std::make_unique<TextInputModel>();
+  EXPECT_TRUE(model->SetText("ABCDE"));
+  model->BeginComposing();
+  // The composing range does not have to contain the selection: this offset
+  // places the caret three characters beyond the end of the range.
+  EXPECT_TRUE(model->SetComposingRange(TextRange(1, 2), 4));
+  EXPECT_EQ(model->selection(), TextRange(5));
+  // Verify deletion is confined to the composing range. The caret is already
+  // past it, so there is nothing after it to delete, and deleting at the caret
+  // would index past the end of the text.
+  EXPECT_FALSE(model->Delete());
+  EXPECT_STREQ(model->GetText().c_str(), "ABCDE");
+  EXPECT_EQ(model->composing_range(), TextRange(1, 2));
+}
+
 TEST(TextInputModel, DeleteSelection) {
   auto model = std::make_unique<TextInputModel>();
   model->SetText("ABCDE");
@@ -915,6 +975,147 @@ TEST(TextInputModel, DeleteSurroundingReverseSelection) {
   EXPECT_STREQ(model->GetText().c_str(), "ABCE");
 }
 
+TEST(TextInputModel, DeleteSurroundingAtCursorSurrogatePairFirst) {
+  auto model = std::make_unique<TextInputModel>();
+  // U+1F600 occupies two UTF-16 code units but counts as one character.
+  model->SetText("\U0001F600ab");
+  EXPECT_TRUE(model->SetSelection(TextRange(0)));
+  // Verify deleting two characters deletes the whole pair and the 'a' that
+  // follows it.
+  EXPECT_TRUE(model->DeleteSurrounding(0, 2));
+  EXPECT_EQ(model->selection(), TextRange(0));
+  EXPECT_STREQ(model->GetText().c_str(), "b");
+}
+
+TEST(TextInputModel, DeleteSurroundingAtCursorSurrogatePairNotFirst) {
+  auto model = std::make_unique<TextInputModel>();
+  // U+1F600 occupies two UTF-16 code units but counts as one character.
+  model->SetText("a\U0001F600b");
+  EXPECT_TRUE(model->SetSelection(TextRange(0)));
+  // Verify deleting two characters deletes the 'a' and the whole pair that
+  // follows it.
+  EXPECT_TRUE(model->DeleteSurrounding(0, 2));
+  EXPECT_EQ(model->selection(), TextRange(0));
+  EXPECT_STREQ(model->GetText().c_str(), "b");
+}
+
+TEST(TextInputModel, DeleteSurroundingAfterCursorSplitPairAtComposingEnd) {
+  auto model = std::make_unique<TextInputModel>();
+  // The composing range ends between the two halves of U+1F600.
+  EXPECT_TRUE(model->SetText("a\U0001F600bcd", TextRange(1), TextRange(1, 2)));
+  EXPECT_FALSE(model->DeleteSurrounding(1, 1));
+  EXPECT_STREQ(model->GetText().c_str(), "a\U0001F600bcd");
+  EXPECT_EQ(model->composing_range(), TextRange(1, 2));
+}
+
+TEST(TextInputModel, DeleteSurroundingAtCursorSplitPairAtComposingEnd) {
+  auto model = std::make_unique<TextInputModel>();
+  // The cursor sits on the leading surrogate, and the composing range ends
+  // between the two halves.
+  EXPECT_TRUE(model->SetText("a\U0001F600bcd", TextRange(1), TextRange(1, 2)));
+  // Only the leading half is inside the range. Verify we don't delete it and
+  // leave an unpaired trailing surrogate that GetText cannot convert.
+  EXPECT_FALSE(model->DeleteSurrounding(0, 1));
+  EXPECT_STREQ(model->GetText().c_str(), "a\U0001F600bcd");
+  EXPECT_EQ(model->composing_range(), TextRange(1, 2));
+}
+
+TEST(TextInputModel, DeleteSurroundingAtCursorStopsAtSplitPair) {
+  auto model = std::make_unique<TextInputModel>();
+  // "ab<U+1F600>cd" with a composing range ending between the two halves.
+  EXPECT_TRUE(model->SetText("ab\U0001F600cd", TextRange(1), TextRange(0, 3)));
+  // The first character requested is whole and the second is not. Verify the
+  // whole one is deleted and the walk stops.
+  EXPECT_TRUE(model->DeleteSurrounding(0, 2));
+  EXPECT_STREQ(model->GetText().c_str(), "a\U0001F600cd");
+  EXPECT_EQ(model->composing_range(), TextRange(0, 2));
+}
+
+TEST(TextInputModel, DeleteSurroundingBeforeCursorSplitPairAtComposingStart) {
+  auto model = std::make_unique<TextInputModel>();
+  // The composing range starts between the two halves.
+  EXPECT_TRUE(model->SetText("\U0001F600bcd", TextRange(2), TextRange(1, 5)));
+  EXPECT_FALSE(model->DeleteSurrounding(-1, 1));
+  EXPECT_STREQ(model->GetText().c_str(), "\U0001F600bcd");
+  EXPECT_EQ(model->composing_range(), TextRange(1, 5));
+}
+
+TEST(TextInputModel, DeleteSurroundingWithSelectionPastComposingRange) {
+  auto model = std::make_unique<TextInputModel>();
+  EXPECT_TRUE(model->SetText("ABCDE"));
+  model->BeginComposing();
+  // The offset places the caret two characters beyond the end of the range.
+  EXPECT_TRUE(model->SetComposingRange(TextRange(1, 2), 4));
+  EXPECT_EQ(model->selection(), TextRange(5));
+  // Verify deletion is confined to the editable range. The caret is already
+  // past it, so there is nothing after it to delete.
+  EXPECT_FALSE(model->DeleteSurrounding(0, 1));
+  EXPECT_STREQ(model->GetText().c_str(), "ABCDE");
+  EXPECT_EQ(model->composing_range(), TextRange(1, 2));
+  // Verify the walk backwards starts from the end of the range rather than from
+  // the caret, deleting the character inside it.
+  EXPECT_TRUE(model->DeleteSurrounding(-1, 1));
+  EXPECT_STREQ(model->GetText().c_str(), "ACDE");
+  EXPECT_EQ(model->composing_range(), TextRange(1, 1));
+}
+
+TEST(TextInputModel, DeleteSurroundingAfterCursorUnpairedSurrogateAtEnd) {
+  auto model = std::make_unique<TextInputModel>();
+  model->SetText("ab");
+  EXPECT_TRUE(model->SetSelection(TextRange(2)));
+  // Composing text arrives from the input method as UTF-16 and is not
+  // well-formed, so the text can end in half a surrogate pair.
+  model->AddText(std::u16string(1, 0xD83D));
+  EXPECT_TRUE(model->SetSelection(TextRange(2)));
+  // Stepping over that half runs the offset past the end of the text. Ensure
+  // the walk stops there rather than keep reading, and index out of bounds.
+  EXPECT_FALSE(model->DeleteSurrounding(2, 1));
+  EXPECT_EQ(model->selection(), TextRange(2));
+}
+
+TEST(TextInputModel, DeleteSurroundingAtCursorUnpairedLeadingSurrogate) {
+  auto model = std::make_unique<TextInputModel>();
+  model->SetText("ab");
+  EXPECT_TRUE(model->SetSelection(TextRange(0)));
+  // An unpaired leading surrogate followed by an ordinary character.
+  model->AddText(std::u16string(1, 0xD83D));
+  EXPECT_TRUE(model->SetSelection(TextRange(0)));
+  // The surrogate is unpaired, so it is one character on its own. Verify we
+  // don't treat it as half of a pair and take the 'a' after it as well.
+  EXPECT_TRUE(model->DeleteSurrounding(0, 1));
+  EXPECT_STREQ(model->GetText().c_str(), "ab");
+  EXPECT_EQ(model->selection(), TextRange(0));
+}
+
+TEST(TextInputModel, DeleteSurroundingAtCursorUnpairedSurrogateAtEnd) {
+  auto model = std::make_unique<TextInputModel>();
+  model->SetText("ab");
+  EXPECT_TRUE(model->SetSelection(TextRange(2)));
+  model->AddText(std::u16string(1, 0xD83D));
+  EXPECT_TRUE(model->SetSelection(TextRange(2)));
+  // Verify the unpaired surrogate ending the text can be deleted. Measuring it
+  // as half of a pair leaves it permanently stuck, since two code units never
+  // fit before the end of the text.
+  EXPECT_TRUE(model->DeleteSurrounding(0, 1));
+  EXPECT_STREQ(model->GetText().c_str(), "ab");
+  EXPECT_EQ(model->selection(), TextRange(2));
+}
+
+TEST(TextInputModel, DeleteSurroundingBeforeCursorUnpairedTrailingSurrogate) {
+  auto model = std::make_unique<TextInputModel>();
+  model->SetText("ab");
+  EXPECT_TRUE(model->SetSelection(TextRange(2)));
+  // The mirror case: an unpaired trailing surrogate preceded by an ordinary
+  // character.
+  model->AddText(std::u16string(1, 0xDE00));
+  EXPECT_TRUE(model->SetSelection(TextRange(3)));
+  // Verify we don't treat it as half of a pair and take the 'b' before it as
+  // well.
+  EXPECT_TRUE(model->DeleteSurrounding(-1, 1));
+  EXPECT_STREQ(model->GetText().c_str(), "ab");
+  EXPECT_EQ(model->selection(), TextRange(2));
+}
+
 TEST(TextInputModel, BackspaceStart) {
   auto model = std::make_unique<TextInputModel>();
   model->SetText("ABCDE");
@@ -953,6 +1154,47 @@ TEST(TextInputModel, BackspaceWideCharacters) {
   EXPECT_EQ(model->selection(), TextRange(2));
   EXPECT_EQ(model->composing_range(), TextRange(0));
   EXPECT_STREQ(model->GetText().c_str(), "😄🤪🧐");
+}
+
+TEST(TextInputModel, BackspaceSplitPairAtComposingStart) {
+  auto model = std::make_unique<TextInputModel>();
+  // The composing range starts between the two halves of U+1F600, and the
+  // cursor sits just after the trailing one.
+  EXPECT_TRUE(model->SetText("\U0001F600bcd", TextRange(2), TextRange(1, 5)));
+  // Only half the character is editable. Verify we don't delete the whole
+  // pair, which reaches outside the composing range.
+  EXPECT_FALSE(model->Backspace());
+  EXPECT_STREQ(model->GetText().c_str(), "\U0001F600bcd");
+  EXPECT_EQ(model->composing_range(), TextRange(1, 5));
+}
+
+TEST(TextInputModel, BackspaceUnpairedTrailingSurrogate) {
+  auto model = std::make_unique<TextInputModel>();
+  model->SetText("ab");
+  EXPECT_TRUE(model->SetSelection(TextRange(2)));
+  // The mirror case: a trailing surrogate that stands alone.
+  model->AddText(std::u16string(1, 0xDE00));
+  EXPECT_TRUE(model->SetSelection(TextRange(3)));
+  // Verify we don't treat it as half of a pair and take the 'b' before it as
+  // well.
+  EXPECT_TRUE(model->Backspace());
+  EXPECT_STREQ(model->GetText().c_str(), "ab");
+  EXPECT_EQ(model->selection(), TextRange(2));
+}
+
+TEST(TextInputModel, BackspaceWithSelectionPastComposingRange) {
+  auto model = std::make_unique<TextInputModel>();
+  EXPECT_TRUE(model->SetText("ABCDE"));
+  model->BeginComposing();
+  EXPECT_TRUE(model->SetComposingRange(TextRange(1, 2), 4));
+  EXPECT_EQ(model->selection(), TextRange(5));
+  // Verify the walk backwards starts from the end of the composing range
+  // rather than from the caret, deleting the character inside it. Starting
+  // from the caret would delete a character outside the range entirely.
+  EXPECT_TRUE(model->Backspace());
+  EXPECT_STREQ(model->GetText().c_str(), "ACDE");
+  EXPECT_EQ(model->selection(), TextRange(1));
+  EXPECT_EQ(model->composing_range(), TextRange(1, 1));
 }
 
 TEST(TextInputModel, BackspaceSelection) {


### PR DESCRIPTION
Fixes surrogate pair stepping in `DeleteSurrounding`, `Delete`, and `Backspace`. Ironically, I landed a very similar change for iOS almost a decade ago: flutter/engine#3590.

Walking forward over the characters to delete was measuring each one against `text_.at(start)` rather than `text_.at(end)`, so after the first step we kept re-reading the character we started from. That over-deletes when the first character is a surrogate pair, and splits the pair when a later one is, leaving an unpaired surrogate in `text_` that `GetText` then can't convert, resulting in a range error.

This also limits both ends of the deletion to the editable range. We need to protect against a surrogate pair that straddles the boundary.

We now stop the walk at the boundary rather than step past it. `start` is clamped on entry because the selection is not required to sit inside the composing range either. `SetComposingRange` accepts a cursor offset that could place the caret beyond the range's end. Without this, `start` could exceed `end` and underflow `deleted_length`, which erases the rest of the buffer and wraps the composing range, or index out of bounds and blow up.

Extracted helpers rather than copy-pasting even more than we already had.

Spotted which working on: https://github.com/flutter/flutter/issues/190704

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
