### PR TITLE
[stable] [flutter_tools] Report preview reload timing analytics in LspPreviewDetector

### DIFF
--- a/packages/flutter_tools/lib/src/widget_preview/lsp_preview_detector.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/lsp_preview_detector.dart
@@ -185,11 +185,17 @@ class LspPreviewDetector {
       onPubspecChangeDetected(filePath);
       return;
     }
-    await _analysisServer?.waitForAnalysis();
+    if (!filePath.isDartFile) {
+      return;
+    }
+    previewAnalytics.startPreviewReloadStopwatch();
     try {
+      await _analysisServer?.waitForAnalysis();
       final FlutterWidgetPreviews result = await dtd.getFlutterWidgetPreviews();
       onChangeDetected(result);
+      previewAnalytics.reportPreviewReloadTiming();
     } catch (e) {
+      previewAnalytics.resetPreviewReloadStopwatch();
       if (_disposed || shutdownHooks.isShuttingDown) {
         logger.printTrace('Failed to get widget previews during shutdown: $e');
       } else if (e is StateError || e is Exception) {
@@ -200,6 +206,7 @@ class LspPreviewDetector {
       } else {
         rethrow;
       }
+      return;
     }
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/lsp_preview_detector_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/lsp_preview_detector_test.dart
@@ -1,0 +1,277 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/dart/analysis.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/widget_preview/analytics.dart';
+import 'package:flutter_tools/src/widget_preview/dtd_services.dart';
+import 'package:flutter_tools/src/widget_preview/dtd_types.dart';
+import 'package:flutter_tools/src/widget_preview/lsp_preview_detector.dart';
+import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
+import 'package:watcher/watcher.dart';
+
+import '../../../src/common.dart';
+import '../../../src/context.dart';
+import '../../../src/fakes.dart';
+
+const String _kProjectRootPath = '/project';
+const String _kDartFilePath = '/project/lib/foo.dart';
+const String _kNonDartFilePath = '/project/README.md';
+const String _kPubspecPath = '/project/pubspec.yaml';
+const String _kIgnoredDartToolPath = '/project/.dart_tool/package_config.json';
+
+void main() {
+  group('$LspPreviewDetector', () {
+    late MemoryFileSystem fs;
+    late BufferLogger logger;
+    late FakePlatform platform;
+    late FakeAnalytics fakeAnalytics;
+    late WidgetPreviewAnalytics previewAnalytics;
+    late FakeFlutterProject project;
+    late FakeWidgetPreviewDtdServices fakeDtd;
+    late FakeWatcher fakeWatcher;
+    late FakeAnalysisServer fakeAnalysisServer;
+    late ShutdownHooks shutdownHooks;
+    late List<FlutterWidgetPreviews> detectedChanges;
+    late List<String> detectedPubspecChanges;
+    late LspPreviewDetector detector;
+
+    setUp(() async {
+      fs = MemoryFileSystem.test();
+      logger = BufferLogger.test();
+      platform = FakePlatform();
+      fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: fs,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
+      previewAnalytics = WidgetPreviewAnalytics(analytics: fakeAnalytics);
+      project = FakeFlutterProject(fs.directory(_kProjectRootPath));
+      fakeDtd = FakeWidgetPreviewDtdServices();
+      fakeWatcher = FakeWatcher();
+      fakeAnalysisServer = FakeAnalysisServer();
+      shutdownHooks = ShutdownHooks();
+      detectedChanges = <FlutterWidgetPreviews>[];
+      detectedPubspecChanges = <String>[];
+
+      detector = LspPreviewDetector(
+        platform: platform,
+        previewAnalytics: previewAnalytics,
+        project: project,
+        fs: fs,
+        logger: logger,
+        onChangeDetected: detectedChanges.add,
+        onPubspecChangeDetected: detectedPubspecChanges.add,
+        dtd: fakeDtd,
+        processManager: FakeProcessManager.any(),
+        terminal: Terminal.test(),
+        suppressAnalytics: false,
+        artifacts: Artifacts.test(),
+        shutdownHooks: shutdownHooks,
+        watcherBuilder: (_) => fakeWatcher,
+        analysisServerFactory: () async => fakeAnalysisServer,
+      );
+      await detector.initialize();
+    });
+
+    tearDown(() async {
+      await detector.dispose();
+      await fakeWatcher.close();
+    });
+
+    void expectNPreviewReloadTimingEvents(int n) {
+      final Iterable<Event> reloadTimingEvents = fakeAnalytics.sentEvents.where(
+        (Event e) =>
+            e.eventData['workflow'] == WidgetPreviewAnalytics.kWorkflow &&
+            e.eventData['variableName'] == WidgetPreviewAnalytics.kPreviewReloadTime,
+      );
+      expect(reloadTimingEvents, hasLength(n));
+    }
+
+    Future<void> emitEvent(WatchEvent event) async {
+      fakeWatcher.emitEvent(event);
+      await pumpEventQueue();
+      await detector.mutex.runGuarded(() async {});
+    }
+
+    testWithoutContext('reports preview reload timing when files are modified', () async {
+      expectNPreviewReloadTimingEvents(0);
+      expect(detectedChanges, isEmpty);
+      expect(fakeAnalysisServer.waitForAnalysisCallCount, 0);
+
+      await emitEvent(WatchEvent(ChangeType.MODIFY, _kDartFilePath));
+
+      expect(detectedChanges, hasLength(1));
+      expectNPreviewReloadTimingEvents(1);
+      expect(fakeAnalysisServer.waitForAnalysisCallCount, 1);
+
+      await emitEvent(WatchEvent(ChangeType.MODIFY, _kDartFilePath));
+
+      expect(detectedChanges, hasLength(2));
+      expectNPreviewReloadTimingEvents(2);
+      expect(fakeAnalysisServer.waitForAnalysisCallCount, 2);
+    });
+
+    testWithoutContext(
+      'does not report preview reload timing when pubspec.yaml is modified',
+      () async {
+        expectNPreviewReloadTimingEvents(0);
+        expect(detectedPubspecChanges, isEmpty);
+
+        await emitEvent(WatchEvent(ChangeType.MODIFY, _kPubspecPath));
+
+        expect(detectedPubspecChanges, <String>[_kPubspecPath]);
+        expectNPreviewReloadTimingEvents(0);
+        expect(fakeAnalysisServer.waitForAnalysisCallCount, 0);
+      },
+    );
+
+    testWithoutContext(
+      'does not report preview reload timing when non-Dart file is modified',
+      () async {
+        expectNPreviewReloadTimingEvents(0);
+        expect(detectedChanges, isEmpty);
+        expect(detectedPubspecChanges, isEmpty);
+
+        await emitEvent(WatchEvent(ChangeType.MODIFY, _kNonDartFilePath));
+
+        expect(detectedChanges, isEmpty);
+        expect(detectedPubspecChanges, isEmpty);
+        expectNPreviewReloadTimingEvents(0);
+        expect(fakeAnalysisServer.waitForAnalysisCallCount, 0);
+      },
+    );
+
+    testWithoutContext('does not report preview reload timing for ignored directories', () async {
+      expectNPreviewReloadTimingEvents(0);
+
+      await emitEvent(WatchEvent(ChangeType.MODIFY, _kIgnoredDartToolPath));
+
+      expect(detectedChanges, isEmpty);
+      expect(detectedPubspecChanges, isEmpty);
+      expectNPreviewReloadTimingEvents(0);
+      expect(fakeAnalysisServer.waitForAnalysisCallCount, 0);
+    });
+
+    testWithoutContext(
+      'resets reload timing stopwatch on DTD exception and does not report timing',
+      () async {
+        fakeDtd.shouldThrow = true;
+        expectNPreviewReloadTimingEvents(0);
+
+        await emitEvent(WatchEvent(ChangeType.MODIFY, _kDartFilePath));
+
+        expect(detectedChanges, isEmpty);
+        expectNPreviewReloadTimingEvents(0);
+
+        fakeDtd.shouldThrow = false;
+        await emitEvent(WatchEvent(ChangeType.MODIFY, _kDartFilePath));
+
+        expect(detectedChanges, hasLength(1));
+        expectNPreviewReloadTimingEvents(1);
+      },
+    );
+
+    testWithoutContext(
+      'resets reload timing stopwatch on analysis server exception and does not report timing',
+      () async {
+        fakeAnalysisServer.shouldThrow = true;
+        expectNPreviewReloadTimingEvents(0);
+
+        await emitEvent(WatchEvent(ChangeType.MODIFY, _kDartFilePath));
+
+        expect(detectedChanges, isEmpty);
+        expectNPreviewReloadTimingEvents(0);
+
+        fakeAnalysisServer.shouldThrow = false;
+        await emitEvent(WatchEvent(ChangeType.MODIFY, _kDartFilePath));
+
+        expect(detectedChanges, hasLength(1));
+        expectNPreviewReloadTimingEvents(1);
+      },
+    );
+  });
+}
+
+class FakeFlutterProject extends Fake implements FlutterProject {
+  FakeFlutterProject(this.directory);
+
+  @override
+  final Directory directory;
+
+  @override
+  void reloadManifest({Logger? logger, FileSystem? fs}) {}
+
+  @override
+  Set<Directory> get ephemeralDirectories => const <Directory>{};
+}
+
+class FakeWatcher extends Fake implements Watcher {
+  final StreamController<WatchEvent> _events = StreamController<WatchEvent>.broadcast();
+
+  @override
+  Stream<WatchEvent> get events => _events.stream;
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  void emitEvent(WatchEvent event) => _events.add(event);
+
+  Future<void> close() => _events.close();
+}
+
+class FakeAnalysisServer extends Fake implements AnalysisServer {
+  int waitForAnalysisCallCount = 0;
+  bool shouldThrow = false;
+
+  @override
+  Future<void> start() async {}
+
+  @override
+  Future<void> connectToDtd({required Uri dtdUri}) async {}
+
+  @override
+  Future<bool?> dispose() async => true;
+
+  @override
+  Future<void> waitForAnalysis({Duration delay = const Duration(milliseconds: 100)}) async {
+    if (shouldThrow) {
+      throw StateError('Fake analysis server error');
+    }
+    waitForAnalysisCallCount++;
+  }
+}
+
+class FakeWidgetPreviewDtdServices extends Fake implements WidgetPreviewDtdServices {
+  @override
+  bool lspServiceAvailable = false;
+
+  @override
+  Uri get dtdUri => Uri.parse('ws://127.0.0.1:12345');
+
+  bool shouldThrow = false;
+  FlutterWidgetPreviews? nextUpdate;
+
+  @override
+  Future<FlutterWidgetPreviews> getFlutterWidgetPreviews() async {
+    if (shouldThrow) {
+      throw StateError('Fake DTD error');
+    }
+    return nextUpdate ??
+        const FlutterWidgetPreviews(
+          namespaces: <String, String>{},
+          previews: <FlutterWidgetPreviewDetails>[],
+          scriptUris: <Uri>[],
+        );
+  }
+}


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
https://github.com/flutter/flutter/pull/192120

### Impact Description:
In Flutter 3.44 ([#184473](https://github.com/flutter/flutter/pull/184473)), `LspPreviewDetector` became the default preview detector, but did not instrument preview reload timing analytics (`previewAnalytics.startPreviewReloadStopwatch()` and `previewAnalytics.reportPreviewReloadTiming()`). This caused a severe drop in reported `preview-reload-time` telemetry events for the widget previewer. This cherry-pick restores reporting of reload timing metrics and filters out non-Dart file edits to avoid spurious reload timing events.

### Changelog Description:
[flutter/192120] Fixes missing preview reload timing analytics in LspPreviewDetector across all platforms.

### Workaround:
None. Telemetry for widget preview reload timing is omitted unless instrumented.

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
Run `packages/flutter_tools` unit tests:
`dart test test/commands.shard/hermetic/widget_preview/lsp_preview_detector_test.dart`
