### PR TITLE
[web] Defer disposal of stale cached paths to FrameArena

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/primitives/path.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/primitives/path.dart
@@ -673,9 +673,17 @@ class EnginePath implements ui.Path, Collectable {
     return _cachedPath!;
   }
 
+  // Invalidated backend paths that must remain alive until the end of the frame
+  // when [collect] is called by the [FrameArena]. Disposing them immediately
+  // here can cause premature deallocation while recorded display list operations
+  // are being rasterized concurrently on the worker thread.
+  final List<BackendPath> _stalePaths = [];
+
   void _invalidateCachedPath() {
-    _cachedPath?.dispose();
-    _cachedPath = null;
+    if (_cachedPath != null) {
+      _stalePaths.add(_cachedPath!);
+      _cachedPath = null;
+    }
   }
 
   void _addCommand(PathCommand command) {
@@ -875,6 +883,10 @@ class EnginePath implements ui.Path, Collectable {
 
   @override
   void collect() {
+    for (final BackendPath path in _stalePaths) {
+      path.dispose();
+    }
+    _stalePaths.clear();
     _cachedPath?.dispose();
     if (!identical(_cachedBuilder, _cachedPath)) {
       _cachedBuilder?.dispose();

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/primitives/path.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/primitives/path.dart
@@ -677,11 +677,11 @@ class EnginePath implements ui.Path, Collectable {
   // when [collect] is called by the [FrameArena]. Disposing them immediately
   // here can cause premature deallocation while recorded display list operations
   // are being rasterized concurrently on the worker thread.
-  final List<BackendPath> _stalePaths = [];
+  List<BackendPath>? _stalePaths;
 
   void _invalidateCachedPath() {
     if (_cachedPath != null) {
-      _stalePaths.add(_cachedPath!);
+      (_stalePaths ??= <BackendPath>[]).add(_cachedPath!);
       _cachedPath = null;
     }
   }
@@ -883,10 +883,12 @@ class EnginePath implements ui.Path, Collectable {
 
   @override
   void collect() {
-    for (final BackendPath path in _stalePaths) {
-      path.dispose();
+    if (_stalePaths != null) {
+      for (final BackendPath path in _stalePaths!) {
+        path.dispose();
+      }
+      _stalePaths = null;
     }
-    _stalePaths.clear();
     _cachedPath?.dispose();
     if (!identical(_cachedBuilder, _cachedPath)) {
       _cachedBuilder?.dispose();

--- a/engine/src/flutter/lib/web_ui/test/skwasm/concurrent_path_mutation_raster_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/skwasm/concurrent_path_mutation_raster_test.dart
@@ -13,53 +13,31 @@ void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
 
-const int _maxFrames = 10;
-const int _pathsPerFrame = 50;
-
 Future<void> testMain() async {
   setUpUnitTests(withImplicitView: true, setUpTestViewDimensions: false);
 
-  ui.Picture recordPicture(int frame) {
+  ui.Picture recordPicture() {
     final recorder = ui.PictureRecorder();
     final canvas = ui.Canvas(recorder, const ui.Rect.fromLTWH(0, 0, 500, 500));
-    canvas.drawColor(const ui.Color(0xFFFFFFFF), ui.BlendMode.src);
+    final path = ui.Path()..lineTo(100.0, 100.0);
+    final paint = ui.Paint();
 
-    for (var i = 0; i < _pathsPerFrame; i++) {
-      final path = ui.Path();
-      path.moveTo(0, 64.0);
-      path.lineTo(250.0, 0.0);
-      path.lineTo(500.0, 64.0);
-
-      final paint = ui.Paint()
-        ..style = ui.PaintingStyle.stroke
-        ..color = const ui.Color(0xFFFF0000)
-        ..strokeWidth = 1.0;
-
-      canvas.drawPath(path, paint);
-
-      path.close();
-      paint.style = ui.PaintingStyle.fill;
-      paint.color = const ui.Color(0x20FF0000);
-      canvas.drawPath(path, paint);
-    }
+    canvas.drawPath(path, paint);
+    path.close();
+    canvas.drawPath(path, paint);
 
     return recorder.endRecording();
   }
 
-  test('concurrent path mutation and rasterization does not corrupt the heap', () async {
-    for (var frame = 0; frame < _maxFrames; frame++) {
-      final ui.Picture picture = recordPicture(frame);
-      final sceneBuilder = ui.SceneBuilder();
-      sceneBuilder.addPicture(ui.Offset.zero, picture);
+  test('mutating a path after drawing does not crash during rasterization', () async {
+    final sceneBuilder = ui.SceneBuilder()..addPicture(ui.Offset.zero, recordPicture());
+    final Future<void> renderFuture = renderScene(sceneBuilder.build());
+    await Future<void>.delayed(Duration.zero);
 
-      final Future<void> renderFuture = renderScene(sceneBuilder.build());
-      await Future<void>.delayed(Duration.zero);
-
-      // Mutate paths on main thread while raster thread is rendering
-      recordPicture(frame + 1).dispose();
-
-      await renderFuture;
-      picture.dispose();
+    for (var i = 0; i < 5; i++) {
+      recordPicture().dispose();
     }
+
+    await renderFuture;
   });
 }

--- a/engine/src/flutter/lib/web_ui/test/skwasm/concurrent_path_mutation_raster_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/skwasm/concurrent_path_mutation_raster_test.dart
@@ -13,8 +13,7 @@ void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
 
-const int _maxFrames = 200;
-const Duration _maxTestTime = Duration(seconds: 10);
+const int _maxFrames = 10;
 const int _pathsPerFrame = 50;
 
 Future<void> testMain() async {
@@ -48,11 +47,7 @@ Future<void> testMain() async {
   }
 
   test('concurrent path mutation and rasterization does not corrupt the heap', () async {
-    final stopwatch = Stopwatch()..start();
-    var frame = 0;
-    while (frame < _maxFrames && stopwatch.elapsed < _maxTestTime) {
-      frame++;
-
+    for (var frame = 0; frame < _maxFrames; frame++) {
       final ui.Picture picture = recordPicture(frame);
       final sceneBuilder = ui.SceneBuilder();
       sceneBuilder.addPicture(ui.Offset.zero, picture);
@@ -66,7 +61,5 @@ Future<void> testMain() async {
       await renderFuture;
       picture.dispose();
     }
-
-    expect(frame, greaterThan(0));
-  }, timeout: const Timeout(Duration(minutes: 2)));
+  });
 }

--- a/engine/src/flutter/lib/web_ui/test/skwasm/concurrent_path_mutation_raster_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/skwasm/concurrent_path_mutation_raster_test.dart
@@ -1,0 +1,72 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/rendering.dart';
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+const int _maxFrames = 200;
+const Duration _maxTestTime = Duration(seconds: 10);
+const int _pathsPerFrame = 50;
+
+Future<void> testMain() async {
+  setUpUnitTests(withImplicitView: true, setUpTestViewDimensions: false);
+
+  ui.Picture recordPicture(int frame) {
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder, const ui.Rect.fromLTWH(0, 0, 500, 500));
+    canvas.drawColor(const ui.Color(0xFFFFFFFF), ui.BlendMode.src);
+
+    for (var i = 0; i < _pathsPerFrame; i++) {
+      final path = ui.Path();
+      path.moveTo(0, 64.0);
+      path.lineTo(250.0, 0.0);
+      path.lineTo(500.0, 64.0);
+
+      final paint = ui.Paint()
+        ..style = ui.PaintingStyle.stroke
+        ..color = const ui.Color(0xFFFF0000)
+        ..strokeWidth = 1.0;
+
+      canvas.drawPath(path, paint);
+
+      path.close();
+      paint.style = ui.PaintingStyle.fill;
+      paint.color = const ui.Color(0x20FF0000);
+      canvas.drawPath(path, paint);
+    }
+
+    return recorder.endRecording();
+  }
+
+  test('concurrent path mutation and rasterization does not corrupt the heap', () async {
+    final stopwatch = Stopwatch()..start();
+    var frame = 0;
+    while (frame < _maxFrames && stopwatch.elapsed < _maxTestTime) {
+      frame++;
+
+      final ui.Picture picture = recordPicture(frame);
+      final sceneBuilder = ui.SceneBuilder();
+      sceneBuilder.addPicture(ui.Offset.zero, picture);
+
+      final Future<void> renderFuture = renderScene(sceneBuilder.build());
+      await Future<void>.delayed(Duration.zero);
+
+      // Mutate paths on main thread while raster thread is rendering
+      recordPicture(frame + 1).dispose();
+
+      await renderFuture;
+      picture.dispose();
+    }
+
+    expect(frame, greaterThan(0));
+  }, timeout: const Timeout(Duration(minutes: 2)));
+}


### PR DESCRIPTION
When mutating an `EnginePath` after building and drawing it in the same frame, `_invalidateCachedPath()` was prematurely disposing `_cachedPath`.

In multi-threaded WebAssembly (`skwasm`), this eager mid-frame deallocation violated the lifecycle contract of `FrameArena` and caused native allocations to be freed on the main thread while background raster thread operations were deallocating previous display lists in the same linear memory space, leading to heap corruption and `RuntimeError: memory access out of bounds` in `$emscripten_builtin_free`.

This change keeps invalidated `BackendPath` instances in `_stalePaths` until the end of the frame when `FrameArena.collect()` runs.

Fixes #191976

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md