### PR TITLE
Explicitly disable HCPP in hybrid_android_views integration test

### DIFF
--- a/dev/integration_tests/android_engine_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_engine_test/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@ found in the LICENSE file. -->
         <meta-data android:name="flutterEmbedding" android:value="2" />
         <meta-data android:name="io.flutter.embedding.android.EnableImpeller" android:value="true" />
         <meta-data android:name="io.flutter.embedding.android.ImpellerBackend" android:value="vulkan" />
-        <!-- Don't delete the meta-data below, even though it matches the platform default.
+        <!-- Don't delete the meta-data below, even if it matches the platform default.
              These tests intentionally exercise explicit platform view modes, and an explicit
              value here stops the tool from injecting the enable-hcpp feature flag default. -->
         <meta-data android:name="io.flutter.embedding.android.EnableHcpp" android:value="false" />

--- a/dev/integration_tests/hybrid_android_views/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/hybrid_android_views/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,12 @@ found in the LICENSE file. -->
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- Don't delete the meta-data below, even if it matches the platform default.
+             These tests intentionally exercise explicit platform view modes, and an explicit
+             value here stops the tool from injecting the enable-hcpp feature flag default. -->
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableHcpp"
+            android:value="false" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and


### PR DESCRIPTION
Fixes the failure in `Linux_mokey hybrid_android_views_integration_test` caused by HCPP being enabled by default in #190623.

The `hybrid_android_views` integration test specifically verifies legacy Hybrid Composition view hierarchy behavior and expects `FlutterImageView`s to be present in the view tree. Since HCPP relies on `SurfaceControl` overlays on API 34+ rather than `FlutterImageView`, this test app needs to explicitly opt out of HCPP to continue testing the legacy HC mode as intended.