### PR TITLE
Fix Expansible crash when PageStorage holds a non-bool value

### DIFF
--- a/packages/flutter/lib/src/widgets/expansible.dart
+++ b/packages/flutter/lib/src/widgets/expansible.dart
@@ -381,8 +381,13 @@ class _ExpansibleState extends State<Expansible> with SingleTickerProviderStateM
   void initState() {
     super.initState();
     _animationController = AnimationController(duration: _duration, vsync: this);
-    final bool initiallyExpanded =
-        PageStorage.maybeOf(context)?.readState(context) as bool? ?? widget.controller.isExpanded;
+    // PageStorage is untyped and the same slot can be written by other widgets,
+    // such as a Scrollable that saves a double. Only use the stored value if it
+    // is a bool, otherwise fall back to the controller's state.
+    final Object? storedExpansionState = PageStorage.maybeOf(context)?.readState(context);
+    final bool initiallyExpanded = storedExpansionState is bool
+        ? storedExpansionState
+        : widget.controller.isExpanded;
     if (initiallyExpanded) {
       _animationController.value = 1.0;
       widget.controller.expand();

--- a/packages/flutter/test/widgets/expansible_test.dart
+++ b/packages/flutter/test/widgets/expansible_test.dart
@@ -533,4 +533,62 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Body'), findsOneWidget);
   });
+
+  testWidgets('Does not crash when PageStorage holds a non-bool value', (
+    WidgetTester tester,
+  ) async {
+    // A Scrollable and other widgets save doubles into PageStorage. If one of
+    // those values ends up in the Expansible's slot, reading it back should not
+    // crash. Regression test for
+    // https://github.com/flutter/flutter/issues/192184.
+    final bucket = PageStorageBucket();
+    const key = PageStorageKey<String>('tile');
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: PageStorage(
+          bucket: bucket,
+          child: const _PageStorageWriter(key: key, value: 42.0),
+        ),
+      ),
+    );
+
+    final controller = ExpansibleController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: PageStorage(
+          bucket: bucket,
+          child: Expansible(
+            key: key,
+            controller: controller,
+            bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+            headerBuilder: (BuildContext context, Animation<double> animation) =>
+                const Text('Header'),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Header'), findsOneWidget);
+    expect(find.text('Body'), findsNothing);
+  });
+}
+
+// Saves a value into the shared PageStorage bucket. Using the same
+// PageStorageKey as the Expansible puts it in the same slot.
+class _PageStorageWriter extends StatelessWidget {
+  const _PageStorageWriter({super.key, required this.value});
+
+  final Object value;
+
+  @override
+  Widget build(BuildContext context) {
+    PageStorage.maybeOf(context)?.writeState(context, value);
+    return const SizedBox();
+  }
 }


### PR DESCRIPTION
## Description

`Expansible` reads its initial expansion state from `PageStorage` in `initState`:

```dart
PageStorage.maybeOf(context)?.readState(context) as bool? ?? widget.controller.isExpanded;
```

`PageStorage` is untyped and its bucket slot is keyed by the `PageStorageKey`s on the path. Different widgets can share the same slot, and some of them save other types, for example a `Scrollable` or `PageView` saves a `double` offset. When that value lands in the `Expansible` slot, the `as bool?` cast throws:

```
type 'double' is not a subtype of type 'bool?' in type cast
  _ExpansibleState.initState (expansible.dart)
```

This crashes real apps that use `ExpansionTile` inside a scroll view without a unique key.

The fix reads the stored value first and only uses it when it is a `bool`, otherwise it falls back to the controller's state, which is what the old `?? controller.isExpanded` was meant to do.

## Related issue

Fixes https://github.com/flutter/flutter/issues/192184

Thanks to @FabriceLeger for reporting it with the exact crash location.

## Tests

Added a regression test in `expansible_test.dart` that seeds a `double` into the shared `PageStorage` bucket and confirms `Expansible` builds without throwing. The test fails on the current code and passes with the fix.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md