### PR TITLE
[AGP 9.1.0 Migration #5] Delete getLegacyAndroidExtension and migrate NDK fallback to public DSL

### DIFF
--- a/packages/flutter_tools/gradle/README.md
+++ b/packages/flutter_tools/gradle/README.md
@@ -42,7 +42,7 @@ Sometimes changing a test name and then running it will cause an IDE error. To g
 to a good state on Mac, run `Help > "Repair IDE"`, and then in the popup window `"Rescan project indexes > Everything works now."`
 
 To add a new test, add a class under `src/test/kotlin`, with methods annotated with `@Test`.
-These tests will get automatically run on CI by `packages/flutter_tools/test/integration.shard/android_run_flutter_gradle_plugin_tests_test.dart`.
+These tests will get automatically run on CI by [`packages/flutter_tools/test/integration.shard/android_run_flutter_gradle_plugin_tests_test.dart`](../test/integration.shard/android_run_flutter_gradle_plugin_tests_test.dart).
 
 ### Kotlin Formatting
 

--- a/packages/flutter_tools/gradle/src/main/kotlin/AgpCommonExtensionWrapper.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/AgpCommonExtensionWrapper.kt
@@ -7,6 +7,7 @@ package com.flutter.gradle
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.BuildType
 import com.android.build.api.dsl.DynamicFeatureExtension
+import com.android.build.api.dsl.ExternalNativeBuild
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.dsl.Splits
 import com.android.build.api.dsl.TestExtension
@@ -104,6 +105,16 @@ class AgpCommonExtensionWrapper(
                 is LibraryExtension -> backingExtension.buildTypes
                 is DynamicFeatureExtension -> backingExtension.buildTypes
                 is TestExtension -> backingExtension.buildTypes
+                else -> throw IllegalArgumentException(unsupportedMessage())
+            }
+
+    val externalNativeBuild: ExternalNativeBuild
+        get() =
+            when (backingExtension) {
+                is ApplicationExtension -> backingExtension.externalNativeBuild
+                is LibraryExtension -> backingExtension.externalNativeBuild
+                is DynamicFeatureExtension -> backingExtension.externalNativeBuild
+                is TestExtension -> backingExtension.externalNativeBuild
                 else -> throw IllegalArgumentException(unsupportedMessage())
             }
 

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -12,7 +12,6 @@ import com.android.build.api.dsl.DynamicFeatureBuildType
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
-import com.android.build.gradle.BaseExtension
 import com.flutter.gradle.plugins.PluginHandler
 import com.flutter.gradle.tasks.DeepLinkJsonFromManifestTask
 import com.flutter.gradle.tasks.EnableHcppManifestTask
@@ -538,22 +537,6 @@ object FlutterPluginUtils {
         return project.property(PROP_LOCAL_ENGINE_BUILD_MODE) == flutterBuildMode
     }
 
-    /**
-     * Returns BaseExtension for the project. Used for compatibility.
-     *
-     * From BaseExtension docs:
-     * "Don't use this extension directly Instead, use one of the following:
-     *  ApplicationExtension, LibraryExtension, TestExtension, DynamicFeatureExtension"
-     *
-     *  For ApplicationExtension use `getAndroidApplicationExtension`.
-     *  For LibraryExtension use `getAndroidLibraryExtension`.
-     */
-    internal fun getLegacyAndroidExtension(project: Project): BaseExtension {
-        // Common supertype of the android extension types.
-        // But maybe this should be https://developer.android.com/reference/tools/gradle-api/8.7/com/android/build/api/dsl/TestedExtension.
-        return project.extensions.findByType(BaseExtension::class.java)!!
-    }
-
     internal fun getAndroidExtension(project: Project): AgpCommonExtensionWrapper {
         // Look up by name to completely avoid importing or resolving CommonExtension
         val androidExtension =
@@ -838,11 +821,11 @@ object FlutterPluginUtils {
         }
 
         // If the project is already configuring a native build, we don't need to do anything.
-        val gradleProjectAndroidExtension = getLegacyAndroidExtension(gradleProject)
+        val gradleProjectAndroidExtension = getAndroidExtension(gradleProject)
         val externalNativeBuild = gradleProjectAndroidExtension.externalNativeBuild
         val forcingNotRequired: Boolean =
-            externalNativeBuild?.cmake?.path != null ||
-                externalNativeBuild?.ndkBuild?.path != null
+            externalNativeBuild.cmake.path != null ||
+                externalNativeBuild.ndkBuild.path != null
         if (forcingNotRequired) {
             return
         }
@@ -966,10 +949,9 @@ object FlutterPluginUtils {
         gradleProject: Project,
         flutterSdkRootPath: String
     ) {
-        val gradleProjectAndroidExtension = getLegacyAndroidExtension(gradleProject)
-        gradleProjectAndroidExtension.externalNativeBuild.cmake.path(
-            "$flutterSdkRootPath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt"
-        )
+        val gradleProjectAndroidExtension = getAndroidExtension(gradleProject)
+        gradleProjectAndroidExtension.externalNativeBuild.cmake.path =
+            File("$flutterSdkRootPath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt")
 
         // AGP defaults to outputting build artifacts in `android/app/.cxx`. This directory is a
         // build artifact, so we move it from that directory to within Flutter's build directory
@@ -981,22 +963,22 @@ object FlutterPluginUtils {
         // but as we are not actually building anything (and are instead only tricking AGP into
         // downloading the NDK), it is acceptable for the buildStagingDirectory to be removed
         // and rebuilt when running clean builds.
-        gradleProjectAndroidExtension.externalNativeBuild.cmake.buildStagingDirectory(
+        gradleProjectAndroidExtension.externalNativeBuild.cmake.buildStagingDirectory =
             gradleProject.layout.buildDirectory
                 .dir("../.cxx")
                 .get()
-                .asFile.path
-        )
+                .asFile
 
         // CMake will print warnings when you try to build an empty project.
         // These arguments silence the warnings - our project is intentionally
         // empty.
         gradleProjectAndroidExtension.buildTypes.forEach { buildType ->
-            buildType.externalNativeBuild.cmake.arguments(
-                "-Wno-dev",
-                "--no-warn-unused-cli",
-                "-DCMAKE_BUILD_TYPE=${buildType.name}"
-            )
+            buildType.externalNativeBuild.cmake.arguments +=
+                listOf(
+                    "-Wno-dev",
+                    "--no-warn-unused-cli",
+                    "-DCMAKE_BUILD_TYPE=${buildType.name}"
+                )
         }
     }
 

--- a/packages/flutter_tools/gradle/src/test/kotlin/AgpCommonExtensionWrapperTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/AgpCommonExtensionWrapperTest.kt
@@ -8,6 +8,7 @@ import com.android.build.api.dsl.ApplicationBuildType
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.DynamicFeatureBuildType
 import com.android.build.api.dsl.DynamicFeatureExtension
+import com.android.build.api.dsl.ExternalNativeBuild
 import com.android.build.api.dsl.LibraryBuildType
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.dsl.Splits
@@ -195,6 +196,20 @@ class AgpCommonExtensionWrapperTest {
     }
 
     @Test
+    fun `externalNativeBuild delegates to application, library, dynamicFeature, and test extensions`() {
+        val mockExternalNativeBuild = mockk<ExternalNativeBuild>(relaxed = true)
+        val appExt = mockk<ApplicationExtension>(relaxed = true) { every { externalNativeBuild } returns mockExternalNativeBuild }
+        val libExt = mockk<LibraryExtension>(relaxed = true) { every { externalNativeBuild } returns mockExternalNativeBuild }
+        val dfExt = mockk<DynamicFeatureExtension>(relaxed = true) { every { externalNativeBuild } returns mockExternalNativeBuild }
+        val testExt = mockk<TestExtension>(relaxed = true) { every { externalNativeBuild } returns mockExternalNativeBuild }
+
+        assertSame(mockExternalNativeBuild, AgpCommonExtensionWrapper(appExt).externalNativeBuild)
+        assertSame(mockExternalNativeBuild, AgpCommonExtensionWrapper(libExt).externalNativeBuild)
+        assertSame(mockExternalNativeBuild, AgpCommonExtensionWrapper(dfExt).externalNativeBuild)
+        assertSame(mockExternalNativeBuild, AgpCommonExtensionWrapper(testExt).externalNativeBuild)
+    }
+
+    @Test
     fun `wrapper throws for an unsupported backing extension type`() {
         val wrapper = AgpCommonExtensionWrapper("not an android extension")
 
@@ -210,5 +225,6 @@ class AgpCommonExtensionWrapperTest {
         assertFailsWith<IllegalArgumentException> { wrapper.ndkVersion = "29.0.0" }
         assertFailsWith<IllegalArgumentException> { wrapper.getDefaultProguardFile("proguard-android.txt") }
         assertFailsWith<IllegalArgumentException> { wrapper.compileOptions {} }
+        assertFailsWith<IllegalArgumentException> { wrapper.externalNativeBuild }
     }
 }

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginUtilsTest.kt
@@ -12,9 +12,6 @@ import com.android.build.api.dsl.LibraryBuildType
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Variant
 import com.android.build.api.variant.VariantBuilder
-import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.internal.dsl.CmakeOptions
-import com.android.build.gradle.internal.dsl.DefaultConfig
 import com.android.builder.model.BuildType
 import com.flutter.gradle.FlutterPluginUtils.BUILT_IN_KOTLIN_DOCS
 import com.flutter.gradle.FlutterPluginUtils.BUILT_IN_KOTLIN_DOCS_FOR_APPS
@@ -24,8 +21,7 @@ import com.flutter.gradle.FlutterPluginUtils.detectApplyingKotlinGradlePlugin
 import com.flutter.gradle.plugins.PluginHandler
 import com.flutter.gradle.tasks.EnableHcppManifestTask
 import com.flutter.gradle.tasks.PrintTask
-import com.flutter.gradle.testing.setUpMockAndroidExtension
-import io.mockk.called
+import com.flutter.gradle.testing.setUpMockExternalNativeBuild
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -37,8 +33,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
-import org.gradle.api.file.Directory
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.logging.Logger
@@ -1969,76 +1963,41 @@ class FlutterPluginUtilsTest {
     fun `forceNdkDownload skips projects which are already configuring a native build`(
         @TempDir tempDir: Path
     ) {
-        val fakeCmakeFile = tempDir.resolve("CMakeLists.txt").toFile()
-        fakeCmakeFile.createNewFile()
+        val fakeCmakeFile = tempDir.resolve("CMakeLists.txt").toFile().apply { createNewFile() }
         val project = mockk<Project>()
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        every {
-            project.extensions
-                .findByType(BaseExtension::class.java)!!
-                .externalNativeBuild.cmake
-        } returns mockCmakeOptions
-        every {
-            project.extensions
-                .findByType(BaseExtension::class.java)!!
-                .externalNativeBuild.ndkBuild
-        } returns mockNdkBuildOptions
-        every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
+        val (mockAndroidExtension, mockCmake) = setUpMockExternalNativeBuild(project, cmakePath = fakeCmakeFile)
 
-        every { mockCmakeOptions.path } returns fakeCmakeFile
-        every { mockNdkBuildOptions.path } returns null
-
-        setUpMockAndroidExtension(project)
         FlutterPluginUtils.forceNdkDownload(project, "ignored")
 
-        verify(exactly = 1) {
-            mockCmakeOptions.path
-        }
-        verify(exactly = 0) { mockCmakeOptions.setPath(any()) }
-        verify { mockDefaultConfig wasNot called }
+        // Verifies the guard checked the cmake.path getter
+        verify(exactly = 1) { mockCmake.path }
+        // Verifies synthetic fallback was not configured (setter never invoked, buildTypes untouched)
+        verify(exactly = 0) { mockCmake.path = any() }
+        verify(exactly = 0) { mockCmake.buildStagingDirectory = any() }
+        verify(exactly = 0) { mockAndroidExtension.buildTypes }
     }
 
     @Test
     fun `forceNdkDownload skips projects which are already configuring an ndk-build`(
         @TempDir tempDir: Path
     ) {
-        val fakeAndroidMkFile = tempDir.resolve("Android.mk").toFile()
-        fakeAndroidMkFile.createNewFile()
+        val fakeAndroidMkFile = tempDir.resolve("Android.mk").toFile().apply { createNewFile() }
         val project = mockk<Project>()
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        every {
-            project.extensions
-                .findByType(BaseExtension::class.java)!!
-                .externalNativeBuild.cmake
-        } returns mockCmakeOptions
-        every {
-            project.extensions
-                .findByType(BaseExtension::class.java)!!
-                .externalNativeBuild.ndkBuild
-        } returns mockNdkBuildOptions
-        every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
+        val (mockAndroidExtension, mockCmake, mockNdkBuild) =
+            setUpMockExternalNativeBuild(project, ndkBuildPath = fakeAndroidMkFile)
 
-        every { mockCmakeOptions.path } returns null
-        every { mockNdkBuildOptions.path } returns fakeAndroidMkFile
-
-        setUpMockAndroidExtension(project)
         FlutterPluginUtils.forceNdkDownload(project, "ignored")
 
-        verify(exactly = 1) {
-            mockCmakeOptions.path
-        }
-        verify(exactly = 1) {
-            mockNdkBuildOptions.path
-        }
-        verify(exactly = 0) { mockCmakeOptions.path(any()) }
-        verify(exactly = 0) { mockCmakeOptions.buildStagingDirectory(any()) }
-        verify { mockDefaultConfig wasNot called }
+        // Verifies the guard checked both cmake.path and ndkBuild.path getters
+        verify(exactly = 1) { mockCmake.path }
+        verify(exactly = 1) { mockNdkBuild.path }
+        // Verifies synthetic fallback was not configured
+        verify(exactly = 0) { mockCmake.path = any() }
+        verify(exactly = 0) { mockCmake.buildStagingDirectory = any() }
+        verify(exactly = 0) { mockAndroidExtension.buildTypes }
     }
 
+    @Test
     fun `forceNdkDownload installs a missing ndk when tool properties are provided`(
         @TempDir tempDir: Path
     ) {
@@ -2048,17 +2007,7 @@ class FlutterPluginUtilsTest {
         val mockExecSpec = mockk<ExecSpec>()
         val mockExecResult = mockk<ExecResult>()
         val mockExecOperations = mockk<ExecOperations>()
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockBaseExtension = mockk<BaseExtension>()
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.externalNativeBuild.ndkBuild } returns mockNdkBuildOptions
-        every { mockNdkBuildOptions.path } returns null
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockBaseExtension.ndkVersion } returns "29.0.13846066"
-        every { mockCmakeOptions.path } returns null
+        val (mockAndroidExtension, mockCmake) = setUpMockExternalNativeBuild(project, ndkVersion = "29.0.13846066")
         every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns "/sdkmanager"
         every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns tempDir.toString()
         every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns ""
@@ -2075,7 +2024,6 @@ class FlutterPluginUtilsTest {
         every { mockExecResult.assertNormalExitValue() } returns mockExecResult
         every { mockExecSpec.commandLine(any<List<String>>()) } returns mockExecSpec
 
-        setUpMockAndroidExtension(project)
         FlutterPluginUtils.forceNdkDownload(project, "/base/path")
         finalizeDslSlot.captured.invoke(Any())
         execActionSlot.captured.execute(mockExecSpec)
@@ -2091,36 +2039,30 @@ class FlutterPluginUtilsTest {
                 )
             )
         }
-        verify(exactly = 0) { mockCmakeOptions.path(any()) }
-        verify { mockDefaultConfig wasNot called }
+        verify(exactly = 0) { mockCmake.path = any() }
+        verify(exactly = 0) { mockCmake.buildStagingDirectory = any() }
+        verify(exactly = 0) { mockAndroidExtension.buildTypes }
     }
 
     @Test
     fun `forceNdkDownload skips sdkmanager install when the requested ndk is already installed`() {
-        val project = mockk<Project>()
+        val project = mockk<ProjectInternal>()
         val finalizeDslSlot = captureFinalizeDslAction(project)
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockBaseExtension = mockk<BaseExtension>()
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.externalNativeBuild.ndkBuild } returns mockNdkBuildOptions
-        every { mockNdkBuildOptions.path } returns null
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockBaseExtension.ndkVersion } returns "29.0.13846066"
-        every { mockCmakeOptions.path } returns null
+        val mockExecOperations = mockk<ExecOperations>()
+        val (mockAndroidExtension, mockCmake) = setUpMockExternalNativeBuild(project, ndkVersion = "29.0.13846066")
         every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns "/sdkmanager"
         every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns "/sdk/root"
         every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns "29.0.13846066"
         every { project.gradle.startParameter.taskNames } returns emptyList()
+        every { project.serviceOf<ExecOperations>() } returns mockExecOperations
 
-        setUpMockAndroidExtension(project)
         FlutterPluginUtils.forceNdkDownload(project, "/base/path")
         finalizeDslSlot.captured.invoke(Any())
 
-        verify(exactly = 0) { mockCmakeOptions.path(any()) }
-        verify { mockDefaultConfig wasNot called }
+        verify(exactly = 0) { mockExecOperations.exec(any<Action<ExecSpec>>()) }
+        verify(exactly = 0) { mockCmake.path = any() }
+        verify(exactly = 0) { mockCmake.buildStagingDirectory = any() }
+        verify(exactly = 0) { mockAndroidExtension.buildTypes }
     }
 
     @Test
