### PR TITLE
[Android] Request unbuffered dispatch on MotionEvent.ACTION_MOVE for HCPP platform views

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -35,6 +35,7 @@ public class FlutterMutatorView extends FrameLayout {
   private int top;
 
   private final AndroidTouchProcessor androidTouchProcessor;
+  private final boolean unbufferOnMove;
   private Paint paint;
 
   /**
@@ -45,15 +46,33 @@ public class FlutterMutatorView extends FrameLayout {
       @NonNull Context context,
       float screenDensity,
       @Nullable AndroidTouchProcessor androidTouchProcessor) {
+    this(context, screenDensity, androidTouchProcessor, /*unbufferOnMove=*/ false);
+  }
+
+  /**
+   * Initialize the FlutterMutatorView. Use this to set the screenDensity, which will be used to
+   * correct the final transform matrix, and whether to request unbuffered dispatch on move events.
+   */
+  public FlutterMutatorView(
+      @NonNull Context context,
+      float screenDensity,
+      @Nullable AndroidTouchProcessor androidTouchProcessor,
+      boolean unbufferOnMove) {
     super(context, null);
     this.screenDensity = screenDensity;
     this.androidTouchProcessor = androidTouchProcessor;
+    this.unbufferOnMove = unbufferOnMove;
     this.paint = new Paint();
   }
 
   /** Initialize the FlutterMutatorView. */
   public FlutterMutatorView(@NonNull Context context) {
-    this(context, 1, /* androidTouchProcessor=*/ null);
+    this(context, 1, /* androidTouchProcessor=*/ null, /*unbufferOnMove=*/ false);
+  }
+
+  @VisibleForTesting
+  boolean getUnbufferOnMove() {
+    return unbufferOnMove;
   }
 
   @Nullable @VisibleForTesting ViewTreeObserver.OnGlobalFocusChangeListener activeFocusListener;
