### PR TITLE
[stable] [web] Use thread local strike caches in skwasm (#190048)

### DIFF
--- a/engine/src/flutter/lib/web_ui/test/skwasm/concurrent_text_layout_raster_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/skwasm/concurrent_text_layout_raster_test.dart
@@ -1,0 +1,120 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart' show renderer;
+import 'package:ui/ui.dart' as ui;
+
+import '../common/rendering.dart';
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+const int _maxFrames = 200;
+const Duration _maxTestTime = Duration(seconds: 10);
+const int _paragraphsPerFrame = 24;
+const int _spansPerParagraph = 3;
+
+const List<String> _fontFamilies = <String>['Roboto', 'RobotoVariable', 'Ahem'];
+const List<ui.FontWeight> _fontWeights = <ui.FontWeight>[
+  ui.FontWeight.w100,
+  ui.FontWeight.w300,
+  ui.FontWeight.w400,
+  ui.FontWeight.w500,
+  ui.FontWeight.w700,
+  ui.FontWeight.w900,
+];
+
+Future<void> testMain() async {
+  setUpUnitTests(withImplicitView: true, setUpTestViewDimensions: false);
+
+  // Advanced by an irrational stride so fractional font sizes never repeat,
+  // forcing a fresh SkStrike for every span.
+  double fontSizeSeed = 0;
+
+  List<ui.Paragraph> buildAndLayoutParagraphs(int frame) {
+    final paragraphs = <ui.Paragraph>[];
+    for (var i = 0; i < _paragraphsPerFrame; i++) {
+      final builder = ui.ParagraphBuilder(ui.ParagraphStyle());
+      for (var span = 0; span < _spansPerParagraph; span++) {
+        fontSizeSeed += 0.6180339887;
+        builder.pushStyle(
+          ui.TextStyle(
+            color: const ui.Color(0xFF000000),
+            fontFamily: _fontFamilies[(i + span) % _fontFamilies.length],
+            fontSize: 8.0 + (fontSizeSeed % 32.0),
+            fontWeight: _fontWeights[(frame + i + span) % _fontWeights.length],
+            fontStyle: (frame + i + span).isEven ? ui.FontStyle.normal : ui.FontStyle.italic,
+          ),
+        );
+        builder.addText('Quick zephyrs blow 0123456789 frame $frame paragraph $i span $span. ');
+        builder.pop();
+      }
+      final ui.Paragraph paragraph = builder.build();
+      paragraph.layout(const ui.ParagraphConstraints(width: 400));
+      paragraphs.add(paragraph);
+    }
+    return paragraphs;
+  }
+
+  ui.Picture recordPicture(List<ui.Paragraph> paragraphs) {
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder, const ui.Rect.fromLTWH(0, 0, 500, 500));
+    canvas.drawColor(const ui.Color(0xFFFFFFFF), ui.BlendMode.src);
+    var offset = 0.0;
+    for (final paragraph in paragraphs) {
+      canvas.drawParagraph(paragraph, ui.Offset(0, offset));
+      offset += 20.0;
+    }
+    return recorder.endRecording();
+  }
+
+  test('concurrent text layout and rasterization does not corrupt the heap', () async {
+    List<ui.Paragraph> paragraphs = buildAndLayoutParagraphs(0);
+    final stopwatch = Stopwatch()..start();
+    var frame = 0;
+    while (frame < _maxFrames && stopwatch.elapsed < _maxTestTime) {
+      frame++;
+
+      final ui.Picture picture = recordPicture(paragraphs);
+      final sceneBuilder = ui.SceneBuilder();
+      sceneBuilder.addPicture(ui.Offset.zero, picture);
+
+      // Kick off rasterization unawaited, then yield once so the render
+      // message reaches the raster thread.
+      final Future<void> renderFuture = renderScene(sceneBuilder.build());
+      await Future<void>.delayed(Duration.zero);
+
+      // Lay out the next frame's paragraphs while the raster thread is
+      // rasterizing this one — the concurrent strike cache access under test.
+      final List<ui.Paragraph> nextParagraphs = buildAndLayoutParagraphs(frame);
+
+      await renderFuture;
+
+      // Disposing exercises the concurrent teardown path of
+      // https://github.com/flutter/flutter/issues/184858.
+      for (final paragraph in paragraphs) {
+        paragraph.dispose();
+      }
+      picture.dispose();
+      paragraphs = nextParagraphs;
+
+      // Shrink and re-grow the GPU resource cache so purging runs against
+      // in-flight rasterization.
+      if (frame % 16 == 0) {
+        renderer.resourceCacheMaxBytes = frame % 32 == 0 ? 1024 * 1024 : 64 * 1024 * 1024;
+      }
+    }
+
+    for (final paragraph in paragraphs) {
+      paragraph.dispose();
+    }
+
+    // Completing without a RuntimeError or hang is the pass condition.
+    expect(frame, greaterThan(0));
+  }, timeout: const Timeout(Duration(minutes: 2)));
+}

