### PR TITLE
[flutter_tools] Ignore widget previews outside lib/ during LSP code generation

### DIFF
--- a/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
@@ -247,7 +247,9 @@ class PreviewCodeGenerator {
     builder
       ..body = cb.literalList([
         for (final preview in sortedPreviews)
-          _buildPreviewsLsp(preview: preview, uri: preview.libraryUri),
+          // Previews can only be defined under the lib/ directory.
+          if (preview.packageName != null)
+            _buildPreviewsLsp(preview: preview, uri: preview.libraryUri),
       ]).code
       ..name = _kPreviewsFunctionName
       ..returns =

--- a/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
@@ -438,6 +438,14 @@ extension on DartObject {
 
 class PreviewPrefixedAllocator implements cb.Allocator {
   static const _doNotPrefix = ['dart:core'];
+  static const _kImportPrefix = '_i';
+  static const _kPackageSchemePrefix = 'package:';
+  static const _kDartSchemePrefix = 'dart:';
+
+  static const _internalHelperUris = <String>{
+    PreviewCodeGenerator._kWidgetPreviewLibraryUri,
+    PreviewCodeGenerator._kUtilsUri,
+  };
 
   final _imports = <String, int>{};
   static const _kInitialKey = 1;
@@ -451,7 +459,7 @@ class PreviewPrefixedAllocator implements cb.Allocator {
       return symbol!;
     }
     url = _fixUrl(url);
-    return '_i${_imports.putIfAbsent(url, _nextKey)}.$symbol';
+    return '$_kImportPrefix${_imports.putIfAbsent(url, _nextKey)}.$symbol';
   }
 
   void populateKnownImportPrefixes(Map<String, String> imports) {
@@ -460,17 +468,31 @@ class PreviewPrefixedAllocator implements cb.Allocator {
         'Attempted to populated known import prefixes when prefixes have been allocated',
       );
     }
-    _imports.addAll({
-      for (final MapEntry(:key, :value) in imports.entries) key: int.parse(value.substring(2)),
-    });
-    _keys += _imports.length;
+    for (final MapEntry(:key, :value) in imports.entries) {
+      final int prefixKey = int.parse(value.substring(_kImportPrefix.length));
+      if (prefixKey >= _keys) {
+        _keys = prefixKey + 1;
+      }
+      final String url = _fixUrl(key);
+      if (_isValidImport(url)) {
+        _imports[url] = prefixKey;
+      }
+    }
   }
+
+  /// Only packages, Dart SDK libraries, and the internal helper files are
+  /// valid imports for the generated preview scaffold. Previews and libraries
+  /// outside of `lib/` cannot be imported into the preview scaffold.
+  static bool _isValidImport(String uri) =>
+      uri.startsWith(_kPackageSchemePrefix) ||
+      uri.startsWith(_kDartSchemePrefix) ||
+      _internalHelperUris.contains(uri);
 
   int _nextKey() => _keys++;
 
   @override
   Iterable<cb.Directive> get imports =>
-      _imports.keys.map((u) => cb.Directive.import(u, as: '_i${_imports[u]}'));
+      _imports.keys.map((u) => cb.Directive.import(u, as: '$_kImportPrefix${_imports[u]}'));
 }
 
 /// Applies hardcoded fixes to [url].

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/widget_preview/analytics.dart';
 import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
+import 'package:flutter_tools/src/widget_preview/dtd_types.dart';
 import 'package:flutter_tools/src/widget_preview/preview_code_generator.dart';
 import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
 import 'package:process/process.dart';
@@ -460,6 +461,78 @@ List<_i1.WidgetPreview> previews() => [];
         expect(generatedPreviewFile.readAsStringSync(), emptyGeneratedPreviewFileContents);
       },
     );
