### PR TITLE
[uber_sdf] Started passing in pixel size instead of using derivatives

### DIFF
--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -852,7 +852,7 @@ bool Canvas::AttemptDrawLineSDF(const Point& p0,
                                 const Paint& paint,
                                 bool reuse_depth) {
   if (!renderer_.GetContext()->GetFlags().use_sdfs ||
-      !IsCompatibleWithSDFRendering(paint)) {
+      !IsCompatibleWithSDFRendering(paint, GetCurrentTransform())) {
     return false;
   }
   // Draw the line as a filled rectangle with width=line_length and
@@ -991,7 +991,7 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
   }
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint)) {
+      IsCompatibleWithSDFRendering(paint, GetCurrentTransform())) {
     Rect effective_rect = rect;
     Color effective_color = paint.color;
 
@@ -1064,7 +1064,7 @@ void Canvas::DrawOval(const Rect& rect, const Paint& paint) {
   entity.SetBlendMode(paint.blend_mode);
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint)) {
+      IsCompatibleWithSDFRendering(paint, GetCurrentTransform())) {
     UberSDFParameters params;
 
     if (paint.style == Paint::Style::kStroke) {
@@ -1152,7 +1152,8 @@ void Canvas::DrawRoundRect(const RoundRect& round_rect, const Paint& paint) {
   const RoundingRadii& radii = round_rect.GetRadii();
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint) && radii.AreAllCornersCircular()) {
+      IsCompatibleWithSDFRendering(paint, GetCurrentTransform()) &&
+      radii.AreAllCornersCircular()) {
     Color effective_color = paint.color;
     Rect bounds = round_rect.GetBounds();
 
@@ -1236,7 +1237,7 @@ void Canvas::DrawRoundSuperellipse(const RoundSuperellipse& round_superellipse,
   entity.SetBlendMode(paint.blend_mode);
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint)) {
+      IsCompatibleWithSDFRendering(paint, GetCurrentTransform())) {
     // Try to draw using UberSDF.
     auto params = UberSDFParameters::MakeRoundedSuperellipse(
         /*color=*/paint.color, /*round_superellipse=*/round_superellipse,
@@ -1300,7 +1301,7 @@ void Canvas::DrawCircle(const Point& center,
   }
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint)) {
+      IsCompatibleWithSDFRendering(paint, GetCurrentTransform())) {
     auto params = UberSDFParameters::MakeCircle(
         /*color=*/paint.color, /*center=*/center, /*radius=*/radius,
         /*stroke=*/paint.GetStroke());
@@ -2665,11 +2666,15 @@ void Canvas::EndReplay() {
   Initialize(initial_cull_rect_);
 }
 
-bool Canvas::IsCompatibleWithSDFRendering(const Paint& paint) {
+bool Canvas::IsCompatibleWithSDFRendering(const Paint& paint,
+                                          const Matrix& transform) {
   if (!paint.anti_alias) {
     return false;
   }
   if (paint.mask_blur_descriptor.has_value()) {
+    return false;
+  }
+  if (transform.HasPerspective()) {
     return false;
   }
   switch (paint.blend_mode) {

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -280,8 +280,8 @@ class Canvas {
 
   /// Returns true if the paint is compatible with SDF rendering.
   ///
-  /// Visible for testing.
-  static bool IsCompatibleWithSDFRendering(const Paint& paint);
+  static bool IsCompatibleWithSDFRendering(const Paint& paint,
+                                           const Matrix& transform = Matrix());
 
  private:
   class BlurShape {

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -73,6 +73,10 @@ bool UberSDFContents::Render(const ContentContext& renderer,
       params_.color.WithAlpha(params_.color.alpha * GetOpacityFactor());
   frag_info.center = params_.center;
   frag_info.size = params_.size;
+  Vector2 transform_scaling = entity.GetTransform().GetBasisScaleXY();
+  frag_info.pixel_size =
+      Point(transform_scaling.x != 0.0f ? 1.0f / transform_scaling.x : 0.0f,
+            transform_scaling.y != 0.0f ? 1.0f / transform_scaling.y : 0.0f);
   frag_info.stroked = params_.stroke ? 1.0f : 0.0f;
   frag_info.stroke_width = params_.stroke ? params_.stroke->width : 0.0f;
   frag_info.stroke_join =

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -93,18 +93,30 @@ float distanceFromRect(vec2 p, vec2 b) {
   return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
 }
 
-float distanceFromOval(vec2 p, vec2 ab) {
-  p = abs(p);
-  vec2 q = ab * (p - ab);
+// Calculates signed distance to an oval (ellipse with semi-axes `ab`) and
+// computes its outward surface normal vector at the closest boundary point.
+//
+// The ellipse boundary is parameterized by angle w as (a * cos(w), b * sin(w)).
+// The tangent vector is (-a * sin(w), b * cos(w)), so the outward normal
+// is orthogonal: (b * cos(w), a * sin(w)).
+float distanceFromOval(vec2 p, vec2 ab, out vec2 normal) {
+  vec2 p_abs = abs(p);
+  vec2 q = ab * (p_abs - ab);
   float w = (q.x < q.y) ? 1.570796327 : 0.0;
+  vec2 cs;
   for (int i = 0; i < 5; i++) {
-    vec2 cs = vec2(cos(w), sin(w));
+    cs = vec2(cos(w), sin(w));
     vec2 u = ab * vec2(cs.x, cs.y);
     vec2 v = ab * vec2(-cs.y, cs.x);
-    w = w + dot(p - u, v) / (dot(p - u, u) + dot(v, v));
+    w = w + dot(p_abs - u, v) / (dot(p_abs - u, u) + dot(v, v));
   }
-  float d = length(p - ab * vec2(cos(w), sin(w)));
-  return (dot(p / ab, p / ab) > 1.0) ? d : -d;
+  cs = vec2(cos(w), sin(w));
+  float d = length(p_abs - ab * cs);
+
+  vec2 s = vec2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
+  normal = s * normalize(vec2(ab.y * cs.x, ab.x * cs.y));
+
+  return (dot(p_abs / ab, p_abs / ab) > 1.0) ? d : -d;
 }
 
 float distanceFromRoundedRect(in vec2 p, in vec2 b, in vec4 r) {
@@ -235,8 +247,9 @@ vec2 filledSDF(vec2 p) {
     // Rect has its own separate logic for calculating pixel size.
     pixel_size = rectPixelSize(p);
   } else if (frag_info.type < 2.5) {  // Oval
-    sdf = distanceFromOval(p, frag_info.size);
-    pixel_size = pixelSize(sdf);
+    vec2 normal;
+    sdf = distanceFromOval(p, frag_info.size, normal);
+    pixel_size = directionalPixelSize(normal);
   } else if (frag_info.type < 3.5) {  // Rounded Rect
     sdf = distanceFromRoundedRect(p, frag_info.size, frag_info.radii);
     // RoundRect has its own separate logic for calculating pixel size.

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -140,9 +140,10 @@ float distanceFromRoundedSuperellipse(vec2 p,
                                       vec2 radii,
                                       vec2 angle_span,
                                       vec2 circle_center_top,
-                                      vec2 circle_center_right) {
-  // Do work in the first quadrant to simply things.
-  p = abs(p);
+                                      vec2 circle_center_right,
+                                      out vec2 normal) {
+  // Do work in the first quadrant to simplify things.
+  vec2 p_abs = abs(p);
 
   // Transition line offset dividing top and right octants.
   float c = size.x - size.y;
@@ -153,12 +154,13 @@ float distanceFromRoundedSuperellipse(vec2 p,
 
   // 'p' in the coordinate system of the octant.
   vec2 p_oct;
+  bool is_top = (p_abs.y + c > p_abs.x);
 
   // We split the quadrant along the diagonal of the transition (p.y + c ==
   // p.x). This allows us to grab the correct set of parameters for the
   // "top" and "right" halves of the corner.
-  if (p.y + c > p.x) {
-    p_oct = p + vec2(0.0, c);
+  if (is_top) {
+    p_oct = p_abs + vec2(0.0, c);
     se_degree = degree.x;
     span = angle_span.x;
     radius = radii.x;
@@ -167,7 +169,7 @@ float distanceFromRoundedSuperellipse(vec2 p,
   } else {
     // For the 'right' octant, we flip the point and shift it according to
     // the CPU's OctantContains/Flip logic.
-    p_oct = p.yx - vec2(0.0, c);
+    p_oct = p_abs.yx - vec2(0.0, c);
     se_degree = degree.y;
     span = angle_span.y;
     radius = radii.y;
@@ -175,8 +177,17 @@ float distanceFromRoundedSuperellipse(vec2 p,
     axis_length = size.y;
   }
 
-  return distanceFromRSEOctant(p_oct, circle_center, radius, span, axis_length,
-                               se_degree);
+  vec3 dist_with_grad = distanceFromRSEOctantWithGrad(
+      p_oct, circle_center, radius, span, axis_length, se_degree);
+
+  float dist = dist_with_grad.x;
+  vec2 grad_oct = dist_with_grad.yz;
+
+  vec2 grad = is_top ? grad_oct : grad_oct.yx;
+  vec2 s = vec2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
+  normal = s * grad;
+
+  return dist;
 }
 
 // Calculates pixel size for rectangles using frag_info.pixel_size.
@@ -225,14 +236,6 @@ float directionalPixelSize(vec2 normal) {
   return length(normal * frag_info.pixel_size);
 }
 
-// Calculates pixel size from the SDF gradient using screen-space derivatives.
-// Used for shapes like Oval and Rounded Superellipse where the surface normal
-// varies along complex curves and cannot be cheaply derived analytically.
-float pixelSize(float sdf) {
-  vec2 gradient = vec2(dFdx(sdf), dFdy(sdf));
-  return length(gradient);
-}
-
 // Evaluates the SDF for the shape selected by frag_info.type.
 // Returns vec2(sdf, pixel_size).
 vec2 filledSDF(vec2 p) {
@@ -255,11 +258,12 @@ vec2 filledSDF(vec2 p) {
     // RoundRect has its own separate logic for calculating pixel size.
     pixel_size = roundRectPixelSize(p);
   } else {  // Symmetric Rounded Superellipse
+    vec2 normal;
     sdf = distanceFromRoundedSuperellipse(
         p, frag_info.superellipse_degree, frag_info.size, frag_info.radii.xy,
         frag_info.angle_span, frag_info.circle_center_top,
-        frag_info.circle_center_right);
-    pixel_size = pixelSize(sdf);
+        frag_info.circle_center_right, normal);
+    pixel_size = directionalPixelSize(normal);
   }
   return vec2(sdf, pixel_size);
 }

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -5,6 +5,7 @@
 precision mediump float;
 
 #include <impeller/color.glsl>
+#include <impeller/constants.glsl>
 #include <impeller/types.glsl>
 
 #include "rse_sdf.glsl"
@@ -35,6 +36,8 @@ uniform FragInfo {
   vec2 center;
   /// The half-dimensions of the shape (half-width, half-height).
   vec2 size;
+  /// The size of a device pixel in local coordinates.
+  vec2 pixel_size;
 
   // --- Superellipse Parameters ---
   /// The exponent degree (n_x, n_y) of the superellipse curvature.
@@ -115,7 +118,7 @@ float distanceFromChamferRect(vec2 p, vec2 half_size, float chamfer_size) {
   p = abs(p);
   float d1 = max(p.x - half_size.x, p.y - half_size.y);
   float d2 =
-      (p.x + p.y - half_size.x - half_size.y + chamfer_size) * 0.70710678;
+      (p.x + p.y - half_size.x - half_size.y + chamfer_size) * kHalfSqrtTwo;
   return max(d1, d2);
 }
 
@@ -164,38 +167,18 @@ float distanceFromRoundedSuperellipse(vec2 p,
                                se_degree);
 }
 
-// Special case pixel size calculation for rectangles. The standard `pixelSize`
-// function uses SDF derivatives, which gives invalid results for very small
-// shapes, where adjacent device pixels span across opposing edges of the shape.
-// This function calculates pixel size for rectangles without using SDF
-// derivatives.
+// Calculates pixel size for rectangles using frag_info.pixel_size.
 float rectPixelSize(vec2 p) {
-  // The change in local coordinates per horizontal device pixel (device_dx)
-  // and vertical device pixel (device_dy).
-  vec2 device_dx = dFdx(v_position);
-  vec2 device_dy = dFdy(v_position);
-  // The size of a device pixel in terms of local coordinates.
-  vec2 device_pixel_size = vec2(length(vec2(device_dx.x, device_dy.x)),
-                                length(vec2(device_dx.y, device_dy.y)));
-
   // Get pixel size in the direction perpendicular to the closest edge of the
-  // rectangle: device_pixel_size.x when closer to a vertical edge, and
-  // pixel_size.y when closer to a horizontal edge.
+  // rectangle: frag_info.pixel_size.x when closer to a vertical edge, and
+  // frag_info.pixel_size.y when closer to a horizontal edge.
   vec2 distance = abs(abs(p) - frag_info.size);
-  return (distance.x < distance.y) ? device_pixel_size.x : device_pixel_size.y;
+  return (distance.x < distance.y) ? frag_info.pixel_size.x
+                                   : frag_info.pixel_size.y;
 }
 
-// Special case pixel size calculation for rounded rectangles, similar to
-// `rectPixelSize` for regular rectangles.
+// Calculates pixel size for rounded rectangles using frag_info.pixel_size.
 float roundRectPixelSize(vec2 p) {
-  // The change in local coordinates per horizontal device pixel (device_dx)
-  // and vertical device pixel (device_dy).
-  vec2 device_dx = dFdx(v_position);
-  vec2 device_dy = dFdy(v_position);
-  // The size of a device pixel in terms of local coordinates.
-  vec2 device_pixel_size = vec2(length(vec2(device_dx.x, device_dy.x)),
-                                length(vec2(device_dx.y, device_dy.y)));
-
   // Select the corner radius for the quadrant of p.
   vec4 r = frag_info.radii;
   r.xy = (p.x > 0.0) ? r.xy : r.zw;
@@ -208,15 +191,31 @@ float roundRectPixelSize(vec2 p) {
   float pixel_size;
   // If in the rounded corner arc, blend X and Y pixel sizes along the normal.
   if (q.x > 0.0 && q.y > 0.0) {
-    pixel_size = length(normalize(q) * device_pixel_size);
+    pixel_size = length(normalize(q) * frag_info.pixel_size);
   } else {
     // Otherwise, we are closer to a straight edge. Get pixel size in the
     // direction perpendicular to the closer edge.
-    pixel_size = (q.x > q.y) ? device_pixel_size.x : device_pixel_size.y;
+    pixel_size = (q.x > q.y) ? frag_info.pixel_size.x : frag_info.pixel_size.y;
   }
   return pixel_size;
 }
 
+// Calculates the effective pixel size in local coordinates along a given
+// surface normal vector.
+//
+// For affine transforms, the size of a screen pixel in local coordinates is
+// constant across the quad and precomputed on the CPU in
+// `frag_info.pixel_size`. Projecting the unit normal onto these local-space
+// pixel dimensions scales the antialiasing width appropriately along the
+// gradient direction (handling both uniform scaling and non-uniform
+// stretching).
+float directionalPixelSize(vec2 normal) {
+  return length(normal * frag_info.pixel_size);
+}
+
+// Calculates pixel size from the SDF gradient using screen-space derivatives.
+// Used for shapes like Oval and Rounded Superellipse where the surface normal
+// varies along complex curves and cannot be cheaply derived analytically.
 float pixelSize(float sdf) {
   vec2 gradient = vec2(dFdx(sdf), dFdy(sdf));
   return length(gradient);
@@ -229,7 +228,8 @@ vec2 filledSDF(vec2 p) {
   float pixel_size;
   if (frag_info.type < 0.5) {  // Circle
     sdf = distanceFromCircle(p, frag_info.size.x);
-    pixel_size = pixelSize(sdf);
+    pixel_size = (length(p) > 0.0) ? directionalPixelSize(normalize(p))
+                                   : frag_info.pixel_size.x;
   } else if (frag_info.type < 1.5) {  // Rect
     sdf = distanceFromRect(p, frag_info.size);
     // Rect has its own separate logic for calculating pixel size.
@@ -268,7 +268,7 @@ vec2 strokedSDF(vec2 p) {
     float outer = distanceFromRect(p, frag_info.size + half_stroke);
     float inner = base_sdf + half_stroke;
     sdf = max(outer, -inner);
-    pixel_size = pixelSize(sdf);
+    pixel_size = rectPixelSize(p);
   } else if (frag_info.type >= 0.5 && frag_info.type < 1.5 &&
              frag_info.stroke_join >= 0.5 && frag_info.stroke_join < 1.5) {
     // Rect with Bevel join
@@ -276,7 +276,11 @@ vec2 strokedSDF(vec2 p) {
         distanceFromChamferRect(p, frag_info.size + half_stroke, half_stroke);
     float inner = base_sdf + half_stroke;
     sdf = max(outer, -inner);
-    pixel_size = pixelSize(sdf);
+    // For a 45-degree bevel join, the unit normal is (1/sqrt(2), 1/sqrt(2)).
+    // The directional pixel size along this normal simplifies to:
+    //   length(vec2(1/sqrt(2), 1/sqrt(2)) * frag_info.pixel_size)
+    //   = length(frag_info.pixel_size) * (1.0 / sqrt(2.0)).
+    pixel_size = length(frag_info.pixel_size) * kHalfSqrtTwo;
   } else {
     // All other shapes
     vec2 sdf_and_pixel_size =

--- a/engine/src/flutter/impeller/tools/malioc.json
+++ b/engine/src/flutter/impeller/tools/malioc.json
@@ -8599,7 +8599,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 32,
+          "fp16_arithmetic": 35,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -8607,10 +8607,10 @@
               "arith_sfu"
             ],
             "longest_path_cycles": [
-              4.0,
-              3.875,
-              1.65625,
-              4.0,
+              3.75,
+              3.737499952316284,
+              1.6875,
+              3.75,
               0.0,
               0.25,
               0.0
@@ -8629,10 +8629,10 @@
               "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.53125,
-              0.53125,
-              0.15625,
-              0.5,
+              0.40625,
+              0.40625,
+              0.21875,
+              0.25,
               0.0,
               0.25,
               0.0
@@ -8642,10 +8642,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              13.625,
-              13.625,
-              4.5,
-              13.4375,
+              12.5,
+              12.5,
+              4.425000190734863,
+              10.75,
               0.0,
               0.25,
               0.0
@@ -8653,7 +8653,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 44,
+          "uniform_registers_used": 46,
           "work_registers_used": 32
         }
       }
@@ -8671,9 +8671,9 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              44.220001220703125,
+              42.56999969482422,
               3.0,
-              4.0
+              2.0
             ],
             "pipelines": [
               "arithmetic",
@@ -8684,21 +8684,21 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              6.269999980926514,
+              4.949999809265137,
               1.0,
-              2.0
+              0.0
             ],
             "total_bound_pipelines": [
               "arithmetic"
             ],
             "total_cycles": [
-              106.0,
+              99.0,
               3.0,
-              24.0
+              8.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 6,
+          "uniform_registers_used": 7,
           "work_registers_used": 4
         }
       }
@@ -11826,7 +11826,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 35,
+          "fp16_arithmetic": 40,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -11834,10 +11834,10 @@
               "arith_sfu"
             ],
             "longest_path_cycles": [
-              4.0,
-              3.387500047683716,
-              1.9249999523162842,
-              4.0,
+              3.75,
+              3.3125,
+              1.9375,
+              3.75,
               0.0,
               0.25,
               0.0
@@ -11853,26 +11853,26 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.5,
-              0.453125,
-              0.171875,
-              0.5,
+              0.375,
+              0.375,
+              0.234375,
+              0.25,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "total_cycles": [
-              13.4375,
-              12.4375,
-              4.84375,
-              13.4375,
+              11.375,
+              11.375,
+              5.03125,
+              10.5,
               0.0,
               0.25,
               0.0
@@ -11880,7 +11880,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 46,
+          "uniform_registers_used": 52,
           "work_registers_used": 32
         }
       }

--- a/engine/src/flutter/impeller/tools/malioc.json
+++ b/engine/src/flutter/impeller/tools/malioc.json
@@ -8599,7 +8599,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 35,
+          "fp16_arithmetic": 34,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -8607,10 +8607,10 @@
               "arith_sfu"
             ],
             "longest_path_cycles": [
-              3.75,
-              3.737499952316284,
-              1.6875,
-              3.75,
+              3.9375,
+              3.862499952316284,
+              2.0,
+              3.9375,
               0.0,
               0.25,
               0.0
@@ -8642,10 +8642,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              12.5,
-              12.5,
-              4.425000190734863,
-              10.75,
+              12.9375,
+              12.9375,
+              5.050000190734863,
+              10.875,
               0.0,
               0.25,
               0.0
@@ -8653,7 +8653,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 46,
+          "uniform_registers_used": 44,
           "work_registers_used": 32
         }
       }
@@ -8671,9 +8671,9 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              42.56999969482422,
-              3.0,
-              2.0
+              42.2400016784668,
+              8.0,
+              0.0
             ],
             "pipelines": [
               "arithmetic",
@@ -8684,21 +8684,21 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              4.949999809265137,
-              1.0,
+              5.28000020980835,
+              2.0,
               0.0
             ],
             "total_bound_pipelines": [
               "arithmetic"
             ],
             "total_cycles": [
-              99.0,
-              3.0,
-              8.0
+              129.0,
+              18.0,
+              0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 7,
+          "uniform_registers_used": 6,
           "work_registers_used": 4
         }
       }
@@ -11826,7 +11826,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 40,
+          "fp16_arithmetic": 38,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -11834,10 +11834,10 @@
               "arith_sfu"
             ],
             "longest_path_cycles": [
-              3.75,
-              3.3125,
-              1.9375,
-              3.75,
+              3.9375,
+              3.5,
+              2.25,
+              3.9375,
               0.0,
               0.25,
               0.0
@@ -11858,7 +11858,7 @@
             "shortest_path_cycles": [
               0.375,
               0.375,
-              0.234375,
+              0.21875,
               0.25,
               0.0,
               0.25,
@@ -11869,10 +11869,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              11.375,
-              11.375,
-              5.03125,
-              10.5,
+              12.125,
+              12.125,
+              5.762499809265137,
+              10.75,
               0.0,
               0.25,
               0.0


### PR DESCRIPTION
Performance optimization demonstrated in malioc results.

Not seen in the malioc results is the removal of thread synchronization because of derivative calls and the removal of potential crashes in ANGLE.

We get away with calculating the derivative on the cpu because the majority of the time we don't care about perspective matrices so the derivative is constant across fragments.  If we detect a perspective matrix we fall back to the mesh renderer.

Ovals and superellipses calculate their normal to calculate the pixel size, they don't rely on the passed in pixel size.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
