### PR TITLE
[CP-stable] Collect analytics about SwiftPM errors and warnings (#191746)

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -172,6 +172,11 @@ Future<XcodeBuildResult> buildXcodeProject({
       fileSystem: globals.fs,
       plistParser: globals.plistParser,
       config: globals.config,
+      analytics: globals.analytics,
+      hostPlatform: globals.platform,
+      operatingSystemUtils: globals.os,
+      flutterVersion: globals.flutterVersion,
+      reportCrashes: !await globals.isRunningOnBot
     ),
     SwiftPackageManagerGitignoreMigration(project, globals.logger),
     MetalAPIValidationMigrator.ios(app.project, globals.logger),
@@ -205,6 +210,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     fileSystem: globals.fs,
     logger: globals.logger,
     cocoapods: globals.cocoaPods,
+    analytics: globals.analytics,
   );
 
   await removeExtendedAttributesForProject(
@@ -933,6 +939,7 @@ Future<void> diagnoseXcodeBuildFailure(
     platform: platform,
     logger: logger,
     fileSystem: fileSystem,
+    analytics: analytics,
     device: device,
   );
 
@@ -1160,6 +1167,7 @@ Future<bool> _handleIssues(
   required FlutterDarwinPlatform platform,
   required Logger logger,
   required FileSystem fileSystem,
+  required Analytics analytics,
   Device? device,
 }) async {
   var requiresProvisioningProfile = false;
@@ -1250,6 +1258,11 @@ Future<bool> _handleIssues(
     final bool usesCocoapods = xcodeProject.podfile.existsSync();
     final bool usesSwiftPackageManager = xcodeProject.usesSwiftPackageManager;
     if (usesCocoapods && usesSwiftPackageManager) {
+      for (final module in duplicateModules) {
+        analytics.send(
+          Event.appleUsageEvent(workflow: 'duplicate-modules-build-failure', parameter: module),
+        );
+      }
       logger.printError(
         'Your project uses both CocoaPods and Swift Package Manager, which can '
         'cause the above error. It may be caused by there being both a CocoaPod '

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -121,6 +121,11 @@ Future<void> buildMacOS({
       fileSystem: globals.fs,
       plistParser: globals.plistParser,
       config: globals.config,
+      analytics: globals.analytics,
+      hostPlatform: globals.platform,
+      operatingSystemUtils: globals.os,
+      flutterVersion: globals.flutterVersion,
+      reportCrashes: !await globals.isRunningOnBot
     ),
     SwiftPackageManagerGitignoreMigration(flutterProject, globals.logger),
     MetalAPIValidationMigrator.macos(flutterProject.macos, globals.logger),
@@ -136,6 +141,7 @@ Future<void> buildMacOS({
     fileSystem: globals.fs,
     logger: globals.logger,
     cocoapods: globals.cocoaPods,
+    analytics: globals.analytics,
   );
 
   final String buildDirectoryPath = getMacOSBuildDirectory();

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -540,6 +540,13 @@ class CocoaPods {
               ),
         );
         if (missingPluginSupportsSwiftPM) {
+          _analytics.send(
+            Event.appleUsageEvent(
+              workflow: 'cocoapod-swiftpm-interdependency-failure',
+              parameter: requiringPlugin,
+              result: missingPlugin,
+            ),
+          );
           return 'Error: A dependency conflict has occurred because $requiringPlugin uses CocoaPods while '
               '$missingPlugin uses Swift Package Manager. Please contact the $requiringPlugin '
               'maintainers to request Swift Package Manager adoption.\n\n'

--- a/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
+++ b/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
@@ -175,6 +175,7 @@ class DarwinDependencyManagement {
     required FileSystem fileSystem,
     required Logger logger,
     required CocoaPods? cocoapods,
+    required Analytics analytics,
   }) async {
     final bool projectUsesSwiftPM =
         xcodeProject.usesSwiftPackageManager &&
@@ -222,6 +223,7 @@ class DarwinDependencyManagement {
       cocoapodOnlyPlugins: cocoapodOnlyPlugins,
       logger: logger,
       platform: platform,
+      analytics: analytics,
     );
 
     await _printRemoveCocoapodIntegrationMessage(
@@ -279,6 +281,7 @@ class DarwinDependencyManagement {
     required List<String> cocoapodOnlyPlugins,
     required Logger logger,
     required FlutterDarwinPlatform platform,
+    required Analytics analytics,
   }) {
     if (cocoapodOnlyPlugins.isEmpty) {
       return;
@@ -289,6 +292,11 @@ class DarwinDependencyManagement {
       'This will become an error in a future version of Flutter. Please contact the plugin '
       'maintainers to request Swift Package Manager adoption.',
     );
+    for (final plugin in cocoapodOnlyPlugins) {
+      analytics.send(
+        Event.appleUsageEvent(workflow: 'cocoapod-only-plugin-warning', parameter: plugin),
+      );
+    }
   }
 
   /// Print a message recommending removing CocoaPod integration when all plugins support SwiftPM.

--- a/packages/flutter_tools/lib/src/migrations/swift_package_manager_integration_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/swift_package_manager_integration_migration.dart
@@ -2,13 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 import 'package:xml/xml.dart';
 
+import '../base/async_guard.dart';
 import '../base/common.dart';
 import '../base/config.dart';
 import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
+import '../base/os.dart';
+import '../base/platform.dart';
 import '../base/project_migrator.dart';
 import '../build_info.dart';
 import '../convert.dart';
@@ -18,6 +23,8 @@ import '../ios/xcodeproj.dart';
 import '../macos/swift_package_manager.dart';
 import '../plugins.dart';
 import '../project.dart';
+import '../reporting/crash_reporting.dart';
+import '../version.dart';
 
 /// Swift Package Manager integration requires changes to the Xcode project's
 /// project.pbxproj and xcscheme. This class handles making those changes.
@@ -31,6 +38,11 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
     required FileSystem fileSystem,
     required PlistParser plistParser,
     required Config config,
+    required Analytics analytics,
+    required Platform hostPlatform,
+    required OperatingSystemUtils operatingSystemUtils,
+    required FlutterVersion flutterVersion,
+    required bool reportCrashes,
   }) : _xcodeProject = project,
        _platform = platform,
        _buildInfo = buildInfo,
@@ -39,6 +51,11 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
        _fileSystem = fileSystem,
        _plistParser = plistParser,
        _config = config,
+       _analytics = analytics,
+       _hostPlatform = hostPlatform,
+       _operatingSystemUtils = operatingSystemUtils,
+       _flutterVersion = flutterVersion,
+       _reportCrashes = reportCrashes,
        super(logger);
 
   final XcodeBasedProject _xcodeProject;
@@ -49,6 +66,11 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
   final File _xcodeProjectInfoFile;
   final PlistParser _plistParser;
   final Config _config;
+  final Analytics _analytics;
+  final Platform _hostPlatform;
+  final OperatingSystemUtils _operatingSystemUtils;
+  final FlutterVersion _flutterVersion;
+  final bool _reportCrashes;
 
   /// New identifier for FlutterGeneratedPluginSwiftPackage PBXBuildFile.
   static const _flutterPluginsSwiftPackageBuildFileIdentifier = '78A318202AECB46A00862997';
@@ -134,6 +156,8 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
   /// If the app is not an example app or the plugin cannot be found, this will return null.
   late final ({String name, String path})? _examplePlugin;
 
+  String _flutterVersionString() => _flutterVersion.getVersionString(redactUnknownBranches: true);
+
   void restoreFromBackup(SchemeInfo? schemeInfo) {
     if (backupProjectSettings.existsSync()) {
       logger.printTrace('Restoring project settings from backup file...');
@@ -171,7 +195,7 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
     var optionalOnly = false;
     try {
       if (!_xcodeProjectInfoFile.existsSync()) {
-        throw Exception('Xcode project not found.');
+        throw SwiftPackageManagerMigrationException('Xcode project not found.');
       }
 
       _examplePlugin = await _loadPluginFromExampleProject(
@@ -219,23 +243,76 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
       // If pbxproj was not already migrated, verify settings were set correctly.
       if (!isPbxprojMigrated) {
         if (!_isPbxprojMigratedCorrectly(updatedInfo, logErrorIfNotMigrated: true)) {
-          throw Exception('Settings were not updated correctly.');
+          throw SwiftPackageManagerMigrationException('Settings were not updated correctly.');
         }
       } else if (!isOptionalFilesMigrated) {
         if (!_areOptionalFilesMigratedCorrectly(updatedInfo, logErrorIfNotMigrated: true)) {
-          throw Exception('Settings were not updated correctly.');
+          throw SwiftPackageManagerMigrationException('Settings were not updated correctly.');
         }
       }
 
       // Get the project info to make sure it compiles with xcodebuild
-      await _xcodeProjectInterpreter.getInfo(
-        _xcodeProject,
-        buildDirectory: _fileSystem.directory(
-          _platform.buildDirectory(config: _config, fileSystem: _fileSystem),
+      try {
+        await _xcodeProjectInterpreter.getInfo(
+          _xcodeProject,
+          buildDirectory: _fileSystem.directory(
+            _platform.buildDirectory(config: _config, fileSystem: _fileSystem),
+          ),
+        );
+      } on Exception catch (e, stackTrace) {
+        // Send error to crash reporter.
+        if (_reportCrashes) {
+          try {
+            await asyncGuard(() async {
+              final crashReportSender = CrashReportSender(
+                platform: _hostPlatform,
+                logger: logger,
+                operatingSystemUtils: _operatingSystemUtils,
+                analytics: _analytics,
+              );
+              await crashReportSender.sendReport(
+                error: e,
+                stackTrace: stackTrace,
+                getFlutterVersion: _flutterVersionString,
+                command: 'swiftpm-migration',
+                typeId: 'XcodeBuildError',
+              );
+            });
+          } on Exception catch (_) {
+            // Fail silently if it fails to send crash report
+          }
+        }
+
+        final message = e.toString();
+        if (message.contains('Could not resolve package dependencies')) {
+          throw SwiftPackageManagerMigrationException(
+            message,
+            analyticsMessage: 'Xcode could not resolve package dependencies.',
+          );
+        } else {
+          throw SwiftPackageManagerMigrationException(
+            message,
+            analyticsMessage: 'Xcode failed for unknown reason.',
+          );
+        }
+      }
+      _analytics.send(
+        Event.appleUsageEvent(
+          workflow: 'swiftpm-migration-success',
+          parameter: optionalOnly ? 'optional' : 'full',
         ),
       );
     } on Exception catch (e) {
       restoreFromBackup(schemeInfo);
+      if (e is SwiftPackageManagerMigrationException) {
+        _analytics.send(
+          Event.appleUsageEvent(
+            workflow: 'swiftpm-migration-failure',
+            parameter: optionalOnly ? 'optional' : 'full',
+            result: e.analyticsMessage ?? e.userMessage,
+          ),
+        );
+      }
       if (optionalOnly) {
         // This part of the migration is optional. We'll log this for debugging sake but don't
         // really expect the user to see it.
@@ -248,7 +325,7 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
         throwToolExit(
           'An error occurred when adding Swift Package Manager integration:\n'
           '  $e\n\n'
-          'Swift Package Manager is currently an experimental feature, please file a bug at\n'
+          'To help the Flutter team improve this process, please file a bug at\n'
           '  https://github.com/flutter/flutter/issues/new?template=01_activation.yml \n'
           'Consider including a copy of the following files in your bug report:\n'
           '  ${_platform.name}/Runner.xcodeproj/project.pbxproj\n'
@@ -271,7 +348,7 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
   Future<SchemeInfo> _getSchemeFile() async {
     final XcodeProjectInfo? projectInfo = await _xcodeProject.projectInfo();
     if (projectInfo == null) {
-      throw Exception('Unable to get Xcode project info.');
+      throw SwiftPackageManagerMigrationException('Unable to get Xcode project info.');
     }
     if (_xcodeProject.xcodeWorkspace == null) {
       throw Exception('Xcode workspace not found.');
@@ -283,7 +360,9 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
 
     final File schemeFile = _xcodeProject.xcodeProjectSchemeFile(scheme: scheme);
     if (!schemeFile.existsSync()) {
-      throw Exception('Unable to get scheme file for $scheme.');
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) => 'Unable to get scheme file for ${sanitize(scheme, .name)}.',
+      );
     }
 
     final String schemeContent = schemeFile.readAsStringSync();
@@ -318,7 +397,10 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
     try {
       document = XmlDocument.parse(schemeContent);
     } on XmlException catch (exception) {
-      throw Exception('Failed to parse ${schemeFile.basename}: Invalid xml: $exception');
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Failed to parse ${sanitize(schemeFile.basename, .basename)}: Invalid xml${sanitize(': $exception', .error)}',
+      );
     }
 
     final Iterable<XmlElement> buildableReferences = document.findAllElements('BuildableReference');
@@ -330,28 +412,36 @@ class SwiftPackageManagerIntegrationMigration extends ProjectMigrator {
       }
     }
     if (targetReference == null) {
-      throw Exception(
-        'Failed to parse ${schemeFile.basename}: Could not find BuildableReference '
-        'for ${_xcodeProject.hostAppProjectName}.',
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Failed to parse ${sanitize(schemeFile.basename, .basename)}: Could not find BuildableReference '
+            'for ${sanitize(_xcodeProject.hostAppProjectName, .name)}.',
       );
     }
 
     final String? buildableNameAttr = targetReference.getAttribute('BuildableName');
     if (buildableNameAttr == null) {
-      throw Exception('Failed to parse ${schemeFile.basename}: Could not find BuildableName.');
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Failed to parse ${sanitize(schemeFile.basename, .basename)}: Could not find BuildableName.',
+      );
     }
     final buildableName = 'BuildableName = "$buildableNameAttr"';
 
     final String? blueprintNameAttr = targetReference.getAttribute('BlueprintName');
     if (blueprintNameAttr == null) {
-      throw Exception('Failed to parse ${schemeFile.basename}: Could not find BlueprintName.');
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Failed to parse ${sanitize(schemeFile.basename, .basename)}: Could not find BlueprintName.',
+      );
     }
     final blueprintName = 'BlueprintName = "$blueprintNameAttr"';
 
     final String? referencedContainerAttr = targetReference.getAttribute('ReferencedContainer');
     if (referencedContainerAttr == null) {
-      throw Exception(
-        'Failed to parse ${schemeFile.basename}: Could not find ReferencedContainer.',
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Failed to parse ${sanitize(schemeFile.basename, .basename)}: Could not find ReferencedContainer.',
       );
     }
     final referencedContainer = 'ReferencedContainer = "$referencedContainerAttr"';
@@ -408,7 +498,10 @@ $newContent
             .firstOrNull;
 
         if (buildAction == null) {
-          throw Exception('Failed to parse ${schemeFile.basename}: Could not find BuildAction.');
+          throw SwiftPackageManagerMigrationException.sanitized(
+            (sanitize) =>
+                'Failed to parse ${sanitize(schemeFile.basename, .basename)}: Could not find BuildAction.',
+          );
         }
       }
       newScheme = schemeContent.replaceFirst(buildAction, '$newContent$buildAction');
@@ -418,8 +511,9 @@ $newContent
     try {
       XmlDocument.parse(newScheme);
     } on XmlException catch (exception) {
-      throw Exception(
-        'Failed to parse ${schemeFile.basename}: Invalid xml: $newScheme\n$exception',
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Failed to parse ${sanitize(schemeFile.basename, .basename)} after updating: Invalid xml${sanitize(': $newScheme\n$exception', .error)}',
       );
     }
   }
@@ -429,17 +523,23 @@ $newContent
   ParsedProjectInfo _parsePbxproj() {
     final String? results = _plistParser.plistJsonContent(_xcodeProjectInfoFile.path);
     if (results == null) {
-      throw Exception('Failed to parse project settings.');
+      throw SwiftPackageManagerMigrationException('Failed to parse project settings.');
     }
 
     try {
       final decodeResult = json.decode(results) as Object;
       if (decodeResult is! Map<String, Object?>) {
-        throw Exception('project.pbxproj returned unexpected JSON response: $results');
+        throw SwiftPackageManagerMigrationException(
+          'project.pbxproj returned unexpected JSON response: $results',
+          analyticsMessage: 'project.pbxproj returned unexpected JSON response',
+        );
       }
       return ParsedProjectInfo.fromJson(decodeResult);
     } on FormatException {
-      throw Exception('project.pbxproj returned non-JSON response: $results');
+      throw SwiftPackageManagerMigrationException(
+        'project.pbxproj returned non-JSON response: $results',
+        analyticsMessage: 'project.pbxproj returned non-JSON response',
+      );
     }
   }
 
@@ -612,19 +712,23 @@ $newContent
           '$_flutterPluginsSwiftPackageBuildFileIdentifier /* $kFlutterGeneratedPluginSwiftPackageName in Frameworks */',
         ) &&
         originalProjectContents.contains(_flutterPluginsSwiftPackageBuildFileIdentifier)) {
-      throw Exception('Duplicate id found for PBXBuildFile.');
+      throw SwiftPackageManagerMigrationException('Duplicate id found for PBXBuildFile.');
     }
     if (!originalProjectContents.contains(
           '$_flutterPluginsSwiftPackageProductDependencyIdentifier /* $kFlutterGeneratedPluginSwiftPackageName */',
         ) &&
         originalProjectContents.contains(_flutterPluginsSwiftPackageProductDependencyIdentifier)) {
-      throw Exception('Duplicate id found for XCSwiftPackageProductDependency.');
+      throw SwiftPackageManagerMigrationException(
+        'Duplicate id found for XCSwiftPackageProductDependency.',
+      );
     }
     if (!originalProjectContents.contains(
           '$_localFlutterPluginsSwiftPackageReferenceIdentifier /* XCLocalSwiftPackageReference',
         ) &&
         originalProjectContents.contains(_localFlutterPluginsSwiftPackageReferenceIdentifier)) {
-      throw Exception('Duplicate id found for XCLocalSwiftPackageReference.');
+      throw SwiftPackageManagerMigrationException(
+        'Duplicate id found for XCLocalSwiftPackageReference.',
+      );
     }
   }
 
@@ -633,7 +737,7 @@ $newContent
           '$_flutterPluginsSwiftPackageFileIdentifer /* $kFlutterGeneratedPluginSwiftPackageName */',
         ) &&
         originalProjectContents.contains(_flutterPluginsSwiftPackageFileIdentifer)) {
-      throw Exception(
+      throw SwiftPackageManagerMigrationException(
         'Duplicate id found for $kFlutterGeneratedPluginSwiftPackageName PBXFileReference.',
       );
     }
@@ -642,13 +746,16 @@ $newContent
             '$_flutterPluginLocalOverrideFileIdenitifier /* ${_examplePlugin.name} */',
           ) &&
           originalProjectContents.contains(_flutterPluginLocalOverrideFileIdenitifier)) {
-        throw Exception('Duplicate id found for ${_examplePlugin.name} PBXFileReference.');
+        throw SwiftPackageManagerMigrationException(
+          'Duplicate id found for ${_examplePlugin.name} PBXFileReference.',
+          analyticsMessage: 'Duplicate id found for plugin PBXFileReference.',
+        );
       }
       if (!originalProjectContents.contains(
             '$_flutterFrameworkLocalOverrideFileIdentifier /* $kFlutterGeneratedFrameworkSwiftPackageTargetName */',
           ) &&
           originalProjectContents.contains(_flutterFrameworkLocalOverrideFileIdentifier)) {
-        throw Exception(
+        throw SwiftPackageManagerMigrationException(
           'Duplicate id found for $kFlutterGeneratedFrameworkSwiftPackageTargetName PBXFileReference.',
         );
       }
@@ -752,8 +859,9 @@ $newContent
     );
     if (runnerFrameworksPhaseStartIndex == -1 ||
         runnerFrameworksPhaseStartIndex > endSectionIndex) {
-      throw Exception(
-        'Unable to find PBXFrameworksBuildPhase for ${_xcodeProject.hostAppProjectName} target.',
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Unable to find PBXFrameworksBuildPhase for ${sanitize(_xcodeProject.hostAppProjectName, .name)} target.',
       );
     }
 
@@ -768,8 +876,9 @@ $newContent
         .toList()
         .firstOrNull;
     if (runnerFrameworksPhase == null) {
-      throw Exception(
-        'Unable to find parsed PBXFrameworksBuildPhase for ${_xcodeProject.hostAppProjectName} target.',
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Unable to find parsed PBXFrameworksBuildPhase for ${sanitize(_xcodeProject.hostAppProjectName, .name)} target.',
       );
     }
 
@@ -788,8 +897,9 @@ $newContent
         runnerFrameworksPhaseStartIndex,
       );
       if (startFilesIndex == -1 || startFilesIndex > endSectionIndex) {
-        throw Exception(
-          'Unable to files for PBXFrameworksBuildPhase ${_xcodeProject.hostAppProjectName} target.',
+        throw SwiftPackageManagerMigrationException.sanitized(
+          (sanitize) =>
+              'Unable to find files for PBXFrameworksBuildPhase for ${sanitize(_xcodeProject.hostAppProjectName, .name)} target.',
         );
       }
       const newContent =
@@ -834,8 +944,9 @@ $newContent
         .where((ParsedNativeTarget target) => target.identifier == _runnerNativeTargetIdentifier)
         .firstOrNull;
     if (runnerNativeTarget == null) {
-      throw Exception(
-        'Unable to find parsed PBXNativeTarget for ${_xcodeProject.hostAppProjectName} target.',
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Unable to find parsed PBXNativeTarget for ${sanitize(_xcodeProject.hostAppProjectName, .name)} target.',
       );
     }
     final String subsectionLineStart = runnerNativeTarget.name != null
@@ -846,8 +957,9 @@ $newContent
       startSectionIndex,
     );
     if (runnerNativeTargetStartIndex == -1 || runnerNativeTargetStartIndex > endSectionIndex) {
-      throw Exception(
-        'Unable to find PBXNativeTarget for ${_xcodeProject.hostAppProjectName} target.',
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Unable to find PBXNativeTarget for ${sanitize(_xcodeProject.hostAppProjectName, .name)} target.',
       );
     }
 
@@ -867,8 +979,9 @@ $newContent
       );
       if (packageProductDependenciesIndex == -1 ||
           packageProductDependenciesIndex > endSectionIndex) {
-        throw Exception(
-          'Unable to find packageProductDependencies for ${_xcodeProject.hostAppProjectName} PBXNativeTarget.',
+        throw SwiftPackageManagerMigrationException.sanitized(
+          (sanitize) =>
+              'Unable to find packageProductDependencies for ${sanitize(_xcodeProject.hostAppProjectName, .name)} PBXNativeTarget.',
         );
       }
       const newContent =
@@ -917,7 +1030,7 @@ $newContent
       startSectionIndex,
     );
     if (flutterGroupStartIndex == -1 || flutterGroupStartIndex > endSectionIndex) {
-      throw Exception('Unable to find Flutter PBXGroup.');
+      throw SwiftPackageManagerMigrationException('Unable to find Flutter PBXGroup.');
     }
 
     // Get the Flutter Group from the parsed project info.
