### PR TITLE
[tool] Let --local-engine reach the build system again

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -353,6 +353,56 @@ abstract class Artifacts {
   LocalEngineInfo? get localEngineInfo;
 }
 
+/// Artifacts that can be changed after they are created.
+///
+/// Commands are created when the tool starts up, before the command line has
+/// been parsed, so the artifacts they need to build against are not yet known.
+/// A [DeferredArtifacts] can be used in their place, then [resolve]d once the
+/// required artifacts are known.
+class DeferredArtifacts implements Artifacts {
+  DeferredArtifacts(this._artifacts);
+
+  Artifacts _artifacts;
+  var _isResolved = false;
+
+  /// Uses [artifacts] from here on.
+  ///
+  /// Called before any command runs, and only once.
+  void resolve(Artifacts artifacts) {
+    assert(!_isResolved, 'The artifacts to build against have already been resolved.');
+    _isResolved = true;
+    _artifacts = artifacts;
+  }
+
+  @override
+  String getArtifactPath(
+    Artifact artifact, {
+    TargetPlatform? platform,
+    BuildMode? mode,
+    EnvironmentType? environmentType,
+  }) {
+    return _artifacts.getArtifactPath(
+      artifact,
+      platform: platform,
+      mode: mode,
+      environmentType: environmentType,
+    );
+  }
+
+  @override
+  FileSystemEntity getHostArtifact(HostArtifact artifact) => _artifacts.getHostArtifact(artifact);
+
+  @override
+  String getEngineType(TargetPlatform platform, [BuildMode? mode]) =>
+      _artifacts.getEngineType(platform, mode);
+
+  @override
+  bool get usesLocalArtifacts => _artifacts.usesLocalArtifacts;
+
+  @override
+  LocalEngineInfo? get localEngineInfo => _artifacts.localEngineInfo;
+}
+
 /// Manages the engine artifacts downloaded to the local cache.
 class CachedArtifacts implements Artifacts {
   CachedArtifacts({

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -359,6 +359,9 @@ abstract class Artifacts {
 /// been parsed, so the artifacts they need to build against are not yet known.
 /// A [DeferredArtifacts] can be used in their place, then [resolve]d once the
 /// required artifacts are known.
+///
+/// Paths read before [resolve] is called are out of date, so must not be
+/// cached.
 class DeferredArtifacts implements Artifacts {
   DeferredArtifacts(this._artifacts);
 

--- a/packages/flutter_tools/lib/src/context/tool_dependencies.dart
+++ b/packages/flutter_tools/lib/src/context/tool_dependencies.dart
@@ -348,11 +348,14 @@ class ToolDependencies {
     final CocoaPodsValidator finalCocoapodsValidator =
         cocoapodsValidator ?? CocoaPodsValidator(finalCocoaPods, finalUserMessages);
 
-    final finalArtifacts = CachedArtifacts(
-      fileSystem: finalFS,
-      cache: finalCache,
-      platform: finalPlatform,
-      operatingSystemUtils: finalOS,
+    // Artifacts will be updated later if a local engine is used.
+    final finalArtifacts = DeferredArtifacts(
+      CachedArtifacts(
+        fileSystem: finalFS,
+        cache: finalCache,
+        platform: finalPlatform,
+        operatingSystemUtils: finalOS,
+      ),
     );
 
     final XCDevice finalXCDevice =

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -562,9 +562,12 @@ class FlutterCommandRunner extends CommandRunner<void> {
       packagePath: topLevelResults[FlutterGlobalOptions.kPackagesOption] as String?,
     );
     if (engineBuildPaths != null) {
-      contextOverrides.addAll(<Type, Object?>{
-        Artifacts: Artifacts.getLocalEngine(engineBuildPaths),
-      });
+      final Artifacts localArtifacts = Artifacts.getLocalEngine(engineBuildPaths);
+      contextOverrides.addAll(<Type, Object?>{Artifacts: localArtifacts});
+      // Update the artifacts the commands were created with.
+      if (_toolContext.artifacts case final DeferredArtifacts artifacts) {
+        artifacts.resolve(localArtifacts);
+      }
     }
 
     await context.run<void>(

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -865,4 +865,50 @@ void main() {
       },
     );
   });
+
+  group('DeferredArtifacts', () {
+    late Artifacts cached;
+    late Artifacts localEngine;
+
+    setUp(() {
+      final fileSystem = MemoryFileSystem.test();
+      cached = Artifacts.test(fileSystem: fileSystem);
+      localEngine = Artifacts.testLocalEngine(
+        localEngine: '/out/host_debug',
+        localEngineHost: '/out/host_debug',
+        fileSystem: fileSystem,
+      );
+    });
+
+    testWithoutContext('builds against the artifacts it was given', () {
+      final artifacts = DeferredArtifacts(cached);
+
+      expect(artifacts.usesLocalArtifacts, isFalse);
+      expect(
+        artifacts.getArtifactPath(Artifact.flutterTester),
+        cached.getArtifactPath(Artifact.flutterTester),
+      );
+    });
+
+    testWithoutContext('builds against the artifacts it is resolved to', () {
+      final artifacts = DeferredArtifacts(cached);
+
+      artifacts.resolve(localEngine);
+
+      expect(artifacts.usesLocalArtifacts, isTrue);
+      expect(artifacts.localEngineInfo?.targetOutPath, '/out/host_debug');
+      expect(
+        artifacts.getArtifactPath(Artifact.flutterTester),
+        localEngine.getArtifactPath(Artifact.flutterTester),
+      );
+    });
+
+    testWithoutContext('cannot be resolved twice', () {
+      final artifacts = DeferredArtifacts(cached);
+
+      artifacts.resolve(localEngine);
+
+      expect(() => artifacts.resolve(localEngine), throwsAssertionError);
+    });
+  });
 }

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -183,6 +183,69 @@ void main() {
       },
     );
 
+    // The artifacts commands are built with are chosen before the command line
+    // is parsed, so they have to be rebuilt once a local engine is found.
+    testUsingContext(
+      'builds commands with the local engine the command line asks for',
+      () async {
+        fileSystem
+            .directory('engine')
+            .childDirectory('src')
+            .childDirectory('out')
+            .childDirectory('host_debug')
+            .createSync(recursive: true);
+        final ranCommands = <ArtifactsRecordingFlutterCommand>[];
+
+        // Exiting is faked out to throw, so catch that rather than the runner
+        // being able to return.
+        final completer = Completer<void>();
+        unawaited(
+          runZonedGuarded<Future<void>?>(
+            () {
+              unawaited(
+                runner.run(
+                  <String>[
+                    '--local-engine=host_debug',
+                    '--local-engine-host=host_debug',
+                    '--local-engine-src-path=./engine/src',
+                    'record',
+                  ],
+                  (ToolDependencies toolDependencies) {
+                    final command = ArtifactsRecordingFlutterCommand();
+                    ranCommands.add(command);
+                    return <FlutterCommand>[command];
+                  },
+                  flutterVersion: '[user-branch]/',
+                  shutdownHooks: ShutdownHooks(),
+                ),
+              );
+              return null;
+            },
+            (Object error, StackTrace stack) {
+              if (!completer.isCompleted) {
+                completer.complete();
+              }
+            },
+          ),
+        );
+        await completer.future;
+
+        final Artifacts? artifacts = ranCommands.singleWhere((command) => command.ran).artifacts;
+        expect(artifacts?.localEngineInfo?.targetOutPath, endsWith('engine/src/out/host_debug'));
+      },
+      overrides: <Type, Generator>{
+        Platform: () => FakePlatform(
+          environment: <String, String>{'FLUTTER_ANALYTICS_LOG_FILE': 'test', 'FLUTTER_ROOT': '/'},
+        ),
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Artifacts: () => Artifacts.test(),
+        HttpClientFactory: () =>
+            () => FakeHttpClient.any(),
+        Analytics: () => fakeAnalytics,
+      },
+    );
+
     testUsingContext(
       'error handling crash report (bot)',
       () async {
@@ -855,6 +918,24 @@ void main() {
       },
     );
   });
+}
+
+class ArtifactsRecordingFlutterCommand extends FlutterCommand {
+  Artifacts? artifacts;
+  bool ran = false;
+
+  @override
+  String get description => '';
+
+  @override
+  String get name => 'record';
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    ran = true;
+    artifacts = toolContext?.artifacts;
+    return FlutterCommandResult.success();
+  }
 }
 
 class CrashingFlutterCommand extends FlutterCommand {


### PR DESCRIPTION
Desktop builds with --local-engine quietly used the cached engine instead of the one just built, and often failed outright with "Can't load Kernel binary: Invalid SDK hash", because cached engine artifacts stop being updated once --local-engine is used and eventually no longer match the Dart SDK.

Commands are created with the artifacts to build against when the tool starts up, which is before the command line has been parsed, so they always used the cached ones. --local-engine and --local-web-sdk were applied afterwards, and only to the legacy zone that commands used to read artifacts from. flutter assemble stopped reading from that zone in #190773, taking the build system with it.

Use artifacts that can be changed after they are created instead, and update them as soon as the runner has parsed the command line, which happens before any command runs. Everything then builds against the right engine.
