### PR TITLE
Allow resetting test invariants in `addTearDown`

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1964,17 +1964,17 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     assert(inTest);
     // So that we can assert that it remains the same after the test finishes.
     _beforeTestCheckIntrinsicSizes = debugCheckIntrinsicSizes;
+    _beforeTestAutoUpdateGoldens = autoUpdateGoldenFiles && !isBrowser;
+    _beforeTestReportTestException = reportTestException;
+    _beforeTestErrorWidgetBuilder = ErrorWidget.builder;
+    _beforeTestShouldPropagateDevicePointerEvents = shouldPropagateDevicePointerEvents;
+    _shouldVerifyInvariants = false;
 
     runApp(Container(key: UniqueKey(), child: _preTestMessage)); // Reset the tree to a known state.
     await pump();
     // Pretend that the first frame produced in the test body is the first frame
     // sent to the engine.
     resetFirstFrameSent();
-
-    final bool autoUpdateGoldensBeforeTest = autoUpdateGoldenFiles && !isBrowser;
-    final TestExceptionReporter reportTestExceptionBeforeTest = reportTestException;
-    final ErrorWidgetBuilder errorWidgetBuilderBeforeTest = ErrorWidget.builder;
-    final bool shouldPropagateDevicePointerEventsBeforeTest = shouldPropagateDevicePointerEvents;
 
     // run the test
     await testBody();
@@ -1994,18 +1994,26 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
         _testTextInput.unregister();
       }
       invariantTester();
-      _verifyAutoUpdateGoldensUnset(autoUpdateGoldensBeforeTest && !isBrowser);
-      _verifyReportTestExceptionUnset(reportTestExceptionBeforeTest);
-      _verifyErrorWidgetBuilderUnset(errorWidgetBuilderBeforeTest);
-      _verifyShouldPropagateDevicePointerEventsUnset(shouldPropagateDevicePointerEventsBeforeTest);
-      _verifyInvariants();
+      _shouldVerifyInvariants = true;
     }
 
     assert(inTest);
     asyncBarrier(); // When using AutomatedTestWidgetsFlutterBinding, this flushes the microtasks.
   }
 
+  bool _beforeTestAutoUpdateGoldens = false;
+  late TestExceptionReporter _beforeTestReportTestException;
+  late ErrorWidgetBuilder _beforeTestErrorWidgetBuilder;
+  bool _beforeTestShouldPropagateDevicePointerEvents = false;
   late bool _beforeTestCheckIntrinsicSizes;
+
+  // Whether post-test invariant verifications should run in [postTest].
+  //
+  // Set to true only if the test body completed without exceptions and the
+  // widget tree was unmounted. If the test encountered an exception, invariant
+  // checks are skipped to avoid spurious errors (e.g., active animations or
+  // unreset debug flags from aborted tests) from obscuring the real failure.
+  bool _shouldVerifyInvariants = false;
 
   void _verifyInvariants() {
     assert(
@@ -2062,13 +2070,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   void _verifyAutoUpdateGoldensUnset(bool valueBeforeTest) {
     assert(() {
       if (autoUpdateGoldenFiles != valueBeforeTest) {
-        FlutterError.reportError(
-          FlutterErrorDetails(
-            exception: FlutterError('The value of autoUpdateGoldenFiles was changed by the test.'),
-            stack: StackTrace.current,
-            library: 'Flutter test framework',
-          ),
-        );
+        throw FlutterError('The value of autoUpdateGoldenFiles was changed by the test.');
       }
       return true;
     }());
@@ -2082,13 +2084,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
         // So we reset the error reporter to its initial value and then report
         // this error.
         reportTestException = valueBeforeTest;
-        FlutterError.reportError(
-          FlutterErrorDetails(
-            exception: FlutterError('The value of reportTestException was changed by the test.'),
-            stack: StackTrace.current,
-            library: 'Flutter test framework',
-          ),
-        );
+        throw FlutterError('The value of reportTestException was changed by the test.');
       }
       return true;
     }());