@@ -926,7 +1039,7 @@ $newContent
         .toList()
         .firstOrNull;
     if (parsedGroup == null) {
-      throw Exception('Unable to find parsed Flutter PBXGroup.');
+      throw SwiftPackageManagerMigrationException('Unable to find parsed Flutter PBXGroup.');
     }
 
     // Find the children field within the Flutter PBXGroup.
@@ -984,7 +1097,10 @@ $newContent
       startSectionIndex,
     );
     if (projectStartIndex == -1 || projectStartIndex > endSectionIndex) {
-      throw Exception('Unable to find PBXProject for ${_xcodeProject.hostAppProjectName}.');
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Unable to find PBXProject for ${sanitize(_xcodeProject.hostAppProjectName, .name)}.',
+      );
     }
 
     // Get the Runner project from the parsed project info.
@@ -993,7 +1109,10 @@ $newContent
         .toList()
         .firstOrNull;
     if (projectObject == null) {
-      throw Exception('Unable to find parsed PBXProject for ${_xcodeProject.hostAppProjectName}.');
+      throw SwiftPackageManagerMigrationException.sanitized(
+        (sanitize) =>
+            'Unable to find parsed PBXProject for ${sanitize(_xcodeProject.hostAppProjectName, .name)}.',
+      );
     }
 
     if (projectObject.packageReferences == null) {
@@ -1011,8 +1130,9 @@ $newContent
         projectStartIndex,
       );
       if (packageReferencesIndex == -1 || packageReferencesIndex > endSectionIndex) {
-        throw Exception(
-          'Unable to find packageReferences for ${_xcodeProject.hostAppProjectName} PBXProject.',
+        throw SwiftPackageManagerMigrationException.sanitized(
+          (sanitize) =>
+              'Unable to find packageReferences for ${sanitize(_xcodeProject.hostAppProjectName, .name)} PBXProject.',
         );
       }
       const newContent =
@@ -1065,7 +1185,7 @@ $newContent
 
       final int index = lines.lastIndexWhere((String line) => line.trim().startsWith('/* End'));
       if (index == -1) {
-        throw Exception('Unable to find any sections.');
+        throw SwiftPackageManagerMigrationException('Unable to find any sections.');
       }
       lines.insertAll(index + 1, newContent);
 
@@ -1127,7 +1247,7 @@ $newContent
 
       final int index = lines.lastIndexWhere((String line) => line.trim().startsWith('/* End'));
       if (index == -1) {
-        throw Exception('Unable to find any sections.');
+        throw SwiftPackageManagerMigrationException('Unable to find any sections.');
       }
       lines.insertAll(index + 1, newContent);
 
@@ -1207,14 +1327,18 @@ $newContent
   (int, int) _sectionRange(String sectionName, List<String> lines, {bool throwIfMissing = true}) {
     final int startSectionIndex = lines.indexOf('/* Begin $sectionName section */');
     if (throwIfMissing && startSectionIndex == -1) {
-      throw Exception('Unable to find beginning of $sectionName section.');
+      throw SwiftPackageManagerMigrationException(
+        'Unable to find beginning of $sectionName section.',
+      );
     }
     final int endSectionIndex = lines.indexOf('/* End $sectionName section */');
     if (throwIfMissing && endSectionIndex == -1) {
-      throw Exception('Unable to find end of $sectionName section.');
+      throw SwiftPackageManagerMigrationException('Unable to find end of $sectionName section.');
     }
     if (throwIfMissing && startSectionIndex > endSectionIndex) {
-      throw Exception('Found the end of $sectionName section before the beginning.');
+      throw SwiftPackageManagerMigrationException(
+        'Found the end of $sectionName section before the beginning.',
+      );
     }
     return (startSectionIndex, endSectionIndex);
   }
@@ -1429,4 +1553,70 @@ class ParsedProject {
   final Map<String, Object?> data;
   final String identifier;
   final List<String>? packageReferences;
+}
+
+/// Exception thrown when the Swift Package Manager integration migration fails.
+@visibleForTesting
+class SwiftPackageManagerMigrationException implements Exception {
+  SwiftPackageManagerMigrationException(this.userMessage, {this.analyticsMessage});
+
+  /// Creates a [SwiftPackageManagerMigrationException] where both [userMessage]
+  /// and [analyticsMessage] are built by [builder].
+  ///
+  /// The [userMessage] is created by evaluating [builder] without sanitization.
+  /// The [analyticsMessage] is created by evaluating [builder] with [sanitizer]
+  /// to anonymize user-specific identifiers and strip sensitive error details
+  /// for analytics reporting.
+  factory SwiftPackageManagerMigrationException.sanitized(
+    String Function(String Function(String, SanitizeType type) sanitize) builder, {
+    String Function(String, SanitizeType type) sanitizer = _defaultSanitizer,
+  }) {
+    return SwiftPackageManagerMigrationException(
+      builder((value, type) => value),
+      analyticsMessage: builder(sanitizer),
+    );
+  }
+
+  /// Default sanitizer used to redact names, file basenames, or error details
+  /// for analytics reporting.
+  static String _defaultSanitizer(String name, SanitizeType type) {
+    switch (type) {
+      case SanitizeType.name:
+        return name == 'Runner' ? 'Runner' : 'custom';
+      case SanitizeType.basename:
+        if (name.startsWith('Runner.')) {
+          return name;
+        }
+        final List<String> parts = name.split('.');
+        if (parts.length >= 2) {
+          return 'custom.${parts.last}';
+        }
+        return 'custom';
+      case SanitizeType.error:
+        return '';
+    }
+  }
+
+  /// The message to display to the user.
+  final String userMessage;
+
+  /// An optional sanitized message for analytics reporting.
+  final String? analyticsMessage;
+
+  @override
+  String toString() => userMessage;
+}
+
+/// The type of data to sanitize for analytics reporting in
+/// [SwiftPackageManagerMigrationException].
+@visibleForTesting
+enum SanitizeType {
+  /// A target or scheme name.
+  name,
+
+  /// A file basename (e.g. `Runner.xcscheme`).
+  basename,
+
+  /// An error message or stack trace.
+  error,
 }

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -146,11 +146,15 @@ class CrashReportSender {
   /// Sends one crash report.
   ///
   /// The report is populated from data in [error] and [stackTrace].
+  ///
+  /// If [typeId] is provided, it will be used as the type of the crash, otherwise will default to
+  /// being a Dart error ([_kDartTypeId]).
   Future<void> sendReport({
     required Object error,
     required StackTrace stackTrace,
     required String Function() getFlutterVersion,
     required String command,
+    String? typeId,
   }) async {
     // Only send one crash report per run.
     if (_crashReportSent) {
@@ -176,7 +180,7 @@ class CrashReportSender {
       req.fields['version'] = flutterVersion;
       req.fields['osName'] = _platform.operatingSystem;
       req.fields['osVersion'] = _operatingSystemUtils.name; // this actually includes version
-      req.fields['type'] = _kDartTypeId;
+      req.fields['type'] = typeId ?? _kDartTypeId;
       req.fields['error_runtime_type'] = '${error.runtimeType}';
       req.fields['error_message'] = '$error';
       req.fields['comments'] = command;

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -152,6 +152,30 @@ void main() {
       await verifyCrashReportSent(requestInfo);
     });
 
+    testWithoutContext('should send crash reports with custom typeId', () async {
+      final requestInfo = RequestInfo();
+
+      final crashReportSender = CrashReportSender(
+        client: FakeCrashReportSender(requestInfo),
+        platform: platform,
+        logger: logger,
+        operatingSystemUtils: operatingSystemUtils,
+        analytics: fakeAnalytics,
+      );
+
+      await crashReportSender.sendReport(
+        error: StateError('Test bad state error'),
+        stackTrace: stackTrace,
+        getFlutterVersion: () => 'test-version',
+        command: 'crash',
+        typeId: 'XcodeBuildError',
+      );
+
+      expect(requestInfo.fields?['type'], 'XcodeBuildError');
+      expect(logger.traceText, contains('Sending crash report to Google.'));
+      expect(logger.traceText, contains('Crash report sent (report ID: test-report-id)'));
+    });
+
     testWithoutContext(
       'should print an explanatory message when there is a SocketException',
       () async {

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -487,6 +487,19 @@ Could not build the precompiled application for the device.''',
           'plugin_1_name, plugin_2_name.',
         ),
       );
+      expect(
+        fakeAnalytics.sentEvents,
+        containsAll(<Event>[
+          Event.appleUsageEvent(
+            workflow: 'duplicate-modules-build-failure',
+            parameter: 'plugin_1_name',
+          ),
+          Event.appleUsageEvent(
+            workflow: 'duplicate-modules-build-failure',
+            parameter: 'plugin_2_name',
+          ),
+        ]),
+      );
     });
 
     testWithoutContext('parses duplicate symbols error with arch and number', () async {
@@ -533,6 +546,15 @@ duplicate symbol '_$s29plugin_1_name23PluginNamePluginC9setDouble3key5valueySS_S
           'plugin_1_name.',
         ),
       );
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.appleUsageEvent(
+            workflow: 'duplicate-modules-build-failure',
+            parameter: 'plugin_1_name',
+          ),
+        ),
+      );
     });
 
     testWithoutContext('parses duplicate symbols error with number', () async {
@@ -576,6 +598,15 @@ duplicate symbol '_$s29plugin_1_name23PluginNamePluginC9setDouble3key5valueySS_S
           'plugin_1_name.',
         ),
       );
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.appleUsageEvent(
+            workflow: 'duplicate-modules-build-failure',
+            parameter: 'plugin_1_name',
+          ),
+        ),
+      );
     });
 
     testWithoutContext('parses duplicate symbols error without arch and number', () async {
@@ -616,6 +647,15 @@ duplicate symbol '_$s29plugin_1_name23PluginNamePluginC9setDouble3key5valueySS_S
           'cause the above error. It may be caused by there being both a CocoaPod '
           'and Swift Package Manager dependency for the following module(s): '
           'plugin_1_name.',
+        ),
+      );
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.appleUsageEvent(
+            workflow: 'duplicate-modules-build-failure',
+            parameter: 'plugin_1_name',
+          ),
         ),
       );
     });

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -1625,6 +1625,16 @@ end''');
           throwsToolExit(),
         );
         expect(logger.errorText, contains('Error: A dependency conflict has occurred because'));
+        expect(
+          fakeAnalytics.sentEvents,
+          contains(
+            Event.appleUsageEvent(
+              workflow: 'cocoapod-swiftpm-interdependency-failure',
+              parameter: 'plugin_2_name',
+              result: 'plugin_1_name',
+            ),
+          ),
+        );
       },
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart
@@ -1100,6 +1100,10 @@ flutter:
       final fileSystem = MemoryFileSystem.test();
       final logger = BufferLogger.test();
       final cocoapods = FakeCocoaPods();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: fileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
       final project = FakeIosProject(fileSystem: fileSystem, usesSwiftPackageManager: true);
       final plugins = <Plugin>[FakePlugin(name: 'plugin', platforms: <String, PluginPlatform>{})];
 
@@ -1110,20 +1114,22 @@ flutter:
         fileSystem: fileSystem,
         logger: logger,
         cocoapods: cocoapods,
+        analytics: fakeAnalytics,
       );
 
       expect(logger.warningText, isEmpty);
+      expect(fakeAnalytics.sentEvents, isEmpty);
     });
 
     testWithoutContext('filters plugins for the correct implementation', () async {
       final fileSystem = MemoryFileSystem.test();
       final logger = BufferLogger.test();
       final cocoapods = FakeCocoaPods();
-      final project = FakeIosProject(
-        fileSystem: fileSystem,
-        usesSwiftPackageManager: false,
-        compatibleWithSwiftPackageManager: true,
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: fileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
       );
+      final project = FakeIosProject(fileSystem: fileSystem, usesSwiftPackageManager: true);
 
       final appFacingPlugin = Plugin(
         name: 'foo',
@@ -1199,15 +1205,21 @@ flutter:
         fileSystem: fileSystem,
         logger: logger,
         cocoapods: cocoapods,
+        analytics: fakeAnalytics,
       );
       expect(logger.warningText, isEmpty);
       expect(logger.errorText, isEmpty);
+      expect(fakeAnalytics.sentEvents, isEmpty);
     });
 
     testWithoutContext('when plugin supports platform but has no podspec or manifest', () async {
       final fileSystem = MemoryFileSystem.test();
       final logger = BufferLogger.test();
       final cocoapods = FakeCocoaPods();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: fileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
       final project = FakeIosProject(fileSystem: fileSystem, usesSwiftPackageManager: true);
       final plugins = <Plugin>[
         FakePlugin(
@@ -1223,15 +1235,21 @@ flutter:
         fileSystem: fileSystem,
         logger: logger,
         cocoapods: cocoapods,
+        analytics: fakeAnalytics,
       );
 
       expect(logger.warningText, isEmpty);
+      expect(fakeAnalytics.sentEvents, isEmpty);
     });
 
     testWithoutContext('throws when using SwiftPM-only plugin but SwiftPM is disabled', () async {
       final fileSystem = MemoryFileSystem.test();
       final logger = BufferLogger.test();
       final cocoapods = FakeCocoaPods();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: fileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
       final project = FakeIosProject(
         fileSystem: fileSystem,
         usesSwiftPackageManager: false,
@@ -1253,6 +1271,7 @@ flutter:
           fileSystem: fileSystem,
           logger: logger,
           cocoapods: cocoapods,
+          analytics: fakeAnalytics,
         ),
         throwsToolExit(
           message:
@@ -1271,6 +1290,10 @@ flutter:
         final fileSystem = MemoryFileSystem.test();
         final logger = BufferLogger.test();
         final cocoapods = FakeCocoaPods();
+        final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+          fs: fileSystem,
+          fakeFlutterVersion: FakeFlutterVersion(),
+        );
         final project = FakeIosProject(
           fileSystem: fileSystem,
           usesSwiftPackageManager: false,
@@ -1292,6 +1315,7 @@ flutter:
             fileSystem: fileSystem,
             logger: logger,
             cocoapods: cocoapods,
+            analytics: fakeAnalytics,
           ),
           throwsToolExit(
             message:
@@ -1310,6 +1334,10 @@ flutter:
       final fileSystem = MemoryFileSystem.test();
       final logger = BufferLogger.test();
       final cocoapods = FakeCocoaPods();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: fileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
       final project = FakeIosProject(fileSystem: fileSystem, usesSwiftPackageManager: true);
       final plugins = <Plugin>[
         FakePlugin(
@@ -1326,6 +1354,7 @@ flutter:
         fileSystem: fileSystem,
         logger: logger,
         cocoapods: cocoapods,
+        analytics: fakeAnalytics,
       );
 
       expect(
@@ -1335,11 +1364,67 @@ flutter:
         'This will become an error in a future version of Flutter. Please contact the plugin '
         'maintainers to request Swift Package Manager adoption.\n',
       );
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.appleUsageEvent(workflow: 'cocoapod-only-plugin-warning', parameter: 'plugin'),
+        ),
+      );
+    });
+
+    testWithoutContext('warns and sends analytics for multiple CocoaPod-only plugins', () async {
+      final fileSystem = MemoryFileSystem.test();
+      final logger = BufferLogger.test();
+      final cocoapods = FakeCocoaPods();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: fileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
+      final project = FakeIosProject(fileSystem: fileSystem, usesSwiftPackageManager: true);
+      final plugins = <Plugin>[
+        FakePlugin(
+          name: 'plugin_a',
+          platforms: <String, PluginPlatform>{IOSPlugin.kConfigKey: FakePluginPlatform()},
+          pluginPodspecPath: '/plugin_a/ios/plugin_a.podspec',
+        ),
+        FakePlugin(
+          name: 'plugin_b',
+          platforms: <String, PluginPlatform>{IOSPlugin.kConfigKey: FakePluginPlatform()},
+          pluginPodspecPath: '/plugin_b/ios/plugin_b.podspec',
+        ),
+      ];
+
+      await DarwinDependencyManagement.validatePluginSupport(
+        platform: FlutterDarwinPlatform.ios,
+        xcodeProject: project,
+        plugins: plugins,
+        fileSystem: fileSystem,
+        logger: logger,
+        cocoapods: cocoapods,
+        analytics: fakeAnalytics,
+      );
+
+      expect(
+        logger.warningText,
+        'The following plugins do not support Swift Package Manager for ios:\n'
+        '  - plugin_a\n'
+        '  - plugin_b\n'
+        'This will become an error in a future version of Flutter. Please contact the plugin '
+        'maintainers to request Swift Package Manager adoption.\n',
+      );
+      expect(fakeAnalytics.sentEvents, <Event>[
+        Event.appleUsageEvent(workflow: 'cocoapod-only-plugin-warning', parameter: 'plugin_a'),
+        Event.appleUsageEvent(workflow: 'cocoapod-only-plugin-warning', parameter: 'plugin_b'),
+      ]);
     });
 
     testWithoutContext('warns when CocoaPod is removeable and podfile matches original', () async {
       final fileSystem = MemoryFileSystem.test();
       final logger = BufferLogger.test();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: fileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
       final project = FakeIosProject(fileSystem: fileSystem, usesSwiftPackageManager: true);
       project.xcodeProjectInfoFile.createSync(recursive: true);
       project.xcodeProjectInfoFile.writeAsStringSync('FlutterGeneratedPluginSwiftPackage');
@@ -1368,6 +1453,7 @@ flutter:
         fileSystem: fileSystem,
         logger: logger,
         cocoapods: cocoapods,
+        analytics: fakeAnalytics,
       );
 
       expect(
@@ -1378,11 +1464,16 @@ flutter:
         '  * Also in the ios/ directory, delete the Podfile\n\n'
         "Removing CocoaPods integration will improve the project's build time.\n",
       );
+      expect(fakeAnalytics.sentEvents, isEmpty);
     });
 
     testWithoutContext('warns when CocoaPod is removeable and podfile does not match original', () async {
       final fileSystem = MemoryFileSystem.test();
       final logger = BufferLogger.test();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: fileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
       final project = FakeIosProject(fileSystem: fileSystem, usesSwiftPackageManager: true);
       project.xcodeProjectInfoFile.createSync(recursive: true);
       project.xcodeProjectInfoFile.writeAsStringSync('FlutterGeneratedPluginSwiftPackage');
@@ -1411,6 +1502,7 @@ flutter:
         fileSystem: fileSystem,
         logger: logger,
         cocoapods: cocoapods,
+        analytics: fakeAnalytics,
       );
 
       expect(
@@ -1423,11 +1515,16 @@ flutter:
         '  * Transition any custom logic\n\n'
         "Removing CocoaPods integration will improve the project's build time.\n",
       );
+      expect(fakeAnalytics.sentEvents, isEmpty);
     });
 
     testWithoutContext('warning when CocoaPod is removeable includes step to edit xcconfig', () async {
       final fileSystem = MemoryFileSystem.test();
       final logger = BufferLogger.test();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: fileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
       final project = FakeIosProject(fileSystem: fileSystem, usesSwiftPackageManager: true);
       project.xcodeProjectInfoFile.createSync(recursive: true);
       project.xcodeProjectInfoFile.writeAsStringSync('FlutterGeneratedPluginSwiftPackage');
@@ -1455,6 +1552,7 @@ flutter:
         fileSystem: fileSystem,
         logger: logger,
         cocoapods: cocoapods,
+        analytics: fakeAnalytics,
       );
 
       expect(
@@ -1467,6 +1565,7 @@ flutter:
         '  * Remove the include to "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig" in your ios/Flutter/Release.xcconfig\n\n'
         "Removing CocoaPods integration will improve the project's build time.\n",
       );
+      expect(fakeAnalytics.sentEvents, isEmpty);
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/migrations/swift_package_manager_integration_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrations/swift_package_manager_integration_migration_test.dart
@@ -7,18 +7,22 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/darwin/darwin.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/migrations/swift_package_manager_integration_migration.dart';
 import 'package:flutter_tools/src/plugins.dart';
-
 import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/version.dart';
 import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 
 const pluginName = 'my_plugin';
 const supportedPlatforms = <FlutterDarwinPlatform>[
@@ -31,6 +35,10 @@ void main() {
     testWithoutContext('skips if swift package manager is off', () async {
       final memoryFileSystem = MemoryFileSystem();
       final testLogger = BufferLogger.test();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: memoryFileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
       final project = FakeXcodeProject(
         platform: FlutterDarwinPlatform.ios.name,
         fileSystem: memoryFileSystem,
@@ -48,6 +56,11 @@ void main() {
         fileSystem: memoryFileSystem,
         plistParser: FakePlistParser(),
         config: FakeConfig(),
+        analytics: fakeAnalytics,
+        hostPlatform: FakePlatform(),
+        operatingSystemUtils: FakeOperatingSystemUtils(),
+        flutterVersion: FakeFlutterVersion(),
+        reportCrashes: true,
       );
       await projectMigration.migrate();
       expect(
@@ -55,11 +68,16 @@ void main() {
         contains('Skipping the migration that adds Swift Package Manager integration...'),
       );
       expect(testLogger.statusText, isEmpty);
+      expect(fakeAnalytics.sentEvents, isEmpty);
     });
 
     testWithoutContext("skips if there's no generated swift package", () async {
       final memoryFileSystem = MemoryFileSystem();
       final testLogger = BufferLogger.test();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: memoryFileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
 
       final projectMigration = SwiftPackageManagerIntegrationMigration(
         FakeXcodeProject(
@@ -74,6 +92,11 @@ void main() {
         fileSystem: memoryFileSystem,
         plistParser: FakePlistParser(),
         config: FakeConfig(),
+        analytics: fakeAnalytics,
+        hostPlatform: FakePlatform(),
+        operatingSystemUtils: FakeOperatingSystemUtils(),
+        flutterVersion: FakeFlutterVersion(),
+        reportCrashes: true,
       );
       await projectMigration.migrate();
       expect(
@@ -82,11 +105,16 @@ void main() {
       );
       expect(testLogger.traceText, contains('The tool did not generate a Swift package.'));
       expect(testLogger.statusText, isEmpty);
+      expect(fakeAnalytics.sentEvents, isEmpty);
     });
 
     testWithoutContext('fails if Xcode project not found', () async {
       final memoryFileSystem = MemoryFileSystem();
       final testLogger = BufferLogger.test();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: memoryFileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
       final project = FakeXcodeProject(
         platform: FlutterDarwinPlatform.ios.name,
         fileSystem: memoryFileSystem,
@@ -104,10 +132,25 @@ void main() {
         fileSystem: memoryFileSystem,
         plistParser: FakePlistParser(),
         config: FakeConfig(),
+        analytics: fakeAnalytics,
+        hostPlatform: FakePlatform(),
+        operatingSystemUtils: FakeOperatingSystemUtils(),
+        flutterVersion: FakeFlutterVersion(),
+        reportCrashes: true,
       );
       await expectLater(
         () => projectMigration.migrate(),
         throwsToolExit(message: 'Xcode project not found.'),
+      );
+      expect(
+        fakeAnalytics.sentEvents,
+        contains(
+          Event.appleUsageEvent(
+            workflow: 'swiftpm-migration-failure',
+            parameter: 'full',
+            result: 'Xcode project not found.',
+          ),
+        ),
       );
       expect(testLogger.traceText, isEmpty);
       expect(testLogger.statusText, isEmpty);
@@ -117,6 +160,10 @@ void main() {
       testWithoutContext('fails if Xcode project info not found', () async {
         final memoryFileSystem = MemoryFileSystem();
         final testLogger = BufferLogger.test();
+        final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+          fs: memoryFileSystem,
+          fakeFlutterVersion: FakeFlutterVersion(),
+        );
         final project = FakeXcodeProject(
           platform: FlutterDarwinPlatform.ios.name,
           fileSystem: memoryFileSystem,
@@ -134,10 +181,25 @@ void main() {
           fileSystem: memoryFileSystem,
           plistParser: FakePlistParser(),
           config: FakeConfig(),
+          analytics: fakeAnalytics,
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
+          reportCrashes: true,
         );
         await expectLater(
           () => projectMigration.migrate(),
           throwsToolExit(message: 'Unable to get Xcode project info.'),
+        );
+        expect(
+          fakeAnalytics.sentEvents,
+          contains(
+            Event.appleUsageEvent(
+              workflow: 'swiftpm-migration-failure',
+              parameter: 'full',
+              result: 'Unable to get Xcode project info.',
+            ),
+          ),
         );
         expect(testLogger.traceText, isEmpty);
         expect(testLogger.statusText, isEmpty);
@@ -146,6 +208,10 @@ void main() {
       testWithoutContext('fails if Xcode workspace not found', () async {
         final memoryFileSystem = MemoryFileSystem();
         final testLogger = BufferLogger.test();
+        final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+          fs: memoryFileSystem,
+          fakeFlutterVersion: FakeFlutterVersion(),
+        );
         final project = FakeXcodeProject(
           platform: FlutterDarwinPlatform.ios.name,
           fileSystem: memoryFileSystem,
@@ -163,6 +229,11 @@ void main() {
           fileSystem: memoryFileSystem,
           plistParser: FakePlistParser(),
           config: FakeConfig(),
+          analytics: fakeAnalytics,
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
+          reportCrashes: true,
         );
         await expectLater(
           () => projectMigration.migrate(),
@@ -175,6 +246,10 @@ void main() {
       testWithoutContext('fails if scheme not found', () async {
         final memoryFileSystem = MemoryFileSystem();
         final testLogger = BufferLogger.test();
+        final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+          fs: memoryFileSystem,
+          fakeFlutterVersion: FakeFlutterVersion(),
+        );
         final project = FakeXcodeProject(
           platform: FlutterDarwinPlatform.ios.name,
           fileSystem: memoryFileSystem,
@@ -192,6 +267,11 @@ void main() {
           fileSystem: memoryFileSystem,
           plistParser: FakePlistParser(),
           config: FakeConfig(),
+          analytics: fakeAnalytics,
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
+          reportCrashes: true,
         );
         await expectLater(
           () => projectMigration.migrate(),
@@ -199,6 +279,7 @@ void main() {
             message: 'You must specify a --flavor option to select one of the available schemes.',
           ),
         );
+        expect(fakeAnalytics.sentEvents, isEmpty);
         expect(testLogger.traceText, isEmpty);
         expect(testLogger.statusText, isEmpty);
       });
@@ -206,6 +287,10 @@ void main() {
       testWithoutContext('fails if scheme file not found', () async {
         final memoryFileSystem = MemoryFileSystem();
         final testLogger = BufferLogger.test();
+        final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+          fs: memoryFileSystem,
+          fakeFlutterVersion: FakeFlutterVersion(),
+        );
         final project = FakeXcodeProject(
           platform: FlutterDarwinPlatform.ios.name,
           fileSystem: memoryFileSystem,
@@ -227,10 +312,89 @@ void main() {
           fileSystem: memoryFileSystem,
           plistParser: FakePlistParser(),
           config: FakeConfig(),
+          analytics: fakeAnalytics,
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
+          reportCrashes: true,
         );
         await expectLater(
           () => projectMigration.migrate(),
           throwsToolExit(message: 'Unable to get scheme file for Runner.'),
+        );
+        expect(
+          fakeAnalytics.sentEvents,
+          contains(
+            Event.appleUsageEvent(
+              workflow: 'swiftpm-migration-failure',
+              parameter: 'full',
+              result: 'Unable to get scheme file for Runner.',
+            ),
+          ),
+        );
+        expect(testLogger.traceText, isEmpty);
+        expect(testLogger.statusText, isEmpty);
+      });
+
+      testWithoutContext('fails if custom scheme file not found', () async {
+        final memoryFileSystem = MemoryFileSystem();
+        final testLogger = BufferLogger.test();
+        final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+          fs: memoryFileSystem,
+          fakeFlutterVersion: FakeFlutterVersion(),
+        );
+        final project = FakeXcodeProject(
+          platform: FlutterDarwinPlatform.ios.name,
+          fileSystem: memoryFileSystem,
+          logger: testLogger,
+        );
+        project._projectInfo = XcodeProjectInfo(
+          <String>['custom_flavor'],
+          <String>['Debug', 'Release', 'Profile'],
+          <String>['custom_flavor'],
+          testLogger,
+        );
+        _createProjectFiles(
+          project,
+          FlutterDarwinPlatform.ios,
+          createSchemeFile: false,
+          schemeMigrated: false,
+          scheme: 'custom_flavor',
+        );
+
+        final projectMigration = SwiftPackageManagerIntegrationMigration(
+          project,
+          FlutterDarwinPlatform.ios,
+          const BuildInfo(
+            BuildMode.debug,
+            'custom_flavor',
+            treeShakeIcons: false,
+            packageConfigPath: '',
+          ),
+          xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+          logger: testLogger,
+          fileSystem: memoryFileSystem,
+          plistParser: FakePlistParser(),
+          config: FakeConfig(),
+          analytics: fakeAnalytics,
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
+          reportCrashes: true,
+        );
+        await expectLater(
+          () => projectMigration.migrate(),
+          throwsToolExit(message: 'Unable to get scheme file for custom_flavor.'),
+        );
+        expect(
+          fakeAnalytics.sentEvents,
+          contains(
+            Event.appleUsageEvent(
+              workflow: 'swiftpm-migration-failure',
+              parameter: 'full',
+              result: 'Unable to get scheme file for custom.',
+            ),
+          ),
         );
         expect(testLogger.traceText, isEmpty);
         expect(testLogger.statusText, isEmpty);
@@ -240,6 +404,10 @@ void main() {
     testWithoutContext('does not migrate if already migrated', () async {
       final memoryFileSystem = MemoryFileSystem();
       final testLogger = BufferLogger.test();
+      final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+        fs: memoryFileSystem,
+        fakeFlutterVersion: FakeFlutterVersion(),
+      );
       final project = FakeXcodeProject(
         platform: FlutterDarwinPlatform.ios.name,
         fileSystem: memoryFileSystem,
@@ -262,12 +430,18 @@ void main() {
         fileSystem: memoryFileSystem,
         plistParser: FakePlistParser(),
         config: FakeConfig(),
+        analytics: fakeAnalytics,
+        hostPlatform: FakePlatform(),
+        operatingSystemUtils: FakeOperatingSystemUtils(),
+        flutterVersion: FakeFlutterVersion(),
+        reportCrashes: true,
       );
       await projectMigration.migrate();
       expect(testLogger.traceText, isEmpty);
       expect(testLogger.statusText, isEmpty);
       expect(testLogger.warningText, isEmpty);
       expect(testLogger.errorText, isEmpty);
+      expect(fakeAnalytics.sentEvents, isEmpty);
     });
 
     group('migrate scheme', () {
@@ -300,6 +474,11 @@ void main() {
           fileSystem: memoryFileSystem,
           plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
           config: FakeConfig(),
+          analytics: const NoOpAnalytics(),
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
+          reportCrashes: true,
         );
         await expectLater(() => projectMigration.migrate(), throwsToolExit());
         expect(testLogger.traceText, contains('Runner.xcscheme already migrated. Skipping...'));
@@ -331,6 +510,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -346,6 +530,10 @@ void main() {
             () async {
               final memoryFileSystem = MemoryFileSystem();
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: platform.name,
                 fileSystem: memoryFileSystem,
@@ -370,12 +558,27 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(),
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
 
               await expectLater(
                 () => projectMigration.migrate(),
                 throwsToolExit(
                   message: 'Failed to parse Runner.xcscheme: Could not find BuildableName',
+                ),
+              );
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(
+                    workflow: 'swiftpm-migration-failure',
+                    parameter: 'full',
+                    result: 'Failed to parse Runner.xcscheme: Could not find BuildableName.',
+                  ),
                 ),
               );
             },
@@ -386,6 +589,10 @@ void main() {
             () async {
               final memoryFileSystem = MemoryFileSystem();
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: platform.name,
                 fileSystem: memoryFileSystem,
@@ -410,12 +617,27 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(),
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
 
               await expectLater(
                 () => projectMigration.migrate(),
                 throwsToolExit(
                   message: 'Failed to parse Runner.xcscheme: Could not find BlueprintName',
+                ),
+              );
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(
+                    workflow: 'swiftpm-migration-failure',
+                    parameter: 'full',
+                    result: 'Failed to parse Runner.xcscheme: Could not find BlueprintName.',
+                  ),
                 ),
               );
             },
@@ -426,6 +648,10 @@ void main() {
             () async {
               final memoryFileSystem = MemoryFileSystem();
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: platform.name,
                 fileSystem: memoryFileSystem,
@@ -450,6 +676,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(),
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
 
               await expectLater(
@@ -458,12 +689,26 @@ void main() {
                   message: 'Failed to parse Runner.xcscheme: Could not find ReferencedContainer',
                 ),
               );
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(
+                    workflow: 'swiftpm-migration-failure',
+                    parameter: 'full',
+                    result: 'Failed to parse Runner.xcscheme: Could not find ReferencedContainer.',
+                  ),
+                ),
+              );
             },
           );
 
           testWithoutContext('fails if cannot find BuildAction in scheme', () async {
             final memoryFileSystem = MemoryFileSystem();
             final testLogger = BufferLogger.test();
+            final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+              fs: memoryFileSystem,
+              fakeFlutterVersion: FakeFlutterVersion(),
+            );
             final project = FakeXcodeProject(
               platform: platform.name,
               fileSystem: memoryFileSystem,
@@ -481,6 +726,11 @@ void main() {
               fileSystem: memoryFileSystem,
               plistParser: FakePlistParser(),
               config: FakeConfig(),
+              analytics: fakeAnalytics,
+              hostPlatform: FakePlatform(),
+              operatingSystemUtils: FakeOperatingSystemUtils(),
+              flutterVersion: FakeFlutterVersion(),
+              reportCrashes: true,
             );
 
             await expectLater(
@@ -489,11 +739,25 @@ void main() {
                 message: 'Failed to parse Runner.xcscheme: Could not find BuildAction',
               ),
             );
+            expect(
+              fakeAnalytics.sentEvents,
+              contains(
+                Event.appleUsageEvent(
+                  workflow: 'swiftpm-migration-failure',
+                  parameter: 'full',
+                  result: 'Failed to parse Runner.xcscheme: Could not find BuildAction.',
+                ),
+              ),
+            );
           });
 
-          testWithoutContext('fails if updated scheme is not valid xml', () async {
+          testWithoutContext('fails if scheme is not valid xml', () async {
             final memoryFileSystem = MemoryFileSystem();
             final testLogger = BufferLogger.test();
+            final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+              fs: memoryFileSystem,
+              fakeFlutterVersion: FakeFlutterVersion(),
+            );
             final project = FakeXcodeProject(
               platform: platform.name,
               fileSystem: memoryFileSystem,
@@ -512,11 +776,26 @@ void main() {
               fileSystem: memoryFileSystem,
               plistParser: FakePlistParser(),
               config: FakeConfig(),
+              analytics: fakeAnalytics,
+              hostPlatform: FakePlatform(),
+              operatingSystemUtils: FakeOperatingSystemUtils(),
+              flutterVersion: FakeFlutterVersion(),
+              reportCrashes: true,
             );
 
             await expectLater(
               () => projectMigration.migrate(),
               throwsToolExit(message: 'Failed to parse Runner.xcscheme: Invalid xml:'),
+            );
+            expect(
+              fakeAnalytics.sentEvents,
+              contains(
+                Event.appleUsageEvent(
+                  workflow: 'swiftpm-migration-failure',
+                  parameter: 'full',
+                  result: 'Failed to parse Runner.xcscheme: Invalid xml',
+                ),
+              ),
             );
           });
 
@@ -549,6 +828,11 @@ void main() {
               fileSystem: memoryFileSystem,
               plistParser: plistParser,
               config: FakeConfig(),
+              analytics: const NoOpAnalytics(),
+              hostPlatform: FakePlatform(),
+              operatingSystemUtils: FakeOperatingSystemUtils(),
+              flutterVersion: FakeFlutterVersion(),
+              reportCrashes: true,
             );
 
             await projectMigration.migrate();
@@ -586,6 +870,11 @@ void main() {
               fileSystem: memoryFileSystem,
               plistParser: plistParser,
               config: FakeConfig(),
+              analytics: const NoOpAnalytics(),
+              hostPlatform: FakePlatform(),
+              operatingSystemUtils: FakeOperatingSystemUtils(),
+              flutterVersion: FakeFlutterVersion(),
+              reportCrashes: true,
             );
 
             await projectMigration.migrate();
@@ -600,6 +889,10 @@ void main() {
             () async {
               final memoryFileSystem = MemoryFileSystem();
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: platform.name,
                 fileSystem: memoryFileSystem,
@@ -624,12 +917,23 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
 
               await projectMigration.migrate();
               expect(
                 project.xcodeProjectSchemeFile().readAsStringSync(),
                 _validBuildActions(platform, hasFrameworkScript: true),
+              );
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(workflow: 'swiftpm-migration-success', parameter: 'full'),
+                ),
               );
             },
           );
@@ -696,6 +1000,11 @@ void main() {
               fileSystem: memoryFileSystem,
               plistParser: plistParser,
               config: FakeConfig(),
+              analytics: const NoOpAnalytics(),
+              hostPlatform: FakePlatform(),
+              operatingSystemUtils: FakeOperatingSystemUtils(),
+              flutterVersion: FakeFlutterVersion(),
+              reportCrashes: true,
             );
 
             await projectMigration.migrate();
@@ -787,6 +1096,11 @@ void main() {
           fileSystem: memoryFileSystem,
           plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
           config: FakeConfig(),
+          analytics: const NoOpAnalytics(),
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
+          reportCrashes: true,
         );
         await projectMigration.migrate();
         expect(testLogger.traceText, isEmpty);
@@ -796,6 +1110,10 @@ void main() {
         testWithoutContext('fails plutil command', () async {
           final memoryFileSystem = MemoryFileSystem();
           final testLogger = BufferLogger.test();
+          final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+            fs: memoryFileSystem,
+            fakeFlutterVersion: FakeFlutterVersion(),
+          );
           final project = FakeXcodeProject(
             platform: FlutterDarwinPlatform.ios.name,
             fileSystem: memoryFileSystem,
@@ -812,16 +1130,35 @@ void main() {
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(),
             config: FakeConfig(),
+            analytics: fakeAnalytics,
+            hostPlatform: FakePlatform(),
+            operatingSystemUtils: FakeOperatingSystemUtils(),
+            flutterVersion: FakeFlutterVersion(),
+            reportCrashes: true,
           );
           await expectLater(
             () => projectMigration.migrate(),
             throwsToolExit(message: 'Failed to parse project settings.'),
+          );
+          expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.appleUsageEvent(
+                workflow: 'swiftpm-migration-failure',
+                parameter: 'full',
+                result: 'Failed to parse project settings.',
+              ),
+            ),
           );
         });
 
         testWithoutContext('returns unexpected JSON', () async {
           final memoryFileSystem = MemoryFileSystem();
           final testLogger = BufferLogger.test();
+          final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+            fs: memoryFileSystem,
+            fakeFlutterVersion: FakeFlutterVersion(),
+          );
           final project = FakeXcodeProject(
             platform: FlutterDarwinPlatform.ios.name,
             fileSystem: memoryFileSystem,
@@ -838,16 +1175,35 @@ void main() {
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(json: '[]'),
             config: FakeConfig(),
+            analytics: fakeAnalytics,
+            hostPlatform: FakePlatform(),
+            operatingSystemUtils: FakeOperatingSystemUtils(),
+            flutterVersion: FakeFlutterVersion(),
+            reportCrashes: true,
           );
           await expectLater(
             () => projectMigration.migrate(),
             throwsToolExit(message: 'project.pbxproj returned unexpected JSON response'),
+          );
+          expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.appleUsageEvent(
+                workflow: 'swiftpm-migration-failure',
+                parameter: 'full',
+                result: 'project.pbxproj returned unexpected JSON response',
+              ),
+            ),
           );
         });
 
         testWithoutContext('returns non-JSON', () async {
           final memoryFileSystem = MemoryFileSystem();
           final testLogger = BufferLogger.test();
+          final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+            fs: memoryFileSystem,
+            fakeFlutterVersion: FakeFlutterVersion(),
+          );
           final project = FakeXcodeProject(
             platform: FlutterDarwinPlatform.ios.name,
             fileSystem: memoryFileSystem,
@@ -864,10 +1220,25 @@ void main() {
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(json: 'this is not json'),
             config: FakeConfig(),
+            analytics: fakeAnalytics,
+            hostPlatform: FakePlatform(),
+            operatingSystemUtils: FakeOperatingSystemUtils(),
+            flutterVersion: FakeFlutterVersion(),
+            reportCrashes: true,
           );
           await expectLater(
             () => projectMigration.migrate(),
             throwsToolExit(message: 'project.pbxproj returned non-JSON response'),
+          );
+          expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.appleUsageEvent(
+                workflow: 'swiftpm-migration-failure',
+                parameter: 'full',
+                result: 'project.pbxproj returned non-JSON response',
+              ),
+            ),
           );
         });
       });
@@ -876,6 +1247,10 @@ void main() {
         testWithoutContext('for PBXBuildFile', () async {
           final memoryFileSystem = MemoryFileSystem();
           final testLogger = BufferLogger.test();
+          final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+            fs: memoryFileSystem,
+            fakeFlutterVersion: FakeFlutterVersion(),
+          );
           final project = FakeXcodeProject(
             platform: FlutterDarwinPlatform.ios.name,
             fileSystem: memoryFileSystem,
@@ -893,16 +1268,35 @@ void main() {
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(),
             config: FakeConfig(),
+            analytics: fakeAnalytics,
+            hostPlatform: FakePlatform(),
+            operatingSystemUtils: FakeOperatingSystemUtils(),
+            flutterVersion: FakeFlutterVersion(),
+            reportCrashes: true,
           );
-          expect(
+          await expectLater(
             () => projectMigration.migrate(),
             throwsToolExit(message: 'Duplicate id found for PBXBuildFile'),
+          );
+          expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.appleUsageEvent(
+                workflow: 'swiftpm-migration-failure',
+                parameter: 'full',
+                result: 'Duplicate id found for PBXBuildFile.',
+              ),
+            ),
           );
         });
 
         testWithoutContext('for XCSwiftPackageProductDependency', () async {
           final memoryFileSystem = MemoryFileSystem();
           final testLogger = BufferLogger.test();
+          final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+            fs: memoryFileSystem,
+            fakeFlutterVersion: FakeFlutterVersion(),
+          );
           final project = FakeXcodeProject(
             platform: FlutterDarwinPlatform.ios.name,
             fileSystem: memoryFileSystem,
@@ -920,16 +1314,35 @@ void main() {
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(),
             config: FakeConfig(),
+            analytics: fakeAnalytics,
+            hostPlatform: FakePlatform(),
+            operatingSystemUtils: FakeOperatingSystemUtils(),
+            flutterVersion: FakeFlutterVersion(),
+            reportCrashes: true,
           );
-          expect(
+          await expectLater(
             () => projectMigration.migrate(),
             throwsToolExit(message: 'Duplicate id found for XCSwiftPackageProductDependency'),
+          );
+          expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.appleUsageEvent(
+                workflow: 'swiftpm-migration-failure',
+                parameter: 'full',
+                result: 'Duplicate id found for XCSwiftPackageProductDependency.',
+              ),
+            ),
           );
         });
 
         testWithoutContext('for XCLocalSwiftPackageReference', () async {
           final memoryFileSystem = MemoryFileSystem();
           final testLogger = BufferLogger.test();
+          final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+            fs: memoryFileSystem,
+            fakeFlutterVersion: FakeFlutterVersion(),
+          );
           final project = FakeXcodeProject(
             platform: FlutterDarwinPlatform.ios.name,
             fileSystem: memoryFileSystem,
@@ -947,16 +1360,35 @@ void main() {
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(),
             config: FakeConfig(),
+            analytics: fakeAnalytics,
+            hostPlatform: FakePlatform(),
+            operatingSystemUtils: FakeOperatingSystemUtils(),
+            flutterVersion: FakeFlutterVersion(),
+            reportCrashes: true,
           );
-          expect(
+          await expectLater(
             () => projectMigration.migrate(),
             throwsToolExit(message: 'Duplicate id found for XCLocalSwiftPackageReference'),
+          );
+          expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.appleUsageEvent(
+                workflow: 'swiftpm-migration-failure',
+                parameter: 'full',
+                result: 'Duplicate id found for XCLocalSwiftPackageReference.',
+              ),
+            ),
           );
         });
 
         testWithoutContext('for FlutterGeneratedPluginSwiftPackage PBXFileReference', () async {
           final memoryFileSystem = MemoryFileSystem();
           final testLogger = BufferLogger.test();
+          final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+            fs: memoryFileSystem,
+            fakeFlutterVersion: FakeFlutterVersion(),
+          );
           final project = FakeXcodeProject(
             platform: FlutterDarwinPlatform.ios.name,
             fileSystem: memoryFileSystem,
@@ -974,11 +1406,27 @@ void main() {
             fileSystem: memoryFileSystem,
             plistParser: FakePlistParser(),
             config: FakeConfig(),
+            analytics: fakeAnalytics,
+            hostPlatform: FakePlatform(),
+            operatingSystemUtils: FakeOperatingSystemUtils(),
+            flutterVersion: FakeFlutterVersion(),
+            reportCrashes: true,
           );
-          expect(
+          await expectLater(
             () => projectMigration.migrate(),
             throwsToolExit(
               message: 'Duplicate id found for FlutterGeneratedPluginSwiftPackage PBXFileReference',
+            ),
+          );
+          expect(
+            fakeAnalytics.sentEvents,
+            contains(
+              Event.appleUsageEvent(
+                workflow: 'swiftpm-migration-failure',
+                parameter: 'full',
+                result:
+                    'Duplicate id found for FlutterGeneratedPluginSwiftPackage PBXFileReference.',
+              ),
             ),
           );
         });
@@ -993,6 +1441,10 @@ void main() {
             'PBXFileReference',
             () async {
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: FlutterDarwinPlatform.ios.name,
                 fileSystem: memoryFileSystem,
@@ -1016,10 +1468,25 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(),
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
-              expect(
+              await expectLater(
                 () => projectMigration.migrate(),
                 throwsToolExit(message: 'Duplicate id found for $pluginName PBXFileReference'),
+              );
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(
+                    workflow: 'swiftpm-migration-failure',
+                    parameter: 'full',
+                    result: 'Duplicate id found for plugin PBXFileReference.',
+                  ),
+                ),
               );
             },
             overrides: <Type, Generator>{
@@ -1032,6 +1499,10 @@ void main() {
             'FlutterFramework PBXFileReference',
             () async {
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: FlutterDarwinPlatform.ios.name,
                 fileSystem: memoryFileSystem,
@@ -1055,10 +1526,25 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(),
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
-              expect(
+              await expectLater(
                 () => projectMigration.migrate(),
                 throwsToolExit(message: 'Duplicate id found for FlutterFramework PBXFileReference'),
+              );
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(
+                    workflow: 'swiftpm-migration-failure',
+                    parameter: 'full',
+                    result: 'Duplicate id found for FlutterFramework PBXFileReference.',
+                  ),
+                ),
               );
             },
             overrides: <Type, Generator>{
@@ -1091,6 +1577,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(<String>[])),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               expect(
                 () => projectMigration.migrate(),
@@ -1130,6 +1621,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(<String>[])),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               expect(
                 () => projectMigration.migrate(),
@@ -1170,6 +1666,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(<String>[])),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               expect(
                 () => projectMigration.migrate(),
@@ -1182,6 +1683,10 @@ void main() {
             testWithoutContext('successfully added', () async {
               final memoryFileSystem = MemoryFileSystem();
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: platform.name,
                 fileSystem: memoryFileSystem,
@@ -1214,6 +1719,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1227,6 +1737,12 @@ void main() {
                 _projectSettings(settingsBeforeMigration),
               );
               expect(plistParser.hasRemainingExpectations, isFalse);
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(workflow: 'swiftpm-migration-success', parameter: 'full'),
+                ),
+              );
             });
           });
 
@@ -1260,6 +1776,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               expect(
                 () => projectMigration.migrate(),
@@ -1299,6 +1820,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               expect(
                 () => projectMigration.migrate(),
@@ -1339,6 +1865,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               expect(
                 () => projectMigration.migrate(),
@@ -1383,6 +1914,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1454,6 +1990,11 @@ void main() {
                     fileSystem: memoryFileSystem,
                     plistParser: plistParser,
                     config: FakeConfig(),
+                    analytics: const NoOpAnalytics(),
+                    hostPlatform: FakePlatform(),
+                    operatingSystemUtils: FakeOperatingSystemUtils(),
+                    flutterVersion: FakeFlutterVersion(),
+                    reportCrashes: true,
                   );
                   await projectMigration.migrate();
                   expect(testLogger.errorText, isEmpty);
@@ -1507,6 +2048,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1550,6 +2096,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await expectLater(
                   () => projectMigration.migrate(),
@@ -1599,6 +2150,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await expectLater(
                   () => projectMigration.migrate(),
@@ -1612,6 +2168,10 @@ void main() {
             testWithoutContext('fails if missing Runner target in parsed settings', () async {
               final memoryFileSystem = MemoryFileSystem();
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: platform.name,
                 fileSystem: memoryFileSystem,
@@ -1639,6 +2199,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1646,7 +2211,79 @@ void main() {
                   message: 'Unable to find parsed PBXFrameworksBuildPhase for Runner target',
                 ),
               );
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(
+                    workflow: 'swiftpm-migration-failure',
+                    parameter: 'full',
+                    result: 'Unable to find parsed PBXFrameworksBuildPhase for Runner target.',
+                  ),
+                ),
+              );
             });
+
+            testWithoutContext(
+              'fails and anonymizes names if missing CustomApp target in parsed settings',
+              () async {
+                final memoryFileSystem = MemoryFileSystem();
+                final testLogger = BufferLogger.test();
+                final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                  fs: memoryFileSystem,
+                  fakeFlutterVersion: FakeFlutterVersion(),
+                );
+                final project = FakeXcodeProject(
+                  platform: platform.name,
+                  fileSystem: memoryFileSystem,
+                  logger: testLogger,
+                );
+                project.hostAppProjectName = 'CustomApp';
+                _createProjectFiles(project, platform);
+
+                final settingsBeforeMigration = <String>[..._allSectionsUnmigrated(platform)];
+                settingsBeforeMigration[_frameworksBuildPhaseSectionIndex] =
+                    unmigratedFrameworksBuildPhaseSection(platform);
+                project.xcodeProjectInfoFile.writeAsStringSync(
+                  _projectSettings(settingsBeforeMigration),
+                );
+                final settingsAsJsonBeforeMigration = <String>[
+                  ..._allSectionsMigratedAsJson(platform),
+                ];
+                settingsAsJsonBeforeMigration.removeAt(_frameworksBuildPhaseSectionIndex);
+
+                final projectMigration = SwiftPackageManagerIntegrationMigration(
+                  project,
+                  platform,
+                  BuildInfo.debug,
+                  xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+                  logger: testLogger,
+                  fileSystem: memoryFileSystem,
+                  plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
+                  config: FakeConfig(),
+                  analytics: fakeAnalytics,
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
+                );
+                await expectLater(
+                  () => projectMigration.migrate(),
+                  throwsToolExit(
+                    message: 'Unable to find parsed PBXFrameworksBuildPhase for CustomApp target',
+                  ),
+                );
+                expect(
+                  fakeAnalytics.sentEvents,
+                  contains(
+                    Event.appleUsageEvent(
+                      workflow: 'swiftpm-migration-failure',
+                      parameter: 'full',
+                      result: 'Unable to find parsed PBXFrameworksBuildPhase for custom target.',
+                    ),
+                  ),
+                );
+              },
+            );
 
             testWithoutContext('successfully added when files field is missing', () async {
               final memoryFileSystem = MemoryFileSystem();
@@ -1687,6 +2324,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1735,6 +2377,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1790,6 +2437,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -1837,6 +2489,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1873,6 +2530,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -1913,6 +2575,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await expectLater(
                   () => projectMigration.migrate(),
@@ -1959,6 +2626,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await expectLater(
                   () => projectMigration.migrate(),
@@ -2012,6 +2684,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -2061,6 +2738,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -2136,6 +2818,11 @@ void main() {
                     fileSystem: memoryFileSystem,
                     plistParser: plistParser,
                     config: FakeConfig(),
+                    analytics: const NoOpAnalytics(),
+                    hostPlatform: FakePlatform(),
+                    operatingSystemUtils: FakeOperatingSystemUtils(),
+                    flutterVersion: FakeFlutterVersion(),
+                    reportCrashes: true,
                   );
                   await projectMigration.migrate();
                   expect(testLogger.errorText, isEmpty);
@@ -2187,6 +2874,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -2197,6 +2889,10 @@ void main() {
             testWithoutContext('fails if missing Runner target in parsed settings', () async {
               final memoryFileSystem = MemoryFileSystem();
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: platform.name,
                 fileSystem: memoryFileSystem,
@@ -2225,12 +2921,90 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
                 throwsToolExit(message: 'Unable to find parsed PBXNativeTarget for Runner target'),
               );
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(
+                    workflow: 'swiftpm-migration-failure',
+                    parameter: 'full',
+                    result: 'Unable to find parsed PBXNativeTarget for Runner target.',
+                  ),
+                ),
+              );
             });
+
+            testWithoutContext(
+              'fails and anonymizes names if missing CustomApp target in parsed settings',
+              () async {
+                final memoryFileSystem = MemoryFileSystem();
+                final testLogger = BufferLogger.test();
+                final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                  fs: memoryFileSystem,
+                  fakeFlutterVersion: FakeFlutterVersion(),
+                );
+                final project = FakeXcodeProject(
+                  platform: platform.name,
+                  fileSystem: memoryFileSystem,
+                  logger: testLogger,
+                );
+                project.hostAppProjectName = 'CustomApp';
+                _createProjectFiles(project, platform);
+
+                final settingsBeforeMigration = <String>[..._allSectionsUnmigrated(platform)];
+                settingsBeforeMigration[_nativeTargetSectionIndex] = unmigratedNativeTargetSection(
+                  platform,
+                );
+                project.xcodeProjectInfoFile.writeAsStringSync(
+                  _projectSettings(settingsBeforeMigration),
+                );
+                final settingsAsJsonBeforeMigration = <String>[
+                  ..._allSectionsUnmigratedAsJson(platform),
+                ];
+                settingsAsJsonBeforeMigration.removeAt(_nativeTargetSectionIndex);
+
+                final projectMigration = SwiftPackageManagerIntegrationMigration(
+                  project,
+                  platform,
+                  BuildInfo.debug,
+                  xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+                  logger: testLogger,
+                  fileSystem: memoryFileSystem,
+                  plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
+                  config: FakeConfig(),
+                  analytics: fakeAnalytics,
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
+                );
+                await expectLater(
+                  () => projectMigration.migrate(),
+                  throwsToolExit(
+                    message: 'Unable to find parsed PBXNativeTarget for CustomApp target',
+                  ),
+                );
+                expect(
+                  fakeAnalytics.sentEvents,
+                  contains(
+                    Event.appleUsageEvent(
+                      workflow: 'swiftpm-migration-failure',
+                      parameter: 'full',
+                      result: 'Unable to find parsed PBXNativeTarget for custom target.',
+                    ),
+                  ),
+                );
+              },
+            );
 
             testWithoutContext(
               'fails if missing Runner target subsection following PBXNativeTarget begin header',
@@ -2265,6 +3039,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await expectLater(
                   () => projectMigration.migrate(),
@@ -2311,6 +3090,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await expectLater(
                   () => projectMigration.migrate(),
@@ -2367,6 +3151,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: plistParser,
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await projectMigration.migrate();
                 expect(testLogger.errorText, isEmpty);
@@ -2419,6 +3208,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: plistParser,
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await projectMigration.migrate();
                 expect(testLogger.errorText, isEmpty);
@@ -2477,6 +3271,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: plistParser,
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await projectMigration.migrate();
                 expect(testLogger.errorText, isEmpty);
@@ -2523,6 +3322,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -2565,6 +3369,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await expectLater(
                   () => projectMigration.migrate(),
@@ -2613,6 +3422,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await expectLater(
                   () => projectMigration.migrate(),
@@ -2624,6 +3438,10 @@ void main() {
             testWithoutContext('fails if missing Runner project in parsed settings', () async {
               final memoryFileSystem = MemoryFileSystem();
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: platform.name,
                 fileSystem: memoryFileSystem,
@@ -2650,12 +3468,86 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
                 throwsToolExit(message: 'Unable to find parsed PBXProject for Runner'),
               );
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(
+                    workflow: 'swiftpm-migration-failure',
+                    parameter: 'full',
+                    result: 'Unable to find parsed PBXProject for Runner.',
+                  ),
+                ),
+              );
             });
+
+            testWithoutContext(
+              'fails and anonymizes names if missing CustomApp project in parsed settings',
+              () async {
+                final memoryFileSystem = MemoryFileSystem();
+                final testLogger = BufferLogger.test();
+                final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                  fs: memoryFileSystem,
+                  fakeFlutterVersion: FakeFlutterVersion(),
+                );
+                final project = FakeXcodeProject(
+                  platform: platform.name,
+                  fileSystem: memoryFileSystem,
+                  logger: testLogger,
+                );
+                project.hostAppProjectName = 'CustomApp';
+                _createProjectFiles(project, platform);
+
+                final settingsBeforeMigration = <String>[..._allSectionsUnmigrated(platform)];
+                settingsBeforeMigration[_projectSectionIndex] = unmigratedProjectSection(platform);
+                project.xcodeProjectInfoFile.writeAsStringSync(
+                  _projectSettings(settingsBeforeMigration),
+                );
+                final settingsAsJsonBeforeMigration = <String>[
+                  ..._allSectionsUnmigratedAsJson(platform),
+                ];
+                settingsAsJsonBeforeMigration.removeAt(_projectSectionIndex);
+
+                final projectMigration = SwiftPackageManagerIntegrationMigration(
+                  project,
+                  platform,
+                  BuildInfo.debug,
+                  xcodeProjectInterpreter: FakeXcodeProjectInterpreter(),
+                  logger: testLogger,
+                  fileSystem: memoryFileSystem,
+                  plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
+                  config: FakeConfig(),
+                  analytics: fakeAnalytics,
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
+                );
+                await expectLater(
+                  () => projectMigration.migrate(),
+                  throwsToolExit(message: 'Unable to find parsed PBXProject for CustomApp'),
+                );
+                expect(
+                  fakeAnalytics.sentEvents,
+                  contains(
+                    Event.appleUsageEvent(
+                      workflow: 'swiftpm-migration-failure',
+                      parameter: 'full',
+                      result: 'Unable to find parsed PBXProject for custom.',
+                    ),
+                  ),
+                );
+              },
+            );
 
             testWithoutContext(
               'successfully added when packageReferences field is missing',
@@ -2704,6 +3596,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: plistParser,
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await projectMigration.migrate();
                 expect(testLogger.errorText, isEmpty);
@@ -2754,6 +3651,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: plistParser,
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await projectMigration.migrate();
                 expect(testLogger.errorText, isEmpty);
@@ -2812,6 +3714,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: plistParser,
                   config: FakeConfig(),
+                  analytics: const NoOpAnalytics(),
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await projectMigration.migrate();
                 expect(testLogger.errorText, isEmpty);
@@ -2853,6 +3760,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -2896,6 +3808,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -2946,6 +3863,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -2999,6 +3921,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -3041,6 +3968,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: FakePlistParser(json: _plutilOutput(settingsAsJsonBeforeMigration)),
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await expectLater(
                 () => projectMigration.migrate(),
@@ -3081,6 +4013,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -3131,6 +4068,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -3184,6 +4126,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: const NoOpAnalytics(),
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(testLogger.errorText, isEmpty);
@@ -3204,6 +4151,10 @@ void main() {
           testWithoutContext('throw if settings not updated correctly', () async {
             final memoryFileSystem = MemoryFileSystem();
             final testLogger = BufferLogger.test();
+            final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+              fs: memoryFileSystem,
+              fakeFlutterVersion: FakeFlutterVersion(),
+            );
             final project = FakeXcodeProject(
               platform: platform.name,
               fileSystem: memoryFileSystem,
@@ -3228,6 +4179,11 @@ void main() {
               fileSystem: memoryFileSystem,
               plistParser: plistParser,
               config: FakeConfig(),
+              analytics: fakeAnalytics,
+              hostPlatform: FakePlatform(),
+              operatingSystemUtils: FakeOperatingSystemUtils(),
+              flutterVersion: FakeFlutterVersion(),
+              reportCrashes: true,
             );
             await expectLater(
               () => projectMigration.migrate(),
@@ -3261,6 +4217,16 @@ void main() {
                 'XCSwiftPackageProductDependency was not migrated or was migrated incorrectly.',
               ),
             );
+            expect(
+              fakeAnalytics.sentEvents,
+              contains(
+                Event.appleUsageEvent(
+                  workflow: 'swiftpm-migration-failure',
+                  parameter: 'full',
+                  result: 'Settings were not updated correctly.',
+                ),
+              ),
+            );
           });
 
           testWithoutContext(
@@ -3268,6 +4234,10 @@ void main() {
             () async {
               final memoryFileSystem = MemoryFileSystem();
               final testLogger = BufferLogger.test();
+              final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                fs: memoryFileSystem,
+                fakeFlutterVersion: FakeFlutterVersion(),
+              );
               final project = FakeXcodeProject(
                 platform: platform.name,
                 fileSystem: memoryFileSystem,
@@ -3304,6 +4274,11 @@ void main() {
                 fileSystem: memoryFileSystem,
                 plistParser: plistParser,
                 config: FakeConfig(),
+                analytics: fakeAnalytics,
+                hostPlatform: FakePlatform(),
+                operatingSystemUtils: FakeOperatingSystemUtils(),
+                flutterVersion: FakeFlutterVersion(),
+                reportCrashes: true,
               );
               await projectMigration.migrate();
               expect(
@@ -3318,6 +4293,15 @@ void main() {
                 _projectSettings([..._allSectionsMigrated(platform)]),
               );
               expect(plistParser.hasRemainingExpectations, isFalse);
+              expect(
+                fakeAnalytics.sentEvents,
+                contains(
+                  Event.appleUsageEvent(
+                    workflow: 'swiftpm-migration-success',
+                    parameter: 'optional',
+                  ),
+                ),
+              );
             },
           );
 
@@ -3331,6 +4315,10 @@ void main() {
               'successfully added',
               () async {
                 final testLogger = BufferLogger.test();
+                final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                  fs: memoryFileSystem,
+                  fakeFlutterVersion: FakeFlutterVersion(),
+                );
                 final project = FakeXcodeProject(
                   platform: platform.name,
                   fileSystem: memoryFileSystem,
@@ -3372,6 +4360,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: plistParser,
                   config: FakeConfig(),
+                  analytics: fakeAnalytics,
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await projectMigration.migrate();
                 expect(
@@ -3388,6 +4381,15 @@ void main() {
                   _projectSettings(expectedSettings),
                 );
                 expect(plistParser.hasRemainingExpectations, isFalse);
+                expect(
+                  fakeAnalytics.sentEvents,
+                  contains(
+                    Event.appleUsageEvent(
+                      workflow: 'swiftpm-migration-success',
+                      parameter: 'optional',
+                    ),
+                  ),
+                );
               },
               overrides: <Type, Generator>{
                 FileSystem: () => memoryFileSystem,
@@ -3399,6 +4401,10 @@ void main() {
               'failure does not throw',
               () async {
                 final testLogger = BufferLogger.test();
+                final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+                  fs: memoryFileSystem,
+                  fakeFlutterVersion: FakeFlutterVersion(),
+                );
                 final project = FakeXcodeProject(
                   platform: platform.name,
                   fileSystem: memoryFileSystem,
@@ -3425,7 +4431,6 @@ void main() {
 
                 final plistParser = FakePlistParser.multiple(<String>[
                   _plutilOutput(settingsAsJsonBeforeMigration),
-                  _plutilOutput(['something went wrong']),
                 ]);
 
                 final projectMigration = SwiftPackageManagerIntegrationMigration(
@@ -3437,6 +4442,11 @@ void main() {
                   fileSystem: memoryFileSystem,
                   plistParser: plistParser,
                   config: FakeConfig(),
+                  analytics: fakeAnalytics,
+                  hostPlatform: FakePlatform(),
+                  operatingSystemUtils: FakeOperatingSystemUtils(),
+                  flutterVersion: FakeFlutterVersion(),
+                  reportCrashes: true,
                 );
                 await projectMigration.migrate();
                 expect(testLogger.errorText, isEmpty);
@@ -3451,6 +4461,16 @@ void main() {
                   _projectSettings(settingsBeforeMigration),
                 );
                 expect(plistParser.hasRemainingExpectations, isFalse);
+                expect(
+                  fakeAnalytics.sentEvents,
+                  contains(
+                    Event.appleUsageEvent(
+                      workflow: 'swiftpm-migration-failure',
+                      parameter: 'optional',
+                      result: 'Failed to parse project settings.',
+                    ),
+                  ),
+                );
               },
               overrides: <Type, Generator>{
                 FileSystem: () => memoryFileSystem,
@@ -3466,6 +4486,10 @@ void main() {
       testWithoutContext('throw if settings fail to compile', () async {
         final memoryFileSystem = MemoryFileSystem();
         final testLogger = BufferLogger.test();
+        final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+          fs: memoryFileSystem,
+          fakeFlutterVersion: FakeFlutterVersion(),
+        );
         const FlutterDarwinPlatform platform = FlutterDarwinPlatform.ios;
         final project = FakeXcodeProject(
           platform: platform.name,
@@ -3491,11 +4515,139 @@ void main() {
           fileSystem: memoryFileSystem,
           plistParser: plistParser,
           config: FakeConfig(),
+          analytics: fakeAnalytics,
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
+          reportCrashes: true,
         );
         await expectLater(
           () => projectMigration.migrate(),
           throwsToolExit(message: 'Unable to get Xcode project information'),
         );
+        expect(
+          fakeAnalytics.sentEvents,
+          contains(
+            Event.appleUsageEvent(
+              workflow: 'swiftpm-migration-failure',
+              parameter: 'full',
+              result: 'Xcode failed for unknown reason.',
+            ),
+          ),
+        );
+        expect(testLogger.traceText, contains('Sending crash report to Google.'));
+      });
+
+      testWithoutContext('throw if settings fail to compile due to package dependencies', () async {
+        final memoryFileSystem = MemoryFileSystem();
+        final testLogger = BufferLogger.test();
+        final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+          fs: memoryFileSystem,
+          fakeFlutterVersion: FakeFlutterVersion(),
+        );
+        const FlutterDarwinPlatform platform = FlutterDarwinPlatform.ios;
+        final project = FakeXcodeProject(
+          platform: platform.name,
+          fileSystem: memoryFileSystem,
+          logger: testLogger,
+        );
+        _createProjectFiles(project, platform);
+        project.xcodeProjectInfoFile.writeAsStringSync(
+          _projectSettings(_allSectionsUnmigrated(platform)),
+        );
+
+        final plistParser = FakePlistParser.multiple(<String>[
+          _plutilOutput(_allSectionsUnmigratedAsJson(platform)),
+          _plutilOutput(_allSectionsMigratedAsJson(platform)),
+        ]);
+
+        final projectMigration = SwiftPackageManagerIntegrationMigration(
+          project,
+          platform,
+          BuildInfo.debug,
+          xcodeProjectInterpreter: FakeXcodeProjectInterpreter(
+            errorMessageOnGetInfo: 'Could not resolve package dependencies: network error',
+          ),
+          logger: testLogger,
+          fileSystem: memoryFileSystem,
+          plistParser: plistParser,
+          config: FakeConfig(),
+          analytics: fakeAnalytics,
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
+          reportCrashes: true,
+        );
+        await expectLater(
+          () => projectMigration.migrate(),
+          throwsToolExit(message: 'Could not resolve package dependencies: network error'),
+        );
+        expect(
+          fakeAnalytics.sentEvents,
+          contains(
+            Event.appleUsageEvent(
+              workflow: 'swiftpm-migration-failure',
+              parameter: 'full',
+              result: 'Xcode could not resolve package dependencies.',
+            ),
+          ),
+        );
+        expect(testLogger.traceText, contains('Sending crash report to Google.'));
+      });
+
+      testWithoutContext('does not send crash report if reportCrashes is false', () async {
+        final memoryFileSystem = MemoryFileSystem();
+        final testLogger = BufferLogger.test();
+        final FakeAnalytics fakeAnalytics = getInitializedFakeAnalyticsInstance(
+          fs: memoryFileSystem,
+          fakeFlutterVersion: FakeFlutterVersion(),
+        );
+        const FlutterDarwinPlatform platform = FlutterDarwinPlatform.ios;
+        final project = FakeXcodeProject(
+          platform: platform.name,
+          fileSystem: memoryFileSystem,
+          logger: testLogger,
+        );
+        _createProjectFiles(project, platform);
+        project.xcodeProjectInfoFile.writeAsStringSync(
+          _projectSettings(_allSectionsUnmigrated(platform)),
+        );
+
+        final plistParser = FakePlistParser.multiple(<String>[
+          _plutilOutput(_allSectionsUnmigratedAsJson(platform)),
+          _plutilOutput(_allSectionsMigratedAsJson(platform)),
+        ]);
+
+        final projectMigration = SwiftPackageManagerIntegrationMigration(
+          project,
+          platform,
+          BuildInfo.debug,
+          xcodeProjectInterpreter: FakeXcodeProjectInterpreter(throwErrorOnGetInfo: true),
+          logger: testLogger,
+          fileSystem: memoryFileSystem,
+          plistParser: plistParser,
+          config: FakeConfig(),
+          analytics: fakeAnalytics,
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
+          reportCrashes: false,
+        );
+        await expectLater(
+          () => projectMigration.migrate(),
+          throwsToolExit(message: 'Unable to get Xcode project information'),
+        );
+        expect(
+          fakeAnalytics.sentEvents,
+          contains(
+            Event.appleUsageEvent(
+              workflow: 'swiftpm-migration-failure',
+              parameter: 'full',
+              result: 'Xcode failed for unknown reason.',
+            ),
+          ),
+        );
+        expect(testLogger.traceText, isNot(contains('Sending crash report to Google.')));
       });
 
       testWithoutContext('restore project settings from backup on failure', () async {
@@ -3528,11 +4680,88 @@ void main() {
           plistParser: plistParser,
           validateBackup: true,
           config: FakeConfig(),
+          hostPlatform: FakePlatform(),
+          operatingSystemUtils: FakeOperatingSystemUtils(),
+          flutterVersion: FakeFlutterVersion(),
         );
         await expectLater(() async => projectMigration.migrate(), throwsToolExit());
         expect(testLogger.traceText, contains('Restoring project settings from backup file...'));
         expect(project.xcodeProjectInfoFile.readAsStringSync(), originalProjectInfo);
         expect(project.xcodeProjectSchemeFile().readAsStringSync(), originalSchemeContents);
+      });
+    });
+
+    group('SwiftPackageManagerMigrationException', () {
+      test('sets user and machine message', () {
+        final exception = SwiftPackageManagerMigrationException(
+          'user message',
+          analyticsMessage: 'machine message',
+        );
+        expect(exception.userMessage, 'user message');
+        expect(exception.analyticsMessage, 'machine message');
+        expect(exception.toString(), 'user message');
+      });
+
+      test('sets user message when machine message is null', () {
+        final exception = SwiftPackageManagerMigrationException('user message');
+        expect(exception.userMessage, 'user message');
+        expect(exception.analyticsMessage, isNull);
+        expect(exception.toString(), 'user message');
+      });
+
+      test('sanitized creates sanitized analyticsMessage', () {
+        final exception = SwiftPackageManagerMigrationException.sanitized(
+          (sanitize) =>
+              'Error for ${sanitize('MyName', SanitizeType.name)}: ${sanitize('some error details', SanitizeType.error)}',
+        );
+        expect(exception.userMessage, 'Error for MyName: some error details');
+        expect(exception.analyticsMessage, 'Error for custom: ');
+        expect(exception.toString(), 'Error for MyName: some error details');
+      });
+
+      test('sanitized preserves Runner for name', () {
+        final exception = SwiftPackageManagerMigrationException.sanitized(
+          (sanitize) => 'Error for ${sanitize('Runner', SanitizeType.name)}',
+        );
+        expect(exception.userMessage, 'Error for Runner');
+        expect(exception.analyticsMessage, 'Error for Runner');
+        expect(exception.toString(), 'Error for Runner');
+      });
+
+      test('sanitized preserves Runner.xcscheme for basename', () {
+        final exception = SwiftPackageManagerMigrationException.sanitized(
+          (sanitize) => 'Error for ${sanitize('Runner.xcscheme', SanitizeType.basename)}',
+        );
+        expect(exception.userMessage, 'Error for Runner.xcscheme');
+        expect(exception.analyticsMessage, 'Error for Runner.xcscheme');
+        expect(exception.toString(), 'Error for Runner.xcscheme');
+      });
+
+      test('sanitized replaces custom scheme for basename', () {
+        final exception = SwiftPackageManagerMigrationException.sanitized(
+          (sanitize) => 'Error for ${sanitize('MyName.xcscheme', SanitizeType.basename)}',
+        );
+        expect(exception.userMessage, 'Error for MyName.xcscheme');
+        expect(exception.analyticsMessage, 'Error for custom.xcscheme');
+        expect(exception.toString(), 'Error for MyName.xcscheme');
+      });
+
+      test('sanitized replaces custom scheme for unexpected basename', () {
+        // Verify basename with multiple "." in the path
+        final exception = SwiftPackageManagerMigrationException.sanitized(
+          (sanitize) => 'Error for ${sanitize('MyName.debug.xcscheme', SanitizeType.basename)}',
+        );
+        expect(exception.userMessage, 'Error for MyName.debug.xcscheme');
+        expect(exception.analyticsMessage, 'Error for custom.xcscheme');
+        expect(exception.toString(), 'Error for MyName.debug.xcscheme');
+
+        // Verify basename with no "." in the path
+        final exception2 = SwiftPackageManagerMigrationException.sanitized(
+          (sanitize) => 'Error for ${sanitize('MyName', SanitizeType.basename)}',
+        );
+        expect(exception2.userMessage, 'Error for MyName');
+        expect(exception2.analyticsMessage, 'Error for custom');
+        expect(exception2.toString(), 'Error for MyName');
       });
     });
   });
@@ -4507,7 +5736,7 @@ const migratedSwiftPackageProductDependencySectionAsJson = '''
     }''';
 
 class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterpreter {
-  FakeXcodeProjectInterpreter({this.throwErrorOnGetInfo = false});
+  FakeXcodeProjectInterpreter({this.throwErrorOnGetInfo = false, this.errorMessageOnGetInfo});
 
   @override
   bool isInstalled = false;
@@ -4516,6 +5745,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
   List<String> xcrunCommand() => <String>['xcrun'];
 
   final bool throwErrorOnGetInfo;
+  final String? errorMessageOnGetInfo;
 
   @override
   Future<XcodeProjectInfo?> getInfo(
@@ -4523,8 +5753,8 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
     String? projectFilename,
     required Directory buildDirectory,
   }) async {
-    if (throwErrorOnGetInfo) {
-      throwToolExit('Unable to get Xcode project information');
+    if (throwErrorOnGetInfo || errorMessageOnGetInfo != null) {
+      throwToolExit(errorMessageOnGetInfo ?? 'Unable to get Xcode project information');
     }
     return null;
   }
@@ -4667,7 +5897,17 @@ class FakeSwiftPackageManagerIntegrationMigration extends SwiftPackageManagerInt
     required super.plistParser,
     this.validateBackup = false,
     required super.config,
-  }) : _xcodeProject = project;
+    super.analytics = const NoOpAnalytics(),
+    Platform? hostPlatform,
+    OperatingSystemUtils? operatingSystemUtils,
+    FlutterVersion? flutterVersion,
+    super.reportCrashes = true,
+  }) : _xcodeProject = project,
+       super(
+         hostPlatform: hostPlatform ?? FakePlatform(),
+         operatingSystemUtils: operatingSystemUtils ?? FakeOperatingSystemUtils(),
+         flutterVersion: flutterVersion ?? FakeFlutterVersion(),
+       );
 
   final XcodeBasedProject _xcodeProject;
 


### PR DESCRIPTION
### Issue Link:
https://github.com/flutter/flutter/issues/181560

### Impact Description:

Flutter team is trying to improve SwiftPM migration experience by gathering more metrics. 

### Changelog Description:
[flutter/181560] When building iOS and macOS app, SwiftPM migration warnings and errors are not tracked in analytics.

### Workaround:
None

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
N/A
