### PR TITLE
Add website documentation item to PR pre-launch checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ To learn more about code review, see our documentation on Tree Hygiene: https://
 - [ ] I signed the [CLA].
 - [ ] I listed at least one issue that this PR fixes in the description above.
 - [ ] I updated/added relevant in-code documentation (doc comments with `///`).
-- [ ] If this PR introduces a new feature or capability, I linked a [flutter/website] issue or PR (or verified none is needed).
+- [ ] If this PR introduces a new feature or capability, I linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
 - [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
 - [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
 - [ ] All existing and new tests are passing.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ To learn more about code review, see our documentation on Tree Hygiene: https://
 - [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
 - [ ] I signed the [CLA].
 - [ ] I listed at least one issue that this PR fixes in the description above.
-- [ ] I updated/added relevant documentation (doc comments with `///`).
+- [ ] I updated/added relevant in-code documentation (doc comments with `///`).
 - [ ] If this PR introduces a new feature or capability, I linked a [flutter/website] issue or PR (or verified none is needed).
 - [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
 - [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ To learn more about code review, see our documentation on Tree Hygiene: https://
 - [ ] I signed the [CLA].
 - [ ] I listed at least one issue that this PR fixes in the description above.
 - [ ] I updated/added relevant in-code documentation (doc comments with `///`).
-- [ ] If this PR introduces a new feature or capability, I linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
+- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
 - [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
 - [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
 - [ ] All existing and new tests are passing.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@ To learn more about code review, see our documentation on Tree Hygiene: https://
 - [ ] I signed the [CLA].
 - [ ] I listed at least one issue that this PR fixes in the description above.
 - [ ] I updated/added relevant documentation (doc comments with `///`).
+- [ ] If this PR introduces a new feature or capability, I linked a [flutter/website] issue or PR (or verified none is needed).
 - [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
 - [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
 - [ ] All existing and new tests are passing.
@@ -38,6 +39,7 @@ If this change needs to override an active code freeze, provide a comment explai
 [Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
 [CLA]: https://cla.developers.google.com/
 [flutter/tests]: https://github.com/flutter/tests
+[flutter/website]: https://github.com/flutter/website
 [breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
 [Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
 [Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


### PR DESCRIPTION
This PR updates the Pre-launch Checklist in `PULL_REQUEST_TEMPLATE.md` to include a reminder for contributors to evaluate whether new features or capabilities require documentation on [docs.flutter.dev](https://docs.flutter.dev) (via a linked issue or PR in [flutter/website](https://github.com/flutter/website)).

This helps ensure community-contributed features are tracked by the technical writing team well ahead of quarterly releases.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I linked a [flutter/website] issue or PR (or verified none is needed).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.