@@ -2129,48 +2071,21 @@ class FlutterPluginUtilsTest {
     ) {
         val project = mockk<Project>()
         val finalizeDslSlot = captureFinalizeDslAction(project)
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockDirectoryProperty = mockk<DirectoryProperty>()
-        val mockDirectory = mockk<Directory>()
-        val mockBaseExtension = mockk<BaseExtension>()
         var cmakePath: File? = null
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.externalNativeBuild.ndkBuild } returns mockNdkBuildOptions
-        every { mockNdkBuildOptions.path } returns null
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockBaseExtension.ndkVersion } returns "29.0.13846066"
-        every { mockCmakeOptions.path } answers { cmakePath }
-        every { mockCmakeOptions.path(any()) } returns Unit
-        every { mockCmakeOptions.buildStagingDirectory(any()) } returns Unit
+        val (mockAndroidExtension, mockCmake) = setUpMockExternalNativeBuild(project, ndkVersion = "29.0.13846066")
+        every { mockCmake.path } answers { cmakePath }
         every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns null
         every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns "/sdk/root"
         every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns ""
         every { project.gradle.startParameter.taskNames } returns emptyList()
-        every { project.layout.buildDirectory } returns mockDirectoryProperty
-        every { mockDirectoryProperty.dir(any<String>()) } returns mockDirectoryProperty
-        every { mockDirectoryProperty.get() } returns mockDirectory
-        every { mockDirectory.asFile.path } returns "/randomapp/build/app/"
 
