### PR TITLE
[CP-stable] Fix Actions.handler to forward the intent type to maybeFind (#191052)

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -809,7 +809,7 @@ class Actions extends StatefulWidget {
   /// returned callback is called. If the return value is needed, consider using
   /// [Actions.invoke] instead.
   static VoidCallback? handler<T extends Intent>(BuildContext context, T intent) {
-    final Action<Intent>? action = Actions.maybeFind(context);
+    final Action<Intent>? action = Actions.maybeFind<T>(context, intent: intent);
     if (action != null && action._isEnabled(intent, context)) {
       return () {
         // Could be that the action was enabled when the closure was created,

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -317,6 +317,64 @@ void main() {
       expect(Actions.maybeFind<DoNothingIntent>(containerKey.currentContext!), isNull);
     });
 
+    testWidgets('Actions.handler forwards the intent type and finds the bound action', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/191045.
+      final GlobalKey containerKey = GlobalKey();
+      var invoked = false;
+      final testAction = TestAction(
+        onInvoke: (Intent intent) {
+          invoked = true;
+          return invoked;
+        },
+      );
+      await tester.pumpWidget(
+        Actions(
+          actions: <Type, Action<Intent>>{TestIntent: testAction},
+          child: Container(key: containerKey),
+        ),
+      );
+
+      final VoidCallback? handler = Actions.handler(
+        containerKey.currentContext!,
+        const TestIntent(),
+      );
+      expect(handler, isNotNull);
+
+      handler!();
+      expect(invoked, isTrue);
+    });
+
+    testWidgets('Actions.handler returns null when the action is disabled', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey containerKey = GlobalKey();
+      final testAction = TestAction(onInvoke: (Intent intent) => null)..enabled = false;
+      await tester.pumpWidget(
+        Actions(
+          actions: <Type, Action<Intent>>{TestIntent: testAction},
+          child: Container(key: containerKey),
+        ),
+      );
+
+      expect(Actions.handler(containerKey.currentContext!, const TestIntent()), isNull);
+    });
+
+    testWidgets('Actions.handler returns null when no matching action is found', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey containerKey = GlobalKey();
+      await tester.pumpWidget(
+        Actions(
+          actions: const <Type, Action<Intent>>{},
+          child: Container(key: containerKey),
+        ),
+      );
+
+      expect(Actions.handler(containerKey.currentContext!, const TestIntent()), isNull);
+    });
+
     testWidgets('FocusableActionDetector keeps track of focus and hover even when disabled.', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
Cherry pick of #191052 (addresses #191045)

- Impacted Users (Approximately who will hit this issue, ex. all Flutter devs, Windows developers, all end-customers, apps using X framework feature).

All end customers

- Impact Description (What is the impact? ex. visual jank on Samsung phones, app crash, cannot ship an iOS app. Does it impact development? ex. flutter doctor crashes when Android Studio is installed. Or shipping a production app? ex. the app crashes on launch).

Action handlers are mistakenly never enabled

- Workaround (Is there a workaround for this issue?)

End users would need to reimplement `Actions.handler` and `Action._isEnabled`, or switch to master/main channel, or revert to 3.44

- Risk (What is the risk level of this cherry-pick?)

Low?

- Test Coverage (Are you confident that your fix is well-tested by automated tests?)

Unit tests cover regression

- Validation Steps (What are the steps to validate that this fix works?)

Compare use of `Actions.handler` on Flutter 3.47 (broken) vs 3.44