### PR TITLE
Fix RawAutocomplete reopening options after Escape during async build

### DIFF
--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -471,6 +471,9 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   // situation where _options is updated by an older call when multiple
   // _onChangedField calls are running simultaneously.
   int _onChangedCallId = 0;
+  // Bumped when the user dismisses the options (e.g. with Escape), so a slow
+  // optionsBuilder call that finishes afterward doesn't reopen the view.
+  int _hideCallId = 0;
   // Called when _textEditingController changes.
   Future<void> _onChangedField() async {
     // During a selection, changes to the field text should not trigger
@@ -488,6 +491,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
     }
     _lastFieldText = value.text;
     final int callId = _onChangedCallId;
+    final int hideId = _hideCallId;
     final Iterable<T> options = await widget.optionsBuilder(value);
 
     if (!mounted) {
@@ -508,6 +512,11 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
       _selection = null;
     }
 
+    // The user dismissed the options while this call was pending, so don't
+    // reopen them.
+    if (hideId != _hideCallId) {
+      return;
+    }
     _updateOptionsViewVisibility();
   }
 
@@ -575,6 +584,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
 
   Object? _hideOptions(DismissIntent intent) {
     if (_optionsViewController.isShowing) {
+      _hideCallId += 1;
       _optionsViewController.hide();
       return null;
     } else {

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -52,6 +52,61 @@ void main() {
     User(name: 'Charlie', email: 'charlie123@gmail.com'),
   ];
 
+  testWidgets('options stay hidden after Escape when a pending async optionsBuilder completes', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/191928.
+    // Escape during a pending async optionsBuilder should keep the options
+    // hidden when that build later completes.
+    final GlobalKey optionsKey = GlobalKey();
+    late FocusNode focusNode;
+    late TextEditingController controller;
+
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: RawAutocomplete<String>(
+          optionsBuilder: (TextEditingValue value) async {
+            await Future<void>.delayed(const Duration(seconds: 1));
+            return kOptions.where((String option) => option.contains(value.text.toLowerCase()));
+          },
+          fieldViewBuilder: (context, fieldController, fieldFocusNode, onFieldSubmitted) {
+            focusNode = fieldFocusNode;
+            controller = fieldController;
+            return TestTextField(focusNode: focusNode, controller: controller);
+          },
+          optionsViewBuilder: (context, onSelected, options) => Container(key: optionsKey),
+        ),
+      ),
+    );
+
+    // Type once and let the build complete so the options view is shown.
+    focusNode.requestFocus();
+    controller.value = const TextEditingValue(
+      text: 'e',
+      selection: TextSelection.collapsed(offset: 1),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byKey(optionsKey), findsOneWidget);
+
+    // Type again to start a new build. It is still pending, so the view stays.
+    controller.value = const TextEditingValue(
+      text: 'el',
+      selection: TextSelection.collapsed(offset: 2),
+    );
+    await tester.pump();
+    expect(find.byKey(optionsKey), findsOneWidget);
+
+    // Press Escape before the pending build completes. The view hides.
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+    expect(find.byKey(optionsKey), findsNothing);
+
+    // The pending build completes. The view must stay hidden.
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byKey(optionsKey), findsNothing);
+  });
+
   testWidgets('can filter and select a list of string options', (WidgetTester tester) async {
     final GlobalKey fieldKey = GlobalKey();
     final GlobalKey optionsKey = GlobalKey();


### PR DESCRIPTION
## Description

Fixes a race in `RawAutocomplete`: pressing Escape to dismiss the options view does not stick when an async `optionsBuilder` call is still in flight. When that pending call resolves, the view reopens, overriding the user's more recent dismissal.

`RawAutocomplete` already guards `_options` against stale results from concurrent text changes with an incrementing `_onChangedCallId`, but there was no equivalent guard for the user dismissing the view during the async gap. This change adds a `_hideCallId` counter that is incremented whenever the options view is dismissed (for example by Escape). `_onChangedField` captures the counter before its `await` and bails out if it changed by the time the call resolves, so a slow options build can no longer reopen a view the user has since dismissed.

This matches the expected behavior from the issue: after Escape, the view stays hidden until the text is edited, the field is re-focused, or an arrow key is pressed. Those reveal paths are untouched, so only the stale async completion is suppressed.

Thanks to @chrisbobbe for the clear report, the diagnosis, and the reproduction. @chrisbobbe mentioned on 2026-08-28 that they planned to send a PR; I did not see one after three days, so I opened this with them credited as a co-author. Happy to defer if they would rather land their own.

## Tests

Adds a regression test in `autocomplete_test.dart`: with an async `optionsBuilder`, it shows the options, starts a new pending build, presses Escape to hide the view, then lets the pending build complete and asserts the view stays hidden. The test fails without the fix and passes with it.

Fixes #191928.

I searched the open pull requests for flutter/flutter and did not find an existing PR addressing this issue before opening this one.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