-        val mockBuildType = mockk<com.android.build.gradle.internal.dsl.BuildType>()
-        every { mockBaseExtension.buildTypes.iterator() } returns mutableListOf(mockBuildType).iterator()
-        every { mockBuildType.name } returns "Debug"
-        every { mockBuildType.externalNativeBuild.cmake.arguments(any(), any(), any()) } returns Unit
-
-        setUpMockAndroidExtension(project)
         FlutterPluginUtils.forceNdkDownload(project, "/base/path")
         cmakePath = tempDir.resolve("CMakeLists.txt").toFile()
         finalizeDslSlot.captured.invoke(Any())
 
-        verify(exactly = 0) {
-            mockCmakeOptions.path(
-                "/base/path/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt"
-            )
-        }
-        verify(exactly = 0) { mockCmakeOptions.buildStagingDirectory(any()) }
-        verify { mockDefaultConfig wasNot called }
+        verify(exactly = 0) { mockCmake.path = any() }
+        verify(exactly = 0) { mockCmake.buildStagingDirectory = any() }
+        verify(exactly = 0) { mockAndroidExtension.buildTypes }
     }
 
     @Test
@@ -2183,18 +2098,9 @@ class FlutterPluginUtilsTest {
         val mockExecSpec = mockk<ExecSpec>()
         val mockExecResult = mockk<ExecResult>()
         val mockExecOperations = mockk<ExecOperations>()
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockBaseExtension = mockk<BaseExtension>()
         var configuredNdkVersion = "26.3.11579264"
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.externalNativeBuild.ndkBuild } returns mockNdkBuildOptions
-        every { mockNdkBuildOptions.path } returns null
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockBaseExtension.ndkVersion } answers { configuredNdkVersion }
-        every { mockCmakeOptions.path } returns null
+        val (mockAndroidExtension, mockCmake) = setUpMockExternalNativeBuild(project, ndkVersion = null)
+        every { mockAndroidExtension.ndkVersion } answers { configuredNdkVersion }
         every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns "/sdkmanager"
         every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns tempDir.toString()
         every {
@@ -2213,8 +2119,6 @@ class FlutterPluginUtilsTest {
         every { mockExecResult.assertNormalExitValue() } returns mockExecResult
         every { mockExecSpec.commandLine(any<List<String>>()) } returns mockExecSpec
 
-        val mockAndroidExtension = setUpMockAndroidExtension(project)
-        every { mockAndroidExtension.ndkVersion } answers { configuredNdkVersion }
         FlutterPluginUtils.forceNdkDownload(project, "/base/path")
         configuredNdkVersion = "27.3.13750724"
         finalizeDslSlot.captured.invoke(Any())
@@ -2231,142 +2135,27 @@ class FlutterPluginUtilsTest {
                 )
             )
         }
