### PR TITLE
[web] Preserve image element pixels for retained pictures

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/primitives/image_source.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/primitives/image_source.dart
@@ -106,8 +106,9 @@ class ImageElementImageSource extends ImageSource {
 
   @override
   void _doClose() {
-    // Clear the src attribute of the image element to release associated memory.
-    imageElement.src = '';
+    // A recorded picture can retain the SkImage after all EngineImage handles
+    // have been disposed. CanvasKit may still need the element for a lazy
+    // texture upload, so leave its pixels intact until the browser collects it.
   }
 
   @override

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/image_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/image_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
@@ -75,14 +77,44 @@ void testMain() {
     expect(imageSource.debugIsClosed, isTrue);
   });
 
-  test('ImageElementImageSource clears src on closure', () async {
+  test('ImageElementImageSource preserves src on closure', () {
     final DomHTMLImageElement imageElement = createDomHTMLImageElement();
     imageElement.src = 'sample_image1.png';
     final ImageSource imageSource = ImageElementImageSource(imageElement);
 
     expect(imageElement.src, contains('sample_image1.png'));
     imageSource.close();
-    expect(imageElement.src, isNot(contains('sample_image1.png')));
+    expect(imageElement.src, contains('sample_image1.png'));
+    expect(imageSource.debugIsClosed, isTrue);
+  });
+
+  test('A picture retains image element pixels after the image is disposed', () async {
+    final DomHTMLImageElement imageElement = createDomHTMLImageElement();
+    imageElement.src = 'data:image/png;base64,${base64.encode(k4x4PngImage)}';
+    await imageElement.decode();
+    final ui.Image image = await renderer.createImageFromTextureSource(
+      imageElement,
+      width: 4,
+      height: 4,
+      transferOwnership: true,
+    );
+    // Read directly from the DOM source without triggering a GPU texture upload.
+    final ByteData expected = (await image.toByteData(format: ui.ImageByteFormat.rawStraightRgba))!;
+    final recorder = ui.PictureRecorder();
+    ui.Canvas(recorder).drawImage(image, ui.Offset.zero, ui.Paint());
+    final ui.Picture picture = recorder.endRecording();
+    addTearDown(picture.dispose);
+
+    image.dispose();
+
+    // The first texture upload happens only after the last Dart image handle
+    // has been disposed, as can happen when ImageCache evicts an image.
+    final ui.Image rasterized = await picture.toImage(4, 4);
+    addTearDown(rasterized.dispose);
+    final ByteData actual = (await rasterized.toByteData(
+      format: ui.ImageByteFormat.rawStraightRgba,
+    ))!;
+    expect(actual.buffer.asUint8List(), expected.buffer.asUint8List());
   });
 }
 

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/image_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/image_test.dart
@@ -114,7 +114,10 @@ void testMain() {
     final ByteData actual = (await rasterized.toByteData(
       format: ui.ImageByteFormat.rawStraightRgba,
     ))!;
-    expect(actual.buffer.asUint8List(), expected.buffer.asUint8List());
+    expect(
+      actual.buffer.asUint8List(actual.offsetInBytes, actual.lengthInBytes),
+      expected.buffer.asUint8List(expected.offsetInBytes, expected.lengthInBytes),
+    );
   });
 }
 


### PR DESCRIPTION
Disposing the last Dart image handle clears the backing HTML image element even when a recorded SkPicture still retains its lazy SkImage. A subsequent texture upload then reads an empty element and renders black.

Leave the element's src intact when ImageElementImageSource closes. The browser can reclaim the element once its remaining references disappear. Update the closure test and add a pixel-level regression test that records an element-backed image, disposes it before its first GPU upload, and rasterizes the retained picture.

Fixes #191800.

The test creates the HTML element directly using the existing embedded PNG fixture, so it exercises the affected ownership path without a network dependency or depending on current URL-decoder routing.

## Validation

- Verified both regression assertions fail with the original src-clearing implementation; the rendered red channel is 0 instead of 255.
- With the fix, all 4 tests in test/canvaskit/image_test.dart pass in both Chrome CanvasKit suites (full and Chromium).
- Targeted dart analyze: no issues found.
- dart format and git diff --check pass.

Command (from engine/src/flutter/lib/web_ui):
`dev/felt -i test --compile --run --browser chrome --renderer canvaskit test/canvaskit/image_test.dart`

Local environment: Dart 3.13.2, Chrome for Testing 145.0.7632.117 on macOS arm64. Tests compile the changed engine Dart sources. Runtime flutter_js and CanvasKit artifacts were copied from the installed Flutter SDK (engine a804b261645ef8c13eb3d5c44a5c2fb0340c5539); a matching locally built engine and the full web test suite were not run. The default artifact-copy step cannot complete in this checkout because gclient font/Skia resources are absent.

This is an AI-assisted change. Codex performed a self-review of the image ownership and picture rasterization paths; the contributor authorized marking the PR ready for review. The CLA check passes. No public API changes or flutter/tests migration are needed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

