### PR TITLE
Add `IsProgram` mock method to `MockGLESImpl`, use it in `BufferBindingsGLESTest`

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -290,6 +290,8 @@ void TestBindUniformBufferRange(size_t buffer_view_length,
 
   const GLuint kProgram = 1;
 
+  ON_CALL(*mock_gles_impl, IsProgram(kProgram))
+      .WillByDefault(::testing::Return(GL_TRUE));
   ON_CALL(*mock_gles_impl,
           GetProgramiv(/*program=*/kProgram,
                        /*pname=*/GL_ACTIVE_UNIFORM_BLOCKS, /*params=*/_))

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -358,6 +358,13 @@ GLboolean mockIsTexture(GLuint texture) {
 static_assert(CheckSameSignature<decltype(mockIsTexture),  //
                                  decltype(glIsTexture)>::value);
 
+GLboolean mockIsProgram(GLuint program) {
+  return CallMockMethod(&IMockGLESImpl::IsProgram, program);
+}
+
+static_assert(CheckSameSignature<decltype(mockIsProgram),  //
+                                 decltype(glIsProgram)>::value);
+
 GLenum mockCheckFramebufferStatus(GLenum target) {
   return CallMockMethod(&IMockGLESImpl::CheckFramebufferStatus, target);
 }
@@ -561,6 +568,8 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockBufferSubData);
   } else if (strcmp(name, "glIsTexture") == 0) {
     return reinterpret_cast<void*>(mockIsTexture);
+  } else if (strcmp(name, "glIsProgram") == 0) {
+    return reinterpret_cast<void*>(mockIsProgram);
   } else if (strcmp(name, "glCheckFramebufferStatus") == 0) {
     return reinterpret_cast<void*>(mockCheckFramebufferStatus);
   } else if (strcmp(name, "glReadPixels") == 0) {

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -102,6 +102,7 @@ class IMockGLESImpl {
                              GLsizeiptr size,
                              const void* data) {}
   virtual GLboolean IsTexture(GLuint texture) { return true; }
+  virtual GLboolean IsProgram(GLuint program) { return true; }
   virtual void DiscardFramebufferEXT(GLenum target,
                                      GLsizei numAttachments,
                                      const GLenum* attachments) {};
@@ -277,6 +278,7 @@ class MockGLESImpl : public IMockGLESImpl {
       (GLenum target, GLintptr offset, GLsizeiptr size, const void* data),
       (override));
   MOCK_METHOD(GLboolean, IsTexture, (GLuint texture), (override));
+  MOCK_METHOD(GLboolean, IsProgram, (GLuint program), (override));
   MOCK_METHOD(void,
               DiscardFramebufferEXT,
               (GLenum target,


### PR DESCRIPTION
Previously, this method was not mocked and would return an undefined value when it was called in the `BufferBindingsGLESTest` unit tests. When the returned value happened to be false, this makes the tests fail. We've seen this failure pop up multiple times recently.

Examples:
https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20linux_unopt/47431/overview
https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20linux_unopt/47434/overview
https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20linux_unopt/19763/overview

I can't consistently repro the failure at HEAD or at the PRs which produced the example failures. But I I tested that modifying this PR to return `GL_FALSE` instead of `GL_TRUE` does consistently reproduce the failure.