-        verify(exactly = 0) { mockCmakeOptions.path(any()) }
-        verify { mockDefaultConfig wasNot called }
-    }
-
-    @Test
-    fun `forceNdkDownload waits for finalized ApplicationExtension ndkVersion before checking installed versions`(
-        @TempDir tempDir: Path
-    ) {
-        val project = mockk<ProjectInternal>()
-        val finalizeDslSlot = captureFinalizeDslAction(project)
-        val execActionSlot = slot<Action<ExecSpec>>()
-        val mockExecSpec = mockk<ExecSpec>()
-        val mockExecResult = mockk<ExecResult>()
-        val mockExecOperations = mockk<ExecOperations>()
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockBaseExtension = mockk<BaseExtension>()
-        val mockApplicationExtension = mockk<ApplicationExtension>()
-        var configuredNdkVersion = "26.3.11579264"
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every {
-            project.extensions.findByType(ApplicationExtension::class.java)
-        } returns mockApplicationExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.externalNativeBuild.ndkBuild } returns mockNdkBuildOptions
-        every { mockNdkBuildOptions.path } returns null
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockBaseExtension.ndkVersion } answers {
-            throw AssertionError(
-                "legacy ndkVersion should not be read when ApplicationExtension is available"
-            )
-        }
-        every { mockApplicationExtension.ndkVersion } answers { configuredNdkVersion }
-        every { project.extensions.findByName("android") } returns mockApplicationExtension
-        every { mockCmakeOptions.path } returns null
-        every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns "/sdkmanager"
-        every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns tempDir.toString()
-        every {
-            project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS)
-        } returns "26.3.11579264"
-        every { project.gradle.startParameter.taskNames } returns emptyList()
-        every { project.gradle.startParameter.isOffline } returns false
-        every { project.serviceOf<ExecOperations>() } returns mockExecOperations
-        every { mockExecOperations.exec(capture(execActionSlot)) } answers {
-            File(tempDir.toFile(), "ndk/27.3.13750724/source.properties").apply {
-                parentFile.mkdirs()
-                createNewFile()
-            }
-            mockExecResult
-        }
-        every { mockExecResult.assertNormalExitValue() } returns mockExecResult
-        every { mockExecSpec.commandLine(any<List<String>>()) } returns mockExecSpec
-
-        val mockAndroidExtension = setUpMockAndroidExtension(project)
-        every { mockAndroidExtension.ndkVersion } answers { configuredNdkVersion }
-        FlutterPluginUtils.forceNdkDownload(project, "/base/path")
-        configuredNdkVersion = "27.3.13750724"
-        finalizeDslSlot.captured.invoke(Any())
-        execActionSlot.captured.execute(mockExecSpec)
-
-        verify(exactly = 1) { mockExecOperations.exec(any<Action<ExecSpec>>()) }
-        verify {
-            mockExecSpec.commandLine(
-                listOf(
-                    "/sdkmanager",
-                    "--sdk_root=$tempDir",
-                    "--install",
-                    "ndk;27.3.13750724"
-                )
-            )
-        }
-        verify(exactly = 0) { mockCmakeOptions.path(any()) }
-        verify { mockDefaultConfig wasNot called }
+        verify(exactly = 0) { mockCmake.path = any() }
+        verify(exactly = 0) { mockCmake.buildStagingDirectory = any() }
+        verify(exactly = 0) { mockAndroidExtension.buildTypes }
     }
 
     @Test
     fun `forceNdkDownload skips fallback when sdkmanager is unavailable but the requested ndk is already installed`() {
         val project = mockk<Project>()
         val finalizeDslSlot = captureFinalizeDslAction(project)
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockBaseExtension = mockk<BaseExtension>()
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.externalNativeBuild.ndkBuild } returns mockNdkBuildOptions
-        every { mockNdkBuildOptions.path } returns null
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockBaseExtension.ndkVersion } returns "29.0.13846066"
-        every { mockCmakeOptions.path } returns null
+        val (mockAndroidExtension, mockCmake) = setUpMockExternalNativeBuild(project, ndkVersion = "29.0.13846066")
         every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns null
         every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns "/sdk/root"
         every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns "29.0.13846066"
         every { project.gradle.startParameter.taskNames } returns emptyList()
 
