### PR TITLE
uber_sdf: Started passing in luma as uniform.

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -69,8 +69,10 @@ bool UberSDFContents::Render(const ContentContext& renderer,
   VS::FrameInfo frame_info;
   FS::FragInfo frag_info;
   frag_info.type = ToShaderType(params_.type);
-  frag_info.color =
+  Color color =
       params_.color.WithAlpha(params_.color.alpha * GetOpacityFactor());
+  frag_info.color = color;
+  frag_info.luma = color.GetLuma();
   frag_info.center = params_.center;
   frag_info.size = params_.size;
   frag_info.stroked = params_.stroke ? 1.0f : 0.0f;

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -61,6 +61,8 @@ uniform FragInfo {
   ///   3: RoundRect
   ///   4: Rounded Superellipse (must have uniform circular corner radii)
   float type;
+  /// The perceived luminance (Rec. 709 luma) of the shape's foreground color.
+  float luma;
   /// The width in device pixels over which to apply antialiasing.
   float aa_pixels;
 
@@ -288,7 +290,7 @@ vec2 strokedSDF(vec2 p) {
 }
 
 // Converts linear coverage alpha to perceptual alpha.
-float gammaCorrectedAlpha(float alpha, vec3 foreground_rgb) {
+float gammaCorrectedAlpha(float alpha, float luma) {
   // Gamma corrected alpha used for dark colors.
   // Fast approximation for `1.0 - pow(1.0 - alpha, 1.0 / 2.2)`.
   float alpha_dark = 1.0 - sqrt(1.0 - alpha);
@@ -299,7 +301,6 @@ float gammaCorrectedAlpha(float alpha, vec3 foreground_rgb) {
 
   // Interpolate between the dark and light gamma corrected alphas based on the
   // foreground luma.
-  float luma = dot(foreground_rgb, vec3(0.2126, 0.7152, 0.0722));
   return mix(alpha_dark, alpha_light, luma);
 }
 
@@ -315,7 +316,7 @@ void main() {
   // Clamp alpha in case floating point precision errors cause it to be outside
   // [0.0, 1.0].
   alpha = clamp(alpha, 0.0, 1.0);
-  alpha = gammaCorrectedAlpha(alpha, frag_info.color.rgb);
+  alpha = gammaCorrectedAlpha(alpha, frag_info.luma);
 
   frag_color = vec4(frag_info.color.rgb, frag_info.color.a * alpha);
   frag_color = IPPremultiply(frag_color);

--- a/engine/src/flutter/impeller/geometry/color.h
+++ b/engine/src/flutter/impeller/geometry/color.h
@@ -246,6 +246,11 @@ struct Color {
                  std::clamp(blue, 0.0f, 1.0f), std::clamp(alpha, 0.0f, 1.0f));
   }
 
+  /// @brief Calculate relative luminance using Rec. 709 luma coefficients.
+  constexpr Scalar GetLuma() const {
+    return red * 0.2126f + green * 0.7152f + blue * 0.0722f;
+  }
+
   /**
    * @brief Convert to R8G8B8A8 representation.
    *

--- a/engine/src/flutter/impeller/geometry/geometry_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/geometry_unittests.cc
@@ -1460,6 +1460,15 @@ TEST(GeometryTest, ColorClamp01) {
   }
 }
 
+TEST(GeometryTest, ColorGetLuma) {
+  EXPECT_NEAR(Color::Black().GetLuma(), 0.0f, 1e-6f);
+  EXPECT_NEAR(Color::White().GetLuma(), 1.0f, 1e-6f);
+  EXPECT_NEAR(Color::Red().GetLuma(), 0.2126f, 1e-6f);
+  EXPECT_NEAR(Color::Green().GetLuma(), 0.7152f, 1e-6f);
+  EXPECT_NEAR(Color::Blue().GetLuma(), 0.0722f, 1e-6f);
+  EXPECT_NEAR(Color(0.5f, 0.5f, 0.5f, 1.0f).GetLuma(), 0.5f, 1e-6f);
+}
+
 TEST(GeometryTest, ColorMakeRGBA8) {
   {
     Color a = Color::MakeRGBA8(0, 0, 0, 0);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
