### PR TITLE
[flutter_tools] Fix Android license status check for cmdline-tools 23.0+

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -80,6 +80,17 @@ class AndroidSdk {
   /// the SDK on demand.
   bool get licensesAvailable => directory.childDirectory('licenses').existsSync();
 
+  /// Whether the core `android-sdk-license` file exists in the Android SDK
+  /// `licenses` directory and contains at least one license signature.
+  bool get hasAcceptedLicenses {
+    try {
+      final File sdkLicense = directory.childDirectory('licenses').childFile('android-sdk-license');
+      return sdkLicense.existsSync() && sdkLicense.readAsStringSync().trim().isNotEmpty;
+    } on FileSystemException {
+      return false;
+    }
+  }
+
   static AndroidSdk? locateAndroidSdk() {
     String? findAndroidHomeDir() {
       String? androidHomeDir;

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -86,7 +86,7 @@ class AndroidSdk {
     try {
       final File sdkLicense = directory.childDirectory('licenses').childFile('android-sdk-license');
       return sdkLicense.existsSync() && sdkLicense.readAsStringSync().trim().isNotEmpty;
-    } on FileSystemException {
+    } on Exception {
       return false;
     }
   }

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -33,6 +33,10 @@ enum LicensesAccepted { none, some, all, unknown }
 final licenseCounts = RegExp(r'(\d+) of (\d+) SDK package licenses? not accepted.');
 final licenseNotAccepted = RegExp(r'licenses? not accepted', caseSensitive: false);
 final licenseAccepted = RegExp(r'All SDK package licenses accepted.');
+final licenseOptionNotNeeded = RegExp(
+  r'The --licenses option is no longer needed',
+  caseSensitive: false,
+);
 
 class AndroidWorkflow implements Workflow {
   AndroidWorkflow({required AndroidSdk? androidSdk, required FeatureFlags featureFlags})
@@ -446,6 +450,7 @@ class AndroidLicenseValidator extends DoctorValidator {
 
   Future<LicensesAccepted> get licensesAccepted async {
     LicensesAccepted? status;
+    var sawOptionNotNeeded = false;
 
     void handleLine(String line) {
       if (licenseCounts.hasMatch(line)) {
@@ -462,6 +467,8 @@ class AndroidLicenseValidator extends DoctorValidator {
         status = LicensesAccepted.none;
       } else if (licenseAccepted.hasMatch(line)) {
         status ??= LicensesAccepted.all;
+      } else if (licenseOptionNotNeeded.hasMatch(line)) {
+        sawOptionNotNeeded = true;
       }
     }
 
@@ -488,7 +495,13 @@ class AndroidLicenseValidator extends DoctorValidator {
           .listen(handleLine)
           .asFuture<void>();
       await Future.wait<void>(<Future<void>>[output, errors]);
-      return status ?? LicensesAccepted.unknown;
+      if (status != null) {
+        return status!;
+      }
+      if (sawOptionNotNeeded) {
+        return _androidSdk.hasAcceptedLicenses ? LicensesAccepted.all : LicensesAccepted.none;
+      }
+      return LicensesAccepted.unknown;
     } on IOException catch (e) {
       _logger.printTrace('Failed to run Android sdk manager: $e');
       return LicensesAccepted.unknown;

--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -510,6 +510,48 @@ void main() {
         Config: () => config,
       },
     );
+
+    testUsingContext(
+      'hasAcceptedLicenses returns true when android-sdk-license file exists and is not empty',
+      () {
+        final Directory sdkDir = createSdkDirectory(fileSystem: fileSystem);
+        config.setValue('android-sdk', sdkDir.path);
+
+        final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+        fileSystem.file(fileSystem.path.join(sdk.directory.path, 'licenses', 'android-sdk-license'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('24333f8a63b6825ea9c5514f83c2829b004d1fee');
+
+        expect(sdk.hasAcceptedLicenses, isTrue);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Config: () => config,
+      },
+    );
+
+    testUsingContext(
+      'hasAcceptedLicenses returns false when android-sdk-license file is empty or does not exist',
+      () {
+        final Directory sdkDir = createSdkDirectory(fileSystem: fileSystem);
+        config.setValue('android-sdk', sdkDir.path);
+
+        final AndroidSdk sdk = AndroidSdk.locateAndroidSdk()!;
+        expect(sdk.hasAcceptedLicenses, isFalse);
+
+        fileSystem
+            .file(fileSystem.path.join(sdk.directory.path, 'licenses', 'android-sdk-license'))
+            .createSync(recursive: true);
+
+        expect(sdk.hasAcceptedLicenses, isFalse);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Config: () => config,
+      },
+    );
   });
 
   const llvmHostDirectoryName = <String, String>{

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -230,6 +230,62 @@ All SDK package licenses accepted.
     expect(result, LicensesAccepted.all);
   });
 
+  testWithoutContext(
+    'licensesAccepted returns LicensesAccepted.all when --licenses option is no longer needed and licenses are accepted',
+    () async {
+      sdk.sdkManagerPath = '/foo/bar/sdkmanager';
+      sdk.hasAcceptedLicenses = true;
+      const output = '''
+WARNING: The SDK Manager CLI tool (sdkmanager) is deprecated. Android CLI will be used instead.
+Warning: The --licenses option is no longer needed.
+''';
+      processManager.addCommand(
+        const FakeCommand(command: <String>['/foo/bar/sdkmanager', '--licenses'], stderr: output),
+      );
+
+      final licenseValidator = AndroidLicenseValidator(
+        java: FakeJava(),
+        androidSdk: sdk,
+        processManager: processManager,
+        platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+        stdio: stdio,
+        logger: BufferLogger.test(),
+        userMessages: UserMessages(),
+      );
+      final LicensesAccepted result = await licenseValidator.licensesAccepted;
+
+      expect(result, LicensesAccepted.all);
+    },
+  );
+
+  testWithoutContext(
+    'licensesAccepted returns LicensesAccepted.none when --licenses option is no longer needed and licenses are not accepted',
+    () async {
+      sdk.sdkManagerPath = '/foo/bar/sdkmanager';
+      sdk.hasAcceptedLicenses = false;
+      const output = '''
+WARNING: The SDK Manager CLI tool (sdkmanager) is deprecated. Android CLI will be used instead.
+Warning: The --licenses option is no longer needed.
+''';
+      processManager.addCommand(
+        const FakeCommand(command: <String>['/foo/bar/sdkmanager', '--licenses'], stderr: output),
+      );
+
+      final licenseValidator = AndroidLicenseValidator(
+        java: FakeJava(),
+        androidSdk: sdk,
+        processManager: processManager,
+        platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+        stdio: stdio,
+        logger: BufferLogger.test(),
+        userMessages: UserMessages(),
+      );
+      final LicensesAccepted result = await licenseValidator.licensesAccepted;
+
+      expect(result, LicensesAccepted.none);
+    },
+  );
+
   testWithoutContext('licensesAccepted sets environment for finding java', () async {
     final Java java = FakeJava();
     sdk.sdkManagerPath = '/foo/bar/sdkmanager';
@@ -963,6 +1019,9 @@ class FakeAndroidSdk extends Fake implements AndroidSdk {
 
   @override
   bool licensesAvailable = false;
+
+  @override
+  bool hasAcceptedLicenses = false;
 
   @override
   bool platformToolsAvailable = false;

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -830,6 +830,9 @@ class FakeAndroidSdk extends Fake implements AndroidSdk {
   late bool licensesAvailable;
 
   @override
+  bool hasAcceptedLicenses = false;
+
+  @override
   AndroidSdkVersion? latestVersion;
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/191963 (but only the checking, not the guided install flow. I'm going to do that in a follow up pr, probably by invoking android-cli for some dummy task because it *seems* like it just auto accepts licenses now).

AI pr description below, which is accurate (I checked 🙂 )
---

Android SDK Command-line Tools 23.0 deprecates `sdkmanager` and replaces it with the `android` CLI. In 23.0, running `sdkmanager --licenses` prints:
```text
WARNING: The SDK Manager CLI tool (sdkmanager) is deprecated. Android CLI will be used instead.
Warning: The --licenses option is no longer needed.
```
and exits `0` without outputting license counts or acceptance text.

Previously, `AndroidLicenseValidator.licensesAccepted` relied strictly on parsing `All SDK package licenses accepted.` or license count patterns from `sdkmanager --licenses`. When this deprecation warning is emitted, none of the patterns matched, causing `flutter doctor` to report `Android license status unknown` even when licenses are already accepted on disk.

This change:
1. Adds `AndroidSdk.hasAcceptedLicenses` to check whether `licenses/android-sdk-license` exists and contains license signatures.
2. Checks for `The --licenses option is no longer needed` in `AndroidLicenseValidator.licensesAccepted` and falls back to `AndroidSdk.hasAcceptedLicenses`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.