### PR TITLE
Add some violations  in a11y inspector

### DIFF
--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -99,18 +99,17 @@ class MinimumTapTargetEvaluation extends AccessibilityEvaluation {
   FutureOr<EvaluationResult> _evaluate(WidgetsBinding binding) {
     final violations = <Violation>[];
     for (final RenderView view in binding.renderViews) {
-      violations.addAll(
-        _traverse(view.flutterView, view.owner!.semanticsOwner!.rootSemanticsNode!),
-      );
+      violations.addAll(traverse(view.flutterView, view.owner!.semanticsOwner!.rootSemanticsNode!));
     }
 
     return EvaluationResult(violations);
   }
 
-  List<Violation> _traverse(ui.FlutterView view, SemanticsNode node) {
+  /// Traverses the given [node] and returns all found violations.
+  List<Violation> traverse(ui.FlutterView view, SemanticsNode node) {
     final violations = <Violation>[];
     node.visitChildren((SemanticsNode child) {
-      violations.addAll(_traverse(view, child));
+      violations.addAll(traverse(view, child));
       return true;
     });
     if (node.isMergedIntoParent) {
@@ -199,16 +198,17 @@ class LabeledTapTargetEvaluation extends AccessibilityEvaluation {
     final violations = <Violation>[];
 
     for (final RenderView view in binding.renderViews) {
-      violations.addAll(_traverse(view.owner!.semanticsOwner!.rootSemanticsNode!));
+      violations.addAll(traverse(view.owner!.semanticsOwner!.rootSemanticsNode!));
     }
 
     return EvaluationResult(violations);
   }
 
-  List<Violation> _traverse(SemanticsNode node) {
+  /// Traverses the given [node] and returns all found violations.
+  List<Violation> traverse(SemanticsNode node) {
     final violations = <Violation>[];
     node.visitChildren((SemanticsNode child) {
-      violations.addAll(_traverse(child));
+      violations.addAll(traverse(child));
       return true;
     });
     if (node.isMergedIntoParent ||
@@ -783,17 +783,18 @@ class UnlabeledLeafNodeEvaluation extends AccessibilityEvaluation {
   FutureOr<EvaluationResult> _evaluate(WidgetsBinding binding) {
     final violations = <Violation>[];
     for (final RenderView view in binding.renderViews) {
-      violations.addAll(_traverse(view.owner!.semanticsOwner!.rootSemanticsNode!));
+      violations.addAll(traverse(view.owner!.semanticsOwner!.rootSemanticsNode!));
     }
     return EvaluationResult(violations);
   }
 
-  List<Violation> _traverse(SemanticsNode node) {
+  /// Traverses the given [node] and returns all found violations.
+  List<Violation> traverse(SemanticsNode node) {
     final violations = <Violation>[];
     var hasChildren = false;
     node.visitChildren((SemanticsNode child) {
       hasChildren = true;
-      violations.addAll(_traverse(child));
+      violations.addAll(traverse(child));
       return true;
     });
 

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -65,6 +65,14 @@ abstract class AccessibilityEvaluation {
   /// A const constructor allows subclasses to be const.
   const AccessibilityEvaluation();
 
+  /// Traverses the given [node] and returns all found violations.
+  ///
+  /// The [view] parameter provides the [ui.FlutterView] context for evaluations
+  /// that require physical metrics (such as tap target size).
+  List<Violation> traverse(SemanticsNode node, {ui.FlutterView? view}) {
+    return const <Violation>[];
+  }
+
   /// Evaluate whether the current state of the `binding` conforms to the rule.
   FutureOr<EvaluationResult> evaluate(WidgetsBinding binding) {
     if (!isAccessibilityEvaluationsEnabled) {
@@ -99,17 +107,19 @@ class MinimumTapTargetEvaluation extends AccessibilityEvaluation {
   FutureOr<EvaluationResult> _evaluate(WidgetsBinding binding) {
     final violations = <Violation>[];
     for (final RenderView view in binding.renderViews) {
-      violations.addAll(traverse(view.flutterView, view.owner!.semanticsOwner!.rootSemanticsNode!));
+      violations.addAll(
+        traverse(view.owner!.semanticsOwner!.rootSemanticsNode!, view: view.flutterView),
+      );
     }
 
     return EvaluationResult(violations);
   }
 
-  /// Traverses the given [node] and returns all found violations.
-  List<Violation> traverse(ui.FlutterView view, SemanticsNode node) {
+  @override
+  List<Violation> traverse(SemanticsNode node, {ui.FlutterView? view}) {
     final violations = <Violation>[];
     node.visitChildren((SemanticsNode child) {
-      violations.addAll(traverse(view, child));
+      violations.addAll(traverse(child, view: view));
       return true;
     });
     if (node.isMergedIntoParent) {
@@ -135,13 +145,23 @@ class MinimumTapTargetEvaluation extends AccessibilityEvaluation {
       current = current.parent;
     }
 
-    final Rect viewRect = Offset.zero & view.physicalSize;
+    final ui.FlutterView? flutterView =
+        view ??
+        (RendererBinding.instance.renderViews.isNotEmpty
+            ? RendererBinding.instance.renderViews.first.flutterView
+            : null) ??
+        ui.PlatformDispatcher.instance.views.firstOrNull;
+    if (flutterView == null) {
+      return violations;
+    }
+
+    final Rect viewRect = Offset.zero & flutterView.physicalSize;
     if (_isAtBoundary(paintBounds, viewRect)) {
       return violations;
     }
 
     // Shrink by device pixel ratio.
-    final Size candidateSize = paintBounds.size / view.devicePixelRatio;
+    final Size candidateSize = paintBounds.size / flutterView.devicePixelRatio;
     if (candidateSize.width < size.width - precisionErrorTolerance ||
         candidateSize.height < size.height - precisionErrorTolerance) {
       violations.add(
@@ -204,11 +224,11 @@ class LabeledTapTargetEvaluation extends AccessibilityEvaluation {
     return EvaluationResult(violations);
   }
 
-  /// Traverses the given [node] and returns all found violations.
-  List<Violation> traverse(SemanticsNode node) {
+  @override
+  List<Violation> traverse(SemanticsNode node, {ui.FlutterView? view}) {
     final violations = <Violation>[];
     node.visitChildren((SemanticsNode child) {
-      violations.addAll(traverse(child));
+      violations.addAll(traverse(child, view: view));
       return true;
     });
     if (node.isMergedIntoParent ||
@@ -788,13 +808,13 @@ class UnlabeledLeafNodeEvaluation extends AccessibilityEvaluation {
     return EvaluationResult(violations);
   }
 
-  /// Traverses the given [node] and returns all found violations.
-  List<Violation> traverse(SemanticsNode node) {
+  @override
+  List<Violation> traverse(SemanticsNode node, {ui.FlutterView? view}) {
     final violations = <Violation>[];
     var hasChildren = false;
     node.visitChildren((SemanticsNode child) {
       hasChildren = true;
-      violations.addAll(traverse(child));
+      violations.addAll(traverse(child, view: view));
       return true;
     });
 

--- a/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
+++ b/packages/flutter/lib/src/widgets/_accessibility_evaluations.dart
@@ -69,7 +69,7 @@ abstract class AccessibilityEvaluation {
   ///
   /// The [view] parameter provides the [ui.FlutterView] context for evaluations
   /// that require physical metrics (such as tap target size).
-  List<Violation> traverse(SemanticsNode node, {ui.FlutterView? view}) {
+  List<Violation> traverse(SemanticsNode node, {required ui.FlutterView view}) {
     return const <Violation>[];
   }
 
@@ -116,7 +116,7 @@ class MinimumTapTargetEvaluation extends AccessibilityEvaluation {
   }
 
   @override
-  List<Violation> traverse(SemanticsNode node, {ui.FlutterView? view}) {
+  List<Violation> traverse(SemanticsNode node, {required ui.FlutterView view}) {
     final violations = <Violation>[];
     node.visitChildren((SemanticsNode child) {
       violations.addAll(traverse(child, view: view));
@@ -145,23 +145,13 @@ class MinimumTapTargetEvaluation extends AccessibilityEvaluation {
       current = current.parent;
     }
 
-    final ui.FlutterView? flutterView =
-        view ??
-        (RendererBinding.instance.renderViews.isNotEmpty
-            ? RendererBinding.instance.renderViews.first.flutterView
-            : null) ??
-        ui.PlatformDispatcher.instance.views.firstOrNull;
-    if (flutterView == null) {
-      return violations;
-    }
-
-    final Rect viewRect = Offset.zero & flutterView.physicalSize;
+    final Rect viewRect = Offset.zero & view.physicalSize;
     if (_isAtBoundary(paintBounds, viewRect)) {
       return violations;
     }
 
     // Shrink by device pixel ratio.
-    final Size candidateSize = paintBounds.size / flutterView.devicePixelRatio;
+    final Size candidateSize = paintBounds.size / view.devicePixelRatio;
     if (candidateSize.width < size.width - precisionErrorTolerance ||
         candidateSize.height < size.height - precisionErrorTolerance) {
       violations.add(
@@ -218,14 +208,16 @@ class LabeledTapTargetEvaluation extends AccessibilityEvaluation {
     final violations = <Violation>[];
 
     for (final RenderView view in binding.renderViews) {
-      violations.addAll(traverse(view.owner!.semanticsOwner!.rootSemanticsNode!));
+      violations.addAll(
+        traverse(view.owner!.semanticsOwner!.rootSemanticsNode!, view: view.flutterView),
+      );
     }
 
     return EvaluationResult(violations);
   }
 
   @override
-  List<Violation> traverse(SemanticsNode node, {ui.FlutterView? view}) {
+  List<Violation> traverse(SemanticsNode node, {required ui.FlutterView view}) {
     final violations = <Violation>[];
     node.visitChildren((SemanticsNode child) {
       violations.addAll(traverse(child, view: view));
@@ -803,13 +795,15 @@ class UnlabeledLeafNodeEvaluation extends AccessibilityEvaluation {
   FutureOr<EvaluationResult> _evaluate(WidgetsBinding binding) {
     final violations = <Violation>[];
     for (final RenderView view in binding.renderViews) {
-      violations.addAll(traverse(view.owner!.semanticsOwner!.rootSemanticsNode!));
+      violations.addAll(
+        traverse(view.owner!.semanticsOwner!.rootSemanticsNode!, view: view.flutterView),
+      );
     }
     return EvaluationResult(violations);
   }
 
   @override
-  List<Violation> traverse(SemanticsNode node, {ui.FlutterView? view}) {
+  List<Violation> traverse(SemanticsNode node, {required ui.FlutterView view}) {
     final violations = <Violation>[];
     var hasChildren = false;
     node.visitChildren((SemanticsNode child) {

--- a/packages/flutter/lib/src/widgets/accessibility_inspector.dart
+++ b/packages/flutter/lib/src/widgets/accessibility_inspector.dart
@@ -77,8 +77,12 @@ class AccessibilityInspector {
       return <String, Object?>{'error': 'rootSemanticsNode is null', 'needsFrame': true};
     }
 
+    // The violations are displayed in Devtool.
+    // TODO(hangyujin): If we add a "target platforms" option on the devtool side,
+    // we can display violations for both iOS/android standards
+    // regardless of the testing device platform.
     final Size minSize = switch (defaultTargetPlatform) {
-      TargetPlatform.android || TargetPlatform.fuchsia => const Size(48.0, 48.0),
+      TargetPlatform.android  => const Size(48.0, 48.0),
       TargetPlatform.iOS || TargetPlatform.macOS => const Size(44.0, 44.0),
       _ => const Size(48.0, 48.0),
     };

--- a/packages/flutter/lib/src/widgets/accessibility_inspector.dart
+++ b/packages/flutter/lib/src/widgets/accessibility_inspector.dart
@@ -66,7 +66,7 @@ class AccessibilityInspector {
       return <String, Object?>{'error': 'Semantics not enabled.'};
     }
     final RenderView? renderView = _findRenderView();
-    final PipelineOwner? pipelineOwner = renderView?.owner ?? _findPipelineOwner();
+    final PipelineOwner? pipelineOwner = renderView?.owner;
     final SemanticsOwner? semanticsOwner = pipelineOwner?.semanticsOwner;
     if (semanticsOwner == null) {
       return <String, Object?>{'error': 'No PipelineOwner with SemanticsOwner found'};

--- a/packages/flutter/lib/src/widgets/accessibility_inspector.dart
+++ b/packages/flutter/lib/src/widgets/accessibility_inspector.dart
@@ -92,7 +92,7 @@ class AccessibilityInspector {
     if (renderView != null) {
       final List<Violation> tapTargetViolations = MinimumTapTargetEvaluation(
         size: minSize,
-      ).traverse(renderView.flutterView, root);
+      ).traverse(root, view: renderView.flutterView);
       for (final violation in tapTargetViolations) {
         nodeIssues.putIfAbsent(violation.node.id, () => <Map<String, Object?>>[]).add(
           <String, Object?>{'rule': 'tapTargetSize', 'description': violation.reason},
@@ -128,7 +128,7 @@ class AccessibilityInspector {
       }
 
       nodes[node.id.toString()] = <String, Object?>{
-        ...node.toJson(),
+        'node': node.toJson(),
         'issues': nodeIssues[node.id] ?? <Map<String, Object?>>[],
       };
 
@@ -151,7 +151,7 @@ class AccessibilityInspector {
     return <String, Object?>{'data': nodes};
   }
 
-  // TODO(hannah-hyj): This returns the first RenderView with a SemanticsOwner.
+  // TODO(hannah-hyj): https://github.com/flutter/devtools/issues/9991 - This returns the first RenderView with a SemanticsOwner.
   // This getSemanticsTree feature is used in DevTools, which currently only supports
   // single-view inspection. Add multi-view support when DevTools needs it.
   RenderView? _findRenderView() {

--- a/packages/flutter/lib/src/widgets/accessibility_inspector.dart
+++ b/packages/flutter/lib/src/widgets/accessibility_inspector.dart
@@ -68,7 +68,7 @@ class AccessibilityInspector {
     final RenderView? renderView = _findRenderView();
     final PipelineOwner? pipelineOwner = renderView?.owner;
     final SemanticsOwner? semanticsOwner = pipelineOwner?.semanticsOwner;
-    if (semanticsOwner == null) {
+    if (renderView == null || semanticsOwner == null) {
       return <String, Object?>{'error': 'No PipelineOwner with SemanticsOwner found'};
     }
     final SemanticsNode? root = semanticsOwner.rootSemanticsNode;
@@ -89,19 +89,18 @@ class AccessibilityInspector {
 
     final nodeIssues = <int, List<Map<String, Object?>>>{};
 
-    if (renderView != null) {
-      final List<Violation> tapTargetViolations = MinimumTapTargetEvaluation(
-        size: minSize,
-      ).traverse(root, view: renderView.flutterView);
-      for (final violation in tapTargetViolations) {
-        nodeIssues.putIfAbsent(violation.node.id, () => <Map<String, Object?>>[]).add(
-          <String, Object?>{'rule': 'tapTargetSize', 'description': violation.reason},
-        );
-      }
+    final List<Violation> tapTargetViolations = MinimumTapTargetEvaluation(
+      size: minSize,
+    ).traverse(root, view: renderView.flutterView);
+    for (final violation in tapTargetViolations) {
+      nodeIssues.putIfAbsent(violation.node.id, () => <Map<String, Object?>>[]).add(
+        <String, Object?>{'rule': 'tapTargetSize', 'description': violation.reason},
+      );
     }
 
     final List<Violation> labeledTapTargetViolations = const LabeledTapTargetEvaluation().traverse(
       root,
+      view: renderView.flutterView,
     );
     for (final violation in labeledTapTargetViolations) {
       nodeIssues.putIfAbsent(violation.node.id, () => <Map<String, Object?>>[]).add(
@@ -111,6 +110,7 @@ class AccessibilityInspector {
 
     final List<Violation> unlabeledLeafViolations = const UnlabeledLeafNodeEvaluation().traverse(
       root,
+      view: renderView.flutterView,
     );
     for (final violation in unlabeledLeafViolations) {
       nodeIssues.putIfAbsent(violation.node.id, () => <Map<String, Object?>>[]).add(

--- a/packages/flutter/lib/src/widgets/accessibility_inspector.dart
+++ b/packages/flutter/lib/src/widgets/accessibility_inspector.dart
@@ -78,11 +78,11 @@ class AccessibilityInspector {
     }
 
     // The violations are displayed in Devtool.
-    // TODO(hangyujin): If we add a "target platforms" option on the devtool side,
+    // TODO(hannah-hyj): If we add a "target platforms" option on the devtool side,
     // we can display violations for both iOS/android standards
     // regardless of the testing device platform.
     final Size minSize = switch (defaultTargetPlatform) {
-      TargetPlatform.android  => const Size(48.0, 48.0),
+      TargetPlatform.android => const Size(48.0, 48.0),
       TargetPlatform.iOS || TargetPlatform.macOS => const Size(44.0, 44.0),
       _ => const Size(48.0, 48.0),
     };
@@ -151,22 +151,9 @@ class AccessibilityInspector {
     return <String, Object?>{'data': nodes};
   }
 
-  // TODO(hannahjin): This returns the first SemanticsOwner of any RenderView.
+  // TODO(hannah-hyj): This returns the first RenderView with a SemanticsOwner.
   // This getSemanticsTree feature is used in DevTools, which currently only supports
   // single-view inspection. Add multi-view support when DevTools needs it.
-  PipelineOwner? _findPipelineOwner() {
-    for (final RenderView renderView in RendererBinding.instance.renderViews) {
-      if (renderView.owner?.semanticsOwner != null) {
-        return renderView.owner;
-      }
-    }
-    final PipelineOwner deprecatedOwner = RendererBinding.instance.pipelineOwner;
-    if (deprecatedOwner.semanticsOwner != null) {
-      return deprecatedOwner;
-    }
-    return null;
-  }
-
   RenderView? _findRenderView() {
     for (final RenderView renderView in RendererBinding.instance.renderViews) {
       if (renderView.owner?.semanticsOwner != null) {

--- a/packages/flutter/lib/src/widgets/accessibility_inspector.dart
+++ b/packages/flutter/lib/src/widgets/accessibility_inspector.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
+import '_accessibility_evaluations.dart';
 import 'service_extensions.dart';
 
 /// Service that handles accessibility and semantics inspection.
@@ -64,7 +65,8 @@ class AccessibilityInspector {
     if (!SemanticsBinding.instance.semanticsEnabled) {
       return <String, Object?>{'error': 'Semantics not enabled.'};
     }
-    final PipelineOwner? pipelineOwner = _findPipelineOwner();
+    final RenderView? renderView = _findRenderView();
+    final PipelineOwner? pipelineOwner = renderView?.owner ?? _findPipelineOwner();
     final SemanticsOwner? semanticsOwner = pipelineOwner?.semanticsOwner;
     if (semanticsOwner == null) {
       return <String, Object?>{'error': 'No PipelineOwner with SemanticsOwner found'};
@@ -75,6 +77,41 @@ class AccessibilityInspector {
       return <String, Object?>{'error': 'rootSemanticsNode is null', 'needsFrame': true};
     }
 
+    final Size minSize = switch (defaultTargetPlatform) {
+      TargetPlatform.android || TargetPlatform.fuchsia => const Size(48.0, 48.0),
+      TargetPlatform.iOS || TargetPlatform.macOS => const Size(44.0, 44.0),
+      _ => const Size(48.0, 48.0),
+    };
+
+    final nodeIssues = <int, List<Map<String, Object?>>>{};
+
+    if (renderView != null) {
+      final List<Violation> tapTargetViolations = MinimumTapTargetEvaluation(
+        size: minSize,
+      ).traverse(renderView.flutterView, root);
+      for (final violation in tapTargetViolations) {
+        nodeIssues.putIfAbsent(violation.node.id, () => <Map<String, Object?>>[]).add(
+          <String, Object?>{'rule': 'tapTargetSize', 'description': violation.reason},
+        );
+      }
+    }
+
+    final List<Violation> labeledViolations = const LabeledTapTargetEvaluation().traverse(root);
+    for (final violation in labeledViolations) {
+      nodeIssues.putIfAbsent(violation.node.id, () => <Map<String, Object?>>[]).add(
+        <String, Object?>{'rule': 'missingLabel', 'description': violation.reason},
+      );
+    }
+
+    final List<Violation> unlabeledLeafViolations = const UnlabeledLeafNodeEvaluation().traverse(
+      root,
+    );
+    for (final violation in unlabeledLeafViolations) {
+      nodeIssues.putIfAbsent(violation.node.id, () => <Map<String, Object?>>[]).add(
+        <String, Object?>{'rule': 'unlabeledLeafNode', 'description': violation.reason},
+      );
+    }
+
     final nodes = <String, Object?>{};
     final visited = <int>{};
     final queue = <SemanticsNode>[root];
@@ -83,7 +120,12 @@ class AccessibilityInspector {
       if (!visited.add(node.id)) {
         continue;
       }
-      nodes[node.id.toString()] = node.toJson();
+
+      nodes[node.id.toString()] = <String, Object?>{
+        ...node.toJson(),
+        'issues': nodeIssues[node.id] ?? <Map<String, Object?>>[],
+      };
+
       for (final SemanticsNode child in node.debugListChildrenInOrder(
         DebugSemanticsDumpOrder.traversalOrder,
       )) {
@@ -115,6 +157,15 @@ class AccessibilityInspector {
     final PipelineOwner deprecatedOwner = RendererBinding.instance.pipelineOwner;
     if (deprecatedOwner.semanticsOwner != null) {
       return deprecatedOwner;
+    }
+    return null;
+  }
+
+  RenderView? _findRenderView() {
+    for (final RenderView renderView in RendererBinding.instance.renderViews) {
+      if (renderView.owner?.semanticsOwner != null) {
+        return renderView;
+      }
     }
     return null;
   }

--- a/packages/flutter/lib/src/widgets/accessibility_inspector.dart
+++ b/packages/flutter/lib/src/widgets/accessibility_inspector.dart
@@ -96,8 +96,10 @@ class AccessibilityInspector {
       }
     }
 
-    final List<Violation> labeledViolations = const LabeledTapTargetEvaluation().traverse(root);
-    for (final violation in labeledViolations) {
+    final List<Violation> labeledTapTargetViolations = const LabeledTapTargetEvaluation().traverse(
+      root,
+    );
+    for (final violation in labeledTapTargetViolations) {
       nodeIssues.putIfAbsent(violation.node.id, () => <Map<String, Object?>>[]).add(
         <String, Object?>{'rule': 'missingLabel', 'description': violation.reason},
       );

--- a/packages/flutter/test/widgets/accessibility_evaluations_service_extension_test.dart
+++ b/packages/flutter/test/widgets/accessibility_evaluations_service_extension_test.dart
@@ -103,15 +103,16 @@ void main() {
       );
 
       // Run LabeledTapTargetEvaluation
-      final Map<String, Object?> labeledResult = await _runEvaluation(tester, <String, String>{
-        'type': 'LabeledTapTargetEvaluation',
-      });
+      final Map<String, Object?> labeledTapTargetResult = await _runEvaluation(
+        tester,
+        <String, String>{'type': 'LabeledTapTargetEvaluation'},
+      );
 
-      expect(labeledResult.keys, contains('result'));
-      final labeledViolations = labeledResult['result']! as List<Object?>;
-      expect(labeledViolations, isNotEmpty);
+      expect(labeledTapTargetResult.keys, contains('result'));
+      final labeledTapTargetViolations = labeledTapTargetResult['result']! as List<Object?>;
+      expect(labeledTapTargetViolations, isNotEmpty);
       expect(
-        labeledViolations.any(
+        labeledTapTargetViolations.any(
           (Object? v) => (v! as Map<String, Object?>)['message'].toString().contains(
             'expected tappable node to have semantic label',
           ),
@@ -196,10 +197,11 @@ void main() {
     expect(tapTargetResult['result'], isEmpty);
 
     // Run LabeledTapTargetEvaluation
-    final Map<String, Object?> labeledResult = await _runEvaluation(tester, <String, String>{
-      'type': 'LabeledTapTargetEvaluation',
-    });
-    expect(labeledResult['result'], isEmpty);
+    final Map<String, Object?> labeledTapTargetResult = await _runEvaluation(
+      tester,
+      <String, String>{'type': 'LabeledTapTargetEvaluation'},
+    );
+    expect(labeledTapTargetResult['result'], isEmpty);
 
     // Run MinimumTextContrastEvaluation
     final Map<String, Object?> contrastResult = await _runEvaluation(tester, <String, String>{

--- a/packages/flutter/test/widgets/accessibility_inspector_test.dart
+++ b/packages/flutter/test/widgets/accessibility_inspector_test.dart
@@ -103,7 +103,8 @@ void main() {
 
     Map<String, Object?> findNodeWithLabel(Map<String, Object?> nodes, String label) {
       for (final Object? value in nodes.values) {
-        final node = value! as Map<String, Object?>;
+        final entry = value! as Map<String, Object?>;
+        final node = entry['node']! as Map<String, Object?>;
         if ((node['label']! as String).contains(label)) {
           return node;
         }
@@ -144,10 +145,11 @@ void main() {
       containsAll(<Object?>[child1['id'], child2['id'], child3['id']]),
     );
 
-    // Verify issues list is present on all nodes.
+    // Verify issues list and node object are present on all entries.
     for (final Object? value in nodes.values) {
-      final node = value! as Map<String, Object?>;
-      expect(node['issues'], isA<List<Object?>>());
+      final entry = value! as Map<String, Object?>;
+      expect(entry['node'], isA<Map<String, Object?>>());
+      expect(entry['issues'], isA<List<Object?>>());
     }
 
     // Calling disposeSemantics succeeds and cleans up semantics handle.
@@ -246,7 +248,9 @@ void main() {
     expect(tapTargetNodes, isNotEmpty);
     expect(missingLabelNodes, isNotEmpty);
     // The small unlabeled tap target node should contain multiple issues.
-    expect(tapTargetNodes.first['id'], missingLabelNodes.first['id']);
+    final tapTargetNode = tapTargetNodes.first['node']! as Map<String, Object?>;
+    final missingLabelNode = missingLabelNodes.first['node']! as Map<String, Object?>;
+    expect(tapTargetNode['id'], missingLabelNode['id']);
     final List<Map<String, Object?>> multiIssueList =
         (tapTargetNodes.first['issues']! as List<Object?>).cast<Map<String, Object?>>();
     expect(
@@ -282,7 +286,8 @@ void main() {
     final Map<String, Object?> accessibleButton = nodes.values
         .map((Object? v) => v! as Map<String, Object?>)
         .firstWhere(
-          (Map<String, Object?> node) => (node['label'] as String?) == 'Accessible Button',
+          (Map<String, Object?> node) =>
+              (node['node']! as Map<String, Object?>)['label'] == 'Accessible Button',
         );
     expect(accessibleButton['issues']! as List<Object?>, isEmpty);
 

--- a/packages/flutter/test/widgets/accessibility_inspector_test.dart
+++ b/packages/flutter/test/widgets/accessibility_inspector_test.dart
@@ -244,12 +244,21 @@ void main() {
     }
 
     expect(tapTargetNodes, isNotEmpty);
+    expect(missingLabelNodes, isNotEmpty);
+    // The small unlabeled tap target node should contain multiple issues.
+    expect(tapTargetNodes.first['id'], missingLabelNodes.first['id']);
+    final List<Map<String, Object?>> multiIssueList =
+        (tapTargetNodes.first['issues']! as List<Object?>).cast<Map<String, Object?>>();
+    expect(
+      multiIssueList.map((Map<String, Object?> issue) => issue['rule']),
+      containsAll(<String>['tapTargetSize', 'missingLabel', 'unlabeledLeafNode']),
+    );
+
     final Map<String, Object?> tapTargetIssue = (tapTargetNodes.first['issues']! as List<Object?>)
         .cast<Map<String, Object?>>()
         .firstWhere((Map<String, Object?> issue) => issue['rule'] == 'tapTargetSize');
     expect(tapTargetIssue['description'], contains('expected tap target size'));
 
-    expect(missingLabelNodes, isNotEmpty);
     final Map<String, Object?> missingLabelIssue =
         (missingLabelNodes.first['issues']! as List<Object?>)
             .cast<Map<String, Object?>>()

--- a/packages/flutter/test/widgets/accessibility_inspector_test.dart
+++ b/packages/flutter/test/widgets/accessibility_inspector_test.dart
@@ -144,6 +144,12 @@ void main() {
       containsAll(<Object?>[child1['id'], child2['id'], child3['id']]),
     );
 
+    // Verify issues list is present on all nodes.
+    for (final Object? value in nodes.values) {
+      final node = value! as Map<String, Object?>;
+      expect(node['issues'], isA<List<Object?>>());
+    }
+
     // Calling disposeSemantics succeeds and cleans up semantics handle.
     // Ensure the returned map is mutable.
     final Map<String, Object?> disposeResult =
@@ -153,6 +159,125 @@ void main() {
     expect(disposeResult, isEmpty);
     expect(() => disposeResult['type'] = '_extensionType', returnsNormally);
 
+    AccessibilityInspector.instance.resetAllState();
+  }, semanticsEnabled: false);
+
+  testWidgets('ext.flutter.accessibility.getSemanticsTree detects accessibility issues', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Padding(
+          padding: const EdgeInsets.all(50.0),
+          child: Column(
+            children: <Widget>[
+              // Small tap target without a label.
+              SizedBox(
+                width: 20.0,
+                height: 20.0,
+                child: Semantics(onTap: () {}, child: const SizedBox(width: 20.0, height: 20.0)),
+              ),
+              // Unlabeled image.
+              Semantics(image: true, child: const SizedBox(width: 50.0, height: 50.0)),
+              // Accessible button with sufficient size and label.
+              SizedBox(
+                width: 48.0,
+                height: 48.0,
+                child: Semantics(
+                  button: true,
+                  label: 'Accessible Button',
+                  onTap: () {},
+                  child: const SizedBox(width: 48.0, height: 48.0),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final accessibilityExtensions = <String, ServiceExtensionCallback>{};
+    AccessibilityInspector.instance.initServiceExtensions(({
+      required String name,
+      required ServiceExtensionCallback callback,
+    }) {
+      accessibilityExtensions[name] = callback;
+    });
+
+    Future<Map<String, Object?>> callExtension(String name) async {
+      return json.decode(
+            json.encode(await accessibilityExtensions[name]!(const <String, String>{})),
+          )
+          as Map<String, Object?>;
+    }
+
+    await callExtension(AccessibilityServiceExtensions.enableSemantics.extensionName);
+    await tester.pump();
+
+    final Map<String, Object?> result = await callExtension(
+      AccessibilityServiceExtensions.getSemanticsTree.extensionName,
+    );
+
+    expect(result['error'], isNull);
+    final nodes = result['data']! as Map<String, Object?>;
+
+    // Find node with tapTargetSize issue.
+    final tapTargetNodes = <Map<String, Object?>>[];
+    final missingLabelNodes = <Map<String, Object?>>[];
+    final unlabeledImageNodes = <Map<String, Object?>>[];
+
+    for (final Object? value in nodes.values) {
+      final node = value! as Map<String, Object?>;
+      final List<Map<String, Object?>> issues = (node['issues']! as List<Object?>)
+          .cast<Map<String, Object?>>();
+      for (final issue in issues) {
+        switch (issue['rule'] as String?) {
+          case 'tapTargetSize':
+            tapTargetNodes.add(node);
+          case 'missingLabel':
+            missingLabelNodes.add(node);
+          case 'unlabeledLeafNode':
+            unlabeledImageNodes.add(node);
+        }
+      }
+    }
+
+    expect(tapTargetNodes, isNotEmpty);
+    final Map<String, Object?> tapTargetIssue = (tapTargetNodes.first['issues']! as List<Object?>)
+        .cast<Map<String, Object?>>()
+        .firstWhere((Map<String, Object?> issue) => issue['rule'] == 'tapTargetSize');
+    expect(tapTargetIssue['description'], contains('expected tap target size'));
+
+    expect(missingLabelNodes, isNotEmpty);
+    final Map<String, Object?> missingLabelIssue =
+        (missingLabelNodes.first['issues']! as List<Object?>)
+            .cast<Map<String, Object?>>()
+            .firstWhere((Map<String, Object?> issue) => issue['rule'] == 'missingLabel');
+    expect(
+      missingLabelIssue['description'],
+      contains('expected tappable node to have semantic label'),
+    );
+
+    expect(unlabeledImageNodes, isNotEmpty);
+    final Map<String, Object?> unlabeledImageIssue =
+        (unlabeledImageNodes.first['issues']! as List<Object?>)
+            .cast<Map<String, Object?>>()
+            .firstWhere((Map<String, Object?> issue) => issue['rule'] == 'unlabeledLeafNode');
+    expect(
+      unlabeledImageIssue['description'],
+      contains('expected leaf semantics node to have a label, value, hint, or tooltip'),
+    );
+
+    // Check accessible button has no issues.
+    final Map<String, Object?> accessibleButton = nodes.values
+        .map((Object? v) => v! as Map<String, Object?>)
+        .firstWhere(
+          (Map<String, Object?> node) => (node['label'] as String?) == 'Accessible Button',
+        );
+    expect(accessibleButton['issues']! as List<Object?>, isEmpty);
+
+    await callExtension(AccessibilityServiceExtensions.disposeSemantics.extensionName);
     AccessibilityInspector.instance.resetAllState();
   }, semanticsEnabled: false);
 }


### PR DESCRIPTION
Make the traverse function in [_accessibility_evaluations.dart] public.
Add violations in a11y inspector.

tracking issue: https://github.com/flutter/devtools/issues/9893



## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