-        setUpMockAndroidExtension(project)
         FlutterPluginUtils.forceNdkDownload(project, "/base/path")
         finalizeDslSlot.captured.invoke(Any())
 
-        verify(exactly = 0) { mockCmakeOptions.path(any()) }
-        verify { mockDefaultConfig wasNot called }
-    }
-
-    @Test
-    fun `forceNdkDownload reads ndkVersion from ApplicationExtension when legacy extension does not expose it`() {
-        val project = mockk<Project>()
-        val finalizeDslSlot = captureFinalizeDslAction(project)
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockBaseExtension = mockk<BaseExtension>()
-        val mockApplicationExtension = mockk<ApplicationExtension>()
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every { project.extensions.findByType(ApplicationExtension::class.java) } returns mockApplicationExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.externalNativeBuild.ndkBuild } returns mockNdkBuildOptions
-        every { mockNdkBuildOptions.path } returns null
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockBaseExtension.ndkVersion } answers {
-            throw AssertionError("legacy ndkVersion should not be read when ApplicationExtension is available")
-        }
-        every { mockApplicationExtension.ndkVersion } returns "29.0.13846066"
-        every { project.extensions.findByName("android") } returns mockApplicationExtension
-        every { mockCmakeOptions.path } returns null
-        every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns "/sdkmanager"
-        every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns "/sdk/root"
-        every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns "29.0.13846066"
-        every { project.gradle.startParameter.taskNames } returns emptyList()
-
-        setUpMockAndroidExtension(project)
-        FlutterPluginUtils.forceNdkDownload(project, "/base/path")
-        finalizeDslSlot.captured.invoke(Any())
-
-        verify(exactly = 0) { mockCmakeOptions.path(any()) }
-        verify { mockDefaultConfig wasNot called }
+        verify(exactly = 0) { mockCmake.path = any() }
+        verify(exactly = 0) { mockCmake.buildStagingDirectory = any() }
+        verify(exactly = 0) { mockAndroidExtension.buildTypes }
     }
 
     @Test
@@ -2377,17 +2166,7 @@ class FlutterPluginUtilsTest {
         val finalizeDslSlot = captureFinalizeDslAction(project)
         val mockExecResult = mockk<ExecResult>()
         val mockExecOperations = mockk<ExecOperations>()
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockBaseExtension = mockk<BaseExtension>()
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.externalNativeBuild.ndkBuild } returns mockNdkBuildOptions
-        every { mockNdkBuildOptions.path } returns null
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockBaseExtension.ndkVersion } returns "29.0.13846066"
-        every { mockCmakeOptions.path } returns null
+        val (mockAndroidExtension, mockCmake) = setUpMockExternalNativeBuild(project, ndkVersion = "29.0.13846066")
         every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns "/sdkmanager"
         every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns tempDir.toString()
         every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns ""
@@ -2397,203 +2176,163 @@ class FlutterPluginUtilsTest {
         every { mockExecOperations.exec(any<Action<ExecSpec>>()) } returns mockExecResult
         every { mockExecResult.assertNormalExitValue() } returns mockExecResult
 
-        setUpMockAndroidExtension(project)
         FlutterPluginUtils.forceNdkDownload(project, "/base/path")
 
         assertThrows<GradleException> {
             finalizeDslSlot.captured.invoke(Any())
         }
 
-        verify(exactly = 0) { mockCmakeOptions.path(any()) }
-        verify { mockDefaultConfig wasNot called }
+        verify(exactly = 0) { mockCmake.path = any() }
+        verify(exactly = 0) { mockCmake.buildStagingDirectory = any() }
+        verify(exactly = 0) { mockAndroidExtension.buildTypes }
     }
 
     @Test
     fun `forceNdkDownload skips when invoking the ndk metadata task`() {
         val project = mockk<Project>()
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockBaseExtension = mockk<BaseExtension>()
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockCmakeOptions.path } returns null
+        val (mockAndroidExtension, mockCmake) = setUpMockExternalNativeBuild(project)
         every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns null
         every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns null
         every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns null
         every { project.gradle.startParameter.taskNames } returns listOf(FlutterPluginUtils.TASK_PRINT_NDK_VERSION)
-        every { project.extensions.findByType(ApplicationExtension::class.java) } returns mockk(relaxed = true)
 
         FlutterPluginUtils.forceNdkDownload(project, "/base/path")
 
-        verify(exactly = 0) { mockCmakeOptions.path(any()) }
-        verify { mockDefaultConfig wasNot called }
+        verify(exactly = 0) { mockCmake.path = any() }
+        verify(exactly = 0) { mockCmake.buildStagingDirectory = any() }
+        verify(exactly = 0) { mockAndroidExtension.buildTypes }
     }
 
     @Test
