### PR TITLE
[Windows] Fix Space input after Alt+Space with previous Microsoft IME

### DIFF
--- a/engine/src/flutter/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/engine/src/flutter/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -167,6 +167,16 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
   uint64_t last_logical_record =
       had_record ? last_logical_record_iter->second : 0;
 
+  const bool is_event_down = action == WM_KEYDOWN || action == WM_SYSKEYDOWN;
+
+  if (is_event_down && key == VK_PROCESSKEY && had_record && !was_down) {
+    // A native modal loop can leave a key recorded as pressed. Release that
+    // stale state before filtering the IME's fresh key-down.
+    SendSynthesizeUpEvent(physical_key, last_logical_record);
+    callback(true);
+    return;
+  }
+
   // The logical key for the current "tap sequence".
   //
   // Key events are formed in tap sequences: down, repeats, up. The logical key
@@ -182,8 +192,6 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
     callback(true);
     return;
   }
-
-  const bool is_event_down = action == WM_KEYDOWN || action == WM_SYSKEYDOWN;
 
   bool event_key_can_be_repeat = true;
   UpdateLastSeenCriticalKey(key, physical_key, sequence_logical_key);

--- a/engine/src/flutter/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
@@ -75,6 +75,7 @@ UINT DefaultMapVkToScan(UINT virtual_key, bool extended) {
 
 constexpr uint64_t kScanCodeKeyA = 0x1e;
 constexpr uint64_t kScanCodeAltLeft = 0x38;
+constexpr uint64_t kScanCodeSpace = 0x39;
 constexpr uint64_t kScanCodeNumpad1 = 0x4f;
 constexpr uint64_t kScanCodeNumLock = 0x45;
 constexpr uint64_t kScanCodeControl = 0x1d;
@@ -325,6 +326,71 @@ TEST(KeyboardKeyEmbedderHandlerTest, ImeEventsAreIgnored) {
   event = &results[0];
   event->callback(true, event->user_data);
   EXPECT_EQ(last_handled, true);
+}
+
+// Press Alt+Space, miss Space's key-up, and press Space with an IME.
+//
+// This is special because the previous Microsoft IME reports the next Space as
+// VK_PROCESSKEY while Flutter still records the previous Space as pressed.
+TEST(KeyboardKeyEmbedderHandlerTest, FreshImeKeyDownReleasesStalePressedKey) {
+  TestKeystate key_state;
+  std::vector<TestFlutterKeyEvent> results;
+  bool last_handled = false;
+
+  std::unique_ptr<KeyboardKeyEmbedderHandler> handler =
+      std::make_unique<KeyboardKeyEmbedderHandler>(
+          [&results](const FlutterKeyEvent& event,
+                     FlutterKeyEventCallback callback, void* user_data) {
+            results.emplace_back(event, callback, user_data);
+          },
+          key_state.Getter(), DefaultMapVkToScan);
+
+  // Press Space while Alt is held. Omit its key-up.
+  handler->KeyboardHook(VK_SPACE, kScanCodeSpace, WM_SYSKEYDOWN, 0, false,
+                        false, [](bool) {});
+  ASSERT_EQ(results.size(), 1u);
+  results[0].callback(false, results[0].user_data);
+  results.clear();
+
+  // Press Space through the IME.
+  handler->KeyboardHook(
+      VK_PROCESSKEY, kScanCodeSpace, WM_KEYDOWN, 0, false, false,
+      [&last_handled](bool handled) { last_handled = handled; });
+  EXPECT_EQ(last_handled, true);
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].type, kFlutterKeyEventTypeUp);
+  EXPECT_EQ(results[0].physical, kPhysicalSpace);
+  EXPECT_EQ(results[0].logical, kLogicalSpace);
+  EXPECT_EQ(results[0].synthesized, true);
+  EXPECT_EQ(handler->GetPressedState().empty(), true);
+  results.clear();
+
+  // Dispatch the translated Space key-down.
+  handler->KeyboardHook(VK_SPACE, kScanCodeSpace, WM_KEYDOWN, ' ', false, false,
+                        [](bool) {});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].type, kFlutterKeyEventTypeDown);
+  EXPECT_EQ(results[0].physical, kPhysicalSpace);
+  EXPECT_EQ(results[0].logical, kLogicalSpace);
+  ASSERT_EQ(handler->GetPressedState().size(), 1u);
+  EXPECT_EQ(handler->GetPressedState().at(kPhysicalSpace), kLogicalSpace);
+  results[0].callback(false, results[0].user_data);
+  results.clear();
+
+  // Repeat Space through the IME.
+  last_handled = false;
+  handler->KeyboardHook(
+      VK_PROCESSKEY, kScanCodeSpace, WM_KEYDOWN, 0, false, true,
+      [&last_handled](bool handled) { last_handled = handled; });
+  EXPECT_EQ(last_handled, false);
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].type, kFlutterKeyEventTypeRepeat);
+  EXPECT_EQ(results[0].logical, kLogicalSpace);
+  EXPECT_EQ(results[0].synthesized, false);
+  ASSERT_EQ(handler->GetPressedState().size(), 1u);
+  EXPECT_EQ(handler->GetPressedState().at(kPhysicalSpace), kLogicalSpace);
+  results[0].callback(false, results[0].user_data);
+  EXPECT_EQ(last_handled, false);
 }
 
 // Test if modifier keys that are told apart by the extended bit can be


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Fixes #189495 