@@ -2097,13 +2093,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   void _verifyErrorWidgetBuilderUnset(ErrorWidgetBuilder valueBeforeTest) {
     assert(() {
       if (ErrorWidget.builder != valueBeforeTest) {
-        FlutterError.reportError(
-          FlutterErrorDetails(
-            exception: FlutterError('The value of ErrorWidget.builder was changed by the test.'),
-            stack: StackTrace.current,
-            library: 'Flutter test framework',
-          ),
-        );
+        throw FlutterError('The value of ErrorWidget.builder was changed by the test.');
       }
       return true;
     }());
@@ -2112,14 +2102,8 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   void _verifyShouldPropagateDevicePointerEventsUnset(bool valueBeforeTest) {
     assert(() {
       if (shouldPropagateDevicePointerEvents != valueBeforeTest) {
-        FlutterError.reportError(
-          FlutterErrorDetails(
-            exception: FlutterError(
-              'The value of shouldPropagateDevicePointerEvents was changed by the test.',
-            ),
-            stack: StackTrace.current,
-            library: 'Flutter test framework',
-          ),
+        throw FlutterError(
+          'The value of shouldPropagateDevicePointerEvents was changed by the test.',
         );
       }
       return true;
@@ -2159,41 +2143,54 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// Called by the [testWidgets] function after a test is executed.
   void postTest() {
     assert(inTest);
-    FlutterError.onError = _oldExceptionHandler;
-    FlutterError.demangleStackTrace = _oldStackTraceDemangler;
-    _pendingExceptionDetails = null;
-    _parentZone = null;
-    _testZone = null;
-    buildOwner!.focusManager.dispose();
+    try {
+      if (_shouldVerifyInvariants) {
+        _shouldVerifyInvariants = false;
+        _verifyAutoUpdateGoldensUnset(_beforeTestAutoUpdateGoldens && !isBrowser);
+        _verifyReportTestExceptionUnset(_beforeTestReportTestException);
+        _verifyErrorWidgetBuilderUnset(_beforeTestErrorWidgetBuilder);
+        _verifyShouldPropagateDevicePointerEventsUnset(
+          _beforeTestShouldPropagateDevicePointerEvents,
+        );
+        _verifyInvariants();
+      }
+    } finally {
+      FlutterError.onError = _oldExceptionHandler;
+      FlutterError.demangleStackTrace = _oldStackTraceDemangler;
+      _pendingExceptionDetails = null;
+      _parentZone = null;
+      _testZone = null;
+      buildOwner!.focusManager.dispose();
 
-    if (TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.checkMockMessageHandler(
-      SystemChannels.accessibility.name,
-      _announcementHandler,
-    )) {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockDecodedMessageHandler(SystemChannels.accessibility, null);
-      _announcementHandler = null;
+      if (TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.checkMockMessageHandler(
+        SystemChannels.accessibility.name,
+        _announcementHandler,
+      )) {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockDecodedMessageHandler(SystemChannels.accessibility, null);
+        _announcementHandler = null;
+      }
+      _announcements = <CapturedAccessibilityAnnouncement>[];
+
+      ServicesBinding.instance.keyEventManager.keyMessageHandler = null;
+      buildOwner!.focusManager = FocusManager()..registerGlobalHandlers();
+
+      // Disabling the warning because @visibleForTesting doesn't take the testing
+      // framework itself into account, but we don't want it visible outside of
+      // tests.
+      // ignore: invalid_use_of_visible_for_testing_member
+      RawKeyboard.instance.clearKeysPressed();
+      // ignore: invalid_use_of_visible_for_testing_member
+      HardwareKeyboard.instance.clearState();
+      // ignore: invalid_use_of_visible_for_testing_member
+      keyEventManager.clearState();
+      // ignore: invalid_use_of_visible_for_testing_member
+      RendererBinding.instance.initMouseTracker();
+
+      assert(ServicesBinding.instance == WidgetsBinding.instance);
+      // ignore: invalid_use_of_visible_for_testing_member
+      ServicesBinding.instance.resetInternalState();
     }
-    _announcements = <CapturedAccessibilityAnnouncement>[];
-
-    ServicesBinding.instance.keyEventManager.keyMessageHandler = null;
-    buildOwner!.focusManager = FocusManager()..registerGlobalHandlers();
-
-    // Disabling the warning because @visibleForTesting doesn't take the testing
-    // framework itself into account, but we don't want it visible outside of
-    // tests.
-    // ignore: invalid_use_of_visible_for_testing_member
-    RawKeyboard.instance.clearKeysPressed();
-    // ignore: invalid_use_of_visible_for_testing_member
-    HardwareKeyboard.instance.clearState();
-    // ignore: invalid_use_of_visible_for_testing_member
-    keyEventManager.clearState();
-    // ignore: invalid_use_of_visible_for_testing_member
-    RendererBinding.instance.initMouseTracker();
-
-    assert(ServicesBinding.instance == WidgetsBinding.instance);
-    // ignore: invalid_use_of_visible_for_testing_member
-    ServicesBinding.instance.resetInternalState();
   }
 }
 
@@ -2574,11 +2571,14 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   void postTest() {
-    super.postTest();
-    assert(_currentFakeAsync != null);
-    assert(_clock != null);
-    _clock = null;
-    _currentFakeAsync = null;
+    try {
+      super.postTest();
+    } finally {
+      assert(_currentFakeAsync != null);
+      assert(_clock != null);
+      _clock = null;
+      _currentFakeAsync = null;
+    }
   }
 }
 
@@ -3129,10 +3129,13 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   void postTest() {
-    super.postTest();
-    assert(!_expectingFrame);
-    assert(_pendingFrame == null);
-    _inTest = false;
+    try {
+      super.postTest();
+    } finally {
+      assert(!_expectingFrame);
+      assert(_pendingFrame == null);
+      _inTest = false;
+    }
   }
 
   @override

--- a/packages/flutter_test/test/bindings_invariants_test.dart
+++ b/packages/flutter_test/test/bindings_invariants_test.dart
@@ -1,0 +1,94 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('foundation debug variables can be reset with addTearDown', (
+    WidgetTester tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    debugDoublePrecision = 3;
+    debugBrightnessOverride = Brightness.dark;
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      debugDoublePrecision = null;
+      debugBrightnessOverride = null;
+    });
+
+    expect(defaultTargetPlatform, TargetPlatform.macOS);
+    expect(debugDoublePrecision, 3);
+    expect(debugBrightnessOverride, Brightness.dark);
+  });
+
+  testWidgets('autoUpdateGoldenFiles can be reset with addTearDown', (WidgetTester tester) async {
+    final bool original = autoUpdateGoldenFiles;
+    autoUpdateGoldenFiles = true;
+    addTearDown(() {
+      autoUpdateGoldenFiles = original;
+    });
+
+    expect(autoUpdateGoldenFiles, isTrue);
+  });
+
+  testWidgets('ErrorWidget.builder can be reset with addTearDown', (WidgetTester tester) async {
+    final ErrorWidgetBuilder original = ErrorWidget.builder;
+    ErrorWidget.builder = (FlutterErrorDetails details) => Container();
+    addTearDown(() {
+      ErrorWidget.builder = original;
+    });
+  });
+
+  testWidgets('shouldPropagateDevicePointerEvents can be reset with addTearDown', (
+    WidgetTester tester,
+  ) async {
+    final bool original = tester.binding.shouldPropagateDevicePointerEvents;
+    tester.binding.shouldPropagateDevicePointerEvents = true;
+    addTearDown(() {
+      tester.binding.shouldPropagateDevicePointerEvents = original;
+    });
+  });
+
+  test('direct runTest invariant failure throws in postTest and cleans up binding', () async {
+    final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+    await binding.runTest(() async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    }, () {});
+
+    expect(
+      () => binding.postTest(),
+      throwsA(
+        isA<FlutterError>().having(
+          (FlutterError e) => e.message,
+          'message',
+          'The value of a foundation debug variable was changed by the test.',
+        ),
+      ),
+    );
+    // Ensure cleanup still happened despite postTest throwing
+    expect(binding.inTest, isFalse);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  test('direct runTest with failed test body skips invariant check in postTest', () async {
+    final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+    final TestExceptionReporter oldReporter = reportTestException;
+    reportTestException = (FlutterErrorDetails details, String testDescription) {};
+    addTearDown(() {
+      reportTestException = oldReporter;
+    });
+
+    await binding.runTest(() async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      throw Exception('test failed');
+    }, () {});
+
+    // postTest should NOT throw invariant error because the test body failed
+    expect(() => binding.postTest(), returnsNormally);
+    expect(binding.inTest, isFalse);
+    debugDefaultTargetPlatformOverride = null;
+  });
+}

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -669,11 +669,6 @@ void main() {
     });
 
     test('Throws assertion message without code', () async {
-      late FlutterErrorDetails flutterErrorDetails;
-      reportTestException = (FlutterErrorDetails details, String testDescription) {
-        flutterErrorDetails = details;
-      };
-
       final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
       debugPrint('DISREGARD NEXT PENDING TIMER LIST, IT IS EXPECTED');
       await binding.runTest(() async {
@@ -681,13 +676,17 @@ void main() {
         expect(timer.isActive, true);
       }, () {});
 
-      expect(flutterErrorDetails.exception, isA<AssertionError>());
       expect(
-        (flutterErrorDetails.exception as AssertionError).message,
-        'A Timer is still pending even after the widget tree was disposed.',
+        () => binding.postTest(),
+        throwsA(
+          isA<AssertionError>().having(
+            (AssertionError e) => e.message,
+            'message',
+            'A Timer is still pending even after the widget tree was disposed.',
+          ),
+        ),
       );
-      expect(binding.inTest, true);
-      binding.postTest();
+      expect(binding.inTest, false);
     });
   });
 


