### PR TITLE
Replace more enum instances comparison to use `equality ==` instead of `identical` and update related tests

### DIFF
--- a/packages/flutter/lib/src/painting/flutter_logo.dart
+++ b/packages/flutter/lib/src/painting/flutter_logo.dart
@@ -45,9 +45,9 @@ class FlutterLogoDecoration extends Decoration {
     this.textColor = const Color(0xFF757575),
     this.style = FlutterLogoStyle.markOnly,
     this.margin = EdgeInsets.zero,
-  }) : _position = identical(style, FlutterLogoStyle.markOnly)
+  }) : _position = style == FlutterLogoStyle.markOnly
            ? 0.0
-           : identical(style, FlutterLogoStyle.horizontal)
+           : style == FlutterLogoStyle.horizontal
            ? 1.0
            : -1.0,
        _opacity = 1.0;

--- a/packages/flutter/test/painting/flutter_logo_test.dart
+++ b/packages/flutter/test/painting/flutter_logo_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  // Here and below, see: https://github.com/dart-lang/sdk/issues/26980
   const start = FlutterLogoDecoration(
     textColor: Color(0xFFD4F144),
     style: FlutterLogoStyle.stacked,
@@ -32,7 +31,7 @@ void main() {
   test('FlutterLogoDecoration.lerp identical a,b', () {
     expect(FlutterLogoDecoration.lerp(null, null, 0), null);
     const logo = FlutterLogoDecoration();
-    expect(identical(FlutterLogoDecoration.lerp(logo, logo, 0.5), logo), true);
+    expect(FlutterLogoDecoration.lerp(logo, logo, 0.5) == logo, true);
   });
 
   test('FlutterLogoDecoration lerp from non-null to null lerps margin', () {


### PR DESCRIPTION
related PRs:
- https://github.com/flutter/flutter/pull/191537
- https://github.com/flutter/flutter/pull/191788
- https://github.com/flutter/packages/pull/12632
see
- https://github.com/dart-lang/language/issues/1811
- https://github.com/dart-lang/language/issues/312
more info :
- https://github.com/dart-lang/sdk/issues/26980
- https://github.com/dart-lang/sdk/issues/36511
- https://github.com/dart-lang/sdk/issues/36564
- https://github.com/dart-lang/sdk/issues/36528

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