--- a/engine/src/flutter/skwasm/library_skwasm_support.js
+++ b/engine/src/flutter/skwasm/library_skwasm_support.js
@@ -161,6 +161,9 @@ mergeInto(LibraryManager.library, {
               data.callbackId,
             );
             return;
+          case 'setResourceCacheLimit':
+            _surface_setResourceCacheLimitOnWorker(data.surface, data.bytes);
+            return;
           default:
             console.warn(`unrecognized skwasm message: ${skwasmMessage}`);
         }
@@ -210,11 +213,10 @@ mergeInto(LibraryManager.library, {
         callbackId,
       }, [canvas], threadId);
     };
-    _skwasm_reportInitialized = function (surfaceHandle, contextLostCallbackId, callbackId) {
+    _skwasm_reportInitialized = function (surfaceHandle, callbackId) {
       skwasm_postMessage({
         skwasmMessage: 'onInitialized',
         surface: surfaceHandle,
-        contextLostCallbackId,
         callbackId,
       }, []);
     };
@@ -289,6 +291,15 @@ mergeInto(LibraryManager.library, {
         callbackId,
       });
     }
+
+    // Resource Cache
+    _skwasm_dispatchSetResourceCacheLimit = function(threadId, surface, bytes) {
+      skwasm_postMessage({
+        skwasmMessage: 'setResourceCacheLimit',
+        surface,
+        bytes,
+      }, [], threadId);
+    };
 
     // Context Loss
     _skwasm_dispatchTriggerContextLoss = function (threadId, surfaceHandle, callbackId) {
@@ -421,6 +432,8 @@ mergeInto(LibraryManager.library, {
   skwasm_createGlTextureFromTextureSource__deps: ['$skwasm_support_setup'],
   skwasm_dispatchDisposeSurface: function() {},
   skwasm_dispatchDisposeSurface__deps: ['$skwasm_support_setup'],
+  skwasm_dispatchSetResourceCacheLimit: function() {},
+  skwasm_dispatchSetResourceCacheLimit__deps: ['$skwasm_support_setup'],
   skwasm_dispatchRasterizeImage: function() {},
   skwasm_dispatchRasterizeImage__deps: ['$skwasm_support_setup'],
   skwasm_postRasterizeResult: function() {},

--- a/engine/src/flutter/skwasm/skwasm_support.h
+++ b/engine/src/flutter/skwasm/skwasm_support.h
@@ -39,8 +39,7 @@ extern uint32_t skwasm_getGlContextForCanvas(SkwasmObject canvas,
                                              bool antialias,
                                              Skwasm::Surface* surface);
 extern void skwasm_reportInitialized(Skwasm::Surface* surface,
-                                     uint32_t callback_id,
-                                     uint32_t context_lost_callback_id);
+                                     uint32_t callback_id);
 extern void skwasm_reportResizeComplete(Skwasm::Surface* surface,
                                         uint32_t callback_id);
 extern void skwasm_dispatchResizeSurface(unsigned long thread_id,
@@ -76,6 +75,9 @@ extern void skwasm_dispatchTransferCanvas(unsigned long thread_id,
                                           uint32_t callback_id);
 extern void skwasm_dispatchDisposeSurface(unsigned long thread_id,
                                           Skwasm::Surface* surface);
+extern void skwasm_dispatchSetResourceCacheLimit(unsigned long thread_id,
+                                                 Skwasm::Surface* surface,
+                                                 int bytes);
 extern void skwasm_dispatchRasterizeImage(unsigned long thread_id,
                                           Skwasm::Surface* surface,
                                           flutter::DlImage* image,

--- a/engine/src/flutter/skwasm/surface.cc
+++ b/engine/src/flutter/skwasm/surface.cc
@@ -41,6 +41,16 @@
 //    the Dart code, which will complete the future that was returned by the
 //    original Dart method call.
 
+// See https://github.com/flutter/flutter/pull/190048
+extern bool
+    gSkUseThreadLocalStrikeCaches_IAcknowledgeThisIsIncrediblyExperimental;
+
+namespace {
+__attribute__((constructor)) void UseThreadLocalStrikeCaches() {
+  gSkUseThreadLocalStrikeCaches_IAcknowledgeThisIsIncrediblyExperimental = true;
+}
+}  // namespace
+
 unsigned long Skwasm::GetRasterThread() {
   static unsigned long thread = []() {
     if (skwasm_isSingleThreaded()) {
@@ -86,6 +96,11 @@ void Skwasm::Surface::Dispose() {
 uint32_t Skwasm::Surface::SetCanvas(SkwasmObject canvas) {
   assert(emscripten_is_main_browser_thread());
   uint32_t callback_id = ++current_callback_id_;
+
+  // Allocated here instead of on the worker so that current_callback_id_ is
+  // only ever modified on the main thread.
+  context_lost_callback_id_ = ++current_callback_id_;
+
   skwasm_dispatchTransferCanvas(GetRasterThread(), this, canvas, callback_id);
   return callback_id;
 }
@@ -129,9 +144,11 @@ void Skwasm::Surface::ReceiveCanvasOnWorker(SkwasmObject canvas,
   render_context_ = Skwasm::RenderContext::Make(sample_count, stencil);
   render_context_->Resize(canvas_width_, canvas_height_);
 
-  context_lost_callback_id_ = ++current_callback_id_;
+  if (resource_cache_limit_) {
+    render_context_->SetResourceCacheLimit(*resource_cache_limit_);
+  }
 
-  skwasm_reportInitialized(this, context_lost_callback_id_, callback_id);
+  skwasm_reportInitialized(this, callback_id);
 }
 
 // Resizing
@@ -288,8 +305,20 @@ void Skwasm::Surface::OnContextLost() {
 
 // Other
 
+// Main thread only
 void Skwasm::Surface::SetResourceCacheLimit(int bytes) {
-  render_context_->SetResourceCacheLimit(bytes);
+  assert(emscripten_is_main_browser_thread());
+  skwasm_dispatchSetResourceCacheLimit(GetRasterThread(), this, bytes);
+}
+
+// Worker thread only
+void Skwasm::Surface::SetResourceCacheLimitOnWorker(int bytes) {
+  // Always stored so ReceiveCanvasOnWorker can reapply it whenever the
+  // render context is (re)created.
+  resource_cache_limit_ = bytes;
+  if (render_context_) {
+    render_context_->SetResourceCacheLimit(bytes);
+  }
 }
 
 std::unique_ptr<Skwasm::TextureSourceWrapper>
@@ -410,7 +439,14 @@ SKWASM_EXPORT void surface_dispose(Skwasm::Surface* surface) {
 
 SKWASM_EXPORT void surface_setResourceCacheLimitBytes(Skwasm::Surface* surface,
                                                       int bytes) {
+  // Dispatch to the worker, which owns the render context.
   surface->SetResourceCacheLimit(bytes);
+}
+
+SKWASM_EXPORT void surface_setResourceCacheLimitOnWorker(
+    Skwasm::Surface* surface,
+    int bytes) {
+  surface->SetResourceCacheLimitOnWorker(bytes);
 }
 
 SKWASM_EXPORT uint32_t surface_renderPictures(Skwasm::Surface* surface,

--- a/engine/src/flutter/skwasm/surface.h
+++ b/engine/src/flutter/skwasm/surface.h
@@ -12,6 +12,7 @@
 #include <emscripten/threading.h>
 #include <webgl/webgl1.h>
 #include <cassert>
+#include <optional>
 #include "export.h"
 #include "render_context.h"
 #include "wrappers.h"
@@ -80,6 +81,7 @@ class Surface {
 
   // Other
   void SetResourceCacheLimit(int bytes);
+  void SetResourceCacheLimitOnWorker(int bytes);
   std::unique_ptr<TextureSourceWrapper> CreateTextureSourceWrapper(
       SkwasmObject textureSource);
 
@@ -89,6 +91,8 @@ class Surface {
   void RecreateSurface();
 
   CallbackHandler* callback_handler_ = nullptr;
+
+  // Main thread only
   uint32_t current_callback_id_ = 0;
 
   int canvas_width_ = 0;
@@ -97,6 +101,10 @@ class Surface {
   EMSCRIPTEN_WEBGL_CONTEXT_HANDLE gl_context_ = 0;
   std::unique_ptr<RenderContext> render_context_;
   uint32_t context_lost_callback_id_ = 0;
+
+  // Worker thread only: the desired resource cache limit for the surface,
+  // reapplied whenever the render context is (re)created.
+  std::optional<int> resource_cache_limit_;
 
   bool is_initialized_ = false;
 };


### PR DESCRIPTION
Cherry-pick of #190048 (`d3ac5cdfb70971a1b28ca67240860675a6b3598c`) onto `flutter-3.47-candidate.0`. It applies cleanly — all four modified files are byte-identical between the fix's parent and the candidate branch, and the added test does not exist on either, so no conflict resolution was involved.

Issue: #190039

### Impacted Users

Anyone shipping a `flutter build web --wasm` app served cross-origin isolated — via COOP/COEP or `Document-Isolation-Policy` — which is what selects multi-threaded skwasm. This hits end users of those apps, not only developers.

### Impact Description

A silent, unrecoverable freeze of the running app.

Multi-threaded skwasm is built with `-sWASM_WORKERS` but without `-pthread`, so it links the single-threaded emscripten system libraries where mutexes are no-ops. Main-thread text layout and the raster worker then share the global `SkStrikeCache` and corrupt the heap under text churn. It surfaces either as `RuntimeError: memory access out of bounds` from `skwasm.wasm`, or as nothing at all in the console; afterwards the page never runs JS again — `requestAnimationFrame` stops, and a core stays pinned.

Field data from our production web app (Flutter 3.44.7, wasm, thousands of daily users), in case it is useful for prioritisation:

- We captured a Chrome DevTools profile of a live freeze. The main thread's stack is `RenderParagraph.performLayout` → `TextPainter._createParagraph` → engine `renderer.dart` → `skwasm.wasm` → a busy-spin on `emscripten_get_now`, held for the full 7.7 s remaining in the trace. The skwasm render worker sits 100% idle beside it. The compositor keeps issuing `BeginFrame` at 60/s with no main frame ever committing.
- `RuntimeError: memory access out of bounds` with a `skwasm` culprit went from 10 events across all prior releases to 111 in the two weeks after we enabled cross-origin isolation — the only change that turned multi-threaded skwasm on.
- The innermost frames of those crash stacks and of the frozen profile are the same `skwasm.wasm` functions, i.e. the trap and the spin are the two presentations of one defect, exactly as described in #190039.

### Workaround

Yes: `forceSingleThreadedSkwasm: true`, or stop serving the app cross-origin isolated. Both give up multi-threaded rendering altogether, which is the feature being paid for. We have taken the second option in production.

### Risk

Low. The change sets a Skia flag from a constructor in `surface.cc` so each thread gets its own strike cache. There is no API or behaviour change beyond removing the shared mutable state.

### Test Coverage

Yes. The upstream PR adds `engine/src/flutter/lib/web_ui/test/skwasm/concurrent_text_layout_raster_test.dart`, which is included in this cherry-pick.

### Validation Steps

1. Build a wasm app that lays out fresh multi-span paragraphs every frame while animating — the reproduction in #190039 does this.
2. Serve `build/web` cross-origin isolated so skwasm picks multi-threaded mode.
3. Open it in Chrome.

Before: the tab freezes within seconds (3–30 s in the reporter's runs). After: the animation keeps running.

---

Two notes for the reviewer:

**This is not a regression introduced in 3.47.** The defect has been present since multi-threaded skwasm shipped, so it sits outside the strict "regression from the previous release" wording of the cherry-pick process. I am requesting it anyway because the failure mode is a silent production freeze with no error surface for most users, the fix is already on master and in beta 3.48, and without a cherry-pick affected apps stay on the single-threaded fallback until 3.50 lands — roughly three months. Entirely happy for this to be closed if the release team would rather it ride the normal train.

**Why this commit and not #191014.** That follow-up swaps the experimental Skia flag for the officially supported one, and depends on a newer Skia roll than 3.47 carries, so this cherry-pick keeps the original form.
