### PR TITLE
Fix parsing of --enable-hcpp-and-surface-control switch and add --no-enable-hcpp tests

### DIFF
--- a/dev/bots/suite_runners/run_android_engine_tests.dart
+++ b/dev/bots/suite_runners/run_android_engine_tests.dart
@@ -57,7 +57,11 @@ Future<void> runAndroidEngineTests({required ImpellerBackend impellerBackend}) a
     // TODO(matanlurey): Enable once `flutter drive` retains error logs.
     // final RegExp impellerStdoutPattern = RegExp('Using the Imepller rendering backend (.*)');
 
-    Future<void> runTest(FileSystemEntity file, {bool useHCPPFlag = false}) async {
+    Future<void> runTest(
+      FileSystemEntity file, {
+      bool? useHCPPFlag,
+      Map<String, String>? additionalEnvironment,
+    }) async {
       final CommandResult result = await runCommand(
         'flutter',
         <String>[
@@ -68,12 +72,16 @@ Future<void> runAndroidEngineTests({required ImpellerBackend impellerBackend}) a
           // make less things start up unnecessarily.
           '--no-dds',
           '--no-enable-dart-profiling',
-          if (useHCPPFlag) '--enable-hcpp',
+          if (useHCPPFlag == true) '--enable-hcpp',
+          if (useHCPPFlag == false) '--no-enable-hcpp',
           '--test-arguments=test',
           '--test-arguments=--reporter=expanded',
         ],
         workingDirectory: androidEngineTestPath,
-        environment: <String, String>{'ANDROID_ENGINE_TEST_GOLDEN_VARIANT': impellerBackend.name},
+        environment: <String, String>{
+          'ANDROID_ENGINE_TEST_GOLDEN_VARIANT': impellerBackend.name,
+          ...?additionalEnvironment,
+        },
       );
       final String? stdout = result.flattenedStdout;
       if (stdout == null) {
@@ -126,6 +134,15 @@ Future<void> runAndroidEngineTests({required ImpellerBackend impellerBackend}) a
           kHcppMetadataEnabled,
         ),
       );
+
+      // Verify that --no-enable-hcpp disables HCPP even when the manifest enables it.
+      for (final testName in runFirstTests) {
+        await runTest(
+          mains.firstWhere((FileSystemEntity file) => file.path.contains(testName)),
+          useHCPPFlag: false,
+          additionalEnvironment: const <String, String>{'EXPECT_HCPP': 'false'},
+        );
+      }
       for (final file in mains) {
         // This statement is attempting to catch all tests inside of the
         // dev/integration_tests/android_engine_test/lib/hcpp

--- a/dev/integration_tests/android_engine_test/test_driver/hcpp/upgrade_legacy_pv_types_main_test.dart
+++ b/dev/integration_tests/android_engine_test/test_driver/hcpp/upgrade_legacy_pv_types_main_test.dart
@@ -13,10 +13,12 @@ import 'package:test/test.dart';
 /// legacy platform view creation APIs (HC via initExpensiveAndroidView,
 /// TLHC with HC fallback via initSurfaceAndroidView, and
 /// TLHC with VD fallback via initAndroidView) are upgraded to HCPP mode
-/// without crashing.
+/// without crashing. When HCPP is disabled via --no-enable-hcpp,
+/// verifies that all three fall back to their legacy creation strategies.
 void main() async {
   late final FlutterDriver flutterDriver;
   late final NativeDriver nativeDriver;
+  final expectHcpp = io.Platform.environment['EXPECT_HCPP'] != 'false';
 
   setUpAll(() async {
     // Clear logcat before the test so we only see logs from this run.
@@ -32,9 +34,9 @@ void main() async {
     await flutterDriver.close();
   });
 
-  test('verify that HCPP is supported and enabled', () async {
+  test('verify that HCPP is ${expectHcpp ? "supported and enabled" : "disabled"}', () async {
     final response = json.decode(await flutterDriver.requestData('')) as Map<String, Object?>;
-    expect(response['supported'], true);
+    expect(response['supported'], expectHcpp);
   }, timeout: Timeout.none);
 
   test('all three platform view types render without crashing', () async {
@@ -50,7 +52,7 @@ void main() async {
     expect(health.status, HealthStatus.ok);
   }, timeout: Timeout.none);
 
-  test('verify HCPP was used for all views via logcat', () async {
+  test('verify platform view rendering strategy via logcat', () async {
     // Dump logcat filtered to the PlatformViewsChannel tag.
     final io.ProcessResult result = await io.Process.run('adb', <String>[
       'logcat',
@@ -60,25 +62,42 @@ void main() async {
     ]);
     final logcat = result.stdout as String;
 
-    // We created 3 platform views — expect 3 HCPP log lines.
+    // We created 3 platform views.
     final int hcppCount = 'Using HCPP platform view rendering strategy.'.allMatches(logcat).length;
     final int legacyCount = 'Using legacy platform view rendering strategy.'
         .allMatches(logcat)
         .length;
 
-    expect(
-      hcppCount,
-      3,
-      reason:
-          'Expected 3 HCPP creations (one per view type), '
-          'got $hcppCount. Logcat:\n$logcat',
-    );
-    expect(
-      legacyCount,
-      0,
-      reason:
-          'Expected 0 legacy creations, '
-          'got $legacyCount. Logcat:\n$logcat',
-    );
+    if (expectHcpp) {
+      expect(
+        hcppCount,
+        3,
+        reason:
+            'Expected 3 HCPP creations (one per view type), '
+            'got $hcppCount. Logcat:\n$logcat',
+      );
+      expect(
+        legacyCount,
+        0,
+        reason:
+            'Expected 0 legacy creations, '
+            'got $legacyCount. Logcat:\n$logcat',
+      );
+    } else {
+      expect(
+        hcppCount,
+        0,
+        reason:
+            'Expected 0 HCPP creations when HCPP is disabled, '
+            'got $hcppCount. Logcat:\n$logcat',
+      );
+      expect(
+        legacyCount,
+        3,
+        reason:
+            'Expected 3 legacy creations when HCPP is disabled, '
+            'got $legacyCount. Logcat:\n$logcat',
+      );
+    }
   }, timeout: Timeout.none);
 }

--- a/engine/src/flutter/shell/common/switches.cc
+++ b/engine/src/flutter/shell/common/switches.cc
@@ -515,8 +515,15 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
   settings.enable_platform_isolates =
       command_line.HasOption(FlagForSwitch(Switch::EnablePlatformIsolates));
 
-  settings.enable_surface_control = command_line.HasOption(
-      FlagForSwitch(Switch::EnableAndroidHcppAndSurfaceControl));
+  {
+    std::string enable_surface_control_value;
+    if (command_line.GetOptionValue(
+            FlagForSwitch(Switch::EnableAndroidHcppAndSurfaceControl),
+            &enable_surface_control_value)) {
+      settings.enable_surface_control = enable_surface_control_value.empty() ||
+                                        "true" == enable_surface_control_value;
+    }
+  }
 
   constexpr std::string_view kMergedThreadEnabled = "enabled";
   constexpr std::string_view kMergedThreadDisabled = "disabled";

--- a/engine/src/flutter/shell/common/switches_unittests.cc
+++ b/engine/src/flutter/shell/common/switches_unittests.cc
@@ -122,6 +122,40 @@ TEST(SwitchesTest, NoEnableImpeller) {
   }
 }
 
+TEST(SwitchesTest, NoEnableHcppAndSurfaceControl) {
+  {
+    // enable with value
+    fml::CommandLine command_line = fml::CommandLineFromInitializerList(
+        {"command", "--enable-hcpp-and-surface-control=true"});
+    EXPECT_TRUE(command_line.HasOption("enable-hcpp-and-surface-control"));
+    Settings settings = SettingsFromCommandLine(command_line);
+    EXPECT_EQ(settings.enable_surface_control, true);
+  }
+  {
+    // enable without value
+    fml::CommandLine command_line = fml::CommandLineFromInitializerList(
+        {"command", "--enable-hcpp-and-surface-control"});
+    EXPECT_TRUE(command_line.HasOption("enable-hcpp-and-surface-control"));
+    Settings settings = SettingsFromCommandLine(command_line);
+    EXPECT_EQ(settings.enable_surface_control, true);
+  }
+  {
+    // disable
+    fml::CommandLine command_line = fml::CommandLineFromInitializerList(
+        {"command", "--enable-hcpp-and-surface-control=false"});
+    EXPECT_TRUE(command_line.HasOption("enable-hcpp-and-surface-control"));
+    Settings settings = SettingsFromCommandLine(command_line);
+    EXPECT_EQ(settings.enable_surface_control, false);
+  }
+  {
+    // default (absent)
+    fml::CommandLine command_line =
+        fml::CommandLineFromInitializerList({"command"});
+    Settings settings = SettingsFromCommandLine(command_line);
+    EXPECT_EQ(settings.enable_surface_control, false);
+  }
+}
+
 TEST(SwitchesTest, ProfileStartup) {
   {
     fml::CommandLine command_line =


### PR DESCRIPTION
## Description

This PR fixes an issue where passing `--no-enable-hcpp` failed to disable SurfaceControl on Android, and adds integration tests to positively validate that `--no-enable-hcpp` disables HCPP and falls back to legacy platform view rendering.

### Background & Root Cause
In PR #190623, `enableHcpp` in the Flutter tool was converted from a non-nullable `bool` to a nullable `bool?` to support overriding manifest metadata via CLI (`--enable-hcpp` vs `--no-enable-hcpp`). This led to `device.dart` forwarding `--ez enable-hcpp-and-surface-control false` as an intent extra when `--no-enable-hcpp` was passed. In turn, `FlutterShellArgs` converted this extra to the command-line flag `--enable-hcpp-and-surface-control=false`.

However, the engine's switch parser in `switches.cc` checked:
```cpp
settings.enable_surface_control =
    command_line.HasOption(FlagForSwitch(Switch::EnableAndroidHcppAndSurfaceControl));
```
Because `fml::CommandLine::HasOption` only checks whether the switch key is present regardless of its assigned value, `--enable-hcpp-and-surface-control=false` evaluated to `true`, keeping SurfaceControl enabled even when `--no-enable-hcpp` was passed.

### Changes
This PR is split into two commits:
1. **Commit 1 (`97a2282ef03`)**: Add integration / driver tests in `run_android_engine_tests.dart` and `upgrade_legacy_pv_types_main_test.dart` to positively test that `--no-enable-hcpp` disables HCPP and falls back to legacy platform view rendering (`Using legacy platform view rendering strategy.`).
2. **Commit 2 (`a00f2c65372`)**: Update `switches.cc` to inspect the switch value using `command_line.GetOptionValue(...)`, verifying that it is empty (flag without value) or `"true"`. Add unit tests in `switches_unittests.cc` covering `--enable-hcpp-and-surface-control=true`, `--enable-hcpp-and-surface-control`, `--enable-hcpp-and-surface-control=false`, and absence of the flag.

---

> [!NOTE]
> This pull request was generated with Gemini / AI assistance for transparency.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
