### PR TITLE
uber_sdf: removes derivatives from rect path

### DIFF
--- a/engine/src/flutter/impeller/compiler/shader_lib/impeller/gradient.glsl
+++ b/engine/src/flutter/impeller/compiler/shader_lib/impeller/gradient.glsl
@@ -149,6 +149,19 @@ vec3 IPComputeFixedGradientValues(float t, float colors_length) {
   return vec3(lower_index, upper_index, scale);
 }
 
+float IPComputeLinearGradientT(vec2 positon,
+                               vec2 start,
+                               vec2 delta,
+                               float inv_gradient_length) {
+  return dot(positon - start, delta) * inv_gradient_length;
+}
+
+float IPComputeRadialGradientT(vec2 position,
+                               vec2 center,
+                               float inv_gradient_length) {
+  return length(position - center) * inv_gradient_length;
+}
+
 /// Samples a linear gradient from a 1D gradient ramp texture.
 vec4 IPSampleLinearGradient(sampler2D tex,
                             vec2 start_point,
@@ -163,7 +176,8 @@ vec4 IPSampleLinearGradient(sampler2D tex,
 
   float t = start_to_end_squared == 0.0
                 ? 0.0
-                : dot(start_to_position, start_to_end) / start_to_end_squared;
+                : IPComputeLinearGradientT(pos, start_point, start_to_end,
+                                           1.0 / start_to_end_squared);
   return IPSampleLinearWithTileMode(tex, vec2(t, 0.5), half_texel, tile_mode,
                                     decal_border_color);
 }
@@ -176,7 +190,7 @@ vec4 IPSampleRadialGradient(sampler2D tex,
                             vec2 half_texel,
                             float tile_mode,
                             vec4 decal_border_color) {
-  float t = radius == 0.0 ? 0.0 : length(pos - center) / radius;
+  float t = IPComputeRadialGradientT(pos, center, 1.0 / radius);
   return IPSampleLinearWithTileMode(tex, vec2(t, 0.5), half_texel, tile_mode,
                                     decal_border_color);
 }

--- a/engine/src/flutter/impeller/display_list/aiks_dl_primitive_shape_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_primitive_shape_unittests.cc
@@ -222,5 +222,21 @@ TEST_P(AiksTest, CanRenderSkewedCircleHairline) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(AiksTest, CanRenderSkewedRectHairline) {
+  DisplayListBuilder builder;
+  builder.Scale(GetContentScale().x, GetContentScale().y);
+  builder.DrawColor(DlColor::kBlack(), DlBlendMode::kSrc);
+
+  RenderParameters params{
+      .render_type = RenderType::kRectangle,
+      .center = GetWindowBounds().GetCenter(),
+      .skew_x = 0.75f,
+      .skew_y = 0.5f,
+  };
+  RenderPrimitiveWithStroke(builder, params);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -930,7 +930,7 @@ bool Canvas::AttemptDrawLineSDF(const Point& p0,
                                 const Paint& paint,
                                 bool reuse_depth) {
   if (!renderer_.GetContext()->GetFlags().use_sdfs ||
-      !IsCompatibleWithSDFRendering(paint)) {
+      !IsCompatibleWithSDFRendering(paint, GetCurrentTransform())) {
     return false;
   }
   // Draw the line as a filled rectangle with width=line_length and
@@ -1069,7 +1069,7 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
   }
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint)) {
+      IsCompatibleWithSDFRendering(paint, GetCurrentTransform())) {
     Rect effective_rect = rect;
     Color effective_color = paint.color;
 
@@ -1142,7 +1142,7 @@ void Canvas::DrawOval(const Rect& rect, const Paint& paint) {
   entity.SetBlendMode(paint.blend_mode);
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint)) {
+      IsCompatibleWithSDFRendering(paint, GetCurrentTransform())) {
     UberSDFParameters params;
 
     if (paint.style == Paint::Style::kStroke) {
@@ -1230,7 +1230,8 @@ void Canvas::DrawRoundRect(const RoundRect& round_rect, const Paint& paint) {
   const RoundingRadii& radii = round_rect.GetRadii();
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint) && radii.AreAllCornersCircular()) {
+      IsCompatibleWithSDFRendering(paint, GetCurrentTransform()) &&
+      radii.AreAllCornersCircular()) {
     Color effective_color = paint.color;
     Rect bounds = round_rect.GetBounds();
 
@@ -1314,7 +1315,7 @@ void Canvas::DrawRoundSuperellipse(const RoundSuperellipse& round_superellipse,
   entity.SetBlendMode(paint.blend_mode);
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint)) {
+      IsCompatibleWithSDFRendering(paint, GetCurrentTransform())) {
     // Try to draw using UberSDF.
     auto params = UberSDFParameters::MakeRoundedSuperellipse(
         /*color=*/paint.color, /*round_superellipse=*/round_superellipse,
@@ -1378,7 +1379,7 @@ void Canvas::DrawCircle(const Point& center,
   }
 
   if (renderer_.GetContext()->GetFlags().use_sdfs &&
-      IsCompatibleWithSDFRendering(paint)) {
+      IsCompatibleWithSDFRendering(paint, GetCurrentTransform())) {
     auto params = UberSDFParameters::MakeCircle(
         /*color=*/paint.color, /*center=*/center, /*radius=*/radius,
         /*stroke=*/paint.GetStroke());
@@ -2752,11 +2753,15 @@ void Canvas::EndReplay() {
   Initialize(initial_cull_rect_);
 }
 
-bool Canvas::IsCompatibleWithSDFRendering(const Paint& paint) {
+bool Canvas::IsCompatibleWithSDFRendering(const Paint& paint,
+                                          const Matrix& transform) {
   if (!paint.anti_alias) {
     return false;
   }
   if (paint.mask_blur_descriptor.has_value()) {
+    return false;
+  }
+  if (transform.HasPerspective()) {
     return false;
   }
   switch (paint.blend_mode) {

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -287,8 +287,8 @@ class Canvas {
 
   /// Returns true if the paint is compatible with SDF rendering.
   ///
-  /// Visible for testing.
-  static bool IsCompatibleWithSDFRendering(const Paint& paint);
+  static bool IsCompatibleWithSDFRendering(const Paint& paint,
+                                           const Matrix& transform = Matrix());
 
  private:
   class BlurShape {

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -116,6 +116,10 @@ bool UberSDFContents::Render(const ContentContext& renderer,
       params_.color.WithAlpha(params_.color.alpha * GetOpacityFactor());
   frag_info.center = params_.center;
   frag_info.size = params_.size;
+  Vector2 transform_scaling = entity.GetTransform().GetBasisScaleXY();
+  frag_info.pixel_size =
+      Point(transform_scaling.x != 0.0f ? 1.0f / transform_scaling.x : 0.0f,
+            transform_scaling.y != 0.0f ? 1.0f / transform_scaling.y : 0.0f);
   frag_info.stroked = params_.stroke ? 1.0f : 0.0f;
   frag_info.stroke_width = params_.stroke ? params_.stroke->width : 0.0f;
   frag_info.stroke_join =

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -70,6 +70,7 @@ SamplerBinding SetupGradientParameters(
     const UberSDFParameters::GradientParameters& gradient,
     const ContentContext& renderer,
     FS::FragInfo& frag_info) {
+  FML_DCHECK(gradient.texture);
   frag_info.tile_mode = static_cast<Scalar>(gradient.tile_mode);
   auto texture_size = gradient.texture->GetSize();
   FML_DCHECK(!texture_size.IsEmpty());

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -79,13 +79,14 @@ SamplerBinding SetupGradientParameters(
   if (gradient.type == UberSDFParameters::GradientParameters::Type::kLinear) {
     Point delta = gradient.end - gradient.start;
     Scalar length_sq = delta.x * delta.x + delta.y * delta.y;
-    Point direction = length_sq > 0.0f ? delta / length_sq : Point(0.0f, 0.0f);
     frag_info.gradient_coords =
-        Vector4(gradient.start.x, gradient.start.y, direction.x, direction.y);
+        Vector4(gradient.start.x, gradient.start.y, delta.x, delta.y);
+    frag_info.inv_gradient_length = length_sq > 0.0f ? 1.0f / length_sq : 0.0f;
   } else {
-    Scalar inv_radius = gradient.end.x > 0.0f ? 1.0f / gradient.end.x : 0.0f;
     frag_info.gradient_coords =
-        Vector4(gradient.start.x, gradient.start.y, inv_radius, 0.0f);
+        Vector4(gradient.start.x, gradient.start.y, 0.0f, 0.0f);
+    frag_info.inv_gradient_length =
+        gradient.end.x > 0.0f ? 1.0f / gradient.end.x : 0.0f;
   }
 
   SamplerDescriptor sampler_desc;
@@ -142,6 +143,7 @@ bool UberSDFContents::Render(const ContentContext& renderer,
   frag_info.gradient_coords = Vector4();
   frag_info.half_texel = 0.0f;
   frag_info.tile_mode = 0.0f;
+  frag_info.inv_gradient_length = 0.0f;
 
   SamplerBinding sampler_binding;
   if (params_.gradient) {

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -70,14 +70,22 @@ SamplerBinding SetupGradientParameters(
     const UberSDFParameters::GradientParameters& gradient,
     const ContentContext& renderer,
     FS::FragInfo& frag_info) {
-  FML_DCHECK(gradient.texture);
-  frag_info.gradient_start = gradient.start;
-  frag_info.gradient_end = gradient.end;
   frag_info.tile_mode = static_cast<Scalar>(gradient.tile_mode);
   auto texture_size = gradient.texture->GetSize();
   FML_DCHECK(!texture_size.IsEmpty());
-  frag_info.half_texel =
-      Point(0.5f, 0.5f) / Point(texture_size.width, texture_size.height);
+  frag_info.half_texel = 0.5f / texture_size.width;
+
+  if (gradient.type == UberSDFParameters::GradientParameters::Type::kLinear) {
+    Point delta = gradient.end - gradient.start;
+    Scalar length_sq = delta.x * delta.x + delta.y * delta.y;
+    Point direction = length_sq > 0.0f ? delta / length_sq : Point(0.0f, 0.0f);
+    frag_info.gradient_coords =
+        Vector4(gradient.start.x, gradient.start.y, direction.x, direction.y);
+  } else {
+    Scalar inv_radius = gradient.end.x > 0.0f ? 1.0f / gradient.end.x : 0.0f;
+    frag_info.gradient_coords =
+        Vector4(gradient.start.x, gradient.start.y, inv_radius, 0.0f);
+  }
 
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kLinear;
@@ -130,6 +138,9 @@ bool UberSDFContents::Render(const ContentContext& renderer,
   frag_info.circle_center_top = params_.circle_center_top;
   frag_info.circle_center_right = params_.circle_center_right;
   frag_info.radii = params_.radii;
+  frag_info.gradient_coords = Vector4();
+  frag_info.half_texel = 0.0f;
+  frag_info.tile_mode = 0.0f;
 
   SamplerBinding sampler_binding;
   if (params_.gradient) {

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -126,10 +126,8 @@ bool UberSDFContents::Render(const ContentContext& renderer,
       params_.color.WithAlpha(params_.color.alpha * GetOpacityFactor());
   frag_info.center = params_.center;
   frag_info.size = params_.size;
-  Vector2 transform_scaling = entity.GetTransform().GetBasisScaleXY();
-  frag_info.pixel_size =
-      Point(transform_scaling.x != 0.0f ? 1.0f / transform_scaling.x : 0.0f,
-            transform_scaling.y != 0.0f ? 1.0f / transform_scaling.y : 0.0f);
+  Vector2 pixel_size = entity.GetTransform().GetTransformedPixelSize();
+  frag_info.pixel_size = Point(pixel_size.x, pixel_size.y);
   frag_info.stroked = params_.stroke ? 1.0f : 0.0f;
   frag_info.stroke_width = params_.stroke ? params_.stroke->width : 0.0f;
   frag_info.stroke_join =

--- a/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
+++ b/engine/src/flutter/impeller/entity/geometry/geometry_unittests.cc
@@ -117,6 +117,21 @@ TEST(EntityGeometryTest, UberSDFGeometryPaddingIsAdjustedByInverseMaxBasis) {
                                       .TransformAndClipBounds(matrix));
     }
   }
+
+  // Under skew, padding should account for non-orthogonal axis scaling and
+  // determinant.
+  {
+    auto matrix = Matrix::MakeSkew(0.75f, 0.5f);
+    auto coverage = geometry.GetCoverage(matrix);
+    EXPECT_TRUE(coverage.has_value());
+    if (coverage.has_value()) {
+      Vector2 pixel_size = matrix.GetTransformedPixelSize();
+      EXPECT_EQ(coverage.value(),
+                Rect::MakeLTRB(-pixel_size.x, -pixel_size.y,
+                               100.0f + pixel_size.x, 100.0f + pixel_size.y)
+                    .TransformAndClipBounds(matrix));
+    }
+  }
 }
 
 TEST(EntityGeometryTest, FillPathGeometryCoversArea) {

--- a/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/uber_sdf_geometry.cc
@@ -65,16 +65,9 @@ bool UberSDFGeometry::IsAxisAlignedRect() const {
 }
 
 Rect UberSDFGeometry::GetExpandedBounds(const Matrix& transform) const {
-  // Get the scaling factor of the transform in the X and Y directions.
-  Vector2 transform_scaling = transform.GetBasisScaleXY();
-
-  // Get the device pixel size in local space units. This is the inverse of the
-  // transform scaling. E.g. if the transform performs a scale of 4 in the X
-  // direction and 0.5 in the Y direction, then 1 device pixel is size
-  // {0.25, 2.0} in local space units.
-  Size device_pixel_size = {
-      transform_scaling.x != 0 ? 1.0f / transform_scaling.x : 0,
-      transform_scaling.y != 0 ? 1.0f / transform_scaling.y : 0};
+  // Get the device pixel size in local space units.
+  Vector2 pixel_size = transform.GetTransformedPixelSize();
+  Size device_pixel_size(pixel_size.x, pixel_size.y);
 
   // The stroke padding is half the stroke width, if the shape is stroked.
   Size stroke_padding;

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -30,16 +30,13 @@ uniform FragInfo {
   /// bottom-right), or the circular cap radii for rounded superellipses in
   /// radii.xy (top octant in x, right octant in y).
   vec4 radii;
-  /// Gradient parameters packed to avoid shader-side uniform division:
+  /// Gradient parameters:
   ///   - Linear gradient:
   ///       xy: Start point in local coordinates.
-  ///       zw: Pre-scaled direction vector (delta / dot(delta, delta)), such
-  ///           that dot(v_position - xy, zw) yields the [0, 1] parameter t.
+  ///       zw: Delta vector (end - start) in local coordinates.
   ///   - Radial gradient:
   ///       xy: Center point in local coordinates.
-  ///       z:  Inverse radius (1.0 / radius), such that
-  ///           length(v_position - xy) * z yields the [0, 1] parameter t.
-  ///       w:  Unused (0.0).
+  ///       zw: Unused (0.0).
   vec4 gradient_coords;
 
   // ===========================================================================
@@ -108,6 +105,10 @@ uniform FragInfo {
   /// Half the size of a single gradient texel in normalized texture
   /// coordinates along the gradient ramp (x axis).
   float half_texel;
+  /// Inverse gradient length:
+  ///   - Linear gradient: 1.0 / dot(delta, delta)
+  ///   - Radial gradient: 1.0 / radius
+  float inv_gradient_length;
 }
 frag_info;
 
@@ -126,11 +127,12 @@ vec4 getColor() {
     if (frag_info.color_source_type < 1.5) {
       // Linear gradient
       t = dot(v_position - frag_info.gradient_coords.xy,
-              frag_info.gradient_coords.zw);
+              frag_info.gradient_coords.zw) *
+          frag_info.inv_gradient_length;
     } else {
       // Radial gradient
       t = length(v_position - frag_info.gradient_coords.xy) *
-          frag_info.gradient_coords.z;
+          frag_info.inv_gradient_length;
     }
     vec4 gradient_color = IPSampleLinearWithTileMode(
         color_source_sampler, vec2(t, 0.5), vec2(frag_info.half_texel, 0.5),

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -126,13 +126,13 @@ vec4 getColor() {
     float t;
     if (frag_info.color_source_type < 1.5) {
       // Linear gradient
-      t = dot(v_position - frag_info.gradient_coords.xy,
-              frag_info.gradient_coords.zw) *
-          frag_info.inv_gradient_length;
+      t = IPComputeLinearGradientT(v_position, frag_info.gradient_coords.xy,
+                                   frag_info.gradient_coords.zw,
+                                   frag_info.inv_gradient_length);
     } else {
       // Radial gradient
-      t = length(v_position - frag_info.gradient_coords.xy) *
-          frag_info.inv_gradient_length;
+      t = IPComputeRadialGradientT(v_position, frag_info.gradient_coords.xy,
+                                   frag_info.inv_gradient_length);
     }
     vec4 gradient_color = IPSampleLinearWithTileMode(
         color_source_sampler, vec2(t, 0.5), vec2(frag_info.half_texel, 0.5),

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -30,6 +30,17 @@ uniform FragInfo {
   /// bottom-right), or the circular cap radii for rounded superellipses in
   /// radii.xy (top octant in x, right octant in y).
   vec4 radii;
+  /// Gradient parameters packed to avoid shader-side uniform division:
+  ///   - Linear gradient:
+  ///       xy: Start point in local coordinates.
+  ///       zw: Pre-scaled direction vector (delta / dot(delta, delta)), such
+  ///           that dot(v_position - xy, zw) yields the [0, 1] parameter t.
+  ///   - Radial gradient:
+  ///       xy: Center point in local coordinates.
+  ///       z:  Inverse radius (1.0 / radius), such that
+  ///           length(v_position - xy) * z yields the [0, 1] parameter t.
+  ///       w:  Unused (0.0).
+  vec4 gradient_coords;
 
   // ===========================================================================
   // vec2 fields
@@ -55,17 +66,6 @@ uniform FragInfo {
   /// The center of the corner transition circle for the right octant of a
   /// rounded superellipse.
   vec2 circle_center_right;
-
-  // --- Gradient Parameters ---
-  /// The starting point of a linear gradient, or the center point of a radial
-  /// gradient.
-  vec2 gradient_start;
-  /// The ending point of a linear gradient, or (radius, 0.0) for a radial
-  /// gradient.
-  vec2 gradient_end;
-  /// Half the size of a single gradient texel in normalized texture
-  /// coordinates.
-  vec2 half_texel;
 
   // ===========================================================================
   // float fields
@@ -105,6 +105,9 @@ uniform FragInfo {
   ///   2: Mirror
   ///   3: Decal
   float tile_mode;
+  /// Half the size of a single gradient texel in normalized texture
+  /// coordinates along the gradient ramp (x axis).
+  float half_texel;
 }
 frag_info;
 
@@ -118,17 +121,19 @@ vec4 getColor() {
   if (frag_info.color_source_type < 0.5) {
     // Solid color
     color = frag_info.color;
-  } else if (frag_info.color_source_type < 1.5) {
-    // Linear gradient
-    vec4 gradient_color = IPSampleLinearGradient(
-        color_source_sampler, frag_info.gradient_start, frag_info.gradient_end,
-        v_position, frag_info.half_texel, frag_info.tile_mode, vec4(0.0));
-    color = vec4(gradient_color.rgb, gradient_color.a * frag_info.color.a);
   } else {
-    // Radial gradient
-    vec4 gradient_color = IPSampleRadialGradient(
-        color_source_sampler, frag_info.gradient_start,
-        frag_info.gradient_end.x, v_position, frag_info.half_texel,
+    float t;
+    if (frag_info.color_source_type < 1.5) {
+      // Linear gradient
+      t = dot(v_position - frag_info.gradient_coords.xy,
+              frag_info.gradient_coords.zw);
+    } else {
+      // Radial gradient
+      t = length(v_position - frag_info.gradient_coords.xy) *
+          frag_info.gradient_coords.z;
+    }
+    vec4 gradient_color = IPSampleLinearWithTileMode(
+        color_source_sampler, vec2(t, 0.5), vec2(frag_info.half_texel, 0.5),
         frag_info.tile_mode, vec4(0.0));
     color = vec4(gradient_color.rgb, gradient_color.a * frag_info.color.a);
   }

--- a/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
+++ b/engine/src/flutter/impeller/entity/shaders/uber_sdf.frag
@@ -5,6 +5,7 @@
 precision mediump float;
 
 #include <impeller/color.glsl>
+#include <impeller/constants.glsl>
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
@@ -39,6 +40,8 @@ uniform FragInfo {
   vec2 center;
   /// The half-dimensions of the shape (half-width, half-height).
   vec2 size;
+  /// The size of a device pixel in local coordinates.
+  vec2 pixel_size;
 
   // --- Superellipse Parameters ---
   /// The exponent degree (n_x, n_y) of the superellipse curvature.
@@ -166,7 +169,7 @@ float distanceFromChamferRect(vec2 p, vec2 half_size, float chamfer_size) {
   p = abs(p);
   float d1 = max(p.x - half_size.x, p.y - half_size.y);
   float d2 =
-      (p.x + p.y - half_size.x - half_size.y + chamfer_size) * 0.70710678;
+      (p.x + p.y - half_size.x - half_size.y + chamfer_size) * kHalfSqrtTwo;
   return max(d1, d2);
 }
 
@@ -215,25 +218,14 @@ float distanceFromRoundedSuperellipse(vec2 p,
                                se_degree);
 }
 
-// Special case pixel size calculation for rectangles. The standard `pixelSize`
-// function uses SDF derivatives, which gives invalid results for very small
-// shapes, where adjacent device pixels span across opposing edges of the shape.
-// This function calculates pixel size for rectangles without using SDF
-// derivatives.
+// Calculates pixel size for rectangles using frag_info.pixel_size.
 float rectPixelSize(vec2 p) {
-  // The change in local coordinates per horizontal device pixel (device_dx)
-  // and vertical device pixel (device_dy).
-  vec2 device_dx = dFdx(v_position);
-  vec2 device_dy = dFdy(v_position);
-  // The size of a device pixel in terms of local coordinates.
-  vec2 device_pixel_size = vec2(length(vec2(device_dx.x, device_dy.x)),
-                                length(vec2(device_dx.y, device_dy.y)));
-
   // Get pixel size in the direction perpendicular to the closest edge of the
-  // rectangle: device_pixel_size.x when closer to a vertical edge, and
-  // pixel_size.y when closer to a horizontal edge.
+  // rectangle: frag_info.pixel_size.x when closer to a vertical edge, and
+  // frag_info.pixel_size.y when closer to a horizontal edge.
   vec2 distance = abs(abs(p) - frag_info.size);
-  return (distance.x < distance.y) ? device_pixel_size.x : device_pixel_size.y;
+  return (distance.x < distance.y) ? frag_info.pixel_size.x
+                                   : frag_info.pixel_size.y;
 }
 
 // Special case pixel size calculation for rounded rectangles, similar to

--- a/engine/src/flutter/impeller/geometry/matrix.h
+++ b/engine/src/flutter/impeller/geometry/matrix.h
@@ -404,6 +404,28 @@ struct Matrix {
     return Vector2(GetBasisX2D().GetLength(), GetBasisY2D().GetLength());
   }
 
+  /// @brief Returns the size of a screen/device pixel in local coordinates
+  ///        along the local X and Y axes, accounting for 2D scale, rotation,
+  ///        and skew.
+  ///
+  ///        For an affine transform, this corresponds to the magnitude of the
+  ///        gradients of local x and y with respect to screen coordinates:
+  ///          pixel_size.x = ||\nabla x|| = ||Basis Y 2D|| / |det 2D|
+  ///          pixel_size.y = ||\nabla y|| = ||Basis X 2D|| / |det 2D|
+  inline Vector2 GetTransformedPixelSize() const {
+    if (m[1] == 0.0f && m[4] == 0.0f) {
+      return Vector2(m[0] != 0.0f ? 1.0f / std::abs(m[0]) : 0.0f,
+                     m[5] != 0.0f ? 1.0f / std::abs(m[5]) : 0.0f);
+    }
+    Scalar det = m[0] * m[5] - m[1] * m[4];
+    if (ScalarNearlyZero(det)) {
+      return Vector2();
+    }
+    Scalar abs_det = std::abs(det);
+    return Vector2(GetBasisY2D().GetLength() / abs_det,
+                   GetBasisX2D().GetLength() / abs_det);
+  }
+
   inline Scalar GetDirectionScale(Vector3 direction) const {
     return 1.0f / (this->Basis().Invert() * direction.Normalize()).GetLength() *
            direction.GetLength();

--- a/engine/src/flutter/impeller/geometry/matrix.h
+++ b/engine/src/flutter/impeller/geometry/matrix.h
@@ -414,8 +414,10 @@ struct Matrix {
   ///          pixel_size.y = ||\nabla y|| = ||Basis X 2D|| / |det 2D|
   inline Vector2 GetTransformedPixelSize() const {
     if (m[1] == 0.0f && m[4] == 0.0f) {
-      return Vector2(m[0] != 0.0f ? 1.0f / std::abs(m[0]) : 0.0f,
-                     m[5] != 0.0f ? 1.0f / std::abs(m[5]) : 0.0f);
+      if (m[0] == 0.0f || m[5] == 0.0f) {
+        return Vector2();
+      }
+      return Vector2(1.0f / std::abs(m[0]), 1.0f / std::abs(m[5]));
     }
     Scalar det = m[0] * m[5] - m[1] * m[4];
     if (ScalarNearlyZero(det)) {

--- a/engine/src/flutter/impeller/geometry/matrix_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/matrix_unittests.cc
@@ -473,5 +473,54 @@ TEST(MatrixTest, MinMaxScales2D) {
   }
 }
 
+TEST(MatrixTest, GetTransformedPixelSize) {
+  {
+    // Identity matrix: 1 device pixel = 1 local unit.
+    Matrix identity;
+    EXPECT_EQ(identity.GetTransformedPixelSize(), Vector2(1.0f, 1.0f));
+  }
+
+  {
+    // Pure scaling: 1 device pixel = 1/scale local units.
+    Matrix scale = Matrix::MakeScale({2.0f, 4.0f, 1.0f});
+    EXPECT_EQ(scale.GetTransformedPixelSize(), Vector2(0.5f, 0.25f));
+  }
+
+  {
+    // Negative scaling: pixel size is always positive.
+    Matrix neg_scale = Matrix::MakeScale({-2.0f, 4.0f, 1.0f});
+    EXPECT_EQ(neg_scale.GetTransformedPixelSize(), Vector2(0.5f, 0.25f));
+  }
+
+  {
+    // Rotation: 1 device pixel = 1 local unit.
+    Matrix rotation = Matrix::MakeRotationZ(Radians(kPiOver2));
+    Vector2 rot_size = rotation.GetTransformedPixelSize();
+    EXPECT_NEAR(rot_size.x, 1.0f, 1e-5);
+    EXPECT_NEAR(rot_size.y, 1.0f, 1e-5);
+  }
+
+  {
+    // Skew: accounts for non-orthogonal axes and determinant.
+    Matrix skew = Matrix::MakeSkew(0.75f, 0.5f);
+    Vector2 skew_size = skew.GetTransformedPixelSize();
+    // det = 1.0 * 1.0 - 0.75 * 0.5 = 0.625
+    // Basis Y length = sqrt(0.75^2 + 1.0^2) = 1.25 -> pixel_size.x = 1.25 /
+    // 0.625 = 2.0 Basis X length = sqrt(1.0^2 + 0.5^2) = sqrt(1.25) ->
+    // pixel_size.y = sqrt(1.25) / 0.625
+    EXPECT_NEAR(skew_size.x, 2.0f, 1e-5);
+    EXPECT_NEAR(skew_size.y, 1.7888544f, 1e-5);
+  }
+
+  {
+    // Singular matrix: returns zero.
+    Matrix singular(1.0f, 2.0f, 0.0f, 0.0f,  //
+                    2.0f, 4.0f, 0.0f, 0.0f,  //
+                    0.0f, 0.0f, 1.0f, 0.0f,  //
+                    0.0f, 0.0f, 0.0f, 1.0f);
+    EXPECT_EQ(singular.GetTransformedPixelSize(), Vector2(0.0f, 0.0f));
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/geometry/matrix_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/matrix_unittests.cc
@@ -501,6 +501,36 @@ TEST(MatrixTest, GetTransformedPixelSize) {
   }
 
   {
+    // Rotation 45 degrees: 1 device pixel = 1 local unit.
+    Matrix rotation = Matrix::MakeRotationZ(Radians(kPiOver4));
+    Vector2 rot_size = rotation.GetTransformedPixelSize();
+    EXPECT_NEAR(rot_size.x, 1.0f, 1e-5);
+    EXPECT_NEAR(rot_size.y, 1.0f, 1e-5);
+  }
+
+  {
+    // Scale then rotate 45 degrees:
+    // Basis vectors rotated by 45 degrees, lengths preserved.
+    Matrix rotate_scale = Matrix::MakeRotationZ(Radians(kPiOver4)) *
+                          Matrix::MakeScale({2.0f, 4.0f, 1.0f});
+    Vector2 rs_size = rotate_scale.GetTransformedPixelSize();
+    EXPECT_NEAR(rs_size.x, 0.5f, 1e-5);
+    EXPECT_NEAR(rs_size.y, 0.25f, 1e-5);
+  }
+
+  {
+    // Rotate 45 degrees then scale:
+    Matrix scale_rotate = Matrix::MakeScale({2.0f, 4.0f, 1.0f}) *
+                          Matrix::MakeRotationZ(Radians(kPiOver4));
+    Vector2 sr_size = scale_rotate.GetTransformedPixelSize();
+    // Basis X = (sqrt(2), 2*sqrt(2)), length = sqrt(10)
+    // Basis Y = (-sqrt(2), 2*sqrt(2)), length = sqrt(10)
+    // det = 8 -> pixel_size = sqrt(10) / 8 ≈ 0.3952847f
+    EXPECT_NEAR(sr_size.x, 0.3952847f, 1e-5);
+    EXPECT_NEAR(sr_size.y, 0.3952847f, 1e-5);
+  }
+
+  {
     // Skew: accounts for non-orthogonal axes and determinant.
     Matrix skew = Matrix::MakeSkew(0.75f, 0.5f);
     Vector2 skew_size = skew.GetTransformedPixelSize();
@@ -519,6 +549,15 @@ TEST(MatrixTest, GetTransformedPixelSize) {
                     0.0f, 0.0f, 1.0f, 0.0f,  //
                     0.0f, 0.0f, 0.0f, 1.0f);
     EXPECT_EQ(singular.GetTransformedPixelSize(), Vector2(0.0f, 0.0f));
+
+    Matrix singular_scale_x = Matrix::MakeScale({0.0f, 4.0f, 1.0f});
+    EXPECT_EQ(singular_scale_x.GetTransformedPixelSize(), Vector2(0.0f, 0.0f));
+
+    Matrix singular_scale_y = Matrix::MakeScale({2.0f, 0.0f, 1.0f});
+    EXPECT_EQ(singular_scale_y.GetTransformedPixelSize(), Vector2(0.0f, 0.0f));
+
+    Matrix singular_scale_xy = Matrix::MakeScale({0.0f, 0.0f, 1.0f});
+    EXPECT_EQ(singular_scale_xy.GetTransformedPixelSize(), Vector2(0.0f, 0.0f));
   }
 }
 

--- a/engine/src/flutter/impeller/tools/malioc.json
+++ b/engine/src/flutter/impeller/tools/malioc.json
@@ -8610,7 +8610,7 @@
             "longest_path_cycles": [
               4.1875,
               4.125,
-              2.15625,
+              2.125,
               4.1875,
               0.0,
               0.25,
@@ -8643,18 +8643,18 @@
               "arith_fma"
             ],
             "total_cycles": [
-              13.5,
-              13.5,
-              5.512499809265137,
-              12.75,
+              13.375,
+              13.375,
+              5.050000190734863,
+              12.625,
               0.0,
               0.25,
-              0.5
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 62,
+          "uniform_registers_used": 58,
           "work_registers_used": 32
         }
       }
@@ -8685,7 +8685,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              5.610000133514404,
+              5.28000020980835,
               3.0,
               0.0
             ],
@@ -8693,9 +8693,9 @@
               "arithmetic"
             ],
             "total_cycles": [
-              119.33333587646484,
-              8.0,
-              22.0
+              112.66666412353516,
+              7.0,
+              21.0
             ]
           },
           "thread_occupancy": 100,
@@ -11837,7 +11837,7 @@
             "longest_path_cycles": [
               4.125,
               3.65625,
-              2.362499952316284,
+              2.34375,
               4.125,
               0.0,
               0.25,
@@ -11871,18 +11871,18 @@
               "arith_sfu"
             ],
             "total_cycles": [
-              12.625,
-              12.5,
-              5.8125,
-              12.625,
+              12.5625,
+              12.375,
+              5.5,
+              12.5625,
               0.0,
               0.25,
-              0.5
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 66,
+          "uniform_registers_used": 64,
           "work_registers_used": 32
         }
       }

--- a/engine/src/flutter/impeller/tools/malioc.json
+++ b/engine/src/flutter/impeller/tools/malioc.json
@@ -8600,7 +8600,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 31,
+          "fp16_arithmetic": 33,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -8627,13 +8627,13 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_fma"
+              "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.4375,
-              0.4375,
-              0.21875,
-              0.375,
+              0.328125,
+              0.3125,
+              0.328125,
+              0.125,
               0.0,
               0.25,
               0.0
@@ -8643,10 +8643,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              14.0625,
-              14.0625,
-              5.574999809265137,
-              13.75,
+              13.5,
+              13.5,
+              5.512499809265137,
+              12.75,
               0.0,
               0.25,
               0.5
@@ -8687,15 +8687,15 @@
             "shortest_path_cycles": [
               5.610000133514404,
               3.0,
-              2.0
+              0.0
             ],
             "total_bound_pipelines": [
               "arithmetic"
             ],
             "total_cycles": [
-              122.0,
+              119.33333587646484,
               8.0,
-              26.0
+              22.0
             ]
           },
           "thread_occupancy": 100,
@@ -11827,7 +11827,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 34,
+          "fp16_arithmetic": 35,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -11837,7 +11837,7 @@
             "longest_path_cycles": [
               4.125,
               3.65625,
-              2.3125,
+              2.362499952316284,
               4.125,
               0.0,
               0.25,
@@ -11854,13 +11854,14 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma",
+              "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.375,
-              0.359375,
-              0.234375,
-              0.375,
+              0.296875,
+              0.296875,
+              0.296875,
+              0.125,
               0.0,
               0.25,
               0.0
@@ -11870,10 +11871,10 @@
               "arith_sfu"
             ],
             "total_cycles": [
-              13.625,
-              12.875,
-              5.625,
-              13.625,
+              12.625,
+              12.5,
+              5.8125,
+              12.625,
               0.0,
               0.25,
               0.5
@@ -11881,7 +11882,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 64,
+          "uniform_registers_used": 66,
           "work_registers_used": 32
         }
       }

--- a/engine/src/flutter/impeller/tools/malioc.json
+++ b/engine/src/flutter/impeller/tools/malioc.json
@@ -5819,9 +5819,9 @@
               "arith_cvt"
             ],
             "longest_path_cycles": [
-              0.375,
+              0.34375,
               0.296875,
-              0.375,
+              0.34375,
               0.1875,
               0.0,
               0.25,
@@ -5837,16 +5837,15 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying"
             ],
             "shortest_path_cycles": [
-              0.234375,
-              0.109375,
-              0.234375,
-              0.125,
+              0.21875,
+              0.203125,
+              0.21875,
+              0.1875,
               0.0,
-              0.0,
+              0.25,
               0.0
             ],
             "total_bound_pipelines": [
@@ -5854,9 +5853,9 @@
               "arith_cvt"
             ],
             "total_cycles": [
-              0.5,
+              0.46875,
               0.328125,
-              0.5,
+              0.46875,
               0.1875,
               0.0,
               0.25,
@@ -5883,7 +5882,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              7.260000228881836,
+              6.599999904632568,
               1.0,
               1.0
             ],
@@ -5896,15 +5895,15 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              1.649999976158142,
-              0.0,
+              2.309999942779541,
+              1.0,
               0.0
             ],
             "total_bound_pipelines": [
               "arithmetic"
             ],
             "total_cycles": [
-              8.0,
+              7.333333492279053,
               1.0,
               1.0
             ]
@@ -8610,7 +8609,7 @@
             "longest_path_cycles": [
               4.1875,
               4.125,
-              2.125,
+              2.112499952316284,
               4.1875,
               0.0,
               0.25,
@@ -8645,7 +8644,7 @@
             "total_cycles": [
               13.375,
               13.375,
-              5.050000190734863,
+              5.03125,
               12.625,
               0.0,
               0.25,
@@ -9916,7 +9915,7 @@
             "longest_path_cycles": [
               0.265625,
               0.265625,
-              0.25,
+              0.234375,
               0.125,
               0.0,
               0.25,
@@ -9935,9 +9934,9 @@
               "varying"
             ],
             "shortest_path_cycles": [
-              0.1875,
               0.171875,
-              0.1875,
+              0.171875,
+              0.171875,
               0.125,
               0.0,
               0.25,
@@ -9948,9 +9947,9 @@
               "arith_cvt"
             ],
             "total_cycles": [
-              0.34375,
+              0.328125,
               0.296875,
-              0.34375,
+              0.328125,
               0.125,
               0.0,
               0.25,
@@ -9959,7 +9958,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 16,
+          "uniform_registers_used": 14,
           "work_registers_used": 7
         }
       }
@@ -11827,7 +11826,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 35,
+          "fp16_arithmetic": 36,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -11837,7 +11836,7 @@
             "longest_path_cycles": [
               4.125,
               3.65625,
-              2.34375,
+              2.325000047683716,
               4.125,
               0.0,
               0.25,
@@ -11873,7 +11872,7 @@
             "total_cycles": [
               12.5625,
               12.375,
-              5.5,
+              5.487500190734863,
               12.5625,
               0.0,
               0.25,
@@ -11882,7 +11881,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 64,
+          "uniform_registers_used": 62,
           "work_registers_used": 32
         }
       }


### PR DESCRIPTION
This removes derivative calls from the rect renderer in uber_sdf.  It rejiggers uniforms for gradients as well to make space for the new uniform.  It also removes uber_sdf from the codepath for rendering perspective matrices.  That allows us to have a stable derivative when rendering with uber_sdf.

spawned from https://github.com/flutter/flutter/pull/192204

Testing: see malioc results for better static analysis

Local performance testing on macos where I removed the derivatives from rects, rrects and circles then drew a lot of those gave this about an 8% improvement in raster time.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
