### PR TITLE
Apply TestSemantics fixes to the material copy of semantics_tester

### DIFF
--- a/packages/flutter/test/material/semantics_tester.dart
+++ b/packages/flutter/test/material/semantics_tester.dart
@@ -508,7 +508,7 @@ class TestSemantics {
       );
     }
 
-    if (controlsNodes != controlsNodes && !setEquals(controlsNodes, node.controlsNodes)) {
+    if (controlsNodes != null && !setEquals(controlsNodes, node.controlsNodes)) {
       return fail(
         'expected node id $id to controls nodes $controlsNodes but found controlling nodes ${node.controlsNodes}',
       );
@@ -715,7 +715,7 @@ class SemanticsTester {
       if (first[i] is LocaleStringAttribute &&
           (second[i] is! LocaleStringAttribute ||
               second[i].range != first[i].range ||
-              (second[i] as LocaleStringAttribute).locale !=
+              (first[i] as LocaleStringAttribute).locale !=
                   (second[i] as LocaleStringAttribute).locale)) {
         return false;
       }
@@ -1168,7 +1168,11 @@ class _IncludesNodeWith extends Matcher {
     this.maxValue,
   }) : assert(
          label != null ||
+             attributedLabel != null ||
              value != null ||
+             attributedValue != null ||
+             hint != null ||
+             attributedHint != null ||
              actions != null ||
              flags != null ||
              flagsCollection != null ||
@@ -1180,8 +1184,15 @@ class _IncludesNodeWith extends Matcher {
              scrollExtentMin != null ||
              maxValueLength != null ||
              currentValueLength != null ||
-             inputType != null,
-         minValue != null || maxValue != null,
+             inputType != null ||
+             minValue != null ||
+             maxValue != null,
+         'At least one matcher field must be non-null so the matcher checks for at least one '
+         'property of a semantics node. Pass any of `label`, `attributedLabel`, `value`, '
+         '`attributedValue`, `hint`, `attributedHint`, `actions`, `flags`, '
+         '`flagsCollection`, `tags`, `increasedValue`, `decreasedValue`, `scrollPosition`, '
+         '`scrollExtentMax`, `scrollExtentMin`, `maxValueLength`, `currentValueLength`, '
+         '`inputType`, `minValue`, or `maxValue`.',
        );
   final AttributedString? attributedLabel;
   final AttributedString? attributedValue;

--- a/packages/flutter/test/material/semantics_tester_test.dart
+++ b/packages/flutter/test/material/semantics_tester_test.dart
@@ -1,0 +1,114 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('Semantics tester compares controlsNodes', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(container: true, controlsNodes: const <String>{'actual'}, child: Container()),
+    );
+
+    final expectedSemantics = TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          id: 1,
+          rect: TestSemantics.fullScreen,
+          controlsNodes: const <String>{'expected'},
+        ),
+      ],
+    );
+
+    expect(semantics, isNot(hasSemantics(expectedSemantics)));
+    semantics.dispose();
+  });
+
+  testWidgets('Semantics tester compares attributed string locales', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        attributedLabel: AttributedString(
+          'label',
+          attributes: <StringAttribute>[
+            LocaleStringAttribute(
+              locale: const Locale('en'),
+              range: const TextRange(start: 0, end: 5),
+            ),
+          ],
+        ),
+        textDirection: TextDirection.ltr,
+        child: Container(),
+      ),
+    );
+
+    expect(
+      semantics,
+      isNot(
+        includesNodeWith(
+          label: 'label',
+          attributedLabel: AttributedString(
+            'label',
+            attributes: <StringAttribute>[
+              LocaleStringAttribute(
+                locale: const Locale('es'),
+                range: const TextRange(start: 0, end: 5),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('includesNodeWith accepts minValue and maxValue', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        value: '5',
+        minValue: '0',
+        maxValue: '10',
+        textDirection: TextDirection.ltr,
+        child: Container(),
+      ),
+    );
+
+    expect(semantics, includesNodeWith(minValue: '0'));
+    expect(semantics, includesNodeWith(maxValue: '10'));
+    semantics.dispose();
+  });
+
+  testWidgets('includesNodeWith accepts attributed fields and hint alone', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        attributedLabel: AttributedString('label'),
+        attributedValue: AttributedString('value'),
+        attributedHint: AttributedString('hint'),
+        textDirection: TextDirection.ltr,
+        child: Container(),
+      ),
+    );
+
+    expect(semantics, includesNodeWith(attributedLabel: AttributedString('label')));
+    expect(semantics, includesNodeWith(attributedValue: AttributedString('value')));
+    expect(semantics, includesNodeWith(attributedHint: AttributedString('hint')));
+    expect(semantics, includesNodeWith(hint: 'hint'));
+    semantics.dispose();
+  });
+}


### PR DESCRIPTION
`packages/flutter/test/material/semantics_tester.dart` is a copy of `packages/flutter/test/widgets/semantics_tester.dart`, kept so material tests do not cross-import from widgets. It did not receive the fixes from #191938, so the two copies had drifted by exactly those four bugs:

- `controlsNodes != controlsNodes` compares the field to itself, so the `setEquals` check is unreachable and the expectation never runs
- the locale comparison reads `second[i]` on both sides instead of `first[i]`, so mismatched locales compare equal
- the `minValue`/`maxValue` checks sit in `assert()`'s message slot rather than its condition, so they gate nothing
- `attributedLabel`, `attributedValue`, `attributedHint` and `hint` were missing from that assert's condition, so passing any one of them alone tripped it

After this change the two files are byte-identical again:

```
diff packages/flutter/test/widgets/semantics_tester.dart \
     packages/flutter/test/material/semantics_tester.dart
```

Also adds `packages/flutter/test/material/semantics_tester_test.dart` covering each fix, mirroring the widgets test file. There was no test file for the material copy previously.

## Testing

`flutter test packages/flutter/test/material/semantics_tester_test.dart packages/flutter/test/widgets/semantics_tester_test.dart` passes 12/12.

Follow-up to #191938.
