### PR TITLE
Bound decoded image allocations in the Skia image generators

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
   'dart_ai_rev': '9c96bfe5f091c9451eff5b59c9bffeb2e806b875',
-  'skia_revision': '2df865d9d369027b115f92da4e0214c253bc9efc',
+  'skia_revision': 'e1437642d2593ab87e122646aeb6e029399a87cf',
 
   # Do not download the Emscripten SDK by default.
   # This prevents us from downloading the Emscripten toolchain for builds

--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
   'dart_ai_rev': '9c96bfe5f091c9451eff5b59c9bffeb2e806b875',
-  'skia_revision': 'e1437642d2593ab87e122646aeb6e029399a87cf',
+  'skia_revision': 'b3fa80a0e16882402ffe8194c315295b9b2f2b60',
 
   # Do not download the Emscripten SDK by default.
   # This prevents us from downloading the Emscripten toolchain for builds

--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
   'dart_ai_rev': '9c96bfe5f091c9451eff5b59c9bffeb2e806b875',
-  'skia_revision': 'c7aa5512d148f89d61ff68b6d3ed0c3c8e93996f',
+  'skia_revision': '2df865d9d369027b115f92da4e0214c253bc9efc',
 
   # Do not download the Emscripten SDK by default.
   # This prevents us from downloading the Emscripten toolchain for builds

