### PR TITLE
[flutter_tools] Safely remove web loading indicator on dart-app-ready

### DIFF
--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -348,9 +348,9 @@ indeterminate.className = "indeterminate";
 loader.appendChild(indeterminate);
 
 document.addEventListener('dart-app-ready', function (e) {
-   loader.parentNode.removeChild(loader);
-   styleSheet.parentNode.removeChild(styleSheet);
-});
+   loader.remove();
+   styleSheet.remove();
+}, { once: true });
 ''';
 }
 

--- a/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
@@ -58,6 +58,22 @@ void main() {
     expect(result, matches(regex), reason: '.flutter-loader must have overflow: hidden');
   });
 
+  // https://github.com/flutter/flutter/issues/192226
+  test('generateBootstrapScript loading indicator listener is removed after first event and safely removes elements', () {
+    final String result = generateBootstrapScript(
+      requireUrl: 'require.js',
+      mapperUrl: 'mapper.js',
+      generateLoadingIndicator: true,
+    );
+
+    expect(result, contains("document.addEventListener('dart-app-ready', function (e) {"));
+    expect(result, contains('loader.remove();'));
+    expect(result, contains('styleSheet.remove();'));
+    expect(result, contains('}, { once: true });'));
+    expect(result, isNot(contains('loader.parentNode.removeChild')));
+    expect(result, isNot(contains('styleSheet.parentNode.removeChild')));
+  });
+
   // https://github.com/flutter/flutter/issues/82524
   test('generateMainModule removes timeout from requireJS', () {
     final String result = generateMainModule(
@@ -247,6 +263,24 @@ void main() {
       final regex = RegExp(r'(?:\.flutter-loader\s*\{)[^}]+(?:overflow\:\s*hidden;)[^}]+}');
 
       expect(result, matches(regex), reason: '.flutter-loader must have overflow: hidden');
+    });
+
+    // https://github.com/flutter/flutter/issues/192226
+    test('bootstrap script loading indicator listener is removed after first event and safely removes elements', () {
+      final String result = generateDDCLibraryBundleBootstrapScript(
+        entrypoint: 'foo/bar/main.js',
+        ddcModuleLoaderUrl: 'ddc_module_loader.js',
+        mapperUrl: 'mapper.js',
+        generateLoadingIndicator: true,
+        isWindows: false,
+      );
+
+      expect(result, contains("document.addEventListener('dart-app-ready', function (e) {"));
+      expect(result, contains('loader.remove();'));
+      expect(result, contains('styleSheet.remove();'));
+      expect(result, contains('}, { once: true });'));
+      expect(result, isNot(contains('loader.parentNode.removeChild')));
+      expect(result, isNot(contains('styleSheet.parentNode.removeChild')));
     });
 
     test('generateDDCLibraryBundleMainModule embeds the entrypoint correctly', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/192226

### Problem
In `packages/flutter_tools/lib/src/web/bootstrap.dart`, when compiling the web bootstrap script (`main.dart.js`), an event listener was added to `window` for `dart-app-ready` that executed:
```javascript
loader.parentNode.removeChild(loader);
```
On initial load, this removes the loader from the DOM, setting `loader.parentNode` to `null`.
When DWDS reconnects or re-dispatches `dart-app-ready` (e.g. following a WebSocket disconnect/reconnect), this listener was invoked again. Attempting to call `.removeChild` on a `null` `parentNode` threw:
```
TypeError: Cannot read properties of null (reading 'removeChild')
```

### Solution
1. Use `loader.remove()` and `styleSheet.remove()` instead of `parentNode.removeChild()`.
2. Configure the event listener with `{ once: true }` so it is automatically removed after firing once.

### Tests
Added regression unit tests to `packages/flutter_tools/test/general.shard/web/bootstrap_test.dart` verifying that `{ once: true }` and `.remove()` are used in generated web bootstrap code.