### PR TITLE
[stable] [flutter_tools] Roll package:dds to 5.4.0

### DIFF
--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   analyzer: 10.1.0
   archive: 3.6.1
   args: 2.7.0
-  dds: 5.3.0
+  dds: 5.4.0
   dwds: 27.1.2
   code_builder: 4.11.1
   collection: 1.19.1
@@ -85,7 +85,7 @@ dependencies:
   csslib: 1.0.2
   dap: 1.4.0
   dds_service_extensions: 2.1.0
-  devtools_shared: 12.1.0
+  devtools_shared: 13.1.0
   dtd: 4.0.0
   extension_discovery: 2.1.0
   fixnum: 1.1.1
@@ -127,4 +127,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: ctgrgi
+# PUBSPEC CHECKSUM: qi12j

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -127,4 +127,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: qi12j
+# PUBSPEC CHECKSUM: 8d140k

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -263,10 +263,10 @@ packages:
     dependency: transitive
     description:
       name: dds
-      sha256: "6673c5b29e502fd44dbf5836685e7c7c16b11c0fa7f91ef241e0cbf0638c8794"
+      sha256: f8e875dcd7b5e5073a7bfe54095144c70487f18e2f8e47fa51c09dd67eccfb0c
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "5.4.0"
   dds_service_extensions:
     dependency: transitive
     description:
@@ -279,10 +279,10 @@ packages:
     dependency: transitive
     description:
       name: devtools_shared
-      sha256: "2daf7a9fba6a470668b26ecbd04200f7bf992aad81a2c31d12457c7791419dea"
+      sha256: "13df2c17d5f21dd7c92d08145386d45e1153364c04e531e994afb0ee7b67554b"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "13.1.0"
   dtd:
     dependency: transitive
     description:


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
https://github.com/flutter/flutter/pull/189507

### Impact Description:
In Flutter 3.47.2 crash reports, `FormatException at _ChunkedJsonParser.fail` was a top crasher accounting for 170 crashes (11.4% of top 10 crashes). When `package:dds` 5.3.0 launches the Dart Development Service and the process experiences a startup failure (such as native library dlopen errors or immediate exit), `stderr` emits non-JSON text or closes prematurely. `package:dds` 5.3.0 piped `stderr` directly to `json.decoder` without an `onError:` callback, throwing an unhandled `FormatException` that crashed `flutter_tools`. Rolling `package:dds` 5.4.0 addresses these stream errors and stabilizes DDS initialization.

### Changelog Description:
[flutter/189507] When Dart Development Service encounters a startup failure, flutter_tools crashes with an unhandled FormatException.

### Workaround:
None.

### Risk:
  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
  - [x] Yes
  - [ ] No

### Validation Steps:
1. Verify hermetic DDS tests pass: `dart test packages/flutter_tools/test/general.shard/base/dds_exception_test.dart`.
2. Verify package dependencies and lockfile integrity.