### PR TITLE
[Linux] Don't allocate a depth/stencil buffer for presentation framebuffers

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -122,10 +122,11 @@ FlFramebuffer* fl_framebuffer_new(GLint format,
   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                          self->texture_id, 0);
 
-  glGenRenderbuffers(1, &self->depth_stencil);
-  glBindRenderbuffer(GL_RENDERBUFFER, self->depth_stencil);
-  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
-  attach_depth_stencil(self->depth_stencil);
+  // No depth or stencil attachment is made - this framebuffer is only used to
+  // present already rendered frames, which is done by copying color data with
+  // glBlitFramebuffer() or drawing a textured quad. Neither uses the depth or
+  // stencil tests, and a depth/stencil renderbuffer would use as much memory
+  // again as the texture itself.
 
   return self;
 }

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.h
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.h
@@ -27,7 +27,12 @@ G_DECLARE_FINAL_TYPE(FlFramebuffer, fl_framebuffer, FL, FRAMEBUFFER, GObject)
  * @shareable: %TRUE if this framebuffer can be shared between contexts
  * (requires EGL).
  *
- * Creates a new frame buffer. Requires a valid OpenGL context to create.
+ * Creates a new frame buffer for presenting rendered frames. Requires a valid
+ * OpenGL context to create.
+ *
+ * The framebuffer has a color attachment only; it has no depth or stencil
+ * attachment. Use fl_framebuffer_new_multisample() for a framebuffer to render
+ * into.
  *
  * Returns: a new #FlFramebuffer.
  */

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
@@ -13,32 +13,50 @@ class FlFramebufferTest : public flutter::testing::LinuxTest {
   ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
 };
 
-TEST_F(FlFramebufferTest, HasDepthStencil) {
+TEST_F(FlFramebufferTest, NoDepthStencil) {
+  // Presentation framebuffers are only ever copied into, so they don't need
+  // a depth/stencil buffer and shouldn't allocate the memory for one.
+  EXPECT_CALL(epoxy, glGenRenderbuffers).Times(0);
+  EXPECT_CALL(epoxy, glRenderbufferStorage).Times(0);
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                        ::testing::_, ::testing::_))
+      .Times(0);
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                        ::testing::_, ::testing::_))
+      .Times(0);
+
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, 100, 100, FALSE);
+}
 
-  GLint depth_type = GL_NONE;
-  glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                                        GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
-                                        &depth_type);
-  EXPECT_NE(depth_type, GL_NONE);
+TEST_F(FlFramebufferTest, MultisampleHasDepthStencil) {
+  // Framebuffers rendered into by the engine still require a depth/stencil
+  // buffer.
+  ON_CALL(epoxy, epoxy_has_gl_extension(::testing::_))
+      .WillByDefault(::testing::Return(false));
 
-  GLint stencil_type = GL_NONE;
-  glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
-                                        GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
-                                        &stencil_type);
-  EXPECT_NE(stencil_type, GL_NONE);
+  EXPECT_CALL(epoxy, glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8,
+                                           100, 100));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                        GL_RENDERBUFFER, ::testing::_));
+  EXPECT_CALL(epoxy,
+              glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                        GL_RENDERBUFFER, ::testing::_));
+
+  g_autoptr(FlFramebuffer) framebuffer =
+      fl_framebuffer_new_multisample(GL_RGBA, 100, 100, /*use_msaa=*/FALSE);
 }
 
 TEST_F(FlFramebufferTest, ResourcesRemoved) {
   EXPECT_CALL(epoxy, glGenFramebuffers);
   EXPECT_CALL(epoxy, glGenTextures);
-  EXPECT_CALL(epoxy, glGenRenderbuffers);
   FlFramebuffer* framebuffer = fl_framebuffer_new(GL_RGB, 100, 100, FALSE);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
   EXPECT_CALL(epoxy, glDeleteTextures);
-  EXPECT_CALL(epoxy, glDeleteRenderbuffers);
   g_object_unref(framebuffer);
 }
 
@@ -94,7 +112,6 @@ TEST_F(FlFramebufferTest, ImpellerImplicitMSAA) {
 
   FlFramebuffer* framebuffer =
       fl_framebuffer_new_multisample(GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
-  EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
   EXPECT_CALL(epoxy, glDeleteTextures);
@@ -116,7 +133,6 @@ TEST_F(FlFramebufferTest, ImpellerNoMSAA) {
 
   FlFramebuffer* framebuffer =
       fl_framebuffer_new_multisample(GL_RGBA, 100, 100, /*use_msaa=*/TRUE);
-  EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
   EXPECT_CALL(epoxy, glDeleteTextures);
@@ -138,7 +154,6 @@ TEST_F(FlFramebufferTest, SkiaNoMSAA) {
 
   FlFramebuffer* framebuffer =
       fl_framebuffer_new_multisample(GL_RGBA, 100, 100, /*use_msaa=*/FALSE);
-  EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
   EXPECT_CALL(epoxy, glDeleteTextures);
@@ -194,7 +209,6 @@ TEST_F(FlFramebufferTest, ImpellerImplicitMSAABgra) {
 
   FlFramebuffer* framebuffer =
       fl_framebuffer_new_multisample(GL_BGRA_EXT, 100, 100, /*use_msaa=*/TRUE);
-  EXPECT_NE(fl_framebuffer_get_texture_id(framebuffer), 0u);
 
   EXPECT_CALL(epoxy, glDeleteFramebuffers);
   EXPECT_CALL(epoxy, glDeleteTextures);


### PR DESCRIPTION
The framebuffers made by `fl_framebuffer_new()` are only used to present frames that have already been rendered - the compositor copies into them with `glBlitFramebuffer(GL_COLOR_BUFFER_BIT)` or by drawing a textured quad, and never enables the depth or stencil test. The depth/stencil renderbuffer attached to them was never used.

`GL_DEPTH24_STENCIL8` is four bytes per pixel, the same as the colour texture, so removing it halves the memory each of these framebuffers needs. They are reallocated on every resize step, so this matters most when resizing or maximizing a window on a large display, where running out of video memory makes `eglMakeCurrent` fail.

Framebuffers the engine renders into are made by `fl_framebuffer_new_multisample()` and keep their depth/stencil buffer.

Verified the rendered output is unchanged - a screenshot of the counter app taken before and after this change is pixel identical.

See https://github.com/flutter/flutter/issues/191775
