### PR TITLE
[CP-stable] Prepare and warn when missing iOS Device Support Symbols

### DIFF
--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -20,6 +20,7 @@ import '../device.dart';
 import '../macos/xcode.dart';
 import '../project.dart';
 import 'application_package.dart';
+import 'device_support.dart';
 import 'lldb.dart';
 import 'xcode_debug.dart';
 import 'xcodeproj.dart';
@@ -101,6 +102,7 @@ class IOSCoreDeviceLauncher {
   /// Requires Xcode 16+.
   Future<bool> launchAppWithLLDBDebugger({
     required String deviceId,
+    required IOSDeviceSupport deviceSupport,
     required String bundlePath,
     required String bundleId,
     required List<String> launchArguments,
@@ -150,12 +152,22 @@ class IOSCoreDeviceLauncher {
       return false;
     }
 
+    // Kill LLDB and devicectl if the CLI shuts down so they do not hang in the background.
+    shutdownHooks.addShutdownHook(() async {
+      try {
+        await stopApp(deviceId: deviceId, processId: processId);
+      } on Exception {
+        // ignore any failures
+      }
+    });
+
     // Start LLDB and attach to the device process.
     final bool attachStatus = await _lldb.attachAndStart(
       deviceId: deviceId,
       appProcessId: processId,
       lldbLogForwarder: lldbLogForwarder,
       mode: mode,
+      deviceSupport: deviceSupport,
     );
 
     // If it fails to attach with lldb, kill the launched process so it doesn't stay hanging.

--- a/packages/flutter_tools/lib/src/ios/device_support.dart
+++ b/packages/flutter_tools/lib/src/ios/device_support.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
@@ -11,47 +12,94 @@ import '../base/version.dart';
 import '../convert.dart';
 import '../macos/xcode.dart';
 
-/// A class to handle preparing the device support for iOS devices.
+/// A class to handle preparing the device support for an iOS/iPad device.
 class IOSDeviceSupport {
   IOSDeviceSupport({
     required Logger logger,
     required ProcessUtils processUtils,
     required Xcode? xcode,
+    required String deviceId,
+    required Directory? homeDirectory,
+    required String? modelCode,
+    required String? operatingSystemVersion,
+    required String? cpuArchitectureString,
   }) : _xcode = xcode,
        _logger = logger,
-       _processUtils = processUtils;
+       _processUtils = processUtils,
+       _deviceId = deviceId,
+       _homeDirectory = homeDirectory,
+       _modelCode = modelCode,
+       _operatingSystemVersion = operatingSystemVersion,
+       _cpuArchitectureString = cpuArchitectureString;
 
   final Logger _logger;
   final ProcessUtils _processUtils;
   final Xcode? _xcode;
 
-  /// Calls `xcodebuild -prepareDeviceSupport` for the given [deviceId] and streams the logs when
-  /// copying is in progress.
+  final String _deviceId;
+  final Directory? _homeDirectory;
+  final String? _modelCode;
+  final String? _operatingSystemVersion;
+  final String? _cpuArchitectureString;
+
+  /// The directory that contains iOS Device Support symbols for all devices.
+  ///
+  /// Return null if the $HOME directory cannot be found.
+  late final Directory? _deviceSupportDirectory = _homeDirectory
+      ?.childDirectory('Library')
+      .childDirectory('Developer')
+      .childDirectory('Xcode')
+      .childDirectory('iOS DeviceSupport');
+
+  /// Command to copy device support symbols from device to host machine.
+  List<String> get _prepareDeviceSupportCommand => [
+    'xcrun',
+    'xcodebuild',
+    '-prepareDeviceSupport',
+    '-destination',
+    'id=$_deviceId',
+  ];
+
+  /// Whether the prepareDeviceSupport command is available. Available on Xcode 16.3+.
+  late final bool _prepareDeviceSupportCommandAvailable = () {
+    final Version? xcodeVersion = _xcode?.currentVersion;
+    if (xcodeVersion == null || xcodeVersion < Version(16, 3, 0)) {
+      return false;
+    }
+    return true;
+  }();
+
+  /// Returns the directory for existing Device Support symbols. If there is not an existing
+  /// directory, returns null.
+  Directory? get existingDeviceSupportSymbols {
+    final (Directory? symbolDirectory, Directory? archSymbolDirectory) = _findSymbolDirectories();
+    if (archSymbolDirectory != null && archSymbolDirectory.existsSync()) {
+      return archSymbolDirectory;
+    }
+    if (symbolDirectory != null && symbolDirectory.existsSync()) {
+      return symbolDirectory;
+    }
+    return null;
+  }
+
+  /// Calls `xcodebuild -prepareDeviceSupport` and streams the logs when copying is in progress.
   ///
   /// The command copies symbols from the iOS device to the host machine and stores them in
   /// $HOME/Library/Developer/Xcode/iOS DeviceSupport. Without these symbols, debugging is
   /// extremely slow.
-  Future<void> prepareDeviceSupport(String deviceId) async {
-    final Version? xcodeVersion = _xcode?.currentVersion;
-    if (xcodeVersion == null || xcodeVersion < Version(16, 3, 0)) {
-      // The prepareDeviceSupport command is only available on Xcode 16.3+
+  Future<void> prepareDeviceSupport() async {
+    if (!_prepareDeviceSupportCommandAvailable || existingDeviceSupportSymbols != null) {
       return;
     }
-    final command = [
-      'xcrun',
-      'xcodebuild',
-      '-prepareDeviceSupport',
-      '-destination',
-      'id=$deviceId',
-    ];
+
     try {
-      final Process process = await _processUtils.start(command);
+      final Process process = await _processUtils.start(_prepareDeviceSupportCommand);
 
       final timer = Timer(const Duration(seconds: 10), () {
         _logger.printError(
           'Xcode is taking longer than expected to start preparing Device Support symbols...\n'
-          'Connect your device via USB and try running this command manually:\n'
-          '  "${command.join(' ')}"',
+          'Try closing Xcode, connecting your device via USB, and running the following command:\n'
+          '  "${_prepareDeviceSupportCommand.join(' ')}"',
         );
       });
 
@@ -63,7 +111,7 @@ class IOSDeviceSupport {
               printToTrace = false;
               _logger.printStatus(
                 'Copying Device Support symbols. This may take several minutes to complete...\n'
-                'Please do not connect or disconnect your device until finished.',
+                'Please do not connect or disconnect your device or open Xcode until finished.',
               );
               timer.cancel();
             }
@@ -110,5 +158,93 @@ class IOSDeviceSupport {
       );
       _logger.printTrace('$stackTrace');
     }
+  }
+
+  /// Returns a warning describing the status of Device Support symbols and guided actions to
+  /// resolve issues.
+  String? missingSymbolsWarning({bool warnWhenSymbolsExist = false}) {
+    const reducePerformance =
+        'This will likely reduce debugging performance and may cause the app to hang on a white '
+        'screen during launch.';
+    const expectedPath =
+        r'Once Device Support symbols are finished being copied, they are expected to be found at';
+
+    if (existingDeviceSupportSymbols != null) {
+      if (warnWhenSymbolsExist) {
+        final String action;
+        if (_prepareDeviceSupportCommandAvailable) {
+          action =
+              'Connect the device via USB and trigger a copy:\n'
+              '     ${_prepareDeviceSupportCommand.join(' ')}';
+        } else {
+          action =
+              'Connect the device via USB, close and then re-open Xcode. It may take several '
+              'minutes for Xcode to copy symbols from the device. $expectedPath ${existingDeviceSupportSymbols!.path}';
+        }
+        return 'Xcode Device Support symbols exist for this device, but are being read from '
+            'process memory. $reducePerformance\n'
+            'To re-copy symbols from your device, complete the following steps:\n'
+            '  1. Remove cached symbols:\n'
+            '     rm -rf "${existingDeviceSupportSymbols!.parent.path}"\n'
+            '  2. $action';
+      }
+      return null;
+    }
+
+    final (Directory? symbolDirectory, Directory? archSymbolDirectory) = _findSymbolDirectories();
+
+    const unableToFind = 'Xcode Device Support was not found for this device.';
+    const incompleteCopy = 'Xcode has not finished copying Device Support symbols for this device.';
+    final String action;
+    if (_prepareDeviceSupportCommandAvailable) {
+      action =
+          'To trigger Device Symbols to be copied, connect the device via USB, and run this command:\n'
+          '  "${_prepareDeviceSupportCommand.join(' ')}"';
+    } else {
+      action =
+          'To trigger Device Symbols to be copied, connect the device via USB, close and then '
+          're-open Xcode. It may take several minutes for Xcode to copy symbols from the device.';
+    }
+
+    const retryAction = 'Please retry "flutter run" once symbols are finished being copied.';
+
+    // The symbol directory may be null if the home directory could not be determined.
+    if (symbolDirectory == null) {
+      return '$unableToFind $reducePerformance\n$action\n$expectedPath '
+          '\$HOME/Library/Developer/Xcode/iOS DeviceSupport\n$retryAction';
+    }
+
+    // If the device's directory exists, it means Xcode has at least started copying symbols.
+    final bool deviceDirExists = symbolDirectory.parent.existsSync();
+    final status = deviceDirExists ? incompleteCopy : unableToFind;
+    final archPath = archSymbolDirectory != null ? ' or ${archSymbolDirectory.path}' : '';
+
+    return '$status $reducePerformance\n$action\n$expectedPath ${symbolDirectory.path}$archPath\n'
+        '$retryAction';
+  }
+
+  /// Helper method to find the Device Support Symbols directories for a given device.
+  ///
+  /// Returns a tuple of the symbol directory and the architecture-specific symbol directory.
+  /// If the paths to the directories cannot be constructed, returns (null, null).
+  ///
+  /// The architecture-specific symbol directory is only present on newer versions of iOS (27+).
+  (Directory?, Directory?) _findSymbolDirectories() {
+    if (_deviceSupportDirectory == null || _modelCode == null || _operatingSystemVersion == null) {
+      return (null, null);
+    }
+    final Directory deviceDirectory = _deviceSupportDirectory.childDirectory(
+      '$_modelCode $_operatingSystemVersion',
+    );
+    final Directory symbolDirectory = deviceDirectory.childDirectory('Symbols');
+
+    // iOS 27+ devices seem to store the symbol directory in a sub-directory
+    // /Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPad14,3 27.0 (24A5380h)/arm64e/Symbols
+    final Directory? archSymbolDirectory =
+        _cpuArchitectureString != null && _cpuArchitectureString.isNotEmpty
+        ? deviceDirectory.childDirectory(_cpuArchitectureString).childDirectory('Symbols')
+        : null;
+
+    return (symbolDirectory, archSymbolDirectory);
   }
 }

--- a/packages/flutter_tools/lib/src/ios/device_support.dart
+++ b/packages/flutter_tools/lib/src/ios/device_support.dart
@@ -1,0 +1,114 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../base/io.dart';
+import '../base/logger.dart';
+import '../base/process.dart';
+import '../base/version.dart';
+import '../convert.dart';
+import '../macos/xcode.dart';
+
+/// A class to handle preparing the device support for iOS devices.
+class IOSDeviceSupport {
+  IOSDeviceSupport({
+    required Logger logger,
+    required ProcessUtils processUtils,
+    required Xcode? xcode,
+  }) : _xcode = xcode,
+       _logger = logger,
+       _processUtils = processUtils;
+
+  final Logger _logger;
+  final ProcessUtils _processUtils;
+  final Xcode? _xcode;
+
+  /// Calls `xcodebuild -prepareDeviceSupport` for the given [deviceId] and streams the logs when
+  /// copying is in progress.
+  ///
+  /// The command copies symbols from the iOS device to the host machine and stores them in
+  /// $HOME/Library/Developer/Xcode/iOS DeviceSupport. Without these symbols, debugging is
+  /// extremely slow.
+  Future<void> prepareDeviceSupport(String deviceId) async {
+    final Version? xcodeVersion = _xcode?.currentVersion;
+    if (xcodeVersion == null || xcodeVersion < Version(16, 3, 0)) {
+      // The prepareDeviceSupport command is only available on Xcode 16.3+
+      return;
+    }
+    final command = [
+      'xcrun',
+      'xcodebuild',
+      '-prepareDeviceSupport',
+      '-destination',
+      'id=$deviceId',
+    ];
+    try {
+      final Process process = await _processUtils.start(command);
+
+      final timer = Timer(const Duration(seconds: 10), () {
+        _logger.printError(
+          'Xcode is taking longer than expected to start preparing Device Support symbols...\n'
+          'Connect your device via USB and try running this command manually:\n'
+          '  "${command.join(' ')}"',
+        );
+      });
+
+      var printToTrace = true;
+      final StreamSubscription<String> stdoutSubscription = process.stdout
+          .transform(utf8.decoder)
+          .listen((String text) {
+            if (text.contains('Copying')) {
+              printToTrace = false;
+              _logger.printStatus(
+                'Copying Device Support symbols. This may take several minutes to complete...\n'
+                'Please do not connect or disconnect your device until finished.',
+              );
+              timer.cancel();
+            }
+            if (printToTrace) {
+              _logger.printTrace(text);
+            } else {
+              _logger.printStatus(text, newline: false);
+            }
+          });
+
+      final StreamSubscription<String> stderrSubscription = process.stderr
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((String line) {
+            _logger.printError(line);
+          });
+
+      try {
+        // Wait for stdout and stderr to be fully processed
+        // because process.exitCode may complete first.
+        await Future.wait<void>(<Future<void>>[
+          stdoutSubscription.asFuture<void>(),
+          stderrSubscription.asFuture<void>(),
+        ]);
+
+        unawaited(stdoutSubscription.cancel());
+        unawaited(stderrSubscription.cancel());
+
+        final int exitCode = await process.exitCode;
+        if (exitCode != 0) {
+          _logger.printError('xcodebuild -prepareDeviceSupport exited with code $exitCode');
+        }
+      } finally {
+        timer.cancel();
+      }
+
+      // Print an empty line so that next prints aren't inline with logs from here.
+      if (!printToTrace) {
+        _logger.printStatus('');
+      }
+    } on ProcessException catch (exception, stackTrace) {
+      _logger.printError(
+        'Process exception running "xcodebuild -prepareDeviceSupport": $exception',
+      );
+      _logger.printTrace('$stackTrace');
+    }
+  }
+}

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -38,6 +38,7 @@ import '../protocol_discovery.dart';
 import '../vmservice.dart';
 import 'application_package.dart';
 import 'core_devices.dart';
+import 'device_support.dart';
 import 'ios_deploy.dart';
 import 'ios_workflow.dart';
 import 'iproxy.dart';
@@ -308,6 +309,7 @@ class IOSDevice extends Device {
   IOSDevice(
     super.id, {
     required FileSystem fileSystem,
+    required ProcessUtils processUtils,
     required this.name,
     required this.cpuArchitecture,
     required this.connectionInterface,
@@ -325,14 +327,17 @@ class IOSDevice extends Device {
     required IProxy iProxy,
     required super.logger,
     required Analytics analytics,
+    required Xcode? xcode,
   }) : _sdkVersion = sdkVersion,
        _iosDeploy = iosDeploy,
        _iMobileDevice = iMobileDevice,
        _coreDeviceControl = coreDeviceControl,
        _coreDeviceLauncher = coreDeviceLauncher,
        _xcodeDebug = xcodeDebug,
+       _xcode = xcode,
        _iproxy = iProxy,
        _fileSystem = fileSystem,
+       _processUtils = processUtils,
        _logger = logger,
        _analytics = analytics,
        _platform = platform,
@@ -347,12 +352,14 @@ class IOSDevice extends Device {
   final IOSDeploy _iosDeploy;
   final Analytics _analytics;
   final FileSystem _fileSystem;
+  final ProcessUtils _processUtils;
   final Logger _logger;
   final Platform _platform;
   final IMobileDevice _iMobileDevice;
   final IOSCoreDeviceControl _coreDeviceControl;
   final IOSCoreDeviceLauncher _coreDeviceLauncher;
   final XcodeDebug _xcodeDebug;
+  final Xcode? _xcode;
   final IProxy _iproxy;
 
   Version? get sdkVersion {
@@ -559,6 +566,15 @@ class IOSDevice extends Device {
       return LaunchResult.failed();
     }
 
+    final bool shouldAttachDebugger = shouldAttachLLDBDebugger(debuggingOptions);
+    if (shouldAttachDebugger) {
+      await IOSDeviceSupport(
+        logger: _logger,
+        processUtils: _processUtils,
+        xcode: _xcode,
+      ).prepareDeviceSupport(id);
+    }
+
     // Step 3: Attempt to install the application on the device.
     final List<String> launchArguments = debuggingOptions.getIOSLaunchArguments(
       EnvironmentType.physical,
@@ -607,6 +623,7 @@ class IOSDevice extends Device {
           mainPath: mainPath,
           discoveryTimeout: discoveryTimeout,
           shutdownHooks: shutdownHooks ?? globals.shutdownHooks,
+          shouldAttachDebugger: shouldAttachDebugger,
         );
         installationResult = result ? 0 : 1;
         deploymentMethod = coreDeviceDeploymentMethod;
@@ -1014,6 +1031,15 @@ class IOSDevice extends Device {
     );
   }
 
+  /// Whether the LLDB debugger should be attached.
+  ///
+  /// The LLDB debugger should only be attached in debug mode or if the user uses the
+  /// `--ios-profile-debugger` flag in profile mode.
+  bool shouldAttachLLDBDebugger(DebuggingOptions debuggingOptions) {
+    return debuggingOptions.buildInfo.isDebug ||
+        (debuggingOptions.buildInfo.isProfile && (debuggingOptions.iosProfileDebugger ?? false));
+  }
+
   /// Uses either `devicectl` or Xcode automation to install, launch, and debug
   /// apps on physical iOS devices.
   ///
@@ -1037,6 +1063,7 @@ class IOSDevice extends Device {
     required IOSApp package,
     required List<String> launchArguments,
     required String? mainPath,
+    required bool shouldAttachDebugger,
     required ShutdownHooks shutdownHooks,
     @visibleForTesting Duration? discoveryTimeout,
   }) async {
@@ -1078,10 +1105,6 @@ class IOSDevice extends Device {
       if (deviceLogReader is IOSDeviceLogReader) {
         await deviceLogReader.listenToCoreDeviceLauncher(_coreDeviceLauncher);
       }
-
-      final bool shouldAttachDebugger =
-          debuggingOptions.buildInfo.isDebug ||
-          (debuggingOptions.buildInfo.isProfile && (debuggingOptions.iosProfileDebugger ?? false));
 
       if (shouldAttachDebugger) {
         final bool launchSuccess = await _coreDeviceLauncher.launchAppWithLLDBDebugger(

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -309,15 +309,19 @@ class IOSDevice extends Device {
   IOSDevice(
     super.id, {
     required FileSystem fileSystem,
+    required FileSystemUtils fileSystemUtils,
     required ProcessUtils processUtils,
     required this.name,
     required this.cpuArchitecture,
+    String? cpuArchitectureString,
     required this.connectionInterface,
     required this.isConnected,
     required this.isPaired,
     required this.devModeEnabled,
     required this.isCoreDevice,
     String? sdkVersion,
+    String? modelCode,
+    String? operatingSystemVersion,
     required Platform platform,
     required IOSDeploy iosDeploy,
     required IMobileDevice iMobileDevice,
@@ -329,6 +333,9 @@ class IOSDevice extends Device {
     required Analytics analytics,
     required Xcode? xcode,
   }) : _sdkVersion = sdkVersion,
+       _modelCode = modelCode,
+       _operatingSystemVersion = operatingSystemVersion,
+       _cpuArchitectureString = cpuArchitectureString,
        _iosDeploy = iosDeploy,
        _iMobileDevice = iMobileDevice,
        _coreDeviceControl = coreDeviceControl,
@@ -337,6 +344,7 @@ class IOSDevice extends Device {
        _xcode = xcode,
        _iproxy = iProxy,
        _fileSystem = fileSystem,
+       _fileSystemUtils = fileSystemUtils,
        _processUtils = processUtils,
        _logger = logger,
        _analytics = analytics,
@@ -349,9 +357,12 @@ class IOSDevice extends Device {
   }
 
   final String? _sdkVersion;
+  final String? _modelCode;
+  final String? _operatingSystemVersion;
   final IOSDeploy _iosDeploy;
   final Analytics _analytics;
   final FileSystem _fileSystem;
+  final FileSystemUtils _fileSystemUtils;
   final ProcessUtils _processUtils;
   final Logger _logger;
   final Platform _platform;
@@ -371,6 +382,19 @@ class IOSDevice extends Device {
     return sdkVersion?.major ?? 0;
   }
 
+  late final IOSDeviceSupport deviceSupport = IOSDeviceSupport(
+    logger: _logger,
+    processUtils: _processUtils,
+    xcode: _xcode,
+    homeDirectory: _fileSystemUtils.homeDirPath == null
+        ? null
+        : _fileSystem.directory(_fileSystemUtils.homeDirPath),
+    modelCode: _modelCode,
+    operatingSystemVersion: _operatingSystemVersion,
+    cpuArchitectureString: _cpuArchitectureString,
+    deviceId: id,
+  );
+
   @override
   final String name;
 
@@ -378,6 +402,8 @@ class IOSDevice extends Device {
   bool supportsRuntimeMode(BuildMode buildMode) => buildMode != BuildMode.jitRelease;
 
   final DarwinArch cpuArchitecture;
+
+  final String? _cpuArchitectureString;
 
   @override
   /// The [connectionInterface] provided from `XCDevice.getAvailableIOSDevices`
@@ -568,11 +594,7 @@ class IOSDevice extends Device {
 
     final bool shouldAttachDebugger = shouldAttachLLDBDebugger(debuggingOptions);
     if (shouldAttachDebugger) {
-      await IOSDeviceSupport(
-        logger: _logger,
-        processUtils: _processUtils,
-        xcode: _xcode,
-      ).prepareDeviceSupport(id);
+      await deviceSupport.prepareDeviceSupport();
     }
 
     // Step 3: Attempt to install the application on the device.
@@ -880,8 +902,8 @@ class IOSDevice extends Device {
         pattern: RegExp(
           '`UIScene` lifecycle will soon be required|This process does not adopt UIScene lifecycle',
         ),
-        action: () {
-          globals.printWarning(uisceneWarning);
+        action: (String message) {
+          _logger.printWarning(uisceneWarning);
         },
         excludeFromStream: true,
       );
@@ -891,7 +913,7 @@ class IOSDevice extends Device {
     final uisceneCrashInterceptor = LogInterceptor(
       identifier: 'uiscene_crash',
       pattern: RegExp(r'UIScene life\s?cycle is required'),
-      action: () {
+      action: (String message) {
         throwToolExit(kUISceneMigrationRequiredError);
       },
       excludeFromStream: false,
@@ -906,7 +928,7 @@ class IOSDevice extends Device {
     final appTerminatedInterceptor = LogInterceptor(
       identifier: 'app_terminated',
       pattern: RegExp('^App terminated due to signal'),
-      action: () {
+      action: (String message) {
         if (!appTerminatedCompleter.isCompleted) {
           appTerminatedCompleter.complete();
         }
@@ -914,6 +936,20 @@ class IOSDevice extends Device {
       excludeFromStream: false,
     );
     deviceLogReader.addLogInterceptor(appTerminatedInterceptor);
+
+    final missingSymbolsInterceptor = LogInterceptor(
+      identifier: 'missing_symbols',
+      pattern: LLDB.missingSymbolsPattern,
+      action: (String message) {
+        _logger.printTrace(message);
+        final String? warning = deviceSupport.missingSymbolsWarning(warnWhenSymbolsExist: true);
+        if (warning != null) {
+          _logger.printWarning(warning);
+        }
+      },
+      excludeFromStream: true,
+    );
+    deviceLogReader.addLogInterceptor(missingSymbolsInterceptor);
   }
 
   /// Find the Dart VM url using ProtocolDiscovery (logs from `idevicesyslog`)
@@ -985,7 +1021,7 @@ class IOSDevice extends Device {
     return LogInterceptor(
       identifier: kJITCrashLogInterceptorIdentifier,
       pattern: kJITCrashFailureMessage,
-      action: () {
+      action: (String message) {
         throwToolExit(jitCrashFailureInstructions(deviceSdkVersion));
       },
       excludeFromStream: false,
@@ -1109,6 +1145,7 @@ class IOSDevice extends Device {
       if (shouldAttachDebugger) {
         final bool launchSuccess = await _coreDeviceLauncher.launchAppWithLLDBDebugger(
           deviceId: id,
+          deviceSupport: deviceSupport,
           bundlePath: package.deviceBundlePath,
           bundleId: package.id,
           launchArguments: launchArguments,
@@ -1447,7 +1484,7 @@ class LogInterceptor {
   final Pattern pattern;
 
   /// If the log contain the [pattern], the [action] will be called.
-  final void Function() action;
+  final void Function(String message) action;
 
   /// If `true`, the log will be excluded from being added to the stream.
   final bool excludeFromStream;
@@ -1485,7 +1522,7 @@ abstract class SharedIOSDeviceLogReader extends DeviceLogReader {
   bool _interceptLog(String message) {
     for (final LogInterceptor interceptor in _logInterceptors) {
       if (message.contains(interceptor.pattern)) {
-        interceptor.action();
+        interceptor.action(message);
         if (interceptor.excludeFromStream) {
           return true;
         }

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -7,11 +7,13 @@ library;
 
 import 'dart:async';
 
+import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
+import 'device_support.dart';
 import 'xcodeproj.dart';
 
 /// LLDB is the default debugger in Xcode on macOS. Once the application has
@@ -38,6 +40,8 @@ class LLDB {
 
   /// Whether or not the LLDB process has attached and resumed the application process.
   var _isAttached = false;
+
+  var _warnedAboutMissingSymbols = false;
 
   /// The process id of the application running on the iOS device.
   int? get appProcessId => _lldbProcess?.appProcessId;
@@ -80,6 +84,12 @@ class LLDB {
     _stopHookProcessedPattern,
   ];
 
+  /// Pattern of lldb log when libobjc.A.dylib is being read from process memory. This indicates
+  /// that Device Support symbols were not found on the host machine.
+  static final missingSymbolsPattern = RegExp(
+    'warning: libobjc.A.dylib is being read from process memory.',
+  );
+
   /// Breakpoint script required for JIT on iOS.
   ///
   /// This should match the "handle_new_rx_page" function in [IosProject._lldbPythonHelperTemplate].
@@ -114,19 +124,24 @@ return False
     required int appProcessId,
     required LLDBLogForwarder lldbLogForwarder,
     required BuildMode mode,
+    required IOSDeviceSupport deviceSupport,
   }) async {
     Timer? timer;
     try {
       timer = Timer(const Duration(minutes: 1), () {
-        _logger.printError(
-          'LLDB is taking longer than expected to start debugging the app. '
-          "LLDB debugging can be disabled for the project by adding the following in the project's pubspec.yaml:\n"
-          'flutter:\n'
-          '  config:\n'
-          '    enable-lldb-debugging: false\n'
-          'Or disable LLDB debugging globally with the following command:\n'
-          '  "flutter config --no-enable-lldb-debugging"',
-        );
+        final String? warning = deviceSupport.missingSymbolsWarning();
+        if (warning != null) {
+          _logger.printWarning(
+            'LLDB is taking longer than expected to start debugging the app. $warning',
+          );
+          _warnedAboutMissingSymbols = true;
+        } else {
+          _logger.printError(
+            'LLDB is taking longer than expected to start debugging the app. Try again using '
+            '--verbose and file a bug including the verbose logs '
+            'at https://github.com/flutter/flutter/issues/new?template=01_activation.yml',
+          );
+        }
       });
 
       final bool start = await _startLLDB(
@@ -137,11 +152,14 @@ return False
         return false;
       }
       await _selectDevice(deviceId);
+      await _addSymbolSearchPaths(deviceSupport);
+
       if (mode == BuildMode.debug) {
         await _setBreakpoint();
       }
       await _attachToAppProcess(appProcessId);
       await _setupStopHooks();
+      await _printDeviceSupportStatus();
       await _resumeProcess(mode);
       _isAttached = true;
     } on _LLDBError catch (e) {
@@ -232,12 +250,34 @@ return False
     }
     _logCompleter = null;
     _isAttached = false;
+    _warnedAboutMissingSymbols = false;
     return success;
   }
 
   /// Selects a device for LLDB to interact with.
   Future<void> _selectDevice(String deviceId) async {
     await _lldbProcess?.stdinWriteln('device select $deviceId');
+  }
+
+  /// Adds the symbol search paths to the LLDB process.
+  Future<void> _addSymbolSearchPaths(IOSDeviceSupport deviceSupport) async {
+    final Directory? symbolDirectory = deviceSupport.existingDeviceSupportSymbols;
+    if (symbolDirectory == null) {
+      return;
+    }
+    await _lldbProcess?.stdinWriteln(
+      'platform select remote-ios --sysroot "${symbolDirectory.path}"',
+    );
+  }
+
+  /// Prints logs of available Device Support
+  Future<void> _printDeviceSupportStatus() async {
+    final Future<String> futureLog = _startWaitingForLog(
+      RegExp(r'\s*Platform:'),
+    ).then((value) => value, onError: _handleAsyncError);
+
+    await _lldbProcess?.stdinWriteln('platform status');
+    await futureLog;
   }
 
   /// Attaches LLDB to the [appProcessId] running on the device.
@@ -346,6 +386,13 @@ return False
   }
 
   bool _ignoreLog(String log) {
+    // We only want to warn about missing symbols once.
+    if (log.contains(missingSymbolsPattern)) {
+      if (_warnedAboutMissingSymbols) {
+        return true;
+      }
+      _warnedAboutMissingSymbols = true;
+    }
     return _ignorePatterns.any((Pattern pattern) => log.contains(pattern));
   }
 }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -829,7 +829,7 @@ class _IOSSimulatorLogReader extends SharedIOSDeviceLogReader {
     final uisceneCrashInterceptor = LogInterceptor(
       identifier: 'uiscene_crash',
       pattern: RegExp(r'UIScene life\s?cycle is required'),
-      action: () {
+      action: (String message) {
         throwToolExit(kUISceneMigrationRequiredError);
       },
       excludeFromStream: false,

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -652,10 +652,12 @@ class XCDevice {
             xcodeProjectInterpreter: globals.xcodeProjectInterpreter!,
           ),
           xcodeDebug: _xcodeDebug,
+          xcode: _xcode,
           platform: globals.platform,
           devModeEnabled: devModeEnabled,
           isPaired: isPaired,
           isCoreDevice: coreDevice != null,
+          processUtils: _processUtils,
         );
       }
     }

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -550,6 +550,9 @@ class XCDevice {
         var devModeEnabled = true;
         var isConnected = true;
         var isPaired = true;
+        final modelCode = device['modelCode'] as String?;
+        final operatingSystemVersion = device['operatingSystemVersion'] as String?;
+        final cpuArchitectureString = device['architecture'] as String?;
         final Map<String, Object?>? errorProperties = _errorProperties(device);
         if (errorProperties != null) {
           final String? errorMessage = _parseErrorMessage(errorProperties);
@@ -633,11 +636,15 @@ class XCDevice {
           identifier,
           name: name,
           cpuArchitecture: _cpuArchitecture(device),
+          cpuArchitectureString: cpuArchitectureString,
           connectionInterface: connectionInterface,
           isConnected: isConnected,
           sdkVersion: sdkVersionString,
+          modelCode: modelCode,
+          operatingSystemVersion: operatingSystemVersion,
           iProxy: _iProxy,
           fileSystem: globals.fs,
+          fileSystemUtils: globals.fsUtils,
           logger: _logger,
           analytics: globals.analytics,
           iosDeploy: _iosDeploy,

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -19,6 +19,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/application_package.dart';
 import 'package:flutter_tools/src/ios/core_devices.dart';
+import 'package:flutter_tools/src/ios/device_support.dart';
 import 'package:flutter_tools/src/ios/lldb.dart';
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
@@ -225,6 +226,7 @@ void main() {
 
         final bool result = await launcher.launchAppWithLLDBDebugger(
           deviceId: 'device-id',
+          deviceSupport: createDeviceSupport(),
           bundlePath: 'bundle-path',
           bundleId: 'bundle-id',
           launchArguments: <String>[],
@@ -234,6 +236,126 @@ void main() {
 
         expect(result, isTrue);
         expect(fakeLLDB.attemptedToAttach, isTrue);
+      });
+
+      testWithoutContext('registers shutdown hook to stop app', () async {
+        final fakeCoreDeviceControl = FakeIOSCoreDeviceControl(
+          installResult: IOSCoreDeviceInstallResult.fromJson(const <String, Object?>{
+            'info': <String, Object?>{'outcome': 'success'},
+            'result': <String, Object?>{
+              'installedApplications': [
+                <String, Object?>{'installationURL': '/asdf'},
+              ],
+            },
+          }),
+          launchResult: IOSCoreDeviceLaunchResult.fromJson(const <String, Object?>{
+            'info': <String, Object?>{'outcome': 'success'},
+            'result': <String, Object?>{
+              'process': <String, Object?>{'processIdentifier': 123},
+            },
+          }),
+          runningProcesses: [
+            IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
+              'processIdentifier': 123,
+              'executable': '/asdf',
+            }),
+          ],
+        );
+        final processManager = FakeProcessManager.any();
+        final logger = BufferLogger.test();
+        final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+        final fakeLLDB = FakeLLDB();
+        fakeLLDB.setIsRunning(true, 123);
+        final launcher = IOSCoreDeviceLauncher(
+          coreDeviceControl: fakeCoreDeviceControl,
+          logger: logger,
+          xcodeDebug: FakeXcodeDebug(),
+          fileSystem: MemoryFileSystem.test(),
+          processUtils: processUtils,
+          xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          lldb: fakeLLDB,
+        );
+        final shutdownHooks = FakeShutdownHooks();
+
+        final bool result = await launcher.launchAppWithLLDBDebugger(
+          deviceId: 'device-id',
+          deviceSupport: createDeviceSupport(
+            operatingSystemVersion: '17.0',
+            modelCode: 'iPhone15,2',
+            cpuArchitectureString: 'arm64e',
+          ),
+          bundlePath: 'bundle-path',
+          bundleId: 'bundle-id',
+          launchArguments: <String>[],
+          shutdownHooks: shutdownHooks,
+          mode: BuildMode.debug,
+        );
+
+        expect(result, isTrue);
+        expect(shutdownHooks.registeredHooks, hasLength(1));
+        await shutdownHooks.registeredHooks.first();
+        expect(fakeCoreDeviceControl.terminateProcessCalled, isTrue);
+        expect(fakeCoreDeviceControl.processTerminated, 123);
+        expect(fakeLLDB.exitCalled, isTrue);
+      });
+
+      testWithoutContext('shutdown hook catches Exception thrown by stopApp', () async {
+        final fakeCoreDeviceControl = FakeIOSCoreDeviceControl(
+          installResult: IOSCoreDeviceInstallResult.fromJson(const <String, Object?>{
+            'info': <String, Object?>{'outcome': 'success'},
+            'result': <String, Object?>{
+              'installedApplications': [
+                <String, Object?>{'installationURL': '/asdf'},
+              ],
+            },
+          }),
+          launchResult: IOSCoreDeviceLaunchResult.fromJson(const <String, Object?>{
+            'info': <String, Object?>{'outcome': 'success'},
+            'result': <String, Object?>{
+              'process': <String, Object?>{'processIdentifier': 123},
+            },
+          }),
+          runningProcesses: [
+            IOSCoreDeviceRunningProcess.fromJson(const <String, Object?>{
+              'processIdentifier': 123,
+              'executable': '/asdf',
+            }),
+          ],
+        );
+        fakeCoreDeviceControl.terminateException = Exception('failed to terminate');
+        final processManager = FakeProcessManager.any();
+        final logger = BufferLogger.test();
+        final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+        final fakeLLDB = FakeLLDB();
+        fakeLLDB.setIsRunning(true, 123);
+        final launcher = IOSCoreDeviceLauncher(
+          coreDeviceControl: fakeCoreDeviceControl,
+          logger: logger,
+          xcodeDebug: FakeXcodeDebug(),
+          fileSystem: MemoryFileSystem.test(),
+          processUtils: processUtils,
+          xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager),
+          lldb: fakeLLDB,
+        );
+        final shutdownHooks = FakeShutdownHooks();
+
+        final bool result = await launcher.launchAppWithLLDBDebugger(
+          deviceId: 'device-id',
+          deviceSupport: createDeviceSupport(
+            operatingSystemVersion: '17.0',
+            modelCode: 'iPhone15,2',
+            cpuArchitectureString: 'arm64e',
+          ),
+          bundlePath: 'bundle-path',
+          bundleId: 'bundle-id',
+          launchArguments: <String>[],
+          shutdownHooks: shutdownHooks,
+          mode: BuildMode.debug,
+        );
+
+        expect(result, isTrue);
+        expect(shutdownHooks.registeredHooks, hasLength(1));
+        await expectLater(shutdownHooks.registeredHooks.first(), completes);
       });
 
       testWithoutContext('ignores app extension processes', () async {
@@ -285,6 +407,7 @@ void main() {
 
         final bool result = await launcher.launchAppWithLLDBDebugger(
           deviceId: 'device-id',
+          deviceSupport: createDeviceSupport(),
           bundlePath: 'bundle-path',
           bundleId: 'bundle-id',
           launchArguments: <String>[],
@@ -338,6 +461,7 @@ void main() {
 
         final bool result = await launcher.launchAppWithLLDBDebugger(
           deviceId: 'device-id',
+          deviceSupport: createDeviceSupport(),
           bundlePath: 'bundle-path',
           bundleId: 'bundle-id',
           launchArguments: <String>[],
@@ -384,6 +508,7 @@ void main() {
 
         final bool result = await launcher.launchAppWithLLDBDebugger(
           deviceId: 'device-id',
+          deviceSupport: createDeviceSupport(),
           bundlePath: 'bundle-path',
           bundleId: 'bundle-id',
           launchArguments: <String>[],
@@ -436,6 +561,7 @@ void main() {
 
         final bool result = await launcher.launchAppWithLLDBDebugger(
           deviceId: 'device-id',
+          deviceSupport: createDeviceSupport(),
           bundlePath: 'bundle-path',
           bundleId: 'bundle-id',
           launchArguments: <String>[],
@@ -482,6 +608,7 @@ void main() {
 
         final bool result = await launcher.launchAppWithLLDBDebugger(
           deviceId: 'device-id',
+          deviceSupport: createDeviceSupport(),
           bundlePath: 'bundle-path',
           bundleId: 'bundle-id',
           launchArguments: <String>[],
@@ -530,6 +657,7 @@ void main() {
 
         final bool result = await launcher.launchAppWithLLDBDebugger(
           deviceId: 'device-id',
+          deviceSupport: createDeviceSupport(),
           bundlePath: 'bundle-path',
           bundleId: 'bundle-id',
           launchArguments: <String>[],
@@ -580,6 +708,7 @@ void main() {
 
         final bool result = await launcher.launchAppWithLLDBDebugger(
           deviceId: 'device-id',
+          deviceSupport: createDeviceSupport(),
           bundlePath: 'bundle-path',
           bundleId: 'bundle-id',
           launchArguments: <String>[],
@@ -3905,6 +4034,7 @@ class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {
   bool launchSuccess;
   IOSCoreDeviceInstallResult? installResult;
   bool terminateSuccess;
+  Exception? terminateException;
   int? processTerminated;
   List<IOSCoreDeviceRunningProcess> runningProcesses;
   bool get terminateProcessCalled => processTerminated != null;
@@ -3956,6 +4086,9 @@ class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {
   @override
   Future<bool> terminateProcess({required String deviceId, required int processId}) async {
     processTerminated = processId;
+    if (terminateException != null) {
+      throw terminateException!;
+    }
     return terminateSuccess;
   }
 
@@ -4056,6 +4189,7 @@ class FakeLLDB extends Fake implements LLDB {
     required int appProcessId,
     required LLDBLogForwarder lldbLogForwarder,
     required BuildMode mode,
+    required IOSDeviceSupport deviceSupport,
   }) async {
     attemptedToAttach = true;
     attachedProcessId = appProcessId;
@@ -4172,4 +4306,28 @@ class FakeShutdownHooks extends Fake implements ShutdownHooks {
   Future<void> runShutdownHooks(Logger logger) async {
     _isShuttingDown = true;
   }
+}
+
+IOSDeviceSupport createDeviceSupport({
+  Logger? logger,
+  ProcessUtils? processUtils,
+  Directory? homeDirectory,
+  String? modelCode,
+  String? operatingSystemVersion,
+  String? cpuArchitectureString,
+  String deviceId = 'device-id',
+}) {
+  final Logger testLogger = logger ?? BufferLogger.test();
+  return IOSDeviceSupport(
+    logger: testLogger,
+    processUtils:
+        processUtils ??
+        ProcessUtils(processManager: FakeProcessManager.empty(), logger: testLogger),
+    xcode: null,
+    homeDirectory: homeDirectory,
+    modelCode: modelCode,
+    operatingSystemVersion: operatingSystemVersion,
+    cpuArchitectureString: cpuArchitectureString,
+    deviceId: deviceId,
+  );
 }

--- a/packages/flutter_tools/test/general.shard/ios/device_support_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/device_support_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:fake_async/fake_async.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/version.dart';
@@ -24,9 +26,14 @@ void main() {
         logger: logger,
         processUtils: processUtils,
         xcode: null,
+        homeDirectory: null,
+        modelCode: null,
+        operatingSystemVersion: null,
+        cpuArchitectureString: null,
+        deviceId: 'id-123',
       );
 
-      await deviceSupport.prepareDeviceSupport('id-123');
+      await deviceSupport.prepareDeviceSupport();
 
       expect(processManager, hasNoRemainingExpectations);
       expect(logger.statusText, isEmpty);
@@ -43,9 +50,50 @@ void main() {
         logger: logger,
         processUtils: processUtils,
         xcode: FakeXcode(currentVersion: Version(16, 2, 0)),
+        homeDirectory: null,
+        modelCode: null,
+        operatingSystemVersion: null,
+        cpuArchitectureString: null,
+        deviceId: 'id-123',
       );
 
-      await deviceSupport.prepareDeviceSupport('id-123');
+      await deviceSupport.prepareDeviceSupport();
+
+      expect(processManager, hasNoRemainingExpectations);
+      expect(logger.statusText, isEmpty);
+      expect(logger.traceText, isEmpty);
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext('does nothing when existingDeviceSupportSymbols is non-null', () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      final Directory homeDir = fileSystem.directory('/Users/username');
+      final Directory supportDir = homeDir
+          .childDirectory('Library')
+          .childDirectory('Developer')
+          .childDirectory('Xcode')
+          .childDirectory('iOS DeviceSupport');
+      supportDir
+          .childDirectory('iPhone15,2 17.0')
+          .childDirectory('Symbols')
+          .createSync(recursive: true);
+
+      final processManager = FakeProcessManager.empty();
+      final logger = BufferLogger.test();
+      final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+      final deviceSupport = IOSDeviceSupport(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+        homeDirectory: homeDir,
+        modelCode: 'iPhone15,2',
+        operatingSystemVersion: '17.0',
+        cpuArchitectureString: 'arm64e',
+        deviceId: 'id-123',
+      );
+
+      await deviceSupport.prepareDeviceSupport();
 
       expect(processManager, hasNoRemainingExpectations);
       expect(logger.statusText, isEmpty);
@@ -77,9 +125,14 @@ void main() {
           logger: logger,
           processUtils: processUtils,
           xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+          homeDirectory: null,
+          modelCode: null,
+          operatingSystemVersion: null,
+          cpuArchitectureString: null,
+          deviceId: 'id-123',
         );
 
-        await deviceSupport.prepareDeviceSupport('id-123');
+        await deviceSupport.prepareDeviceSupport();
 
         expect(processManager, hasNoRemainingExpectations);
         expect(logger.traceText, contains('Preparing device support...'));
@@ -110,16 +163,21 @@ void main() {
         logger: logger,
         processUtils: processUtils,
         xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+        homeDirectory: null,
+        modelCode: null,
+        operatingSystemVersion: null,
+        cpuArchitectureString: null,
+        deviceId: 'id-123',
       );
 
-      await deviceSupport.prepareDeviceSupport('id-123');
+      await deviceSupport.prepareDeviceSupport();
 
       expect(processManager, hasNoRemainingExpectations);
       expect(
         logger.statusText,
         contains(
           'Copying Device Support symbols. This may take several minutes to complete...\n'
-          'Please do not connect or disconnect your device until finished.',
+          'Please do not connect or disconnect your device or open Xcode until finished.',
         ),
       );
       expect(logger.statusText, contains('Copying symbols...'));
@@ -153,9 +211,14 @@ void main() {
         logger: logger,
         processUtils: processUtils,
         xcode: FakeXcode(currentVersion: Version(17, 0, 0)),
+        homeDirectory: null,
+        modelCode: null,
+        operatingSystemVersion: null,
+        cpuArchitectureString: null,
+        deviceId: 'id-123',
       );
 
-      await deviceSupport.prepareDeviceSupport('id-123');
+      await deviceSupport.prepareDeviceSupport();
 
       expect(processManager, hasNoRemainingExpectations);
       expect(logger.errorText, contains('Error occurred'));
@@ -186,9 +249,14 @@ void main() {
             logger: logger,
             processUtils: processUtils,
             xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+            homeDirectory: null,
+            modelCode: null,
+            operatingSystemVersion: null,
+            cpuArchitectureString: null,
+            deviceId: 'id-123',
           );
 
-          deviceSupport.prepareDeviceSupport('id-123');
+          deviceSupport.prepareDeviceSupport();
 
           fakeAsync.elapse(const Duration(seconds: 10));
 
@@ -196,7 +264,7 @@ void main() {
             logger.errorText,
             contains(
               'Xcode is taking longer than expected to start preparing Device Support symbols...\n'
-              'Connect your device via USB and try running this command manually:\n'
+              'Try closing Xcode, connecting your device via USB, and running the following command:\n'
               '  "xcrun xcodebuild -prepareDeviceSupport -destination id=id-123"',
             ),
           );
@@ -230,13 +298,542 @@ void main() {
           logger: logger,
           processUtils: processUtils,
           xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+          homeDirectory: null,
+          modelCode: null,
+          operatingSystemVersion: null,
+          cpuArchitectureString: null,
+          deviceId: 'id-123',
         );
 
-        deviceSupport.prepareDeviceSupport('id-123');
+        deviceSupport.prepareDeviceSupport();
 
         fakeAsync.elapse(const Duration(seconds: 11));
 
         expect(logger.errorText, isEmpty);
+      });
+    });
+
+    group('missingSymbolsWarning', () {
+      group('Xcode < 16.3', () {
+        testWithoutContext('returns unable to find warning when supportDir is null', () {
+          final deviceSupport = IOSDeviceSupport(
+            logger: BufferLogger.test(),
+            processUtils: ProcessUtils(
+              processManager: FakeProcessManager.empty(),
+              logger: BufferLogger.test(),
+            ),
+            xcode: FakeXcode(currentVersion: Version(16, 2, 0)),
+            homeDirectory: null,
+            modelCode: 'iPhone15,2',
+            operatingSystemVersion: '17.0',
+            cpuArchitectureString: 'arm64e',
+            deviceId: 'id-123',
+          );
+          final String? warning = deviceSupport.missingSymbolsWarning();
+          expect(
+            warning,
+            'Xcode Device Support was not found for this device. This will likely reduce debugging '
+            'performance and may cause the app to hang on a white screen during launch.\n'
+            'To trigger Device Symbols to be copied, connect the device via USB, close and then '
+            're-open Xcode. It may take several minutes for Xcode to copy symbols from the device.\n'
+            'Once Device Support symbols are finished being copied, they are expected to be found at '
+            '\$HOME/Library/Developer/Xcode/iOS DeviceSupport\n'
+            'Please retry "flutter run" once symbols are finished being copied.',
+          );
+        });
+
+        testWithoutContext('returns unable to find warning when device directory does not exist', () {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final Directory homeDir = fileSystem.directory('/Users/username');
+          final deviceSupport = IOSDeviceSupport(
+            logger: BufferLogger.test(),
+            processUtils: ProcessUtils(
+              processManager: FakeProcessManager.empty(),
+              logger: BufferLogger.test(),
+            ),
+            xcode: FakeXcode(currentVersion: Version(16, 2, 0)),
+            homeDirectory: homeDir,
+            modelCode: 'iPhone15,2',
+            operatingSystemVersion: '17.0',
+            cpuArchitectureString: 'arm64e',
+            deviceId: 'id-123',
+          );
+          final String? warning = deviceSupport.missingSymbolsWarning();
+          expect(
+            warning,
+            'Xcode Device Support was not found for this device. This will likely reduce debugging '
+            'performance and may cause the app to hang on a white screen during launch.\n'
+            'To trigger Device Symbols to be copied, connect the device via USB, close and then '
+            're-open Xcode. It may take several minutes for Xcode to copy symbols from the device.\n'
+            'Once Device Support symbols are finished being copied, they are expected to be found at '
+            '/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0/Symbols or '
+            '/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0/arm64e/Symbols\n'
+            'Please retry "flutter run" once symbols are finished being copied.',
+          );
+        });
+
+        testWithoutContext(
+          'returns incomplete copy warning when device directory exists but symbols folder does not',
+          () {
+            final FileSystem fileSystem = MemoryFileSystem.test();
+            final Directory homeDir = fileSystem.directory('/Users/username');
+            final Directory supportDir = homeDir
+                .childDirectory('Library')
+                .childDirectory('Developer')
+                .childDirectory('Xcode')
+                .childDirectory('iOS DeviceSupport');
+            supportDir.childDirectory('iPhone15,2 17.0').createSync(recursive: true);
+
+            final deviceSupport = IOSDeviceSupport(
+              logger: BufferLogger.test(),
+              processUtils: ProcessUtils(
+                processManager: FakeProcessManager.empty(),
+                logger: BufferLogger.test(),
+              ),
+              xcode: FakeXcode(currentVersion: Version(16, 2, 0)),
+              homeDirectory: homeDir,
+              modelCode: 'iPhone15,2',
+              operatingSystemVersion: '17.0',
+              cpuArchitectureString: 'arm64e',
+              deviceId: 'id-123',
+            );
+            final String? warning = deviceSupport.missingSymbolsWarning();
+            expect(
+              warning,
+              'Xcode has not finished copying Device Support symbols for this device. This will '
+              'likely reduce debugging performance and may cause the app to hang on a white screen '
+              'during launch.\n'
+              'To trigger Device Symbols to be copied, connect the device via USB, close and then '
+              're-open Xcode. It may take several minutes for Xcode to copy symbols from the device.\n'
+              'Once Device Support symbols are finished being copied, they are expected to be found at '
+              '/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0/Symbols or '
+              '/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0/arm64e/Symbols\n'
+              'Please retry "flutter run" once symbols are finished being copied.',
+            );
+          },
+        );
+
+        testWithoutContext('returns null when symbol directory exists', () {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final Directory homeDir = fileSystem.directory('/Users/username');
+          final Directory supportDir = homeDir
+              .childDirectory('Library')
+              .childDirectory('Developer')
+              .childDirectory('Xcode')
+              .childDirectory('iOS DeviceSupport');
+          supportDir
+              .childDirectory('iPhone15,2 17.0')
+              .childDirectory('Symbols')
+              .createSync(recursive: true);
+
+          final deviceSupport = IOSDeviceSupport(
+            logger: BufferLogger.test(),
+            processUtils: ProcessUtils(
+              processManager: FakeProcessManager.empty(),
+              logger: BufferLogger.test(),
+            ),
+            xcode: FakeXcode(currentVersion: Version(16, 2, 0)),
+            homeDirectory: homeDir,
+            modelCode: 'iPhone15,2',
+            operatingSystemVersion: '17.0',
+            cpuArchitectureString: 'arm64e',
+            deviceId: 'id-123',
+          );
+          final String? warning = deviceSupport.missingSymbolsWarning();
+          expect(warning, isNull);
+        });
+
+        testWithoutContext('returns null when architecture symbol directory exists', () {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final Directory homeDir = fileSystem.directory('/Users/username');
+          final Directory supportDir = homeDir
+              .childDirectory('Library')
+              .childDirectory('Developer')
+              .childDirectory('Xcode')
+              .childDirectory('iOS DeviceSupport');
+          supportDir
+              .childDirectory('iPhone15,2 17.0')
+              .childDirectory('arm64e')
+              .childDirectory('Symbols')
+              .createSync(recursive: true);
+
+          final deviceSupport = IOSDeviceSupport(
+            logger: BufferLogger.test(),
+            processUtils: ProcessUtils(
+              processManager: FakeProcessManager.empty(),
+              logger: BufferLogger.test(),
+            ),
+            xcode: FakeXcode(currentVersion: Version(16, 2, 0)),
+            homeDirectory: homeDir,
+            modelCode: 'iPhone15,2',
+            operatingSystemVersion: '17.0',
+            cpuArchitectureString: 'arm64e',
+            deviceId: 'id-123',
+          );
+          final String? warning = deviceSupport.missingSymbolsWarning();
+          expect(warning, isNull);
+        });
+
+        testWithoutContext(
+          'returns warning when symbol directory exists and warnWhenSymbolsExist is true',
+          () {
+            final FileSystem fileSystem = MemoryFileSystem.test();
+            final Directory homeDir = fileSystem.directory('/Users/username');
+            final Directory supportDir = homeDir
+                .childDirectory('Library')
+                .childDirectory('Developer')
+                .childDirectory('Xcode')
+                .childDirectory('iOS DeviceSupport');
+            supportDir
+                .childDirectory('iPhone15,2 17.0')
+                .childDirectory('Symbols')
+                .createSync(recursive: true);
+
+            final deviceSupport = IOSDeviceSupport(
+              logger: BufferLogger.test(),
+              processUtils: ProcessUtils(
+                processManager: FakeProcessManager.empty(),
+                logger: BufferLogger.test(),
+              ),
+              xcode: FakeXcode(currentVersion: Version(16, 2, 0)),
+              homeDirectory: homeDir,
+              modelCode: 'iPhone15,2',
+              operatingSystemVersion: '17.0',
+              cpuArchitectureString: 'arm64e',
+              deviceId: 'id-123',
+            );
+            final String? warning = deviceSupport.missingSymbolsWarning(warnWhenSymbolsExist: true);
+            expect(
+              warning,
+              'Xcode Device Support symbols exist for this device, but are being read from '
+              'process memory. This will likely reduce debugging performance and may cause the app to hang on a white screen during launch.\n'
+              'To re-copy symbols from your device, complete the following steps:\n'
+              '  1. Remove cached symbols:\n'
+              '     rm -rf "/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0"\n'
+              '  2. Connect the device via USB, close and then re-open Xcode. It may take several '
+              'minutes for Xcode to copy symbols from the device. Once Device Support symbols are finished being copied, they are expected to be found at '
+              '/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0/Symbols',
+            );
+          },
+        );
+      });
+
+      group('Xcode 16.3+', () {
+        testWithoutContext('returns unable to find warning when supportDir is null', () {
+          final deviceSupport = IOSDeviceSupport(
+            logger: BufferLogger.test(),
+            processUtils: ProcessUtils(
+              processManager: FakeProcessManager.empty(),
+              logger: BufferLogger.test(),
+            ),
+            xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+            homeDirectory: null,
+            modelCode: 'iPhone15,2',
+            operatingSystemVersion: '17.0',
+            cpuArchitectureString: 'arm64e',
+            deviceId: 'id-123',
+          );
+          final String? warning = deviceSupport.missingSymbolsWarning();
+          expect(
+            warning,
+            'Xcode Device Support was not found for this device. This will likely reduce debugging '
+            'performance and may cause the app to hang on a white screen during launch.\n'
+            'To trigger Device Symbols to be copied, connect the device via USB, and run this command:\n'
+            '  "xcrun xcodebuild -prepareDeviceSupport -destination id=id-123"\n'
+            'Once Device Support symbols are finished being copied, they are expected to be found at '
+            '\$HOME/Library/Developer/Xcode/iOS DeviceSupport\n'
+            'Please retry "flutter run" once symbols are finished being copied.',
+          );
+        });
+
+        testWithoutContext('returns unable to find warning when device directory does not exist', () {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final Directory homeDir = fileSystem.directory('/Users/username');
+          final deviceSupport = IOSDeviceSupport(
+            logger: BufferLogger.test(),
+            processUtils: ProcessUtils(
+              processManager: FakeProcessManager.empty(),
+              logger: BufferLogger.test(),
+            ),
+            xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+            homeDirectory: homeDir,
+            modelCode: 'iPhone15,2',
+            operatingSystemVersion: '17.0',
+            cpuArchitectureString: 'arm64e',
+            deviceId: 'id-123',
+          );
+          final String? warning = deviceSupport.missingSymbolsWarning();
+          expect(
+            warning,
+            'Xcode Device Support was not found for this device. This will likely reduce debugging '
+            'performance and may cause the app to hang on a white screen during launch.\n'
+            'To trigger Device Symbols to be copied, connect the device via USB, and run this command:\n'
+            '  "xcrun xcodebuild -prepareDeviceSupport -destination id=id-123"\n'
+            'Once Device Support symbols are finished being copied, they are expected to be found at '
+            '/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0/Symbols or '
+            '/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0/arm64e/Symbols\n'
+            'Please retry "flutter run" once symbols are finished being copied.',
+          );
+        });
+
+        testWithoutContext(
+          'returns incomplete copy warning when device directory exists but symbols folder does not',
+          () {
+            final FileSystem fileSystem = MemoryFileSystem.test();
+            final Directory homeDir = fileSystem.directory('/Users/username');
+            final Directory supportDir = homeDir
+                .childDirectory('Library')
+                .childDirectory('Developer')
+                .childDirectory('Xcode')
+                .childDirectory('iOS DeviceSupport');
+            supportDir.childDirectory('iPhone15,2 17.0').createSync(recursive: true);
+
+            final deviceSupport = IOSDeviceSupport(
+              logger: BufferLogger.test(),
+              processUtils: ProcessUtils(
+                processManager: FakeProcessManager.empty(),
+                logger: BufferLogger.test(),
+              ),
+              xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+              homeDirectory: homeDir,
+              modelCode: 'iPhone15,2',
+              operatingSystemVersion: '17.0',
+              cpuArchitectureString: 'arm64e',
+              deviceId: 'id-123',
+            );
+            final String? warning = deviceSupport.missingSymbolsWarning();
+            expect(
+              warning,
+              'Xcode has not finished copying Device Support symbols for this device. This will '
+              'likely reduce debugging performance and may cause the app to hang on a white screen '
+              'during launch.\n'
+              'To trigger Device Symbols to be copied, connect the device via USB, and run this command:\n'
+              '  "xcrun xcodebuild -prepareDeviceSupport -destination id=id-123"\n'
+              'Once Device Support symbols are finished being copied, they are expected to be found at '
+              '/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0/Symbols or '
+              '/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0/arm64e/Symbols\n'
+              'Please retry "flutter run" once symbols are finished being copied.',
+            );
+          },
+        );
+
+        testWithoutContext('returns null when symbol directory exists', () {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final Directory homeDir = fileSystem.directory('/Users/username');
+          final Directory supportDir = homeDir
+              .childDirectory('Library')
+              .childDirectory('Developer')
+              .childDirectory('Xcode')
+              .childDirectory('iOS DeviceSupport');
+          supportDir
+              .childDirectory('iPhone15,2 17.0')
+              .childDirectory('Symbols')
+              .createSync(recursive: true);
+
+          final deviceSupport = IOSDeviceSupport(
+            logger: BufferLogger.test(),
+            processUtils: ProcessUtils(
+              processManager: FakeProcessManager.empty(),
+              logger: BufferLogger.test(),
+            ),
+            xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+            homeDirectory: homeDir,
+            modelCode: 'iPhone15,2',
+            operatingSystemVersion: '17.0',
+            cpuArchitectureString: 'arm64e',
+            deviceId: 'id-123',
+          );
+          final String? warning = deviceSupport.missingSymbolsWarning();
+          expect(warning, isNull);
+        });
+
+        testWithoutContext('returns null when architecture symbol directory exists', () {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final Directory homeDir = fileSystem.directory('/Users/username');
+          final Directory supportDir = homeDir
+              .childDirectory('Library')
+              .childDirectory('Developer')
+              .childDirectory('Xcode')
+              .childDirectory('iOS DeviceSupport');
+          supportDir
+              .childDirectory('iPhone15,2 17.0')
+              .childDirectory('arm64e')
+              .childDirectory('Symbols')
+              .createSync(recursive: true);
+
+          final deviceSupport = IOSDeviceSupport(
+            logger: BufferLogger.test(),
+            processUtils: ProcessUtils(
+              processManager: FakeProcessManager.empty(),
+              logger: BufferLogger.test(),
+            ),
+            xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+            homeDirectory: homeDir,
+            modelCode: 'iPhone15,2',
+            operatingSystemVersion: '17.0',
+            cpuArchitectureString: 'arm64e',
+            deviceId: 'id-123',
+          );
+          final String? warning = deviceSupport.missingSymbolsWarning();
+          expect(warning, isNull);
+        });
+
+        testWithoutContext(
+          'returns warning when symbol directory exists and warnWhenSymbolsExist is true',
+          () {
+            final FileSystem fileSystem = MemoryFileSystem.test();
+            final Directory homeDir = fileSystem.directory('/Users/username');
+            final Directory supportDir = homeDir
+                .childDirectory('Library')
+                .childDirectory('Developer')
+                .childDirectory('Xcode')
+                .childDirectory('iOS DeviceSupport');
+            supportDir
+                .childDirectory('iPhone15,2 17.0')
+                .childDirectory('Symbols')
+                .createSync(recursive: true);
+
+            final deviceSupport = IOSDeviceSupport(
+              logger: BufferLogger.test(),
+              processUtils: ProcessUtils(
+                processManager: FakeProcessManager.empty(),
+                logger: BufferLogger.test(),
+              ),
+              xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+              homeDirectory: homeDir,
+              modelCode: 'iPhone15,2',
+              operatingSystemVersion: '17.0',
+              cpuArchitectureString: 'arm64e',
+              deviceId: 'id-123',
+            );
+            final String? warning = deviceSupport.missingSymbolsWarning(warnWhenSymbolsExist: true);
+            expect(
+              warning,
+              'Xcode Device Support symbols exist for this device, but are being read from '
+              'process memory. This will likely reduce debugging performance and may cause the app to hang on a white screen during launch.\n'
+              'To re-copy symbols from your device, complete the following steps:\n'
+              '  1. Remove cached symbols:\n'
+              '     rm -rf "/Users/username/Library/Developer/Xcode/iOS DeviceSupport/iPhone15,2 17.0"\n'
+              '  2. Connect the device via USB and trigger a copy:\n'
+              '     xcrun xcodebuild -prepareDeviceSupport -destination id=id-123',
+            );
+          },
+        );
+      });
+    });
+
+    group('existingDeviceSupportSymbols', () {
+      testWithoutContext('returns null when neither directory exists', () {
+        final FileSystem fileSystem = MemoryFileSystem.test();
+        final Directory homeDir = fileSystem.directory('/Users/username');
+        final deviceSupport = IOSDeviceSupport(
+          logger: BufferLogger.test(),
+          processUtils: ProcessUtils(
+            processManager: FakeProcessManager.empty(),
+            logger: BufferLogger.test(),
+          ),
+          xcode: null,
+          homeDirectory: homeDir,
+          modelCode: 'iPhone15,2',
+          operatingSystemVersion: '17.0',
+          cpuArchitectureString: 'arm64e',
+          deviceId: 'id-123',
+        );
+        expect(deviceSupport.existingDeviceSupportSymbols, isNull);
+      });
+
+      testWithoutContext('is dynamic getter and re-evaluates symbol directories', () {
+        final FileSystem fileSystem = MemoryFileSystem.test();
+        final Directory homeDir = fileSystem.directory('/Users/username');
+        final deviceSupport = IOSDeviceSupport(
+          logger: BufferLogger.test(),
+          processUtils: ProcessUtils(
+            processManager: FakeProcessManager.empty(),
+            logger: BufferLogger.test(),
+          ),
+          xcode: null,
+          homeDirectory: homeDir,
+          modelCode: 'iPhone15,2',
+          operatingSystemVersion: '17.0',
+          cpuArchitectureString: 'arm64e',
+          deviceId: 'id-123',
+        );
+        expect(deviceSupport.existingDeviceSupportSymbols, isNull);
+
+        final Directory symbolDir =
+            homeDir
+                .childDirectory('Library')
+                .childDirectory('Developer')
+                .childDirectory('Xcode')
+                .childDirectory('iOS DeviceSupport')
+                .childDirectory('iPhone15,2 17.0')
+                .childDirectory('Symbols')
+              ..createSync(recursive: true);
+
+        expect(deviceSupport.existingDeviceSupportSymbols?.path, symbolDir.path);
+      });
+
+      testWithoutContext('returns symbolDirectory when symbolDirectory exists', () {
+        final FileSystem fileSystem = MemoryFileSystem.test();
+        final Directory homeDir = fileSystem.directory('/Users/username');
+        final Directory supportDir = homeDir
+            .childDirectory('Library')
+            .childDirectory('Developer')
+            .childDirectory('Xcode')
+            .childDirectory('iOS DeviceSupport');
+        final Directory symbolDir =
+            supportDir.childDirectory('iPhone15,2 17.0').childDirectory('Symbols')
+              ..createSync(recursive: true);
+
+        final deviceSupport = IOSDeviceSupport(
+          logger: BufferLogger.test(),
+          processUtils: ProcessUtils(
+            processManager: FakeProcessManager.empty(),
+            logger: BufferLogger.test(),
+          ),
+          xcode: null,
+          homeDirectory: homeDir,
+          modelCode: 'iPhone15,2',
+          operatingSystemVersion: '17.0',
+          cpuArchitectureString: 'arm64e',
+          deviceId: 'id-123',
+        );
+        expect(deviceSupport.existingDeviceSupportSymbols?.path, symbolDir.path);
+      });
+
+      testWithoutContext('returns archSymbolDirectory when archSymbolDirectory exists', () {
+        final FileSystem fileSystem = MemoryFileSystem.test();
+        final Directory homeDir = fileSystem.directory('/Users/username');
+        final Directory supportDir = homeDir
+            .childDirectory('Library')
+            .childDirectory('Developer')
+            .childDirectory('Xcode')
+            .childDirectory('iOS DeviceSupport');
+        supportDir
+            .childDirectory('iPhone15,2 17.0')
+            .childDirectory('Symbols')
+            .createSync(recursive: true);
+        final Directory archSymbolDir =
+            supportDir
+                .childDirectory('iPhone15,2 17.0')
+                .childDirectory('arm64e')
+                .childDirectory('Symbols')
+              ..createSync(recursive: true);
+
+        final deviceSupport = IOSDeviceSupport(
+          logger: BufferLogger.test(),
+          processUtils: ProcessUtils(
+            processManager: FakeProcessManager.empty(),
+            logger: BufferLogger.test(),
+          ),
+          xcode: null,
+          homeDirectory: homeDir,
+          modelCode: 'iPhone15,2',
+          operatingSystemVersion: '17.0',
+          cpuArchitectureString: 'arm64e',
+          deviceId: 'id-123',
+        );
+        expect(deviceSupport.existingDeviceSupportSymbols?.path, archSymbolDir.path);
       });
     });
   });

--- a/packages/flutter_tools/test/general.shard/ios/device_support_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/device_support_test.dart
@@ -1,0 +1,250 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/base/version.dart';
+import 'package:flutter_tools/src/ios/device_support.dart';
+import 'package:flutter_tools/src/macos/xcode.dart';
+import 'package:test/fake.dart';
+
+import '../../src/common.dart';
+import '../../src/fake_process_manager.dart';
+
+void main() {
+  group('IOSDeviceSupport', () {
+    testWithoutContext('does nothing when Xcode is null', () async {
+      final processManager = FakeProcessManager.empty();
+      final logger = BufferLogger.test();
+      final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+      final deviceSupport = IOSDeviceSupport(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: null,
+      );
+
+      await deviceSupport.prepareDeviceSupport('id-123');
+
+      expect(processManager, hasNoRemainingExpectations);
+      expect(logger.statusText, isEmpty);
+      expect(logger.traceText, isEmpty);
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext('does nothing when Xcode version is less than 16.3.0', () async {
+      final processManager = FakeProcessManager.empty();
+      final logger = BufferLogger.test();
+      final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+      final deviceSupport = IOSDeviceSupport(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: FakeXcode(currentVersion: Version(16, 2, 0)),
+      );
+
+      await deviceSupport.prepareDeviceSupport('id-123');
+
+      expect(processManager, hasNoRemainingExpectations);
+      expect(logger.statusText, isEmpty);
+      expect(logger.traceText, isEmpty);
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext(
+      'runs prepareDeviceSupport and logs stdout to trace when Copying is not present',
+      () async {
+        final processManager = FakeProcessManager.empty();
+        final logger = BufferLogger.test();
+        final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'xcrun',
+              'xcodebuild',
+              '-prepareDeviceSupport',
+              '-destination',
+              'id=id-123',
+            ],
+            stdout: 'Preparing device support...',
+          ),
+        );
+
+        final deviceSupport = IOSDeviceSupport(
+          logger: logger,
+          processUtils: processUtils,
+          xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+        );
+
+        await deviceSupport.prepareDeviceSupport('id-123');
+
+        expect(processManager, hasNoRemainingExpectations);
+        expect(logger.traceText, contains('Preparing device support...'));
+        expect(logger.statusText, isEmpty);
+        expect(logger.errorText, isEmpty);
+      },
+    );
+
+    testWithoutContext('runs prepareDeviceSupport and logs Copying messages to status', () async {
+      final processManager = FakeProcessManager.empty();
+      final logger = BufferLogger.test();
+      final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'xcrun',
+            'xcodebuild',
+            '-prepareDeviceSupport',
+            '-destination',
+            'id=id-123',
+          ],
+          stdout: 'Copying symbols...',
+        ),
+      );
+
+      final deviceSupport = IOSDeviceSupport(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+      );
+
+      await deviceSupport.prepareDeviceSupport('id-123');
+
+      expect(processManager, hasNoRemainingExpectations);
+      expect(
+        logger.statusText,
+        contains(
+          'Copying Device Support symbols. This may take several minutes to complete...\n'
+          'Please do not connect or disconnect your device until finished.',
+        ),
+      );
+      expect(logger.statusText, contains('Copying symbols...'));
+      expect(logger.statusText, endsWith('\n'));
+      expect(
+        logger.traceText,
+        'executing: xcrun xcodebuild -prepareDeviceSupport -destination id=id-123\n',
+      );
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext('runs prepareDeviceSupport and logs stderr to error', () async {
+      final processManager = FakeProcessManager.empty();
+      final logger = BufferLogger.test();
+      final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'xcrun',
+            'xcodebuild',
+            '-prepareDeviceSupport',
+            '-destination',
+            'id=id-123',
+          ],
+          stderr: 'Error occurred',
+        ),
+      );
+
+      final deviceSupport = IOSDeviceSupport(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: FakeXcode(currentVersion: Version(17, 0, 0)),
+      );
+
+      await deviceSupport.prepareDeviceSupport('id-123');
+
+      expect(processManager, hasNoRemainingExpectations);
+      expect(logger.errorText, contains('Error occurred'));
+    });
+
+    testWithoutContext(
+      'prints error message when prepareDeviceSupport takes longer than 10 seconds',
+      () {
+        FakeAsync().run((fakeAsync) {
+          final processManager = FakeProcessManager.empty();
+          final logger = BufferLogger.test();
+          final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+          processManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'xcrun',
+                'xcodebuild',
+                '-prepareDeviceSupport',
+                '-destination',
+                'id=id-123',
+              ],
+              duration: Duration(seconds: 11),
+            ),
+          );
+
+          final deviceSupport = IOSDeviceSupport(
+            logger: logger,
+            processUtils: processUtils,
+            xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+          );
+
+          deviceSupport.prepareDeviceSupport('id-123');
+
+          fakeAsync.elapse(const Duration(seconds: 10));
+
+          expect(
+            logger.errorText,
+            contains(
+              'Xcode is taking longer than expected to start preparing Device Support symbols...\n'
+              'Connect your device via USB and try running this command manually:\n'
+              '  "xcrun xcodebuild -prepareDeviceSupport -destination id=id-123"',
+            ),
+          );
+
+          fakeAsync.elapse(const Duration(seconds: 1));
+        });
+      },
+    );
+
+    testWithoutContext('does not print error message if Copying is printed within 10 seconds', () {
+      FakeAsync().run((fakeAsync) {
+        final processManager = FakeProcessManager.empty();
+        final logger = BufferLogger.test();
+        final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'xcrun',
+              'xcodebuild',
+              '-prepareDeviceSupport',
+              '-destination',
+              'id=id-123',
+            ],
+            duration: Duration(seconds: 11),
+            stdout: 'Copying symbols...',
+          ),
+        );
+
+        final deviceSupport = IOSDeviceSupport(
+          logger: logger,
+          processUtils: processUtils,
+          xcode: FakeXcode(currentVersion: Version(16, 3, 0)),
+        );
+
+        deviceSupport.prepareDeviceSupport('id-123');
+
+        fakeAsync.elapse(const Duration(seconds: 11));
+
+        expect(logger.errorText, isEmpty);
+      });
+    });
+  });
+}
+
+class FakeXcode extends Fake implements Xcode {
+  FakeXcode({this.currentVersion});
+
+  @override
+  final Version? currentVersion;
+}

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -49,11 +50,13 @@ void main() {
     late IOSCoreDeviceControl coreDeviceControl;
     late IOSCoreDeviceLauncher coreDeviceLauncher;
     late XcodeDebug xcodeDebug;
+    late ProcessUtils processUtils;
 
     setUp(() {
       final artifacts = Artifacts.test();
       cache = Cache.test(processManager: FakeProcessManager.any());
       logger = BufferLogger.test();
+      processUtils = ProcessUtils(processManager: FakeProcessManager.any(), logger: logger);
       fileSystem = MemoryFileSystem.test();
       iosDeploy = IOSDeploy(
         artifacts: artifacts,
@@ -94,8 +97,54 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       );
       expect(await device.isSupported(), isTrue);
+    });
+
+    group('shouldAttachLLDBDebugger', () {
+      testWithoutContext('returns expected values for different BuildInfo and options', () {
+        final device = IOSDevice(
+          'device-123',
+          iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
+          fileSystem: fileSystem,
+          logger: logger,
+          platform: macPlatform,
+          iosDeploy: iosDeploy,
+          analytics: FakeAnalytics(),
+          iMobileDevice: iMobileDevice,
+          coreDeviceControl: coreDeviceControl,
+          coreDeviceLauncher: coreDeviceLauncher,
+          xcodeDebug: xcodeDebug,
+          name: 'iPhone 1',
+          sdkVersion: '13.3',
+          cpuArch: .arm64,
+          connectionInterface: DeviceConnectionInterface.attached,
+          isConnected: true,
+          isPaired: true,
+          devModeEnabled: true,
+          isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
+        );
+
+        expect(device.shouldAttachLLDBDebugger(DebuggingOptions.enabled(BuildInfo.debug)), isTrue);
+        expect(
+          device.shouldAttachLLDBDebugger(
+            DebuggingOptions.enabled(BuildInfo.profile, iosProfileDebugger: true),
+          ),
+          isTrue,
+        );
+        expect(device.shouldAttachLLDBDebugger(DebuggingOptions.enabled(BuildInfo.profile)), isFalse);
+        expect(
+          device.shouldAttachLLDBDebugger(
+            DebuggingOptions.enabled(BuildInfo.profile, iosProfileDebugger: false),
+          ),
+          isFalse,
+        );
+        expect(device.shouldAttachLLDBDebugger(DebuggingOptions.enabled(BuildInfo.release)), isFalse);
+      });
     });
 
     testWithoutContext('32-bit devices are unsupported', () async {
@@ -118,6 +167,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       );
       expect(await device.isSupported(), isFalse);
     });
@@ -144,6 +195,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         ).majorSdkVersion,
         1,
       );
@@ -168,6 +221,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         ).majorSdkVersion,
         13,
       );
@@ -192,6 +247,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         ).majorSdkVersion,
         10,
       );
@@ -216,6 +273,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         ).majorSdkVersion,
         0,
       );
@@ -240,6 +299,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         ).majorSdkVersion,
         0,
       );
@@ -266,6 +327,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       var expectedVersion = Version(13, 3, 1, text: '13.3.1');
       expect(sdkVersion, isNotNull);
@@ -292,6 +355,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       expectedVersion = Version(13, 3, 1, text: '13.3.1 (20ADBC)');
       expect(sdkVersion, isNotNull);
@@ -318,6 +383,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       expectedVersion = Version(16, 4, 1, text: '16.4.1(a) (20ADBC)');
       expect(sdkVersion, isNotNull);
@@ -344,6 +411,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       expectedVersion = Version(0, 0, 0, text: '0');
       expect(sdkVersion, isNotNull);
@@ -369,6 +438,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       expect(sdkVersion, isNull);
 
@@ -392,6 +463,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       ).sdkVersion;
       expect(sdkVersion, isNull);
     });
@@ -417,6 +490,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       );
 
       expect(await device.sdkNameAndVersion, 'iOS 13.3 17C54');
@@ -443,6 +518,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: processUtils,
+        xcode: null,
       );
 
       expect(device.supportsRuntimeMode(BuildMode.debug), true);
@@ -476,6 +553,8 @@ void main() {
               isPaired: true,
               devModeEnabled: true,
               isCoreDevice: false,
+              processUtils: processUtils,
+              xcode: null,
             );
           }, throwsAssertionError);
         },
@@ -567,6 +646,8 @@ void main() {
           isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
+          processUtils: processUtils,
+          xcode: null,
         );
         logReader1 = createLogReader(device, appPackage1, process1);
         logReader2 = createLogReader(device, appPackage2, process2);
@@ -642,6 +723,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: ProcessUtils(processManager: fakeProcessManager, logger: logger),
+        xcode: null,
       );
 
       device2 = IOSDevice(
@@ -664,6 +747,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: ProcessUtils(processManager: fakeProcessManager, logger: logger),
+        xcode: null,
       );
     });
 
@@ -994,6 +1079,8 @@ void main() {
         isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
+        processUtils: ProcessUtils(processManager: fakeProcessManager, logger: logger),
+        xcode: null,
       );
     });
 

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io' as io;
 
-import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -47,6 +46,7 @@ void main() {
     late IOSDeploy iosDeploy;
     late IMobileDevice iMobileDevice;
     late FileSystem fileSystem;
+    late FileSystemUtils fileSystemUtils;
     late IOSCoreDeviceControl coreDeviceControl;
     late IOSCoreDeviceLauncher coreDeviceLauncher;
     late XcodeDebug xcodeDebug;
@@ -58,6 +58,7 @@ void main() {
       logger = BufferLogger.test();
       processUtils = ProcessUtils(processManager: FakeProcessManager.any(), logger: logger);
       fileSystem = MemoryFileSystem.test();
+      fileSystemUtils = FileSystemUtils(fileSystem: fileSystem, platform: macPlatform);
       iosDeploy = IOSDeploy(
         artifacts: artifacts,
         cache: cache,
@@ -81,6 +82,7 @@ void main() {
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
+        fileSystemUtils: fileSystemUtils,
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
@@ -109,6 +111,7 @@ void main() {
           'device-123',
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
+          fileSystemUtils: fileSystemUtils,
           logger: logger,
           platform: macPlatform,
           iosDeploy: iosDeploy,
@@ -119,7 +122,7 @@ void main() {
           xcodeDebug: xcodeDebug,
           name: 'iPhone 1',
           sdkVersion: '13.3',
-          cpuArch: .arm64,
+          cpuArchitecture: DarwinArch.arm64,
           connectionInterface: DeviceConnectionInterface.attached,
           isConnected: true,
           isPaired: true,
@@ -136,14 +139,20 @@ void main() {
           ),
           isTrue,
         );
-        expect(device.shouldAttachLLDBDebugger(DebuggingOptions.enabled(BuildInfo.profile)), isFalse);
+        expect(
+          device.shouldAttachLLDBDebugger(DebuggingOptions.enabled(BuildInfo.profile)),
+          isFalse,
+        );
         expect(
           device.shouldAttachLLDBDebugger(
             DebuggingOptions.enabled(BuildInfo.profile, iosProfileDebugger: false),
           ),
           isFalse,
         );
-        expect(device.shouldAttachLLDBDebugger(DebuggingOptions.enabled(BuildInfo.release)), isFalse);
+        expect(
+          device.shouldAttachLLDBDebugger(DebuggingOptions.enabled(BuildInfo.release)),
+          isFalse,
+        );
       });
     });
 
@@ -152,6 +161,7 @@ void main() {
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
+        fileSystemUtils: fileSystemUtils,
         logger: logger,
         analytics: FakeAnalytics(),
         platform: macPlatform,
@@ -179,6 +189,7 @@ void main() {
           'device-123',
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
+          fileSystemUtils: fileSystemUtils,
           logger: logger,
           analytics: FakeAnalytics(),
           platform: macPlatform,
@@ -205,6 +216,7 @@ void main() {
           'device-123',
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
+          fileSystemUtils: fileSystemUtils,
           logger: logger,
           analytics: FakeAnalytics(),
           platform: macPlatform,
@@ -231,6 +243,7 @@ void main() {
           'device-123',
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
+          fileSystemUtils: fileSystemUtils,
           logger: logger,
           analytics: FakeAnalytics(),
           platform: macPlatform,
@@ -257,6 +270,7 @@ void main() {
           'device-123',
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
+          fileSystemUtils: fileSystemUtils,
           logger: logger,
           analytics: FakeAnalytics(),
           platform: macPlatform,
@@ -283,6 +297,7 @@ void main() {
           'device-123',
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
+          fileSystemUtils: fileSystemUtils,
           logger: logger,
           analytics: FakeAnalytics(),
           platform: macPlatform,
@@ -311,6 +326,7 @@ void main() {
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
+        fileSystemUtils: fileSystemUtils,
         logger: logger,
         analytics: FakeAnalytics(),
         platform: macPlatform,
@@ -339,6 +355,7 @@ void main() {
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
+        fileSystemUtils: fileSystemUtils,
         logger: logger,
         analytics: FakeAnalytics(),
         platform: macPlatform,
@@ -367,6 +384,7 @@ void main() {
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
+        fileSystemUtils: fileSystemUtils,
         logger: logger,
         analytics: FakeAnalytics(),
         platform: macPlatform,
@@ -395,6 +413,7 @@ void main() {
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
+        fileSystemUtils: fileSystemUtils,
         logger: logger,
         analytics: FakeAnalytics(),
         platform: macPlatform,
@@ -423,6 +442,7 @@ void main() {
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
+        fileSystemUtils: fileSystemUtils,
         logger: logger,
         analytics: FakeAnalytics(),
         platform: macPlatform,
@@ -447,6 +467,7 @@ void main() {
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
+        fileSystemUtils: fileSystemUtils,
         logger: logger,
         analytics: FakeAnalytics(),
         platform: macPlatform,
@@ -474,6 +495,7 @@ void main() {
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
+        fileSystemUtils: fileSystemUtils,
         logger: logger,
         analytics: FakeAnalytics(),
         platform: macPlatform,
@@ -502,6 +524,7 @@ void main() {
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
+        fileSystemUtils: fileSystemUtils,
         logger: logger,
         analytics: FakeAnalytics(),
         platform: macPlatform,
@@ -537,6 +560,7 @@ void main() {
               'device-123',
               iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
               fileSystem: fileSystem,
+              fileSystemUtils: fileSystemUtils,
               logger: logger,
               analytics: FakeAnalytics(),
               platform: platform,
@@ -630,6 +654,7 @@ void main() {
           '123',
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
+          fileSystemUtils: fileSystemUtils,
           logger: logger,
           analytics: FakeAnalytics(),
           platform: macPlatform,
@@ -703,6 +728,12 @@ void main() {
       coreDeviceLauncher = FakeIOSCoreDeviceLauncher();
       xcodeDebug = FakeXcodeDebug();
 
+      final testFileSystem = MemoryFileSystem.test();
+      final testFileSystemUtils = FileSystemUtils(
+        fileSystem: testFileSystem,
+        platform: macPlatform,
+      );
+
       device1 = IOSDevice(
         'd83d5bc53967baa0ee18626ba87b6254b2ab5418',
         name: 'Paired iPhone',
@@ -717,7 +748,8 @@ void main() {
         xcodeDebug: xcodeDebug,
         logger: logger,
         platform: macPlatform,
-        fileSystem: MemoryFileSystem.test(),
+        fileSystem: testFileSystem,
+        fileSystemUtils: testFileSystemUtils,
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
         isPaired: true,
@@ -741,7 +773,8 @@ void main() {
         xcodeDebug: xcodeDebug,
         logger: logger,
         platform: macPlatform,
-        fileSystem: MemoryFileSystem.test(),
+        fileSystem: testFileSystem,
+        fileSystemUtils: testFileSystemUtils,
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
         isPaired: true,
@@ -1059,6 +1092,11 @@ void main() {
       coreDeviceControl = FakeIOSCoreDeviceControl();
       coreDeviceLauncher = FakeIOSCoreDeviceLauncher();
       xcodeDebug = FakeXcodeDebug();
+      final testFileSystem = MemoryFileSystem.test();
+      final testFileSystemUtils = FileSystemUtils(
+        fileSystem: testFileSystem,
+        platform: macPlatform,
+      );
       notConnected1 = IOSDevice(
         '00000001-0000000000000000',
         name: 'iPad',
@@ -1073,7 +1111,8 @@ void main() {
         xcodeDebug: xcodeDebug,
         logger: logger,
         platform: macPlatform,
-        fileSystem: MemoryFileSystem.test(),
+        fileSystem: testFileSystem,
+        fileSystemUtils: testFileSystemUtils,
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: false,
         isPaired: true,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -364,6 +365,8 @@ IOSDevice setUpIOSDevice({
     '1234',
     name: 'iPhone 1',
     logger: logger,
+    processUtils: ProcessUtils(processManager: processManager, logger: logger),
+    xcode: null,
     fileSystem: fileSystem ?? MemoryFileSystem.test(),
     sdkVersion: '13.3',
     cpuArchitecture: DarwinArch.arm64,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -361,13 +361,15 @@ IOSDevice setUpIOSDevice({
     artifacts: <ArtifactSet>[FakeDyldEnvironmentArtifact()],
     processManager: FakeProcessManager.any(),
   );
+  final FileSystem testFileSystem = fileSystem ?? MemoryFileSystem.test();
   return IOSDevice(
     '1234',
     name: 'iPhone 1',
     logger: logger,
+    fileSystem: testFileSystem,
+    fileSystemUtils: FileSystemUtils(fileSystem: testFileSystem, platform: platform),
     processUtils: ProcessUtils(processManager: processManager, logger: logger),
     xcode: null,
-    fileSystem: fileSystem ?? MemoryFileSystem.test(),
     sdkVersion: '13.3',
     cpuArchitecture: DarwinArch.arm64,
     platform: platform,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -101,6 +102,8 @@ IOSDevice setUpIOSDevice(FileSystem fileSystem) {
     'test',
     fileSystem: fileSystem,
     logger: logger,
+    processUtils: ProcessUtils(processManager: processManager, logger: logger),
+    xcode: null,
     iosDeploy: IOSDeploy(
       platform: platform,
       logger: logger,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -101,6 +101,7 @@ IOSDevice setUpIOSDevice(FileSystem fileSystem) {
   return IOSDevice(
     'test',
     fileSystem: fileSystem,
+    fileSystemUtils: FileSystemUtils(fileSystem: fileSystem, platform: platform),
     logger: logger,
     processUtils: ProcessUtils(processManager: processManager, logger: logger),
     xcode: null,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -1481,6 +1481,11 @@ IOSDevice setUpIOSDevice({
     sdkVersion: sdkVersion,
     fileSystem: fileSystem ?? MemoryFileSystem.test(),
     platform: macPlatform,
+    processUtils: ProcessUtils(
+      processManager: processManager ?? FakeProcessManager.any(),
+      logger: logger,
+    ),
+    xcode: null,
     iProxy: IProxy.test(logger: logger, processManager: processManager ?? FakeProcessManager.any()),
     logger: logger,
     iosDeploy: IOSDeploy(

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwarder.dart';
 import 'package:flutter_tools/src/ios/application_package.dart';
 import 'package:flutter_tools/src/ios/core_devices.dart';
+import 'package:flutter_tools/src/ios/device_support.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
@@ -1052,6 +1053,85 @@ void main() {
         },
       );
 
+      testUsingContext(
+        'logs warning when missing symbols pattern is detected in log reader',
+        () async {
+          final IOSDevice iosDevice = setUpIOSDevice(
+            fileSystem: fileSystem,
+            processManager: FakeProcessManager.any(),
+            logger: logger,
+            artifacts: artifacts,
+            isCoreDevice: true,
+            coreDeviceControl: FakeIOSCoreDeviceControl(),
+            xcodeDebug: FakeXcodeDebug(
+              expectedProject: XcodeDebugProject(
+                scheme: 'Runner',
+                xcodeWorkspace: fileSystem.directory('/ios/Runner.xcworkspace'),
+                xcodeProject: fileSystem.directory('/ios/Runner.xcodeproj'),
+                hostAppProjectName: 'Runner',
+              ),
+              expectedDeviceId: '123',
+              expectedLaunchArguments: <String>['--enable-dart-profiling'],
+            ),
+          );
+
+          setUpIOSProject(fileSystem);
+          final FlutterProject flutterProject = FlutterProject.fromDirectory(
+            fileSystem.currentDirectory,
+          );
+          final buildableIOSApp = BuildableIOSApp(
+            flutterProject.ios,
+            'flutter',
+            'My Super Awesome App',
+          );
+          fileSystem
+              .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
+              .createSync(recursive: true);
+
+          final deviceLogReader = FakeSharedIOSDeviceLogReader();
+
+          iosDevice.portForwarder = const NoOpDevicePortForwarder();
+          iosDevice.setLogReader(buildableIOSApp, deviceLogReader);
+
+          Timer.run(() {
+            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+            deviceLogReader.addLine('warning: libobjc.A.dylib is being read from process memory.');
+          });
+
+          final LaunchResult launchResult = await iosDevice.startApp(
+            buildableIOSApp,
+            debuggingOptions: DebuggingOptions.enabled(
+              const BuildInfo(
+                BuildMode.debug,
+                null,
+                buildName: '1.2.3',
+                buildNumber: '4',
+                treeShakeIcons: false,
+                packageConfigPath: '.dart_tool/package_config.json',
+              ),
+            ),
+            platformArgs: <String, Object>{},
+          );
+
+          expect(launchResult.started, true);
+          expect(
+            logger.warningText,
+            contains('Xcode Device Support was not found for this device.'),
+          );
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => FakeProcessManager.any(),
+          Pub: () => const ThrowingPub(),
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
+          OperatingSystemUtils: () => os,
+          Platform: () => macPlatform,
+          XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
+          Xcode: () => xcode,
+          Artifacts: () => artifacts,
+        },
+      );
+
       group('with flavor', () {
         setUp(() {
           projectInfo = XcodeProjectInfo(
@@ -1475,11 +1555,13 @@ IOSDevice setUpIOSDevice({
   );
 
   logger ??= BufferLogger.test();
+  final FileSystem testFileSystem = fileSystem ?? MemoryFileSystem.test();
   return IOSDevice(
     '123',
     name: 'iPhone 1',
     sdkVersion: sdkVersion,
-    fileSystem: fileSystem ?? MemoryFileSystem.test(),
+    fileSystem: testFileSystem,
+    fileSystemUtils: FileSystemUtils(fileSystem: testFileSystem, platform: macPlatform),
     platform: macPlatform,
     processUtils: ProcessUtils(
       processManager: processManager ?? FakeProcessManager.any(),
@@ -1736,6 +1818,7 @@ class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {
   @override
   Future<bool> launchAppWithLLDBDebugger({
     required String deviceId,
+    required IOSDeviceSupport deviceSupport,
     required String bundlePath,
     required String bundleId,
     required List<String> launchArguments,
@@ -1782,4 +1865,43 @@ class FakeArtifacts extends Fake implements Artifacts {
 
   @override
   LocalEngineInfo? get localEngineInfo => null;
+}
+
+class FakeSharedIOSDeviceLogReader extends SharedIOSDeviceLogReader {
+  @override
+  String get name => 'FakeLogReader';
+
+  bool disposed = false;
+
+  final _lineQueue = <String>[];
+  late final _linesController = StreamController<String>.broadcast(onListen: _onListen);
+
+  @override
+  Stream<String> get logLines => _linesController.stream;
+
+  @override
+  StreamController<String> get linesController => _linesController;
+
+  void _onListen() {
+    _lineQueue.forEach(addLogToStream);
+    _lineQueue.clear();
+  }
+
+  void addLine(String line) {
+    if (_linesController.hasListener) {
+      addLogToStream(line);
+    } else {
+      _lineQueue.add(line);
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    _lineQueue.clear();
+    await _linesController.close();
+    disposed = true;
+  }
+
+  @override
+  Future<void> provideVmService(Object? connectedVmService) async {}
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -908,6 +908,72 @@ void main() {
         },
       );
 
+      testUsingContext(
+        'calls prepareDeviceSupport when Xcode version is >= 16.3',
+        () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final processManager = FakeProcessManager.empty();
+          processManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'xcrun',
+                'xcodebuild',
+                '-prepareDeviceSupport',
+                '-destination',
+                'id=123',
+              ],
+            ),
+          );
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
+          final fakeLauncher = FakeIOSCoreDeviceLauncher();
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            isCoreDevice: true,
+            coreDeviceLauncher: fakeLauncher,
+            analytics: fakeAnalytics,
+            xcode: FakeXcode(currentVersion: Version(26, 0, 0)),
+          );
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final DeviceLogReader deviceLogReader = IOSDeviceLogReader.test(
+            iMobileDevice: FakeIMobileDevice(),
+            xcode: FakeXcode(currentVersion: Version(26, 0, 0)),
+            isCoreDevice: true,
+          );
+
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
+
+          // Start writing messages to the log reader.
+          Timer(const Duration(milliseconds: 50), () {
+            fakeLauncher.coreDeviceLogForwarder.addLog('Foo');
+            fakeLauncher.coreDeviceLogForwarder.addLog(
+              'The Dart VM service is listening on http://127.0.0.1:456',
+            );
+          });
+
+          final LaunchResult launchResult = await device.startApp(
+            iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            platformArgs: <String, dynamic>{},
+          );
+
+          expect(launchResult.started, true);
+          expect(processManager, hasNoRemainingExpectations);
+        },
+        overrides: {
+          Xcode: () => FakeXcode(currentVersion: Version(26, 0, 0)),
+          Analytics: () => FakeAnalytics(),
+        },
+      );
+
       testUsingContext('uses Xcode if LLDB fails', () async {
         final FileSystem fileSystem = MemoryFileSystem.test();
         final processManager = FakeProcessManager.empty();
@@ -1860,6 +1926,72 @@ void main() {
       );
 
       testUsingContext(
+        'calls prepareDeviceSupport when iosProfileDebugger is true and Xcode version is >= 16.3',
+        () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final processManager = FakeProcessManager.empty();
+          processManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'xcrun',
+                'xcodebuild',
+                '-prepareDeviceSupport',
+                '-destination',
+                'id=123',
+              ],
+            ),
+          );
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
+          final fakeLauncher = FakeIOSCoreDeviceLauncher();
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            isCoreDevice: true,
+            coreDeviceLauncher: fakeLauncher,
+            analytics: fakeAnalytics,
+            xcode: FakeXcode(currentVersion: Version(26, 0, 0)),
+          );
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final DeviceLogReader deviceLogReader = IOSDeviceLogReader.test(
+            iMobileDevice: FakeIMobileDevice(),
+            xcode: FakeXcode(currentVersion: Version(26, 0, 0)),
+            isCoreDevice: true,
+          );
+
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
+
+          // Start writing messages to the log reader.
+          Timer(const Duration(milliseconds: 50), () {
+            fakeLauncher.coreDeviceLogForwarder.addLog('Foo');
+            fakeLauncher.coreDeviceLogForwarder.addLog(
+              'The Dart VM service is listening on http://127.0.0.1:456',
+            );
+          });
+
+          final LaunchResult launchResult = await device.startApp(
+            iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, iosProfileDebugger: true),
+            platformArgs: <String, dynamic>{},
+          );
+
+          expect(launchResult.started, true);
+          expect(processManager, hasNoRemainingExpectations);
+        },
+        overrides: {
+          Xcode: () => FakeXcode(currentVersion: Version(26, 0, 0)),
+          Analytics: () => FakeAnalytics(),
+        },
+      );
+
+      testUsingContext(
         'uses Xcode if less than Xcode 26',
         () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
@@ -1945,6 +2077,7 @@ IOSDevice setUpIOSDevice({
   Analytics? analytics,
   FakeXcodeDebug? xcodeDebug,
   FakePlatform? platform,
+  Xcode? xcode,
 }) {
   final artifacts = Artifacts.test();
   final FakePlatform macPlatform =
@@ -1962,6 +2095,11 @@ IOSDevice setUpIOSDevice({
     sdkVersion: sdkVersion,
     fileSystem: fileSystem ?? MemoryFileSystem.test(),
     platform: macPlatform,
+    processUtils: ProcessUtils(
+      processManager: processManager ?? FakeProcessManager.any(),
+      logger: logger,
+    ),
+    xcode: xcode,
     iProxy: IProxy.test(logger: logger, processManager: processManager ?? FakeProcessManager.any()),
     logger: logger,
     iosDeploy:

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -22,6 +22,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwarder.dart';
 import 'package:flutter_tools/src/ios/application_package.dart';
 import 'package:flutter_tools/src/ios/core_devices.dart';
+import 'package:flutter_tools/src/ios/device_support.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
@@ -1680,6 +1681,7 @@ void main() {
               fileSystem: fileSystem,
               isCoreDevice: true,
               coreDeviceControl: FakeIOSCoreDeviceControl(),
+              logger: testLogger,
               xcodeDebug: FakeXcodeDebug(
                 expectedProject: XcodeDebugProject(
                   scheme: 'Runner',
@@ -2089,11 +2091,13 @@ IOSDevice setUpIOSDevice({
     processManager: FakeProcessManager.any(),
   );
   logger ??= BufferLogger.test();
+  final FileSystem testFileSystem = fileSystem ?? MemoryFileSystem.test();
   return IOSDevice(
     '123',
     name: 'iPhone 1',
     sdkVersion: sdkVersion,
-    fileSystem: fileSystem ?? MemoryFileSystem.test(),
+    fileSystem: testFileSystem,
+    fileSystemUtils: FileSystemUtils(fileSystem: testFileSystem, platform: macPlatform),
     platform: macPlatform,
     processUtils: ProcessUtils(
       processManager: processManager ?? FakeProcessManager.any(),
@@ -2274,6 +2278,7 @@ class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {
   @override
   Future<bool> launchAppWithLLDBDebugger({
     required String deviceId,
+    required IOSDeviceSupport deviceSupport,
     required String bundlePath,
     required String bundleId,
     required List<String> launchArguments,

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -7,10 +7,13 @@ import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:fake_async/fake_async.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/ios/device_support.dart';
 import 'package:flutter_tools/src/ios/lldb.dart';
 import 'package:test/fake.dart';
 
@@ -49,6 +52,7 @@ void main() {
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
       mode: BuildMode.debug,
+      deviceSupport: createDeviceSupport(),
     );
     expect(success, isFalse);
     expect(lldb.isRunning, isFalse);
@@ -65,12 +69,14 @@ void main() {
     final breakPointCompleter = Completer<List<int>>();
     final processAttachCompleter = Completer<List<int>>();
     final setupStopHooksCompleter = Completer<List<int>>();
+    final platformStatusCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       breakPointCompleter.future,
       processAttachCompleter.future,
       setupStopHooksCompleter.future,
+      platformStatusCompleter.future,
       processResumedCompleted.future,
     ]);
 
@@ -99,6 +105,7 @@ void main() {
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
     const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
+    const platformStatusMatcher = 'platform status';
     final expectedInputs = [
       'device select $deviceId',
       breakPointMatcher,
@@ -106,6 +113,7 @@ void main() {
       'script lldb.debugger.SetAsync(False)',
       processAttachMatcher,
       setupStopHooksMatcher,
+      platformStatusMatcher,
       processResumedMatcher,
     ];
 
@@ -136,6 +144,9 @@ Target 0: (Runner) stopped.
       if (line == setupStopHooksMatcher) {
         setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
       }
+      if (line == platformStatusMatcher) {
+        platformStatusCompleter.complete(utf8.encode('  Platform: remote-ios\n'));
+      }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));
       }
@@ -146,6 +157,7 @@ Target 0: (Runner) stopped.
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
       mode: BuildMode.debug,
+      deviceSupport: createDeviceSupport(),
     );
     expect(success, isTrue);
     expect(lldb.isRunning, isTrue);
@@ -161,11 +173,13 @@ Target 0: (Runner) stopped.
 
     final processAttachCompleter = Completer<List<int>>();
     final setupStopHooksCompleter = Completer<List<int>>();
+    final platformStatusCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
 
     final stdoutStream = Stream<List<int>>.fromFutures([
       processAttachCompleter.future,
       setupStopHooksCompleter.future,
+      platformStatusCompleter.future,
       processResumedCompleted.future,
     ]);
 
@@ -193,10 +207,12 @@ Target 0: (Runner) stopped.
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
     const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
+    const platformStatusMatcher = 'platform status';
     final expectedInputs = [
       'device select $deviceId',
       processAttachMatcher,
       setupStopHooksMatcher,
+      platformStatusMatcher,
       processResumedMatcher,
     ];
 
@@ -222,6 +238,9 @@ Target 0: (Runner) stopped.
       if (line == setupStopHooksMatcher) {
         setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
       }
+      if (line == platformStatusMatcher) {
+        platformStatusCompleter.complete(utf8.encode('  Platform: remote-ios\n'));
+      }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
       }
@@ -232,6 +251,7 @@ Target 0: (Runner) stopped.
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
       mode: BuildMode.profile,
+      deviceSupport: createDeviceSupport(),
     );
     expect(success, isTrue);
     expect(lldb.isRunning, isTrue);
@@ -291,6 +311,7 @@ Target 0: (Runner) stopped.
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
       mode: BuildMode.debug,
+      deviceSupport: createDeviceSupport(),
     );
     expect(success, isFalse);
     expect(lldb.isRunning, isFalse);
@@ -351,6 +372,7 @@ Target 0: (Runner) stopped.
       appProcessId: appProcessId,
       lldbLogForwarder: FakeLLDBLogForwarder(),
       mode: BuildMode.debug,
+      deviceSupport: createDeviceSupport(),
     );
     expect(success, isFalse);
     expect(lldb.isRunning, isFalse);
@@ -401,6 +423,7 @@ Target 0: (Runner) stopped.
         appProcessId: appProcessId,
         lldbLogForwarder: FakeLLDBLogForwarder(),
         mode: BuildMode.debug,
+        deviceSupport: createDeviceSupport(),
       );
       time.elapse(const Duration(minutes: 2));
       time.flushMicrotasks();
@@ -408,7 +431,7 @@ Target 0: (Runner) stopped.
     });
 
     expect(
-      logger.errorText,
+      logger.warningText,
       contains('LLDB is taking longer than expected to start debugging the app'),
     );
   });
@@ -421,6 +444,7 @@ Target 0: (Runner) stopped.
     final breakPointCompleter = Completer<List<int>>();
     final processAttachCompleter = Completer<List<int>>();
     final setupStopHooksCompleter = Completer<List<int>>();
+    final platformStatusCompleter = Completer<List<int>>();
     final processResumedCompleted = Completer<List<int>>();
     final logAfterAttachCompleter = Completer<List<int>>();
 
@@ -428,6 +452,7 @@ Target 0: (Runner) stopped.
       breakPointCompleter.future,
       processAttachCompleter.future,
       setupStopHooksCompleter.future,
+      platformStatusCompleter.future,
       processResumedCompleted.future,
       logAfterAttachCompleter.future,
     ]);
@@ -457,6 +482,7 @@ Target 0: (Runner) stopped.
     const processAttachMatcher = 'device process attach --pid $appProcessId';
     const processResumedMatcher = 'process continue';
     const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
+    const platformStatusMatcher = 'platform status';
     final expectedInputs = [
       'device select $deviceId',
       breakPointMatcher,
@@ -464,6 +490,7 @@ Target 0: (Runner) stopped.
       'script lldb.debugger.SetAsync(False)',
       processAttachMatcher,
       setupStopHooksMatcher,
+      platformStatusMatcher,
       processResumedMatcher,
     ];
 
@@ -494,6 +521,9 @@ Target 0: (Runner) stopped.
       if (line == setupStopHooksMatcher) {
         setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
       }
+      if (line == platformStatusMatcher) {
+        platformStatusCompleter.complete(utf8.encode('  Platform: remote-ios\n'));
+      }
       if (line == processResumedMatcher) {
         processResumedCompleted.complete(utf8.encode('1 location added to breakpoint 1\n'));
       }
@@ -508,6 +538,7 @@ Target 0: (Runner) stopped.
       appProcessId: appProcessId,
       lldbLogForwarder: lldbLogForwarder,
       mode: BuildMode.debug,
+      deviceSupport: createDeviceSupport(),
     );
 
     logAfterAttachCompleter.complete(utf8.encode('$ignoreLog\n$expectedForwardedLog\n'));
@@ -564,6 +595,7 @@ Target 0: (Runner) stopped.
         appProcessId: appProcessId,
         lldbLogForwarder: FakeLLDBLogForwarder(),
         mode: BuildMode.debug,
+        deviceSupport: createDeviceSupport(),
       ),
     );
 
@@ -591,6 +623,227 @@ Target 0: (Runner) stopped.
     expect(exitStatus, isTrue);
     expect(lldb.isRunning, isFalse);
     expect(lldb.appProcessId, isNull);
+  });
+
+  group('addSymbolSearchPaths', () {
+    testWithoutContext(
+      'sends platform select remote-ios sysroot for arch symbol directory',
+      () async {
+        final fileSystem = MemoryFileSystem.test();
+        final Directory homeDir = fileSystem.directory('/Users/username');
+        final Directory archSymbols =
+            homeDir
+                .childDirectory('Library')
+                .childDirectory('Developer')
+                .childDirectory('Xcode')
+                .childDirectory('iOS DeviceSupport')
+                .childDirectory('iPhone15,2 17.0')
+                .childDirectory('arm64e')
+                .childDirectory('Symbols')
+              ..createSync(recursive: true);
+
+        const deviceId = '123';
+        const appProcessId = 5678;
+
+        final platformSelectCompleter = Completer<List<int>>();
+        final processAttachCompleter = Completer<List<int>>();
+        final setupStopHooksCompleter = Completer<List<int>>();
+        final platformStatusCompleter = Completer<List<int>>();
+        final processResumedCompleted = Completer<List<int>>();
+
+        final stdoutStream = Stream<List<int>>.fromFutures([
+          platformSelectCompleter.future,
+          processAttachCompleter.future,
+          setupStopHooksCompleter.future,
+          platformStatusCompleter.future,
+          processResumedCompleted.future,
+        ]);
+
+        final stdinController = StreamController<List<int>>();
+
+        final processCompleter = Completer<void>();
+        final lldbCommand = FakeLLDBCommand(
+          command: const <String>['xcrun', 'lldb'],
+          completer: processCompleter,
+          stdin: io.IOSink(stdinController.sink),
+          stdout: stdoutStream,
+          stderr: const Stream.empty(),
+        );
+
+        final logger = BufferLogger.test();
+
+        final processManager = FakeLLDBProcessManager([lldbCommand]);
+        final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+        final lldb = LLDB(
+          logger: logger,
+          processUtils: processUtils,
+          xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+        );
+
+        final platformSelectMatcher = 'platform select remote-ios --sysroot "${archSymbols.path}"';
+        const processAttachMatcher = 'device process attach --pid $appProcessId';
+        const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
+        const processResumedMatcher = 'process continue';
+        const platformStatusMatcher = 'platform status';
+        final expectedInputs = [
+          'device select $deviceId',
+          platformSelectMatcher,
+          processAttachMatcher,
+          setupStopHooksMatcher,
+          platformStatusMatcher,
+          processResumedMatcher,
+        ];
+
+        stdinController.stream
+            .transform<String>(utf8.decoder)
+            .transform(const LineSplitter())
+            .listen((String line) {
+              expectedInputs.remove(line);
+              if (line == platformSelectMatcher) {
+                platformSelectCompleter.complete(utf8.encode('\n'));
+              }
+              if (line == processAttachMatcher) {
+                processAttachCompleter.complete(
+                  utf8.encode('Process 568 stopped\nTarget 0: (Runner) stopped.\n'),
+                );
+              }
+              if (line == setupStopHooksMatcher) {
+                setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
+              }
+              if (line == platformStatusMatcher) {
+                platformStatusCompleter.complete(utf8.encode('  Platform: remote-ios\n'));
+              }
+              if (line == processResumedMatcher) {
+                processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
+              }
+            });
+
+        final bool success = await lldb.attachAndStart(
+          deviceId: deviceId,
+          appProcessId: appProcessId,
+          lldbLogForwarder: FakeLLDBLogForwarder(),
+          mode: BuildMode.profile,
+          deviceSupport: createDeviceSupport(
+            modelCode: 'iPhone15,2',
+            operatingSystemVersion: '17.0',
+            cpuArchitectureString: 'arm64e',
+            homeDirectory: homeDir,
+          ),
+        );
+
+        expect(success, isTrue);
+        expect(expectedInputs, isEmpty);
+      },
+    );
+
+    testWithoutContext(
+      'sends platform select remote-ios sysroot for non-arch symbol directory',
+      () async {
+        final fileSystem = MemoryFileSystem.test();
+        final Directory homeDir = fileSystem.directory('/Users/username');
+        final Directory symbols =
+            homeDir
+                .childDirectory('Library')
+                .childDirectory('Developer')
+                .childDirectory('Xcode')
+                .childDirectory('iOS DeviceSupport')
+                .childDirectory('iPhone15,2 17.0')
+                .childDirectory('Symbols')
+              ..createSync(recursive: true);
+
+        const deviceId = '123';
+        const appProcessId = 5678;
+
+        final platformSelectCompleter = Completer<List<int>>();
+        final processAttachCompleter = Completer<List<int>>();
+        final setupStopHooksCompleter = Completer<List<int>>();
+        final platformStatusCompleter = Completer<List<int>>();
+        final processResumedCompleted = Completer<List<int>>();
+
+        final stdoutStream = Stream<List<int>>.fromFutures([
+          platformSelectCompleter.future,
+          processAttachCompleter.future,
+          setupStopHooksCompleter.future,
+          platformStatusCompleter.future,
+          processResumedCompleted.future,
+        ]);
+
+        final stdinController = StreamController<List<int>>();
+
+        final processCompleter = Completer<void>();
+        final lldbCommand = FakeLLDBCommand(
+          command: const <String>['xcrun', 'lldb'],
+          completer: processCompleter,
+          stdin: io.IOSink(stdinController.sink),
+          stdout: stdoutStream,
+          stderr: const Stream.empty(),
+        );
+
+        final logger = BufferLogger.test();
+
+        final processManager = FakeLLDBProcessManager([lldbCommand]);
+        final processUtils = ProcessUtils(processManager: processManager, logger: logger);
+        final lldb = LLDB(
+          logger: logger,
+          processUtils: processUtils,
+          xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+        );
+
+        final platformSelectMatcher = 'platform select remote-ios --sysroot "${symbols.path}"';
+        const processAttachMatcher = 'device process attach --pid $appProcessId';
+        const setupStopHooksMatcher = 'target stop-hook add -o "thread backtrace all" -o "detach"';
+        const processResumedMatcher = 'process continue';
+        const platformStatusMatcher = 'platform status';
+        final expectedInputs = [
+          'device select $deviceId',
+          platformSelectMatcher,
+          processAttachMatcher,
+          setupStopHooksMatcher,
+          platformStatusMatcher,
+          processResumedMatcher,
+        ];
+
+        stdinController.stream
+            .transform<String>(utf8.decoder)
+            .transform(const LineSplitter())
+            .listen((String line) {
+              expectedInputs.remove(line);
+              if (line == platformSelectMatcher) {
+                platformSelectCompleter.complete(utf8.encode('\n'));
+              }
+              if (line == processAttachMatcher) {
+                processAttachCompleter.complete(
+                  utf8.encode('Process 568 stopped\nTarget 0: (Runner) stopped.\n'),
+                );
+              }
+              if (line == setupStopHooksMatcher) {
+                setupStopHooksCompleter.complete(utf8.encode('Stop hook #1 added.\n'));
+              }
+              if (line == platformStatusMatcher) {
+                platformStatusCompleter.complete(utf8.encode('  Platform: remote-ios\n'));
+              }
+              if (line == processResumedMatcher) {
+                processResumedCompleted.complete(utf8.encode('Process 568 resuming\n'));
+              }
+            });
+
+        final bool success = await lldb.attachAndStart(
+          deviceId: deviceId,
+          appProcessId: appProcessId,
+          lldbLogForwarder: FakeLLDBLogForwarder(),
+          mode: BuildMode.profile,
+          deviceSupport: createDeviceSupport(
+            modelCode: 'iPhone15,2',
+            operatingSystemVersion: '17.0',
+            cpuArchitectureString: 'arm64e',
+            homeDirectory: homeDir,
+          ),
+        );
+
+        expect(success, isTrue);
+        expect(expectedInputs, isEmpty);
+      },
+    );
   });
 
   group('LLDBLogForwarder', () {
@@ -824,4 +1077,28 @@ class FakeLLDBLogForwarder extends Fake implements LLDBLogForwarder {
       expectedLogCompleter.complete();
     }
   }
+}
+
+IOSDeviceSupport createDeviceSupport({
+  Logger? logger,
+  ProcessUtils? processUtils,
+  Directory? homeDirectory,
+  String? modelCode,
+  String? operatingSystemVersion,
+  String? cpuArchitectureString,
+  String deviceId = '123',
+}) {
+  final Logger testLogger = logger ?? BufferLogger.test();
+  return IOSDeviceSupport(
+    logger: testLogger,
+    processUtils:
+        processUtils ??
+        ProcessUtils(processManager: FakeProcessManager.empty(), logger: testLogger),
+    xcode: null,
+    homeDirectory: homeDirectory,
+    modelCode: modelCode,
+    operatingSystemVersion: operatingSystemVersion,
+    cpuArchitectureString: cpuArchitectureString,
+    deviceId: deviceId,
+  );
 }


### PR DESCRIPTION
### Issue Link:
https://github.com/flutter/flutter/issues/189284

### Impact Description:

When debugging on iOS 27 devices, the app may launch and hang for multiple minutes.

### Changelog Description:
[flutter/189284] When debugging with an iOS 27 device, the app may launch to a white screen and hang for multiple minutes.

### Workaround:
Run `xcrun xcodebuild -prepareDeviceSupport -destination id=[insert device id]`

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
See repro steps in https://github.com/flutter/flutter/issues/189284.
