### PR TITLE
Handle a floating cursor Update that arrives without a Start

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3860,6 +3860,17 @@ class EditableTextState extends State<EditableText>
         _lastTextPosition = currentTextPosition;
         renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!);
       case FloatingCursorDragState.Update:
+        if (_pointOffsetOrigin == null || _startCaretCenter == null) {
+          // The Start of this drag never reached this client. The input
+          // connection can change hands mid-drag (focus moved, or the field
+          // re-attached), and the platform keeps sending updates to whichever
+          // client is current. Anchor the floating cursor at this client's
+          // caret and treat this point as the drag origin.
+          updateFloatingCursor(
+            RawFloatingCursorPoint(state: FloatingCursorDragState.Start, offset: point.offset),
+          );
+          return;
+        }
         final Offset centeredPoint = point.offset! - _pointOffsetOrigin!;
         final Offset rawCursorOffset = _startCaretCenter! + centeredPoint - _floatingCursorOffset;
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -13177,6 +13177,86 @@ void main() {
     expect(tester.hasRunningAnimations, isFalse);
   });
 
+  testWidgets('Floating cursor Update without a Start anchors at the caret', (
+    WidgetTester tester,
+  ) async {
+    // The platform sends floating cursor messages to whichever client is
+    // current, so a client that took over the input connection mid-drag sees
+    // Update and End with no preceding Start.
+    EditableText.debugDeterministicCursor = true;
+    final GlobalKey key = GlobalKey();
+    controller.text = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    controller.selection = const TextSelection.collapsed(offset: 0);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EditableText(
+          key: key,
+          autofocus: true,
+          controller: controller,
+          focusNode: focusNode,
+          style: textStyle,
+          cursorColor: Colors.blue,
+          backgroundCursorColor: Colors.grey,
+          cursorOpacityAnimates: true,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    Future<void> sendFloatingCursor(String state, Offset offset) async {
+      final ByteData? message = const JSONMessageCodec().encodeMessage(<String, dynamic>{
+        'method': 'TextInputClient.updateFloatingCursor',
+        'args': <dynamic>[
+          -1, // The magic client id that points to the current client.
+          'FloatingCursorDragState.$state',
+          <String, dynamic>{'X': offset.dx, 'Y': offset.dy},
+        ],
+      });
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/textinput',
+        message,
+        (ByteData? _) {},
+      );
+    }
+
+    await sendFloatingCursor('update', const Offset(30, 0));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+
+    // The first Update stands in for the missing Start: the floating cursor
+    // appears at the caret.
+    expect(
+      key.currentContext!.findRenderObject(),
+      paints..rrect(
+        rrect: RRect.fromRectAndRadius(
+          const Rect.fromLTWH(0.5, 1, 3, 12),
+          const Radius.circular(1),
+        ),
+      ),
+    );
+
+    // Later Updates move relative to that first point.
+    await sendFloatingCursor('update', const Offset(80, 0));
+    await tester.pump();
+    expect(
+      key.currentContext!.findRenderObject(),
+      paints..rrect(
+        rrect: RRect.fromRectAndRadius(
+          const Rect.fromLTWH(50.5, 1, 3, 12),
+          const Radius.circular(1),
+        ),
+      ),
+    );
+
+    await sendFloatingCursor('end', Offset.zero);
+    await tester.pumpAndSettle(const Duration(milliseconds: 125));
+    expect(tester.takeException(), isNull);
+    expect(controller.selection.isCollapsed, isTrue);
+    expect(controller.selection.baseOffset, 4);
+    EditableText.debugDeterministicCursor = false;
+  });
+
   testWidgets('Floating cursor affinity', (WidgetTester tester) async {
     EditableText.debugDeterministicCursor = true;
     final GlobalKey key = GlobalKey();


### PR DESCRIPTION
`EditableTextState.updateFloatingCursor` records the drag origin (`_pointOffsetOrigin`, `_startCaretCenter`) on `FloatingCursorDragState.Start` and dereferences it with `!` on every `Update`. The platform routes `TextInputClient.updateFloatingCursor` to whichever `TextInputClient` currently owns the connection, so when the connection changes hands mid-drag (focus moves, or a field re-attaches) the new `EditableTextState` receives `Update` and `End` with no `Start`. Today that throws `TypeError: Null check operator used on a null value` on every pointer move for the rest of the drag, and the floating cursor never moves. Seen in production on iOS 26.6.1 with 3.41.0; the method is unchanged on `master`.

This PR treats an `Update` with no recorded origin as the start of the drag: it re-enters the `Start` path with the update's offset as the origin, so the floating cursor anchors at the caret and later updates move relative to that point. `End` was already null-safe.

The new test sends `update`, `update`, `end` over the `flutter/textinput` channel to a focused `EditableText` that never received `start`. Without the fix it fails with the `TypeError` above; with it, the cursor anchors at the caret, follows the second update, and `End` commits the selection.

Fixes https://github.com/flutter/flutter/issues/192323 (same failure as https://github.com/flutter/flutter/issues/166476).

Opened as a draft: prepared with an AI coding assistant, and the author is reviewing the change before marking it ready, per the AI contribution guidelines.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md