### PR TITLE
Deprecate legacy gen_defaults tool

### DIFF
--- a/dev/bots/suite_runners/run_framework_tests.dart
+++ b/dev/bots/suite_runners/run_framework_tests.dart
@@ -306,7 +306,6 @@ Future<void> frameworkTestsRunner() async {
     await runFlutterTest(path.join(flutterRoot, 'dev', 'manual_tests'));
     await runFlutterTest(path.join(flutterRoot, 'dev', 'tools'));
     await runFlutterTest(path.join(flutterRoot, 'dev', 'tools', 'vitool'));
-    await runFlutterTest(path.join(flutterRoot, 'dev', 'tools', 'gen_defaults'));
     await runFlutterTest(path.join(flutterRoot, 'dev', 'tools', 'gen_keycodes'));
     await runFlutterTest(path.join(flutterRoot, 'dev', 'benchmarks', 'test_apps', 'stocks'));
     await runFlutterTest(

--- a/dev/tools/gen_defaults/README.md
+++ b/dev/tools/gen_defaults/README.md
@@ -1,14 +1,22 @@
-## Token Defaults Generator
+## Legacy Token Defaults Generator
 
-Script that generates component theme data defaults based on token data.
+This legacy tool is deprecated. It only targets the frozen SDK Material library
+under `packages/flutter/lib/src/material`, and should not be used for new
+Material defaults work.
 
-## Usage
+Active Material defaults generation has moved to the standalone `material_ui`
+package in the `flutter/packages` repository. Use
+[`packages/material_ui/tool/gen_defaults`](https://github.com/flutter/packages/tree/main/packages/material_ui/tool/gen_defaults)
+there instead.
+
+## Legacy Usage
 Run this program from the root of the git repository:
 ```sh
 dart dev/tools/gen_defaults/bin/gen_defaults.dart [-v]
 ```
 
-This updates `generated/used_tokens.csv` and the various component theme files.
+This updates `generated/used_tokens.csv` and the frozen SDK Material component
+theme files.
 
 ## Templates
 

--- a/dev/tools/gen_defaults/README.md
+++ b/dev/tools/gen_defaults/README.md
@@ -1,8 +1,9 @@
 ## Legacy Token Defaults Generator
 
-This legacy tool is deprecated. It only targets the frozen SDK Material library
-under `packages/flutter/lib/src/material`, and should not be used for new
-Material defaults work.
+> [!WARNING]
+> This legacy tool is deprecated. It only targets the frozen SDK Material library
+> under `packages/flutter/lib/src/material`, and should not be used for new
+> Material defaults work.
 
 Active Material defaults generation has moved to the standalone `material_ui`
 package in the `flutter/packages` repository. Use


### PR DESCRIPTION
Related to #184950 

This PR is to deprecate the legacy `dev/tools/gen_defaults` tool. The PR:
* stops the framework test shard from running the legacy `dev/tools/gen_defaults` unit tests.
* marks the legacy tool as deprecated in its README
* points developers to `packages/material_ui/tool/gen_defaults` in `flutter/packages`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