-    fun `forceNdkDownload falls back when tool properties are present but sdkmanager is unavailable`() {
+    fun `forceNdkDownload configures synthetic cmake fallback when AndroidComponentsExtension is missing`() {
+        val project = mockk<Project>()
+        val (_, mockCmake, _, cmakeArguments) = setUpMockExternalNativeBuild(project, ndkVersion = "29.0.13846066")
+        every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns "/sdkmanager"
+        every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns "/sdk/root"
+        every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns ""
+        every { project.gradle.startParameter.taskNames } returns emptyList()
+        every { project.extensions.findByType(AndroidComponentsExtension::class.java) } returns null
+        val basePath = "/base/path"
+
+        FlutterPluginUtils.forceNdkDownload(project, basePath)
+
+        verify(exactly = 1) {
+            mockCmake.path = File("$basePath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt")
+        }
+        verify(exactly = 1) { mockCmake.buildStagingDirectory = any() }
+        assertEquals(
+            listOf("-Wno-dev", "--no-warn-unused-cli", "-DCMAKE_BUILD_TYPE=Debug"),
+            cmakeArguments
+        )
+    }
+
+    @Test
+    fun `forceNdkDownload configures synthetic cmake fallback when tool properties are present but sdkmanager is unavailable`() {
         val project = mockk<Project>()
         val finalizeDslSlot = captureFinalizeDslAction(project)
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockDirectoryProperty = mockk<DirectoryProperty>()
-        val mockDirectory = mockk<Directory>()
-        val mockBaseExtension = mockk<BaseExtension>()
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.externalNativeBuild.ndkBuild } returns mockNdkBuildOptions
-        every { mockNdkBuildOptions.path } returns null
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockBaseExtension.ndkVersion } returns "29.0.13846066"
-        every { mockCmakeOptions.path } returns null
-        every { mockCmakeOptions.path(any()) } returns Unit
-        every { mockCmakeOptions.buildStagingDirectory(any()) } returns Unit
+        val (_, mockCmake, _, cmakeArguments) = setUpMockExternalNativeBuild(project, ndkVersion = "29.0.13846066")
         every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns null
         every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns "/sdk/root"
         every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns ""
         every { project.gradle.startParameter.taskNames } returns emptyList()
-        every { project.layout.buildDirectory } returns mockDirectoryProperty
-        every { mockDirectoryProperty.dir(any<String>()) } returns mockDirectoryProperty
-        every { mockDirectoryProperty.get() } returns mockDirectory
-        every { mockDirectory.asFile.path } returns "/randomapp/build/app/"
+        every { project.gradle.startParameter.isOffline } returns false
         val basePath = "/base/path"
 
-        val mockBuildType = mockk<com.android.build.gradle.internal.dsl.BuildType>()
-        every { mockBaseExtension.buildTypes.iterator() } returns mutableListOf(mockBuildType).iterator()
-        every { mockBuildType.name } returns "Debug"
-        every { mockBuildType.externalNativeBuild.cmake.arguments(any(), any(), any()) } returns Unit
-
-        setUpMockAndroidExtension(project)
         FlutterPluginUtils.forceNdkDownload(project, basePath)
         finalizeDslSlot.captured.invoke(Any())
 
         verify(exactly = 1) {
-            mockCmakeOptions.path("$basePath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt")
+            mockCmake.path = File("$basePath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt")
         }
-        verify(exactly = 1) { mockCmakeOptions.buildStagingDirectory(any()) }
-        verify(exactly = 1) {
-            mockBuildType.externalNativeBuild.cmake.arguments(
-                "-Wno-dev",
-                "--no-warn-unused-cli",
-                "-DCMAKE_BUILD_TYPE=Debug"
-            )
-        }
+        verify(exactly = 1) { mockCmake.buildStagingDirectory = any() }
+        assertEquals(
+            listOf("-Wno-dev", "--no-warn-unused-cli", "-DCMAKE_BUILD_TYPE=Debug"),
+            cmakeArguments
+        )
     }
 
     @Test
