### PR TITLE
feat(web): support --web-content-hash for physical static assets

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -1607,7 +1607,7 @@ Map<String, File> _hashWebAssets(Directory assetsDir) {
         .convert(file.readAsBytesSync())
         .toString()
         .substring(0, 8);
-    final String newBasename = _computeHashedBasename(basename, contentHash);
+    final String newBasename = _computeHashedBasename(basename, contentHash, fileSystem);
 
     final String relativePath = fileSystem.path.relative(file.path, from: assetsDir.path);
     final String newRelativePath = fileSystem.path.join(

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -1588,16 +1588,16 @@ extension on Environment {
 }
 
 Map<String, File> _hashWebAssets(Directory assetsDir) {
-  final Map<String, File> renamedFileMap = <String, File>{};
+  final renamedFileMap = <String, File>{};
   if (!assetsDir.existsSync()) {
     return renamedFileMap;
   }
 
   final FileSystem fileSystem = assetsDir.fileSystem;
   final List<File> files = assetsDir.listSync(recursive: true).whereType<File>().toList();
-  final Map<String, String> renamedAssets = <String, String>{};
+  final renamedAssets = <String, String>{};
 
-  for (final File file in files) {
+  for (final file in files) {
     final String basename = file.basename;
     if (_kUnhashedAssetBasenames.contains(basename)) {
       continue;
@@ -1632,26 +1632,26 @@ Map<String, File> _hashWebAssets(Directory assetsDir) {
   final File assetManifestBin = assetsDir.childFile('AssetManifest.bin');
   if (assetManifestBin.existsSync()) {
     final Uint8List rawBytes = assetManifestBin.readAsBytesSync();
-    final ByteData message = ByteData.sublistView(rawBytes);
+    final message = ByteData.sublistView(rawBytes);
     final Object? decoded = const StandardMessageCodec().decodeMessage(message);
     if (decoded is Map<Object?, Object?>) {
-      final Map<String, dynamic> newManifest = <String, dynamic>{};
+      final newManifest = <String, dynamic>{};
       for (final MapEntry<Object?, Object?> entry in decoded.entries) {
-        final String key = entry.key.toString();
+        final key = entry.key.toString();
         final Object? variantsVal = entry.value;
         if (variantsVal is! List<Object?>) {
           continue;
         }
-        final List<dynamic> newVariants = <dynamic>[];
+        final newVariants = <dynamic>[];
         for (final Object? variantObj in variantsVal) {
           if (variantObj is! Map<Object?, Object?>) {
             continue;
           }
-          final Map<String, dynamic> newVariantMap = <String, dynamic>{};
+          final newVariantMap = <String, dynamic>{};
           for (final MapEntry<Object?, Object?> vEntry in variantObj.entries) {
-            final String vKey = vEntry.key.toString();
+            final vKey = vEntry.key.toString();
             if (vKey == 'asset') {
-              final String vValue = vEntry.value.toString();
+              final vValue = vEntry.value.toString();
               newVariantMap[vKey] = renamedAssets[vValue] ?? vValue;
             } else {
               newVariantMap[vKey] = vEntry.value;
@@ -1662,7 +1662,7 @@ Map<String, File> _hashWebAssets(Directory assetsDir) {
         newManifest[key] = newVariants;
       }
       final ByteData encoded = const StandardMessageCodec().encodeMessage(newManifest)!;
-      final Uint8List encodedBytes = Uint8List.sublistView(encoded);
+      final encodedBytes = Uint8List.sublistView(encoded);
       assetManifestBin.writeAsBytesSync(encodedBytes);
 
       // Update AssetManifest.bin.json
@@ -1670,6 +1670,28 @@ Map<String, File> _hashWebAssets(Directory assetsDir) {
       if (assetManifestBinJson.existsSync()) {
         assetManifestBinJson.writeAsStringSync(json.encode(base64.encode(encodedBytes)));
       }
+    }
+  }
+
+  // Update legacy AssetManifest.json if present
+  final File assetManifestJson = assetsDir.childFile('AssetManifest.json');
+  if (assetManifestJson.existsSync()) {
+    final Object? decodedJson = json.decode(assetManifestJson.readAsStringSync());
+    if (decodedJson is Map<String, dynamic>) {
+      final newManifest = <String, dynamic>{};
+      for (final MapEntry<String, dynamic> entry in decodedJson.entries) {
+        final Object? variants = entry.value;
+        if (variants is List<dynamic>) {
+          final newVariants = <String>[];
+          for (final Object? variant in variants) {
+            if (variant is String) {
+              newVariants.add(renamedAssets[variant] ?? variant);
+            }
+          }
+          newManifest[entry.key] = newVariants;
+        }
+      }
+      assetManifestJson.writeAsStringSync(json.encode(newManifest));
     }
   }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -1604,7 +1603,7 @@ Map<String, File> _hashWebAssets(Directory assetsDir) {
     final String posixRelativePath = p.posix.joinAll(segments);
 
     if (_kUnhashedAssetRelativePaths.contains(posixRelativePath) ||
-        fileSystem.path.extension(file.path) == '.frag' ||
+        fileSystem.path.extension(file.path).toLowerCase() == '.frag' ||
         segments.firstOrNull == 'shaders') {
       continue;
     }

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -2,12 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+import 'dart:convert';
+import 'dart:typed_data';
 import 'dart:math';
 
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:unified_analytics/unified_analytics.dart';
+import 'package:standard_message_codec/standard_message_codec.dart';
 
 import '../../artifacts.dart';
 import '../../base/common.dart';
@@ -1119,6 +1123,13 @@ class WebReleaseBundle extends Target {
     final DepfileService depfileService = environment.depFileService;
     depfileService.writeToFile(bundledDepfile, environment.buildDir.childFile('flutter_assets.d'));
 
+    final bool webContentHash = compileTargets.any(
+      (Dart2WebTarget t) => t.compilerConfig.webContentHash,
+    );
+    if (webContentHash) {
+      _hashWebAssets(outputDirectory);
+    }
+
     final Directory webResources = environment.projectDir.childDirectory('web');
     final List<File> inputResourceFiles = webResources
         .listSync(recursive: true)
@@ -1552,4 +1563,104 @@ extension on Environment {
   ServiceWorkerStrategy get serviceWorkerStrategy =>
       ServiceWorkerStrategy.fromCliName(defines[kServiceWorkerStrategy]) ??
       ServiceWorkerStrategy.offlineFirst;
+}
+
+void _hashWebAssets(Directory assetsDir) {
+  if (!assetsDir.existsSync()) {
+    return;
+  }
+
+  final FileSystem fileSystem = assetsDir.fileSystem;
+  final List<File> files = assetsDir.listSync(recursive: true).whereType<File>().toList();
+  final Map<String, String> renamedAssets = <String, String>{};
+
+  for (final File file in files) {
+    final String basename = file.basename;
+    if (basename == 'AssetManifest.json' ||
+        basename == 'AssetManifest.bin' ||
+        basename == 'AssetManifest.bin.json' ||
+        basename == 'FontManifest.json') {
+      continue;
+    }
+
+    final String contentHash = crypto.sha256
+        .convert(file.readAsBytesSync())
+        .toString()
+        .substring(0, 8);
+    final String newBasename = _computeHashedBasename(basename, contentHash);
+
+    final String relativePath = fileSystem.path.relative(file.path, from: assetsDir.path);
+    final String newRelativePath = fileSystem.path.join(
+      fileSystem.path.dirname(relativePath),
+      newBasename,
+    );
+
+    // Rename the file
+    final String newPath = fileSystem.path.join(assetsDir.path, newRelativePath);
+    file.renameSync(newPath);
+
+    // Note: use forward slashes for mapping since the manifest uses them.
+    final String posixOldPath = relativePath.replaceAll(fileSystem.path.separator, '/');
+    final String posixNewPath = newRelativePath.replaceAll(fileSystem.path.separator, '/');
+    renamedAssets[posixOldPath] = posixNewPath;
+  }
+
+  // Now update the manifests if they exist
+  final File assetManifestBin = assetsDir.childFile('AssetManifest.bin');
+  if (assetManifestBin.existsSync()) {
+    final ByteData message = assetManifestBin.readAsBytesSync().buffer.asByteData();
+    final Object? decoded = const StandardMessageCodec().decodeMessage(message);
+    if (decoded is Map<Object?, Object?>) {
+      final Map<String, dynamic> newManifest = <String, dynamic>{};
+      for (final MapEntry<Object?, Object?> entry in decoded.entries) {
+        final String key = entry.key as String;
+        final List<Object?> variants = entry.value as List<Object?>;
+        final List<dynamic> newVariants = <dynamic>[];
+        for (final Object? variantObj in variants) {
+          final Map<Object?, Object?> variantMap = variantObj as Map<Object?, Object?>;
+          final Map<String, dynamic> newVariantMap = <String, dynamic>{};
+          for (final MapEntry<Object?, Object?> vEntry in variantMap.entries) {
+            final String vKey = vEntry.key as String;
+            if (vKey == 'asset') {
+              final String vValue = vEntry.value as String;
+              newVariantMap[vKey] = renamedAssets[vValue] ?? vValue;
+            } else {
+              newVariantMap[vKey] = vEntry.value;
+            }
+          }
+          newVariants.add(newVariantMap);
+        }
+        newManifest[key] = newVariants;
+      }
+      final ByteData encoded = const StandardMessageCodec().encodeMessage(newManifest)!;
+      final Uint8List encodedBytes = encoded.buffer.asUint8List(0, encoded.lengthInBytes);
+      assetManifestBin.writeAsBytesSync(encodedBytes);
+
+      // Update AssetManifest.bin.json
+      final File assetManifestBinJson = assetsDir.childFile('AssetManifest.bin.json');
+      if (assetManifestBinJson.existsSync()) {
+        assetManifestBinJson.writeAsStringSync(json.encode(base64.encode(encodedBytes)));
+      }
+    }
+  }
+
+  final File fontManifest = assetsDir.childFile('FontManifest.json');
+  if (fontManifest.existsSync()) {
+    // List of map with 'fonts' -> List of map 'asset' string
+    final List<dynamic> decoded = json.decode(fontManifest.readAsStringSync()) as List<dynamic>;
+    for (final dynamic font in decoded) {
+      final Map<String, dynamic> fontMap = font as Map<String, dynamic>;
+      if (fontMap.containsKey('fonts')) {
+        final List<dynamic> fonts = fontMap['fonts'] as List<dynamic>;
+        for (final dynamic fontAsset in fonts) {
+          final Map<String, dynamic> fontAssetMap = fontAsset as Map<String, dynamic>;
+          if (fontAssetMap.containsKey('asset')) {
+            final String asset = fontAssetMap['asset'] as String;
+            fontAssetMap['asset'] = renamedAssets[asset] ?? asset;
+          }
+        }
+      }
+    }
+    fontManifest.writeAsStringSync(json.encode(decoded));
+  }
 }

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
+import 'package:path/path.dart' as p; // flutter_ignore: package_path_import
 import 'package:standard_message_codec/standard_message_codec.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
@@ -45,7 +46,7 @@ const String _kBundledFallbackRobotoFamily = 'Roboto';
 const String _kBundledFallbackRobotoAsset = 'fonts/fallback/Roboto-Regular.ttf';
 const String _kFontManifestJsonFile = 'FontManifest.json';
 
-const Set<String> _kUnhashedAssetBasenames = <String>{
+const Set<String> _kUnhashedAssetRelativePaths = <String>{
   'AssetManifest.json',
   'AssetManifest.bin',
   'AssetManifest.bin.json',
@@ -1598,37 +1599,46 @@ Map<String, File> _hashWebAssets(Directory assetsDir) {
   final renamedAssets = <String, String>{};
 
   for (final file in files) {
-    final String basename = file.basename;
-    if (_kUnhashedAssetBasenames.contains(basename)) {
+    final String relativePath = fileSystem.path.relative(file.path, from: assetsDir.path);
+    final List<String> segments = fileSystem.path.split(relativePath);
+    final String posixRelativePath = p.posix.joinAll(segments);
+
+    if (_kUnhashedAssetRelativePaths.contains(posixRelativePath) ||
+        fileSystem.path.extension(file.path) == '.frag' ||
+        segments.firstOrNull == 'shaders') {
       continue;
     }
 
+    final String basename = fileSystem.path.basename(file.path);
     final String contentHash = crypto.sha256
         .convert(file.readAsBytesSync())
         .toString()
         .substring(0, 8);
     final String newBasename = _computeHashedBasename(basename, contentHash, fileSystem);
 
-    final String relativePath = fileSystem.path.relative(file.path, from: assetsDir.path);
-    final String newRelativePath = fileSystem.path.join(
-      fileSystem.path.dirname(relativePath),
-      newBasename,
-    );
+    final newSegments = <String>[...segments.sublist(0, segments.length - 1), newBasename];
+    final String newRelativePath = fileSystem.path.joinAll(newSegments);
+    final String posixNewPath = p.posix.joinAll(newSegments);
 
-    // Rename the file
+    // Rename the physical file on disk.
     final String newPath = fileSystem.path.join(assetsDir.path, newRelativePath);
     final String oldPath = file.path;
     file.renameSync(newPath);
     renamedFileMap[oldPath] = fileSystem.file(newPath);
 
-    // Note: use forward slashes for mapping since the manifest uses them.
-    final String posixOldPath = relativePath.replaceAll(fileSystem.path.separator, '/');
-    final String posixNewPath = newRelativePath.replaceAll(fileSystem.path.separator, '/');
-    renamedAssets[posixOldPath] = posixNewPath;
-    renamedAssets[Uri.decodeFull(posixOldPath)] = posixNewPath;
+    // Map POSIX paths (for manifests). Handle raw, decoded, and encoded paths.
+    renamedAssets[posixRelativePath] = posixNewPath;
+    try {
+      final String decoded = Uri.decodeFull(posixRelativePath);
+      renamedAssets[decoded] = posixNewPath;
+    } on FormatException {
+      // Retain raw path if malformed percent escape sequence.
+    }
+    final String encoded = Uri.encodeFull(posixRelativePath);
+    renamedAssets[encoded] = posixNewPath;
   }
 
-  // Now update the manifests if they exist
+  // Now update the manifests if they exist.
   final File assetManifestBin = assetsDir.childFile('AssetManifest.bin');
   if (assetManifestBin.existsSync()) {
     final Uint8List rawBytes = assetManifestBin.readAsBytesSync();
@@ -1640,11 +1650,13 @@ Map<String, File> _hashWebAssets(Directory assetsDir) {
         final key = entry.key.toString();
         final Object? variantsVal = entry.value;
         if (variantsVal is! List<Object?>) {
+          newManifest[key] = variantsVal;
           continue;
         }
         final newVariants = <dynamic>[];
         for (final Object? variantObj in variantsVal) {
           if (variantObj is! Map<Object?, Object?>) {
+            newVariants.add(variantObj);
             continue;
           }
           final newVariantMap = <String, dynamic>{};
@@ -1673,7 +1685,7 @@ Map<String, File> _hashWebAssets(Directory assetsDir) {
     }
   }
 
-  // Update legacy AssetManifest.json if present
+  // Update legacy AssetManifest.json if present.
   final File assetManifestJson = assetsDir.childFile('AssetManifest.json');
   if (assetManifestJson.existsSync()) {
     final Object? decodedJson = json.decode(assetManifestJson.readAsStringSync());
@@ -1681,15 +1693,19 @@ Map<String, File> _hashWebAssets(Directory assetsDir) {
       final newManifest = <String, dynamic>{};
       for (final MapEntry<String, dynamic> entry in decodedJson.entries) {
         final Object? variants = entry.value;
-        if (variants is List<dynamic>) {
-          final newVariants = <String>[];
-          for (final Object? variant in variants) {
-            if (variant is String) {
-              newVariants.add(renamedAssets[variant] ?? variant);
-            }
-          }
-          newManifest[entry.key] = newVariants;
+        if (variants is! List<dynamic>) {
+          newManifest[entry.key] = variants;
+          continue;
         }
+        final newVariants = <String>[];
+        for (final Object? variant in variants) {
+          if (variant is String) {
+            newVariants.add(renamedAssets[variant] ?? variant);
+          } else if (variant != null) {
+            newVariants.add(variant.toString());
+          }
+        }
+        newManifest[entry.key] = newVariants;
       }
       assetManifestJson.writeAsStringSync(json.encode(newManifest));
     }

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -2,16 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:typed_data';
 import 'dart:convert';
-import 'dart:typed_data';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
-import 'package:unified_analytics/unified_analytics.dart';
 import 'package:standard_message_codec/standard_message_codec.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../artifacts.dart';
 import '../../base/common.dart';
@@ -45,6 +44,15 @@ import 'native_assets.dart';
 const String _kBundledFallbackRobotoFamily = 'Roboto';
 const String _kBundledFallbackRobotoAsset = 'fonts/fallback/Roboto-Regular.ttf';
 const String _kFontManifestJsonFile = 'FontManifest.json';
+
+const Set<String> _kUnhashedAssetBasenames = <String>{
+  'AssetManifest.json',
+  'AssetManifest.bin',
+  'AssetManifest.bin.json',
+  'FontManifest.json',
+  'NOTICES',
+  'NOTICES.Z',
+};
 
 /// Generates an entry point for a web target.
 // Keep this in sync with build_runner/resident_web_runner.dart
@@ -1109,6 +1117,9 @@ class WebReleaseBundle extends Target {
 
     createVersionFile(environment, environment.defines);
     final Directory outputDirectory = environment.outputDir.childDirectory('assets');
+    if (outputDirectory.existsSync()) {
+      outputDirectory.deleteSync(recursive: true);
+    }
     outputDirectory.createSync(recursive: true);
 
     final DartHooksResult dartHookResult = await LinkHooks.loadHookResult(environment);
@@ -1121,13 +1132,24 @@ class WebReleaseBundle extends Target {
     );
     final Depfile bundledDepfile = _bundleLocalRobotoFallback(environment, depfile);
     final DepfileService depfileService = environment.depFileService;
-    depfileService.writeToFile(bundledDepfile, environment.buildDir.childFile('flutter_assets.d'));
 
     final bool webContentHash = compileTargets.any(
       (Dart2WebTarget t) => t.compilerConfig.webContentHash,
     );
     if (webContentHash) {
-      _hashWebAssets(outputDirectory);
+      final Map<String, File> renamedOutputs = _hashWebAssets(outputDirectory);
+      final List<File> updatedOutputs = bundledDepfile.outputs.map((File f) {
+        return renamedOutputs[f.path] ?? f;
+      }).toList();
+      depfileService.writeToFile(
+        Depfile(bundledDepfile.inputs, updatedOutputs),
+        environment.buildDir.childFile('flutter_assets.d'),
+      );
+    } else {
+      depfileService.writeToFile(
+        bundledDepfile,
+        environment.buildDir.childFile('flutter_assets.d'),
+      );
     }
 
     final Directory webResources = environment.projectDir.childDirectory('web');
@@ -1565,9 +1587,10 @@ extension on Environment {
       ServiceWorkerStrategy.offlineFirst;
 }
 
-void _hashWebAssets(Directory assetsDir) {
+Map<String, File> _hashWebAssets(Directory assetsDir) {
+  final Map<String, File> renamedFileMap = <String, File>{};
   if (!assetsDir.existsSync()) {
-    return;
+    return renamedFileMap;
   }
 
   final FileSystem fileSystem = assetsDir.fileSystem;
@@ -1576,10 +1599,7 @@ void _hashWebAssets(Directory assetsDir) {
 
   for (final File file in files) {
     final String basename = file.basename;
-    if (basename == 'AssetManifest.json' ||
-        basename == 'AssetManifest.bin' ||
-        basename == 'AssetManifest.bin.json' ||
-        basename == 'FontManifest.json') {
+    if (_kUnhashedAssetBasenames.contains(basename)) {
       continue;
     }
 
@@ -1597,32 +1617,41 @@ void _hashWebAssets(Directory assetsDir) {
 
     // Rename the file
     final String newPath = fileSystem.path.join(assetsDir.path, newRelativePath);
+    final String oldPath = file.path;
     file.renameSync(newPath);
+    renamedFileMap[oldPath] = fileSystem.file(newPath);
 
     // Note: use forward slashes for mapping since the manifest uses them.
     final String posixOldPath = relativePath.replaceAll(fileSystem.path.separator, '/');
     final String posixNewPath = newRelativePath.replaceAll(fileSystem.path.separator, '/');
     renamedAssets[posixOldPath] = posixNewPath;
+    renamedAssets[Uri.decodeFull(posixOldPath)] = posixNewPath;
   }
 
   // Now update the manifests if they exist
   final File assetManifestBin = assetsDir.childFile('AssetManifest.bin');
   if (assetManifestBin.existsSync()) {
-    final ByteData message = assetManifestBin.readAsBytesSync().buffer.asByteData();
+    final Uint8List rawBytes = assetManifestBin.readAsBytesSync();
+    final ByteData message = ByteData.sublistView(rawBytes);
     final Object? decoded = const StandardMessageCodec().decodeMessage(message);
     if (decoded is Map<Object?, Object?>) {
       final Map<String, dynamic> newManifest = <String, dynamic>{};
       for (final MapEntry<Object?, Object?> entry in decoded.entries) {
-        final String key = entry.key as String;
-        final List<Object?> variants = entry.value as List<Object?>;
+        final String key = entry.key.toString();
+        final Object? variantsVal = entry.value;
+        if (variantsVal is! List<Object?>) {
+          continue;
+        }
         final List<dynamic> newVariants = <dynamic>[];
-        for (final Object? variantObj in variants) {
-          final Map<Object?, Object?> variantMap = variantObj as Map<Object?, Object?>;
+        for (final Object? variantObj in variantsVal) {
+          if (variantObj is! Map<Object?, Object?>) {
+            continue;
+          }
           final Map<String, dynamic> newVariantMap = <String, dynamic>{};
-          for (final MapEntry<Object?, Object?> vEntry in variantMap.entries) {
-            final String vKey = vEntry.key as String;
+          for (final MapEntry<Object?, Object?> vEntry in variantObj.entries) {
+            final String vKey = vEntry.key.toString();
             if (vKey == 'asset') {
-              final String vValue = vEntry.value as String;
+              final String vValue = vEntry.value.toString();
               newVariantMap[vKey] = renamedAssets[vValue] ?? vValue;
             } else {
               newVariantMap[vKey] = vEntry.value;
@@ -1633,7 +1662,7 @@ void _hashWebAssets(Directory assetsDir) {
         newManifest[key] = newVariants;
       }
       final ByteData encoded = const StandardMessageCodec().encodeMessage(newManifest)!;
-      final Uint8List encodedBytes = encoded.buffer.asUint8List(0, encoded.lengthInBytes);
+      final Uint8List encodedBytes = Uint8List.sublistView(encoded);
       assetManifestBin.writeAsBytesSync(encodedBytes);
 
       // Update AssetManifest.bin.json
@@ -1646,21 +1675,26 @@ void _hashWebAssets(Directory assetsDir) {
 
   final File fontManifest = assetsDir.childFile('FontManifest.json');
   if (fontManifest.existsSync()) {
-    // List of map with 'fonts' -> List of map 'asset' string
-    final List<dynamic> decoded = json.decode(fontManifest.readAsStringSync()) as List<dynamic>;
-    for (final dynamic font in decoded) {
-      final Map<String, dynamic> fontMap = font as Map<String, dynamic>;
-      if (fontMap.containsKey('fonts')) {
-        final List<dynamic> fonts = fontMap['fonts'] as List<dynamic>;
-        for (final dynamic fontAsset in fonts) {
-          final Map<String, dynamic> fontAssetMap = fontAsset as Map<String, dynamic>;
-          if (fontAssetMap.containsKey('asset')) {
-            final String asset = fontAssetMap['asset'] as String;
-            fontAssetMap['asset'] = renamedAssets[asset] ?? asset;
+    final Object? decodedJson = json.decode(fontManifest.readAsStringSync());
+    if (decodedJson is List<dynamic>) {
+      for (final Object? font in decodedJson) {
+        if (font is Map<String, dynamic>) {
+          final Object? fonts = font['fonts'];
+          if (fonts is List<dynamic>) {
+            for (final Object? fontAsset in fonts) {
+              if (fontAsset is Map<String, dynamic>) {
+                final Object? asset = fontAsset['asset'];
+                if (asset is String && renamedAssets.containsKey(asset)) {
+                  fontAsset['asset'] = renamedAssets[asset];
+                }
+              }
+            }
           }
         }
       }
+      fontManifest.writeAsStringSync(json.encode(decodedJson));
     }
-    fontManifest.writeAsStringSync(json.encode(decoded));
   }
+
+  return renamedFileMap;
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -2329,6 +2329,40 @@ console.log(mapName);
   );
 
   test(
+    'WebReleaseBundle hashes physical assets and updates AssetManifest when webContentHash is true',
+    () => testbed.run(() async {
+      environment.defines[kBuildMode] = 'release';
+      environment.projectDir.childDirectory('web').createSync(recursive: true);
+      environment.buildDir.childFile('main.dart.js').createSync(recursive: true);
+
+      // Create a pubspec.yaml with assets
+      environment.projectDir.childFile('pubspec.yaml').writeAsStringSync('''
+name: my_app
+flutter:
+  assets:
+    - images/logo.png
+''');
+
+      final File logo = environment.projectDir.childDirectory('images').childFile('logo.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(<int>[1, 2, 3, 4]);
+
+      final String logoHash = '9f64a747'; // sha256 of [1,2,3,4]
+
+      await WebReleaseBundle(<WebCompilerConfig>[
+        const JsCompilerConfig(webContentHash: true),
+      ], const NoOpAnalytics()).build(environment);
+
+      final Directory assetsDir = environment.outputDir.childDirectory('assets');
+
+      expect(assetsDir.childDirectory('images').childFile('logo.$logoHash.png').existsSync(), true);
+      expect(assetsDir.childDirectory('images').childFile('logo.png').existsSync(), false);
+
+      final File manifestFile = assetsDir.childFile('AssetManifest.bin');
+      expect(manifestFile.existsSync(), true);
+    }),
+  );
+  test(
     'WebTemplatedFiles populates wasmHashes from compileTargets on clean builds before outputDir is copied',
     () => testbed.run(() async {
       environment.projectDir.childDirectory('web').createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:file_testing/file_testing.dart';
@@ -21,6 +22,7 @@ import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/web/compile.dart';
 import 'package:flutter_tools/src/web/file_generators/flutter_service_worker_js.dart';
 import 'package:flutter_tools/src/web_template.dart';
+import 'package:standard_message_codec/standard_message_codec.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../../src/common.dart';
@@ -2329,29 +2331,57 @@ console.log(mapName);
   );
 
   test(
-    'WebReleaseBundle hashes physical assets, leaves NOTICES unhashed, and updates AssetManifest when webContentHash is true',
+    'WebReleaseBundle hashes physical assets, leaves unhashed assets and shaders unhashed, and updates manifests when webContentHash is true',
     () => testbed.run(() async {
       environment.defines[kBuildMode] = 'release';
       environment.projectDir.childDirectory('web').createSync(recursive: true);
       environment.buildDir.childFile('main.dart.js').createSync(recursive: true);
 
-      // Create a pubspec.yaml with assets and notices
+      // Create a pubspec.yaml with assets, variants, shaders, fonts, and notices.
       environment.projectDir.childFile('pubspec.yaml').writeAsStringSync('''
 name: my_app
 flutter:
   assets:
     - images/logo.png
+    - images/2.0x/logo.png
     - NOTICES
+    - nested/NOTICES
+    - shaders/ink_sparkle.frag
+    - fonts/my_font.ttf
+    - images/100%_deal.png
+  fonts:
+    - family: MyFont
+      fonts:
+        - asset: fonts/my_font.ttf
 ''');
 
       final File logo = environment.projectDir.childDirectory('images').childFile('logo.png')
         ..createSync(recursive: true)
         ..writeAsBytesSync(<int>[1, 2, 3, 4]);
+      environment.projectDir.childDirectory('images').childDirectory('2.0x').childFile('logo.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(<int>[1, 2, 3, 4, 5]);
       environment.projectDir.childFile('NOTICES')
         ..createSync(recursive: true)
-        ..writeAsStringSync('License notices');
+        ..writeAsStringSync('Root license notices');
+      environment.projectDir.childDirectory('nested').childFile('NOTICES')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('Nested notices');
+      environment.projectDir.childDirectory('shaders').childFile('ink_sparkle.frag')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('void main() {}');
+      environment.projectDir.childDirectory('fonts').childFile('my_font.ttf')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(<int>[10, 20, 30]);
+      environment.projectDir.childDirectory('images').childFile('100%_deal.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(<int>[99, 100]);
 
       const logoHash = '9f64a747'; // sha256 of [1,2,3,4]
+      const logo2xHash = '74f81fe1'; // sha256 of [1,2,3,4,5]
+      const fontHash = '6951bbd9'; // sha256 of [10,20,30]
+      const dealHash = '21e721c3'; // sha256 of [99,100]
+      const nestedNoticesHash = '642c7c36'; // sha256 of 'Nested notices'
 
       await WebReleaseBundle(<WebCompilerConfig>[
         const JsCompilerConfig(webContentHash: true),
@@ -2359,16 +2389,69 @@ flutter:
 
       final Directory assetsDir = environment.outputDir.childDirectory('assets');
 
+      // Hashed assets
       expect(assetsDir.childDirectory('images').childFile('logo.$logoHash.png').existsSync(), true);
       expect(assetsDir.childDirectory('images').childFile('logo.png').existsSync(), false);
-      expect(assetsDir.childFile('NOTICES').existsSync(), true);
-      expect(assetsDir.childFile('AssetManifest.bin').existsSync(), true);
-      expect(assetsDir.childFile('AssetManifest.bin.json').existsSync(), true);
+      expect(
+        assetsDir
+            .childDirectory('images')
+            .childDirectory('2.0x')
+            .childFile('logo.$logo2xHash.png')
+            .existsSync(),
+        true,
+      );
+      expect(
+        assetsDir.childDirectory('fonts').childFile('my_font.$fontHash.ttf').existsSync(),
+        true,
+      );
+      expect(
+        assetsDir.childDirectory('images').childFile('100%25_deal.$dealHash.png').existsSync(),
+        true,
+      );
+      expect(
+        assetsDir.childDirectory('nested').childFile('NOTICES.$nestedNoticesHash').existsSync(),
+        true,
+      );
 
-      // Verify flutter_assets.d references the hashed logo path
+      // Unhashed assets: root NOTICES and shaders
+      expect(assetsDir.childFile('NOTICES').existsSync(), true);
+      expect(assetsDir.childDirectory('shaders').childFile('ink_sparkle.frag').existsSync(), true);
+
+      // Manifest files exist unhashed
+      final File assetManifestBin = assetsDir.childFile('AssetManifest.bin');
+      final File assetManifestBinJson = assetsDir.childFile('AssetManifest.bin.json');
+      final File fontManifest = assetsDir.childFile('FontManifest.json');
+      expect(assetManifestBin.existsSync(), true);
+      expect(assetManifestBinJson.existsSync(), true);
+      expect(fontManifest.existsSync(), true);
+
+      // Decode AssetManifest.bin and verify variant mappings
+      final Uint8List rawBytes = assetManifestBin.readAsBytesSync();
+      final decodedManifest =
+          const StandardMessageCodec().decodeMessage(ByteData.sublistView(rawBytes))!
+              as Map<Object?, Object?>;
+      final List<Map<Object?, Object?>> logoVariants =
+          (decodedManifest['images/logo.png']! as List<Object?>).cast<Map<Object?, Object?>>();
+      expect(logoVariants, hasLength(2));
+      expect(logoVariants[0]['asset'], 'images/logo.$logoHash.png');
+      expect(logoVariants[1]['asset'], 'images/2.0x/logo.$logo2xHash.png');
+      expect(logoVariants[1]['dpr'], 2.0);
+
+      // Verify FontManifest.json rewriting
+      final decodedFonts = json.decode(fontManifest.readAsStringSync()) as List<dynamic>;
+      expect(decodedFonts, hasLength(1));
+      final fontMap = decodedFonts.first as Map<String, dynamic>;
+      expect(fontMap['family'], 'MyFont');
+      final List<Map<String, dynamic>> fontEntries = (fontMap['fonts'] as List<dynamic>)
+          .cast<Map<String, dynamic>>();
+      expect(fontEntries[0]['asset'], 'fonts/my_font.$fontHash.ttf');
+
+      // Verify flutter_assets.d references the hashed paths
       final File depfile = environment.buildDir.childFile('flutter_assets.d');
       expect(depfile.existsSync(), true);
       expect(depfile.readAsStringSync(), contains('logo.$logoHash.png'));
+      expect(depfile.readAsStringSync(), contains('logo.$logo2xHash.png'));
+      expect(depfile.readAsStringSync(), contains('my_font.$fontHash.ttf'));
 
       // Test stale asset cleanup on rebuild: modify logo content
       logo.writeAsBytesSync(<int>[5, 6, 7, 8]);
@@ -2386,6 +2469,34 @@ flutter:
         assetsDir.childDirectory('images').childFile('logo.$logoHash.png').existsSync(),
         false,
       );
+    }),
+  );
+
+  test(
+    'WebReleaseBundle leaves assets and manifests unhashed when webContentHash is false',
+    () => testbed.run(() async {
+      environment.defines[kBuildMode] = 'release';
+      environment.projectDir.childDirectory('web').createSync(recursive: true);
+      environment.buildDir.childFile('main.dart.js').createSync(recursive: true);
+
+      environment.projectDir.childFile('pubspec.yaml').writeAsStringSync('''
+name: my_app
+flutter:
+  assets:
+    - images/logo.png
+''');
+
+      environment.projectDir.childDirectory('images').childFile('logo.png')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(<int>[1, 2, 3, 4]);
+
+      await WebReleaseBundle(<WebCompilerConfig>[
+        const JsCompilerConfig(),
+      ], const NoOpAnalytics()).build(environment);
+
+      final Directory assetsDir = environment.outputDir.childDirectory('assets');
+      expect(assetsDir.childDirectory('images').childFile('logo.png').existsSync(), true);
+      expect(assetsDir.childDirectory('images').childFile('logo.9f64a747.png').existsSync(), false);
     }),
   );
   test(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -2351,7 +2351,7 @@ flutter:
         ..createSync(recursive: true)
         ..writeAsStringSync('License notices');
 
-      const String logoHash = '9f64a747'; // sha256 of [1,2,3,4]
+      const logoHash = '9f64a747'; // sha256 of [1,2,3,4]
 
       await WebReleaseBundle(<WebCompilerConfig>[
         const JsCompilerConfig(webContentHash: true),
@@ -2372,7 +2372,7 @@ flutter:
 
       // Test stale asset cleanup on rebuild: modify logo content
       logo.writeAsBytesSync(<int>[5, 6, 7, 8]);
-      const String newLogoHash = '55e5509f'; // sha256 of [5,6,7,8]
+      const newLogoHash = '55e5509f'; // sha256 of [5,6,7,8]
 
       await WebReleaseBundle(<WebCompilerConfig>[
         const JsCompilerConfig(webContentHash: true),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -2329,25 +2329,29 @@ console.log(mapName);
   );
 
   test(
-    'WebReleaseBundle hashes physical assets and updates AssetManifest when webContentHash is true',
+    'WebReleaseBundle hashes physical assets, leaves NOTICES unhashed, and updates AssetManifest when webContentHash is true',
     () => testbed.run(() async {
       environment.defines[kBuildMode] = 'release';
       environment.projectDir.childDirectory('web').createSync(recursive: true);
       environment.buildDir.childFile('main.dart.js').createSync(recursive: true);
 
-      // Create a pubspec.yaml with assets
+      // Create a pubspec.yaml with assets and notices
       environment.projectDir.childFile('pubspec.yaml').writeAsStringSync('''
 name: my_app
 flutter:
   assets:
     - images/logo.png
+    - NOTICES
 ''');
 
       final File logo = environment.projectDir.childDirectory('images').childFile('logo.png')
         ..createSync(recursive: true)
         ..writeAsBytesSync(<int>[1, 2, 3, 4]);
+      environment.projectDir.childFile('NOTICES')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('License notices');
 
-      final String logoHash = '9f64a747'; // sha256 of [1,2,3,4]
+      const String logoHash = '9f64a747'; // sha256 of [1,2,3,4]
 
       await WebReleaseBundle(<WebCompilerConfig>[
         const JsCompilerConfig(webContentHash: true),
@@ -2357,9 +2361,31 @@ flutter:
 
       expect(assetsDir.childDirectory('images').childFile('logo.$logoHash.png').existsSync(), true);
       expect(assetsDir.childDirectory('images').childFile('logo.png').existsSync(), false);
+      expect(assetsDir.childFile('NOTICES').existsSync(), true);
+      expect(assetsDir.childFile('AssetManifest.bin').existsSync(), true);
+      expect(assetsDir.childFile('AssetManifest.bin.json').existsSync(), true);
 
-      final File manifestFile = assetsDir.childFile('AssetManifest.bin');
-      expect(manifestFile.existsSync(), true);
+      // Verify flutter_assets.d references the hashed logo path
+      final File depfile = environment.buildDir.childFile('flutter_assets.d');
+      expect(depfile.existsSync(), true);
+      expect(depfile.readAsStringSync(), contains('logo.$logoHash.png'));
+
+      // Test stale asset cleanup on rebuild: modify logo content
+      logo.writeAsBytesSync(<int>[5, 6, 7, 8]);
+      const String newLogoHash = '55e5509f'; // sha256 of [5,6,7,8]
+
+      await WebReleaseBundle(<WebCompilerConfig>[
+        const JsCompilerConfig(webContentHash: true),
+      ], const NoOpAnalytics()).build(environment);
+
+      expect(
+        assetsDir.childDirectory('images').childFile('logo.$newLogoHash.png').existsSync(),
+        true,
+      );
+      expect(
+        assetsDir.childDirectory('images').childFile('logo.$logoHash.png').existsSync(),
+        false,
+      );
     }),
   );
   test(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -2347,6 +2347,7 @@ flutter:
     - NOTICES
     - nested/NOTICES
     - shaders/ink_sparkle.frag
+    - custom/blur.FRAG
     - fonts/my_font.ttf
     - images/100%_deal.png
   fonts:
@@ -2368,6 +2369,9 @@ flutter:
         ..createSync(recursive: true)
         ..writeAsStringSync('Nested notices');
       environment.projectDir.childDirectory('shaders').childFile('ink_sparkle.frag')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('void main() {}');
+      environment.projectDir.childDirectory('custom').childFile('blur.FRAG')
         ..createSync(recursive: true)
         ..writeAsStringSync('void main() {}');
       environment.projectDir.childDirectory('fonts').childFile('my_font.ttf')
@@ -2416,6 +2420,7 @@ flutter:
       // Unhashed assets: root NOTICES and shaders
       expect(assetsDir.childFile('NOTICES').existsSync(), true);
       expect(assetsDir.childDirectory('shaders').childFile('ink_sparkle.frag').existsSync(), true);
+      expect(assetsDir.childDirectory('custom').childFile('blur.FRAG').existsSync(), true);
 
       // Manifest files exist unhashed
       final File assetManifestBin = assetsDir.childFile('AssetManifest.bin');


### PR DESCRIPTION
Supports content-hashing physical static assets under `assets/` and rewrites target path mappings in `AssetManifest.bin`, `AssetManifest.bin.json`, `AssetManifest.json`, and `FontManifest.json` when building Flutter Web with `--web-content-hash`.

### What this PR accomplishes
* Computes SHA-256 (first 8 hex characters) for project static assets under `build/web/assets/`.
* Renames physical assets on disk prior to file extension (`image.<hash>.png`).
* Rewrites `AssetManifest.bin`, `AssetManifest.bin.json`, and `AssetManifest.json` variant maps to point to hashed filenames so `AssetImage` transparently resolves content-hashed assets at runtime.
* Rewrites font asset target paths in `FontManifest.json`.
* Excludes special files (`AssetManifest.*`, `FontManifest.json`, `NOTICES`, `NOTICES.Z`) and all shaders (`*.frag` and `shaders/`) from content-hashing to prevent runtime discovery and CanvasKit `FragmentProgram` 404s.
* Cleans `build/web/assets/` on incremental rebuilds to prevent stale asset accumulation, and updates `flutter_assets.d` for hermetic build tracking.
* Follows `dart-use-path-package` conventions (`fileSystem.path` context decomposition and `p.posix.joinAll` manifest bridging).

> [!NOTE]
> Direct runtime resolution for arbitrary `rootBundle.load(...)` and `rootBundle.loadString(...)` calls (which pass raw keys to the engine channel without consulting `AssetManifest`) will be completed in a companion framework task.

Part of #191915
Part of #149031
