### PR TITLE
Avoids release mode crash due to incorrect use of ParentData

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1598,16 +1598,7 @@ abstract class ParentDataWidget<T extends ParentData> extends ProxyWidget {
   @override
   ParentDataElement<T> createElement() => ParentDataElement<T>(this);
 
-  /// Checks if this widget can apply its parent data to the provided
-  /// `renderObject`.
-  ///
-  /// The [RenderObject.parentData] of the provided `renderObject` is
-  /// typically set up by an ancestor [RenderObjectWidget] of the type returned
-  /// by [debugTypicalAncestorWidgetClass].
-  ///
-  /// This is called just before [applyParentData] is invoked with the same
-  /// [RenderObject] provided to that method.
-  bool debugIsValidRenderObject(RenderObject renderObject) {
+  bool _isValidRenderObject(RenderObject renderObject) {
     assert(T != dynamic);
     assert(T != ParentData);
     return renderObject.parentData is T;
@@ -6766,7 +6757,7 @@ abstract class RenderObjectElement extends Element {
     //    KeepAlive, and another ParentDataWidget with ParentData type
     //    TwoDimensionalViewportParentData or a subclass thereof.
     // The first and second cases are verified here. The third is verified in
-    // debugIsValidRenderObject.
+    // _isValidRenderObject.
 
     while (ancestor != null && ancestor is! RenderObjectElement) {
       if (ancestor is ParentDataElement<ParentData>) {
@@ -6891,11 +6882,11 @@ abstract class RenderObjectElement extends Element {
   }
 
   void _updateParentData(ParentDataWidget<ParentData> parentDataWidget) {
-    var applyParentData = true;
-    assert(() {
-      try {
-        if (!parentDataWidget.debugIsValidRenderObject(renderObject)) {
-          applyParentData = false;
+    if (parentDataWidget._isValidRenderObject(renderObject)) {
+      parentDataWidget.applyParentData(renderObject);
+    } else {
+      assert(() {
+        try {
           throw FlutterError.fromParts(<DiagnosticsNode>[
             ErrorSummary('Incorrect use of ParentDataWidget.'),
             ...parentDataWidget._debugDescribeIncorrectParentDataType(
@@ -6904,18 +6895,15 @@ abstract class RenderObjectElement extends Element {
               ownershipChain: ErrorDescription(debugGetCreatorChain(10)),
             ),
           ]);
+        } on FlutterError catch (e) {
+          // We catch the exception directly to avoid activating the ErrorWidget,
+          // while still allowing debuggers to break on exception. Since the tree
+          // is in a broken state, adding the ErrorWidget would likely cause more
+          // exceptions, which is not good for the debugging experience.
+          _reportException(ErrorSummary('while applying parent data.'), e, e.stackTrace);
         }
-      } on FlutterError catch (e) {
-        // We catch the exception directly to avoid activating the ErrorWidget,
-        // while still allowing debuggers to break on exception. Since the tree
-        // is in a broken state, adding the ErrorWidget would likely cause more
-        // exceptions, which is not good for the debugging experience.
-        _reportException(ErrorSummary('while applying parent data.'), e, e.stackTrace);
-      }
-      return true;
-    }());
-    if (applyParentData) {
-      parentDataWidget.applyParentData(renderObject);
+        return true;
+      }());
     }
   }
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1604,6 +1604,21 @@ abstract class ParentDataWidget<T extends ParentData> extends ProxyWidget {
     return renderObject.parentData is T;
   }
 
+  /// Checks if this widget can apply its parent data to the provided
+  /// `renderObject`.
+  ///
+  /// The [RenderObject.parentData] of the provided `renderObject` is
+  /// typically set up by an ancestor [RenderObjectWidget] of the type returned
+  /// by [debugTypicalAncestorWidgetClass].
+  ///
+  /// This is called just before [applyParentData] is invoked with the same
+  /// [RenderObject] provided to that method.
+  @Deprecated(
+    'This method is no longer used by the framework and will be removed in a future release. '
+    'This feature was deprecated after v3.48.0-0.4.pre.',
+  )
+  bool debugIsValidRenderObject(RenderObject renderObject) => _isValidRenderObject(renderObject);
+
   /// Describes the [RenderObjectWidget] that is typically used to set up the
   /// [ParentData] that [applyParentData] will write to.
   ///

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1599,8 +1599,6 @@ abstract class ParentDataWidget<T extends ParentData> extends ProxyWidget {
   ParentDataElement<T> createElement() => ParentDataElement<T>(this);
 
   bool _isValidRenderObject(RenderObject renderObject) {
-    assert(T != dynamic);
-    assert(T != ParentData);
     return renderObject.parentData is T;
   }
 

--- a/packages/flutter/test/widgets/parent_data_test.dart
+++ b/packages/flutter/test/widgets/parent_data_test.dart
@@ -479,6 +479,29 @@ void main() {
     expect(parentData.string, 'Bar');
   });
 
+  testWidgets('debugIsValidRenderObject still functions as deprecated method', (
+    WidgetTester tester,
+  ) async {
+    final renderParagraph = RenderParagraph(
+      const TextSpan(text: 'Test'),
+      textDirection: TextDirection.ltr,
+    );
+    renderParagraph.parentData = FlexParentData();
+    const flexible = Flexible(child: SizedBox());
+    const positioned = Positioned(child: SizedBox());
+
+    // ignore: deprecated_member_use_from_same_package
+    expect(flexible.debugIsValidRenderObject(renderParagraph), isTrue);
+    // ignore: deprecated_member_use_from_same_package
+    expect(positioned.debugIsValidRenderObject(renderParagraph), isFalse);
+
+    renderParagraph.parentData = StackParentData();
+    // ignore: deprecated_member_use_from_same_package
+    expect(positioned.debugIsValidRenderObject(renderParagraph), isTrue);
+    // ignore: deprecated_member_use_from_same_package
+    expect(flexible.debugIsValidRenderObject(renderParagraph), isFalse);
+  });
+
   testWidgets('applyParentData is not called when ParentData is incompatible', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/widgets/parent_data_test.dart
+++ b/packages/flutter/test/widgets/parent_data_test.dart
@@ -479,29 +479,6 @@ void main() {
     expect(parentData.string, 'Bar');
   });
 
-  testWidgets('debugIsValidRenderObject still functions as deprecated method', (
-    WidgetTester tester,
-  ) async {
-    final renderParagraph = RenderParagraph(
-      const TextSpan(text: 'Test'),
-      textDirection: TextDirection.ltr,
-    );
-    renderParagraph.parentData = FlexParentData();
-    const flexible = Flexible(child: SizedBox());
-    const positioned = Positioned(child: SizedBox());
-
-    // ignore: deprecated_member_use_from_same_package
-    expect(flexible.debugIsValidRenderObject(renderParagraph), isTrue);
-    // ignore: deprecated_member_use_from_same_package
-    expect(positioned.debugIsValidRenderObject(renderParagraph), isFalse);
-
-    renderParagraph.parentData = StackParentData();
-    // ignore: deprecated_member_use_from_same_package
-    expect(positioned.debugIsValidRenderObject(renderParagraph), isTrue);
-    // ignore: deprecated_member_use_from_same_package
-    expect(flexible.debugIsValidRenderObject(renderParagraph), isFalse);
-  });
-
   testWidgets('applyParentData is not called when ParentData is incompatible', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/widgets/parent_data_test.dart
+++ b/packages/flutter/test/widgets/parent_data_test.dart
@@ -478,6 +478,81 @@ void main() {
     parentData = tester.renderObject(find.byType(Container)).parentData! as DummyParentData;
     expect(parentData.string, 'Bar');
   });
+
+  testWidgets('applyParentData is not called when ParentData is incompatible', (
+    WidgetTester tester,
+  ) async {
+    var applyParentDataCalled = false;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Stack(
+          children: <Widget>[
+            TestCallbackParentDataWidget(
+              onApplyParentData: () {
+                applyParentDataCalled = true;
+              },
+              child: const SizedBox(),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(applyParentDataCalled, isFalse);
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(exception.toString(), startsWith('Incorrect use of ParentDataWidget.\n'));
+  });
+
+  testWidgets('applyParentData is called when ParentData is compatible', (
+    WidgetTester tester,
+  ) async {
+    var applyParentDataCalled = false;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Row(
+          children: <Widget>[
+            TestCallbackParentDataWidget(
+              onApplyParentData: () {
+                applyParentDataCalled = true;
+              },
+              child: const SizedBox(),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(applyParentDataCalled, isTrue);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('ParentData is not overwritten when ParentDataWidget is used incorrectly', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Row(
+          children: <Widget>[
+            Stack(
+              textDirection: TextDirection.ltr,
+              children: <Widget>[Expanded(child: Container())],
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final RenderObject renderObject = tester.renderObject(find.byType(Container));
+    expect(renderObject.parentData, isA<StackParentData>());
+    expect(renderObject.parentData, isNot(isA<FlexParentData>()));
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+  });
 }
 
 class SubclassPositioned extends Positioned {
@@ -575,4 +650,22 @@ class DummyWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => child;
+}
+
+class TestCallbackParentDataWidget extends ParentDataWidget<FlexParentData> {
+  const TestCallbackParentDataWidget({
+    super.key,
+    required this.onApplyParentData,
+    required super.child,
+  });
+
+  final VoidCallback onApplyParentData;
+
+  @override
+  void applyParentData(RenderObject renderObject) {
+    onApplyParentData();
+  }
+
+  @override
+  Type get debugTypicalAncestorWidgetClass => Row;
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->
fixes https://github.com/flutter/flutter/issues/108186

based on https://github.com/flutter/flutter/pull/155091

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