@@ -196,6 +215,9 @@ public class FlutterMutatorView extends FrameLayout {
   public boolean onTouchEvent(MotionEvent event) {
     if (androidTouchProcessor == null) {
       return super.onTouchEvent(event);
+    }
+    if (unbufferOnMove && event.getActionMasked() == MotionEvent.ACTION_MOVE) {
+      requestUnbufferedDispatch(event);
     }
     final Matrix screenMatrix = new Matrix();
     screenMatrix.postTranslate(getLeft(), getTop());

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -465,7 +465,10 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     }
     final FlutterMutatorView parentView =
         new FlutterMutatorView(
-            context, context.getResources().getDisplayMetrics().density, androidTouchProcessor);
+            context,
+            context.getResources().getDisplayMetrics().density,
+            androidTouchProcessor,
+            /*unbufferOnMove=*/ true);
 
     parentView.setOnDescendantFocusChangeListener(
         (view, hasFocus) -> {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -238,6 +238,64 @@ public class FlutterMutatorViewTest {
     assertFalse(eventSent);
   }
 
+  @Test
+  @Config(
+      shadows = {
+        ShadowViewWithUnbufferedDispatch.class,
+      })
+  public void requestsUnbufferedDispatchOnMoveOnly_whenUnbufferOnMoveEnabled() {
+    final AndroidTouchProcessor touchProcessor = mock(AndroidTouchProcessor.class);
+    final FlutterMutatorView view =
+        new FlutterMutatorView(ctx, 1.0f, touchProcessor, /*unbufferOnMove=*/ true);
+
+    ShadowViewWithUnbufferedDispatch.lastRequestedEvent = null;
+
+    final MotionEvent downEvent = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 0.0f, 0.0f, 0);
+    view.onTouchEvent(downEvent);
+    assertNull(ShadowViewWithUnbufferedDispatch.lastRequestedEvent);
+
+    final MotionEvent moveEvent = MotionEvent.obtain(0, 0, MotionEvent.ACTION_MOVE, 0.0f, 0.0f, 0);
+    view.onTouchEvent(moveEvent);
+    assertEquals(moveEvent, ShadowViewWithUnbufferedDispatch.lastRequestedEvent);
+
+    ShadowViewWithUnbufferedDispatch.lastRequestedEvent = null;
+
+    final MotionEvent upEvent = MotionEvent.obtain(0, 0, MotionEvent.ACTION_UP, 0.0f, 0.0f, 0);
+    view.onTouchEvent(upEvent);
+    assertNull(ShadowViewWithUnbufferedDispatch.lastRequestedEvent);
+  }
+
+  @Test
+  @Config(
+      shadows = {
+        ShadowViewWithUnbufferedDispatch.class,
+      })
+  public void doesNotRequestUnbufferedDispatchOnMove_whenUnbufferOnMoveDisabled() {
+    final AndroidTouchProcessor touchProcessor = mock(AndroidTouchProcessor.class);
+    final FlutterMutatorView defaultView = new FlutterMutatorView(ctx, 1.0f, touchProcessor);
+
+    ShadowViewWithUnbufferedDispatch.lastRequestedEvent = null;
+
+    final MotionEvent moveEvent = MotionEvent.obtain(0, 0, MotionEvent.ACTION_MOVE, 0.0f, 0.0f, 0);
+    defaultView.onTouchEvent(moveEvent);
+    assertNull(ShadowViewWithUnbufferedDispatch.lastRequestedEvent);
+
+    final FlutterMutatorView explicitDisabledView =
+        new FlutterMutatorView(ctx, 1.0f, touchProcessor, /*unbufferOnMove=*/ false);
+    explicitDisabledView.onTouchEvent(moveEvent);
+    assertNull(ShadowViewWithUnbufferedDispatch.lastRequestedEvent);
+  }
+
+  @Implements(View.class)
+  public static class ShadowViewWithUnbufferedDispatch extends org.robolectric.shadows.ShadowView {
+    public static MotionEvent lastRequestedEvent;
+
+    @Implementation
+    protected void requestUnbufferedDispatch(MotionEvent event) {
+      lastRequestedEvent = event;
+    }
+  }
+
   @Implements(ViewGroup.class)
   public static class ShadowViewGroup extends org.robolectric.shadows.ShadowViewGroup {
     @Implementation

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -462,6 +462,7 @@ public class PlatformViewsController2Test {
 
     assertNotNull(androidView.getParent());
     assertTrue(androidView.getParent() instanceof FlutterMutatorView);
+    assertTrue(((FlutterMutatorView) androidView.getParent()).getUnbufferOnMove());
 
     // Simulate dispose call from the framework.
     disposePlatformView(jni, PlatformViewsController2, platformViewId);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -1414,6 +1414,7 @@ public class PlatformViewsControllerTest {
 
     assertNotNull(androidView.getParent());
     assertTrue(androidView.getParent() instanceof FlutterMutatorView);
+    assertFalse(((FlutterMutatorView) androidView.getParent()).getUnbufferOnMove());
 
     // Simulate dispose call from the framework.
     disposePlatformView(jni, platformViewsController, platformViewId);


### PR DESCRIPTION
It makes scrolling a lot smoother 👍 

AI pr description below

## Description

When scrolling a Flutter scrollable by dragging across an embedded platform view, the mutator view was not calling `requestUnbufferedDispatch(event)` (unlike `FlutterView`, which calls it on every touch). As a result, Android's input pipeline kept the touch stream batched to VSYNC (typically 60Hz), making scrolling over platform views feel noticeably less smooth or lower-FPS compared to scrolling over regular Flutter content.

This PR adds support to request unbuffered dispatch on `MotionEvent.ACTION_MOVE` for HCPP platform views:
- **Scoped to HCPP**: Configured via `unbufferOnMove` on `FlutterMutatorView`, which defaults to `false` and is explicitly enabled in `PlatformViewsController2` (HCPP). Legacy Hybrid Composition (`PlatformViewsController`) and Texture Layer (`PlatformViewWrapper`) remain completely untouched to avoid breaking changes for existing modes.
- **Move only**: Gating on `MotionEvent.ACTION_MOVE` ensures that stationary taps never request unbuffered delivery, protecting native tap recognizers from capacitive digitizer micro-jitter.

## Tests
- Added Robolectric unit tests in `FlutterMutatorViewTest.java` verifying unbuffered dispatch is requested on `ACTION_MOVE` when `unbufferOnMove` is enabled, and not on `ACTION_DOWN` or `ACTION_UP` or when disabled.
- Added assertions in `PlatformViewsController2Test.java` and `PlatformViewsControllerTest.java` verifying that HCPP enables `unbufferOnMove` and legacy Hybrid Composition keeps it disabled.

---
*Generated with Gemini / AI assistance.*