### PR DESCRIPTION
Fixes #110488.

### Background: The `testWidgets` Lifecycle
Understanding this change requires distinguishing between two layers of `Future`s and two distinct verification steps in `testWidgets`:

#### 1. Two Layers of `Future`s
* **`testBody()` Future**: The closure containing the user's test logic.
* **`runTest()` Future**: The overall async harness returned by `binding.runTest()`. It manages the test zone, unmounts the widget tree, and resolves only after `testBody()` and test-specific verifications finish.

#### 2. Two Distinct Verification Phases
* **Test-specific verifications (`invariantTester`)**: Passed as a callback to `runTest` and executed synchronously inside `_runTestBody` immediately after the `testBody()` Future completes and the widget tree is unmounted. In `testWidgets`, this runs `tester._endOfTestVerifications` to verify that tickers and semantics handles were disposed.
* **Framework-level invariant checks**: Verifies global framework state, including ensuring foundation/rendering/widgets debug flags were reset and no non-periodic timers or animations remain.

#### 3. The Teardown Lifecycle & Root Cause of #110488
When `testWidgets` runs:
1. `testWidgets` registers `test_package.addTearDown(binding.postTest)` with `package:test`.
2. `testWidgets` calls and returns `binding.runTest(...)`.
3. Inside `testBody()`, users may register cleanups using `addTearDown` (for example, `addTearDown(() => debugDefaultTargetPlatformOverride = null)`).
4. `package:test` executes teardowns in **LIFO (reverse registration) order** only *after* the Future returned by `runTest` completes.

