### PR TITLE
Evict removed/renamed assets from the asset bundle and running app on hot restart

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -176,6 +176,19 @@ abstract class AssetBundle {
   /// in a pubspec, indexed by component name and asset key.
   Map<String, Map<String, AssetBundleEntry>> get deferredComponentsEntries;
 
+  /// Asset keys that were present in [entries] after the previous successful
+  /// [build] call but are no longer present after the most recent one, e.g.
+  /// because the underlying file was deleted or renamed.
+  ///
+  /// Repopulated at the start of every [build] call. Does not include shader
+  /// entries; see [removedShaderEntries] for those.
+  Set<String> get removedEntries;
+
+  /// The same as [removedEntries], but for entries whose [AssetBundleEntry.kind]
+  /// was [AssetKind.shader], which are evicted from a running application
+  /// through a different service extension than other asset kinds.
+  Set<String> get removedShaderEntries;
+
   /// Additional files that this bundle depends on that are not included in the
   /// output result.
   List<File> get additionalDependencies;
@@ -254,6 +267,12 @@ class ManifestAssetBundle implements AssetBundle {
   final entries = <String, AssetBundleEntry>{};
 
   @override
+  final removedEntries = <String>{};
+
+  @override
+  final removedShaderEntries = <String>{};
+
+  @override
   final deferredComponentsEntries = <String, Map<String, AssetBundleEntry>>{};
 
   @override
@@ -328,6 +347,8 @@ class ManifestAssetBundle implements AssetBundle {
     String? flavor,
     bool includeAssetsFromDevDependencies = false,
   }) async {
+    final previousKeys = Set<String>.of(entries.keys);
+    final touchedKeys = <String>{};
     if (flutterProject == null) {
       try {
         flutterProject = FlutterProject.fromDirectory(_fileSystem.file(manifestPath).parent);
@@ -355,6 +376,7 @@ class ManifestAssetBundle implements AssetBundle {
         kind: AssetKind.regular,
         transformers: const <AssetTransformerEntry>[],
       );
+      touchedKeys.add(_kAssetManifestBinFilename);
       // Create .bin.json on web builds.
       if (targetPlatform == TargetPlatform.web_javascript) {
         entries[_kAssetManifestBinJsonFilename] = AssetBundleEntry(
@@ -362,7 +384,9 @@ class ManifestAssetBundle implements AssetBundle {
           kind: AssetKind.regular,
           transformers: const <AssetTransformerEntry>[],
         );
+        touchedKeys.add(_kAssetManifestBinJsonFilename);
       }
+      _pruneRemovedEntries(previousKeys, touchedKeys);
       return 0;
     }
 
@@ -590,6 +614,7 @@ class ManifestAssetBundle implements AssetBundle {
             transformers: variant.transformers,
           ),
         );
+        touchedKeys.add(variant.entryUri.path);
       }
     }
     // Save the contents of each deferred component image, image variant, and font
@@ -646,6 +671,7 @@ class ManifestAssetBundle implements AssetBundle {
         kind: asset.kind,
         transformers: const <AssetTransformerEntry>[],
       );
+      touchedKeys.add(asset.entryUri.path);
     }
 
     // Update wildcard directories we can detect changes in them.
@@ -686,16 +712,42 @@ class ManifestAssetBundle implements AssetBundle {
     }
 
     _setIfChanged(_kAssetManifestBinFilename, assetManifestBinary, AssetKind.regular);
+    touchedKeys.add(_kAssetManifestBinFilename);
     // Create .bin.json on web builds.
     if (targetPlatform == TargetPlatform.web_javascript) {
       final assetManifestBinaryJson = DevFSStringContent(
         json.encode(base64.encode(assetManifestBinary.bytes)),
       );
       _setIfChanged(_kAssetManifestBinJsonFilename, assetManifestBinaryJson, AssetKind.regular);
+      touchedKeys.add(_kAssetManifestBinJsonFilename);
     }
     _setIfChanged(kFontManifestJson, fontManifest, AssetKind.regular);
+    touchedKeys.add(kFontManifestJson);
     _setLicenseIfChanged(licenseResult.combinedLicenses, targetPlatform);
+    touchedKeys.add(
+      targetPlatform == TargetPlatform.web_javascript ? _kNoticeFile : _kNoticeZippedFile,
+    );
+    _pruneRemovedEntries(previousKeys, touchedKeys);
     return 0;