## Description

After `Alt+Space` opens the Windows system menu, the Space key-up does not always reach Flutter while the native menu is active. Flutter can therefore retain a stale pressed record that maps the physical Space key to the logical Space key.

With **Use previous version of Microsoft IME** enabled, the next physical Space press can first arrive as a fresh `WM_KEYDOWN(VK_PROCESSKEY)` with the Space scan code, followed by the translated `WM_KEYDOWN(VK_SPACE)` event.

The existing stale-state recovery synthesizes the missing Space key-up, but then continues processing the `VK_PROCESSKEY` event and records it as the logical key for physical Space. The following translated `VK_SPACE` event consequently inherits `VK_PROCESSKEY` as its sequence logical key and is filtered as an IME event. Space input then remains unavailable.

When this state is detected, the handler now synthesizes the missing key-up and filters the fresh `VK_PROCESSKEY` event without recording it. The following translated `VK_SPACE` event is then processed normally.

The observed failing event is `WM_KEYDOWN(VK_PROCESSKEY)`. The implementation reuses the handler's existing definition of a key-down event, which also includes `WM_SYSKEYDOWN`, so the same pressed-state invariant is preserved for system key-down messages. The early path additionally requires an existing record for the same physical key and a previous-key-state bit indicating a fresh press.

Normal IME events without a stale pressed record, key-up events, and repeated key-down events continue through the existing paths.


