### PR TITLE
[flutter_tools] Gracefully handle EROFS and write-protected file system errors

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -1382,7 +1382,18 @@ void _handlePosixException(
       '$message. The target device is full.'
           '\n$e\n'
           'Free up space and try again.',
-    eperm || eacces || erofs => () {
+    erofs => () {
+      final errorBuffer = StringBuffer();
+      if (message != null && message.isNotEmpty) {
+        errorBuffer.writeln('$message.');
+      }
+      errorBuffer.writeln(
+        'The file system is read-only. Please ensure that the SDK and/or project '
+        'is installed in a location with write permissions.',
+      );
+      return errorBuffer.toString().trim();
+    }(),
+    eperm || eacces => () {
       final errorBuffer = StringBuffer();
       if (message != null && message.isNotEmpty) {
         errorBuffer.writeln('$message.');

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -96,8 +96,9 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
       final T result = operation();
       if (result is Future) {
         return (result.whenComplete(() {
-          ErrorHandlingFileSystem._noExitOnFailure = previousValue;
-        })) as T;
+              ErrorHandlingFileSystem._noExitOnFailure = previousValue;
+            }))
+            as T;
       }
       ErrorHandlingFileSystem._noExitOnFailure = previousValue;
       return result;
@@ -1367,8 +1368,9 @@ void _handlePosixException(
   // https://github.com/apple/darwin-xnu/blob/main/bsd/dev/dtrace/scripts/errno.d
   const eperm = 1;
   const enoent = 2;
-  const enospc = 28;
   const eacces = 13;
+  const enospc = 28;
+  const erofs = 30;
   // Catch errors and bail when:
   final String? errorMessage = switch (errorCode) {
     enoent =>
@@ -1380,7 +1382,7 @@ void _handlePosixException(
       '$message. The target device is full.'
           '\n$e\n'
           'Free up space and try again.',
-    eperm || eacces => () {
+    eperm || eacces || erofs => () {
       final errorBuffer = StringBuffer();
       if (message != null && message.isNotEmpty) {
         errorBuffer.writeln('$message.');
@@ -1443,16 +1445,18 @@ void _handleWindowsException(Exception e, String? message, int errorCode) {
   // https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes
   const kFileNotFound = 2;
   const kPathNotFound = 3;
-  const kDeviceFull = 112;
+  const kAccessDenied = 5;
+  const kWriteProtect = 19;
   const kSharingViolation = 32;
   const kLockViolation = 33;
-  const kUserMappedSectionOpened = 1224;
-  const kAccessDenied = 5;
-  const kFatalDeviceHardwareError = 483;
+  const kDeviceFull = 112;
   const kDeviceDoesNotExist = 433;
-  const kApplicationControlPolicyBlocked = 4551;
-  const kAccessDisabledByPolicy = 1260;
   const kSystemIntegrityPolicyViolation = 454;
+  const kFatalDeviceHardwareError = 483;
+  const kUserMappedSectionOpened = 1224;
+  const kAccessDisabledByPolicy = 1260;
+  const kPrivilegeNotHeld = 1314;
+  const kApplicationControlPolicyBlocked = 4551;
 
   // Catch errors and bail when:
   final String? errorMessage = switch (errorCode) {
@@ -1461,7 +1465,7 @@ void _handleWindowsException(Exception e, String? message, int errorCode) {
           '\n$e\n'
           'This can sometimes happen if the file was deleted or moved while the tool was running.'
           ' Try running "flutter clean" and try again.',
-    kAccessDenied =>
+    kAccessDenied || kWriteProtect || kPrivilegeNotHeld =>
       '$message. The flutter tool cannot access the file or directory.\n'
           'Please ensure that the SDK and/or project is installed in a location '
           'that has read/write permissions for the current user.',

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -479,9 +479,8 @@ void main() {
 
       const writeMessage =
           'Flutter failed to write to a file at "dir/file".\n'
-          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
-          'Try running:\n'
-          r'  sudo chown -R $(whoami) /dir/file';
+          'The file system is read-only. Please ensure that the SDK and/or project '
+          'is installed in a location with write permissions.';
       expect(() async => file.writeAsBytes(<int>[0]), throwsToolExit(message: writeMessage));
       expect(() async => file.writeAsString(''), throwsToolExit(message: writeMessage));
       expect(() => file.writeAsBytesSync(<int>[0]), throwsToolExit(message: writeMessage));
@@ -489,20 +488,10 @@ void main() {
 
       const createMessage =
           'Flutter failed to create file at "dir/file".\n'
-          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
-          'Try running:\n'
-          r'  sudo chown -R $(whoami) /dir';
+          'The file system is read-only. Please ensure that the SDK and/or project '
+          'is installed in a location with write permissions.';
       expect(() => file.createSync(), throwsToolExit(message: createMessage));
-      expect(
-        () async => file.createSync(recursive: true),
-        throwsA(
-          isA<ToolExit>().having(
-            (ToolExit e) => e.message,
-            'message',
-            isNot(contains('sudo chown')),
-          ),
-        ),
-      );
+      expect(() async => file.createSync(recursive: true), throwsToolExit(message: createMessage));
 
       final Directory parent = fileSystem.directory('parent')..createSync();
       final Directory childDir = parent.childDirectory('childDir');
@@ -520,20 +509,13 @@ void main() {
 
       const dirCreateMessage =
           'Flutter failed to create a directory at "parent/childDir".\n'
-          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
-          'Try running:\n'
-          r'  sudo chown -R $(whoami) /parent';
+          'The file system is read-only. Please ensure that the SDK and/or project '
+          'is installed in a location with write permissions.';
       expect(() async => childDir.create(), throwsToolExit(message: dirCreateMessage));
       expect(() => childDir.createSync(), throwsToolExit(message: dirCreateMessage));
       expect(
         () async => childDir.createSync(recursive: true),
-        throwsA(
-          isA<ToolExit>().having(
-            (ToolExit e) => e.message,
-            'message',
-            isNot(contains('sudo chown')),
-          ),
-        ),
+        throwsToolExit(message: dirCreateMessage),
       );
     });
 
@@ -786,9 +768,8 @@ void main() {
 
       const writeMessage =
           'Flutter failed to write to a file at "dir/file".\n'
-          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
-          'Try running:\n'
-          r'  sudo chown -R $(whoami) /dir/file';
+          'The file system is read-only. Please ensure that the SDK and/or project '
+          'is installed in a location with write permissions.';
       expect(() async => file.writeAsBytes(<int>[0]), throwsToolExit(message: writeMessage));
       expect(() async => file.writeAsString(''), throwsToolExit(message: writeMessage));
       expect(() => file.writeAsBytesSync(<int>[0]), throwsToolExit(message: writeMessage));
@@ -796,20 +777,10 @@ void main() {
 
       const createMessage =
           'Flutter failed to create file at "dir/file".\n'
-          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
-          'Try running:\n'
-          r'  sudo chown -R $(whoami) /dir';
+          'The file system is read-only. Please ensure that the SDK and/or project '
+          'is installed in a location with write permissions.';
       expect(() => file.createSync(), throwsToolExit(message: createMessage));
-      expect(
-        () async => file.createSync(recursive: true),
-        throwsA(
-          isA<ToolExit>().having(
-            (ToolExit e) => e.message,
-            'message',
-            isNot(contains('sudo chown')),
-          ),
-        ),
-      );
+      expect(() async => file.createSync(recursive: true), throwsToolExit(message: createMessage));
 
       final Directory parent = fileSystem.directory('parent')..createSync();
       final Directory childDir = parent.childDirectory('childDir');
@@ -827,20 +798,13 @@ void main() {
 
       const dirCreateMessage =
           'Flutter failed to create a directory at "parent/childDir".\n'
-          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
-          'Try running:\n'
-          r'  sudo chown -R $(whoami) /parent';
+          'The file system is read-only. Please ensure that the SDK and/or project '
+          'is installed in a location with write permissions.';
       expect(() async => childDir.create(), throwsToolExit(message: dirCreateMessage));
       expect(() => childDir.createSync(), throwsToolExit(message: dirCreateMessage));
       expect(
         () async => childDir.createSync(recursive: true),
-        throwsA(
-          isA<ToolExit>().having(
-            (ToolExit e) => e.message,
-            'message',
-            isNot(contains('sudo chown')),
-          ),
-        ),
+        throwsToolExit(message: dirCreateMessage),
       );
     });
 

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -157,6 +157,8 @@ void main() {
     const kDeviceFull = 112;
     const kUserMappedSectionOpened = 1224;
     const kUserPermissionDenied = 5;
+    const kWriteProtect = 19;
+    const kPrivilegeNotHeld = 1314;
     const kFatalDeviceHardwareError = 483;
     const kDeviceDoesNotExist = 433;
 
@@ -225,6 +227,29 @@ void main() {
       expect(() => file.writeAsBytesSync(<int>[0]), throwsToolExit(message: expectedMessage));
       expect(() => file.writeAsStringSync(''), throwsToolExit(message: expectedMessage));
       expect(() => file.openSync(), throwsToolExit(message: expectedMessage));
+      expect(() => file.createSync(), throwsToolExit(message: expectedMessage));
+    });
+
+    testWithoutContext('when write protected or privilege not held', () async {
+      final fileSystem = ErrorHandlingFileSystem(
+        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        platform: windowsPlatform,
+      );
+      final File file = fileSystem.file('file');
+
+      exceptionHandler.addError(
+        file,
+        FileSystemOp.write,
+        FileSystemException('', file.path, const OSError('', kWriteProtect)),
+      );
+      exceptionHandler.addError(
+        file,
+        FileSystemOp.create,
+        FileSystemException('', file.path, const OSError('', kPrivilegeNotHeld)),
+      );
+
+      const expectedMessage = 'The flutter tool cannot access the file';
+      expect(() async => file.writeAsString(''), throwsToolExit(message: expectedMessage));
       expect(() => file.createSync(), throwsToolExit(message: expectedMessage));
     });
 
@@ -420,11 +445,96 @@ void main() {
     const eperm = 1;
     const enospc = 28;
     const eacces = 13;
+    const erofs = 30;
 
     late FileExceptionHandler exceptionHandler;
 
     setUp(() {
       exceptionHandler = FileExceptionHandler();
+    });
+
+    testWithoutContext('when on a read-only file system (erofs)', () async {
+      final fileSystem = ErrorHandlingFileSystem(
+        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        platform: linuxPlatform,
+      );
+      final Directory directory = fileSystem.directory('dir')..createSync();
+      final File file = directory.childFile('file');
+
+      exceptionHandler.addError(
+        file,
+        FileSystemOp.create,
+        FileSystemException('', file.path, const OSError('', erofs)),
+      );
+      exceptionHandler.addError(
+        file,
+        FileSystemOp.write,
+        FileSystemException('', file.path, const OSError('', erofs)),
+      );
+      exceptionHandler.addError(
+        file,
+        FileSystemOp.delete,
+        FileSystemException('', file.path, const OSError('', erofs)),
+      );
+
+      const writeMessage =
+          'Flutter failed to write to a file at "dir/file".\n'
+          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
+          'Try running:\n'
+          r'  sudo chown -R $(whoami) /dir/file';
+      expect(() async => file.writeAsBytes(<int>[0]), throwsToolExit(message: writeMessage));
+      expect(() async => file.writeAsString(''), throwsToolExit(message: writeMessage));
+      expect(() => file.writeAsBytesSync(<int>[0]), throwsToolExit(message: writeMessage));
+      expect(() => file.writeAsStringSync(''), throwsToolExit(message: writeMessage));
+
+      const createMessage =
+          'Flutter failed to create file at "dir/file".\n'
+          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
+          'Try running:\n'
+          r'  sudo chown -R $(whoami) /dir';
+      expect(() => file.createSync(), throwsToolExit(message: createMessage));
+      expect(
+        () async => file.createSync(recursive: true),
+        throwsA(
+          isA<ToolExit>().having(
+            (ToolExit e) => e.message,
+            'message',
+            isNot(contains('sudo chown')),
+          ),
+        ),
+      );
+
+      final Directory parent = fileSystem.directory('parent')..createSync();
+      final Directory childDir = parent.childDirectory('childDir');
+
+      exceptionHandler.addError(
+        childDir,
+        FileSystemOp.create,
+        FileSystemException('', childDir.path, const OSError('', erofs)),
+      );
+      exceptionHandler.addError(
+        childDir,
+        FileSystemOp.delete,
+        FileSystemException('', childDir.path, const OSError('', erofs)),
+      );
+
+      const dirCreateMessage =
+          'Flutter failed to create a directory at "parent/childDir".\n'
+          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
+          'Try running:\n'
+          r'  sudo chown -R $(whoami) /parent';
+      expect(() async => childDir.create(), throwsToolExit(message: dirCreateMessage));
+      expect(() => childDir.createSync(), throwsToolExit(message: dirCreateMessage));
+      expect(
+        () async => childDir.createSync(recursive: true),
+        throwsA(
+          isA<ToolExit>().having(
+            (ToolExit e) => e.message,
+            'message',
+            isNot(contains('sudo chown')),
+          ),
+        ),
+      );
     });
 
     testWithoutContext('when access is denied', () async {
@@ -643,10 +753,95 @@ void main() {
     const eperm = 1;
     const enospc = 28;
     const eacces = 13;
+    const erofs = 30;
     late FileExceptionHandler exceptionHandler;
 
     setUp(() {
       exceptionHandler = FileExceptionHandler();
+    });
+
+    testWithoutContext('when on a read-only file system (erofs)', () async {
+      final fileSystem = ErrorHandlingFileSystem(
+        delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
+        platform: macOSPlatform,
+      );
+      final Directory directory = fileSystem.directory('dir')..createSync();
+      final File file = directory.childFile('file');
+
+      exceptionHandler.addError(
+        file,
+        FileSystemOp.create,
+        FileSystemException('', file.path, const OSError('', erofs)),
+      );
+      exceptionHandler.addError(
+        file,
+        FileSystemOp.write,
+        FileSystemException('', file.path, const OSError('', erofs)),
+      );
+      exceptionHandler.addError(
+        file,
+        FileSystemOp.delete,
+        FileSystemException('', file.path, const OSError('', erofs)),
+      );
+
+      const writeMessage =
+          'Flutter failed to write to a file at "dir/file".\n'
+          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
+          'Try running:\n'
+          r'  sudo chown -R $(whoami) /dir/file';
+      expect(() async => file.writeAsBytes(<int>[0]), throwsToolExit(message: writeMessage));
+      expect(() async => file.writeAsString(''), throwsToolExit(message: writeMessage));
+      expect(() => file.writeAsBytesSync(<int>[0]), throwsToolExit(message: writeMessage));
+      expect(() => file.writeAsStringSync(''), throwsToolExit(message: writeMessage));
+
+      const createMessage =
+          'Flutter failed to create file at "dir/file".\n'
+          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
+          'Try running:\n'
+          r'  sudo chown -R $(whoami) /dir';
+      expect(() => file.createSync(), throwsToolExit(message: createMessage));
+      expect(
+        () async => file.createSync(recursive: true),
+        throwsA(
+          isA<ToolExit>().having(
+            (ToolExit e) => e.message,
+            'message',
+            isNot(contains('sudo chown')),
+          ),
+        ),
+      );
+
+      final Directory parent = fileSystem.directory('parent')..createSync();
+      final Directory childDir = parent.childDirectory('childDir');
+
+      exceptionHandler.addError(
+        childDir,
+        FileSystemOp.create,
+        FileSystemException('', childDir.path, const OSError('', erofs)),
+      );
+      exceptionHandler.addError(
+        childDir,
+        FileSystemOp.delete,
+        FileSystemException('', childDir.path, const OSError('', erofs)),
+      );
+
+      const dirCreateMessage =
+          'Flutter failed to create a directory at "parent/childDir".\n'
+          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.\n'
+          'Try running:\n'
+          r'  sudo chown -R $(whoami) /parent';
+      expect(() async => childDir.create(), throwsToolExit(message: dirCreateMessage));
+      expect(() => childDir.createSync(), throwsToolExit(message: dirCreateMessage));
+      expect(
+        () async => childDir.createSync(recursive: true),
+        throwsA(
+          isA<ToolExit>().having(
+            (ToolExit e) => e.message,
+            'message',
+            isNot(contains('sudo chown')),
+          ),
+        ),
+      );
     });
 
     testWithoutContext('when access is denied', () async {


### PR DESCRIPTION
When `flutter assemble` or other Flutter tool commands attempt to create build directories or write files to a read-only file system (such as Xcode build sandboxes or read-only volume mounts), the tool previously threw an unhandled `FileSystemException` instead of exiting cleanly with an actionable message.

This change:
- Handles POSIX errno 30 (`EROFS`, Read-only file system) in `_handlePosixException` in `packages/flutter_tools/lib/src/base/error_handling_io.dart`.
- Handles Windows `ERROR_WRITE_PROTECT` (19) and `ERROR_PRIVILEGE_NOT_HELD` (1314) in `_handleWindowsException`.
- Translates these errors into clean `ToolExit` messages instructing users to verify read/write permissions for the project and SDK.
- Adds comprehensive regression unit tests for Linux, macOS, and Windows in `packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart`.

Fixes [#83053](https://github.com/flutter/flutter/issues/83053)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
