### PR TITLE
Fix self-comparison and assert typos in TestSemantics

### DIFF
--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -1183,6 +1183,11 @@ class _IncludesNodeWith extends Matcher {
              inputType != null ||
              minValue != null ||
              maxValue != null,
+         'At least one matcher field must be non-null so the matcher checks for at least one '
+         'property of a semantics node. Pass any of `label`, `value`, `actions`, `flags`, '
+         '`flagsCollection`, `tags`, `increasedValue`, `decreasedValue`, `scrollPosition`, '
+         '`scrollExtentMax`, `scrollExtentMin`, `maxValueLength`, `currentValueLength`, '
+         '`inputType`, `minValue`, or `maxValue`.',
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -715,7 +715,7 @@ class SemanticsTester {
       if (first[i] is LocaleStringAttribute &&
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
-              (second[i] as LocaleStringAttribute).locale !=
+              (first[i] as LocaleStringAttribute).locale !=
                   (second[i] as LocaleStringAttribute).locale)) {
         return false;
       }
@@ -1180,8 +1180,9 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null ||
+             maxValue != null,
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -1168,7 +1168,11 @@ class _IncludesNodeWith extends Matcher {
     this.maxValue,
   }) : assert(
          label != null ||
+             attributedLabel != null ||
              value != null ||
+             attributedValue != null ||
+             hint != null ||
+             attributedHint != null ||
              actions != null ||
              flags != null ||
              flagsCollection != null ||
@@ -1184,7 +1188,8 @@ class _IncludesNodeWith extends Matcher {
              minValue != null ||
              maxValue != null,
          'At least one matcher field must be non-null so the matcher checks for at least one '
-         'property of a semantics node. Pass any of `label`, `value`, `actions`, `flags`, '
+         'property of a semantics node. Pass any of `label`, `attributedLabel`, `value`, '
+         '`attributedValue`, `hint`, `attributedHint`, `actions`, `flags`, '
          '`flagsCollection`, `tags`, `increasedValue`, `decreasedValue`, `scrollPosition`, '
          '`scrollExtentMax`, `scrollExtentMin`, `maxValueLength`, `currentValueLength`, '
          '`inputType`, `minValue`, or `maxValue`.',

--- a/packages/flutter/test/widgets/semantics_tester_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_test.dart
@@ -5,6 +5,7 @@
 import 'dart:ui';
 
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -147,6 +148,101 @@ void main() {
         ),
       ),
     );
+    semantics.dispose();
+  });
+
+  testWidgets('Semantics tester compares controlsNodes', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(container: true, controlsNodes: const <String>{'actual'}, child: Container()),
+    );
+
+    final expectedSemantics = TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          id: 1,
+          rect: TestSemantics.fullScreen,
+          controlsNodes: const <String>{'expected'},
+        ),
+      ],
+    );
+
+    expect(semantics, isNot(hasSemantics(expectedSemantics)));
+    semantics.dispose();
+  });
+
+  testWidgets('Semantics tester compares attributed string locales', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        attributedLabel: AttributedString(
+          'label',
+          attributes: <StringAttribute>[
+            LocaleStringAttribute(
+              locale: const Locale('en'),
+              range: const TextRange(start: 0, end: 5),
+            ),
+          ],
+        ),
+        textDirection: TextDirection.ltr,
+        child: Container(),
+      ),
+    );
+
+    expect(
+      semantics,
+      includesNodeWith(
+        label: 'label',
+        attributedLabel: AttributedString(
+          'label',
+          attributes: <StringAttribute>[
+            LocaleStringAttribute(
+              locale: const Locale('en'),
+              range: const TextRange(start: 0, end: 5),
+            ),
+          ],
+        ),
+      ),
+    );
+    expect(
+      semantics,
+      isNot(
+        includesNodeWith(
+          label: 'label',
+          attributedLabel: AttributedString(
+            'label',
+            attributes: <StringAttribute>[
+              LocaleStringAttribute(
+                locale: const Locale('es'),
+                range: const TextRange(start: 0, end: 5),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('includesNodeWith accepts minValue and maxValue', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        value: '5',
+        minValue: '0',
+        maxValue: '10',
+        textDirection: TextDirection.ltr,
+        child: Container(),
+      ),
+    );
+
+    expect(semantics, includesNodeWith(minValue: '0'));
+    expect(semantics, includesNodeWith(maxValue: '10'));
     semantics.dispose();
   });
 }

--- a/packages/flutter/test/widgets/semantics_tester_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_test.dart
@@ -245,4 +245,27 @@ void main() {
     expect(semantics, includesNodeWith(maxValue: '10'));
     semantics.dispose();
   });
+
+  testWidgets('includesNodeWith accepts attributed fields and hint alone', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        attributedLabel: AttributedString('label'),
+        attributedValue: AttributedString('value'),
+        attributedHint: AttributedString('hint'),
+        textDirection: TextDirection.ltr,
+        child: Container(),
+      ),
+    );
+
+    expect(semantics, includesNodeWith(attributedLabel: AttributedString('label')));
+    expect(semantics, includesNodeWith(attributedValue: AttributedString('value')));
+    expect(semantics, includesNodeWith(attributedHint: AttributedString('hint')));
+    expect(semantics, includesNodeWith(hint: 'hint'));
+    semantics.dispose();
+  });
 }


### PR DESCRIPTION
This replaces #185975, which the stale bot auto-closed on Jul 1. The requested tests had been pushed on May 21 (commit "Add semantics tester regression tests"), but the `waiting for response` label was never cleared, so the timer kept running. #185975 could not be reopened, hence this PR.

@chunhtai you'd reviewed #185975 and said it lgtm pending a test. That test is here — three regression tests, one per fix:

- `Semantics tester compares controlsNodes`
- `Semantics tester compares attributed string locales`
- `includesNodeWith accepts minValue and maxValue`

## The bugs

Rebased onto current master, where all three are still present:

- **`semantics_tester.dart:511`** — `controlsNodes != controlsNodes` compares the field to itself, so it is always `false` and the `setEquals` check is unreachable. The `controlsNodes` expectation is silently never enforced. Fixed to `controlsNodes != null`.
- **`semantics_tester.dart:715`** — the locale comparison reads `(second[i] as LocaleStringAttribute).locale != (second[i] as LocaleStringAttribute).locale`, comparing `second` against itself rather than against `first`. Always `false`, so mismatched locales compare equal. Fixed to read `first[i]` on the left.
- **`semantics_tester.dart:1184`** — the `minValue != null || maxValue != null` checks sit in `assert()`'s *message* slot rather than its condition, so they never gate anything and `includesNodeWith(minValue: ...)` alone trips the assert. Folded into the condition, with a descriptive message added.

## Testing

`flutter test packages/flutter/test/widgets/semantics_tester_test.dart` — 7/7 passing locally against current master.

The competing PR #185921 was also closed without merging, so there is no longer any overlap. PTAL when you have a moment.
