### PR TITLE
[flutter_tools] Gracefully handle Windows Application Control and security policy execution blocks

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -1450,6 +1450,9 @@ void _handleWindowsException(Exception e, String? message, int errorCode) {
   const kAccessDenied = 5;
   const kFatalDeviceHardwareError = 483;
   const kDeviceDoesNotExist = 433;
+  const kApplicationControlPolicyBlocked = 4551;
+  const kAccessDisabledByPolicy = 1260;
+  const kSystemIntegrityPolicyViolation = 454;
 
   // Catch errors and bail when:
   final String? errorMessage = switch (errorCode) {
@@ -1478,6 +1481,13 @@ void _handleWindowsException(Exception e, String? message, int errorCode) {
       '$message. The device was not found.'
           '\n$e\n'
           'Verify the device is mounted and try again.',
+    kApplicationControlPolicyBlocked ||
+    kAccessDisabledByPolicy ||
+    kSystemIntegrityPolicyViolation =>
+      '${message != null ? "$message. " : ""}An Application Control policy or security policy has blocked execution.\n'
+          '$e\n'
+          'Please verify your Windows Security Smart App Control, Application Control policy (WDAC), '
+          'or Group Policy settings, or add an exclusion for the Flutter SDK directory.',
     _ => null,
   };
   _throwFileSystemException(errorMessage);

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -986,6 +986,9 @@ Please ensure that the SDK and/or project is installed in a location that has re
     const kDeviceFull = 112;
     const kUserMappedSectionOpened = 1224;
     const kUserPermissionDenied = 5;
+    const kApplicationControlPolicyBlocked = 4551;
+    const kAccessDisabledByPolicy = 1260;
+    const kSystemIntegrityPolicyViolation = 454;
 
     testWithoutContext(
       'when PackageProcess throws an exception containing non-executable bits',
@@ -1180,6 +1183,49 @@ Please ensure that the SDK and/or project is installed in a location that has re
         throwsToolExit(message: expectedMessage),
       );
     });
+
+    for (final (name, errorCode) in const <(String, int)>[
+      ('Windows Application Control policy', kApplicationControlPolicyBlocked),
+      ('Windows group policy', kAccessDisabledByPolicy),
+      ('Windows system integrity policy violation', kSystemIntegrityPolicyViolation),
+    ]) {
+      testWithoutContext('when blocked by $name', () {
+        final fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: const <String>['foo'],
+            exception: ProcessException('foo', const <String>[], 'Blocked', errorCode),
+          ),
+          FakeCommand(
+            command: const <String>['foo'],
+            exception: ProcessException('foo', const <String>[], 'Blocked', errorCode),
+          ),
+          FakeCommand(
+            command: const <String>['foo'],
+            exception: ProcessException('foo', const <String>[], 'Blocked', errorCode),
+          ),
+        ]);
+
+        final ProcessManager processManager = createProcessManager(
+          delegate: fakeProcessManager,
+          platform: windowsPlatform,
+        );
+
+        const expectedMessage =
+            'An Application Control policy or security policy has blocked execution.';
+        expect(
+          () async => processManager.start(<String>['foo']),
+          throwsToolExit(message: expectedMessage),
+        );
+        expect(
+          () async => processManager.run(<String>['foo']),
+          throwsToolExit(message: expectedMessage),
+        );
+        expect(
+          () => processManager.runSync(<String>['foo']),
+          throwsToolExit(message: expectedMessage),
+        );
+      });
+    }
   });
 
   group('ProcessManager on linux throws tool exit', () {


### PR DESCRIPTION
When Windows Smart App Control (SAC), Windows Defender Application Control (WDAC), or Group Policy blocks execution of Flutter binaries (such as `dartaotruntime.exe` during frontend_server compilation), Dart's Win32 process runner raises a `ProcessException` with Win32 error code 4551 (`ERROR_APPLICATION_CONTROL_POLICY_BLOCK`), 1260 (`ERROR_ACCESS_DISABLED_BY_POLICY`), or 454 (`ERROR_SYSTEM_INTEGRITY_POLICY_VIOLATION`).

Previously, `_handleWindowsException` did not recognize these error codes and returned `null`, which resulted in an unhandled `ProcessException` crash report (accounting for 354 crashes in Flutter 3.47.1).

This PR catches these security and application control policy error codes in `_handleWindowsException` and surfaces a clean, actionable `ToolExit` instructing users to check their Windows Security Smart App Control, WDAC, or Group Policy settings and configure an exclusion for the Flutter SDK directory.

Fixes #191899