Microsoft documents the previous IME setting here: [Revert to a previous version of an Input Method Editor (IME)](https://support.microsoft.com/en-us/windows/hardware/input-devices/revert-to-a-previous-version-of-an-input-method-editor-ime)


## Win32 behavior

Microsoft documents that:

- [`WM_SYSKEYDOWN`](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-syskeydown) is posted when Alt is held while another key is pressed.
- Bit 30 of [`WM_KEYDOWN`](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-keydown) indicates the previous key state, allowing a fresh down transition to be distinguished from an auto-repeat.
- An IME changes the virtual-key value of an already processed key message to `VK_PROCESSKEY`, as described by [`ImmGetVirtualKey`](https://learn.microsoft.com/en-us/windows/win32/api/imm/nf-imm-immgetvirtualkey).
- [`SC_KEYMENU`](https://learn.microsoft.com/en-us/windows/win32/menurc/wm-syscommand) identifies a window-menu request caused by a keystroke.

Here, `229` is `VK_PROCESSKEY`, `32` is `VK_SPACE`, and scan code `57` is the physical Space key.

<details>
<summary>Diagnostic log excerpts</summary>

### Current Microsoft IME

The next Space press arrives directly as `VK_SPACE`. The existing stale-state recovery handles this case:

```text
[flutter#189495][child-window] message=256 wparam=32 scan_code=57 extended=0 context=0 was_down=0 transition=0 space_async_down=1 alt_async_down=0
[flutter#189495][child-window] message=258 wparam=32 scan_code=57 extended=0 context=0 was_down=0 transition=0 space_async_down=1 alt_async_down=0
[flutter#189495][embedder:entry] action=256 key=32 scancode=57 character=32 extended=0 was_down=0 physical_key=458796 logical_key=32 had_record=1 last_logical_record=32 pressed_count=1
[flutter#189495][embedder:stale-record] physical_key=458796 last_logical_record=32 incoming_logical_key=32
```

### Previous Microsoft IME before this change

A fresh `VK_PROCESSKEY` arrives first. The existing recovery replaces the logical record with `229`, so the translated `VK_SPACE` event is also filtered:

```text
[flutter#189495][window] WM_KEYDOWN message=256 wparam=229 scan_code=57 extended=0 context=0 was_down=0 transition=0 space_async_down=1 alt_async_down=0 has_focus=1 is_active=0 is_foreground=0
[flutter#189495][embedder:entry] action=256 key=229 scancode=57 character=0 extended=0 was_down=0 physical_key=458796 logical_key=229 had_record=1 last_logical_record=32 pressed_count=1
[flutter#189495][embedder:stale-record] physical_key=458796 last_logical_record=32 incoming_logical_key=229
[flutter#189495][window] WM_KEYDOWN message=256 wparam=32 scan_code=57 extended=0 context=0 was_down=0 transition=0 space_async_down=1 alt_async_down=0 has_focus=1 is_active=0 is_foreground=0
[flutter#189495][window] WM_CHAR message=258 wparam=32 scan_code=57 extended=0 context=0 was_down=0 transition=0 space_async_down=1 alt_async_down=0 has_focus=1 is_active=0 is_foreground=0
[flutter#189495][embedder:entry] action=256 key=32 scancode=57 character=32 extended=0 was_down=0 physical_key=458796 logical_key=32 had_record=1 last_logical_record=229 pressed_count=1
[flutter#189495][embedder:ime-filter] action=256 key=32 sequence_logical_key=229 had_record=1
```

### Previous Microsoft IME after this change

The stale Space record is released while filtering the fresh `VK_PROCESSKEY`. The translated `VK_SPACE` event then arrives with no stale record and is processed as a normal key-down:

```text
[flutter#189495][window] message=256 wparam=229 scan_code=57 extended=0 context=0 was_down=0 transition=0
[flutter#189495][embedder:entry] action=256 key=229 scancode=57 character=0 extended=0 was_down=0 physical_key=458796 logical_key=229 had_record=1 last_logical_record=32 pressed_count=1
[flutter#189495][embedder:synthesize-up] physical_key=458796 logical_key=32 pressed_count_before=1
[flutter#189495][embedder:synthesize-up] pressed_count_after=0
[flutter#189495][window] message=256 wparam=32 scan_code=57 extended=0 context=0 was_down=0 transition=0
[flutter#189495][window] message=258 wparam=32 scan_code=57 extended=0 context=0 was_down=0 transition=0
[flutter#189495][embedder:entry] action=256 key=32 scancode=57 character=32 extended=0 was_down=0 physical_key=458796 logical_key=32 had_record=0 last_logical_record=0 pressed_count=0
[flutter#189495][embedder:sequence] key=32 sequence_logical_key=32 ime_filter=0
[flutter#189495][embedder:decision] down result_logical_key=32
```

</details>

## Screenshot

https://github.com/user-attachments/assets/ae2a66c1-6536-442c-a430-c8fdb0dc1c6e



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
