### PR TITLE
Reject glyph packer placements that don't fit in int16_t

### DIFF
--- a/engine/src/flutter/impeller/typographer/rectangle_packer.cc
+++ b/engine/src/flutter/impeller/typographer/rectangle_packer.cc
@@ -5,6 +5,8 @@
 #include "impeller/typographer/rectangle_packer.h"
 
 #include <algorithm>
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -85,6 +87,17 @@ bool SkylineRectanglePacker::AddRect(int p_width, int p_height, IPoint16* loc) {
 
   // add rectangle to skyline
   if (-1 != bestIndex) {
+    // IPoint16::x_/y_ are int16_t. A placement whose origin does not fit in
+    // that range would otherwise be silently truncated below, reporting a
+    // corrupted (wrapped) coordinate as a successful placement. Reject it
+    // instead, the same way an out-of-bounds request is already rejected
+    // above.
+    if (bestX > std::numeric_limits<int16_t>::max() ||
+        bestY > std::numeric_limits<int16_t>::max()) {
+      loc->x_ = 0;
+      loc->y_ = 0;
+      return false;
+    }
     AddSkylineLevel(bestIndex, bestX, bestY, p_width, p_height);
     loc->x_ = bestX;
     loc->y_ = bestY;

--- a/engine/src/flutter/impeller/typographer/typographer_unittests.cc
+++ b/engine/src/flutter/impeller/typographer/typographer_unittests.cc
@@ -470,8 +470,33 @@ TEST(TypographerTest, RectanglePackerFillsRows) {
     skyline->AddRect(16, 16, &loc);
   }
 
-  EXPECT_EQ(loc.x(), 256 - 16);
+   EXPECT_EQ(loc.x(), 256 - 16);
   EXPECT_EQ(loc.y(), 16);
+}
+
+TEST(TypographerTest, RectanglePackerRejectsPlacementsExceedingInt16Range) {
+  // Regression test: SkylineRectanglePacker::AddRect() used to narrow its
+  // computed placement coordinates from `int` into `IPoint16::x_`/`y_`
+  // (`int16_t`) with no range check, silently wrapping a valid placement
+  // above y=32767 into a corrupted, negative coordinate while still
+  // reporting success. A sufficiently tall glyph atlas (reachable on
+  // backends where the max texture size is read unclamped from the
+  // driver, e.g. Vulkan's `maxImageDimension2D`) could hit this.
+  constexpr int kAtlasWidth = 4096;
+  constexpr int kAtlasHeight = 40000;  // taller than INT16_MAX (32767)
+  auto packer = RectanglePacker::Factory(kAtlasWidth, kAtlasHeight);
+  ASSERT_NE(packer, nullptr);
+
+  // Fill the skyline up to a height above INT16_MAX.
+  const int kFillHeight = 32800;
+  IPoint16 fill_loc;
+  ASSERT_TRUE(packer->AddRect(kAtlasWidth, kFillHeight, &fill_loc));
+
+  // The next rectangle would be placed at y == kFillHeight, which does not
+  // fit in an int16_t. The packer must reject the placement instead of
+  // truncating the coordinate and reporting a corrupted result as success.
+  IPoint16 glyph_loc;
+  EXPECT_FALSE(packer->AddRect(24, 24, &glyph_loc));
 }
 
 TEST_P(TypographerTest, GlyphAtlasTextureWillGrowTilMaxTextureSize) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

`SkylineRectanglePacker::AddRect()` narrows its computed placement coordinates from `int` to `IPoint16`'s `int16_t` fields with no range check, so a placement above y=32767 silently wraps into a corrupted (often negative) coordinate while still reporting success. This can be reached once the glyph atlas grows tall enough (e.g. on the Vulkan backend, where the atlas height cap is read unclamped from the driver's `maxImageDimension2D`), and the corrupted coordinate then flows unvalidated into the atlas texture blit.

This PR adds a bounds check before the narrowing assignment, rejecting the placement (the same way an oversized request is already rejected) instead of truncating it, and adds a regression test that exercises the boundary directly against the packer (no GPU required).

Fixes #192140

## Pre-launch Checklist

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x ] I signed the [CLA].
- [x ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
