### PR TITLE
et: Fix compile_commands.json post-processing

### DIFF
--- a/docs/engine/contributing/Setting-up-the-Engine-development-environment.md
+++ b/docs/engine/contributing/Setting-up-the-Engine-development-environment.md
@@ -100,6 +100,14 @@ gclient sync
 
 ## Editor autocomplete support
 
+Building with `et` writes two compilation databases into the build directory:
+
+* `src/out/<config>/compile_commands.json` is GN's own database, covering C,
+  C++ and Objective-C++. GN rewrites it whenever the build files are
+  regenerated.
+* `src/out/<config>/lsp/compile_commands.json` includes additional targets,
+  including Swift. This is the one that should be used by editors and LSPs.
+
 ### Xcode [Objective-C++]
 
 On Mac, you can simply use Xcode (e.g., `open out/host_debug_unopt/flutter_engine.xcodeproj`).
@@ -108,7 +116,7 @@ On Mac, you can simply use Xcode (e.g., `open out/host_debug_unopt/flutter_engin
 
 VSCode can provide some IDE features using the [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools). It will provide basic support on install without needing any additional configuration. There will probably be some issues, like header not found errors and incorrect jump to definitions.
 
-Intellisense can also use our `compile_commands.json` for more robust functionality. Either symlink `src/out/compile_commands.json` to the project root at `src` or provide an absolute path to it in the `c_cpp_properties.json` config file. See ["compile commands" in the c_cpp_properties.json reference](https://code.visualstudio.com/docs/cpp/c-cpp-properties-schema-reference). This will likely resolve the basic issues mentioned above.
+Intellisense can also use our `compile_commands.json` for more robust functionality. Either symlink `src/out/<configuration>/lsp/compile_commands.json` to the project root at `src` or provide an absolute path to it in the `c_cpp_properties.json` config file. See ["compile commands" in the c_cpp_properties.json reference](https://code.visualstudio.com/docs/cpp/c-cpp-properties-schema-reference). This will likely resolve the basic issues mentioned above.
 
 The easiest way to do this is create a [multi-root workspace](https://code.visualstudio.com/docs/editor/workspaces/workspaces#_multiroot-workspaces) that includes the Flutter SDK. For example, something like this:
 
@@ -134,7 +142,7 @@ Then, install the [`clangd` extension](https://marketplace.visualstudio.com/item
     ],
     "clangd.path": "engine/src/flutter/buildtools/mac-arm64/clang/bin/clangd",
     "clangd.arguments": [
-        "--compile-commands-dir=engine/src/out/host_debug_unopt_arm64"
+        "--compile-commands-dir=engine/src/out/host_debug_unopt_arm64/lsp"
     ],
     "clang-format.executable": "engine/src/flutter/buildtools/mac-arm64/clang/bin/clang-format"
 }
@@ -153,7 +161,7 @@ For adding IDE support to the Java code in the engine with VSCode, see ["Using V
 
 ### Zed Editor
 
-[Zed](https://zed.dev/) can be used to edit C++ code in the Engine. To enable analysis and auto-completion, symlink `src/out/compile_commands.json` to the project root at `src`.
+[Zed](https://zed.dev/) can be used to edit C++ code in the Engine. To enable analysis and auto-completion, symlink `src/out/<configuration>/lsp/compile_commands.json` to the project root at `src`.
 
 ### cquery/ccls (multiple editors) [C/C++/Objective-C++]
 
@@ -165,9 +173,9 @@ To set up:
 1. Install cquery
     1. `brew install cquery` or `brew install ccls` on osx; or
     1. [Build from source](https://github.com/cquery-project/cquery/wiki/Getting-started)
-1. Generate compile_commands.json which our GN tool already does such as via `src/flutter/tools/gn --ios --unoptimized`
+1. Generate compile_commands.json, which `et build` does as part of any build.
 1. Install an editor extension such as [VSCode-cquery](https://marketplace.visualstudio.com/items?itemName=cquery-project.cquery) or [vscode-ccls](https://marketplace.visualstudio.com/items?itemName=ccls-project.ccls)
-    1. VSCode-query and vscode-ccls requires the compile_commands.json to be at the project root. Copy or symlink `src/out/compile_commands.json` to `src/` or `src/flutter` depending on which folder you want to open.
+    1. VSCode-query and vscode-ccls requires the compile_commands.json to be at the project root. Copy or symlink `src/out/<configuration>/lsp/compile_commands.json` to `src/` or `src/flutter` depending on which folder you want to open.
     1. Follow [Setting up the extension](https://github.com/cquery-project/cquery/wiki/Visual-Studio-Code#setting-up-the-extension) to configure VSCode-query.
 
 ![](https://media.giphy.com/media/xjIrToRDVvMPvjkBcl/giphy.gif)

--- a/engine/src/flutter/tools/clangd_check/bin/main.dart
+++ b/engine/src/flutter/tools/clangd_check/bin/main.dart
@@ -88,10 +88,12 @@ void main(List<String> args) {
       // This now looks like "../../flutter/buildtools/{platform}/{...}"
       final String commandPath = p.dirname(command.split(' ').first);
 
-      // Find the canonical path to the command (i.e. resolve "../" and ".")
+      // Find the canonical path to the command (i.e. resolve "../" and ".").
+      // Relative paths in `command` are relative to the entry's `directory`,
+      // not necessarily the directory the database was read from.
       //
       // This now looks like "/path/to/engine/src/flutter/buildtools/{platform}/{...}"
-      final String path = p.canonicalize(p.join(compileCommandsDir, commandPath));
+      final String path = p.canonicalize(p.join(directory, commandPath));
 
       // Extract which platform we're building for (e.g. linux-x64, mac-arm64, mac-x64).
       final String platform = RegExp(r'buildtools/([^/]+)/').firstMatch(path)!.group(1)!;

--- a/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
@@ -330,25 +330,43 @@ final class BuildRunner extends Runner {
       return false;
     }
 
+    // Generate the build files.
     if (runGn) {
       if (!await _runGn(eventHandler)) {
         return false;
       }
+    }
+
+    // Invoke the build.
+    //
+    // Ninja regenerates the build files first, build.ninja.stamp is stale.
+    // We don't return immediately on failure, since the post-gn steps below
+    // should run either way.
+    var ninjaOk = true;
+    if (runNinja) {
+      ninjaOk = await _runNinja(eventHandler);
+    }
+
+    // Update the compilation databases.
+    //
+    // Runs after ninja because it rewrites compile_commands.json in place, and
+    // ninja's regeneration would otherwise overwrite that.
+    if (runGn || runNinja) {
       await _postGn();
     }
 
-    if (runNinja) {
-      if (!await _runNinja(eventHandler)) {
-        return false;
-      }
+    if (!ninjaOk) {
+      return false;
     }
 
+    // Run generator scripts such as `felt`.
     if (runGenerators) {
       if (!await _runGenerators(eventHandler)) {
         return false;
       }
     }
 
+    // Run the build's tests.
     if (runTests) {
       if (!await _runTests(eventHandler)) {
         return false;
@@ -383,14 +401,19 @@ final class BuildRunner extends Runner {
     return result.ok;
   }
 
-  /// Generates and returns the ninja compilation database for the build.
+  /// Generates and returns the ninja compilation database for Swift targets.
   ///
-  /// GN's default compile_commands.json generator only exports C and C++
-  /// targets and omits custom wrapper rules like `swiftc.py`. This invokes
-  /// `ninja -t compdb` to retrieve all compilation targets in the build graph
-  /// and falls back to reading `compile_commands.json` from disk if the command
-  /// fails or returns empty.
-  Future<String?> _getCompilationDatabase() async {
+  /// GN's `--export-compile-commands` doesn't emit the `swiftc` invocations
+  /// needed for SourceKit LSP.
+  ///
+  /// We intentionally limit to the `swift` rule here, since otherwise, `ninja
+  /// -t compdb` includes every edge in the build graph, including link, copy,
+  /// and phony edges, which can result in duplicate mappings for some files and
+  /// LSPs selecting the wrong one.
+  ///
+  /// Returns the empty string if the command fails or the build has no Swift
+  /// targets.
+  Future<String> _getSwiftCompilationDatabase() async {
     final String ninjaPath = p.join(
       engineSrcDir.parent.parent.path,
       'third_party',
@@ -399,41 +422,53 @@ final class BuildRunner extends Runner {
     );
     final String outDir = p.join(engineSrcDir.path, 'out', build.ninja.config);
     final ProcessRunnerResult result = await processRunner.runProcess(
-      <String>[ninjaPath, '-t', 'compdb'],
+      <String>[ninjaPath, '-t', 'compdb', 'swift'],
       workingDirectory: io.Directory(outDir),
       failOk: true,
     );
-    if (result.exitCode == 0 && result.stdout.isNotEmpty) {
-      return result.stdout;
-    }
-    final commandsFile = io.File(p.join(outDir, 'compile_commands.json'));
-    if (commandsFile.existsSync()) {
-      return commandsFile.readAsString();
-    }
-    return null;
+    return result.exitCode == 0 ? result.stdout : '';
   }
 
   /// Performs post-GN build steps.
   ///
-  /// Retrieves the full compilation database from Ninja and processes it to
-  /// strip compiler wrapper prefixes and expand Swift compilation rules for IDE
-  /// language server compatibility.
+  /// Performs two main functions:
+  /// * Rewrites compile-commands.json in-place to strip RBE wrappers.
+  /// * Generates a separate lsp/compile-commands.json for LSPs, which includes
+  ///   the Swift compile.
   Future<void> _postGn() async {
     if (dryRun) {
       return;
     }
 
-    final String? rawContents = await _getCompilationDatabase();
-    if (rawContents == null) {
+    final String outDir = p.join(engineSrcDir.path, 'out', build.ninja.config);
+    final commandsFile = io.File(p.join(outDir, 'compile_commands.json'));
+    if (!commandsFile.existsSync()) {
       return;
     }
 
-    final String updated = updateCompilationDatabase(rawContents);
-    final commandsFile = io.File(
-      p.join(engineSrcDir.path, 'out', build.ninja.config, 'compile_commands.json'),
+    // Strip wrappers in-place in GN's database.
+    //
+    // `clang_tidy` and `clangd_check` read that file directly and and don't
+    // understand rewrapper.
+    final String contents = await commandsFile.readAsString();
+    final String stripped = stripCompilerWrappers(contents);
+    if (contents != stripped) {
+      await commandsFile.writeAsString(stripped);
+    }
+
+    // Emit a compilation database for LSPs.
+    //
+    // GN rewrites compile_commands.json whenever the build files are
+    // regenerated, by et or by anything else that runs ninja. Keep the LSP
+    // database separate so it doesn't constantly get stomped.
+    final String updated = updateCompilationDatabase(
+      stripped,
+      await _getSwiftCompilationDatabase(),
     );
-    if (rawContents != updated || !commandsFile.existsSync()) {
-      await commandsFile.writeAsString(updated);
+    final lspFile = io.File(p.join(outDir, 'lsp', 'compile_commands.json'));
+    await lspFile.parent.create(recursive: true);
+    if (!lspFile.existsSync() || await lspFile.readAsString() != updated) {
+      await lspFile.writeAsString(updated);
     }
   }
 

--- a/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/update_compdb.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/update_compdb.dart
@@ -61,12 +61,39 @@ String expandSwiftcCommands(String contents) {
 
 /// Post-processes the contents of a `compile_commands.json` file.
 ///
-/// Strips compiler wrapper prefixes (such as rewrapper and ccache) from clang
-/// commands, and converts GN `swiftc.py` invocations into native `swiftc`
-/// commands expanded per-file for SourceKit-LSP.
-String updateCompilationDatabase(String contents) {
-  contents = stripCompilerWrappers(contents);
-  return expandSwiftcCommands(contents);
+/// [compileCommands] is GN's exported database and [swiftCompileCommands] the
+/// output of `ninja -t compdb swift`. Strips compiler wrapper prefixes (such as
+/// rewrapper and ccache) from [compileCommands], converts the GN `swiftc.py`
+/// invocations in [swiftCompileCommands] into native `swiftc` commands expanded
+/// per-file for SourceKit-LSP, and appends them.
+///
+/// GN's exporter has no Swift tool type, so only the Swift entries are sourced
+/// from ninja. Ninja's unrestricted database also describes link, copy, and
+/// phony edges, whose `file` fields shadow the real compile command for the
+/// files they name.
+String updateCompilationDatabase(String compileCommands, String swiftCompileCommands) {
+  final String stripped = stripCompilerWrappers(compileCommands);
+  if (swiftCompileCommands.trim().isEmpty) {
+    return stripped;
+  }
+  final entries = convert.jsonDecode(expandSwiftcCommands(swiftCompileCommands)) as List<Object?>;
+  return entries.isEmpty ? stripped : _appendEntries(stripped, entries);
+}
+
+/// Appends [entries] to the JSON array in [database].
+String _appendEntries(String database, List<Object?> entries) {
+  final int close = database.lastIndexOf(']');
+  if (close < 0) {
+    return database;
+  }
+  String head = database.substring(0, close).trimRight();
+  // GN has emitted a trailing comma after the final entry, which would
+  // otherwise double up with the separator below.
+  if (head.endsWith(',')) {
+    head = head.substring(0, head.length - 1);
+  }
+  final String rendered = entries.map(_jsonEncoder.convert).join(',\n  ');
+  return '$head${head.endsWith('[') ? '' : ','}\n  $rendered\n]\n';
 }
 
 /// Expands a single `swiftc.py` [entry] into per-file `swiftc` compilation entries.

--- a/engine/src/flutter/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
@@ -810,6 +810,170 @@ void main() {
     }
   });
 
+  test('GlobalBuildRunner merges Swift commands into compile_commands.json', () async {
+    final io.Directory emptyDir = io.Directory.systemTemp.createTempSync(
+      'build_config_runner.test',
+    );
+    try {
+      final srcDir = io.Directory(path.join(emptyDir.path, 'src'));
+      final outDir = io.Directory(path.join(srcDir.path, 'out', 'build_name'))
+        ..createSync(recursive: true);
+      final file = io.File(path.join(outDir.path, 'compile_commands.json'));
+      const gnDatabase = '''
+[
+  {
+    "file": "../../flutter/assets/asset_manager.cc",
+    "directory": "/src/out/build_name",
+    "command": "../../flutter/buildtools/mac-arm64/clang/bin/clang++ -c ../../flutter/assets/asset_manager.cc"
+  }
+]
+''';
+      file.writeAsStringSync(gnDatabase, flush: true);
+
+      const swiftDatabase = '''
+[
+  {
+    "file": "../../flutter/bar.swift",
+    "directory": "/src/out/build_name",
+    "command": "python3 ../../build/toolchain/darwin/swiftc.py -module-name Bar ../../flutter/bar.swift"
+  }
+]
+''';
+
+      final commandLog = <FakeCommandLogEntry>[];
+      final Build targetBuild = buildConfig.builds[0];
+      final buildRunner = BuildRunner(
+        platform: FakePlatform(operatingSystem: Platform.linux, numberOfProcessors: 32),
+        processRunner: ProcessRunner(
+          processManager: _fakeProcessManager(
+            commandLog: commandLog,
+            ninjaResult: io.ProcessResult(1, 0, swiftDatabase, ''),
+          ),
+        ),
+        abi: ffi.Abi.linuxX64,
+        engineSrcDir: srcDir,
+        build: targetBuild,
+        runNinja: false,
+        runGenerators: false,
+        runTests: false,
+      );
+      await buildRunner.run((RunnerEvent event) {});
+
+      // Verify only the Swift rule is queried: an unrestricted compdb also
+      // describes link, copy, and phony edges, which shadow the real compile
+      // command for the files they name.
+      final FakeCommandLogEntry compdbEntry = commandLog.firstWhere(
+        (FakeCommandLogEntry entry) => entry.command.contains('compdb'),
+      );
+      expect(compdbEntry.command.sublist(1), equals(<String>['-t', 'compdb', 'swift']));
+
+      // Verify GN's own database is left as GN wrote it. Anything merged into
+      // it is discarded the next time the build files are regenerated.
+      expect(file.readAsStringSync(), equals(gnDatabase));
+
+      final lspFile = io.File(path.join(outDir.path, 'lsp', 'compile_commands.json'));
+      final json = convert.jsonDecode(lspFile.readAsStringSync()) as List<dynamic>;
+      expect(json.length, equals(2));
+      // Verify GN's entry survives untouched alongside the appended Swift one.
+      expect(convert.jsonDecode(gnDatabase), equals(<dynamic>[json[0]]));
+      final swiftEntry = json[1] as Map<String, dynamic>;
+      expect(swiftEntry['file'], equals('/src/flutter/bar.swift'));
+      expect(swiftEntry['command'], startsWith('swiftc '));
+    } finally {
+      emptyDir.deleteSync(recursive: true);
+    }
+  });
+
+  test('GlobalBuildRunner post-processes compile_commands.json when only ninja runs', () async {
+    final io.Directory emptyDir = io.Directory.systemTemp.createTempSync(
+      'build_config_runner.test',
+    );
+    try {
+      final srcDir = io.Directory(path.join(emptyDir.path, 'src'));
+      final outDir = io.Directory(path.join(srcDir.path, 'out', 'build_name'))
+        ..createSync(recursive: true);
+      final file = io.File(path.join(outDir.path, 'compile_commands.json'));
+      file.writeAsStringSync('''
+[
+  {
+    "file": "../../flutter/assets/asset_manager.cc",
+    "directory": "/src/out/build_name",
+    "command": "../../flutter/buildtools/mac-arm64/reclient/rewrapper --cfg=x ../../flutter/buildtools/mac-arm64/clang/bin/clang++ -c ../../flutter/assets/asset_manager.cc"
+  }
+]
+''', flush: true);
+
+      final Build targetBuild = buildConfig.builds[0];
+      final buildRunner = BuildRunner(
+        platform: FakePlatform(operatingSystem: Platform.linux, numberOfProcessors: 32),
+        processRunner: ProcessRunner(processManager: _fakeProcessManager(failUnknown: false)),
+        abi: ffi.Abi.linuxX64,
+        engineSrcDir: srcDir,
+        build: targetBuild,
+        runGn: false,
+        runGenerators: false,
+        runTests: false,
+      );
+      await buildRunner.run((RunnerEvent event) {});
+
+      // Ninja regenerates the build files on its own whenever they are stale,
+      // which restores GN's raw database. Verify the post-processing runs even
+      // though this build skipped the GN step.
+      expect(file.readAsStringSync(), isNot(contains('rewrapper')));
+      expect(io.File(path.join(outDir.path, 'lsp', 'compile_commands.json')).existsSync(), isTrue);
+    } finally {
+      emptyDir.deleteSync(recursive: true);
+    }
+  });
+
+  test('GlobalBuildRunner post-processes compile_commands.json after ninja', () async {
+    final io.Directory emptyDir = io.Directory.systemTemp.createTempSync(
+      'build_config_runner.test',
+    );
+    try {
+      final srcDir = io.Directory(path.join(emptyDir.path, 'src'));
+      final outDir = io.Directory(path.join(srcDir.path, 'out', 'build_name'))
+        ..createSync(recursive: true);
+      io.File(path.join(outDir.path, 'compile_commands.json')).writeAsStringSync('[\n]\n');
+
+      final commandLog = <FakeCommandLogEntry>[];
+      final Build targetBuild = buildConfig.builds[0];
+      final buildRunner = BuildRunner(
+        platform: FakePlatform(operatingSystem: Platform.linux, numberOfProcessors: 32),
+        processRunner: ProcessRunner(
+          processManager: _fakeProcessManager(commandLog: commandLog, failUnknown: false),
+        ),
+        abi: ffi.Abi.linuxX64,
+        engineSrcDir: srcDir,
+        build: targetBuild,
+        runGenerators: false,
+        runTests: false,
+      );
+      await buildRunner.run((RunnerEvent event) {});
+
+      // Ninja regenerates the build files at the start of its run, and that
+      // rewrites GN's compile_commands.json. Verify the post-processing runs
+      // after ninja, or its output is discarded before anything reads it.
+      final int gnIndex = commandLog.indexWhere(
+        (FakeCommandLogEntry entry) => entry.command.first.endsWith('gn'),
+      );
+      final int compdbIndex = commandLog.indexWhere(
+        (FakeCommandLogEntry entry) => entry.command.contains('compdb'),
+      );
+      final int ninjaIndex = commandLog.indexWhere(
+        (FakeCommandLogEntry entry) =>
+            entry.command.first.endsWith('ninja') && !entry.command.contains('compdb'),
+      );
+      expect(gnIndex, isNonNegative);
+      expect(ninjaIndex, isNonNegative);
+      expect(compdbIndex, isNonNegative);
+      expect(gnIndex, lessThan(ninjaIndex));
+      expect(ninjaIndex, lessThan(compdbIndex));
+    } finally {
+      emptyDir.deleteSync(recursive: true);
+    }
+  });
+
   test('Bootstrap collects reproxy status before shutting down reproxy', () async {
     final Build targetBuild = buildConfig.builds[0];
     final commandLog = <FakeCommandLogEntry>[];

--- a/engine/src/flutter/tools/pkg/engine_build_configs/test/update_compdb_test.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/test/update_compdb_test.dart
@@ -28,7 +28,7 @@ void main() {
   }
 ]
 ''';
-      expect(updateCompilationDatabase(input), equals(expected));
+      expect(updateCompilationDatabase(input, '[]'), equals(expected));
       expect(stripCompilerWrappers(input), equals(expected));
     });
 
@@ -51,7 +51,7 @@ void main() {
   }
 ]
 ''';
-      expect(updateCompilationDatabase(input), equals(expected));
+      expect(updateCompilationDatabase(input, '[]'), equals(expected));
       expect(stripCompilerWrappers(input), equals(expected));
     });
 
@@ -74,7 +74,7 @@ void main() {
   }
 ]
 ''';
-      expect(updateCompilationDatabase(input), equals(expected));
+      expect(updateCompilationDatabase(input, '[]'), equals(expected));
       expect(stripCompilerWrappers(input), equals(expected));
     });
 
@@ -88,7 +88,7 @@ void main() {
   }
 ]
 ''';
-      expect(updateCompilationDatabase(input), equals(input));
+      expect(updateCompilationDatabase(input, '[]'), equals(input));
       expect(stripCompilerWrappers(input), equals(input));
     });
   });
