### PR TITLE
[web] Account for canvas scale in WebParagraph rendering

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/web_paragraph_painter.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/web_paragraph_painter.dart
@@ -14,15 +14,15 @@ import 'image.dart';
 class CanvasKitPainter extends WebParagraphPainter {
   CanvasKitPainter(super.paragraph);
 
-  EngineImage? _singleImageCache;
+  EngineImage? _cachedImage;
 
   @override
-  bool get hasCache => _singleImageCache != null;
+  bool get hasCache => _cachedImage != null;
 
   @override
   void clearCache() {
-    _singleImageCache?.dispose();
-    _singleImageCache = null;
+    _cachedImage?.dispose();
+    _cachedImage = null;
   }
 
   double? _lastDevicePixelRatio;
@@ -35,9 +35,10 @@ class CanvasKitPainter extends WebParagraphPainter {
     required ParagraphImageGenerator generateParagraphImage,
   }) {
     final double dpr = ui.window.devicePixelRatio;
-    if (_lastDevicePixelRatio != dpr ||
-        _singleImageCache?.width != sourceRect.width.toInt() ||
-        _singleImageCache?.height != sourceRect.height.toInt()) {
+    if (hasCache &&
+        (_lastDevicePixelRatio != dpr ||
+            _cachedImage?.width != sourceRect.width.toInt() ||
+            _cachedImage?.height != sourceRect.height.toInt())) {
       clearCache();
     }
     _lastDevicePixelRatio = dpr;
@@ -60,7 +61,7 @@ class CanvasKitPainter extends WebParagraphPainter {
       if (skImage == null) {
         throw Exception('Failed to convert text image bitmap to an SkImage.');
       }
-      _singleImageCache = EngineImage(
+      _cachedImage = EngineImage(
         CkImageDelegate(skImage),
         skImage.width().toInt(),
         skImage.height().toInt(),
@@ -68,7 +69,7 @@ class CanvasKitPainter extends WebParagraphPainter {
     }
 
     canvas.drawImageRect(
-      _singleImageCache!,
+      _cachedImage!,
       sourceRect,
       targetRect,
       ui.Paint()..filterQuality = ui.FilterQuality.none,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/web_paragraph_painter.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/web_paragraph_painter.dart
@@ -35,7 +35,9 @@ class CanvasKitPainter extends WebParagraphPainter {
     required ParagraphImageGenerator generateParagraphImage,
   }) {
     final double dpr = ui.window.devicePixelRatio;
-    if (_lastDevicePixelRatio != dpr) {
+    if (_lastDevicePixelRatio != dpr ||
+        _singleImageCache?.width != sourceRect.width.toInt() ||
+        _singleImageCache?.height != sourceRect.height.toInt()) {
       clearCache();
     }
     _lastDevicePixelRatio = dpr;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
@@ -22,10 +23,10 @@ typedef ParagraphImageGenerator = Uint8List Function();
 ///
 /// The paint canvas is scaled by the device pixel ratio to avoid pixelation
 /// that would happen if it wasn't resized.
-void _resizePaintCanvas(double devicePixelRatio, ui.Rect rect) {
+void _resizePaintCanvas(double scaleX, double scaleY, ui.Rect rect) {
   _paintCanvas.width = rect.width.ceil();
   _paintCanvas.height = rect.height.ceil();
-  _paintContext.scale(devicePixelRatio, devicePixelRatio);
+  _paintContext.scale(scaleX, scaleY);
 }
 
 /// Calculates the source (on Canvas2D) and target (on the output canvas) rectangles for a text block.
@@ -45,26 +46,26 @@ void _resizePaintCanvas(double devicePixelRatio, ui.Rect rect) {
   return (sourceRect, targetRect);
 }
 
-/// Calculates the source (on Canvas2D) and target (on the output canvas) rectangles for the entire paragraph
+/// Calculates the source (on Canvas2D) and target (on the output canvas) rectangles for the entire paragraph.
 (ui.Rect sourceRect, ui.Rect targetRect) _calculateParagraph(
   WebParagraph paragraph,
   ui.Offset offset,
-  double devicePixelRatio,
+  double scaleX,
+  double scaleY,
 ) {
-  // Define the paragraph rect (using advances, not selected rects)
-  // Source rect must take in account the scaling
   final sourceRect = ui.Rect.fromLTWH(
     0,
     0,
-    ((paragraph.paintBounds.width) * devicePixelRatio).ceilToDouble(),
-    ((paragraph.paintBounds.height) * devicePixelRatio).ceilToDouble(),
+    ((paragraph.paintBounds.width) * scaleX).ceilToDouble(),
+    ((paragraph.paintBounds.height) * scaleY).ceilToDouble(),
   );
+
   // Target rect will be scaled by the canvas transform, so we don't scale it here
   final targetRect = ui.Rect.fromLTWH(
     offset.dx + paragraph.paintBounds.left,
     offset.dy + paragraph.paintBounds.top,
-    sourceRect.width / devicePixelRatio,
-    sourceRect.height / devicePixelRatio,
+    sourceRect.width / scaleX,
+    sourceRect.height / scaleY,
   );
 
   return (sourceRect, targetRect);
@@ -144,10 +145,20 @@ abstract class WebParagraphPainter {
 
     final TextLayout layout = _paragraph.getLayout();
 
+    final Float64List canvasTransform = canvas.getTransform();
+    final double dpr = ui.window.devicePixelRatio;
+    final (double scaleX, double scaleY) = canvasTransform != null
+        ? canvasTransform.getScale()
+        : (1.0, 1.0);
+
+    final double totalScaleX = scaleX * dpr;
+    final double totalScaleY = scaleY * dpr;
+
     final (ui.Rect sourceRect, ui.Rect targetRect) = _calculateParagraph(
       _paragraph,
       offset,
-      ui.window.devicePixelRatio,
+      totalScaleX,
+      totalScaleY,
     );
 
     const epsilon = 0.001;
@@ -165,7 +176,7 @@ abstract class WebParagraphPainter {
       sourceRect,
       targetRect,
       generateParagraphImage: () {
-        _resizePaintCanvas(ui.window.devicePixelRatio, sourceRect);
+        _resizePaintCanvas(totalScaleX, totalScaleY, sourceRect);
 
         // We only want to paint the actual paint bounds of the paragraph.
         _paintContext.translate(-_paragraph.paintBounds.left, -_paragraph.paintBounds.top);
@@ -275,5 +286,13 @@ class DomCanvasParagraphPainter {
     _paintContext.shadowOffsetY = shadow.offset.dy;
 
     webTextCluster.addToContext(_paintContext, 0, 0);
+  }
+}
+
+extension on Float64List {
+  (double, double) getScale() {
+    final double scaleX = math.sqrt(this[0] * this[0] + this[1] * this[1] + this[2] * this[2]);
+    final double scaleY = math.sqrt(this[4] * this[4] + this[5] * this[5] + this[6] * this[6]);
+    return (scaleX == 0.0 ? 1.0 : scaleX, scaleY == 0.0 ? 1.0 : scaleY);
   }
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
@@ -50,22 +50,22 @@ void _resizePaintCanvas(double scaleX, double scaleY, ui.Rect rect) {
 (ui.Rect sourceRect, ui.Rect targetRect) _calculateParagraph(
   WebParagraph paragraph,
   ui.Offset offset,
-  double scaleX,
-  double scaleY,
+  double totalScaleX,
+  double totalScaleY,
 ) {
   final sourceRect = ui.Rect.fromLTWH(
     0,
     0,
-    ((paragraph.paintBounds.width) * scaleX).ceilToDouble(),
-    ((paragraph.paintBounds.height) * scaleY).ceilToDouble(),
+    ((paragraph.paintBounds.width) * totalScaleX).ceilToDouble(),
+    ((paragraph.paintBounds.height) * totalScaleY).ceilToDouble(),
   );
 
   // Target rect will be scaled by the canvas transform, so we don't scale it here
   final targetRect = ui.Rect.fromLTWH(
     offset.dx + paragraph.paintBounds.left,
     offset.dy + paragraph.paintBounds.top,
-    sourceRect.width / scaleX,
-    sourceRect.height / scaleY,
+    sourceRect.width / totalScaleX,
+    sourceRect.height / totalScaleY,
   );
 
   return (sourceRect, targetRect);
@@ -147,9 +147,7 @@ abstract class WebParagraphPainter {
 
     final Float64List canvasTransform = canvas.getTransform();
     final double dpr = ui.window.devicePixelRatio;
-    final (double scaleX, double scaleY) = canvasTransform != null
-        ? canvasTransform.getScale()
-        : (1.0, 1.0);
+    final (double scaleX, double scaleY) = canvasTransform.getScale();
 
     final double totalScaleX = scaleX * dpr;
     final double totalScaleY = scaleY * dpr;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/web_paragraph/painter.dart
@@ -165,8 +165,8 @@ abstract class WebParagraphPainter {
       return;
     }
 
-    // Draw background blocks directly on the output canvas
-    // so it will be cached together with the text blocks on Canvas2D canvas
+    // Draw background blocks directly on the output canvas. It's not cached with the text blocks on
+    // the 2d canvas.
     _paintAllBlocks(StyleElements.background, canvas, offset);
 
     paintParagraphText(

--- a/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/webparagraph/paragraph_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
@@ -1338,10 +1339,61 @@ Future<void> testMain() async {
         expect(targetRect!.width, closeTo(sourceRect.width / dpr, 0.0001));
         expect(targetRect.height, closeTo(sourceRect.height / dpr, 0.0001));
 
-        // Verify subpixel position precision
-        expect(targetRect.left, closeTo(offset.dx + paragraph.paintBounds.left, 0.0001));
-        expect(targetRect.top, closeTo(offset.dy + paragraph.paintBounds.top, 0.0001));
+        // Verify targetRect origin is not snapped (uses raw logical coordinates)
+        expect(targetRect.left, offset.dx + paragraph.paintBounds.left);
+        expect(targetRect.top, offset.dy + paragraph.paintBounds.top);
       }
+    } finally {
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(originalDpr);
+    }
+  });
+
+  test('WebParagraph correctly handles canvas scale and translation', () {
+    final double originalDpr = EngineFlutterDisplay.instance.devicePixelRatio;
+    try {
+      const dpr = 2.0;
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpr);
+
+      final arialStyle = WebParagraphStyle(fontFamily: 'Arial', fontSize: 50);
+      final builder = WebParagraphBuilder(arialStyle);
+      builder.pushStyle(WebTextStyle(color: const Color(0xFF000000)));
+      builder.addText('Scaled canvas text');
+      final WebParagraph paragraph = builder.build();
+      paragraph.layout(const ParagraphConstraints(width: double.infinity));
+
+      final mockCanvas = _MockCanvas();
+      // Canvas with scale 1.5 and translation (10.2, 5.7)
+      const scaleX = 1.5;
+      const scaleY = 1.5;
+      const tx = 10.2;
+      const ty = 5.7;
+      final matrix = Matrix4.identity()
+        ..translate(tx, ty)
+        ..scale(scaleX, scaleY);
+      mockCanvas.mockTransform = Float64List.fromList(matrix.storage);
+
+      const offset = Offset(12.3, 24.6);
+      paragraph.paint(mockCanvas, offset);
+
+      final Rect? sourceRect = mockCanvas.lastSourceRect;
+      final Rect? targetRect = mockCanvas.lastTargetRect;
+
+      expect(sourceRect, isNotNull);
+      expect(targetRect, isNotNull);
+
+      // Verify sourceRect accounts for both canvas scale and DPR
+      const double totalScaleX = scaleX * dpr;
+      const double totalScaleY = scaleY * dpr;
+      expect(sourceRect!.width, (paragraph.paintBounds.width * totalScaleX).ceilToDouble());
+      expect(sourceRect.height, (paragraph.paintBounds.height * totalScaleY).ceilToDouble());
+
+      // Verify targetRect dimensions preserve exact 1:1 physical pixel scale
+      expect(targetRect!.width, closeTo(sourceRect.width / totalScaleX, 0.0001));
+      expect(targetRect.height, closeTo(sourceRect.height / totalScaleY, 0.0001));
+
+      // Verify targetRect origin matches offset + paintBounds (no snapping applied)
+      expect(targetRect.left, offset.dx + paragraph.paintBounds.left);
+      expect(targetRect.top, offset.dy + paragraph.paintBounds.top);
     } finally {
       EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(originalDpr);
     }
@@ -1351,6 +1403,16 @@ Future<void> testMain() async {
 class _MockCanvas implements Canvas {
   Rect? lastSourceRect;
   Rect? lastTargetRect;
+  Float64List? mockTransform;
+
+  @override
+  Float64List getTransform() =>
+      mockTransform ??
+      (Float64List(16)
+        ..[0] = 1.0
+        ..[5] = 1.0
+        ..[10] = 1.0
+        ..[15] = 1.0);
 
   @override
   void drawImageRect(Image image, Rect src, Rect dst, Paint paint) {


### PR DESCRIPTION
## Description

Fixes text pixelation in `WebParagraph` when rendered under a scaled canvas.

Previously, `WebParagraphPainter` only factored `window.devicePixelRatio` into the 2D backing canvas resolution and target bounds. When drawn onto a canvas transformed with scaling (e.g. via `Transform` or `canvas.scale`), the paragraph bitmap was rasterized at base DPR resolution and subsequently upscaled by Skia/Skwasm with point sampling, causing blurry or pixelated text.

This change:
- Extracts the affine scale components from `canvas.getTransform()`.
- Combines canvas scale with `window.devicePixelRatio` (`totalScale = canvasScale * dpr`) when allocating and drawing to the offscreen 2D canvas.
- Updates `sourceRect` and `targetRect` to map 1:1 with device pixels under the active canvas transform.
- Adds unit tests verifying raster buffer sizing and target mapping under non-identity canvas transforms.

## Related Issues
Fixes https://github.com/flutter/flutter/issues/188323

## Tests
- Added unit test: `WebParagraph correctly handles canvas scale and translation` in `paragraph_test.dart`.