### PR TITLE
[flutter_tools] Fix unhandled DebugAdapterException on early process termination

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -466,9 +466,12 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
       waitingForDebugger = true;
       try {
         await Future.any<void>([debuggerInitialized, debuggerInitializationFailedCompleter.future]);
-      } catch (e) {
+      } on DebugAdapterException catch (e) {
+        sendConsoleOutput(e.message);
+        return;
+      } on Object catch (e) {
         if (!isTerminating) {
-          rethrow;
+          sendConsoleOutput('Failed to initialize debugger: $e');
         }
         return;
       } finally {

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
@@ -58,10 +58,13 @@ abstract class FlutterBaseDebugAdapter
 
   @override
   void handleSessionTerminate([String exitSuffix = '']) {
+    isTerminating = true;
     if (waitingForDebugger && !debuggerInitializationFailedCompleter.isCompleted) {
-      debuggerInitializationFailedCompleter.completeError(
-        DebugAdapterException('Session terminated before debugger initialized: $exitSuffix'),
-      );
+      final String suffix = exitSuffix.trim();
+      final message = suffix.isNotEmpty
+          ? 'Session terminated before debugger initialized: $suffix'
+          : 'Session terminated before debugger initialized';
+      debuggerInitializationFailedCompleter.completeError(DebugAdapterException(message));
     }
     super.handleSessionTerminate(exitSuffix);
   }

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -353,6 +353,47 @@ void main() {
         // Also ensure we got console output with the error.
         expect(consoleOutputMessages, contains('App stopped due to an error\n'));
       });
