### PR TITLE
Support wide gamut colors in gradient_generator's CreateGradientTexture

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/gradient_generator.cc
+++ b/engine/src/flutter/impeller/entity/contents/gradient_generator.cc
@@ -18,6 +18,10 @@ namespace {
 
 std::vector<uint8_t> ToR32G32B32A32FloatBytes(
     const std::vector<Color>& colors) {
+  static_assert(sizeof(Color) == sizeof(float) * 4,
+                "Color must be exactly 4 floats with no padding.");
+  static_assert(std::is_standard_layout_v<Color>,
+                "Color must be standard layout.");
   // `Color` is a standard-layout struct of 4 contiguous 32-bit floats (RGBA),
   // directly matching the `kR32G32B32A32Float` pixel format layout.
   const auto* bytes = reinterpret_cast<const uint8_t*>(colors.data());

--- a/engine/src/flutter/impeller/entity/contents/gradient_generator.cc
+++ b/engine/src/flutter/impeller/entity/contents/gradient_generator.cc
@@ -14,21 +14,57 @@
 
 namespace impeller {
 
+namespace {
+
+std::vector<uint8_t> ToR32G32B32A32FloatBytes(
+    const std::vector<Color>& colors) {
+  // `Color` is a standard-layout struct of 4 contiguous 32-bit floats (RGBA),
+  // directly matching the `kR32G32B32A32Float` pixel format layout.
+  const auto* bytes = reinterpret_cast<const uint8_t*>(colors.data());
+  return std::vector<uint8_t>(bytes, bytes + colors.size() * sizeof(Color));
+}
+
+std::vector<uint8_t> ToR8G8B8A8Bytes(const std::vector<Color>& colors) {
+  std::vector<uint8_t> bytes;
+  bytes.reserve(colors.size() * 4);
+  for (const auto& color : colors) {
+    auto converted = color.ToR8G8B8A8();
+    bytes.push_back(converted[0]);
+    bytes.push_back(converted[1]);
+    bytes.push_back(converted[2]);
+    bytes.push_back(converted[3]);
+  }
+  return bytes;
+}
+
+}  // namespace
+
 std::shared_ptr<Texture> CreateGradientTexture(
     const GradientData& gradient_data,
     const std::shared_ptr<impeller::Context>& context) {
-  if (gradient_data.texture_size == 0) {
+  if (gradient_data.colors.empty()) {
     FML_DLOG(ERROR) << "Invalid gradient data.";
     return nullptr;
   }
 
   impeller::TextureDescriptor texture_descriptor;
   texture_descriptor.storage_mode = impeller::StorageMode::kHostVisible;
-  texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
-  texture_descriptor.size = {gradient_data.texture_size, 1};
+  texture_descriptor.size = ISize(gradient_data.colors.size(), 1);
 
-  return CreateTexture(texture_descriptor, gradient_data.color_bytes, context,
-                       "Gradient");
+  bool is_wide_gamut =
+      std::any_of(gradient_data.colors.begin(), gradient_data.colors.end(),
+                  [](const Color& c) { return c.IsWideGamut(); });
+
+  std::vector<uint8_t> bytes;
+  if (is_wide_gamut) {
+    texture_descriptor.format = PixelFormat::kR32G32B32A32Float;
+    bytes = ToR32G32B32A32FloatBytes(gradient_data.colors);
+  } else {
+    texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
+    bytes = ToR8G8B8A8Bytes(gradient_data.colors);
+  }
+
+  return CreateTexture(texture_descriptor, bytes, context, "Gradient");
 }
 
 std::vector<StopData> CreateGradientColors(const std::vector<Color>& colors,

--- a/engine/src/flutter/impeller/geometry/color.h
+++ b/engine/src/flutter/impeller/geometry/color.h
@@ -220,6 +220,13 @@ struct Color {
     return {red / alpha, green / alpha, blue / alpha, alpha};
   }
 
+  /// @brief Returns true if any color channel lies outside the standard
+  ///        [0.0, 1.0] sRGB gamut.
+  constexpr bool IsWideGamut() const {
+    return red < 0.0f || red > 1.0f || green < 0.0f || green > 1.0f ||
+           blue < 0.0f || blue > 1.0f;
+  }
+
   /**
    * @brief Return a color that is linearly interpolated between colors a
    *        and b, according to the value of t.

--- a/engine/src/flutter/impeller/geometry/color.h
+++ b/engine/src/flutter/impeller/geometry/color.h
@@ -223,8 +223,9 @@ struct Color {
   /// @brief Returns true if any color channel lies outside the standard
   ///        [0.0, 1.0] sRGB gamut.
   constexpr bool IsWideGamut() const {
-    return red < 0.0f || red > 1.0f || green < 0.0f || green > 1.0f ||
-           blue < 0.0f || blue > 1.0f;
+    return red < -kEhCloseEnough || red > 1.0f + kEhCloseEnough ||
+           green < -kEhCloseEnough || green > 1.0f + kEhCloseEnough ||
+           blue < -kEhCloseEnough || blue > 1.0f + kEhCloseEnough;
   }
 
   /**

--- a/engine/src/flutter/impeller/geometry/geometry_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/geometry_unittests.cc
@@ -1842,8 +1842,8 @@ TEST(GeometryTest, Gradient) {
 
     auto gradient = CreateGradientBuffer(colors, stops);
 
-    ASSERT_COLORS_NEAR(gradient.colors, colors);
-    ASSERT_EQ(gradient.colors.size(), 2u);
+    EXPECT_COLORS_NEAR(gradient.colors, colors);
+    EXPECT_EQ(gradient.colors.size(), 2u);
   }
 
   {
@@ -1853,7 +1853,7 @@ TEST(GeometryTest, Gradient) {
     std::vector<Scalar> stops = {0.0, 0.25, 0.25, 1.0};
 
     auto gradient = CreateGradientBuffer(colors, stops);
-    ASSERT_EQ(gradient.colors.size(), 1024u);
+    EXPECT_EQ(gradient.colors.size(), 1024u);
 
     std::vector<Color> expected_colors(1024);
     for (size_t i = 0; i < 1024; i++) {
@@ -1868,7 +1868,7 @@ TEST(GeometryTest, Gradient) {
             Color::Lerp(Color::Black(), Color::Blue(), (t - 0.25) / 0.75);
       }
     }
-    ASSERT_COLORS_NEAR(gradient.colors, expected_colors);
+    EXPECT_COLORS_NEAR(gradient.colors, expected_colors);
   }
 
   {
@@ -1880,8 +1880,8 @@ TEST(GeometryTest, Gradient) {
 
     auto gradient = CreateGradientBuffer(colors, stops);
 
-    ASSERT_COLORS_NEAR(gradient.colors, colors);
-    ASSERT_EQ(gradient.colors.size(), 4u);
+    EXPECT_COLORS_NEAR(gradient.colors, colors);
+    EXPECT_EQ(gradient.colors.size(), 4u);
   }
 
   {
@@ -1898,8 +1898,8 @@ TEST(GeometryTest, Gradient) {
         Color::Lerp(Color::Blue(), Color::Green(), 0.6666),
         Color::Green(),
     };
-    ASSERT_COLORS_NEAR(gradient.colors, lerped_colors);
-    ASSERT_EQ(gradient.colors.size(), 5u);
+    EXPECT_COLORS_NEAR(gradient.colors, lerped_colors);
+    EXPECT_EQ(gradient.colors.size(), 5u);
   }
 
   {
@@ -1913,7 +1913,7 @@ TEST(GeometryTest, Gradient) {
 
     auto gradient = CreateGradientBuffer(colors, stops);
 
-    ASSERT_EQ(gradient.colors.size(), 1024u);
+    EXPECT_EQ(gradient.colors.size(), 1024u);
   }
 
   {
@@ -1926,8 +1926,8 @@ TEST(GeometryTest, Gradient) {
 
     auto gradient = CreateGradientBuffer(colors, stops);
 
-    ASSERT_EQ(gradient.colors.size(), 2u);
-    ASSERT_COLORS_NEAR(gradient.colors, colors);
+    EXPECT_EQ(gradient.colors.size(), 2u);
+    EXPECT_COLORS_NEAR(gradient.colors, colors);
   }
 
   {
@@ -1939,8 +1939,8 @@ TEST(GeometryTest, Gradient) {
 
     auto gradient = CreateGradientBuffer(colors, stops);
 
-    ASSERT_EQ(gradient.colors.size(), 3u);
-    ASSERT_COLORS_NEAR(gradient.colors, colors);
+    EXPECT_EQ(gradient.colors.size(), 3u);
+    EXPECT_COLORS_NEAR(gradient.colors, colors);
   }
 }
 

--- a/engine/src/flutter/impeller/geometry/geometry_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/geometry_unittests.cc
@@ -1820,6 +1820,19 @@ TEST(GeometryTest, ToIColor) {
   ASSERT_EQ(Color::ToIColor(Color(0.5, 0.5, 1.0, 1.0)), 0xFF8080FF);
 }
 
+TEST(GeometryTest, ColorIsWideGamut) {
+  EXPECT_FALSE(Color::Red().IsWideGamut());
+  EXPECT_FALSE(Color::White().IsWideGamut());
+  EXPECT_FALSE(Color::BlackTransparent().IsWideGamut());
+  EXPECT_FALSE(Color(0.5f, 0.5f, 0.5f, 1.0f).IsWideGamut());
+
+  // Wide gamut Display P3 values in extended linear sRGB
+  EXPECT_TRUE(Color(1.0931f, -0.2268f, -0.1501f, 1.0f).IsWideGamut());
+  EXPECT_TRUE(Color(-0.5116f, 1.0183f, -0.3107f, 1.0f).IsWideGamut());
+  EXPECT_TRUE(Color(1.5f, 0.5f, 0.5f, 1.0f).IsWideGamut());
+  EXPECT_TRUE(Color(-0.1f, 0.5f, 0.5f, 1.0f).IsWideGamut());
+}
+
 TEST(GeometryTest, Gradient) {
   {
     // Simple 2 color gradient produces color buffer containing exactly those
@@ -1829,8 +1842,8 @@ TEST(GeometryTest, Gradient) {
 
     auto gradient = CreateGradientBuffer(colors, stops);
 
-    ASSERT_COLOR_BUFFER_NEAR(gradient.color_bytes, colors);
-    ASSERT_EQ(gradient.texture_size, 2u);
+    ASSERT_COLORS_NEAR(gradient.colors, colors);
+    ASSERT_EQ(gradient.colors.size(), 2u);
   }
 
   {
@@ -1840,7 +1853,7 @@ TEST(GeometryTest, Gradient) {
     std::vector<Scalar> stops = {0.0, 0.25, 0.25, 1.0};
 
     auto gradient = CreateGradientBuffer(colors, stops);
-    ASSERT_EQ(gradient.texture_size, 1024u);
+    ASSERT_EQ(gradient.colors.size(), 1024u);
 
     std::vector<Color> expected_colors(1024);
     for (size_t i = 0; i < 1024; i++) {
@@ -1855,7 +1868,7 @@ TEST(GeometryTest, Gradient) {
             Color::Lerp(Color::Black(), Color::Blue(), (t - 0.25) / 0.75);
       }
     }
-    ASSERT_COLOR_BUFFER_NEAR(gradient.color_bytes, expected_colors);
+    ASSERT_COLORS_NEAR(gradient.colors, expected_colors);
   }
 
   {
@@ -1867,8 +1880,8 @@ TEST(GeometryTest, Gradient) {
 
     auto gradient = CreateGradientBuffer(colors, stops);
 
-    ASSERT_COLOR_BUFFER_NEAR(gradient.color_bytes, colors);
-    ASSERT_EQ(gradient.texture_size, 4u);
+    ASSERT_COLORS_NEAR(gradient.colors, colors);
+    ASSERT_EQ(gradient.colors.size(), 4u);
   }
 
   {
@@ -1885,8 +1898,8 @@ TEST(GeometryTest, Gradient) {
         Color::Lerp(Color::Blue(), Color::Green(), 0.6666),
         Color::Green(),
     };
-    ASSERT_COLOR_BUFFER_NEAR(gradient.color_bytes, lerped_colors);
-    ASSERT_EQ(gradient.texture_size, 5u);
+    ASSERT_COLORS_NEAR(gradient.colors, lerped_colors);
+    ASSERT_EQ(gradient.colors.size(), 5u);
   }
 
   {
@@ -1900,8 +1913,34 @@ TEST(GeometryTest, Gradient) {
 
     auto gradient = CreateGradientBuffer(colors, stops);
 
-    ASSERT_EQ(gradient.texture_size, 1024u);
-    ASSERT_EQ(gradient.color_bytes.size(), 1024u * 4);
+    ASSERT_EQ(gradient.colors.size(), 1024u);
+  }
+
+  {
+    // Gradient with wide-gamut (out of [0, 1]) colors produces wide-gamut
+    // values.
+    Color p3_red = Color(1.0931f, -0.2268f, -0.1501f, 1.0f);
+    Color p3_green = Color(-0.5116f, 1.0183f, -0.3107f, 1.0f);
+    std::vector<Color> colors = {p3_red, p3_green};
+    std::vector<Scalar> stops = {0.0f, 1.0f};
+
+    auto gradient = CreateGradientBuffer(colors, stops);
+
+    ASSERT_EQ(gradient.colors.size(), 2u);
+    ASSERT_COLORS_NEAR(gradient.colors, colors);
+  }
+
+  {
+    // Multi-stop wide-gamut gradient interpolates floats accurately.
+    Color p3_red = Color(1.0931f, -0.2268f, -0.1501f, 1.0f);
+    Color p3_green = Color(-0.5116f, 1.0183f, -0.3107f, 1.0f);
+    std::vector<Color> colors = {p3_red, Color::White(), p3_green};
+    std::vector<Scalar> stops = {0.0f, 0.5f, 1.0f};
+
+    auto gradient = CreateGradientBuffer(colors, stops);
+
+    ASSERT_EQ(gradient.colors.size(), 3u);
+    ASSERT_COLORS_NEAR(gradient.colors, colors);
   }
 }
 

--- a/engine/src/flutter/impeller/geometry/gradient.cc
+++ b/engine/src/flutter/impeller/geometry/gradient.cc
@@ -2,24 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "impeller/geometry/gradient.h"
+
 #include <algorithm>
 
 #include "flutter/fml/logging.h"
-#include "impeller/geometry/gradient.h"
 
 namespace impeller {
 
 // TODO(b-luk): this should use a platform specific max texture size.
 // https://github.com/flutter/flutter/issues/191820
 static constexpr uint32_t kMaxGradientTextureSize = 1024;
-
-static void AppendColor(const Color& color, GradientData* data) {
-  auto converted = color.ToR8G8B8A8();
-  data->color_bytes.push_back(converted[0]);
-  data->color_bytes.push_back(converted[1]);
-  data->color_bytes.push_back(converted[2]);
-  data->color_bytes.push_back(converted[3]);
-}
 
 GradientData CreateGradientBuffer(const std::vector<Color>& colors,
                                   const std::vector<Scalar>& stops) {
@@ -45,16 +38,15 @@ GradientData CreateGradientBuffer(const std::vector<Color>& colors,
     }
     texture_size = static_cast<uint32_t>(std::round(1.0 / minimum_delta)) + 1;
   }
-  GradientData data = {
-      .color_bytes = {},
-      .texture_size = texture_size,
+  GradientData result = {
+      .colors = {},
   };
-  data.color_bytes.reserve(texture_size * 4);
+  result.colors.reserve(texture_size);
 
   if (texture_size == colors.size() &&
       colors.size() <= kMaxGradientTextureSize) {
     for (auto i = 0u; i < colors.size(); i++) {
-      AppendColor(colors[i], &data);
+      result.colors.push_back(colors[i]);
     }
   } else {
     Color previous_color = colors[0];
@@ -62,7 +54,7 @@ GradientData CreateGradientBuffer(const std::vector<Color>& colors,
     auto previous_color_index = 0;
 
     // The first index is always equal to the first color, exactly.
-    AppendColor(previous_color, &data);
+    result.colors.push_back(previous_color);
 
     for (auto i = 1u; i < texture_size - 1; i++) {
       auto scaled_i = i / (texture_size - 1.0);
@@ -70,7 +62,7 @@ GradientData CreateGradientBuffer(const std::vector<Color>& colors,
       auto next_stop = stops[previous_color_index + 1];
       // We're almost exactly equal to the next stop.
       if (ScalarNearlyEqual(scaled_i, next_stop)) {
-        AppendColor(next_color, &data);
+        result.colors.push_back(next_color);
 
         previous_color = next_color;
         previous_stop = next_stop;
@@ -80,7 +72,7 @@ GradientData CreateGradientBuffer(const std::vector<Color>& colors,
         auto t = (scaled_i - previous_stop) / (next_stop - previous_stop);
         auto mixed_color = Color::Lerp(previous_color, next_color, t);
 
-        AppendColor(mixed_color, &data);
+        result.colors.push_back(mixed_color);
       } else {
         // We've passed the next stop. Advance to the next stop interval.
         // Decrement `i` to re-evaluate the current texel against the new
@@ -93,9 +85,9 @@ GradientData CreateGradientBuffer(const std::vector<Color>& colors,
       }
     }
     // The last index is always equal to the last color, exactly.
-    AppendColor(colors.back(), &data);
+    result.colors.push_back(colors.back());
   }
-  return data;
+  return result;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/geometry/gradient.cc
+++ b/engine/src/flutter/impeller/geometry/gradient.cc
@@ -38,17 +38,12 @@ GradientData CreateGradientBuffer(const std::vector<Color>& colors,
     }
     texture_size = static_cast<uint32_t>(std::round(1.0 / minimum_delta)) + 1;
   }
-  GradientData result = {
-      .colors = {},
-  };
-  result.colors.reserve(texture_size);
-
+  GradientData result;
   if (texture_size == colors.size() &&
       colors.size() <= kMaxGradientTextureSize) {
-    for (auto i = 0u; i < colors.size(); i++) {
-      result.colors.push_back(colors[i]);
-    }
+    result.colors = colors;
   } else {
+    result.colors.reserve(texture_size);
     Color previous_color = colors[0];
     auto previous_stop = 0.0;
     auto previous_color_index = 0;

--- a/engine/src/flutter/impeller/geometry/gradient.h
+++ b/engine/src/flutter/impeller/geometry/gradient.h
@@ -12,14 +12,13 @@
 
 namespace impeller {
 
-// If texture_size is 0 then the gradient is invalid.
+// If colors is empty then the gradient is invalid.
 struct GradientData {
-  std::vector<uint8_t> color_bytes;
-  uint32_t texture_size;
+  std::vector<Color> colors;
 };
 
 /**
- * @brief Populate a vector with the interpolated color bytes for the linear
+ * @brief Populate GradientData with the interpolated colors for the linear
  * gradient described by colors and stops.
  *
  * @param colors


### PR DESCRIPTION
This is a prerequisite to re-implementing https://github.com/flutter/flutter/pull/190874. This addresses the unsupported wide gamut issue which was originally present in that PR and which caused it to be reverted.

Related: https://github.com/flutter/flutter/issues/190401

### Previously:
- `CreateGradientBuffer` converts a gradient's colors and stops to an interpolated list of colors. This interpolated list of colors is converted to bytes with `ToR8G8B8A8()` and is returned in a `GradientData`.
- The `R8G8B8A8` `GradientData` is passed to `CreateGradientTexture`, which allocates a `PixelFormat::kR8G8B8A8UNormInt` texture.

Wide gamut colors can't be converted to `R8G8B8A8`, so they end up getting clamped.

### Now:
- `CreateGradientBuffer` converts a gradient's colors and stops to an interpolated list of colors (same as before). But now no conversion to bytes happens here. The interpolated list of colors is directly returned in a `GradientData`.
- The `Color`-based `GradientData` is passed to `CreateGradientTexture`. `CreateGradientTexture` now handles the conversion to bytes. If there are wide gamut colors, it converts to `kR32G32B32A32Float`. Otherwise it does the old behavior of converting to `PixelFormat::kR8G8B8A8UNormInt`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