+
+    testUsingContext('ignores previews with null packageName for LSP updates', () async {
+      await previewDetector.initialize();
+      final File generatedPreviewFile = project.widgetPreviewScaffold.childFile(
+        PreviewCodeGenerator.getGeneratedPreviewFilePath(fs),
+      );
+      generatedPreviewFile.createSync(recursive: true);
+
+      final update = FlutterWidgetPreviews(
+        namespaces: <String, String>{
+          'widget_preview.dart': '_i1',
+          'utils.dart': '_i2',
+          'package:foo_project/preview.dart': '_i3',
+          'preview.dart': '_i4',
+          'package:flutter/src/widget_previews/widget_previews.dart': '_i5',
+        },
+        previews: <FlutterWidgetPreviewDetails>[
+          FlutterWidgetPreviewDetails(
+            functionName: 'validPreview',
+            hasError: false,
+            dependencyHasErrors: false,
+            isBuilder: false,
+            isMultiPreview: false,
+            packageName: 'foo_project',
+            position: const Position(character: 1, line: 4),
+            previewAnnotation: "const _i5.Preview(name: 'valid')",
+            scriptUri: Uri.file('/user/flutter_project/lib/preview.dart'),
+            libraryUri: Uri.parse('package:foo_project/preview.dart'),
+          ),
+          FlutterWidgetPreviewDetails(
+            functionName: 'rootPreview',
+            hasError: false,
+            dependencyHasErrors: false,
+            isBuilder: false,
+            isMultiPreview: false,
+            position: const Position(character: 1, line: 4),
+            previewAnnotation: "const _i5.Preview(name: 'root')",
+            scriptUri: Uri.file('/user/flutter_project/preview.dart'),
+            libraryUri: Uri.parse('preview.dart'),
+          ),
+        ],
+        scriptUris: <Uri>[
+          Uri.file('/user/flutter_project/lib/preview.dart'),
+          Uri.file('/user/flutter_project/preview.dart'),
+        ],
+      );
+
+      codeGenerator.populatePreviewsInGeneratedPreviewScaffoldLsp(update);
+
+      const expectedGeneratedPreviewFileContents = '''
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'widget_preview.dart' as _i1;
+import 'utils.dart' as _i2;
+import 'package:foo_project/preview.dart' as _i3;
+import 'preview.dart' as _i4;
+import 'package:flutter/src/widget_previews/widget_previews.dart' as _i5;
+
+List<_i1.WidgetPreview> previews() => [
+  _i2.buildWidgetPreview(
+    packageName: 'foo_project',
+    scriptUri: 'file:///user/flutter_project/lib/preview.dart',
+    line: 4,
+    column: 1,
+    previewFunction: () => _i3.validPreview(),
+    transformedPreview: const _i5.Preview(name: 'valid').transform(),
+  ),
+];
+''';
+      expect(generatedPreviewFile.readAsStringSync(), expectedGeneratedPreviewFileContents);
+    });
 
     testUsingContext(
       'correctly generates ${PreviewCodeGenerator.getGeneratedDtdConnectionInfoFilePath(fs)}',

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:code_builder/code_builder.dart' as cb;
 import 'package:dart_style/dart_style.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
@@ -476,6 +477,7 @@ List<_i1.WidgetPreview> previews() => [];
           'package:foo_project/preview.dart': '_i3',
           'preview.dart': '_i4',
           'package:flutter/src/widget_previews/widget_previews.dart': '_i5',
+          'dart:ui': '_i6',
         },
         previews: <FlutterWidgetPreviewDetails>[
           FlutterWidgetPreviewDetails(
@@ -517,8 +519,8 @@ List<_i1.WidgetPreview> previews() => [];
 import 'widget_preview.dart' as _i1;
 import 'utils.dart' as _i2;
 import 'package:foo_project/preview.dart' as _i3;
-import 'preview.dart' as _i4;
 import 'package:flutter/src/widget_previews/widget_previews.dart' as _i5;
+import 'dart:ui' as _i6;
 
 List<_i1.WidgetPreview> previews() => [
   _i2.buildWidgetPreview(
@@ -566,5 +568,41 @@ const String kProjectRootPath = r'${project.directory.absolute.path}';
         expect(generatedDtdConnectionInfoFile.readAsStringSync(), expectedDtdConnectionInfo);
       },
     );
+  });
+
+  group('PreviewPrefixedAllocator', () {
+    test('filters out non-package/non-SDK imports and allocates non-colliding prefixes', () {
+      final allocator = PreviewPrefixedAllocator();
+      allocator.populateKnownImportPrefixes(<String, String>{
+        'widget_preview.dart': '_i1',
+        'utils.dart': '_i2',
+        'package:foo/foo.dart': '_i3',
+        'preview.dart': '_i4',
+        'package:flutter/widgets.dart': '_i5',
+        'dart:ui': '_i6',
+        'root.dart': '_i7',
+      });
+
+      expect(allocator.imports.map((cb.Directive d) => d.url).toList(), <String>[
+        'widget_preview.dart',
+        'utils.dart',
+        'package:foo/foo.dart',
+        'package:flutter/widgets.dart',
+        'dart:ui',
+      ]);
+
+      // Allocating a new reference must not collide with existing or skipped prefixes.
+      // Maximum prefix from the populate call was _i7, so the next allocated key must be >= _i8.
+      expect(allocator.allocate(cb.refer('Bar', 'package:bar/bar.dart')), '_i8.Bar');
+    });
+
+    test('throws StateError when prefixes have already been allocated', () {
+      final allocator = PreviewPrefixedAllocator();
+      allocator.allocate(cb.refer('Foo', 'package:foo/foo.dart'));
+      expect(
+        () => allocator.populateKnownImportPrefixes(<String, String>{'dart:ui': '_i1'}),
+        throwsStateError,
+      );
+    });
   });
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/191755

Previews outside of `lib/` (such as at the root of a project or in `test/`) do not have a `package:` URI, so `FlutterWidgetPreviewDetails.packageName` is null.

In #180768, it was established that widget previews must be defined within importable libraries under `lib/`. Files outside `lib/` cannot be safely imported into the widget preview scaffold without breaking asset path mappings or failing to resolve `dev_dependencies`. While legacy `PreviewDetector` explicitly ignores libraries where `packageName == null`, the Dart Analysis Server (LSP) preview detector returns all `@Preview` annotations across the workspace.

When `_buildPreviewsLsp` generated the preview list, it force-unwrapped `preview.packageName!`, crashing with `_TypeError: Null check operator used on a null value`.

This change filters out previews where `packageName == null` in `PreviewCodeGenerator._buildGeneratedPreviewMethodLsp`, ensuring that previews outside `lib/` are safely ignored when using LSP preview detection.

## Tests

- Added hermetic unit test `ignores previews with null packageName for LSP updates` in `packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart`.