### PR TITLE
[flutter_tools] Safely handle non-JSON messages in test stream parsers

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -904,20 +904,14 @@ Future<void> pipeHarnessToRemote({
       globals.printTrace('test $id: Test process is no longer needed by test harness');
     }),
     remoteChannel.stream
-        .transform(
-          StreamTransformer<String, Object?>.fromHandlers(
-            handleData: (String message, EventSink<Object?> sink) {
-              try {
-                sink.add(json.decode(message));
-              } on FormatException catch (error) {
-                globals.printWarning(
-                  'Received unexpected non-JSON output from test runner: $message',
-                );
-                globals.printTrace('test $id: JSON decoding failed: $error');
-              }
-            },
-          ),
-        )
+        .map<Object?>(json.decode)
+        .handleError((Object error) {
+          final formatException = error as FormatException;
+          globals.printWarning(
+            'Received unexpected non-JSON output from test runner: ${formatException.source}',
+          );
+          globals.printTrace('test $id: JSON decoding failed: $formatException');
+        }, test: (error) => error is FormatException)
         .pipe(harnessChannel.sink)
         .then<void>((void value) {
           globals.printTrace('test $id: Test harness is no longer needed by test process');

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -721,7 +721,7 @@ class FlutterPlatform extends PlatformPlugin {
             'test $ourTestCount: connected to test device, now awaiting test result',
           );
 
-          await _pipeHarnessToRemote(
+          await pipeHarnessToRemote(
             id: ourTestCount,
             harnessChannel: testHarnessChannel,
             remoteChannel: remoteChannel,
@@ -889,9 +889,10 @@ class _AsyncError {
 ///
 /// The returned future completes when either side is closed, which also
 /// indicates when the tests have finished.
-Future<void> _pipeHarnessToRemote({
+@visibleForTesting
+Future<void> pipeHarnessToRemote({
   required int id,
-  required StreamChannel<dynamic> harnessChannel,
+  required StreamChannel<Object?> harnessChannel,
   required StreamChannel<String> remoteChannel,
 }) async {
   globals.printTrace('test $id: Waiting for test harness or tests to finish');
@@ -902,10 +903,24 @@ Future<void> _pipeHarnessToRemote({
     ) {
       globals.printTrace('test $id: Test process is no longer needed by test harness');
     }),
-    remoteChannel.stream.map<dynamic>(json.decode).pipe(harnessChannel.sink).then<void>((
-      void value,
-    ) {
-      globals.printTrace('test $id: Test harness is no longer needed by test process');
-    }),
+    remoteChannel.stream
+        .transform(
+          StreamTransformer<String, Object?>.fromHandlers(
+            handleData: (String message, EventSink<Object?> sink) {
+              try {
+                sink.add(json.decode(message));
+              } on FormatException catch (error) {
+                globals.printWarning(
+                  'Received unexpected non-JSON output from test runner: $message',
+                );
+                globals.printTrace('test $id: JSON decoding failed: $error');
+              }
+            },
+          ),
+        )
+        .pipe(harnessChannel.sink)
+        .then<void>((void value) {
+          globals.printTrace('test $id: Test harness is no longer needed by test process');
+        }),
   ]);
 }

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -793,44 +793,28 @@ class BrowserManager {
       }
     })..cancel();
 
-    final safeJsonTransformer = StreamChannelTransformer<Object?, Object?>(
-      StreamTransformer<Object?, Object?>.fromHandlers(
-        handleData: (Object? data, EventSink<Object?> sink) {
-          if (data is String) {
-            try {
-              sink.add(json.decode(data));
-            } on FormatException catch (err) {
-              _logger.printWarning(
-                'Received unexpected non-JSON message from browser WebSocket: $data',
-              );
-              _logger.printTrace('JSON decode error: $err');
-            }
-          } else {
-            sink.add(data);
-          }
-        },
-      ),
-      StreamSinkTransformer<Object?, Object?>.fromHandlers(
-        handleData: (Object? data, EventSink<Object?> sink) {
-          sink.add(json.encode(data));
-        },
-      ),
-    );
-
     // Whenever we get a message, no matter which child channel it's for, we know
     // the browser is still running code which means the user isn't debugging.
     _channel = MultiChannel<dynamic>(
-      webSocket.transform(safeJsonTransformer).changeStream((Stream<Object?> stream) {
-        return stream.map((Object? message) {
-          if (!_closed) {
-            _timer.reset();
-          }
-          for (final RunnerSuiteController controller in _controllers) {
-            controller.setDebugging(false);
-          }
+      webSocket.cast<String>().transform(jsonDocument).changeStream((Stream<Object?> stream) {
+        return stream
+            .handleError((Object error) {
+              final formatException = error as FormatException;
+              _logger.printWarning(
+                'Received unexpected non-JSON message from browser WebSocket: ${formatException.source}',
+              );
+              _logger.printTrace('JSON decode error: $formatException');
+            }, test: (error) => error is FormatException)
+            .map((Object? message) {
+              if (!_closed) {
+                _timer.reset();
+              }
+              for (final RunnerSuiteController controller in _controllers) {
+                controller.setDebugging(false);
+              }
 
-          return message;
-        });
+              return message;
+            });
       }),
     );
 

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -793,10 +793,34 @@ class BrowserManager {
       }
     })..cancel();
 
+    final safeJsonTransformer = StreamChannelTransformer<Object?, Object?>(
+      StreamTransformer<Object?, Object?>.fromHandlers(
+        handleData: (Object? data, EventSink<Object?> sink) {
+          if (data is String) {
+            try {
+              sink.add(json.decode(data));
+            } on FormatException catch (err) {
+              _logger.printWarning(
+                'Received unexpected non-JSON message from browser WebSocket: $data',
+              );
+              _logger.printTrace('JSON decode error: $err');
+            }
+          } else {
+            sink.add(data);
+          }
+        },
+      ),
+      StreamSinkTransformer<Object?, Object?>.fromHandlers(
+        handleData: (Object? data, EventSink<Object?> sink) {
+          sink.add(json.encode(data));
+        },
+      ),
+    );
+
     // Whenever we get a message, no matter which child channel it's for, we know
     // the browser is still running code which means the user isn't debugging.
     _channel = MultiChannel<dynamic>(
-      webSocket.cast<String>().transform(jsonDocument).changeStream((Stream<Object?> stream) {
+      webSocket.transform(safeJsonTransformer).changeStream((Stream<Object?> stream) {
         return stream.map((Object? message) {
           if (!_closed) {
             _timer.reset();

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -246,6 +246,48 @@ void main() {
       expect(flutterPlatform.testAssetDirectory, '/build/test');
       expect(flutterPlatform.icudtlPath, equals('ghi'));
     });
+
+    testUsingContext('pipeHarnessToRemote safely ignores non-JSON string and logs warning', () async {
+      final harnessController = StreamChannelController<Object?>();
+      final remoteController = StreamChannelController<String>();
+
+      final Future<void> pipeFuture = pipeHarnessToRemote(
+        id: 0,
+        harnessChannel: harnessController.foreign,
+        remoteChannel: remoteController.foreign,
+      );
+
+      final receivedFromRemote = <Object?>[];
+      harnessController.local.stream.listen(receivedFromRemote.add);
+
+      // Send non-JSON error string from remote channel followed by valid JSON.
+      remoteController.local.sink.add(
+        'Loading dynamic library failed: dlopen(/opt/homebrew/share/flutter/bin/cache/libflutter.dylib)',
+      );
+      remoteController.local.sink.add('{"valid": true}');
+
+      await pumpEventQueue();
+
+      await remoteController.local.sink.close();
+      await harnessController.local.sink.close();
+
+      await pipeFuture;
+
+      expect(
+        receivedFromRemote,
+        equals(<Object?>[
+          <String, Object?>{'valid': true},
+        ]),
+      );
+      final logger = globals.logger as BufferLogger;
+      expect(
+        logger.warningText,
+        contains(
+          'Received unexpected non-JSON output from test runner: Loading dynamic library failed: dlopen',
+        ),
+      );
+      expect(logger.traceText, contains('test 0: JSON decoding failed:'));
+    });
   });
 
   group('generateTestBootstrap', () {


### PR DESCRIPTION
When communicating with remote test runners or browsers over test streams or WebSockets, unhandled non-JSON strings (such as dynamic library loading errors or missing snapshot warnings) caused `_ChunkedJsonParser` to throw an unhandled `FormatException` at character 1, crashing the tool.

This changes `pipeHarnessToRemote` in `flutter_platform.dart` and `BrowserManager` in `flutter_web_platform.dart` to intercept non-JSON payloads, log warnings and traces, and ignore invalid frames rather than crashing the tool process.

Fixes https://github.com/flutter/flutter/issues/191898

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