@@ -104,7 +104,7 @@ void main() {
   }
 ]
 ''';
-      expect(updateCompilationDatabase(input), equals(input));
+      expect(updateCompilationDatabase(input, '[]'), equals(input));
       expect(stripCompilerWrappers(input), equals(input));
       expect(expandSwiftcCommands(input), equals(input));
     });
@@ -119,7 +119,7 @@ void main() {
   }
 ]
 ''';
-      final String output = updateCompilationDatabase(input);
+      final String output = expandSwiftcCommands(input);
       final json = convert.jsonDecode(output) as List<dynamic>;
       expect(json.length, equals(1));
       final entry = json[0] as Map<String, dynamic>;
@@ -146,7 +146,7 @@ void main() {
   }
 ]
 ''';
-      final String output = updateCompilationDatabase(input);
+      final String output = expandSwiftcCommands(input);
       final json = convert.jsonDecode(output) as List<dynamic>;
       final entry = json[0] as Map<String, dynamic>;
       final List<String> args = splitShellWords(entry['command'] as String);
@@ -176,7 +176,7 @@ void main() {
   }
 ]
 ''';
-      final String output = updateCompilationDatabase(input);
+      final String output = expandSwiftcCommands(input);
       final json = convert.jsonDecode(output) as List<dynamic>;
       final entry = json[0] as Map<String, dynamic>;
       final List<String> args = splitShellWords(entry['command'] as String);
