### PR TITLE
[Flutter GPU] Reuse HostBuffer blocks after a block boundary, and view only the write

### DIFF
--- a/engine/src/flutter/lib/gpu/lib/src/buffer.dart
+++ b/engine/src/flutter/lib/gpu/lib/src/buffer.dart
@@ -264,15 +264,21 @@ base class HostBuffer {
     // So reset the padding to zero.
     padding %= _gpuContext.minimumUniformByteAlignment;
     if (_offsetCursor + padding >= blockLengthInBytes) {
-      DeviceBuffer buffer = _allocateNewBlock(blockLengthInBytes);
-      _buffers[_frameCursor].add(buffer);
       _bufferCursor++;
+      // [reset] rewinds the cursors without dropping the blocks, so a block
+      // allocated for this position on an earlier frame is reused here rather
+      // than replaced.
+      final List<DeviceBuffer> frameBuffers = _buffers[_frameCursor];
+      if (_bufferCursor >= frameBuffers.length) {
+        frameBuffers.add(_allocateNewBlock(blockLengthInBytes));
+      }
+      final DeviceBuffer buffer = frameBuffers[_bufferCursor];
       _offsetCursor = bytes.lengthInBytes;
 
       return BufferView(
         buffer,
         offsetInBytes: 0,
-        lengthInBytes: blockLengthInBytes,
+        lengthInBytes: bytes.lengthInBytes,
       );
     }
 

--- a/engine/src/flutter/testing/dart/gpu_test.dart
+++ b/engine/src/flutter/testing/dart/gpu_test.dart
@@ -303,6 +303,44 @@ void main() async {
     expect(view0.buffer, equals(view1.buffer));
   }, skip: !(impellerEnabled && flutterGpuEnabled));
 
+  test('HostBuffer.emplace across a block boundary views only the write', () async {
+    final int blockLength = gpu.gpuContext.minimumUniformByteAlignment * 2;
+    final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer(
+      blockLengthInBytes: blockLength,
+    );
+
+    hostBuffer.emplace(Uint8List(blockLength).buffer.asByteData());
+    final gpu.BufferView view = hostBuffer.emplace(
+      Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
+    );
+
+    expect(view.offsetInBytes, 0);
+    expect(view.lengthInBytes, 4);
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
+  test('HostBuffer reuses blocks allocated after a block boundary', () async {
+    final int blockLength = gpu.gpuContext.minimumUniformByteAlignment * 2;
+    final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer(
+      blockLengthInBytes: blockLength,
+    );
+
+    hostBuffer.emplace(Uint8List(blockLength).buffer.asByteData());
+    final gpu.BufferView view0 = hostBuffer.emplace(
+      Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
+    );
+
+    for (var i = 0; i < hostBuffer.frameCount; i++) {
+      hostBuffer.reset();
+    }
+
+    hostBuffer.emplace(Uint8List(blockLength).buffer.asByteData());
+    final gpu.BufferView view1 = hostBuffer.emplace(
+      Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
+    );
+
+    expect(view1.buffer, equals(view0.buffer));
+  }, skip: !(impellerEnabled && flutterGpuEnabled));
+
   test('GpuContext.createDeviceBuffer', () async {
     final gpu.DeviceBuffer deviceBuffer = gpu.gpuContext.createDeviceBuffer(
       gpu.StorageMode.hostVisible,


### PR DESCRIPTION
`HostBuffer._allocateEmplacement`'s block-rollover branch always allocated a new block and appended it, without checking whether the frame slot already held one at that cursor from an earlier frame. `reset()` only rewinds the cursors, so every frame whose transient writes crossed a block boundary appended another `blockLengthInBytes` block, for the life of the `HostBuffer`. The same branch also returned a `BufferView` describing the whole block rather than the write it had just placed.

Fixes https://github.com/flutter/flutter/issues/192392

The off-by-one in the size check itself is left alone here — that is #186526, with PR #186539 already open for it.

The two new tests need a block boundary, so they create a `HostBuffer` with a two-alignment block rather than the 1 MB default. The existing `HostBuffer reuses DeviceBuffers after N frames` test only ever exercises the first block, which is allocated in the constructor, and that is why the missing reuse of later blocks went unnoticed.

Verified locally on macOS/Metal, `host_debug_unopt_arm64`. `gpu_test.dart` run under `flutter_tester --enable-impeller --impeller-backend=metal --enable-flutter-gpu` passes: 99 passed, 1 skipped. Reverting only the `buffer.dart` change and rebuilding makes exactly the two new tests fail, which is what they are there for:

```
HostBuffer.emplace across a block boundary views only the write
  Expected: <4>
    Actual: <512>
HostBuffer reuses blocks allocated after a block boundary
  Expected: <Instance of 'DeviceBuffer'>
    Actual: <Instance of 'DeviceBuffer'>
```

The reproduction from the issue, run on macOS/Metal against a 3.47.0 SDK with the same patch applied:

| | before | after |
|---|---|---|
| distinct `DeviceBuffer`s over 200 crossings | 200 | 4 (`frameCount`) |
| blocks never handed back | 196 (~191 MB of blocks) | 0 |
| rollover `BufferView.lengthInBytes` for a 256-byte write | 1024000 | 256 |

(An earlier version of this description also quoted process RSS. I've dropped it: the reproduction allocates 200 MB of `ByteData` of its own, so RSS varies by ~120 MB between runs of the same binary and says nothing useful here. The block count is the stable measurement.)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md

