### PR TITLE
Disable impeller shader optimization to avoid segfault on Vivante driver in Linux

### DIFF
--- a/engine/src/flutter/impeller/compiler/compiler.cc
+++ b/engine/src/flutter/impeller/compiler/compiler.cc
@@ -472,6 +472,20 @@ Compiler::Compiler(const std::shared_ptr<const fml::Mapping>& source_mapping,
         spirv_options.macro_definitions.push_back("IMPELLER_GRAPHICS_BACKEND");
         spirv_options.relaxed_vulkan_rules = true;
       }
+
+      // When optimization is enabled, loop-carried phi merges are sunk into the
+      // SPIR-V continue block. SPIRV-Cross cannot fold those back into a for
+      // increment, so it emits `for (int i = 0; i < n; ) { ...; i++; continue;
+      // }` instead. Vivante's shader compiler (libVSC.so) segfaults inside
+      // glLinkProgram on that form, taking down the whole process. Building
+      // GLES shaders unoptimized keeps the loops in their `for (...; i++)`
+      // form, which the driver handles. Same class of problem the SkSL target
+      // works around below.
+      if (source_options.target_platform == TargetPlatform::kOpenGLES) {
+        spirv_options.optimization_level =
+            shaderc_optimization_level::shaderc_optimization_level_zero;
+      }
+
       spirv_options.target = target;
     } break;
     case TargetPlatform::kRuntimeStageMetal:
@@ -493,6 +507,10 @@ Compiler::Compiler(const std::shared_ptr<const fml::Mapping>& source_mapping,
         // Flutter <= 3.44 before the OpenGLES flip was removed.
         spirv_options.macro_definitions.push_back(
             "IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED");
+        // User fragment programs reach the same Vivante link crash as the
+        // built-in GLES shaders; see the kOpenGLES case above.
+        spirv_options.optimization_level =
+            shaderc_optimization_level::shaderc_optimization_level_zero;
       }
     } break;
     case TargetPlatform::kSkSL: {

--- a/engine/src/flutter/impeller/compiler/compiler_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/compiler_unittests.cc
@@ -179,6 +179,62 @@ TEST(CompilerTest, YFlipInjectionForGLESVertexShaders) {
       << mtl_vert;
 }
 
+TEST(CompilerTest, GLESLoopsKeepTheirIncrementClause) {
+  // The Vivante GLES compiler segfaults while linking a loop that SPIRV-Cross
+  // emits as `for (int i = 0; i < 5; ) { ...; i++; continue; }`, which is what
+  // it produces once the optimizer sinks loop-carried phi merges into the
+  // SPIR-V continue block. GLES shaders are therefore built unoptimized; this
+  // guards that. See flutter/flutter#167850.
+  auto compile = [](TargetPlatform platform) -> std::string {
+    std::shared_ptr<fml::Mapping> fixture =
+        flutter::testing::OpenFixtureAsMapping("loop_continue.frag");
+    FML_CHECK(fixture);
+
+    SourceOptions options("loop_continue.frag", SourceType::kFragmentShader);
+    options.source_language = SourceLanguage::kGLSL;
+    options.target_platform = platform;
+    options.working_directory = std::make_shared<fml::UniqueFD>(
+        flutter::testing::OpenFixturesDirectory());
+    options.entry_point_name = "main";
+
+    Reflector::Options reflector_options;
+    reflector_options.target_platform = platform;
+    reflector_options.header_file_name = "loop_continue.h";
+    reflector_options.shader_name = "shader";
+
+    Compiler compiler(fixture, options, reflector_options);
+    if (!compiler.IsValid()) {
+      return "";
+    }
+    auto sl = compiler.GetSLShaderSource();
+    if (!sl || !sl->GetMapping()) {
+      return "";
+    }
+    return std::string(reinterpret_cast<const char*>(sl->GetMapping()),
+                       sl->GetSize());
+  };
+
+  const std::string gl_frag = compile(TargetPlatform::kOpenGLES);
+  ASSERT_FALSE(gl_frag.empty());
+
+  // A `continue;` closing a block is the signature of the crashing form.
+  constexpr std::string_view kContinue = "continue;";
+  for (size_t pos = gl_frag.find(kContinue); pos != std::string::npos;
+       pos = gl_frag.find(kContinue, pos + 1)) {
+    const size_t next =
+        gl_frag.find_first_not_of(" \t\r\n", pos + kContinue.size());
+    EXPECT_TRUE(next == std::string::npos || gl_frag[next] != '}')
+        << "Loop emitted in the form that crashes Vivante:\n"
+        << gl_frag;
+  }
+
+  // The counter must be incremented in the loop header, not the body.
+  EXPECT_NE(gl_frag.find("for ("), std::string::npos) << gl_frag;
+  EXPECT_EQ(gl_frag.find("; )"), std::string::npos)
+      << "Loop has an empty increment clause:\n"
+      << gl_frag;
+}
+
 TEST(CompilerTest, YFlipInjectionHandlesEarlyReturnsInGLESVertexShader) {
   // `y_flip_early_return.vert` has an early `return` before main's implicit
   // exit; the wrap-main injection must flip on both paths.

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -189,6 +189,7 @@ test_fixtures("file_fixtures") {
     "texture_lookup.frag",
     "mat2_test.frag",
     "y_flip_early_return.vert",
+    "loop_continue.frag",
   ]
   if (host_os == "mac") {
     fixtures += [ "/System/Library/Fonts/Apple Color Emoji.ttc" ]

--- a/engine/src/flutter/impeller/fixtures/loop_continue.frag
+++ b/engine/src/flutter/impeller/fixtures/loop_continue.frag
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Fragment shader whose loop SPIRV-Cross cannot fold into a for-increment, so
+// it emits a trailing `continue;` in the loop body. See
+// flutter/flutter#167850.
+
+uniform UniformBufferObject {
+  vec2 size;
+}
+ubo;
+
+in vec2 v_position;
+out vec4 frag_color;
+
+void main() {
+  vec2 p = abs(v_position);
+  vec2 ab = ubo.size;
+  vec2 q = ab * (p - ab);
+  float w = (q.x < q.y) ? 1.570796327 : 0.0;
+  for (int i = 0; i < 5; i++) {
+    vec2 cs = vec2(cos(w), sin(w));
+    vec2 u = ab * cs;
+    vec2 v = ab * vec2(-cs.y, cs.x);
+    w = w + dot(p - u, v) / (dot(p - u, u) + dot(v, v));
+  }
+  frag_color = vec4(vec3(w), 1.0);
+}


### PR DESCRIPTION
Disable impeller shader optimization to avoid segfault on Vivante driver in Linux.
Related to https://github.com/flutter/flutter/issues/167850  

@rekire and @jonahwilliams I found this fix makes Impeller work on Vivante drivers in Linux. I'm not sure if it would work on Android too. Also I can't find a good way of making it part of the general Flutter codebase, so I can propose a PR.  
Any ideas welcomed.  

