### PR TITLE
Remove the redundant flutter/shell/platform/android:robolectric_tests build target

### DIFF
--- a/engine/src/flutter/ci/builders/linux_unopt.json
+++ b/engine/src/flutter/ci/builders/linux_unopt.json
@@ -236,7 +236,7 @@
                 "config": "ci/android_debug_unopt",
                 "targets": [
                     "flutter/impeller",
-                    "flutter/shell/platform/android:android_jar",
+                    "flutter/shell/platform/android:android_jar"
                 ]
             },
             "tests": [
@@ -329,7 +329,7 @@
                     "flutter/sky/dist:zip_old_location",
                     "flutter/lib/gpu/dist:zip_old_location",
                     "flutter/shell/platform/android:embedding_jars",
-                    "flutter/shell/platform/android:abi_jars",
+                    "flutter/shell/platform/android:abi_jars"
                 ]
             },
             "tests": [

--- a/engine/src/flutter/ci/builders/linux_unopt.json
+++ b/engine/src/flutter/ci/builders/linux_unopt.json
@@ -237,7 +237,6 @@
                 "targets": [
                     "flutter/impeller",
                     "flutter/shell/platform/android:android_jar",
-                    "flutter/shell/platform/android:robolectric_tests"
                 ]
             },
             "tests": [
@@ -331,7 +330,6 @@
                     "flutter/lib/gpu/dist:zip_old_location",
                     "flutter/shell/platform/android:embedding_jars",
                     "flutter/shell/platform/android:abi_jars",
-                    "flutter/shell/platform/android:robolectric_tests"
                 ]
             },
             "tests": [

--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -702,11 +702,6 @@ action("pom_content_hash_embedding") {
   ]
 }
 
-# TODO(jsimmons): remove this placeholder when it is no longer used by the LUCI recipes
-group("robolectric_tests") {
-  deps = [ ":android_jar" ]
-}
-
 zip_bundle("android_symbols") {
   output = "$android_zip_archive_dir/symbols.zip"
   files = [


### PR DESCRIPTION
This target was an alias for flutter/shell/platform/android:android_jar that was kept in the build script because it was used by some LUCI recipes.  That dependency has since been removed from the recipes.