### PR TITLE
Makes snapshots not have mip levels (since they weren't propogated)

### DIFF
--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -2629,6 +2629,53 @@ TEST_F(ShellTest, RasterizerMakeSkiaSnapshot) {
   DestroyShell(std::move(shell), task_runners);
 }
 
+TEST_F(ShellTest, RasterizerMakeImpellerSnapshotDoesNotGenerateMipmaps) {
+#if !SHELL_ENABLE_METAL
+  // This test uses the Metal backend.
+  GTEST_SKIP();
+#else
+  Settings settings = CreateSettingsForFixture();
+  settings.enable_impeller = true;
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  auto task_runner = CreateNewThread();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .task_runners = task_runners,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .rendering_backend =
+              ShellTestPlatformView::BackendType::kMetalBackend,
+      }),
+  });
+
+  ASSERT_TRUE(ValidateShell(shell.get()));
+  PlatformViewNotifyCreated(shell.get());
+
+  RunEngine(shell.get(), std::move(configuration));
+
+  auto latch = std::make_shared<fml::AutoResetWaitableEvent>();
+
+  PumpOneFrame(shell.get());
+
+  fml::TaskRunner::RunNowOrPostTask(
+      shell->GetTaskRunners().GetRasterTaskRunner(), [&shell, &latch]() {
+        SnapshotDelegate* delegate =
+            reinterpret_cast<Rasterizer*>(shell->GetRasterizer().get());
+        std::shared_ptr<impeller::Texture> texture =
+            delegate->MakeImpellerSnapshotSync(MakeSizedDisplayList(50, 50),
+                                               DlISize(50, 50),
+                                               SnapshotPixelFormat::kDontCare);
+        ASSERT_NE(texture, nullptr);
+        EXPECT_EQ(texture->GetTextureDescriptor().mip_count, 1u);
+
+        latch->Signal();
+      });
+  latch->Wait();
+  DestroyShell(std::move(shell), task_runners);
+#endif  // !SHELL_ENABLE_METAL
+}
+
 TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
   Settings settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell(settings);

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -2666,8 +2666,10 @@ TEST_F(ShellTest, RasterizerMakeImpellerSnapshotDoesNotGenerateMipmaps) {
             delegate->MakeImpellerSnapshotSync(MakeSizedDisplayList(50, 50),
                                                DlISize(50, 50),
                                                SnapshotPixelFormat::kDontCare);
-        ASSERT_NE(texture, nullptr);
-        EXPECT_EQ(texture->GetTextureDescriptor().mip_count, 1u);
+        EXPECT_NE(texture, nullptr);
+        if (texture != nullptr) {
+          EXPECT_EQ(texture->GetTextureDescriptor().mip_count, 1u);
+        }
 
         latch->Signal();
       });

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -2660,8 +2660,7 @@ TEST_F(ShellTest, RasterizerMakeImpellerSnapshotDoesNotGenerateMipmaps) {
 
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetRasterTaskRunner(), [&shell, &latch]() {
-        SnapshotDelegate* delegate =
-            reinterpret_cast<Rasterizer*>(shell->GetRasterizer().get());
+        SnapshotDelegate* delegate = shell->GetRasterizer().get();
         std::shared_ptr<impeller::Texture> texture =
             delegate->MakeImpellerSnapshotSync(MakeSizedDisplayList(50, 50),
                                                DlISize(50, 50),

--- a/engine/src/flutter/shell/common/snapshot_controller_impeller.cc
+++ b/engine/src/flutter/shell/common/snapshot_controller_impeller.cc
@@ -64,7 +64,7 @@ std::shared_ptr<impeller::Texture> DoMakeRasterSnapshot(
   return impeller::DisplayListToTexture(
       display_list, render_target_size, *context,
       /*reset_host_buffer=*/false,
-      /*generate_mips=*/true, impeller_pixel_format);
+      /*generate_mips=*/false, impeller_pixel_format);
 }
 
 std::shared_ptr<impeller::Texture> DoMakeRasterSnapshot(


### PR DESCRIPTION
Previously snapshots would contain 12 mips layers, but it was seen that the mips layers were never propagated so it's a waste of space best case scenario, a render bug worst case.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
