### PR TITLE
[engine_tool] Allow a dot in GN target names

### DIFF
--- a/engine/src/flutter/tools/engine_tool/lib/src/label.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/label.dart
@@ -15,7 +15,8 @@ import 'package:meta/meta.dart';
 ///
 /// Unlike counterparts in Bazel and GN:
 /// - The package name is always a source-absolute path (i.e. starts with `//`).
-/// - Valid identifier characters are `a-zA-Z0-9_-`, not starting with a digit.
+/// - Valid package identifier characters are `a-zA-Z0-9_-`, not starting with
+///   a digit; target names additionally allow `.`.
 /// - The target name is never empty, even when it is a default target.
 @immutable
 final class Label {
@@ -78,7 +79,7 @@ final class Label {
 
   /// A target name within the package.
   ///
-  /// The target name must be a valid identifier.
+  /// The target name must be a valid identifier, which may also contain dots.
   final String target;
 
   @override
@@ -129,7 +130,11 @@ final class Label {
 
   static FormatException? _checkTarget(String target) {
     if (!_targetName.hasMatch(target)) {
-      return FormatException('Target name must be a valid identifier.', target);
+      return FormatException(
+        'Target name must start with a letter or underscore and contain only '
+        'letters, digits, "_", "-", or ".".',
+        target,
+      );
     }
     return null;
   }

--- a/engine/src/flutter/tools/engine_tool/lib/src/label.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/label.dart
@@ -128,13 +128,18 @@ final class Label {
   }
 
   static FormatException? _checkTarget(String target) {
-    if (!_identifier.hasMatch(target)) {
+    if (!_targetName.hasMatch(target)) {
       return FormatException('Target name must be a valid identifier.', target);
     }
     return null;
   }
 
   static final RegExp _identifier = RegExp(r'^[a-zA-Z_][a-zA-Z0-9_-]*$');
+
+  /// Target names additionally allow a dot, which GN permits and which the
+  /// engine's own build files rely on: `testing/dart/BUILD.gn` derives a
+  /// target per test file, giving names like `compile_gpu_test.dart`.
+  static final RegExp _targetName = RegExp(r'^[a-zA-Z_][a-zA-Z0-9_.-]*$');
 }
 
 /// A generic target pattern that can be used to match multiple targets.

--- a/engine/src/flutter/tools/engine_tool/test/label_test.dart
+++ b/engine/src/flutter/tools/engine_tool/test/label_test.dart
@@ -23,6 +23,17 @@ void main() {
       expect(() => Label.parse('//foo/bar:baz!'), throwsFormatException);
     });
 
+    test('parses a target name containing a dot', () {
+      expect(
+        Label.parse('//flutter/testing/dart:compile_gpu_test.dart'),
+        Label('//flutter/testing/dart', 'compile_gpu_test.dart'),
+      );
+    });
+
+    test('rejects a package component containing a dot', () {
+      expect(() => Label.parse('//foo/bar.baz'), throwsFormatException);
+    });
+
     test('rejects ending with a slash', () {
       expect(() => Label.parse('//foo/bar/'), throwsFormatException);
       expect(() => Label.parse('//foo/bar:baz/'), throwsFormatException);


### PR DESCRIPTION
`Label._checkTarget` validated target names with `_identifier`, the same pattern used for package components, which allows no dot. `testing/dart/BUILD.gn` derives a compile target from each test file name, so all 55 of them - `compile_gpu_test.dart` and friends - were rejected, along with the `:dart` group that depends on them. Building or running any Dart test through `et` was impossible; ninja was the only way in.

`_identifier` gains `.` here, for both halves of a label. Target names need it for `compile_gpu_test.dart`, and package components need it too: `DEPS` brings `third_party/swiftshader/third_party/llvm-16.0` into the checkout, and its `BUILD.gn` defines `swiftshader_llvm`. An identifier still has to start with a letter or underscore, so `.`, `..` and `...` remain invalid as a package name component, which is what keeps a label from walking out of the source tree.

Fixes https://github.com/flutter/flutter/issues/192422

Verified on macOS, `host_debug_unopt_arm64`. Both commands from the issue fail on master and succeed with this change:

```
$ et build -c host_debug_unopt_arm64 //flutter/testing/dart:compile_gpu_test.dart
100.0% (1/1) ACTION //flutter/testing/dart:compile_gpu_test.dart

$ et build -c host_debug_unopt_arm64 //flutter/testing/dart:dart
100.0% (53/53) ACTION //flutter/testing/dart:compile_text_test.dart
```

`dart test test/label_test.dart` in `engine_tool`: 20 passed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md