Previously, framework-level invariant checks ran at the end of `_runTestBody` *before* the `runTest` Future completed. As a result, they ran before `package:test` executed any user-registered `addTearDown` callbacks, causing tests that clean up debug flags via `addTearDown` to fail invariant verification (#110488).

The following diagram shows the code flow after this PR:
```
testWidgets(description, (tester) async { ... })
 │
 ├── 1. Registration Phase
 │    └── test_package.addTearDown(binding.postTest)     [Teardown Stack: #1]
 │
 ├── 2. Test Execution Phase: binding.runTest(...)
 │    │
 │    │   [ Future 1: testBody() ]
 │    ├──► Run testBody(tester)
 │    │     └── User calls addTearDown(...)              [Teardown Stack: #2]
 │    │
 │    │   [ Post-testBody cleanup (inside runTest) ]
 │    ├──► Unmount widget tree (runApp)
 │    ├──► Verification 1: invariantTester()             (tickers, semantics)
 │    └──► Set _shouldVerifyInvariants = true
 │
 │    [ Future 2: runTest() completes ]
 │
 └── 3. Teardown Phase: package:test executes in LIFO order
      │
      ├──► [Step 1] User Teardowns (Stack #2)
      │     └── e.g., debugDefaultTargetPlatformOverride = null
      │
      └──► [Step 2] binding.postTest() (Stack #1)
            ├── Verification 2: Framework Invariants     (debug vars, timers)
            ├── Reset Binding State                      (_currentFakeAsync, etc.)
            └── reportTestException(...)                 (if Verification 2 failed)
```
### Changes & Design Rationale
#### 1. Defer Framework Invariant Checks to `postTest`

Framework invariant checks (`_verifyInvariants()`, `_verifyAutoUpdateGoldensUnset`, etc.) are moved from `_runTestBody` into `TestWidgetsFlutterBinding.postTest`.
Because `testWidgets` registers `binding.postTest` before running the test body, `package:test`'s LIFO teardown ordering guarantees that all user-registered `addTearDown` callbacks execute before `binding.postTest`.

#### 2. Clarifying the `postTest` Error Contract

Previously, `postTest` only performed state cleanup and did not check invariants. Moving invariant checks into `postTest` introduced the question of how invariant failures should be propagated: allowing `postTest` to throw, or absorbing errors and reporting them via `reportTestException`.

We explicitly define the contract of `postTest` to **not throw exceptions**, reporting any invariant failures via `reportTestException`:

* **Rationale & Trade-offs**:
  * *Alternative considered (throwing)*: If `super.postTest()` threw on an invariant failure, `package:test` would still capture the failure. However, subclasses (`AutomatedTestWidgetsFlutterBinding`, `LiveTestWidgetsFlutterBinding`, or custom bindings) override `postTest` to reset their own state (e.g. nulling `_currentFakeAsync` / `_clock`, or setting `_inTest = false`). Allowing `super.postTest()` to throw would require every subclass to defensively wrap `super.postTest()` in `try ... finally`. If any subclass omitted this, an invariant failure would leave the binding in a dirty state and trigger cascading `!inTest` failures in subsequent tests.
  * *Chosen approach (non-throwing)*: Absorbing errors in `postTest` and forwarding them to `reportTestException` guarantees that all cleanup in base and subclass implementations executes sequentially without defensive `try ... finally` boilerplate, while still cleanly failing the test.

**Why this does not break existing behavior:**
In the previous implementation, when invariant assertions failed inside `_runTestBody`, they were caught by `_testZone.handleUncaughtError` and forwarded to `reportTestException` (which delegates to `package:test.registerException`). They never escaped `runTest` as unhandled thrown exceptions. Catching invariant failures in `postTest` and routing them to `reportTestException` preserves this exact error reporting pipeline, diagnostic output, and failure semantics without disrupting teardown execution.

#### 3. Preserving Existing Behavior on Failed Tests (`_shouldVerifyInvariants`)

Historically, `_runTestBody` only verified invariants if the test body did not fail:

```dart
if (_pendingExceptionDetails == null) {
  // We only try to clean up and verify invariants if we didn't already
  // fail. If we got an exception already, then we instead leave everything
  // alone so that we don't cause more spurious errors.
  ...
  _verifyInvariants();
}
```

When invariant checks are moved to `postTest`, `_pendingExceptionDetails` is no longer available because it has already been reported and cleared by `testCompletionHandler` when `runTest` completed.

To preserve this exact existing behavior across the lifecycle boundary, `_shouldVerifyInvariants` is introduced. It is set to `true` at the end of `_runTestBody` only when `_pendingExceptionDetails == null`. If a test fails in its body, `_shouldVerifyInvariants` remains `false`, and `postTest` skips invariant checks—ensuring no behavior change and preventing spurious errors (e.g. active animations on an unmounted tree) from masking the real failure.

#### 4. Documentation Updates
Updated the doc comments on:
* `TestWidgetsFlutterBinding.postTest`: Documents the non-throwing contract, the `@mustCallSuper` requirement, and error reporting via `reportTestException`.
* `TestWidgetsFlutterBinding.runTest`: Clarifies the distinction between `invariantTester` (which runs before `runTest` completes) and framework invariant checks (which run in `postTest` after `runTest` and user teardowns complete).

### Tests
- Added unit tests in `packages/flutter_test/test/bindings_invariants_test.dart` verifying that foundation variables (`debugDefaultTargetPlatformOverride`, `debugDoublePrecision`, `debugBrightnessOverride`), `autoUpdateGoldenFiles`, `ErrorWidget.builder`, and `shouldPropagateDevicePointerEvents` can all be reset using `addTearDown`.
- Added test cases verifying invariant failures in `postTest` and ensuring invariant checks are skipped when the test body throws.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