@@ -211,7 +211,7 @@ void main() {
   }
 ]
 ''';
-      final String output = updateCompilationDatabase(input);
+      final String output = expandSwiftcCommands(input);
       final json = convert.jsonDecode(output) as List<dynamic>;
       final entry = json[0] as Map<String, dynamic>;
       final List<String> args = splitShellWords(entry['command'] as String);
@@ -241,7 +241,7 @@ void main() {
   }
 ]
 ''';
-      final String output = updateCompilationDatabase(input);
+      final String output = expandSwiftcCommands(input);
       final json = convert.jsonDecode(output) as List<dynamic>;
       final entry = json[0] as Map<String, dynamic>;
       final command = entry['command'] as String;
@@ -273,7 +273,7 @@ void main() {
   }
 ]
 ''';
-      final String output = updateCompilationDatabase(input);
+      final String output = expandSwiftcCommands(input);
       final json = convert.jsonDecode(output) as List<dynamic>;
       expect(json.length, equals(2));
       final entry1 = json[0] as Map<String, dynamic>;
@@ -281,6 +281,56 @@ void main() {
       expect(entry1['file'], equals('/flutter/bar.swift'));
       expect(entry2['file'], equals('/flutter/baz.swift'));
       expect(entry1['command'], equals(entry2['command']));
+    });
+  });
+
+  group('updateCompilationDatabase', () {
+    const gnDatabase = r'''
+[
+  {
+    "file": "../../flutter/foo.cc",
+    "directory": "/out/config",
+    "command": "../../clang/bin/clang++ -c ../../flutter/foo.cc"
+  }
+]
+''';
+    const swiftDatabase = r'''
+[
+  {
+    "file": "../../flutter/bar.swift",
+    "directory": "/out/config",
+    "command": "python3 ../../flutter/tools/swiftc.py -module-name Bar ../../flutter/bar.swift"
+  }
+]
+''';
+
+    test("appends the Swift entries to GN's database", () {
+      final String output = updateCompilationDatabase(gnDatabase, swiftDatabase);
+      final json = convert.jsonDecode(output) as List<dynamic>;
+      expect(json.length, equals(2));
+      // Verify GN's entries survive untouched, since they are the ones clangd
+      // already relies on.
+      expect(convert.jsonDecode(gnDatabase), equals(<dynamic>[json[0]]));
+      final swiftEntry = json[1] as Map<String, dynamic>;
+      expect(swiftEntry['file'], equals('/flutter/bar.swift'));
+      expect(swiftEntry['command'], startsWith('swiftc '));
+    });
+
+    test("leaves GN's database untouched when there are no Swift targets", () {
+      expect(updateCompilationDatabase(gnDatabase, '[\n]\n'), equals(gnDatabase));
+      expect(updateCompilationDatabase(gnDatabase, ''), equals(gnDatabase));
+    });
+
+    test('appends to a database whose final entry carries a trailing comma', () {
+      // GN has emitted a trailing comma before the closing bracket.
+      final String trailingComma = gnDatabase.replaceFirst('  }\n]', '  },\n]');
+      final String output = updateCompilationDatabase(trailingComma, swiftDatabase);
+      expect(convert.jsonDecode(output), hasLength(2));
+    });
+
+    test('appends to an empty database', () {
+      final String output = updateCompilationDatabase('[\n]\n', swiftDatabase);
+      expect(convert.jsonDecode(output), hasLength(1));
     });
   });
 

--- a/engine/src/flutter/tools/pkg/engine_repo_tools/lib/engine_repo_tools.dart
+++ b/engine/src/flutter/tools/pkg/engine_repo_tools/lib/engine_repo_tools.dart
@@ -295,8 +295,9 @@ final class Output {
   /// The directory containing the output target.
   final io.Directory path;
 
-  /// The `compile_commands.json` file that should exist for this output target.
+  /// The GN `compile_commands.json` for this output target.
   ///
+  /// This is GN's database, and includes C, C++ and Objective-C++ targets.
   /// The file may not exist.
   io.File get compileCommandsJson {
     return io.File(p.join(path.path, 'compile_commands.json'));


### PR DESCRIPTION
Previously, `_postGn` ran immediately after GN and rewrote GN's `compile_commands.json` in-place with the output of `ninja -t compdb` in order to pick up additional commands not emitted by `gn` but needed by language servers, such as `swiftc` invocations.

However, `ninja -t compdb` includes every edge in the build graph, including copy and link commands, not just compiles. LSPs key off the `file` field, and the additional non-compile edges produced additional entries for some files that shadow the compile command that LSPs need. Among others, some of the public header copy rules ended up causing symbols in `embedder.h` and others to stop resolving correctly.

This reverts the post-build rewriting of `compile-commands.json` to what it was before #189761: just stripping RBE rewrapper prefxies from C++/Objective-C++ compile commands. The in-place rewriting is still required because `clang_tidy` and `clangd_check` use it directly and don't understand rewrapper prefixes.

Once the in-place cleanup is done, we now run `ninja -t compdb swift` to get *just* the Swift compilation commands required rather than the whole graph, and tack those onto a new output at `lsp/compile-commands.json` which can be used by LSPs. This has the additional benefit of sticking around in case any tools (run_test.py for example) issue `gn` invocations directly, which stomps the compilation database.

Followup to: https://github.com/flutter/flutter/pull/189761
Fixes: https://github.com/flutter/flutter/issues/185741

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant in-code documentation (doc comments with `///`).
- [X] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
