### PR TITLE
Fix LiveTestWidgetsFlutterBinding dropping synthetic pointer cancels for test-sourced pointers

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -2973,7 +2973,36 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     }
   }
 
+  // The [pointerEventSource] that was active when each currently-down
+  // pointer's down event was handled. Cancel events for a pointer (e.g. the
+  // ones `GestureBinding.cancelPointer` schedules in a microtask when the
+  // [Navigator] cancels active pointers on a route push) can arrive outside
+  // the `withPointerEventSource` scope that produced the down event, so
+  // [pointerEventSource] can no longer be trusted to reflect where the
+  // pointer actually came from by the time the cancel is handled. Routing
+  // such a cancel as a [TestBindingEventSource.device] event would silently
+  // drop it (see [deviceEventDispatcher]) instead of delivering it to the
+  // recognizers that are still tracking the pointer, permanently wedging
+  // them. See https://github.com/flutter/flutter/issues/191757.
+  final Map<int, TestBindingEventSource> _pointerEventSourceForPointer =
+      <int, TestBindingEventSource>{};
+
   void _handlePointerEvent(PointerEvent event) {
+    if (event is PointerDownEvent || event is PointerPanZoomStartEvent) {
+      _pointerEventSourceForPointer[event.pointer] = pointerEventSource;
+    }
+    final TestBindingEventSource? originSource =
+        event is PointerUpEvent || event is PointerCancelEvent || event is PointerPanZoomEndEvent
+        ? _pointerEventSourceForPointer.remove(event.pointer)
+        : null;
+    if (originSource != null && originSource != pointerEventSource) {
+      withPointerEventSource(originSource, () => _dispatchPointerEvent(event));
+    } else {
+      _dispatchPointerEvent(event);
+    }
+  }
+
+  void _dispatchPointerEvent(PointerEvent event) {
     switch (pointerEventSource) {
       case TestBindingEventSource.test:
         RenderView? target;

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -2974,16 +2974,17 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }
 
   // The [pointerEventSource] that was active when each currently-down
-  // pointer's down event was handled. Cancel events for a pointer (e.g. the
-  // ones `GestureBinding.cancelPointer` schedules in a microtask when the
-  // [Navigator] cancels active pointers on a route push) can arrive outside
-  // the `withPointerEventSource` scope that produced the down event, so
-  // [pointerEventSource] can no longer be trusted to reflect where the
-  // pointer actually came from by the time the cancel is handled. Routing
-  // such a cancel as a [TestBindingEventSource.device] event would silently
-  // drop it (see [deviceEventDispatcher]) instead of delivering it to the
-  // recognizers that are still tracking the pointer, permanently wedging
-  // them. See https://github.com/flutter/flutter/issues/191757.
+  // pointer's down event was handled, kept for the rest of that pointer's
+  // lifecycle (cleared on up/cancel/pan-zoom-end). Later events for a
+  // pointer (e.g. the cancel that `GestureBinding.cancelPointer` schedules
+  // in a microtask when the [Navigator] cancels active pointers on a route
+  // push) can arrive outside the `withPointerEventSource` scope that
+  // produced the down event, so [pointerEventSource] can no longer be
+  // trusted to reflect where the pointer actually came from by the time
+  // such an event is handled. Routing it as a [TestBindingEventSource.device]
+  // event would silently drop it (see [deviceEventDispatcher]) instead of
+  // delivering it to the recognizers that are still tracking the pointer,
+  // permanently wedging them. See https://github.com/flutter/flutter/issues/191757.
   final Map<int, TestBindingEventSource> _pointerEventSourceForPointer =
       <int, TestBindingEventSource>{};
 
@@ -2991,10 +2992,10 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     if (event is PointerDownEvent || event is PointerPanZoomStartEvent) {
       _pointerEventSourceForPointer[event.pointer] = pointerEventSource;
     }
-    final TestBindingEventSource? originSource =
-        event is PointerUpEvent || event is PointerCancelEvent || event is PointerPanZoomEndEvent
-        ? _pointerEventSourceForPointer.remove(event.pointer)
-        : null;
+    final TestBindingEventSource? originSource = _pointerEventSourceForPointer[event.pointer];
+    if (event is PointerUpEvent || event is PointerCancelEvent || event is PointerPanZoomEndEvent) {
+      _pointerEventSourceForPointer.remove(event.pointer);
+    }
     if (originSource != null && originSource != pointerEventSource) {
       withPointerEventSource(originSource, () => _dispatchPointerEvent(event));
     } else {

--- a/packages/flutter_test/test/live_binding_test.dart
+++ b/packages/flutter_test/test/live_binding_test.dart
@@ -283,6 +283,48 @@ void main() {
     },
   );
 
+  testWidgets(
+    'a pointer cancelled via cancelPointer is delivered to recognizers tracking a test-sourced pointer (regression for #191757)',
+    (WidgetTester tester) async {
+      var tapCount = 0;
+      var cancelCount = 0;
+      await tester.pumpWidget(
+        TestWidgetsApp(
+          home: GestureDetector(
+            onTapCancel: () => cancelCount++,
+            onTap: () => tapCount++,
+            child: const Text('Target'),
+          ),
+        ),
+      );
+
+      const pointer = 23;
+      final TestGesture gesture = await tester.startGesture(
+        tester.getCenter(find.text('Target')),
+        pointer: pointer,
+      );
+
+      // This mimics what Navigator._cancelActivePointers does when a route
+      // is pushed mid-gesture: it calls WidgetsBinding.instance.cancelPointer,
+      // which schedules a PointerCancelEvent to be dispatched in a microtask
+      // — i.e. outside the synchronous `withPointerEventSource(test, ...)`
+      // scope that TestGesture's own events run in.
+      binding.cancelPointer(pointer);
+      await tester.pump();
+
+      // The GestureDetector's recognizer must actually receive the cancel...
+      expect(cancelCount, 1);
+      expect(tapCount, 0);
+
+      await gesture.up();
+
+      // ...and must be left in a clean state so a later, unrelated gesture
+      // on the same widget still works.
+      await tester.tap(find.text('Target'));
+      expect(tapCount, 1);
+    },
+  );
+
   testWidgets('resetLayers resets configuration and replaces root layer', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
This PR is AI-assisted (drafted and tested with Claude Code); I reviewed the diff and test results before opening this PR.

## What this changes

`GestureBinding.cancelPointer` (used by `Navigator._cancelActivePointers` when a route is pushed mid-gesture, e.g. from an `onLongPress` callback that opens a `showModalBottomSheet`) schedules the synthesized `PointerCancelEvent` in a **microtask**, outside the synchronous `withPointerEventSource(TestBindingEventSource.test, ...)` scope that produced the pointer's original down event.

`LiveTestWidgetsFlutterBinding._handlePointerEvent` classified that cancel using the *ambient* `pointerEventSource` at flush time, which defaults back to `TestBindingEventSource.device` once the synchronous test-event scope has exited. As a `device`-sourced event, the cancel was routed to `deviceEventDispatcher` (the `WidgetTester`, in live `testWidgets` runs) instead of through the normal `GestureBinding` dispatch path — and `WidgetTester.dispatchEvent` only reacts to `PointerDownEvent`, silently discarding everything else. The recognizers that were still tracking the pointer never received the cancel, so they were left wedged in a `possible` state and never responded to any later gesture on the same widget for the rest of the test/process.

- `LiveTestWidgetsFlutterBinding` now records the `pointerEventSource` that was active when each currently-down pointer's down event was handled (`_pointerEventSourceForPointer`).
- When a pointer's up/cancel event is handled, it's routed through that recorded origin source instead of the ambient `pointerEventSource`, so a cancel for a pointer that `TestGesture` is driving is correctly delivered to the framework's gesture recognizers rather than dropped.

## Fixes

Fixes #191757

## Testing

- Added a regression test in `packages/flutter_test/test/live_binding_test.dart` that starts a test-sourced gesture, calls `binding.cancelPointer` directly (mirroring what `Navigator._cancelActivePointers` does), and asserts both that the recognizer receives the cancel and that the widget responds normally to a later, unrelated gesture.
- Verified the added test fails without the fix (`tapCount` stays `0` after the follow-up tap — the exact symptom from the issue) and passes with it.
- `dart analyze` and `dart format` clean on touched files.
- Full `flutter_test` package test suite passes (701 tests).

## Pre-launch Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines) and understand my responsibilities.
- [ ] I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md)