### PR TITLE
[iOS] Hide the iOS 26 scroll-edge effect on the embedder's helper scrollviews

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSemanticsScrollView.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterSemanticsScrollView.mm
@@ -17,6 +17,17 @@ FLUTTER_ASSERT_ARC
     _semanticsObject = semanticsObject;
     _isDoingSystemScrolling = NO;
     self.delegate = self;
+    // This view mirrors the Dart scroll position for assistive technology and
+    // draws nothing itself. iOS 26 paints a scroll-edge effect (a blur and a
+    // light wash under the status bar) over any scrolled UIScrollView, which
+    // would frost whatever Flutter rendered beneath this one as soon as the
+    // Dart scrollable moves.
+#if defined(__IPHONE_26_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+    if (@available(iOS 26.0, *)) {
+      self.topEdgeEffect.hidden = YES;
+      self.bottomEdgeEffect.hidden = YES;
+    }
+#endif
   }
   return self;
 }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -546,6 +546,14 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
   scrollView.contentSize = CGSizeMake(kScrollViewContentSize, kScrollViewContentSize);
   // This is an arbitrary offset that is not CGPointZero.
   scrollView.contentOffset = CGPointMake(kScrollViewContentSize, kScrollViewContentSize);
+  // A non-zero offset reads as scrolled content to iOS 26, which paints a
+  // scroll-edge effect under the status bar over whatever Flutter rendered.
+#if defined(__IPHONE_26_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+  if (@available(iOS 26.0, *)) {
+    scrollView.topEdgeEffect.hidden = YES;
+    scrollView.bottomEdgeEffect.hidden = YES;
+  }
+#endif
 
   [self.view addSubview:scrollView];
   self.scrollView = scrollView;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -340,6 +340,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 @property(nonatomic, strong) FlutterVSyncClient* keyboardAnimationVSyncClient;
 @property(nonatomic, strong) FlutterVSyncClient* touchRateCorrectionVSyncClient;
 @property(nonatomic, assign) BOOL awokenFromNib;
+@property(nonatomic, strong) UIScrollView* scrollView;
 
 - (void)createTouchRateCorrectionVSyncClientIfNeeded;
 - (void)surfaceUpdated:(BOOL)appeared;
@@ -1475,6 +1476,21 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [viewController updateViewportMetricsIfNeeded];
 
   OCMVerifyAll(mockEngine);
+}
+
+- (void)testLoadViewHidesScrollEdgeEffectsOnScrollToTopHelper {
+#if defined(__IPHONE_26_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+  if (@available(iOS 26.0, *)) {
+    FlutterEngine* engine = [[FlutterEngine alloc] init];
+    [engine runWithEntrypoint:nil];
+    FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                  nibName:nil
+                                                                                   bundle:nil];
+    [viewController loadView];
+    XCTAssertTrue(viewController.scrollView.topEdgeEffect.hidden);
+    XCTAssertTrue(viewController.scrollView.bottomEdgeEffect.hidden);
+  }
+#endif
 }
 
 - (void)testViewDidLoadDoesntInvokeEngineWhenNotTheViewController {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -41,6 +41,21 @@ const float kFloatCompareEpsilon = 0.001;
   XCTAssertNotNil(object);
 }
 
+- (void)testFlutterSemanticsScrollViewHidesScrollEdgeEffects {
+#if defined(__IPHONE_26_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+  if (@available(iOS 26.0, *)) {
+    fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
+        new flutter::testing::MockAccessibilityBridge());
+    fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+    SemanticsObject* object = [[SemanticsObject alloc] initWithBridge:bridge uid:0];
+    FlutterSemanticsScrollView* scrollView =
+        [[FlutterSemanticsScrollView alloc] initWithSemanticsObject:object];
+    XCTAssertTrue(scrollView.topEdgeEffect.hidden);
+    XCTAssertTrue(scrollView.bottomEdgeEffect.hidden);
+  }
+#endif
+}
+
 - (void)testUIFocusSystemMethodsDoNotCrashWhenBridgeIsDead {
   fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge;
   SemanticsObject* object;


### PR DESCRIPTION
iOS 26 paints a scroll-edge effect (a blur and a light wash under the status bar) over any `UIScrollView` whose content offset is non-zero. The iOS embedder keeps two scroll views under `FlutterView` that never draw anything but do sit at a non-zero offset: the scroll-to-top helper in `-[FlutterViewController loadView]`, and a `FlutterSemanticsScrollView` per scrollable semantics node, whose offset mirrors the Dart scroll position for assistive technology. As soon as a Dart scrollable scrolls, iOS frosts the top ~60pt of whatever Flutter rendered. Over a full-bleed image it reads as a frosted band, and during an interactive pop it smears the page's colour outside the rounded corner clip.

This hides `topEdgeEffect` and `bottomEdgeEffect` on both views. The change is behind `@available(iOS 26.0, *)` and an `__IPHONE_26_0` SDK guard, so it is a no-op on earlier iOS and compiles on toolchains without the iOS 26 SDK.

Reproduced on an iPhone 17 simulator (iOS 26 runtime) with a plain UIKit probe: a coloured view under the status bar shows no band, a transparent `UIScrollView` at a non-zero offset on top of it reproduces the band exactly, and `topEdgeEffect.hidden = YES` removes it. Applying the same change from app code to a Flutter app removed the band there. Before/after screenshots are on the issue.

Fixes flutter/flutter#192372

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
