### PR TITLE
[flutter_tools] Add --no-plugins flag and disable plugins for benchmark

### DIFF
--- a/dev/devicelab/lib/tasks/analysis.dart
+++ b/dev/devicelab/lib/tasks/analysis.dart
@@ -65,7 +65,7 @@ abstract class _Benchmark {
 
   Directory get directory;
 
-  List<String> get options => <String>['--benchmark', if (watch) '--watch'];
+  List<String> get options => <String>['--benchmark', '--no-plugins', if (watch) '--watch'];
 
   Future<double> execute(int iteration, int targetIterations) async {
     section('Analyze $title ${watch ? 'with watcher' : ''} - ${iteration + 1} / $targetIterations');

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -96,6 +96,7 @@ class AnalyzeCommand extends FlutterCommand {
       hide: !verboseHelp,
       help: 'Also output the analysis time.',
     );
+    argParser.addFlag('plugins', defaultsTo: true, help: 'Whether to enable analyzer plugins.');
 
     usesPubOption();
 

--- a/packages/flutter_tools/lib/src/commands/analyze_base.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_base.dart
@@ -98,6 +98,14 @@ abstract class AnalyzeBase {
   bool get isBenchmarking => argResults['benchmark'] as bool;
   String? get protocolTrafficLog => argResults['protocol-traffic-log'] as String?;
 
+  @protected
+  bool get usePlugins {
+    if (argResults.options.contains('plugins') && argResults.wasParsed('plugins')) {
+      return argResults['plugins'] as bool;
+    }
+    return !isBenchmarking;
+  }
+
   /// Generate an analysis summary for both [AnalyzeOnce], [AnalyzeContinuously].
   static String generateErrorsMessage({
     required int issueCount,

--- a/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
@@ -58,6 +58,7 @@ class AnalyzeContinuously extends AnalyzeBase {
       terminal: terminal,
       protocolTrafficLog: protocolTrafficLog,
       suppressAnalytics: suppressAnalytics,
+      usePlugins: usePlugins,
     );
     server.onAnalyzing.listen((bool isAnalyzing) => _handleAnalysisStatus(server, isAnalyzing));
     server.onErrors.listen(_handleAnalysisErrors);

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -62,6 +62,7 @@ class AnalyzeOnce extends AnalyzeBase {
       terminal: terminal,
       protocolTrafficLog: protocolTrafficLog,
       suppressAnalytics: suppressAnalytics,
+      usePlugins: usePlugins,
     );
 
     Stopwatch? timer;

--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -27,6 +27,7 @@ class AnalysisServer {
     required Platform platform,
     required Terminal terminal,
     required this.suppressAnalytics,
+    this.usePlugins = true,
     String? protocolTrafficLog,
   }) : _fileSystem = fileSystem,
        _processManager = processManager,
@@ -35,6 +36,7 @@ class AnalysisServer {
        _terminal = terminal,
        _protocolTrafficLog = protocolTrafficLog;
 
+  final bool usePlugins;
   final String sdkPath;
   final List<String> directories;
   final FileSystem _fileSystem;
@@ -75,6 +77,7 @@ class AnalysisServer {
       sdkPath,
       '--disable-server-feature-completion',
       '--disable-server-feature-search',
+      if (!usePlugins) '--no-plugins',
       if (suppressAnalytics) '--suppress-analytics',
       if (_protocolTrafficLog != null) '--protocol-traffic-log=$_protocolTrafficLog',
     ];

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
@@ -189,6 +189,92 @@ void main() {
         ProcessManager: () => processManager,
       },
     );
+
+    testUsingContext(
+      '--no-plugins passes --no-plugins to language-server',
+      () async {
+        processManager.addCommands(<FakeCommand>[
+          const FakeCommand(
+            command: <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'language-server',
+              '--dart-sdk',
+              'Artifact.engineDartSdkPath',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--no-plugins',
+              '--suppress-analytics',
+            ],
+            exitCode: 255,
+            stderr: 'error',
+          ),
+        ]);
+        await expectLater(
+          runner.run(<String>['analyze', '--no-plugins']),
+          throwsA(isA<ToolExit>()),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+
+    testUsingContext(
+      '--benchmark passes --no-plugins to language-server by default',
+      () async {
+        processManager.addCommands(<FakeCommand>[
+          const FakeCommand(
+            command: <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'language-server',
+              '--dart-sdk',
+              'Artifact.engineDartSdkPath',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--no-plugins',
+              '--suppress-analytics',
+            ],
+            exitCode: 255,
+            stderr: 'error',
+          ),
+        ]);
+        await expectLater(runner.run(<String>['analyze', '--benchmark']), throwsA(isA<ToolExit>()));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
+
+    testUsingContext(
+      '--benchmark with --plugins enables plugins',
+      () async {
+        processManager.addCommands(<FakeCommand>[
+          const FakeCommand(
+            command: <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'language-server',
+              '--dart-sdk',
+              'Artifact.engineDartSdkPath',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--suppress-analytics',
+            ],
+            exitCode: 255,
+            stderr: 'error',
+          ),
+        ]);
+        await expectLater(
+          runner.run(<String>['analyze', '--benchmark', '--plugins']),
+          throwsA(isA<ToolExit>()),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+      },
+    );
   });
 
   testWithoutContext('analyze inRepo', () {


### PR DESCRIPTION
## Description

Adds the `--[no-]plugins` flag to `flutter analyze` (defaulting to enabled).

In `AnalyzeBase`, when `--benchmark` is active, `usePlugins` defaults to `false` unless `--plugins` is explicitly parsed.

Also updates the Devicelab `analyzer_benchmark` task in `dev/devicelab/lib/tasks/analysis.dart` to explicitly pass `--no-plugins`, ensuring the benchmark measures the core analyzer baseline without isolate memory overhead from analyzer plugins.

Towards https://github.com/flutter/flutter/issues/175276

## Tests
- Added hermetic tests in `packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart` verifying `--no-plugins`, `--benchmark` (defaults to `--no-plugins`), and `--benchmark --plugins`.