### PR TITLE
Fixes OverlayPortal semantics bounds corruption

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -331,15 +331,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (void)setChildrenInHitTestOrder:(NSArray<SemanticsObject*>*)childrenInHitTestOrder {
-  for (SemanticsObject* child in _childrenInHitTestOrder) {
-    if (child.parent == self) {
-      child.parent = nil;
-    }
-  }
   _childrenInHitTestOrder = [childrenInHitTestOrder copy];
-  for (SemanticsObject* child in _childrenInHitTestOrder) {
-    child.parent = self;
-  }
 }
 
 - (BOOL)hasChildren {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -88,6 +88,24 @@ const float kFloatCompareEpsilon = 0.001;
   XCTAssertEqual(child.parent, newParent);
 }
 
+- (void)testSetChildrenInHitTestOrderDoesNotModifyParent {
+  fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
+      new flutter::testing::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+  SemanticsObject* traversalParent = [[SemanticsObject alloc] initWithBridge:bridge uid:0];
+  SemanticsObject* hitTestParent = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
+  SemanticsObject* child = [[SemanticsObject alloc] initWithBridge:bridge uid:2];
+
+  traversalParent.children = @[ child ];
+  XCTAssertEqual(child.parent, traversalParent);
+
+  hitTestParent.childrenInHitTestOrder = @[ child ];
+  XCTAssertEqual(child.parent, traversalParent);
+
+  hitTestParent.childrenInHitTestOrder = @[];
+  XCTAssertEqual(child.parent, traversalParent);
+}
+
 - (void)testAccessibilityHitTestFocusAtLeaf {
   fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
       new flutter::testing::MockAccessibilityBridge());


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/182604

Historically, the configuration/order of children and parents for widgets is identical across both traversal and hit test order. However, with introduction over OverlayPortal, https://github.com/flutter/flutter/commit/fccfa978a97633800aff123b776937d28262c04f, this is no longer always the case. 

For example when traversing, the actual portal child, eg, a floating drop down box, is a child of the `OverlayPortal`. However when hit testing, the portal child is a child of the `Overlay`.

Prior to this pr, both setChildrenInHitTestOrder and setChildren have identical implementations. 

```
  for (SemanticsObject* child in _childrenInHitTestOrder) {
    if (child.parent == self) {
      child.parent = nil;
    }
  }
  _childrenInHitTestOrder = [childrenInHitTestOrder copy];
  for (SemanticsObject* child in _childrenInHitTestOrder) {
    child.parent = self;
  }
```

On every frame, setChildren and setChildrenInHitTestOrder is run sequentially on every widget. 
So first, when setChildren is run for `OverlayPortal`, it sets `portalChild.parent = overlayPortal`. This is the correct traversal order.
Then, sometime later, it runs setChildrenInHitTestOrder for `Overlay`, which sets portalChild.parent = overlay`. This is incorrect. 

This is why in the bug the accessibility nodes still exist, just weirdly offset - because its now anchored to 0, 0 of `Overlay` instead of the the position over `OverlayPortal`.

Because hittest order strictly walks top down (parent isnt ever accessed), we don't actually have to do any mutation to the parents. 

https://github.com/user-attachments/assets/df093797-7482-42ba-ba4c-b9a172484031