--- a/engine/src/flutter/lib/ui/painting/image_generator.cc
+++ b/engine/src/flutter/lib/ui/painting/image_generator.cc
@@ -19,6 +19,13 @@ ImageGenerator::~ImageGenerator() = default;
 sk_sp<SkImage> ImageGenerator::GetImage() {
   SkImageInfo info = GetInfo();
 
+  if (info.computeMinByteSize() > kMaxDecodedImageBytes) {
+    FML_DLOG(ERROR) << "Decoded image of size " << info.computeMinByteSize()
+                    << "B exceeds the maximum supported decoded image size of "
+                    << kMaxDecodedImageBytes << "B.";
+    return nullptr;
+  }
+
   SkBitmap bitmap;
   if (!bitmap.tryAllocPixels(info)) {
     FML_DLOG(ERROR) << "Failed to allocate memory for bitmap of size "
@@ -194,6 +201,15 @@ std::unique_ptr<ImageGenerator> BuiltinSkiaCodecImageGenerator::MakeFromData(
   if (!codec) {
     return nullptr;
   }
+
+  SkImageInfo info = getInfoIncludingExif(codec.get());
+  if (info.computeMinByteSize() > ImageGenerator::kMaxDecodedImageBytes) {
+    FML_DLOG(ERROR) << "Decoded image of size " << info.computeMinByteSize()
+                    << "B exceeds the maximum supported decoded image size of "
+                    << ImageGenerator::kMaxDecodedImageBytes << "B.";
+    return nullptr;
+  }
+
   return std::make_unique<BuiltinSkiaCodecImageGenerator>(std::move(codec));
 }
 

--- a/engine/src/flutter/lib/ui/painting/image_generator.h
+++ b/engine/src/flutter/lib/ui/painting/image_generator.h
@@ -30,6 +30,14 @@ class ImageGenerator {
   const static unsigned int kInfinitePlayCount =
       std::numeric_limits<unsigned int>::max();
 
+  /// The maximum number of bytes a decoded image, animation frame, or frame
+  /// canvas may occupy. Dimensions are taken verbatim from encoded image
+  /// headers, which are untrusted input: without a bound, a tiny encoded
+  /// buffer can drive a multi-gigabyte pixel allocation and terminate the
+  /// process. This bound mirrors the maximum decoded image size used by other
+  /// browser-class engines and the Impeller decoder's max_texture_size clamp.
+  const static size_t kMaxDecodedImageBytes = 1u << 28;  // 256 MiB
+
   /// @brief  Info about a single frame in the context of a multi-frame image,
   ///         useful for animation and blending.
   struct FrameInfo {

--- a/engine/src/flutter/lib/ui/painting/image_generator.h
+++ b/engine/src/flutter/lib/ui/painting/image_generator.h
@@ -36,7 +36,7 @@ class ImageGenerator {
   /// buffer can drive a multi-gigabyte pixel allocation and terminate the
   /// process. This bound mirrors the maximum decoded image size used by other
   /// browser-class engines and the Impeller decoder's max_texture_size clamp.
-  const static size_t kMaxDecodedImageBytes = 1u << 28;  // 256 MiB
+  static constexpr size_t kMaxDecodedImageBytes = 1u << 28;  // 256 MiB
 
   /// @brief  Info about a single frame in the context of a multi-frame image,
   ///         useful for animation and blending.

--- a/engine/src/flutter/lib/ui/painting/image_generator_apng.cc
+++ b/engine/src/flutter/lib/ui/painting/image_generator_apng.cc
@@ -111,6 +111,15 @@ bool APNGImageGenerator::GetPixels(const SkImageInfo& info,
                       << ") of APNG due to pixel buffer size overflow.";
       return false;
     }
+    if (pixels_bytes > ImageGenerator::kMaxDecodedImageBytes) {
+      FML_DLOG(ERROR) << "Failed to decode image at index " << image_index
+                      << " (frame index: " << frame_index
+                      << ") of APNG: frame pixel buffer size " << pixels_bytes
+                      << "B exceeds the maximum supported decoded image size "
+                         "of "
+                      << ImageGenerator::kMaxDecodedImageBytes << "B.";
+      return false;
+    }
     frame.pixels.resize(pixels_bytes);
     SkCodec::Result result = frame.codec->getPixels(
         frame.codec->getInfo(), frame.pixels.data(), frame_row_bytes);
@@ -316,6 +325,13 @@ std::unique_ptr<ImageGenerator> APNGImageGenerator::MakeFromData(
   }
 
   SkImageInfo image_info = default_image.value().codec->getInfo();
+  if (image_info.computeMinByteSize() > ImageGenerator::kMaxDecodedImageBytes) {
+    FML_DLOG(ERROR) << "APNG default image of size "
+                    << image_info.computeMinByteSize()
+                    << "B exceeds the maximum supported decoded image size of "
+                    << ImageGenerator::kMaxDecodedImageBytes << "B.";
+    return nullptr;
+  }
   return std::unique_ptr<APNGImageGenerator>(
       new APNGImageGenerator(data, image_info, std::move(default_image.value()),
                              animation_data->get_num_frames(), play_count,

--- a/engine/src/flutter/lib/ui/painting/image_generator_apng_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_generator_apng_unittests.cc
@@ -111,6 +111,109 @@ std::vector<uint8_t> BuildMaliciousApng(uint32_t fdat_data_length) {
   return apng;
 }
 
+// Appends an IHDR chunk with the given dimensions (RGBA, 8-bit).
+void AppendImageHeaderChunk(std::vector<uint8_t>& apng,
+                            uint32_t width,
+                            uint32_t height) {
+  std::vector<uint8_t> ihdr;
+  WriteBE32(ihdr, width);
+  WriteBE32(ihdr, height);
+  ihdr.push_back(8);  // bit depth
+  ihdr.push_back(6);  // color type (RGBA)
+  ihdr.push_back(0);  // compression
+  ihdr.push_back(0);  // filter
+  ihdr.push_back(0);  // interlace
+  AppendChunk(apng, "IHDR", ihdr);
+}
+
+// Appends an fcTL chunk for a frame with the given dimensions.
+void AppendFrameControlChunk(std::vector<uint8_t>& apng,
+                             uint32_t sequence_number,
+                             uint32_t width,
+                             uint32_t height) {
+  std::vector<uint8_t> fctl;
+  WriteBE32(fctl, sequence_number);
+  WriteBE32(fctl, width);
+  WriteBE32(fctl, height);
+  WriteBE32(fctl, 0);   // x_offset
+  WriteBE32(fctl, 0);   // y_offset
+  WriteBE16(fctl, 1);   // delay_num
+  WriteBE16(fctl, 10);  // delay_den
+  fctl.push_back(0);    // dispose_op
+  fctl.push_back(0);    // blend_op
+  AppendChunk(apng, "fcTL", fctl);
+}
+
+// Appends an fdAT chunk with the given sequence number and zlib data.
+void AppendFrameDataChunk(std::vector<uint8_t>& apng,
+                          uint32_t sequence_number,
+                          const std::vector<uint8_t>& zlib_data) {
+  std::vector<uint8_t> fdat;
+  WriteBE32(fdat, sequence_number);
+  fdat.insert(fdat.end(), zlib_data.begin(), zlib_data.end());
+  AppendChunk(apng, "fdAT", fdat);
+}
+
+// The zlib stream of a valid 1x1 RGBA image (a single transparent pixel).
+std::vector<uint8_t> OnePixelZlibData() {
+  return {0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01};
+}
+
+// Builds a PNG whose header declares dimensions requiring ~1 GiB of decoded
+// pixel data (16383 * 16383 * 4 bytes), which exceeds
+// ImageGenerator::kMaxDecodedImageBytes.
+std::vector<uint8_t> BuildPngWithOversizedHeader() {
+  std::vector<uint8_t> png(APNGImageGenerator::kPngSignature.begin(),
+                           APNGImageGenerator::kPngSignature.end());
+  AppendImageHeaderChunk(png, 16383, 16383);
+  AppendChunk(png, "IDAT", {0, 0, 0, 0});
+  AppendChunk(png, "IEND", {});
+  return png;
+}
+
+// Builds an APNG whose default image declares dimensions requiring ~1 GiB of
+// decoded pixel data. The multi-frame canvas is allocated from the default
+// image dimensions, so the generator must be rejected at creation time.
+std::vector<uint8_t> BuildApngWithOversizedDefaultImage() {
+  std::vector<uint8_t> apng(APNGImageGenerator::kPngSignature.begin(),
+                            APNGImageGenerator::kPngSignature.end());
+  AppendImageHeaderChunk(apng, 16383, 16383);
+  {
+    std::vector<uint8_t> actl;
+    WriteBE32(actl, 1);  // num_frames
+    WriteBE32(actl, 0);  // num_plays (0 = infinite)
+    AppendChunk(apng, "acTL", actl);
+  }
+  AppendChunk(apng, "IDAT", {0, 0, 0, 0});
+  AppendFrameControlChunk(apng, 0, 1, 1);
+  AppendFrameDataChunk(apng, 0, {0, 0, 0, 0});
+  AppendChunk(apng, "IEND", {});
+  return apng;
+}
+
+// Builds an APNG with a valid 1x1 default frame followed by a frame whose
+// fcTL dimensions require ~1 GiB of decoded pixel data. Without a decoded
+// image budget, decoding the second frame attempts a ~1 GiB allocation.
+// Note: the demuxer only tracks frame info for default images demuxed from
+// fcTL frames, so the first chunk after acTL must be an fcTL (no IDAT).
+std::vector<uint8_t> BuildApngWithOversizedFrame() {
+  std::vector<uint8_t> apng(APNGImageGenerator::kPngSignature.begin(),
+                            APNGImageGenerator::kPngSignature.end());
+  AppendImageHeaderChunk(apng, 1, 1);
+  {
+    std::vector<uint8_t> actl;
+    WriteBE32(actl, 2);  // num_frames
+    WriteBE32(actl, 0);  // num_plays (0 = infinite)
+    AppendChunk(apng, "acTL", actl);
+  }
+  AppendFrameControlChunk(apng, 0, 1, 1);
+  AppendFrameDataChunk(apng, 0, OnePixelZlibData());
+  AppendFrameControlChunk(apng, 1, 16383, 16383);
+  AppendFrameDataChunk(apng, 1, OnePixelZlibData());
+  AppendChunk(apng, "IEND", {});
+  return apng;
+}
+
 }  // namespace
 
 // Verify that the APNG decoder can handle fdAT chunks whose length is shorter
@@ -178,6 +281,56 @@ TEST(APNGImageGeneratorTest, FdATWithOverflowDataLengthIsRejected) {
   auto generator = APNGImageGenerator::MakeFromData(data);
   // The generator should reject the malformed APNG without crashing.
   EXPECT_EQ(generator, nullptr);
+}
+
+// Verify that a PNG header declaring dimensions beyond the decoded image
+// budget is rejected when the generator is created, before any allocation
+// is attempted.
+TEST(BuiltinSkiaCodecImageGeneratorTest, OversizedHeaderIsRejected) {
+  // Constructing a registry registers the Skia codecs, which
+  // SkCodec::MakeFromData relies on.
+  ImageGeneratorRegistry registry;
+
+  std::vector<uint8_t> png_bytes = BuildPngWithOversizedHeader();
+  auto data = SkData::MakeWithCopy(png_bytes.data(), png_bytes.size());
+  EXPECT_EQ(BuiltinSkiaCodecImageGenerator::MakeFromData(data), nullptr);
+}
+
+// Verify that an APNG default image beyond the decoded image budget is
+// rejected when the generator is created.
+TEST(APNGImageGeneratorTest, OversizedDefaultImageIsRejected) {
+  // Constructing a registry registers the Skia codecs, which the APNG
+  // demuxer relies on.
+  ImageGeneratorRegistry registry;
+
+  std::vector<uint8_t> apng_bytes = BuildApngWithOversizedDefaultImage();
+  auto data = SkData::MakeWithCopy(apng_bytes.data(), apng_bytes.size());
+  EXPECT_EQ(APNGImageGenerator::MakeFromData(data), nullptr);
+}
+
+// Verify that an APNG frame beyond the decoded image budget is rejected
+// before its pixel buffer is allocated, while normal frames still decode.
+TEST(APNGImageGeneratorTest, OversizedFrameIsRejectedWithoutAllocation) {
+  // Constructing a registry registers the Skia codecs, which the APNG
+  // demuxer relies on.
+  ImageGeneratorRegistry registry;
+
+  std::vector<uint8_t> apng_bytes = BuildApngWithOversizedFrame();
+  auto data = SkData::MakeWithCopy(apng_bytes.data(), apng_bytes.size());
+  auto generator = APNGImageGenerator::MakeFromData(data);
+  ASSERT_NE(generator, nullptr);
+  EXPECT_EQ(generator->GetFrameCount(), 2u);
+
+  SkImageInfo info = SkImageInfo::MakeN32(1, 1, kPremul_SkAlphaType);
+  std::vector<uint8_t> pixels(info.computeMinByteSize());
+
+  // The first frame (1x1) decodes normally.
+  EXPECT_TRUE(generator->GetPixels(info, pixels.data(), info.minRowBytes(),
+                                   /*frame_index=*/0));
+
+  // The oversized frame is rejected without attempting its pixel allocation.
+  EXPECT_FALSE(generator->GetPixels(info, pixels.data(), info.minRowBytes(),
+                                    /*frame_index=*/1));
 }
 
 }  // namespace testing


### PR DESCRIPTION
## Problem

The Skia decode path in `lib/ui/painting` allocates pixel buffers directly from
dimensions parsed out of encoded image headers, with no upper bound anywhere in
the chain:

- `BuiltinSkiaCodecImageGenerator::MakeFromData` and `ImageGenerator::GetImage`
  allocate a bitmap sized from the header's width/height (`image_generator.cc`).
- The multi-frame canvas in `MultiFrameCodec` is allocated from the generator's
  info without any cap.
- The APNG generator's per-frame buffer (`frame.pixels.resize(pixels_bytes)`) is
  sized from `fcTL` frame dimensions, which are independent of the default image
  dimensions (`image_generator_apng.cc`).

`fml::SafeMath` guards integer overflow only. A small handcrafted file (e.g. a
~200-byte APNG whose `fcTL` declares 1,000,000x1,000,000, or a sub-KB PNG header
of 16,000x16,000) drives a multi-gigabyte allocation: `tryAllocPixels` returns
false gracefully in the common case, but under memory overcommit the allocation
"succeeds" at malloc time and the process is OOM-killed on commit, and the APNG
path's `std::vector::resize` throws an unhandled `std::bad_alloc` that terminates
the process. The Impeller decoder already clamps to `max_texture_size` before
allocating; this change brings the Skia path in line with the other backend.

## Change

Add a single engine-wide decoded-image budget,
`ImageGenerator::kMaxDecodedImageBytes` (256 MiB, mirroring the decoded-image cap
applied by other browser-class engines), enforced at every allocation point
driven by header dimensions:

- `BuiltinSkiaCodecImageGenerator::MakeFromData`: reject at creation if the
  header (including the EXIF orientation swap) exceeds the budget — covers
  single- and multi-frame Skia codecs before any generator exists.
- `ImageGenerator::GetImage`: reject before `tryAllocPixels` — covers platform
  image generators on macOS/Windows.
- `APNGImageGenerator::MakeFromData`: reject at creation if the default image
  (the multi-frame canvas size) exceeds the budget.
- `APNGImageGenerator::GetPixels`: reject per-frame before `frame.pixels.resize`
  when an `fcTL` frame exceeds the budget.

All rejections return failure through the existing graceful error paths (no new
exception paths, no crash).

## Tests

Three new regression tests in `image_generator_apng_unittests.cc`:

- oversized PNG header rejected at generator creation,
- oversized APNG default image rejected at creation,
- oversized APNG `fcTL` frame rejected at decode time while the normal frame
  still decodes.

## Notes

- Behavior change: images whose decoded size exceeds 256 MiB are now rejected
  instead of decoded (previously they either failed to allocate or, on
  constrained devices, killed the process). This matches the Impeller backend's
  existing clamp behavior.
- Follow-up (not in this PR): oversized still images could be decoded at a
  reduced scale (as `ImageDecoderImpeller` does) instead of being rejected
  outright, if there is demand.

No issue filed — robustness fix.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
