### PR TITLE
Add TextOverflow.ellipsisStart and TextOverflow.ellipsisMiddle

### DIFF
--- a/packages/flutter/examples/api/lib/painting/text_painter/text_overflow.0.dart
+++ b/packages/flutter/examples/api/lib/painting/text_painter/text_overflow.0.dart
@@ -1,0 +1,165 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+/// Flutter code sample for [TextOverflow].
+
+void main() => runApp(const ExampleApp());
+
+const Color _background = Color(0xFFFFFFFF);
+const Color _foreground = Color(0xFF202124);
+const Color _accent = Color(0xFF1A73E8);
+const Color _outline = Color(0xFFBDC1C6);
+
+class ExampleApp extends StatelessWidget {
+  const ExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WidgetsApp(
+      color: _background,
+      textStyle: const TextStyle(fontSize: 14.0, color: _foreground),
+      builder: (BuildContext context, Widget? child) =>
+          const TextOverflowExample(),
+    );
+  }
+}
+
+class TextOverflowExample extends StatefulWidget {
+  const TextOverflowExample({super.key});
+
+  @override
+  State<TextOverflowExample> createState() => _TextOverflowExampleState();
+}
+
+class _TextOverflowExampleState extends State<TextOverflowExample> {
+  static const String _path =
+      '/Users/someone/Documents/reports/2019/november/summary.txt';
+  static const double _minWidth = 60.0;
+  static const double _maxWidth = 320.0;
+
+  TextOverflow _overflow = TextOverflow.ellipsisStart;
+  double _width = 240.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: _background,
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            // Changing the overflow mode or the width updates this Text in
+            // place; the paragraph recomputes where the ellipsis goes as part
+            // of its next layout.
+            SizedBox(
+              width: _width,
+              child: DecoratedBox(
+                decoration: BoxDecoration(border: Border.all(color: _outline)),
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(
+                    _path,
+                    overflow: _overflow,
+                    semanticsLabel: _path,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24.0),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 8.0,
+              children: <Widget>[
+                for (final TextOverflow overflow in <TextOverflow>[
+                  TextOverflow.ellipsisStart,
+                  TextOverflow.ellipsisMiddle,
+                  TextOverflow.ellipsis,
+                ])
+                  _OverflowButton(
+                    overflow: overflow,
+                    selected: overflow == _overflow,
+                    onTap: () => setState(() => _overflow = overflow),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 24.0),
+            // Drag horizontally to change how much room the text has to fit in.
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onHorizontalDragUpdate: (DragUpdateDetails details) {
+                setState(() {
+                  _width = clampDouble(
+                    _width + details.delta.dx,
+                    _minWidth,
+                    _maxWidth,
+                  );
+                });
+              },
+              child: SizedBox(
+                width: _maxWidth,
+                child: Column(
+                  children: <Widget>[
+                    Align(
+                      // Map the width onto the -1 to 1 range Alignment uses.
+                      alignment: Alignment(
+                        (_width - _minWidth) / (_maxWidth - _minWidth) * 2.0 -
+                            1.0,
+                        0.0,
+                      ),
+                      child: const DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: _accent,
+                          shape: BoxShape.circle,
+                        ),
+                        child: SizedBox.square(dimension: 20.0),
+                      ),
+                    ),
+                    const SizedBox(height: 8.0),
+                    Text('Drag to resize the box (${_width.round()} px)'),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OverflowButton extends StatelessWidget {
+  const _OverflowButton({
+    required this.overflow,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final TextOverflow overflow;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: selected ? _accent : _background,
+          border: Border.all(color: selected ? _accent : _outline),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+          child: Text(
+            overflow.name,
+            style: TextStyle(color: selected ? _background : _foreground),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter/examples/api/test/painting/text_painter/text_overflow.0_test.dart
+++ b/packages/flutter/examples/api/test/painting/text_painter/text_overflow.0_test.dart
@@ -1,0 +1,63 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_api_samples/painting/text_painter/text_overflow.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // The paragraph the sample truncates, picked out of the other paragraphs on
+  // the screen (the app bar title and the button labels) by its content.
+  String renderedText(WidgetTester tester) {
+    return tester
+        .renderObjectList<RenderParagraph>(find.byType(RichText))
+        .firstWhere((RenderParagraph paragraph) {
+          return paragraph.text.toPlainText().endsWith('summary.txt');
+        })
+        .debugRenderedText;
+  }
+
+  testWidgets('The ellipsis moves when the overflow mode changes', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.ExampleApp());
+
+    // ellipsisStart drops the front of the path and keeps the file name.
+    expect(renderedText(tester), startsWith('…'));
+    expect(renderedText(tester), endsWith('.txt'));
+
+    await tester.tap(find.text('ellipsisMiddle'));
+    await tester.pumpAndSettle();
+    // ellipsisMiddle keeps the root of the path as well as the file name.
+    expect(renderedText(tester), startsWith('/Users'));
+    expect(renderedText(tester), endsWith('.txt'));
+    expect(renderedText(tester), contains('…'));
+
+    await tester.tap(find.text('ellipsis'));
+    await tester.pumpAndSettle();
+    // The engine adds the trailing ellipsis while painting, so the text that
+    // is laid out is still the whole path.
+    expect(renderedText(tester), startsWith('/Users'));
+    expect(renderedText(tester), isNot(contains('…')));
+  });
+
+  testWidgets('Narrowing the box keeps less of the text', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.ExampleApp());
+    final int atFullWidth = renderedText(tester).length;
+
+    await tester.drag(
+      find.textContaining('Drag to resize'),
+      const Offset(-100.0, 0.0),
+    );
+    await tester.pumpAndSettle();
+
+    expect(renderedText(tester).length, lessThan(atFullWidth));
+    expect(renderedText(tester), startsWith('…'));
+    expect(renderedText(tester), endsWith('.txt'));
+  });
+}

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -44,6 +44,14 @@ const double kDefaultFontSize = 14.0;
 ///
 /// A [TextOverflow] can be passed to [Text] and [RichText] via their
 /// [Text.overflow] and [RichText.overflow] properties respectively.
+///
+/// {@tool dartpad}
+/// This sample shows a file path that does not fit the box it is in, and how
+/// [TextOverflow.ellipsisStart], [TextOverflow.ellipsisMiddle] and
+/// [TextOverflow.ellipsis] each choose a different part of it to keep.
+///
+/// ** See code in examples/api/lib/painting/text_painter/text_overflow.0.dart **
+/// {@end-tool}
 enum TextOverflow {
   /// Clip the overflowing text to fix its container.
   clip,
@@ -52,7 +60,55 @@ enum TextOverflow {
   fade,
 
   /// Use an ellipsis to indicate that the text has overflowed.
+  ///
+  /// The ellipsis is placed at the end of the last visible line.
   ellipsis,
+
+  /// Use an ellipsis at the beginning of the text to indicate that the text has
+  /// overflowed, keeping as much of the end of the text as fits.
+  ///
+  /// This is useful when the end of the text is the most informative part of
+  /// it, such as a file path: `/Users/someone/Documents/report.txt` renders as
+  /// `…ocuments/report.txt` rather than `/Users/someone/D…`.
+  ///
+  /// The text is always rendered on a single line, so `maxLines` must be null
+  /// or 1 and soft wrapping does not apply. Rendering the trailing lines of a
+  /// wrapped paragraph is not supported.
+  ///
+  /// Unlike [TextOverflow.ellipsis], which is applied by the text engine while
+  /// the text is laid out, the truncated text is computed by
+  /// [RenderParagraph]. This has two consequences: text is only ever truncated
+  /// at grapheme cluster boundaries, and the text that is laid out is the
+  /// truncated text, so selection and semantics reflect what is on screen
+  /// rather than the full string. Use [Text.semanticsLabel] to announce the
+  /// full string to assistive technologies.
+  ///
+  /// A paragraph that contains a [WidgetSpan] (or any other [PlaceholderSpan])
+  /// cannot be split, so it falls back to [TextOverflow.clip].
+  ellipsisStart,
+
+  /// Use an ellipsis in the middle of the text to indicate that the text has
+  /// overflowed, keeping as much of both ends of the text as fits.
+  ///
+  /// This is useful when both ends of the text are informative, such as a file
+  /// path whose root and file name both matter:
+  /// `/Users/someone/Documents/report.txt` renders as `/Users/s…eport.txt`.
+  ///
+  /// The text is always rendered on a single line, so `maxLines` must be null
+  /// or 1 and soft wrapping does not apply. Rendering the trailing lines of a
+  /// wrapped paragraph is not supported.
+  ///
+  /// Unlike [TextOverflow.ellipsis], which is applied by the text engine while
+  /// the text is laid out, the truncated text is computed by
+  /// [RenderParagraph]. This has two consequences: text is only ever truncated
+  /// at grapheme cluster boundaries, and the text that is laid out is the
+  /// truncated text, so selection and semantics reflect what is on screen
+  /// rather than the full string. Use [Text.semanticsLabel] to announce the
+  /// full string to assistive technologies.
+  ///
+  /// A paragraph that contains a [WidgetSpan] (or any other [PlaceholderSpan])
+  /// cannot be split, so it falls back to [TextOverflow.clip].
+  ellipsisMiddle,
 
   /// Render overflowing text outside of its container.
   visible,

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -83,8 +83,10 @@ enum TextOverflow {
   /// rather than the full string. Use [Text.semanticsLabel] to announce the
   /// full string to assistive technologies.
   ///
-  /// A paragraph that contains a [WidgetSpan] (or any other [PlaceholderSpan])
-  /// cannot be split, so it falls back to [TextOverflow.clip].
+  /// The text is only truncated when it is made up entirely of plain
+  /// [TextSpan]s. A paragraph containing a [WidgetSpan] (or any other
+  /// [PlaceholderSpan]), or a subclass of [TextSpan], cannot be split and falls
+  /// back to [TextOverflow.clip].
   ellipsisStart,
 
   /// Use an ellipsis in the middle of the text to indicate that the text has
@@ -106,8 +108,10 @@ enum TextOverflow {
   /// rather than the full string. Use [Text.semanticsLabel] to announce the
   /// full string to assistive technologies.
   ///
-  /// A paragraph that contains a [WidgetSpan] (or any other [PlaceholderSpan])
-  /// cannot be split, so it falls back to [TextOverflow.clip].
+  /// The text is only truncated when it is made up entirely of plain
+  /// [TextSpan]s. A paragraph containing a [WidgetSpan] (or any other
+  /// [PlaceholderSpan]), or a subclass of [TextSpan], cannot be split and falls
+  /// back to [TextOverflow.clip].
   ellipsisMiddle,
 
   /// Render overflowing text outside of its container.

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1067,9 +1067,9 @@ class RenderParagraph extends RenderBox
   // in full.
   //
   // Null is returned when the text already fits, when it is empty, and when it
-  // cannot be split because it contains spans other than [TextSpan]s, such as
-  // the [PlaceholderSpan] of a [WidgetSpan]. In the last case the text falls
-  // back to being clipped.
+  // cannot be split because it contains anything but plain [TextSpan]s, such as
+  // the [PlaceholderSpan] of a [WidgetSpan] or a [TextSpan] subclass. In the
+  // last case the text falls back to being clipped.
   InlineSpan? _truncatedSpan(double maxWidth) {
     assert(_truncatesText);
     if (_cachedTruncationWidth == maxWidth) {
@@ -1101,9 +1101,14 @@ class RenderParagraph extends RenderBox
     final int clusterCount = boundaries.length - 1;
 
     // Find the largest number of grapheme clusters that fits alongside the
-    // ellipsis. The width of a candidate grows monotonically with the number
-    // of clusters it keeps, so this is a binary search; `low` is always a
-    // number of clusters that fits and `high` one that may not.
+    // ellipsis, by binary search; `low` is always a number of clusters that
+    // fits and `high` one that may not.
+    //
+    // Keeping more clusters usually makes a candidate wider, but not always:
+    // the ellipsis is styled after the first cluster it replaces, and for
+    // TextOverflow.ellipsisMiddle that cluster moves through the text as more
+    // of it is kept, so the ellipsis itself can become narrower. The two
+    // passes after the search correct for that.
     var low = 0;
     int high = clusterCount - 1;
     while (low < high) {
@@ -1115,14 +1120,26 @@ class RenderParagraph extends RenderBox
       }
     }
 
-    // Kerning and ligatures across the ellipsis can make the width of a
-    // candidate very slightly non-monotonic, so shrink until the result really
-    // does fit. The loop almost always exits without iterating; keeping only
-    // the ellipsis is the last resort, even if the ellipsis alone overflows.
+    // Shrink until the result really does fit, so that the text is never
+    // rendered wider than maxWidth. Keeping only the ellipsis is the last
+    // resort, even if the ellipsis alone overflows.
     var keptClusters = low;
     InlineSpan truncated = _buildTruncatedSpan(boundaries, keptClusters);
     while (keptClusters > 0 && _measureWidth(truncated) > maxWidth) {
       truncated = _buildTruncatedSpan(boundaries, --keptClusters);
+    }
+
+    // Then grow again while the next candidate also fits, so that a candidate
+    // the binary search stepped over because a wider ellipsis made it overflow
+    // is not left behind. Both loops stop immediately unless the elided text
+    // spans more than one style.
+    while (keptClusters < clusterCount - 1) {
+      final InlineSpan wider = _buildTruncatedSpan(boundaries, keptClusters + 1);
+      if (_measureWidth(wider) > maxWidth) {
+        break;
+      }
+      keptClusters += 1;
+      truncated = wider;
     }
     return truncated;
   }
@@ -1155,7 +1172,14 @@ class RenderParagraph extends RenderBox
     if (leadingClusters > 0) {
       children.add(_SpanSlicer(0, boundaries[leadingClusters]).slice(_text)!);
     }
-    children.add(TextSpan(text: _kEllipsis, style: _text.style));
+    // The ellipsis takes the style of the first grapheme cluster it replaces,
+    // which is what the text engine does for TextOverflow.ellipsis and what
+    // UIKit does for its head and middle truncation modes. Only the style is
+    // taken: a gesture recognizer or a semantics label describes the text that
+    // was elided, not the glyph standing in for it.
+    children.add(
+      TextSpan(text: _kEllipsis, style: _StyleAtOffset(boundaries[leadingClusters]).of(_text)),
+    );
     if (trailingClusters > 0) {
       children.add(
         _SpanSlicer(boundaries[clusterCount - trailingClusters], boundaries.last).slice(_text)!,
@@ -1780,6 +1804,48 @@ class RenderParagraph extends RenderBox
   }
 }
 
+/// Finds the style that applies to a code unit offset in an [InlineSpan] tree,
+/// merging the styles of the spans containing that offset from the outside in.
+class _StyleAtOffset {
+  _StyleAtOffset(this.offset) : assert(offset >= 0);
+
+  /// The code unit offset whose style to resolve.
+  final int offset;
+
+  int _cursor = 0;
+  bool _found = false;
+  TextStyle? _style;
+
+  /// The style [offset] is rendered with, or null if [span] has no text at that
+  /// offset or no style applies to it.
+  TextStyle? of(InlineSpan span) {
+    _visit(span, null);
+    return _style;
+  }
+
+  void _visit(InlineSpan span, TextStyle? inherited) {
+    final TextStyle? style = inherited?.merge(span.style) ?? span.style;
+    if (span is! TextSpan) {
+      return;
+    }
+    final String? text = span.text;
+    if (text != null) {
+      if (offset < _cursor + text.length) {
+        _found = true;
+        _style = style;
+        return;
+      }
+      _cursor += text.length;
+    }
+    for (final InlineSpan child in span.children ?? const <InlineSpan>[]) {
+      _visit(child, style);
+      if (_found) {
+        return;
+      }
+    }
+  }
+}
+
 /// Rebuilds an [InlineSpan] tree so that it only contains the text within a
 /// code unit range, preserving the style and the other properties of every span
 /// the range intersects.
@@ -1797,14 +1863,15 @@ class _SpanSlicer {
   /// The code unit offset within the paragraph of the span being visited.
   int _offset = 0;
 
-  /// Whether [span] is made up entirely of [TextSpan]s, and so can be split at
-  /// an arbitrary code unit offset.
+  /// Whether [span] is made up entirely of plain [TextSpan]s, and so can be
+  /// split at an arbitrary code unit offset.
   ///
   /// A [PlaceholderSpan] stands for a single code unit that renders an inline
-  /// widget, and other [InlineSpan] subclasses cannot be copied, so neither can
-  /// be split.
+  /// widget, so it cannot be split. Subclasses of [TextSpan] are rejected as
+  /// well: slicing rebuilds the tree out of plain [TextSpan]s, which would
+  /// silently drop whatever state and behavior a subclass adds.
   static bool canSlice(InlineSpan span) {
-    if (span is! TextSpan) {
+    if (span is! TextSpan || span.runtimeType != TextSpan) {
       return false;
     }
     var result = true;

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -680,6 +680,7 @@ class RenderParagraph extends RenderBox
       'TextOverflow.ellipsisStart and TextOverflow.ellipsisMiddle place the ellipsis inside a '
       'single line of text, so maxLines must be null or 1.',
     );
+    final bool wasTruncating = _truncatesText;
     _overflow = value;
     // Restore the untruncated text: the next layout recomputes the truncation
     // from scratch, and the other overflow modes lay out the text in full.
@@ -688,6 +689,13 @@ class RenderParagraph extends RenderBox
       ..maxLines = _truncatesText ? 1 : _maxLines
       ..text = _text;
     _renderedPlainText = null;
+    if (wasTruncating && !_truncatesText) {
+      // The full text is back in the text painter as of this assignment, so
+      // the state indexing into the truncated text is already stale. Entering
+      // a truncating mode does not need this, because the truncated text is
+      // only computed during the layout that follows, which does it there.
+      _didChangeRenderedText();
+    }
     markNeedsLayout();
   }
 
@@ -1187,6 +1195,13 @@ class RenderParagraph extends RenderBox
       return;
     }
     _renderedPlainText = plainText;
+    _didChangeRenderedText();
+  }
+
+  // Rebuilds the state that addresses the text the text painter holds: the
+  // semantics information and the selectable fragments, both of which index
+  // into it by code unit offset.
+  void _didChangeRenderedText() {
     _cachedAttributedLabels = null;
     _cachedCombinedSemanticsInfos = null;
     markNeedsSemanticsUpdate();

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -20,6 +20,7 @@ import 'dart:ui'
         TextBox,
         TextHeightBehavior;
 
+import 'package:characters/characters.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
@@ -41,12 +42,25 @@ typedef _TextBoundaryAtPosition = _TextBoundaryRecord Function(TextPosition posi
 
 /// Signature for a function that determines the [_TextBoundaryRecord] at the given
 /// [TextPosition], for the given [String].
-typedef _TextBoundaryAtPositionInText = _TextBoundaryRecord Function(
-  TextPosition position,
-  String text,
-);
+typedef _TextBoundaryAtPositionInText =
+    _TextBoundaryRecord Function(TextPosition position, String text);
 
 const String _kEllipsis = '\u2026';
+
+// Whether [overflow] places the ellipsis somewhere other than the end of the
+// text.
+//
+// The text engine can only place an ellipsis at the end of the last line, so
+// [RenderParagraph] computes the truncated text itself for these values.
+bool _hasNonTrailingEllipsis(TextOverflow overflow) {
+  return switch (overflow) {
+    TextOverflow.ellipsisStart || TextOverflow.ellipsisMiddle => true,
+    TextOverflow.clip ||
+    TextOverflow.ellipsis ||
+    TextOverflow.fade ||
+    TextOverflow.visible => false,
+  };
+}
 
 /// Used by the [RenderParagraph] to map its rendering children to their
 /// corresponding semantics nodes.
@@ -359,6 +373,11 @@ class RenderParagraph extends RenderBox
   }) : assert(text.debugAssertIsValid()),
        assert(maxLines == null || maxLines > 0),
        assert(
+         maxLines == null || maxLines == 1 || !_hasNonTrailingEllipsis(overflow),
+         'TextOverflow.ellipsisStart and TextOverflow.ellipsisMiddle place the ellipsis inside a '
+         'single line of text, so maxLines must be null or 1.',
+       ),
+       assert(
          identical(textScaler, const _UnspecifiedTextScaler()) || textScaleFactor == 1.0,
          'textScaleFactor is deprecated and cannot be specified when textScaler is specified.',
        ),
@@ -366,6 +385,8 @@ class RenderParagraph extends RenderBox
        _overflow = overflow,
        _devicePixelRatio = devicePixelRatio,
        _selectionColor = selectionColor,
+       _text = text,
+       _maxLines = maxLines,
        _textPainter = TextPainter(
          text: text,
          textAlign: textAlign,
@@ -373,7 +394,10 @@ class RenderParagraph extends RenderBox
          textScaler: textScaler == const _UnspecifiedTextScaler()
              ? TextScaler.linear(textScaleFactor)
              : textScaler,
-         maxLines: maxLines,
+         // ellipsisStart and ellipsisMiddle render on a single line, and
+         // compute the truncated text themselves rather than handing the
+         // ellipsis string to the engine.
+         maxLines: _hasNonTrailingEllipsis(overflow) ? 1 : maxLines,
          ellipsis: overflow == TextOverflow.ellipsis ? _kEllipsis : null,
          locale: locale,
          strutStyle: strutStyle,
@@ -398,9 +422,11 @@ class RenderParagraph extends RenderBox
   //  non-destructive operation.
   TextPainter? _textIntrinsicsCache;
 
+  // Every access resets the painter's configuration, which invalidates its
+  // layout; hold the result in a local when it has to be read twice.
   TextPainter get _textIntrinsics {
     return (_textIntrinsicsCache ??= TextPainter())
-      ..text = _textPainter.text
+      ..text = _text
       ..textAlign = _textPainter.textAlign
       ..textDirection = _textPainter.textDirection
       ..textScaler = _textPainter.textScaler
@@ -412,29 +438,44 @@ class RenderParagraph extends RenderBox
       ..textHeightBehavior = _textPainter.textHeightBehavior;
   }
 
+  // Whether [overflow] makes this render object compute the truncated text
+  // itself instead of letting the text engine append a trailing ellipsis.
+  bool get _truncatesText => _hasNonTrailingEllipsis(_overflow);
+
   List<AttributedString>? _cachedAttributedLabels;
 
   List<InlineSpanSemanticsInformation>? _cachedCombinedSemanticsInfos;
 
   /// The text to display.
-  InlineSpan get text => _textPainter.text!;
+  ///
+  /// When [overflow] is [TextOverflow.ellipsisStart] or
+  /// [TextOverflow.ellipsisMiddle] this is the full, untruncated text; the
+  /// truncated text that is actually laid out is not exposed.
+  InlineSpan get text => _text;
+  InlineSpan _text;
 
   set text(InlineSpan value) {
-    switch (_textPainter.text!.compareTo(value)) {
+    final RenderComparison comparison = _text.compareTo(value);
+    if (comparison == RenderComparison.identical) {
+      return;
+    }
+    _text = value;
+    _textPainter.text = value;
+    // The truncated text is derived from the text, so when it is in use every
+    // change has to go through a layout pass, even one that would otherwise
+    // only affect painting or semantics: the text painter is holding the text
+    // truncated from the previous value until then.
+    switch (_truncatesText ? RenderComparison.layout : comparison) {
       case RenderComparison.identical:
-        return;
       case RenderComparison.metadata:
-        _textPainter.text = value;
         _cachedCombinedSemanticsInfos = null;
         markNeedsSemanticsUpdate();
       case RenderComparison.paint:
-        _textPainter.text = value;
         _cachedAttributedLabels = null;
         _cachedCombinedSemanticsInfos = null;
         markNeedsPaint();
         markNeedsSemanticsUpdate();
       case RenderComparison.layout:
-        _textPainter.text = value;
         _overflowShader = null;
         _cachedAttributedLabels = null;
         _cachedCombinedSemanticsInfos = null;
@@ -506,7 +547,10 @@ class RenderParagraph extends RenderBox
   }
 
   List<_SelectableFragment> _getSelectableFragments() {
-    final String plainText = text.toPlainText(includeSemanticsLabels: false);
+    // Selection addresses the text that is laid out, which for
+    // TextOverflow.ellipsisStart and TextOverflow.ellipsisMiddle is the
+    // truncated text rather than `text`.
+    final String plainText = _textPainter.text!.toPlainText(includeSemanticsLabels: false);
     final result = <_SelectableFragment>[];
     var start = 0;
     while (start < plainText.length) {
@@ -559,6 +603,7 @@ class RenderParagraph extends RenderBox
     _lastSelectableFragments?.forEach(
       (_SelectableFragment element) => element.didChangeParagraphLayout(),
     );
+    _cachedTruncationWidth = null;
     super.markNeedsLayout();
   }
 
@@ -568,6 +613,7 @@ class RenderParagraph extends RenderBox
     _disposeSelectableFragments();
     _textPainter.dispose();
     _textIntrinsicsCache?.dispose();
+    _truncationPainter?.dispose();
     super.dispose();
   }
 
@@ -629,8 +675,19 @@ class RenderParagraph extends RenderBox
     if (_overflow == value) {
       return;
     }
+    assert(
+      _maxLines == null || _maxLines == 1 || !_hasNonTrailingEllipsis(value),
+      'TextOverflow.ellipsisStart and TextOverflow.ellipsisMiddle place the ellipsis inside a '
+      'single line of text, so maxLines must be null or 1.',
+    );
     _overflow = value;
-    _textPainter.ellipsis = value == TextOverflow.ellipsis ? _kEllipsis : null;
+    // Restore the untruncated text: the next layout recomputes the truncation
+    // from scratch, and the other overflow modes lay out the text in full.
+    _textPainter
+      ..ellipsis = value == TextOverflow.ellipsis ? _kEllipsis : null
+      ..maxLines = _truncatesText ? 1 : _maxLines
+      ..text = _text;
+    _renderedPlainText = null;
     markNeedsLayout();
   }
 
@@ -691,16 +748,26 @@ class RenderParagraph extends RenderBox
   /// An optional maximum number of lines for the text to span, wrapping if
   /// necessary. If the text exceeds the given number of lines, it will be
   /// truncated according to [overflow] and [softWrap].
-  int? get maxLines => _textPainter.maxLines;
+  ///
+  /// Must be null or 1 when [overflow] is [TextOverflow.ellipsisStart] or
+  /// [TextOverflow.ellipsisMiddle], which render on a single line.
+  int? get maxLines => _maxLines;
+  int? _maxLines;
 
   /// The value may be null. If it is not null, then it must be greater than
   /// zero.
   set maxLines(int? value) {
     assert(value == null || value > 0);
-    if (_textPainter.maxLines == value) {
+    assert(
+      value == null || value == 1 || !_truncatesText,
+      'TextOverflow.ellipsisStart and TextOverflow.ellipsisMiddle place the ellipsis inside a '
+      'single line of text, so maxLines must be null or 1.',
+    );
+    if (_maxLines == value) {
       return;
     }
-    _textPainter.maxLines = value;
+    _maxLines = value;
+    _textPainter.maxLines = _truncatesText ? 1 : value;
     _overflowShader = null;
     markNeedsLayout();
   }
@@ -883,6 +950,7 @@ class RenderParagraph extends RenderBox
   @override
   void systemFontsDidChange() {
     super.systemFontsDidChange();
+    _cachedTruncationWidth = null;
     _textPainter.markNeedsLayout();
   }
 
@@ -894,7 +962,9 @@ class RenderParagraph extends RenderBox
   List<PlaceholderDimensions>? _placeholderDimensions;
 
   double _adjustMaxWidth(double maxWidth) {
-    return softWrap || overflow == TextOverflow.ellipsis ? maxWidth : double.infinity;
+    return softWrap || _overflow == TextOverflow.ellipsis || _truncatesText
+        ? maxWidth
+        : double.infinity;
   }
 
   void _layoutTextWithConstraints(BoxConstraints constraints) {
@@ -908,6 +978,9 @@ class RenderParagraph extends RenderBox
   Size computeDryLayout(covariant BoxConstraints constraints) {
     final Size size =
         (_textIntrinsics
+              // Apply the same truncation performLayout would, so that the dry
+              // size matches the size the text is actually laid out at.
+              ..text = _spanForMaxWidth(constraints.maxWidth)
               ..setPlaceholderDimensions(
                 layoutInlineChildren(
                   constraints.maxWidth,
@@ -940,7 +1013,13 @@ class RenderParagraph extends RenderBox
   @override
   double computeDryBaseline(covariant BoxConstraints constraints, TextBaseline baseline) {
     assert(constraints.debugAssertIsValid());
-    _textIntrinsics
+    // Held in a local: reading _textIntrinsics again would reset its text to
+    // the untruncated span and discard the layout computed just below.
+    final TextPainter textIntrinsics = _textIntrinsics;
+    textIntrinsics
+      // Apply the same truncation performLayout would, so that the dry
+      // baseline matches the baseline the text is actually laid out at.
+      ..text = _spanForMaxWidth(constraints.maxWidth)
       ..setPlaceholderDimensions(
         layoutInlineChildren(
           constraints.maxWidth,
@@ -949,8 +1028,180 @@ class RenderParagraph extends RenderBox
         ),
       )
       ..layout(minWidth: constraints.minWidth, maxWidth: _adjustMaxWidth(constraints.maxWidth));
-    return _textIntrinsics.computeDistanceToActualBaseline(TextBaseline.alphabetic);
+    return textIntrinsics.computeDistanceToActualBaseline(TextBaseline.alphabetic);
   }
+
+  // The span to lay out for an incoming maximum width: the truncated text when
+  // [overflow] places the ellipsis inside the text, and [text] otherwise.
+  InlineSpan _spanForMaxWidth(double maxWidth) {
+    return _truncatesText ? _truncatedSpan(maxWidth) ?? _text : _text;
+  }
+
+  // A single-line painter used to measure truncation candidates. Reused across
+  // measurements so that a binary search does not allocate a painter per probe.
+  TextPainter? _truncationPainter;
+
+  // Single entry memo for [_truncatedSpan], keyed by the maximum width it was
+  // computed for. A null width means there is no memoized value; the memoized
+  // span is itself nullable, so the width is what marks the entry as valid.
+  //
+  // Invalidated by [markNeedsLayout], which every property setter that affects
+  // the truncation calls.
+  double? _cachedTruncationWidth;
+  InlineSpan? _cachedTruncatedSpan;
+
+  // The plain text the text painter was last laid out with. See
+  // [_updateRenderedSpan].
+  String? _renderedPlainText;
+
+  // The text to render so that it fits within [maxWidth] with an ellipsis at
+  // the position [overflow] asks for, or null if the text should be rendered
+  // in full.
+  //
+  // Null is returned when the text already fits, when it is empty, and when it
+  // cannot be split because it contains spans other than [TextSpan]s, such as
+  // the [PlaceholderSpan] of a [WidgetSpan]. In the last case the text falls
+  // back to being clipped.
+  InlineSpan? _truncatedSpan(double maxWidth) {
+    assert(_truncatesText);
+    if (_cachedTruncationWidth == maxWidth) {
+      return _cachedTruncatedSpan;
+    }
+    _cachedTruncationWidth = maxWidth;
+    return _cachedTruncatedSpan = _computeTruncatedSpan(maxWidth);
+  }
+
+  InlineSpan? _computeTruncatedSpan(double maxWidth) {
+    if (!_SpanSlicer.canSlice(_text)) {
+      return null;
+    }
+    final String plainText = _text.toPlainText(includeSemanticsLabels: false);
+    if (plainText.isEmpty || _measureWidth(_text) <= maxWidth) {
+      return null;
+    }
+
+    // The code unit offsets the text may be split at. Splitting on grapheme
+    // cluster boundaries keeps surrogate pairs, combining marks and emoji
+    // sequences intact. boundaries.first is 0 and boundaries.last is the
+    // length of the text.
+    final boundaries = <int>[0];
+    var offset = 0;
+    for (final String cluster in plainText.characters) {
+      offset += cluster.length;
+      boundaries.add(offset);
+    }
+    final int clusterCount = boundaries.length - 1;
+
+    // Find the largest number of grapheme clusters that fits alongside the
+    // ellipsis. The width of a candidate grows monotonically with the number
+    // of clusters it keeps, so this is a binary search; `low` is always a
+    // number of clusters that fits and `high` one that may not.
+    var low = 0;
+    int high = clusterCount - 1;
+    while (low < high) {
+      final int mid = low + (high - low + 1) ~/ 2;
+      if (_measureWidth(_buildTruncatedSpan(boundaries, mid)) <= maxWidth) {
+        low = mid;
+      } else {
+        high = mid - 1;
+      }
+    }
+
+    // Kerning and ligatures across the ellipsis can make the width of a
+    // candidate very slightly non-monotonic, so shrink until the result really
+    // does fit. The loop almost always exits without iterating; keeping only
+    // the ellipsis is the last resort, even if the ellipsis alone overflows.
+    var keptClusters = low;
+    InlineSpan truncated = _buildTruncatedSpan(boundaries, keptClusters);
+    while (keptClusters > 0 && _measureWidth(truncated) > maxWidth) {
+      truncated = _buildTruncatedSpan(boundaries, --keptClusters);
+    }
+    return truncated;
+  }
+
+  // Builds the span that keeps [keptClusters] grapheme clusters of [text],
+  // taken from the end for [TextOverflow.ellipsisStart] and split evenly
+  // between both ends for [TextOverflow.ellipsisMiddle].
+  //
+  // [boundaries] are the code unit offsets of the grapheme cluster boundaries,
+  // as computed by [_computeTruncatedSpan].
+  InlineSpan _buildTruncatedSpan(List<int> boundaries, int keptClusters) {
+    final int clusterCount = boundaries.length - 1;
+    assert(keptClusters >= 0 && keptClusters <= clusterCount);
+    final int leadingClusters;
+    final int trailingClusters;
+    switch (_overflow) {
+      case TextOverflow.ellipsisStart:
+        leadingClusters = 0;
+        trailingClusters = keptClusters;
+      case TextOverflow.ellipsisMiddle:
+        // The leading half gets the odd cluster: the beginning of the text is
+        // read first, so it is the more useful half to round up.
+        leadingClusters = (keptClusters + 1) ~/ 2;
+        trailingClusters = keptClusters ~/ 2;
+      case TextOverflow.clip || TextOverflow.ellipsis || TextOverflow.fade || TextOverflow.visible:
+        throw StateError('$_overflow does not place an ellipsis inside the text.');
+    }
+
+    final children = <InlineSpan>[];
+    if (leadingClusters > 0) {
+      children.add(_SpanSlicer(0, boundaries[leadingClusters]).slice(_text)!);
+    }
+    children.add(TextSpan(text: _kEllipsis, style: _text.style));
+    if (trailingClusters > 0) {
+      children.add(
+        _SpanSlicer(boundaries[clusterCount - trailingClusters], boundaries.last).slice(_text)!,
+      );
+    }
+    return TextSpan(children: children);
+  }
+
+  // The width [span] occupies when laid out on a single unconstrained line,
+  // using this paragraph's text style configuration.
+  double _measureWidth(InlineSpan span) {
+    final TextPainter painter = _truncationPainter ??= TextPainter();
+    return (painter
+          ..text = span
+          ..textAlign = _textPainter.textAlign
+          ..textDirection = _textPainter.textDirection
+          ..textScaler = _textPainter.textScaler
+          ..maxLines = 1
+          ..locale = _textPainter.locale
+          ..strutStyle = _textPainter.strutStyle
+          ..textWidthBasis = _textPainter.textWidthBasis
+          ..textHeightBehavior = _textPainter.textHeightBehavior
+          ..layout())
+        .width;
+  }
+
+  // Lays the text painter out over [span], and rebuilds the state that indexes
+  // into the laid out text if the text changed.
+  //
+  // The selectable fragments and the semantics tree address the text the text
+  // painter holds, which for [TextOverflow.ellipsisStart] and
+  // [TextOverflow.ellipsisMiddle] is the truncated text rather than [text].
+  void _updateRenderedSpan(InlineSpan span) {
+    _textPainter.text = span;
+    final String plainText = span.toPlainText(includeSemanticsLabels: false);
+    if (plainText == _renderedPlainText) {
+      return;
+    }
+    _renderedPlainText = plainText;
+    _cachedAttributedLabels = null;
+    _cachedCombinedSemanticsInfos = null;
+    markNeedsSemanticsUpdate();
+    _removeSelectionRegistrarSubscription();
+    _disposeSelectableFragments();
+    _updateSelectionRegistrarSubscription();
+  }
+
+  /// The plain text that is currently laid out, which is a truncated version of
+  /// [text] when [overflow] is [TextOverflow.ellipsisStart] or
+  /// [TextOverflow.ellipsisMiddle] and the text does not fit.
+  ///
+  /// Used to test this object. Not for use in production.
+  @visibleForTesting
+  String get debugRenderedText => _textPainter.text!.toPlainText();
 
   @override
   void performLayout() {
@@ -963,6 +1214,10 @@ class RenderParagraph extends RenderBox
       ChildLayoutHelper.layoutChild,
       ChildLayoutHelper.getBaseline,
     );
+
+    if (_truncatesText) {
+      _updateRenderedSpan(_spanForMaxWidth(constraints.maxWidth));
+    }
     _layoutTextWithConstraints(constraints);
     positionInlineChildren(_textPainter.inlinePlaceholderBoxes!);
 
@@ -984,6 +1239,11 @@ class RenderParagraph extends RenderBox
           _overflowShader = null;
         case TextOverflow.clip:
         case TextOverflow.ellipsis:
+        // The truncated text fits the constraints horizontally, but text that
+        // could not be truncated (a paragraph containing a WidgetSpan) and
+        // vertical overflow are still clipped.
+        case TextOverflow.ellipsisStart:
+        case TextOverflow.ellipsisMiddle:
           _needsClipping = true;
           _overflowShader = null;
         case TextOverflow.fade:
@@ -1217,7 +1477,10 @@ class RenderParagraph extends RenderBox
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
-    _semanticsInfo = text.getSemanticsInformation();
+    // Semantics rectangles are resolved against the text that is laid out, so
+    // the semantics information has to describe that text and not `text`. See
+    // TextOverflow.ellipsisStart for what this means for truncated paragraphs.
+    _semanticsInfo = _textPainter.text!.getSemanticsInformation();
     var needsAssembleSemanticsNode = false;
     var needsChildConfigurationsDelegate = false;
     for (final InlineSpanSemanticsInformation info in _semanticsInfo!) {
@@ -1499,6 +1762,87 @@ class RenderParagraph extends RenderBox
     properties.add(DiagnosticsProperty<Locale>('locale', locale, defaultValue: null));
     properties.add(IntProperty('maxLines', maxLines, ifNull: 'unlimited'));
     properties.add(DoubleProperty('devicePixelRatio', devicePixelRatio, defaultValue: 1.0));
+  }
+}
+
+/// Rebuilds an [InlineSpan] tree so that it only contains the text within a
+/// code unit range, preserving the style and the other properties of every span
+/// the range intersects.
+///
+/// Only trees made up entirely of [TextSpan]s can be sliced; see [canSlice].
+class _SpanSlicer {
+  _SpanSlicer(this.start, this.end) : assert(start <= end);
+
+  /// The code unit offset the slice starts at, inclusive.
+  final int start;
+
+  /// The code unit offset the slice ends at, exclusive.
+  final int end;
+
+  /// The code unit offset within the paragraph of the span being visited.
+  int _offset = 0;
+
+  /// Whether [span] is made up entirely of [TextSpan]s, and so can be split at
+  /// an arbitrary code unit offset.
+  ///
+  /// A [PlaceholderSpan] stands for a single code unit that renders an inline
+  /// widget, and other [InlineSpan] subclasses cannot be copied, so neither can
+  /// be split.
+  static bool canSlice(InlineSpan span) {
+    if (span is! TextSpan) {
+      return false;
+    }
+    var result = true;
+    span.visitDirectChildren((InlineSpan child) => result = canSlice(child));
+    return result;
+  }
+
+  /// Returns the part of [span] within the `[start, end)` code unit range, or
+  /// null if the range covers none of its text.
+  ///
+  /// Must be called at most once per [_SpanSlicer], as it consumes the offset
+  /// the traversal tracks.
+  InlineSpan? slice(InlineSpan span) {
+    final textSpan = span as TextSpan;
+    String? slicedText;
+    final String? text = textSpan.text;
+    if (text != null) {
+      final int spanStart = _offset;
+      _offset += text.length;
+      final int from = math.max(start, spanStart);
+      final int to = math.min(end, _offset);
+      if (from < to) {
+        slicedText = text.substring(from - spanStart, to - spanStart);
+      }
+    }
+    List<InlineSpan>? slicedChildren;
+    final List<InlineSpan>? children = textSpan.children;
+    if (children != null) {
+      for (final InlineSpan child in children) {
+        final InlineSpan? slicedChild = slice(child);
+        if (slicedChild != null) {
+          (slicedChildren ??= <InlineSpan>[]).add(slicedChild);
+        }
+      }
+    }
+    if (slicedText == null && slicedChildren == null) {
+      return null;
+    }
+    return TextSpan(
+      text: slicedText,
+      children: slicedChildren,
+      style: textSpan.style,
+      recognizer: textSpan.recognizer,
+      mouseCursor: textSpan.mouseCursor,
+      onEnter: textSpan.onEnter,
+      onExit: textSpan.onExit,
+      // TextSpan asserts that a span with a semantics label has text; a span
+      // whose own text falls entirely outside the range keeps only children.
+      semanticsLabel: slicedText == null ? null : textSpan.semanticsLabel,
+      semanticsIdentifier: textSpan.semanticsIdentifier,
+      locale: textSpan.locale,
+      spellOut: textSpan.spellOut,
+    );
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6609,6 +6609,9 @@ class RichText extends MultiChildRenderObjectWidget {
   ///
   /// If this is 1, text will not wrap. Otherwise, text will be wrapped at the
   /// edge of the box.
+  ///
+  /// Must be null or 1 when [overflow] is [TextOverflow.ellipsisStart] or
+  /// [TextOverflow.ellipsisMiddle], which render on a single line.
   final int? maxLines;
 
   /// Used to select a font when the same Unicode character can

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -164,6 +164,10 @@ class DefaultTextStyle extends InheritedTheme {
   /// If this is 1, text will not wrap. Otherwise, text will be wrapped at the
   /// edge of the box.
   ///
+  /// Must be null or 1 when [DefaultTextStyle.overflow] is
+  /// [TextOverflow.ellipsisStart] or [TextOverflow.ellipsisMiddle], which
+  /// render on a single line.
+  ///
   /// If this is non-null, it will override even explicit null values of
   /// [Text.maxLines].
   final int? maxLines;
@@ -665,6 +669,9 @@ class Text extends StatelessWidget {
   ///
   /// If this is 1, text will not wrap. Otherwise, text will be wrapped at the
   /// edge of the box.
+  ///
+  /// Must be null or 1 when [overflow] is [TextOverflow.ellipsisStart] or
+  /// [TextOverflow.ellipsisMiddle], which render on a single line.
   ///
   /// If this is null, but there is an ambient [DefaultTextStyle] that specifies
   /// an explicit number for its [DefaultTextStyle.maxLines], then the

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1889,6 +1889,159 @@ void main() {
           expect(hitSpan.recognizer, same(recognizer));
         });
 
+        test('the ellipsis takes the style of the first cluster it replaces', () {
+          // The root carries no colour, so an ellipsis styled after the root
+          // would render in the default colour instead of matching the text it
+          // stands in for.
+          const red = TextStyle(fontSize: 10.0, color: Color(0xFFFF0000));
+          const green = TextStyle(fontSize: 10.0, color: Color(0xFF00FF00));
+          final RenderParagraph paragraph = makeParagraph(
+            overflow,
+            span: const TextSpan(
+              children: <InlineSpan>[
+                TextSpan(text: 'AAAAAAAAAA', style: red),
+                TextSpan(text: 'BBBBBBBBBB', style: green),
+              ],
+            ),
+          );
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+
+          final String rendered = paragraph.debugRenderedText;
+          final int ellipsisIndex = rendered.indexOf('…');
+          final Offset caret = paragraph.getOffsetForCaret(
+            TextPosition(offset: ellipsisIndex),
+            Rect.zero,
+          );
+          final result = BoxHitTestResult();
+          paragraph.hitTest(result, position: Offset(caret.dx + 1.0, 5.0));
+          final TextSpan hit = result.path
+              .map((HitTestEntry entry) => entry.target)
+              .whereType<TextSpan>()
+              .single;
+          // ellipsisStart elides from the start, so the first elided cluster is
+          // always red; ellipsisMiddle elides from the middle of this text,
+          // which also falls in the red run at this width.
+          expect(hit.style?.color, const Color(0xFFFF0000));
+        });
+
+        test('the ellipsis does not inherit the recognizer of the elided text', () {
+          final recognizer = TapGestureRecognizer();
+          addTearDown(recognizer.dispose);
+          final RenderParagraph paragraph = makeParagraph(
+            overflow,
+            span: TextSpan(
+              style: kStyle,
+              children: <InlineSpan>[
+                TextSpan(text: 'AAAAAAAAAA', recognizer: recognizer),
+                const TextSpan(text: 'BBBBBBBBBB'),
+              ],
+            ),
+          );
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+
+          final String rendered = paragraph.debugRenderedText;
+          final Offset caret = paragraph.getOffsetForCaret(
+            TextPosition(offset: rendered.indexOf('…')),
+            Rect.zero,
+          );
+          final result = BoxHitTestResult();
+          paragraph.hitTest(result, position: Offset(caret.dx + 1.0, 5.0));
+          final Iterable<TextSpan> hits = result.path
+              .map((HitTestEntry entry) => entry.target)
+              .whereType<TextSpan>();
+          // The glyph stands in for hidden text, so tapping it must do nothing.
+          expect(hits.every((TextSpan span) => span.recognizer == null), isTrue);
+        });
+
+        test('keeps as much text as fits when the elided text changes size', () {
+          // A large run followed by a small one: as more of the text is kept,
+          // the cluster the ellipsis is styled after crosses from the large run
+          // into the small one and the ellipsis narrows, so candidate widths do
+          // not grow monotonically with the number of clusters kept.
+          const span = TextSpan(
+            children: <InlineSpan>[
+              TextSpan(text: 'AAAAA', style: TextStyle(fontSize: 40.0)),
+              TextSpan(text: 'BBBBBBBBBB', style: TextStyle(fontSize: 10.0)),
+            ],
+          );
+          var previousKept = 0;
+          for (var width = 20.0; width <= 300.0; width += 10.0) {
+            final RenderParagraph paragraph = makeParagraph(overflow, span: span);
+            layout(paragraph, constraints: BoxConstraints(maxWidth: width));
+            final String rendered = paragraph.debugRenderedText;
+
+            // The caret past the last character sits at the right edge of the
+            // text, which is the width it actually occupies.
+            final double renderedRight = paragraph
+                .getOffsetForCaret(TextPosition(offset: rendered.length), Rect.zero)
+                .dx;
+            expect(
+              renderedRight,
+              lessThanOrEqualTo(width),
+              reason: 'overflowed at maxWidth $width with "$rendered"',
+            );
+
+            // Widening the box never renders less of the text, which is what a
+            // candidate skipped by the binary search would look like.
+            final int kept = rendered.replaceAll('…', '').length;
+            expect(
+              kept,
+              greaterThanOrEqualTo(previousKept),
+              reason:
+                  'kept $kept clusters at maxWidth $width after $previousKept in a narrower box',
+            );
+            previousKept = kept;
+          }
+        });
+
+        test('mixed bidirectional text is elided in logical order and fits', () {
+          // One LTR character, five RTL characters, then six LTR characters.
+          const bidi = 'AاااااAAAAAA';
+          for (final width in <double>[40.0, 60.0, 80.0, 100.0]) {
+            final RenderParagraph paragraph = makeParagraph(
+              overflow,
+              span: const TextSpan(text: bidi, style: kStyle),
+            );
+            layout(paragraph, constraints: BoxConstraints(maxWidth: width));
+            final String rendered = paragraph.debugRenderedText;
+            expect(
+              renderedWidth(paragraph),
+              lessThanOrEqualTo(width),
+              reason: 'overflowed at maxWidth $width with "$rendered"',
+            );
+            // What is kept is a logical prefix and/or a logical suffix of the
+            // original text, whichever the mode asks for; the text direction
+            // only decides where the engine paints them.
+            final List<String> parts = rendered.split('…');
+            expect(parts.length, 2);
+            expect(bidi, startsWith(parts.first));
+            expect(bidi, endsWith(parts.last));
+          }
+        });
+
+        test('falls back to clipping when the text contains a TextSpan subclass', () {
+          // Truncating rebuilds the tree out of plain TextSpans, which would
+          // drop what the subclass carries, so such a tree is left alone.
+          final RenderParagraph paragraph = makeParagraph(
+            overflow,
+            span: const TextSpan(
+              style: kStyle,
+              children: <InlineSpan>[_PayloadSpan(text: kText26, payload: 'kept')],
+            ),
+          );
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+          expect(paragraph.debugRenderedText, kText26);
+          expect(paragraph.debugRenderedText, isNot(contains('…')));
+
+          final result = BoxHitTestResult();
+          paragraph.hitTest(result, position: const Offset(5.0, 5.0));
+          final TextSpan hit = result.path
+              .map((HitTestEntry entry) => entry.target)
+              .whereType<TextSpan>()
+              .first;
+          expect(hit, isA<_PayloadSpan>());
+        });
+
         test('falls back to clipping when the text contains a WidgetSpan', () {
           final child = RenderConstrainedBox(
             additionalConstraints: const BoxConstraints.tightFor(width: 20.0, height: 20.0),
@@ -2113,6 +2266,13 @@ class MockPaintingContext extends Fake implements PaintingContext {
     operations.add('pushLayer');
     pushedLayers.add(childLayer);
   }
+}
+
+// A TextSpan subclass carrying state that rebuilding the tree would discard.
+class _PayloadSpan extends TextSpan {
+  const _PayloadSpan({super.text, required this.payload});
+
+  final String payload;
 }
 
 class TestSelectionRegistrar extends SelectionRegistrar {

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1989,6 +1989,24 @@ void main() {
           expect(paragraph.debugRenderedText, contains('…'));
         });
 
+        test('selection covers the full text again after switching to clip', () async {
+          final registrar = TestSelectionRegistrar();
+          final RenderParagraph paragraph = makeParagraph(overflow, registrar: registrar);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+          expect(paragraph.debugRenderedText, contains('…'));
+
+          // Leaving a truncating mode puts the full text back in the text
+          // painter, so the fragments built over the truncated text have to be
+          // rebuilt or selecting everything yields the truncated string,
+          // ellipsis and all.
+          paragraph.overflow = TextOverflow.clip;
+          pumpFrame();
+
+          final Selectable selectable = registrar.selectables.single;
+          selectable.dispatchSelectionEvent(const SelectAllSelectionEvent());
+          expect(selectable.getSelectedContent()!.plainText, kText26);
+        });
+
         test('selection covers the text that is rendered', () async {
           final registrar = TestSelectionRegistrar();
           final RenderParagraph paragraph = makeParagraph(overflow, registrar: registrar);

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle, ClipOp, Paragraph, TextBox;
 
 import 'package:flutter/foundation.dart';
@@ -1660,6 +1661,363 @@ void main() {
       // We expect the function to not throw an exception
       // ignore: invalid_use_of_protected_member
       expect(() => paragraph.positionInlineChildren(boxes), returnsNormally);
+    });
+  });
+
+  group('TextOverflow.ellipsisStart and TextOverflow.ellipsisMiddle', () {
+    // Every glyph of the test font is one font size wide, so `_kText26` is
+    // 260px wide at a font size of 10 and the ellipsis is 10px wide.
+    const kText26 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const kStyle = TextStyle(fontSize: 10.0);
+    const kInlineEllipsisModes = <TextOverflow>[
+      TextOverflow.ellipsisStart,
+      TextOverflow.ellipsisMiddle,
+    ];
+
+    RenderParagraph makeParagraph(
+      TextOverflow overflow, {
+      InlineSpan span = const TextSpan(text: kText26, style: kStyle),
+      TextDirection textDirection = TextDirection.ltr,
+      int? maxLines,
+      bool softWrap = true,
+      SelectionRegistrar? registrar,
+      List<RenderBox>? children,
+    }) {
+      return RenderParagraph(
+        span,
+        textDirection: textDirection,
+        overflow: overflow,
+        softWrap: softWrap,
+        maxLines: maxLines,
+        registrar: registrar,
+        children: children,
+      );
+    }
+
+    // Lays `paragraph` out at `maxWidth` and returns the width the text it
+    // renders actually occupies, measured independently of the paragraph.
+    double renderedWidth(RenderParagraph paragraph) {
+      final painter = TextPainter(
+        text: TextSpan(text: paragraph.debugRenderedText, style: kStyle),
+        textDirection: paragraph.textDirection,
+        maxLines: 1,
+      )..layout();
+      final double width = painter.width;
+      painter.dispose();
+      return width;
+    }
+
+    for (final overflow in kInlineEllipsisModes) {
+      group('$overflow', () {
+        test('asserts when the constructor is given a maxLines above 1', () {
+          expect(() => makeParagraph(overflow, maxLines: 2), throwsAssertionError);
+          expect(() => makeParagraph(overflow, maxLines: 10), throwsAssertionError);
+          // null and 1 both mean a single line, and are allowed.
+          expect(() => makeParagraph(overflow), returnsNormally);
+          expect(() => makeParagraph(overflow, maxLines: 1), returnsNormally);
+        });
+
+        test('asserts when maxLines is set above 1', () {
+          final RenderParagraph paragraph = makeParagraph(overflow);
+          expect(() => paragraph.maxLines = 2, throwsAssertionError);
+          expect(() => paragraph.maxLines = 1, returnsNormally);
+          expect(() => paragraph.maxLines = null, returnsNormally);
+        });
+
+        test('asserts when overflow is set while maxLines is above 1', () {
+          final RenderParagraph paragraph = makeParagraph(TextOverflow.clip, maxLines: 2);
+          expect(() => paragraph.overflow = overflow, throwsAssertionError);
+          paragraph.maxLines = 1;
+          expect(() => paragraph.overflow = overflow, returnsNormally);
+        });
+
+        test('renders on a single line even though softWrap is true', () {
+          final RenderParagraph paragraph = makeParagraph(overflow);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+          expect(paragraph.softWrap, isTrue);
+          expect(paragraph.size, const Size(80.0, 10.0));
+        });
+
+        test('never renders text wider than the constraint', () {
+          // Widths that do not line up with a character boundary included: the
+          // truncated text must still fit, or its last glyph is clipped.
+          const widths = <double>[0.0, 3.0, 15.0, 21.0, 47.0, 85.0, 111.0, 259.0];
+          for (final width in widths) {
+            final RenderParagraph paragraph = makeParagraph(overflow);
+            layout(paragraph, constraints: BoxConstraints(maxWidth: width));
+            expect(
+              renderedWidth(paragraph),
+              lessThanOrEqualTo(math.max(width, 10.0)),
+              reason: 'overflowed at maxWidth $width with "${paragraph.debugRenderedText}"',
+            );
+          }
+        });
+
+        test('renders the full text when it fits', () {
+          final RenderParagraph paragraph = makeParagraph(overflow);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 500.0));
+          expect(paragraph.debugRenderedText, kText26);
+        });
+
+        test('renders nothing but the ellipsis when nothing else fits', () {
+          final RenderParagraph paragraph = makeParagraph(overflow);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 5.0));
+          expect(paragraph.debugRenderedText, '…');
+        });
+
+        test('leaves empty text alone', () {
+          final RenderParagraph paragraph = makeParagraph(
+            overflow,
+            span: const TextSpan(text: '', style: kStyle),
+          );
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 5.0));
+          expect(paragraph.debugRenderedText, isEmpty);
+        });
+
+        test('text returns the untruncated span', () {
+          final RenderParagraph paragraph = makeParagraph(overflow);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+          expect(paragraph.debugRenderedText, isNot(kText26));
+          expect(paragraph.text.toPlainText(), kText26);
+        });
+
+        test('setting the same span again is a no-op after a truncating layout', () {
+          final RenderParagraph paragraph = makeParagraph(overflow);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+          // An equal span compares as identical, so this must not relayout
+          // even though the painter now holds the truncated text.
+          paragraph.text = const TextSpan(text: kText26, style: kStyle);
+          expect(paragraph.debugNeedsLayout, isFalse);
+          expect(paragraph.text.toPlainText(), kText26);
+        });
+
+        test('splits on grapheme cluster boundaries', () {
+          // A ZWJ emoji sequence and a combining mark, either side of the text
+          // the truncation lands in.
+          const text = 'éaaaaaaaa\u{1F469}\u{200D}\u{1F469}\u{200D}\u{1F467}aaaaaaaa';
+          for (var width = 10.0; width <= 200.0; width += 5.0) {
+            final RenderParagraph paragraph = makeParagraph(
+              overflow,
+              span: const TextSpan(text: text, style: kStyle),
+            );
+            layout(paragraph, constraints: BoxConstraints(maxWidth: width));
+            final String rendered = paragraph.debugRenderedText;
+            final reason =
+                'split a grapheme cluster at maxWidth $width: '
+                '${rendered.codeUnits}';
+            // Surrogates always come in pairs.
+            for (var i = 0; i < rendered.length; i += 1) {
+              final int unit = rendered.codeUnitAt(i);
+              if (unit >= 0xD800 && unit <= 0xDBFF) {
+                expect(i + 1 < rendered.length, isTrue, reason: reason);
+                expect(
+                  rendered.codeUnitAt(i + 1),
+                  inInclusiveRange(0xDC00, 0xDFFF),
+                  reason: reason,
+                );
+              } else if (unit >= 0xDC00 && unit <= 0xDFFF) {
+                expect(i > 0, isTrue, reason: reason);
+                expect(
+                  rendered.codeUnitAt(i - 1),
+                  inInclusiveRange(0xD800, 0xDBFF),
+                  reason: reason,
+                );
+              }
+            }
+            // The text on either side of an ellipsis was cut at a cluster
+            // boundary, so it never starts with a continuation of a cluster
+            // (a combining mark or a zero width joiner) or ends with a joiner.
+            for (int i = rendered.indexOf('…'); i != -1; i = rendered.indexOf('…', i + 1)) {
+              if (i + 1 < rendered.length) {
+                final int next = rendered.codeUnitAt(i + 1);
+                expect(next, isNot(0x200D), reason: reason);
+                expect(next < 0x0300 || next > 0x036F, isTrue, reason: reason);
+              }
+              if (i > 0) {
+                expect(rendered.codeUnitAt(i - 1), isNot(0x200D), reason: reason);
+              }
+            }
+          }
+        });
+
+        test('right to left text fits the constraint', () {
+          const rtlText = 'السلام عليكم';
+          for (final width in <double>[30.0, 60.0, 90.0]) {
+            final RenderParagraph paragraph = makeParagraph(
+              overflow,
+              span: const TextSpan(text: rtlText, style: kStyle),
+              textDirection: TextDirection.rtl,
+            );
+            layout(paragraph, constraints: BoxConstraints(maxWidth: width));
+            expect(
+              renderedWidth(paragraph),
+              lessThanOrEqualTo(width),
+              reason: 'overflowed at maxWidth $width with "${paragraph.debugRenderedText}"',
+            );
+          }
+        });
+
+        test('preserves the styles and recognizers of the spans it keeps', () {
+          final recognizer = TapGestureRecognizer();
+          addTearDown(recognizer.dispose);
+          const boldStyle = TextStyle(fontSize: 10.0, fontWeight: FontWeight.bold);
+          final RenderParagraph paragraph = makeParagraph(
+            overflow,
+            span: TextSpan(
+              style: kStyle,
+              children: <InlineSpan>[
+                const TextSpan(text: 'AAAAAAAAAAAAAAAA'),
+                TextSpan(text: 'BBBBBBBB', style: boldStyle, recognizer: recognizer),
+              ],
+            ),
+          );
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+
+          // The tail of the text is kept in both modes, so the styled and
+          // tappable span is partly visible; hit test its last glyph.
+          final result = BoxHitTestResult();
+          final Offset endOfText = paragraph.getOffsetForCaret(
+            TextPosition(offset: paragraph.debugRenderedText.length),
+            Rect.zero,
+          );
+          paragraph.hitTest(result, position: Offset(endOfText.dx - 1.0, 5.0));
+          final TextSpan hitSpan = result.path
+              .map((HitTestEntry entry) => entry.target)
+              .whereType<TextSpan>()
+              .single;
+          expect(hitSpan.style, boldStyle);
+          expect(hitSpan.recognizer, same(recognizer));
+        });
+
+        test('falls back to clipping when the text contains a WidgetSpan', () {
+          final child = RenderConstrainedBox(
+            additionalConstraints: const BoxConstraints.tightFor(width: 20.0, height: 20.0),
+          );
+          const span = TextSpan(
+            style: kStyle,
+            children: <InlineSpan>[
+              TextSpan(text: 'AAAAAAAA'),
+              WidgetSpan(child: SizedBox.shrink()),
+              TextSpan(text: 'BBBBBBBB'),
+            ],
+          );
+          final RenderParagraph paragraph = makeParagraph(
+            overflow,
+            span: span,
+            children: <RenderBox>[child],
+          );
+          _applyParentData(<RenderBox>[child], span);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 50.0));
+          expect(paragraph.debugRenderedText, isNot(contains('…')));
+          expect(paragraph.debugRenderedText, span.toPlainText());
+        });
+
+        test('the dry layout matches the real layout', () {
+          for (final width in <double>[15.0, 47.0, 85.0, 500.0]) {
+            final RenderParagraph paragraph = makeParagraph(overflow);
+            final constraints = BoxConstraints(maxWidth: width);
+            final Size dry = paragraph.getDryLayout(constraints);
+            layout(paragraph, constraints: constraints);
+            expect(dry, paragraph.size, reason: 'dry layout differed at maxWidth $width');
+          }
+        });
+
+        test('retruncates when the constraint changes', () {
+          final RenderParagraph paragraph = makeParagraph(overflow);
+          final constrainedBox = RenderConstrainedBox(
+            additionalConstraints: const BoxConstraints(maxWidth: 80.0),
+            child: paragraph,
+          );
+          // Wrapped the way layout() wraps a box it is given constraints for,
+          // so that the constraints can be changed between frames.
+          layout(RenderPositionedBox(child: constrainedBox));
+          final String atEighty = paragraph.debugRenderedText;
+          expect(atEighty.length, 8);
+
+          constrainedBox.additionalConstraints = const BoxConstraints(maxWidth: 150.0);
+          pumpFrame();
+          expect(paragraph.debugRenderedText.length, 15);
+          expect(renderedWidth(paragraph), lessThanOrEqualTo(150.0));
+
+          constrainedBox.additionalConstraints = const BoxConstraints(maxWidth: 80.0);
+          pumpFrame();
+          expect(paragraph.debugRenderedText, atEighty);
+        });
+
+        test('retruncates when the text changes', () {
+          final RenderParagraph paragraph = makeParagraph(overflow);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+          expect(paragraph.debugRenderedText, contains('…'));
+
+          paragraph.text = const TextSpan(text: 'AB', style: kStyle);
+          pumpFrame();
+          expect(paragraph.text.toPlainText(), 'AB');
+          expect(paragraph.debugRenderedText, 'AB');
+        });
+
+        test('retruncates when only the style of the text changes', () {
+          final RenderParagraph paragraph = makeParagraph(overflow);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+          final String before = paragraph.debugRenderedText;
+          expect(before, contains('…'));
+
+          // A colour change only affects painting for an untruncated
+          // paragraph, but the truncated text is built from the span, so it
+          // has to be rebuilt by a layout pass rather than painted directly.
+          paragraph.text = const TextSpan(
+            text: kText26,
+            style: TextStyle(fontSize: 10.0, color: Color(0xFFFF0000)),
+          );
+          expect(paragraph.debugNeedsLayout, isTrue);
+          pumpFrame();
+          expect(paragraph.debugRenderedText, before);
+          expect(paragraph.text.style!.color, const Color(0xFFFF0000));
+        });
+
+        test('lays the full text out again after overflow changes', () {
+          final RenderParagraph paragraph = makeParagraph(overflow);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+          expect(paragraph.debugRenderedText, contains('…'));
+
+          paragraph.overflow = TextOverflow.clip;
+          pumpFrame();
+          expect(paragraph.text.toPlainText(), kText26);
+          expect(paragraph.debugRenderedText, kText26);
+
+          paragraph.overflow = overflow;
+          pumpFrame();
+          expect(paragraph.debugRenderedText, contains('…'));
+        });
+
+        test('selection covers the text that is rendered', () async {
+          final registrar = TestSelectionRegistrar();
+          final RenderParagraph paragraph = makeParagraph(overflow, registrar: registrar);
+          layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+
+          final Selectable selectable = registrar.selectables.single;
+          selectable.dispatchSelectionEvent(const SelectAllSelectionEvent());
+          expect(selectable.value.status, SelectionStatus.uncollapsed);
+          expect(selectable.getSelectedContent()!.plainText, paragraph.debugRenderedText);
+        });
+      });
+    }
+
+    test('ellipsisStart keeps the end of the text', () {
+      final RenderParagraph paragraph = makeParagraph(TextOverflow.ellipsisStart);
+      layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+      expect(paragraph.debugRenderedText, '…TUVWXYZ');
+    });
+
+    test('ellipsisMiddle keeps both ends of the text', () {
+      final RenderParagraph paragraph = makeParagraph(TextOverflow.ellipsisMiddle);
+      layout(paragraph, constraints: const BoxConstraints(maxWidth: 80.0));
+      expect(paragraph.debugRenderedText, 'ABCD…XYZ');
+    });
+
+    test('ellipsisMiddle gives the odd grapheme cluster to the leading half', () {
+      final RenderParagraph paragraph = makeParagraph(TextOverflow.ellipsisMiddle);
+      layout(paragraph, constraints: const BoxConstraints(maxWidth: 70.0));
+      expect(paragraph.debugRenderedText, 'ABC…XYZ');
     });
   });
 }

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -1869,6 +1869,143 @@ void main() {
     );
     expect(tester.getSize(find.byType(Text)), Size.zero);
   });
+
+  group('TextOverflow.ellipsisStart and TextOverflow.ellipsisMiddle', () {
+    const kPath = '/Users/someone/Documents/report.txt';
+    const kStyle = TextStyle(fontSize: 10.0);
+
+    Widget boxed(double width, Widget child) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(width: width, child: child),
+        ),
+      );
+    }
+
+    String rendered(WidgetTester tester) {
+      return tester.renderObject<RenderParagraph>(find.byType(RichText)).debugRenderedText;
+    }
+
+    testWidgets('Text truncates at the position the overflow asks for', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        boxed(100.0, const Text(kPath, style: kStyle, overflow: TextOverflow.ellipsisStart)),
+      );
+      expect(rendered(tester), '…eport.txt');
+
+      await tester.pumpWidget(
+        boxed(100.0, const Text(kPath, style: kStyle, overflow: TextOverflow.ellipsisMiddle)),
+      );
+      expect(rendered(tester), '/User….txt');
+    });
+
+    testWidgets('Text retruncates when its box is resized in place', (WidgetTester tester) async {
+      const text = Text(kPath, style: kStyle, overflow: TextOverflow.ellipsisStart);
+      await tester.pumpWidget(boxed(100.0, text));
+      final Element element = tester.element(find.byType(Text));
+      expect(rendered(tester), '…eport.txt');
+
+      await tester.pumpWidget(boxed(200.0, text));
+      // The same element was updated in place rather than rebuilt from scratch.
+      expect(tester.element(find.byType(Text)), same(element));
+      expect(rendered(tester), '…ocuments/report.txt');
+
+      await tester.pumpWidget(boxed(40.0, text));
+      expect(tester.element(find.byType(Text)), same(element));
+      expect(rendered(tester), '…txt');
+    });
+
+    testWidgets('Text.rich keeps the styles of the spans it truncates into', (
+      WidgetTester tester,
+    ) async {
+      const fileNameStyle = TextStyle(fontSize: 10.0, fontWeight: FontWeight.bold);
+      await tester.pumpWidget(
+        boxed(
+          100.0,
+          const Text.rich(
+            TextSpan(
+              style: kStyle,
+              children: <InlineSpan>[
+                TextSpan(text: '/Users/someone/Documents/'),
+                TextSpan(text: 'report.txt', style: fileNameStyle),
+              ],
+            ),
+            overflow: TextOverflow.ellipsisStart,
+          ),
+        ),
+      );
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.byType(RichText));
+      // The bold file name is wider than the rest of the text, so exactly how
+      // much of it fits is font dependent; what matters is that the tail of
+      // the path is what was kept.
+      expect(paragraph.debugRenderedText, startsWith('…'));
+      expect(kPath, endsWith(paragraph.debugRenderedText.substring(1)));
+      // The bold file name is still bold after the truncation.
+      final result = BoxHitTestResult();
+      final Offset endOfText = paragraph.getOffsetForCaret(
+        TextPosition(offset: paragraph.debugRenderedText.length),
+        Rect.zero,
+      );
+      paragraph.hitTest(result, position: Offset(endOfText.dx - 1.0, 5.0));
+      final TextSpan hit = result.path
+          .map((HitTestEntry entry) => entry.target)
+          .whereType<TextSpan>()
+          .single;
+      expect(hit.style, fileNameStyle);
+    });
+
+    testWidgets('semantics describe the truncated text, and semanticsLabel overrides it', (
+      WidgetTester tester,
+    ) async {
+      final semantics = SemanticsTester(tester);
+      await tester.pumpWidget(
+        boxed(100.0, const Text(kPath, style: kStyle, overflow: TextOverflow.ellipsisStart)),
+      );
+      expect(semantics, includesNodeWith(label: '…eport.txt'));
+
+      await tester.pumpWidget(
+        boxed(
+          100.0,
+          const Text(
+            kPath,
+            style: kStyle,
+            overflow: TextOverflow.ellipsisStart,
+            semanticsLabel: kPath,
+          ),
+        ),
+      );
+      expect(semantics, includesNodeWith(label: kPath));
+      semantics.dispose();
+    });
+
+    testWidgets('Text asserts when maxLines is above 1', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        boxed(
+          100.0,
+          const Text(kPath, style: kStyle, maxLines: 2, overflow: TextOverflow.ellipsisStart),
+        ),
+      );
+      expect(tester.takeException(), isAssertionError);
+    });
+
+    testWidgets('an overflow inherited from DefaultTextStyle truncates too', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        boxed(
+          100.0,
+          const DefaultTextStyle(
+            style: kStyle,
+            overflow: TextOverflow.ellipsisMiddle,
+            child: Text(kPath),
+          ),
+        ),
+      );
+      expect(rendered(tester), '/User….txt');
+    });
+  });
 }
 
 Future<void> _pumpTextWidget({


### PR DESCRIPTION
Adds `TextOverflow.ellipsisStart` and `TextOverflow.ellipsisMiddle`, which place the ellipsis at the beginning or the middle of the text instead of at the end. A file path such as `/Users/someone/Documents/report.txt` renders as
`…ocuments/report.txt` or `/Users/s…eport.txt` rather than `/Users/someone/D…`.

https://github.com/user-attachments/assets/1cc187a9-81a0-4498-bccc-18c0f4e6a5dc

Fixes https://github.com/flutter/flutter/issues/45336

## Design notes for reviewers

**Why an enum value rather than a new widget or constructor.** Both new values are positions of the same ellipsis, so they belong beside `TextOverflow.ellipsis`. Named constructors would not compose with `Text.rich` and would multiply if more positions are added later. This matches Android's `TextUtils.TruncateAt.START` and `MIDDLE`, and iOS's `NSLineBreakMode.byTruncatingHead`/`byTruncatingMiddle`.

**Why the framework computes the truncated text.** The engine only supports a trailing ellipsis, so `RenderParagraph` computes the truncated text itself and lays that out. Consequences worth reviewing:

* The truncation point is found by a binary search over grapheme cluster boundaries, measuring each candidate with a reusable single-line `TextPainter`, memoised per maximum width so `performLayout` and the dry layout share one search. This is roughly `log2(n)` short single-line layouts, only when the text does not fit. Measuring candidates rather than mapping an x offset back to a character index is what makes right-to-left and bidirectional text correct; an offset-based version overflowed its constraint by 3x on Arabic text.
* The span tree is rebuilt over the ranges that are kept, so styles, gesture recognizers, mouse cursors and semantics labels of surviving spans are preserved. A paragraph containing a `WidgetSpan` cannot be split and falls
  back to being clipped.
* Selection and semantics describe the truncated text, because that is what is laid out. This differs from `TextOverflow.ellipsis`, where the painter holds the full string and the engine adds the ellipsis while painting. Documented on both enum values, with `Text.semanticsLabel` as the way to announce the full string. `RenderParagraph.text` still returns the full, untruncated span.

**Why single-line, and why the assert lives on the render object.** Both values render on one line, matching the platform behaviour they mirror, so `RenderParagraph` asserts `maxLines` is null or 1. The assert is not on `Text`
because the effective overflow can come from an ambient `DefaultTextStyle` and is not known at widget construction time.

**One unrelated line.** `dart format` reflows a `typedef` near the top of `paragraph.dart`. That is a pre-existing formatting drift on `main` under the pinned SDK, not something this change introduces; it comes along because this PR
touches the file.

## Breaking change

Adding values to `TextOverflow` breaks exhaustive `switch`es over it in user code. Default behaviour is unchanged: `TextOverflow.clip` remains the default and no existing value changes meaning. There is no mechanical migration to supply as a Data Driven Fix, because no existing API changes meaning — the only breakage is switch exhaustiveness, which the analyzer reports directly.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.