-    fun `forceNdkDownload falls back when Gradle is offline`() {
+    fun `forceNdkDownload configures synthetic cmake fallback when Gradle is offline`() {
         val project = mockk<Project>()
         val finalizeDslSlot = captureFinalizeDslAction(project)
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockDirectoryProperty = mockk<DirectoryProperty>()
-        val mockDirectory = mockk<Directory>()
-        val mockBaseExtension = mockk<BaseExtension>()
-        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
-        every { mockBaseExtension.externalNativeBuild.cmake } returns mockCmakeOptions
-        every { mockBaseExtension.externalNativeBuild.ndkBuild } returns mockNdkBuildOptions
-        every { mockNdkBuildOptions.path } returns null
-        every { mockBaseExtension.defaultConfig } returns mockDefaultConfig
-        every { mockBaseExtension.ndkVersion } returns "29.0.13846066"
-        every { mockCmakeOptions.path } returns null
-        every { mockCmakeOptions.path(any()) } returns Unit
-        every { mockCmakeOptions.buildStagingDirectory(any()) } returns Unit
+        val (_, mockCmake, _, cmakeArguments) = setUpMockExternalNativeBuild(project, ndkVersion = "29.0.13846066")
         every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns "/sdkmanager"
         every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns "/sdk/root"
         every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns ""
         every { project.gradle.startParameter.taskNames } returns emptyList()
         every { project.gradle.startParameter.isOffline } returns true
-        every { project.layout.buildDirectory } returns mockDirectoryProperty
-        every { mockDirectoryProperty.dir(any<String>()) } returns mockDirectoryProperty
-        every { mockDirectoryProperty.get() } returns mockDirectory
-        every { mockDirectory.asFile.path } returns "/randomapp/build/app/"
         val basePath = "/base/path"
 
-        val mockBuildType = mockk<com.android.build.gradle.internal.dsl.BuildType>()
-        every { mockBaseExtension.buildTypes.iterator() } returns mutableListOf(mockBuildType).iterator()
-        every { mockBuildType.name } returns "Debug"
-        every { mockBuildType.externalNativeBuild.cmake.arguments(any(), any(), any()) } returns Unit
-
-        setUpMockAndroidExtension(project)
-        every { project.gradle.startParameter.isOffline } returns true
         FlutterPluginUtils.forceNdkDownload(project, basePath)
         finalizeDslSlot.captured.invoke(Any())
 
         verify(exactly = 1) {
-            mockCmakeOptions.path("$basePath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt")
+            mockCmake.path = File("$basePath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt")
         }
-        verify(exactly = 1) { mockCmakeOptions.buildStagingDirectory(any()) }
-        verify(exactly = 1) {
-            mockBuildType.externalNativeBuild.cmake.arguments(
-                "-Wno-dev",
-                "--no-warn-unused-cli",
-                "-DCMAKE_BUILD_TYPE=Debug"
-            )
-        }
+        verify(exactly = 1) { mockCmake.buildStagingDirectory = any() }
+        assertEquals(
+            listOf("-Wno-dev", "--no-warn-unused-cli", "-DCMAKE_BUILD_TYPE=Debug"),
+            cmakeArguments
+        )
     }
 
     @Test
     fun `forceNdkDownload sets externalNativeBuild properties`() {
         val project = mockk<Project>()
-        val mockCmakeOptions = mockk<CmakeOptions>()
-        val mockNdkBuildOptions = mockk<com.android.build.gradle.internal.dsl.NdkBuildOptions>()
-        val mockDefaultConfig = mockk<DefaultConfig>()
-        val mockDirectoryProperty = mockk<DirectoryProperty>()
-        val mockDirectory = mockk<Directory>()
         every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns null
         every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns null
         every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns null
-        every {
-            project.extensions
-                .findByType(BaseExtension::class.java)!!
-                .externalNativeBuild.cmake
-        } returns mockCmakeOptions
-        every {
-            project.extensions
-                .findByType(BaseExtension::class.java)!!
-                .externalNativeBuild.ndkBuild
-        } returns mockNdkBuildOptions
-        every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
 
+        val (_, mockCmake, _, cmakeArguments) = setUpMockExternalNativeBuild(project)
         val basePath = "/base/path"
-        val fakeBuildPath = "/randomapp/build/app/"
-        every { mockCmakeOptions.path } returns null
-        every { mockNdkBuildOptions.path } returns null
-        every { mockCmakeOptions.path(any()) } returns Unit
-        every { mockCmakeOptions.buildStagingDirectory(any()) } returns Unit
-        every { project.layout.buildDirectory } returns mockDirectoryProperty
-        every { mockDirectoryProperty.dir(any<String>()) } returns mockDirectoryProperty
-        every { mockDirectoryProperty.get() } returns mockDirectory
-        val realFile = File(fakeBuildPath)
-        every { mockDirectory.asFile } returns realFile
 
-        val mockBuildType = mockk<com.android.build.gradle.internal.dsl.BuildType>()
-        every {
-            project.extensions
-                .findByType(BaseExtension::class.java)!!
-                .buildTypes
-                .iterator()
-        } returns mutableListOf(mockBuildType).iterator()
-        every { mockBuildType.name } returns "Debug"
-        every { mockBuildType.externalNativeBuild.cmake.arguments(any(), any(), any()) } returns Unit
+        FlutterPluginUtils.forceNdkDownload(project, basePath)
 
-        setUpMockAndroidExtension(project)
+        verify(exactly = 1) { mockCmake.path }
+        verify(exactly = 1) {
+            mockCmake.path = File("$basePath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt")
+        }
+        verify(exactly = 1) { mockCmake.buildStagingDirectory = any() }
+        assertEquals(
+            listOf("-Wno-dev", "--no-warn-unused-cli", "-DCMAKE_BUILD_TYPE=Debug"),
+            cmakeArguments
+        )
+    }
+
+    @Test
+    fun `forceNdkDownload configures cmake arguments for all build types`() {
+        val project = mockk<Project>()
+        every { project.findProperty(FlutterPluginUtils.PROP_SDK_MANAGER_PATH) } returns null
+        every { project.findProperty(FlutterPluginUtils.PROP_ANDROID_SDK_ROOT) } returns null
+        every { project.findProperty(FlutterPluginUtils.PROP_INSTALLED_NDK_VERSIONS) } returns null
+
+        val debugArgs = mutableListOf<String>()
+        val releaseArgs = mutableListOf<String>()
+        val debugBuildType =
+            mockk<ApplicationBuildType>(relaxed = true) {
+                every { name } returns "debug"
+                every { externalNativeBuild.cmake.arguments } returns debugArgs
+            }
+        val releaseBuildType =
+            mockk<ApplicationBuildType>(relaxed = true) {
+                every { name } returns "release"
+                every { externalNativeBuild.cmake.arguments } returns releaseArgs
+            }
+
+        val (mockAndroidExtension, mockCmake) = setUpMockExternalNativeBuild(project)
+        every { mockAndroidExtension.buildTypes.iterator() } answers {
+            mutableListOf(debugBuildType, releaseBuildType).iterator()
+        }
+        val basePath = "/base/path"
+
         FlutterPluginUtils.forceNdkDownload(project, basePath)
 
         verify(exactly = 1) {
-            mockCmakeOptions.path
+            mockCmake.path = File("$basePath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt")
         }
-        verify(exactly = 1) { mockCmakeOptions.path("$basePath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt") }
-        verify(exactly = 1) { mockCmakeOptions.buildStagingDirectory(any()) }
-        verify(exactly = 1) {
-            mockBuildType.externalNativeBuild.cmake.arguments(
-                "-Wno-dev",
-                "--no-warn-unused-cli",
-                "-DCMAKE_BUILD_TYPE=Debug"
-            )
-        }
+        verify(exactly = 1) { mockCmake.buildStagingDirectory = any() }
+        assertEquals(listOf("-Wno-dev", "--no-warn-unused-cli", "-DCMAKE_BUILD_TYPE=debug"), debugArgs)
+        assertEquals(listOf("-Wno-dev", "--no-warn-unused-cli", "-DCMAKE_BUILD_TYPE=release"), releaseArgs)
     }
 
     @Test

--- a/packages/flutter_tools/gradle/src/test/kotlin/testing/AndroidExtensionMocks.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/testing/AndroidExtensionMocks.kt
@@ -6,13 +6,18 @@ package com.flutter.gradle.testing
 
 import com.android.build.api.dsl.ApplicationBuildType
 import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.Cmake
 import com.android.build.api.dsl.LibraryBuildType
 import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.dsl.NdkBuild
 import io.mockk.every
 import io.mockk.mockk
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import java.io.File
 
 /**
  * Mocks the Android extension for unit tests reading `compileSdk`, `ndkVersion`, or `buildTypes` via the public DSL.
@@ -112,4 +117,79 @@ fun setUpMockLibraryAndroidExtension(
     every { project.gradle.startParameter.isOffline } returns false
 
     return mockLibraryExtension
+}
+
+/**
+ * Test fixture holding the mocked public DSL objects for external native build and NDK fallback tests.
+ */
+data class MockExternalNativeBuildConfig(
+    val androidExtension: ApplicationExtension,
+    val cmake: Cmake,
+    val ndkBuild: NdkBuild,
+    val cmakeArguments: MutableList<String>,
+    val buildType: ApplicationBuildType
+)
+
+/**
+ * Mocks `externalNativeBuild` (`cmake` and `ndkBuild`), `buildTypes`, and `layout.buildDirectory`
+ * on a Gradle [Project] for testing NDK download and synthetic CMake fallback configuration.
+ */
+fun setUpMockExternalNativeBuild(
+    project: Project,
+    ndkVersion: String? = "29.0.13846066",
+    cmakePath: File? = null,
+    ndkBuildPath: File? = null,
+    buildDirectory: File = File("/randomapp/build/app/")
+): MockExternalNativeBuildConfig {
+    val mockCmake =
+        mockk<Cmake>(relaxed = true) {
+            every { path } returns cmakePath
+        }
+    val mockNdkBuild =
+        mockk<NdkBuild>(relaxed = true) {
+            every { path } returns ndkBuildPath
+        }
+    val cmakeArguments = mutableListOf<String>()
+    val mockBuildType =
+        mockk<ApplicationBuildType>(relaxed = true) {
+            every { name } returns "Debug"
+            every { externalNativeBuild.cmake.arguments } returns cmakeArguments
+        }
+    val mockAndroidExtension =
+        mockk<ApplicationExtension>(relaxed = true) {
+            every { externalNativeBuild.cmake } returns mockCmake
+            every { externalNativeBuild.ndkBuild } returns mockNdkBuild
+            if (ndkVersion != null) {
+                every { this@mockk.ndkVersion } returns ndkVersion
+            }
+            val container =
+                mockk<NamedDomainObjectContainer<ApplicationBuildType>>(relaxed = true) {
+                    every { iterator() } answers { mutableListOf(mockBuildType).iterator() }
+                }
+            every { buildTypes } returns container
+        }
+    every { project.extensions.findByType(ApplicationExtension::class.java) } returns mockAndroidExtension
+    every { project.extensions.findByName("android") } returns mockAndroidExtension
+
+    val mockDirectory =
+        mockk<Directory> {
+            every { asFile } returns buildDirectory
+        }
+    val mockDirectoryProperty =
+        mockk<DirectoryProperty>(relaxed = true) {
+            every { dir(any<String>()) } returns this
+            every { get() } returns mockDirectory
+        }
+    every { project.layout.buildDirectory } returns mockDirectoryProperty
+
+    every { project.gradle.startParameter.taskNames } returns emptyList()
+    every { project.gradle.startParameter.isOffline } returns false
+
+    return MockExternalNativeBuildConfig(
+        androidExtension = mockAndroidExtension,
+        cmake = mockCmake,
+        ndkBuild = mockNdkBuild,
+        cmakeArguments = cmakeArguments,
+        buildType = mockBuildType
+    )
 }


### PR DESCRIPTION
This is PR 5 of 11 in the AGP 9.1.0 / public `gradle-api` / newdsl migration stack.

Add externalNativeBuild to the shared type. Extracted some shared mocking logic to a utility. 
No external visible changes expected. 
Also improved the README.md so that the test file for multiple agp versions was a markdown link. 

- @reidbaker

---
Standard review context for this pr stack

This is PR is part of an 11 pr stack to migrate the "newdsl" `gradle-api` specifically in agp 9.1.0.

All of the code was LLM authored. A mix of manual prompting, automatic prompting, several models and adversarial review. The combined sessions are enough that I cannot include relevant prompts like I have been doing on other prs.

If you want to review the pr stack you can find it here. These prs will be abandoned/closed as prs land into flutter/flutter.
1. https://github.com/reidbaker-agent/flutter/pull/1 (branch: agp-api-doc)
2. https://github.com/reidbaker-agent/flutter/pull/2 (branch: agp-internal-utils)
3. https://github.com/reidbaker-agent/flutter/pull/3 (branch: agp-buildmode-deps)
4. https://github.com/reidbaker-agent/flutter/pull/4 (branch: agp-plugin-buildtypes)
5. https://github.com/reidbaker-agent/flutter/pull/5 (branch: agp-ndk-fallback)
6. https://github.com/reidbaker-agent/flutter/pull/6 (branch: agp-assets-onvariants)
7. https://github.com/reidbaker-agent/flutter/pull/7 (branch: agp-apk-copy-versioncode)
8. https://github.com/reidbaker-agent/flutter/pull/8 (branch: agp-add-to-app)
9. https://github.com/reidbaker-agent/flutter/pull/9 (branch: agp-aar-script)
10. https://github.com/reidbaker-agent/flutter/pull/10 (branch: agp-newdsl-flip)
11. https://github.com/reidbaker-agent/flutter/pull/11 (branch: agp-gradle-api)

This work is urgent in the sense that we are worried that android will publish agp 10 with no opt out but not so urgent that we are willing to break flutter users because we didn't review or understand the code because we were in a rush.

Breaking changes are expected as part of this work. There are patterns the android team explicitly does not want apps to use and apis that have no equivalent.

As part of the effort to ensure this work does not slip into ai slop, prs from this stack will be reviewed by me (@reidbaker) before asking for review. Then we will have 2 android expert reviewers also review every pr.

---
Agent authored description.
This is PR 5 of 11 in the AGP 9.1.0 / public `gradle-api` migration stack (flutter/flutter#180137, flutter/flutter#166550).

### Key Changes
- **Public DSL Wrapper `externalNativeBuild`**: Exposes `val externalNativeBuild: ExternalNativeBuild` in `AgpCommonExtensionWrapper.kt` dispatching across `ApplicationExtension`, `LibraryExtension`, `DynamicFeatureExtension`, and `TestExtension` without referencing `CommonExtension` (bypassing AGP binary incompatibility).
- **Zero Legacy `BaseExtension` in Production Sources**: Deletes `getLegacyAndroidExtension(project: Project): BaseExtension` and removes the `com.android.build.gradle.BaseExtension` import from `FlutterPluginUtils.kt`.
- **Public DSL NDK Fallback Configuration**: Migrates `forceNdkDownload` and `configureSyntheticExternalNativeBuildFallback` in `FlutterPluginUtils.kt` to `getAndroidExtension(gradleProject)` using `externalNativeBuild.cmake` / `externalNativeBuild.ndkBuild`. Sets `cmake.path = File(...)`, `cmake.buildStagingDirectory = ...`, and `buildType.externalNativeBuild.cmake.arguments += ...` through the public DSL while preserving the upstream PR #187201 `ndkBuild.path` check.
- **Unit Test Public DSL Mocking & Cleanup**: Migrates unit tests in `FlutterPluginUtilsTest.kt` to mock public DSL types (`ApplicationExtension`, `Cmake`, `NdkBuild`), asserts CMake arguments by list content, deletes obsolete tests asserting `ApplicationExtension`-vs-`BaseExtension` `ndkVersion` preference, and removes unused `import io.mockk.called` as well as all legacy `com.android.build.gradle.internal.*` imports.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.