### PR TITLE
Clarify MatrixTransition filterQuality performance

### DIFF
--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -304,6 +304,17 @@ class MatrixTransition extends AnimatedWidget {
   /// When the animation is stopped (either in [AnimationStatus.dismissed] or
   /// [AnimationStatus.completed]), the filter quality argument will be ignored.
   ///
+  /// While the animation is running, a null value applies the updated matrix
+  /// directly to the child's painting operations on each animation tick. This
+  /// does not rebuild or lay out the child subtree, does not create an
+  /// [ImageFilterLayer], and lets repaint boundaries retain descendant layers.
+  ///
+  /// A non-null value renders the child into an intermediate bitmap and applies
+  /// the matrix through an [ImageFilterLayer] with the selected sampling
+  /// quality. This path forces compositing and incurs an offscreen `saveLayer`
+  /// operation while the animation is running. Consider profiling both paths
+  /// when the child is complex or the animation is performance-sensitive.
+  ///
   /// {@macro flutter.widgets.Transform.optional.FilterQuality}
   final FilterQuality? filterQuality;
 


### PR DESCRIPTION
Draft status: contributor review and CLA completion are pending. This PR should not be marked ready for review until the contributor has reviewed the diff and this description and completed the unchecked pre-launch items.

## What this changes

Clarifies the `MatrixTransition.filterQuality` API documentation by explaining:

- what the null path does on each animation tick;
- that this path does not rebuild or lay out the child subtree and can retain descendant repaint-boundary layers;
- when an `ImageFilterLayer` and intermediate bitmap are used; and
- the compositing and offscreen `saveLayer` cost of a non-null value.

The wording follows the current `MatrixTransition.build` and `RenderTransform.paint` implementations.

Fixes https://github.com/flutter/flutter/issues/192071

## Validation

- `bin/dart format packages/flutter/lib/src/widgets/transitions.dart`
- `bin/dart analyze --fatal-infos packages/flutter/lib/src/widgets/transitions.dart`
- `bin/flutter test packages/flutter/test/widgets/transitions_test.dart` (34 tests passed)
- `codespell packages/flutter/lib/src/widgets/transitions.dart`
- `git diff --check`

This is a documentation-only change and qualifies for the automatic test exemption, although the focused widget test was also run.

## AI assistance

OpenAI Codex assisted with issue discovery, source inspection, the documentation draft, and local validation. The contributor must review and understand every changed line and verify this description before marking the PR ready for review, as required by Flutter's AI contribution guidelines.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
