### PR TITLE
[flutter_tools] Add --flavor to flutter attach

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -86,6 +86,7 @@ class AttachCommand extends FlutterCommand {
     usesFilesystemOptions(hide: !verboseHelp);
     usesFuchsiaOptions(hide: !verboseHelp);
     usesDartDefineOption();
+    usesFlavorOption();
     usesDeviceUserOption();
     addEnableExperimentation(hide: !verboseHelp);
     usesInitializeFromDillOption(hide: !verboseHelp);

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -873,6 +873,54 @@ void main() {
       );
 
       testUsingContext(
+        'passes --flavor into the build info so hot restart keeps $kAppFlavor',
+        () async {
+          device.onGetLogReader = () {
+            fakeLogReader.addLine('Foo');
+            fakeLogReader.addLine(
+              'The Dart VM service is listening on http://127.0.0.1:$devicePort',
+            );
+            return fakeLogReader;
+          };
+          testDeviceManager.devices = <Device>[device];
+
+          final hotRunner = FakeHotRunner();
+          hotRunner.onAttach =
+              (
+                Completer<DebugConnectionInfo>? connectionInfoCompleter,
+                Completer<void>? appStartedCompleter,
+                bool enableDevTools,
+              ) async => 0;
+          hotRunner.exited = false;
+          hotRunner.isWaitingForVmService = false;
+
+          final hotRunnerFactory = FakeHotRunnerFactory()..hotRunner = hotRunner;
+
+          final command = AttachCommand(
+            hotRunnerFactory: hotRunnerFactory,
+            stdio: stdio,
+            logger: logger,
+            terminal: terminal,
+            signals: signals,
+            platform: platform,
+            processInfo: processInfo,
+            fileSystem: testFileSystem,
+          );
+          await createTestCommandRunner(command).run(<String>['attach', '--flavor', 'strawberry']);
+
+          expect(hotRunnerFactory.devices, hasLength(1));
+          final BuildInfo buildInfo = hotRunnerFactory.devices.first.buildInfo;
+          expect(buildInfo.flavor, 'strawberry');
+          expect(buildInfo.dartDefines, contains('$kAppFlavor=strawberry'));
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => testFileSystem,
+          ProcessManager: () => FakeProcessManager.any(),
+          DeviceManager: () => testDeviceManager,
+        },
+      );
+
+      testUsingContext(
         'exits when ipv6 is specified and debug-port is not on non-iOS device',
         () async {
           testDeviceManager.devices = <Device>[device];


### PR DESCRIPTION
## Summary

Adds `--flavor` to `flutter attach`, so that the resident compiler behind attach injects `FLUTTER_APP_FLAVOR` and `appFlavor` keeps its value across hot restarts of an app that was built with a flavor.

## Why

Since #169298, `FlutterCommand.getBuildInfo()` resolves the flavor as `--flavor ?? default-flavor` and adds `FLUTTER_APP_FLAVOR=<flavor>` to the dart defines. That fixed `appFlavor` being `null` after hot restart under `flutter run` (#165803).

`flutter attach` shares that `getBuildInfo()` but never registers the `--flavor` option, so `cliFlavor` is always `null` there. When attaching to an app that was built with a flavor by another tool (Gradle/xcodebuild directly, an IDE, or a test runner such as Patrol), the first frame of the app reports the right `appFlavor` (baked in by the native build), but the first hot restart recompiles without `FLUTTER_APP_FLAVOR` and `appFlavor` becomes `null`. The only way around it today is a static `default-flavor` entry in `pubspec.yaml`, which can't follow a per-invocation flavor.

The `--dart-define`/environment routes are intentionally rejected by the tool, so a CLI option is the only sanctioned way to pass the value.

Measured on Flutter 3.44.1 with an Android app built via Gradle with `--flavor dev` and hot-restarted through `flutter attach`:

| | `appFlavor` |
|---|---|
| first run (native build) | `dev` |
| after hot restart via `flutter attach` | `null` |
| after hot restart via `flutter attach` with a flavor reaching `getBuildInfo` | `dev` |

## Change

- `AttachCommand`: register `usesFlavorOption()` next to `usesDartDefineOption()`. No other plumbing is needed — `getBuildInfo()` already turns it into the dart define.
- Hermetic test in `attach_test.dart` asserting that `attach --flavor strawberry` produces a `BuildInfo` with `flavor == 'strawberry'` and `FLUTTER_APP_FLAVOR=strawberry` in `dartDefines`.

Deliberately *not* included: the `run`-style "flavor not supported on this device" warning. Attach doesn't build anything, so the flavor only affects compilation; happy to add the warning for parity if preferred.

Fixes #192261

Related: flutter/flutter-intellij#5217 / #5237 (IDE "Attach" button failing with `Could not find an option named 'flavor'`), leancodepl/patrol#2256. No overlap with #191376 (platform-specific `default-flavor`): that PR changes the `getBuildInfo()` call site inside attach, while this one only registers the option.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
