### PR TITLE
[flutter_tools] Pause web server requests until initial compilation finishes

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -243,6 +243,16 @@ class WebDevFS implements DevFS {
     return baseUri;
   }
 
+  /// Signal that the underlying web asset server is ready to handle requests.
+  ///
+  /// The HTTP server starts listening early during [create] so the port and URI
+  /// are known before compilation. However, incoming HTTP requests are held
+  /// until initial compilation completes and the DWDS connection listener is
+  /// registered so clients do not load incomplete assets or miss connection events.
+  void markReady() {
+    webAssetServer.markReady();
+  }
+
   @override
   Future<void> destroy() async {
     await webAssetServer.dispose();

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -367,6 +367,13 @@ class ResidentWebRunner extends ResidentRunner {
         final Future<ConnectionResult?>? connectDebug = supportsServiceProtocol
             ? webDevFS.connect(useDebugExtension)
             : null;
+        // Unpause incoming HTTP requests now that:
+        // 1. Initial compilation has finished and WebMemoryFS has received the
+        //    compiled modules and merged metadata (preventing DWDS from memoizing
+        //    an empty module list).
+        // 2. `webDevFS.connect()` has begun listening for connected applications
+        //    so early connections are not dropped.
+        webDevFS.markReady();
         await flutterDevice!.device!.startApp(
           package,
           mainPath: target,

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -99,6 +99,23 @@ class WebAssetServer implements AssetReader {
   final Map<String, String> _modules;
   final Map<String, String> _digests;
 
+  final Completer<void> _readyCompleter = Completer<void>();
+
+  /// A future that completes when the server is ready to handle requests.
+  ///
+  /// Requests received before this future completes are paused by middleware.
+  Future<void> get isReady => _readyCompleter.future;
+
+  /// Signal that the server is ready to handle incoming requests.
+  ///
+  /// This unpauses any HTTP requests that were received while the server was
+  /// initializing or waiting for initial compilation to complete.
+  void markReady() {
+    if (!_readyCompleter.isCompleted) {
+      _readyCompleter.complete();
+    }
+  }
+
   int get selectedPort => _httpServer.port;
 
   /// Given a list of [modules] that need to be loaded, compute module names and
@@ -298,6 +315,13 @@ class WebAssetServer implements AssetReader {
       return server;
     }
 
+    shelf.Handler waitMiddleware(shelf.Handler innerHandler) {
+      return (shelf.Request request) async {
+        await server.isReady;
+        return innerHandler(request);
+      };
+    }
+
     // In release builds (or wasm builds) deploy a simpler proxy server.
     if (buildInfo.mode != BuildMode.debug || isWasm) {
       final releaseAssetServer = ReleaseAssetServer(
@@ -309,9 +333,12 @@ class WebAssetServer implements AssetReader {
         basePath: server.basePath,
         needsCoopCoep: crossOriginIsolation,
       );
+      final shelf.Handler releaseHandler = const shelf.Pipeline()
+          .addMiddleware(waitMiddleware)
+          .addHandler(releaseAssetServer.handle);
       runZonedGuarded(
         () {
-          shelf.serveRequests(httpServer!, releaseAssetServer.handle);
+          shelf.serveRequests(httpServer!, releaseHandler);
         },
         (Object e, StackTrace s) {
           logger.printTrace('Release asset server: error serving requests: $e:$s');
@@ -388,9 +415,12 @@ class WebAssetServer implements AssetReader {
     pipeline = pipeline.addMiddleware(proxyMiddleware(proxy, globals.logger));
     final shelf.Handler dwdsHandler = pipeline.addHandler(server.handleRequest);
     final shelf.Cascade cascade = shelf.Cascade().add(dwds.handler).add(dwdsHandler);
+    final shelf.Handler serverHandler = const shelf.Pipeline()
+        .addMiddleware(waitMiddleware)
+        .addHandler(cascade.handler);
     runZonedGuarded(
       () {
-        shelf.serveRequests(httpServer!, cascade.handler);
+        shelf.serveRequests(httpServer!, serverHandler);
       },
       (Object e, StackTrace s) {
         logger.printTrace('Dwds server: error serving requests: $e:$s');
@@ -574,6 +604,9 @@ class WebAssetServer implements AssetReader {
 
   /// Tear down the http server running.
   Future<void> dispose() async {
+    if (!_readyCompleter.isCompleted) {
+      _readyCompleter.complete();
+    }
     if (_dwdsInit) {
       await dwds.stop();
     }

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -231,6 +231,9 @@ class FakeWebDevFS extends Fake implements WebDevFS {
   Future<Uri> create() async {
     return Uri.base;
   }
+
+  @override
+  void markReady() {}
 }
 
 class FakeWebDevice extends Fake implements Device {

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -272,6 +272,26 @@ name: my_app
   );
 
   testUsingContext(
+    'ResidentWebRunner marks WebDevFS as ready before starting app',
+    () async {
+      final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice);
+      fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
+      setupMocks();
+
+      final connectionInfoCompleter = Completer<DebugConnectionInfo>();
+      unawaited(residentWebRunner.run(connectionInfoCompleter: connectionInfoCompleter));
+      await connectionInfoCompleter.future;
+
+      expect(webDevFS.wasMarkedReady, true);
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+    },
+  );
+
+  testUsingContext(
     'Does not crash if the application exits during DDS startup',
     () async {
       // Regression test for https://github.com/flutter/flutter/issues/178151
@@ -2477,6 +2497,12 @@ class FakeWebDevFS extends Fake implements WebDevFS {
   late UpdateFSReport report;
 
   Uri? mainUri;
+  bool wasMarkedReady = false;
+
+  @override
+  void markReady() {
+    wasMarkedReady = true;
+  }
 
   @override
   List<Uri> sources = <Uri>[];

--- a/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:dwds/dwds.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
@@ -10,6 +12,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/isolated/release_asset_server.dart';
 import 'package:flutter_tools/src/isolated/web_asset_server.dart';
 import 'package:flutter_tools/src/web/compile.dart';
@@ -511,6 +514,126 @@ void main() {
 
       expect(server.basePath, isEmpty);
     });
+
+    testWithoutContext('isReady is completed by markReady() or dispose()', () async {
+      final WebAssetServer server = await WebAssetServer.start(
+        null,
+        null,
+        false,
+        false,
+        false,
+        BuildInfo.debug,
+        false,
+        const DartDevelopmentServiceConfiguration(enable: false),
+        Uri.base,
+        null,
+        crossOriginIsolation: false,
+        webDevServerConfig: const WebDevServerConfig(host: 'localhost'),
+        webRenderer: WebRendererMode.canvaskit,
+        isWasm: false,
+        useLocalCanvasKit: false,
+        testMode: true,
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: platform,
+      );
+
+      var serverReady = false;
+      unawaited(server.isReady.then((_) => serverReady = true));
+      expect(serverReady, false);
+
+      server.markReady();
+      await pumpEventQueue();
+      expect(serverReady, true);
+
+      final WebAssetServer server2 = await WebAssetServer.start(
+        null,
+        null,
+        false,
+        false,
+        false,
+        BuildInfo.debug,
+        false,
+        const DartDevelopmentServiceConfiguration(enable: false),
+        Uri.base,
+        null,
+        crossOriginIsolation: false,
+        webDevServerConfig: const WebDevServerConfig(host: 'localhost'),
+        webRenderer: WebRendererMode.canvaskit,
+        isWasm: false,
+        useLocalCanvasKit: false,
+        testMode: true,
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: platform,
+      );
+
+      var server2Ready = false;
+      unawaited(server2.isReady.then((_) => server2Ready = true));
+      expect(server2Ready, false);
+
+      await server2.dispose();
+      await pumpEventQueue();
+      expect(server2Ready, true);
+    });
+
+    testUsingContext(
+      'pauses requests until markReady() is called',
+      () async {
+        fileSystem.file('build/web/index.html')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('hello');
+
+        final WebAssetServer server = await WebAssetServer.start(
+          null,
+          null,
+          false,
+          false,
+          false,
+          BuildInfo.release,
+          false,
+          const DartDevelopmentServiceConfiguration(enable: false),
+          Uri.base,
+          null,
+          crossOriginIsolation: false,
+          webDevServerConfig: const WebDevServerConfig(host: 'localhost'),
+          webRenderer: WebRendererMode.canvaskit,
+          isWasm: true,
+          useLocalCanvasKit: false,
+          fileSystem: fileSystem,
+          logger: BufferLogger.test(),
+          platform: platform,
+        );
+
+        final client = HttpClient();
+        try {
+          final Future<HttpClientResponse> responseFuture = client
+              .getUrl(Uri.parse('http://localhost:${server.selectedPort}/'))
+              .then((HttpClientRequest request) => request.close());
+
+          var responseReceived = false;
+          unawaited(responseFuture.then((_) => responseReceived = true));
+
+          // Pump events to ensure request is in flight.
+          await pumpEventQueue();
+          expect(responseReceived, false);
+
+          server.markReady();
+
+          final HttpClientResponse response = await responseFuture;
+          expect(response.statusCode, HttpStatus.ok);
+          expect(await utf8.decoder.bind(response).join(), 'hello');
+        } finally {
+          client.close();
+          await server.dispose();
+        }
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        Platform: () => platform,
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
 
     testUsingContext(
       'serves assets with exact key and does not serve non-source project files as assets',


### PR DESCRIPTION
## Description

When launching a web application using `flutter run -d web-server`, the HTTP server begins listening as soon as `WebDevFS.create()` starts `WebAssetServer`. However, application compilation in `_updateDevFS()` has not yet completed.

If a client requests the page before compilation finishes, DWDS attempts to read module metadata while `_webMemoryFS.mergedMetadata` is still null. DWDS then injects an empty module list into the bootstrap script (`main_module.bootstrap.js`) and permanently memoizes that 0 modules exist in `MetadataProvider._metadataMemoizer`, causing the page to only load `dart_sdk.js` and hang on a blank white screen. In Chrome console logs, this exhibits as `DDC is about to load 1/2 scripts with pool size = 1000` with nothing else loading afterwards.

Additionally, if the client connects to DWDS before `webDevFS.connect()` starts listening, the `connectedApps` broadcast event is dropped without listeners, causing the tool to hang waiting for a connection.

This PR adds a readiness completer to `WebAssetServer` and a Shelf middleware to pause incoming HTTP requests until initial compilation completes and the DWDS connection listener is attached.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/191957

## Tests

- Added tests in `packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart` verifying that `isReady` completes on `markReady()`/`dispose()` and that incoming HTTP requests are held until `markReady()` is called.
- Added test in `packages/flutter_tools/test/general.shard/resident_web_runner_test.dart` verifying that `ResidentWebRunner.run()` marks `WebDevFS` as ready before starting the app.