+  }
+
+  /// Removes entries that existed in [previousKeys] but were not touched
+  /// during this build, and records their keys in [removedEntries] (or
+  /// [removedShaderEntries], for shaders) so that callers (e.g.
+  /// [DevFS.update]) can evict any stale cached copies from a running
+  /// application.
+  void _pruneRemovedEntries(Set<String> previousKeys, Set<String> touchedKeys) {
+    final Set<String> staleKeys = previousKeys.difference(touchedKeys);
+    removedEntries.clear();
+    removedShaderEntries.clear();
+    for (final key in staleKeys) {
+      if (entries[key]?.kind == AssetKind.shader) {
+        removedShaderEntries.add(key);
+      } else {
+        removedEntries.add(key);
+      }
+      entries.remove(key);
+    }
   }
 
   @override

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -349,6 +349,8 @@ class ManifestAssetBundle implements AssetBundle {
   }) async {
     final previousKeys = Set<String>.of(entries.keys);
     final touchedKeys = <String>{};
+    removedEntries.clear();
+    removedShaderEntries.clear();
     if (flutterProject == null) {
       try {
         flutterProject = FlutterProject.fromDirectory(_fileSystem.file(manifestPath).parent);

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -826,6 +826,13 @@ class DevFS {
     for (final entry in syncedEntries) {
       entry.content.markClean();
     }
+    if (!bundleFirstUpload) {
+      // Assets that were removed or renamed since the previous build are no
+      // longer visited by bundle.entries.forEach above, so without this they
+      // would never be evicted from a running application's asset cache.
+      assetPathsToEvict.addAll(bundle.removedEntries);
+      shaderPathsToEvict.addAll(bundle.removedShaderEntries);
+    }
     return syncedBytes;
   }
 }

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -248,23 +248,101 @@ name: my_app''')
         // touch the package config to make sure its change time is after pubspec.yaml's
         packageConfig.setLastModifiedSync(modifiedTime);
 
-        // Even though the previous file was removed, it is left in the
-        // asset manifest and not updated. This is due to the devfs not
-        // supporting file deletion.
         expect(bundle.needsBuild(), true);
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           targetPlatform: TargetPlatform.tester,
         );
+        // The removed file's entry is dropped from the manifest, and its key
+        // is reported via removedEntries so a running application's asset
+        // cache can be told to evict it.
         expect(
           bundle.entries.keys,
-          unorderedEquals(<String>[
-            'AssetManifest.bin',
-            'FontManifest.json',
-            'NOTICES.Z',
-            'assets/foo/bar.txt',
-          ]),
+          unorderedEquals(<String>['AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z']),
         );
+        expect(bundle.removedEntries, unorderedEquals(<String>['assets/foo/bar.txt']));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => testFileSystem,
+        Platform: () => platform,
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
+
+    testUsingContext(
+      'handle renaming an explicitly listed asset',
+      () async {
+        globals.fs.file('assets/foo.txt').createSync(recursive: true);
+        globals.fs.file('pubspec.yaml')
+          ..createSync()
+          ..writeAsStringSync(r'''
+name: my_app
+flutter:
+  assets:
+    - assets/foo.txt
+''');
+        writePackageConfigFiles(directory: globals.fs.currentDirectory, mainLibName: 'my_app');
+        final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
+        expect(bundle.entries.keys, contains('assets/foo.txt'));
+        expect(bundle.removedEntries, isEmpty);
+
+        // Rename the asset on disk and in the pubspec.
+        globals.fs.file('assets/foo.txt').renameSync('assets/bar.txt');
+        globals.fs.file('pubspec.yaml')
+          ..createSync()
+          ..writeAsStringSync(r'''
+name: my_app
+flutter:
+  assets:
+    - assets/bar.txt
+''');
+
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
+        // The old key must not linger in entries forever, and the new key
+        // must be present.
+        expect(bundle.entries.keys, contains('assets/bar.txt'));
+        expect(bundle.entries.keys, isNot(contains('assets/foo.txt')));
+        expect(bundle.removedEntries, unorderedEquals(<String>['assets/foo.txt']));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => testFileSystem,
+        Platform: () => platform,
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
+
+    testUsingContext(
+      'a removed shader entry is reported via removedShaderEntries, not removedEntries',
+      () async {
+        globals.fs.file('pubspec.yaml')
+          ..createSync()
+          ..writeAsStringSync('name: my_app');
+        writePackageConfigFiles(directory: globals.fs.currentDirectory, mainLibName: 'my_app');
+        final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
+
+        // Seed a pre-existing shader entry as if a previous build had picked
+        // it up, then rebuild with a manifest that no longer references it.
+        bundle.entries['assets/shader.frag'] = AssetBundleEntry(
+          DevFSStringContent(''),
+          kind: AssetKind.shader,
+          transformers: const [],
+        );
+
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
+
+        expect(bundle.entries.keys, isNot(contains('assets/shader.frag')));
+        expect(bundle.removedShaderEntries, unorderedEquals(<String>['assets/shader.frag']));
+        expect(bundle.removedEntries, isNot(contains('assets/shader.frag')));
       },
       overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -332,4 +332,10 @@ void main() {
 class FakeAssetBundle extends Fake implements AssetBundle {
   @override
   final entries = <String, AssetBundleEntry>{};
+
+  @override
+  final removedEntries = <String>{};
+
+  @override
+  final removedShaderEntries = <String>{};
 }

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -1166,6 +1166,12 @@ class FakeBundle extends AssetBundle {
   final entries = <String, AssetBundleEntry>{};
 
   @override
+  final removedEntries = <String>{};
+
+  @override
+  final removedShaderEntries = <String>{};
+
+  @override
   List<File> get inputFiles => <File>[];
 
   @override

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -1089,6 +1089,119 @@ void main() {
         expect(dirtyEntries, isEmpty);
       },
     );
+
+    test(
+      'DevFS.updateBundle evicts assets that were removed from the bundle since the last build',
+      () async {
+        final FileSystem fileSystem = MemoryFileSystem.test();
+        final dirtyEntries = <Uri, DevFSContent>{};
+        final assetBundle = FakeBundle();
+        assetBundle.removedEntries.add('assets/removed.txt');
+
+        const shaderCompiler = FakeShaderCompiler();
+        final assetTransformer = DevelopmentAssetTransformer(
+          fileSystem: fileSystem,
+          transformer: AssetTransformer(
+            processManager: FakeProcessManager.any(),
+            fileSystem: fileSystem,
+            dartBinaryPath: 'dart',
+            buildMode: BuildMode.debug,
+          ),
+          logger: BufferLogger.test(),
+        );
+
+        final assetPathsToEvict = <String>{};
+        await DevFS.updateBundle(
+          bundle: assetBundle,
+          dirtyEntries: dirtyEntries,
+          assetDirectory: 'assets',
+          assetTransformer: assetTransformer,
+          shaderCompiler: shaderCompiler,
+          fileSystem: fileSystem,
+          rootDirectoryPath: '/',
+          assetPathsToEvict: assetPathsToEvict,
+          shaderPathsToEvict: <String>{},
+          bundleFirstUpload: false,
+        );
+
+        expect(assetPathsToEvict, unorderedEquals(<String>['assets/removed.txt']));
+      },
+    );
+
+    test(
+      'DevFS.updateBundle evicts removed shaders via shaderPathsToEvict, not assetPathsToEvict',
+      () async {
+        final FileSystem fileSystem = MemoryFileSystem.test();
+        final dirtyEntries = <Uri, DevFSContent>{};
+        final assetBundle = FakeBundle();
+        assetBundle.removedShaderEntries.add('assets/removed.frag');
+
+        const shaderCompiler = FakeShaderCompiler();
+        final assetTransformer = DevelopmentAssetTransformer(
+          fileSystem: fileSystem,
+          transformer: AssetTransformer(
+            processManager: FakeProcessManager.any(),
+            fileSystem: fileSystem,
+            dartBinaryPath: 'dart',
+            buildMode: BuildMode.debug,
+          ),
+          logger: BufferLogger.test(),
+        );
+
+        final assetPathsToEvict = <String>{};
+        final shaderPathsToEvict = <String>{};
+        await DevFS.updateBundle(
+          bundle: assetBundle,
+          dirtyEntries: dirtyEntries,
+          assetDirectory: 'assets',
+          assetTransformer: assetTransformer,
+          shaderCompiler: shaderCompiler,
+          fileSystem: fileSystem,
+          rootDirectoryPath: '/',
+          assetPathsToEvict: assetPathsToEvict,
+          shaderPathsToEvict: shaderPathsToEvict,
+          bundleFirstUpload: false,
+        );
+
+        expect(shaderPathsToEvict, unorderedEquals(<String>['assets/removed.frag']));
+        expect(assetPathsToEvict, isEmpty);
+      },
+    );
+
+    test('DevFS.updateBundle does not evict removed assets on the first upload', () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      final dirtyEntries = <Uri, DevFSContent>{};
+      final assetBundle = FakeBundle();
+      assetBundle.removedEntries.add('assets/removed.txt');
+
+      const shaderCompiler = FakeShaderCompiler();
+      final assetTransformer = DevelopmentAssetTransformer(
+        fileSystem: fileSystem,
+        transformer: AssetTransformer(
+          processManager: FakeProcessManager.any(),
+          fileSystem: fileSystem,
+          dartBinaryPath: 'dart',
+          buildMode: BuildMode.debug,
+        ),
+        logger: BufferLogger.test(),
+      );
+
+      final assetPathsToEvict = <String>{};
+      await DevFS.updateBundle(
+        bundle: assetBundle,
+        dirtyEntries: dirtyEntries,
+        assetDirectory: 'assets',
+        assetTransformer: assetTransformer,
+        shaderCompiler: shaderCompiler,
+        fileSystem: fileSystem,
+        rootDirectoryPath: '/',
+        assetPathsToEvict: assetPathsToEvict,
+        shaderPathsToEvict: <String>{},
+        bundleFirstUpload: true,
+      );
+
+      expect(assetPathsToEvict, isEmpty);
+    });
   });
 }
 

--- a/packages/flutter_tools/test/src/fake_web_devfs.dart
+++ b/packages/flutter_tools/test/src/fake_web_devfs.dart
@@ -145,6 +145,12 @@ class FakeShaderCompiler implements DevelopmentShaderCompiler {
 class FakeAssetBundle extends Fake implements AssetBundle {
   @override
   final Map<String, AssetBundleEntry> entries = <String, AssetBundleEntry>{};
+
+  @override
+  final Set<String> removedEntries = <String>{};
+
+  @override
+  final Set<String> removedShaderEntries = <String>{};
 }
 
 /// A fake [Dwds] service for testing.


### PR DESCRIPTION
This PR is AI-assisted (drafted and tested with Claude Code); I reviewed the diff and test results before opening this PR.

## What this changes

`ManifestAssetBundle.entries` never dropped a key once added, even after the underlying asset file was deleted or renamed — the stale entry stayed in the manifest forever across builds, and `DevFS.updateBundle()` only ever iterated the *current* bundle's entries, so a removed/renamed asset was never evicted from a running app's asset cache during hot restart.

- `AssetBundle` gains two new members: `removedEntries` and `removedShaderEntries`. `ManifestAssetBundle.build()` now tracks which keys are touched during a successful build and prunes anything from the previous build that wasn't touched, splitting removed keys by kind (shaders route through a different VM service extension than other assets).
- `DevFS.updateBundle()` now adds `bundle.removedEntries` / `bundle.removedShaderEntries` to `assetPathsToEvict` / `shaderPathsToEvict` (skipped on first upload), so the existing eviction pipeline tells the running engine to drop its cached copy of the removed asset on the next hot restart.

## Fixes

Fixes #192163

## Testing

- Added regression tests covering: renaming an explicitly-listed asset, removing a wildcard-directory asset, removing a shader asset (routed to `removedShaderEntries`, not `removedEntries`), and `DevFS.updateBundle` correctly populating `assetPathsToEvict`/`shaderPathsToEvict` from removed entries (including the on-first-upload no-op case).
- Fixed a pre-existing test (`handle removal of wildcard directories`) whose comment previously documented the bug as expected behavior ("left in the asset manifest and not updated... due to the devfs not supporting file deletion") — it now asserts the corrected behavior.
- `dart analyze` and `dart format` clean on all touched files.
- Full relevant `flutter_tools` unit test suite passes (asset/devfs/bundle-builder/web-devfs/manifest/build-target tests, 234 tests).
- Not verified end-to-end against a real `flutter run` + hot restart session on a device/simulator — only unit-tested at the `flutter_tools` level.

## Pre-launch Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines) and understand my responsibilities.
- [ ] I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md), including [Features we expect every widget to implement](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement).
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests).
- [ ] I followed the [breaking change policy](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes) and added [Data Driven Fixes](https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md) where supported. (Note: this adds two new members to the `AssetBundle` interface — flagging for reviewer attention as a potential API-surface concern.)
- [x] All existing and new tests are passing (locally; have not yet seen CI results).