+
+      test(
+        'does not throw unhandled exception if process exits before debugger initialized',
+        () async {
+          final debuggerCompleter = Completer<void>();
+          final adapter = FakeFlutterDebugAdapter(
+            fileSystem: MemoryFileSystem.test(style: fsStyle),
+            platform: platform,
+            customDebuggerInitialized: debuggerCompleter.future,
+          );
+          final responseCompleter = Completer<void>();
+          final args = FlutterLaunchRequestArguments(cwd: '.', program: 'foo.dart');
+
+          final consoleOutputMessages = <String>[];
+          final StreamSubscription<String> consoleOutputMessagesSubscription = adapter
+              .dapToClientMessages
+              .where((Map<String, Object?> message) => message['event'] == 'output')
+              .map((Map<String, Object?> message) => message['body']! as Map<String, Object?>)
+              .where(
+                (Map<String, Object?> body) =>
+                    body['category'] == 'console' || body['category'] == null,
+              )
+              .map((Map<String, Object?> body) => body['output']! as String)
+              .listen(consoleOutputMessages.add);
+
+          await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+          await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
+          await responseCompleter.future;
+
+          expect(adapter.waitingForDebugger, isTrue);
+
+          adapter.handleExitCode(255);
+          await pumpEventQueue();
+          await consoleOutputMessagesSubscription.cancel();
+
+          expect(
+            consoleOutputMessages,
+            contains('Session terminated before debugger initialized: (255)\n'),
+          );
+        },
+      );
     });
 
     group('attachRequest', () {
@@ -545,6 +586,47 @@ void main() {
 
         expect(adapter.dapToFlutterRequests, contains('app.detach'));
       });
+
+      test(
+        'does not throw unhandled exception if process exits before debugger initialized',
+        () async {
+          final debuggerCompleter = Completer<void>();
+          final adapter = FakeFlutterDebugAdapter(
+            fileSystem: MemoryFileSystem.test(style: fsStyle),
+            platform: platform,
+            customDebuggerInitialized: debuggerCompleter.future,
+          );
+          final responseCompleter = Completer<void>();
+          final args = FlutterAttachRequestArguments(cwd: '.');
+
+          final consoleOutputMessages = <String>[];
+          final StreamSubscription<String> consoleOutputMessagesSubscription = adapter
+              .dapToClientMessages
+              .where((Map<String, Object?> message) => message['event'] == 'output')
+              .map((Map<String, Object?> message) => message['body']! as Map<String, Object?>)
+              .where(
+                (Map<String, Object?> body) =>
+                    body['category'] == 'console' || body['category'] == null,
+              )
+              .map((Map<String, Object?> body) => body['output']! as String)
+              .listen(consoleOutputMessages.add);
+
+          await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+          await adapter.attachRequest(FakeRequest(), args, responseCompleter.complete);
+          await responseCompleter.future;
+
+          expect(adapter.waitingForDebugger, isTrue);
+
+          adapter.handleExitCode(255);
+          await pumpEventQueue();
+          await consoleOutputMessagesSubscription.cancel();
+
+          expect(
+            consoleOutputMessages,
+            contains('Session terminated before debugger initialized: (255)\n'),
+          );
+        },
+      );
     });
 
     group('forwards events', () {

--- a/packages/flutter_tools/test/general.shard/dap/flutter_test_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_test_adapter_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:dap_adapters/dap_adapters.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -121,6 +122,41 @@ void main() {
         expect(adapter.processArgs, isNot(contains('--machine')));
         expect(adapter.processArgs, contains('tool_args'));
       });
+    });
+
+    test('surfaces clean error when process terminates before debugger initialized', () async {
+      final debuggerCompleter = Completer<void>();
+      final adapter = FakeFlutterTestDebugAdapter(
+        fileSystem: MemoryFileSystem.test(style: fsStyle),
+        platform: platform,
+        customDebuggerInitialized: debuggerCompleter.future,
+      );
+      final responseCompleter = Completer<void>();
+      final request = FakeRequest();
+      final args = FlutterLaunchRequestArguments(cwd: '.', program: 'foo.dart', noDebug: false);
+
+      await adapter.configurationDoneRequest(request, null, () {});
+      final Future<void> launchFuture = adapter.launchRequest(
+        request,
+        args,
+        responseCompleter.complete,
+      );
+      await pumpEventQueue();
+
+      expect(adapter.waitingForDebugger, isTrue);
+
+      adapter.handleExitCode(255);
+
+      expect(
+        launchFuture,
+        throwsA(
+          isA<DebugAdapterException>().having(
+            (DebugAdapterException e) => e.message,
+            'message',
+            'Session terminated before debugger initialized: (255)',
+          ),
+        ),
+      );
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/dap/mocks.dart
+++ b/packages/flutter_tools/test/general.shard/dap/mocks.dart
@@ -16,10 +16,11 @@ class FakeFlutterDebugAdapter extends FlutterDebugAdapter {
   factory FakeFlutterDebugAdapter({
     required FileSystem fileSystem,
     required Platform platform,
+    Future<void>? customDebuggerInitialized,
+    FutureOr<void> Function(FakeFlutterDebugAdapter adapter)? preAppStart,
     bool simulateAppStarted = true,
     bool simulateAppStopError = false,
     bool supportsRestart = true,
-    FutureOr<void> Function(FakeFlutterDebugAdapter adapter)? preAppStart,
   }) {
     final stdinController = StreamController<List<int>>();
     final stdoutController = StreamController<List<int>>();
@@ -35,10 +36,11 @@ class FakeFlutterDebugAdapter extends FlutterDebugAdapter {
       clientChannel: clientChannel,
       fileSystem: fileSystem,
       platform: platform,
+      customDebuggerInitialized: customDebuggerInitialized,
+      preAppStart: preAppStart,
       simulateAppStarted: simulateAppStarted,
       simulateAppStopError: simulateAppStopError,
       supportsRestart: supportsRestart,
-      preAppStart: preAppStart,
     );
   }
 
@@ -47,10 +49,11 @@ class FakeFlutterDebugAdapter extends FlutterDebugAdapter {
     required this.clientChannel,
     required super.fileSystem,
     required super.platform,
+    this.customDebuggerInitialized,
+    this.preAppStart,
     this.simulateAppStarted = true,
     this.simulateAppStopError = false,
     this.supportsRestart = true,
-    this.preAppStart,
   }) {
     clientChannel.listen((ProtocolMessage message) {
       _handleDapToClientMessage(message);
@@ -59,6 +62,7 @@ class FakeFlutterDebugAdapter extends FlutterDebugAdapter {
 
   var _seq = 1;
   final ByteStreamServerChannel clientChannel;
+  final Future<void>? customDebuggerInitialized;
   final bool simulateAppStarted;
   final bool simulateAppStopError;
   final bool supportsRestart;
@@ -206,6 +210,9 @@ class FakeFlutterDebugAdapter extends FlutterDebugAdapter {
 
   @override
   Future<void> get debuggerInitialized {
+    if (customDebuggerInitialized != null) {
+      return customDebuggerInitialized!;
+    }
     // If we were mocking debug mode, then simulate the debugger initializing.
     return enableDebugger
         ? Future<void>.value()
@@ -218,6 +225,7 @@ class FakeFlutterTestDebugAdapter extends FlutterTestDebugAdapter {
   factory FakeFlutterTestDebugAdapter({
     required FileSystem fileSystem,
     required Platform platform,
+    Future<void>? customDebuggerInitialized,
   }) {
     final stdinController = StreamController<List<int>>();
     final stdoutController = StreamController<List<int>>();
@@ -229,6 +237,7 @@ class FakeFlutterTestDebugAdapter extends FlutterTestDebugAdapter {
       channel,
       fileSystem: fileSystem,
       platform: platform,
+      customDebuggerInitialized: customDebuggerInitialized,
     );
   }
 
@@ -238,10 +247,12 @@ class FakeFlutterTestDebugAdapter extends FlutterTestDebugAdapter {
     ByteStreamServerChannel channel, {
     required super.fileSystem,
     required super.platform,
+    this.customDebuggerInitialized,
   }) : super(channel);
 
   final StreamSink<List<int>> stdin;
   final Stream<List<int>> stdout;
+  final Future<void>? customDebuggerInitialized;
 
   late String executable;
   late List<String> processArgs;
@@ -260,6 +271,9 @@ class FakeFlutterTestDebugAdapter extends FlutterTestDebugAdapter {
 
   @override
   Future<void> get debuggerInitialized {
+    if (customDebuggerInitialized != null) {
+      return customDebuggerInitialized!;
+    }
     // If we were mocking debug mode, then simulate the debugger initializing.
     return enableDebugger
         ? Future<void>.value()


### PR DESCRIPTION
## Description

When a target application process exits prematurely (e.g. exit code 255) before the Debug Adapter Protocol (DAP) initialization handshake completes, `flutter_tools` crashed with an unhandled `DebugAdapterException` in the Dart Zone.

In Flutter 3.47.2 telemetry, this was the #3 top crasher with 203 crashes (`DebugAdapterException-34d39b25`).

### Root Cause
1. `FlutterBaseDebugAdapter.handleSessionTerminate` completed `debuggerInitializationFailedCompleter.completeError(...)` before calling `super.handleSessionTerminate(...)`.
2. In `package:dap_adapters` (`DartDebugAdapter`), `handleSessionTerminate` is asynchronous and awaits pending output events before setting `isTerminating = true`.
3. In `FlutterDebugAdapter._handleAppStarted`, the unawaited asynchronous message handler caught the error while `isTerminating` was still `false`, rethrowing `DebugAdapterException` into the Zone.

### Fix
1. Synchronously set `isTerminating = true` in `FlutterBaseDebugAdapter.handleSessionTerminate`.
2. In `FlutterDebugAdapter._handleAppStarted`, catch `DebugAdapterException` and send the message to console output rather than rethrowing into the Zone.
3. Clean up early termination message formatting when `exitSuffix` is provided.

## Related Issues
* Fixes crasher `DebugAdapterException-34d39b25` in Flutter 3.47.1 and 3.47.2 telemetry.

## Tests
* Added regression tests in `packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart` and `flutter_test_adapter_test.dart` verifying that early process exit outputs cleanly to console and does not produce unhandled asynchronous exceptions.