### PR TITLE
Fix hardware keyboard paste (Ctrl+V) with TextInputType.none on Android

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1125,6 +1125,25 @@ public class FlutterView extends FrameLayout
 
   // -------- Start: Keyboard -------
 
+  /**
+   * Invoked by Android when the window containing this view gains or loses focus.
+   *
+   * <p>Android tears down the input connection when the app loses window focus (e.g. when the app
+   * is backgrounded), but the framework is unaware of this: it still considers its input connection
+   * to be active and will not call TextInput.show again when the window regains focus. Forward
+   * window focus changes to the {@link TextInputPlugin} so that it can re-establish the input
+   * connection if necessary.
+   *
+   * <p>See https://github.com/flutter/flutter/issues/182941.
+   */
+  @Override
+  public void onWindowFocusChanged(boolean hasFocus) {
+    super.onWindowFocusChanged(hasFocus);
+    if (textInputPlugin != null) {
+      textInputPlugin.onWindowFocusChanged(hasFocus);
+    }
+  }
+
   @Override
   public BinaryMessenger getBinaryMessenger() {
     return flutterEngine.getDartExecutor();

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -187,6 +187,33 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
     return mImm;
   }
 
+  /**
+   * Handles window focus changes for text input.
+   *
+   * <p>Android tears down the input connection when the app loses window focus (e.g. when the app
+   * is backgrounded), but the framework is unaware of this: it still considers its input connection
+   * to be active and will not call TextInput.show again when the window regains focus. Without an
+   * active input connection, Android delivers hardware key events to the IME first (ViewRootImpl's
+   * ImeInputStage), which consumes editor shortcuts such as Ctrl+V, and the framework never
+   * receives the key events.
+   *
+   * <p>When the window regains focus and there is a framework text input client but no active input
+   * connection, request the framework to resend its text input state. This re-attaches the client
+   * and restarts the input connection without showing the soft keyboard.
+   *
+   * <p>See https://github.com/flutter/flutter/issues/182941.
+   */
+  public void onWindowFocusChanged(boolean hasFocus) {
+    if (hasFocus
+        && inputTarget.type == InputTarget.Type.FRAMEWORK_CLIENT
+        && !mImm.isAcceptingText()) {
+      Log.i(
+          TAG,
+          "Window focus regained without an active input connection; re-establishing input connection.");
+      textInputChannel.requestExistingInputState();
+    }
+  }
+
   @VisibleForTesting
   Editable getEditable() {
     return mEditable;
@@ -435,6 +462,16 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
       view.requestFocus();
       mImm.showSoftInput(view, 0);
     } else {
+      // TextInputType.none means "do not show the soft keyboard", not "no text input".
+      // Establish (and focus) the input connection without showing the soft keyboard so
+      // that hardware key events (e.g. Ctrl+V paste from a physical keyboard or a
+      // barcode scanner) are dispatched to an active IME editor. Without an active input
+      // connection, Android's ViewRootImpl delivers hardware key events to the IME first
+      // (ImeInputStage), which consumes editor shortcuts such as Ctrl+V, and the
+      // framework never receives the key events.
+      // See https://github.com/flutter/flutter/issues/182941.
+      view.requestFocus();
+      mImm.restartInput(view);
       hideTextInput(view);
     }
   }

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1569,6 +1569,12 @@ public class TextInputPluginTest {
 
     textInputPlugin.showTextInput(testView);
     assertFalse(testImm.isSoftInputVisible());
+    // The input connection must still be (re)started for TextInputType.none so that
+    // hardware key events (e.g. Ctrl+V paste from a physical keyboard) are dispatched
+    // to an active IME editor. Without it, Android's ViewRootImpl routes hardware key
+    // events to the IME first, which consumes editor shortcuts and the framework never
+    // receives them. See https://github.com/flutter/flutter/issues/182941.
+    assertEquals(1, testImm.getRestartCount(testView));
   }
 
   @Test


### PR DESCRIPTION
## Description

On Android, pasting from a physical keyboard (Ctrl+V, e.g. USB/Bluetooth barcode scanners) does not work in a text field with `TextInputType.none` until the on-screen keyboard has been shown once or a character has been typed. The framework never receives the key events at all.

Two changes in the Android embedder fix this:

1. `TextInputPlugin.showTextInput()` treated `TextInputType.none` as "no text input" instead of "do not show the soft keyboard": it only called `hideTextInput`, without focusing the view or establishing an input connection. Without an active IME editor, Android delivers hardware key events to the IME first (`ViewRootImpl`'s `ImeInputStage`), which consumes editor shortcuts such as Ctrl+V, so the framework never received the key events. For `TextInputType.none`, `showTextInput` now requests focus and calls `restartInput` to establish the input connection without showing the soft keyboard (`hideTextInput` is still called to keep the keyboard hidden).

2. Android tears down the input connection when the app loses window focus, but the framework still considers its input connection active and never calls `TextInput.show` again after the app is resumed, which brought the dead-session state back after backgrounding. `FlutterView` now forwards window focus changes to `TextInputPlugin`; when focus is regained with a text input client attached but no active input session (`!isAcceptingText()`), the plugin asks the framework to resend its input state via the existing `TextInputClient.requestExistingInputState` flow, which re-attaches the client and re-establishes the input connection.

Verified manually on a Pixel 6a (Android 17) with a locally built engine (`android_debug_unopt_arm64`): Ctrl+V from a hardware keyboard pastes immediately on a fresh app with `TextInputType.none` (previously 0 key events reached the framework), the soft keyboard never appears, and paste keeps working after backgrounding/resuming the app.

## Issues

Fixes #182941

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

Note: the updated `TextInputPluginTest` compiles cleanly and the full suite run was
attempted locally but blocked by a stalled Robolectric artifact download; CI will
run it on this PR.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
