### PR TITLE
Fix #191979: Possible performance regression between the Skia and Impelle

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -260,12 +260,13 @@ static void EncodeViewport(const ProcTableGLES& gl,
 
   TextureGLES& color_gles = TextureGLES::Cast(*pass_data.color_attachment);
   const bool is_wrapped_fbo = color_gles.IsWrapped();
+  std::optional<bool> is_default_fbo;
 
   std::optional<GLuint> fbo = 0;
   if (is_wrapped_fbo) {
-    if (color_gles.GetFBO().has_value()) {
-      // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-      gl.BindFramebuffer(GL_FRAMEBUFFER, *color_gles.GetFBO());
+    if (auto wrapped_fbo = color_gles.GetFBO(); wrapped_fbo.has_value()) {
+      gl.BindFramebuffer(GL_FRAMEBUFFER, wrapped_fbo.value());
+      is_default_fbo = wrapped_fbo.value() == 0u;
     }
   } else {
     // Create (once) and bind an offscreen FBO. The cached FBO remembers which
@@ -318,6 +319,7 @@ static void EncodeViewport(const ProcTableGLES& gl,
       color_gles.SetCachedFBOSubresource(pass_data.color_mip_level,
                                          pass_data.color_slice);
     }
+    is_default_fbo = false;
   }
 
   gl.ClearColor(pass_data.clear_color.red,    // red
@@ -362,8 +364,11 @@ static void EncodeViewport(const ProcTableGLES& gl,
   const float y_flip_value = flip_y ? -1.0f : 1.0f;
 
   std::optional<Viewport> current_viewport;
+  std::optional<IRect32> current_scissor;
   CullMode current_cull_mode = CullMode::kNone;
   WindingOrder current_winding_order = WindingOrder::kClockwise;
+  const PipelineGLES* current_pipeline = nullptr;
+  std::optional<uint32_t> current_stencil_reference;
   // Inverted to keep front-facing consistent under the vertex y-flip.
   gl.FrontFace(flip_y ? GL_CCW : GL_CW);
 
@@ -387,28 +392,37 @@ static void EncodeViewport(const ProcTableGLES& gl,
           << "Color attachment is too complicated for a legacy renderer.";
       return false;
     }
+    const bool pipeline_changed = current_pipeline != &pipeline;
 
     //--------------------------------------------------------------------------
     /// Configure blending.
     ///
-    ConfigureBlending(gl, color_attachment);
+    if (pipeline_changed) {
+      ConfigureBlending(gl, color_attachment);
+    }
 
     //--------------------------------------------------------------------------
     /// Setup stencil.
     ///
-    ConfigureStencil(gl, pipeline.GetDescriptor(), command.stencil_reference);
+    if (pipeline_changed ||
+        current_stencil_reference != command.stencil_reference) {
+      ConfigureStencil(gl, pipeline.GetDescriptor(), command.stencil_reference);
+      current_stencil_reference = command.stencil_reference;
+    }
 
     //--------------------------------------------------------------------------
     /// Configure depth.
     ///
-    if (auto depth =
-            pipeline.GetDescriptor().GetDepthStencilAttachmentDescriptor();
-        depth.has_value()) {
-      gl.Enable(GL_DEPTH_TEST);
-      gl.DepthFunc(ToCompareFunction(depth->depth_compare));
-      gl.DepthMask(depth->depth_write_enabled ? GL_TRUE : GL_FALSE);
-    } else {
-      gl.Disable(GL_DEPTH_TEST);
+    if (pipeline_changed) {
+      if (auto depth =
+              pipeline.GetDescriptor().GetDepthStencilAttachmentDescriptor();
+          depth.has_value()) {
+        gl.Enable(GL_DEPTH_TEST);
+        gl.DepthFunc(ToCompareFunction(depth->depth_compare));
+        gl.DepthMask(depth->depth_write_enabled ? GL_TRUE : GL_FALSE);
+      } else {
+        gl.Disable(GL_DEPTH_TEST);
+      }
     }
 
     //--------------------------------------------------------------------------
@@ -425,16 +439,21 @@ static void EncodeViewport(const ProcTableGLES& gl,
     //--------------------------------------------------------------------------
     /// Setup the scissor rect.
     ///
-    if (command.scissor.has_value()) {
-      const auto& scissor = command.scissor.value();
-      gl.Enable(GL_SCISSOR_TEST);
-      // Same flip handling as the viewport above.
-      const auto scissor_y_gl =
-          flip_y ? scissor.GetY()
-                 : target_size.height - scissor.GetY() - scissor.GetHeight();
-      gl.Scissor(scissor.GetX(),  // x
-                 scissor_y_gl,    // y
-                 scissor.GetWidth(), scissor.GetHeight());
+    if (current_scissor != command.scissor) {
+      current_scissor = command.scissor;
+      if (command.scissor.has_value()) {
+        const auto& scissor = command.scissor.value();
+        gl.Enable(GL_SCISSOR_TEST);
+        // Same flip handling as the viewport above.
+        const auto scissor_y_gl =
+            flip_y ? scissor.GetY()
+                   : target_size.height - scissor.GetY() - scissor.GetHeight();
+        gl.Scissor(scissor.GetX(),  // x
+                   scissor_y_gl,    // y
+                   scissor.GetWidth(), scissor.GetHeight());
+      } else {
+        gl.Disable(GL_SCISSOR_TEST);
+      }
     }
 
     //--------------------------------------------------------------------------
@@ -496,15 +515,20 @@ static void EncodeViewport(const ProcTableGLES& gl,
     //--------------------------------------------------------------------------
     /// Bind the pipeline program.
     ///
-    if (!pipeline.BindProgram()) {
-      return false;
+    if (pipeline_changed) {
+      if (!pipeline.BindProgram()) {
+        return false;
+      }
+      current_pipeline = &pipeline;
     }
 
     //--------------------------------------------------------------------------
     /// Bind the y-flip uniform if the vertex shader declares it.
-    const GLint y_flip_loc = pipeline.GetYFlipUniformLocation();
-    if (y_flip_loc >= 0) {
-      gl.Uniform1fv(y_flip_loc, 1, &y_flip_value);
+    if (pipeline_changed) {
+      const GLint y_flip_loc = pipeline.GetYFlipUniformLocation();
+      if (y_flip_loc >= 0) {
+        gl.Uniform1fv(y_flip_loc, 1, &y_flip_value);
+      }
     }
 
     //--------------------------------------------------------------------------
@@ -693,29 +717,32 @@ static void EncodeViewport(const ProcTableGLES& gl,
     gl.BindFramebuffer(GL_FRAMEBUFFER, fbo.value());
   }
 
-  GLint framebuffer_id = 0;
-  gl.GetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer_id);
-  const bool is_default_fbo = framebuffer_id == 0;
+  if (!is_default_fbo.has_value()) {
+    GLint framebuffer_id = 0;
+    gl.GetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer_id);
+    is_default_fbo = framebuffer_id == 0;
+  }
+  const bool default_fbo = is_default_fbo.value();
 
   if (gl.InvalidateFramebuffer.IsAvailable()) {
     std::array<GLenum, 3> attachments;
     size_t attachment_count = 0;
 
-    bool angle_safe = gl.GetCapabilities()->IsANGLE() ? !is_default_fbo : true;
+    bool angle_safe = gl.GetCapabilities()->IsANGLE() ? !default_fbo : true;
 
     if (pass_data.discard_color_attachment) {
       attachments[attachment_count++] =
-          (is_default_fbo ? GL_COLOR_EXT : GL_COLOR_ATTACHMENT0);
+          (default_fbo ? GL_COLOR_EXT : GL_COLOR_ATTACHMENT0);
     }
 
     if (pass_data.discard_depth_attachment && angle_safe) {
       attachments[attachment_count++] =
-          (is_default_fbo ? GL_DEPTH_EXT : GL_DEPTH_ATTACHMENT);
+          (default_fbo ? GL_DEPTH_EXT : GL_DEPTH_ATTACHMENT);
     }
 
     if (pass_data.discard_stencil_attachment && angle_safe) {
       attachments[attachment_count++] =
-          (is_default_fbo ? GL_STENCIL_EXT : GL_STENCIL_ATTACHMENT);
+          (default_fbo ? GL_STENCIL_EXT : GL_STENCIL_ATTACHMENT);
     }
     gl.InvalidateFramebuffer(GL_FRAMEBUFFER,     // target
                              attachment_count,   // attachments to discard
@@ -728,21 +755,21 @@ static void EncodeViewport(const ProcTableGLES& gl,
     // TODO(130048): discarding stencil or depth on the default fbo causes Angle
     // to discard the entire render target. Until we know the reason, default to
     // storing.
-    bool angle_safe = gl.GetCapabilities()->IsANGLE() ? !is_default_fbo : true;
+    bool angle_safe = gl.GetCapabilities()->IsANGLE() ? !default_fbo : true;
 
     if (pass_data.discard_color_attachment) {
       attachments[attachment_count++] =
-          (is_default_fbo ? GL_COLOR_EXT : GL_COLOR_ATTACHMENT0);
+          (default_fbo ? GL_COLOR_EXT : GL_COLOR_ATTACHMENT0);
     }
 
     if (pass_data.discard_depth_attachment && angle_safe) {
       attachments[attachment_count++] =
-          (is_default_fbo ? GL_DEPTH_EXT : GL_DEPTH_ATTACHMENT);
+          (default_fbo ? GL_DEPTH_EXT : GL_DEPTH_ATTACHMENT);
     }
 
     if (pass_data.discard_stencil_attachment && angle_safe) {
       attachments[attachment_count++] =
-          (is_default_fbo ? GL_STENCIL_EXT : GL_STENCIL_ATTACHMENT);
+          (default_fbo ? GL_STENCIL_EXT : GL_STENCIL_ATTACHMENT);
     }
     gl.DiscardFramebufferEXT(GL_FRAMEBUFFER,     // target
                              attachment_count,   // attachments to discard
@@ -751,7 +778,7 @@ static void EncodeViewport(const ProcTableGLES& gl,
   }
 
 #ifdef IMPELLER_DEBUG
-  if (is_default_fbo) {
+  if (default_fbo) {
     tracer->MarkFrameEnd(gl);
   }
 #endif  // IMPELLER_DEBUG

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -28,7 +28,6 @@ using ::testing::Args;
 using ::testing::ElementsAreArray;
 using ::testing::NiceMock;
 using ::testing::Return;
-using ::testing::SetArgPointee;
 using ::testing::TestWithParam;
 
 class TestReactorGLES : public ReactorGLES {
@@ -108,7 +107,7 @@ TEST_P(RenderPassGLESWithDiscardFrameBufferExtTest, DiscardFramebufferExt) {
   const auto render_pass = command_buffer->CreateRenderPass(render_target);
 
   EXPECT_CALL(mock_gl_impl_ref, GetIntegerv(GL_FRAMEBUFFER_BINDING, _))
-      .WillOnce(SetArgPointee<1>(test_params.frame_buffer_id));
+      .Times(0);
 
   EXPECT_CALL(mock_gl_impl_ref, DiscardFramebufferEXT(GL_FRAMEBUFFER, _, _))
       .With(Args<2, 1>(ElementsAreArray(test_params.expected_attachments)))
@@ -157,7 +156,7 @@ TEST_P(RenderPassGLESWithDiscardFrameBufferExtTest, InvalidateFramebuffer) {
   const auto render_pass = command_buffer->CreateRenderPass(render_target);
 
   EXPECT_CALL(mock_gl_impl_ref, GetIntegerv(GL_FRAMEBUFFER_BINDING, _))
-      .WillOnce(SetArgPointee<1>(test_params.frame_buffer_id));
+      .Times(0);
 
   // InvalidateFramebuffer should be called instead of DiscardFramebufferEXT
   EXPECT_CALL(mock_gl_impl_ref, InvalidateFramebuffer(GL_FRAMEBUFFER, _, _))
@@ -320,6 +319,46 @@ TEST_F(RenderPassGLESCommandTest, ViewportCachedAcrossCommands) {
   EXPECT_CALL(mock_gl_impl_ref, Viewport(_, _, _, _)).Times(0);
   EXPECT_CALL(mock_gl_impl_ref, Viewport(0, 0, 100, 100)).Times(1);
   EXPECT_CALL(mock_gl_impl_ref, Viewport(0, 0, 50, 50)).Times(1);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+TEST_F(RenderPassGLESCommandTest, OffscreenFramebufferBindingIsKnown) {
+  auto ctx = CreateRenderPassGLESContext();
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  EXPECT_CALL(mock_gl_impl_ref, GetIntegerv(GL_FRAMEBUFFER_BINDING, _))
+      .Times(0);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+TEST_F(RenderPassGLESCommandTest, PipelineStateCachedAcrossCommands) {
+  auto ctx = CreateRenderPassGLESContext();
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  for (size_t i = 0; i < 3; i++) {
+    render_pass->SetPipeline(PipelineRef(pipeline));
+    render_pass->SetElementCount(1);
+    render_pass->SetIndexBuffer({}, IndexType::kNone);
+    EXPECT_TRUE(render_pass->Draw().ok());
+  }
+
+  EXPECT_CALL(mock_gl_impl_ref, UseProgram(_)).Times(1);
+  // ResetGLState configures each of these once. The first command configures
+  // the pipeline state once more; subsequent commands reuse it.
+  EXPECT_CALL(mock_gl_impl_ref, Disable(GL_BLEND)).Times(2);
+  EXPECT_CALL(mock_gl_impl_ref, Disable(GL_STENCIL_TEST)).Times(2);
+  EXPECT_CALL(mock_gl_impl_ref, Disable(GL_DEPTH_TEST)).Times(2);
+  EXPECT_CALL(mock_gl_impl_ref, ColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE))
+      .Times(2);
 
   EXPECT_TRUE(render_pass->EncodeCommands());
   EXPECT_TRUE(reactor->React());


### PR DESCRIPTION
This reduces per-render-pass CPU overhead in the Impeller OpenGLES backend for layer-heavy scenes such as the reproducer in #191979.

The GLES render pass already knows the framebuffer ID for cached offscreen FBOs and textures created with `WrapFBO`. The pass now uses that information directly instead of synchronously querying `GL_FRAMEBUFFER_BINDING` at the end of every pass. The existing query remains as a fallback for wrapped resources where the current framebuffer cannot be inferred.

The change also keeps pipeline and scissor state cached only for the lifetime of a single render pass. Consecutive commands using the same pipeline no longer repeat blending, depth, stencil, `UseProgram`, or y-flip uniform setup, while stencil-reference and scissor changes still update the corresponding GL state.

Mock GLES coverage now verifies that wrapped default/non-default FBOs preserve the correct discard/invalidate attachment selection without querying the framebuffer binding, that offscreen FBOs avoid the query, and that repeated commands reuse pipeline state.

Fixes #191979

## Testing

- `git diff --check` — passed.
- `clang-format --dry-run --Werror engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc` — passed.
- `cd engine/src && ./flutter/tools/gn --unoptimized` — unavailable because `vpython3` is not installed in the environment.
- `cd engine/src && python3 flutter/tools/gn --unoptimized` — unavailable because this engine checkout is not dependency-synced; `flutter/third_party/skia` is missing.
- `cd engine/src && ninja -C out/host_debug_unopt impeller_unittests` — unavailable because the GN output directory could not be generated.

The Linux profile sweep from the issue could not be run in this checkout for the same engine-environment limitation.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md