### PR TITLE
[Linux] Don't clear the OpenGL context when a frame has been drawn

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_view_renderer_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view_renderer_opengl.cc
@@ -169,6 +169,15 @@ static gboolean fl_view_renderer_opengl_draw(GtkWidget* widget, cairo_t* cr) {
     wait_for_frame(self, window, scale_factor);
   }
 
+  // The frame is drawn from an OpenGL texture, so make a context current that
+  // can access it. This is deliberately not cleared once the frame is drawn -
+  // GTK makes the context it needs current before using OpenGL but doesn't
+  // check that this succeeded, and then uses whatever context is current. If
+  // that is nothing it dereferences NULL and crashes.
+  //
+  // Leaving this context current gives GTK one to fall back on. It is created
+  // on the same window and shares with the context GTK would have used itself,
+  // so GTK can safely draw with it.
   if (self->render_context != nullptr) {
     gdk_gl_context_make_current(self->render_context);
   }
@@ -179,10 +188,6 @@ static gboolean fl_view_renderer_opengl_draw(GtkWidget* widget, cairo_t* cr) {
     size_t height = gdk_window_get_height(window) * scale_factor;
     result = fl_opengl_frame_draw(self->frame, cr, window, scale_factor, width,
                                   height);
-  }
-
-  if (self->render_context != nullptr) {
-    gdk_gl_context_clear_current();
   }
 
   g_mutex_unlock(&self->frame_mutex);


### PR DESCRIPTION
The draw handler made a context current to draw the frame with, then cleared it, leaving no context current at all while GTK finished the frame.

GTK makes the context it needs current before using OpenGL, so this doesn't need to be cleared. But GTK doesn't check that making its context current succeeded, and if it fails it carries on and uses OpenGL with no context current, which crashes.

Leaving the context current means GTK still has one to fall back on when this happens, so it doesn't crash.

See https://github.com/flutter/flutter/issues/191775
