### PR TITLE
[devicelab] Fix Mac ios_universal_link_test CI build and scheme configuration

### DIFF
--- a/dev/devicelab/bin/tasks/ios_universal_link_test.dart
+++ b/dev/devicelab/bin/tasks/ios_universal_link_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/ios.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
@@ -11,11 +12,14 @@ import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:path/path.dart' as path;
 
 Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
   await task(() async {
     TaskResult? result;
+    String? simulatorDeviceId;
 
-    await testWithNewIOSSimulator('UniversalLinkTestSim', (String deviceId) async {
-      try {
+    try {
+      await testWithNewIOSSimulator('UniversalLinkTestSim', (String deviceId) async {
+        simulatorDeviceId = deviceId;
         Future<bool> buildAndTestApp(String projectName) async {
           section('Building and testing $projectName');
           final String projectDir = path.join(
@@ -26,20 +30,17 @@ Future<void> main() async {
           );
 
           await inDirectory(projectDir, () async {
-            await flutter('build', options: <String>['ios', '--simulator']);
+            await flutter('build', options: <String>['ios', '-v', '--simulator', '--config-only']);
           });
 
           final String iosDir = path.join(projectDir, 'ios');
-          final String buildDir = path.join(projectDir, 'build', 'ios');
 
           return runXcodeTests(
             platformDirectory: iosDir,
             destination: 'id=$deviceId',
             testName: projectName,
             configuration: 'Debug',
-            scheme: 'RunnerUITests',
             skipCodesign: true,
-            extraOptions: <String>['SYMROOT=$buildDir'],
           );
         }
 
@@ -49,10 +50,10 @@ Future<void> main() async {
         } else {
           result = TaskResult.failure('ios_universal_link test failed');
         }
-      } finally {
-        await removeIOSSimulator(deviceId);
-      }
-    });
+      });
+    } finally {
+      await removeIOSSimulator(simulatorDeviceId);
+    }
 
     return result ?? TaskResult.failure('Test failed to set a result');
   });

--- a/dev/integration_tests/ios_universal_link/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_universal_link/ios/Runner.xcodeproj/project.pbxproj
@@ -20,6 +20,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		214A66A30B4D23EBB1BF888E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
+			remoteInfo = Runner;
+		};
 		331C8085294A63A400263BE5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
@@ -179,6 +186,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				214A66A40B4D23EBB1BF888E /* PBXTargetDependency */,
 			);
 			name = RunnerUITests;
 			productName = RunnerUITests;
@@ -232,6 +240,10 @@
 				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
+					214A669F0B4D23EBB1BF888E = {
+						CreatedOnToolsVersion = 15.1;
+						TestTargetID = 97C146ED1CF9000F007C117D;
+					};
 					331C8080294A63A400263BE5 = {
 						CreatedOnToolsVersion = 14.0;
 						TestTargetID = 97C146ED1CF9000F007C117D;
@@ -354,6 +366,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		214A66A40B4D23EBB1BF888E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 97C146ED1CF9000F007C117D /* Runner */;
+			targetProxy = 214A66A30B4D23EBB1BF888E /* PBXContainerItemProxy */;
+		};
 		331C8086294A63A400263BE5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
@@ -468,8 +485,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.experimental0.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Experimental App 0 Dev";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -670,8 +685,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.experimental0.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Experimental App 0 Dev";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -700,8 +713,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.experimental0.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Experimental App 0 Dev";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/dev/integration_tests/ios_universal_link/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/ios_universal_link/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -39,24 +39,23 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "331C8080294A63A400263BE5"
-               BuildableName = "RunnerTests.xctest"
-               BlueprintName = "RunnerTests"
+               BlueprintIdentifier = "214A669F0B4D23EBB1BF888E"
+               BuildableName = "RunnerUITests.xctest"
+               BlueprintName = "RunnerUITests"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Profile"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
-      launchStyle = "1"
+      launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"

--- a/dev/integration_tests/ios_universal_link/ios/RunnerUITests/RunnerUITests.swift
+++ b/dev/integration_tests/ios_universal_link/ios/RunnerUITests/RunnerUITests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 class RunnerUITests: XCTestCase {
 
-  override func setUpWithError() throws {
+  override func setUp() {
     continueAfterFailure = false
   }
 


### PR DESCRIPTION
The `ios_universal_link_test` devicelab task introduced in #191443 failed in post-submit CI during `flutter build ios --simulator` with "No Xcode build settings have been found." On headless CI bots that lack developer provisioning profiles, physical device code signing specifiers in `project.pbxproj` prevented Xcode from querying build settings. In addition, running a full simulator build prior to `runXcodeTests` triggered redundant code signing evaluations on bots without codesigning support.

This fixes the failure by removing the `PROVISIONING_PROFILE_SPECIFIER` properties from `project.pbxproj` and building with `--config-only` during the task's preliminary Flutter build step, matching the pattern in `native_platform_view_ui_tests_ios`. It also sets `deviceOperatingSystem = DeviceOperatingSystem.ios` for proper Devicelab device handling, updates `Runner.xcscheme` to reference `RunnerUITests` under Debug configuration, wires up the missing target dependency in `project.pbxproj`, and simplifies `setUpWithError` in `RunnerUITests.swift`.

Fixes https://github.com/flutter/flutter/issues/192320

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
