### PR TITLE
[flutter_tools] Detect macOS TCC permission crashes and provide diagnostic guidance

### DIFF
--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -377,10 +377,7 @@ class DesktopLogReader extends DeviceLogReader {
         _inputController.add(data);
         stderrController.add(data);
       },
-      onError: (Object error, StackTrace stackTrace) {
-        _inputController.addError(error, stackTrace);
-        stderrController.addError(error, stackTrace);
-      },
+      onError: _inputController.addError,
       onDone: () => unawaited(stderrController.close()),
     );
   }

--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import 'application_package.dart';
@@ -43,7 +44,11 @@ abstract class DesktopDevice extends Device {
   final FileSystem _fileSystem;
   final OperatingSystemUtils _operatingSystemUtils;
   final _runningProcesses = <Process>{};
-  final _deviceLogReader = DesktopLogReader();
+  late final DesktopLogReader _deviceLogReader = createLogReader();
+
+  /// Creates the [DesktopLogReader] instance used by this device.
+  @protected
+  DesktopLogReader createLogReader() => DesktopLogReader();
 
   @override
   DevFSWriter createDevFSWriter(ApplicationPackage? app, String? userIdentifier) {
@@ -364,8 +369,28 @@ class DesktopLogReader extends DeviceLogReader {
   /// Adds the stdout and stderr streams of the provided [process] to [logLines].
   void listenToProcessOutput(Process process) {
     process.stdout.listen(_inputController.add, onError: _inputController.addError);
-    process.stderr.listen(_inputController.add, onError: _inputController.addError);
+    final stderrController = StreamController<List<int>>();
+    stderrController.stream.transform(utf8AllowMalformedLineDecoder).listen(handleStderrLine);
+
+    process.stderr.listen(
+      (List<int> data) {
+        _inputController.add(data);
+        stderrController.add(data);
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        _inputController.addError(error, stackTrace);
+        stderrController.addError(error, stackTrace);
+      },
+      onDone: () => unawaited(stderrController.close()),
+    );
   }
+
+  /// Called for each line written to stderr by the process.
+  ///
+  /// Subclasses can override this to inspect stderr for platform-specific
+  /// crash messages.
+  @protected
+  void handleStderrLine(String line) {}
 
   @override
   Stream<String> get logLines {

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -2,8 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
+import '../application_package.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -32,6 +34,41 @@ class MacOSDevice extends DesktopDevice {
   final ProcessManager _processManager;
   final Logger _logger;
   final OperatingSystemUtils _operatingSystemUtils;
+
+  /// The [MacOSLogReader] instance used by this device.
+  late final MacOSLogReader macosLogReader = MacOSLogReader(logger: _logger);
+
+  @override
+  DesktopLogReader createLogReader() => macosLogReader;
+
+  @override
+  Future<LaunchResult> startApp(
+    ApplicationPackage package, {
+    required DebuggingOptions debuggingOptions,
+    String? mainPath,
+    Map<String, dynamic> platformArgs = const <String, dynamic>{},
+    bool prebuiltApplication = false,
+    String? route,
+    String? userIdentifier,
+  }) async {
+    macosLogReader.bundlePath = null;
+    if (package is MacOSApp) {
+      try {
+        macosLogReader.bundlePath = package.applicationBundle(debuggingOptions.buildInfo);
+      } on UnimplementedError {
+        // Can be thrown by test fakes that do not implement applicationBundle.
+      }
+    }
+    return super.startApp(
+      package,
+      mainPath: mainPath,
+      route: route,
+      debuggingOptions: debuggingOptions,
+      platformArgs: platformArgs,
+      prebuiltApplication: prebuiltApplication,
+      userIdentifier: userIdentifier,
+    );
+  }
 
   @override
   Future<bool> isSupported() async => true;
@@ -152,4 +189,110 @@ class MacOSDevices extends PollingDeviceDiscovery {
 
   @override
   List<String> get wellKnownIds => const <String>['macos'];
+}
+
+/// A [DesktopLogReader] for macOS devices that inspects stderr for
+/// platform-specific crash signatures such as TCC privacy violations.
+class MacOSLogReader extends DesktopLogReader {
+  MacOSLogReader({required this.logger});
+
+  final Logger logger;
+
+  /// The path to the application bundle, if known.
+  String? bundlePath;
+
+  bool _detectedPrivacyCrash = false;
+
+  /// The message printed to stderr by macOS when an application crashes due to a
+  /// missing privacy usage description in its Info.plist.
+  @visibleForTesting
+  static const String kMacOSPrivacyCrashPattern =
+      'This app has crashed because it attempted to access privacy-sensitive '
+      'data without a usage description';
+
+  /// A pattern matching the missing usage description key name in the macOS crash log.
+  @visibleForTesting
+  static final RegExp privacyKeyPattern = RegExp(
+    r'must (?:supply|contain) an?\s+([A-Za-z0-9_]+)\s+key',
+  );
+
+  @override
+  void listenToProcessOutput(Process process) {
+    _detectedPrivacyCrash = false;
+    super.listenToProcessOutput(process);
+  }
+
+  @override
+  @visibleForTesting
+  void handleStderrLine(String line) {
+    if (_detectedPrivacyCrash) {
+      return;
+    }
+    checkPrivacyCrash(line);
+  }
+
+  /// Checks if [line] contains the macOS privacy crash signature and, if so,
+  /// prints an actionable diagnostic message.
+  @visibleForTesting
+  bool checkPrivacyCrash(String line) {
+    if (!line.contains(kMacOSPrivacyCrashPattern)) {
+      return false;
+    }
+    _detectedPrivacyCrash = true;
+    _printPrivacyDiagnostic(line);
+    return true;
+  }
+
+  void _printPrivacyDiagnostic(String line) {
+    final RegExpMatch? match = privacyKeyPattern.firstMatch(line);
+    final String? key = match?.group(1);
+    final keyNotice = key != null ? ' (requiring $key)' : '';
+    final keyDetail = key != null
+        ? 'Even if $key is already present in macos/Runner/Info.plist, '
+        : 'Even if the usage description key is already present in '
+              'macos/Runner/Info.plist, ';
+    final runCommand = bundlePath != null ? 'open "$bundlePath"' : 'open <path-to-app-bundle>';
+
+    final message = StringBuffer()
+      ..writeln()
+      ..writeln('═' * 80)
+      ..writeln('macOS Privacy Permission Crash Detected')
+      ..writeln('═' * 80)
+      ..write('The application crashed while requesting access to ')
+      ..writeln('privacy-sensitive data$keyNotice.')
+      ..writeln()
+      ..writeln(
+        'When launched from an IDE (such as VS Code or Android Studio) or '
+        'terminal via',
+      )
+      ..writeln(
+        '"flutter run", macOS Transparency, Consent, and Control (TCC) '
+        'attributes',
+      )
+      ..writeln(
+        'permission requests to the parent IDE or terminal process rather than '
+        'the',
+      )
+      ..writeln('application bundle.')
+      ..writeln()
+      ..write(keyDetail)
+      ..writeln('macOS terminates the process if the parent process lacks the usage')
+      ..writeln('description.')
+      ..writeln()
+      ..writeln('Workaround:')
+      ..writeln('1. Open the application bundle directly once from Terminal or Finder:')
+      ..writeln('   $runCommand')
+      ..writeln('   (or run the project directly from Xcode)')
+      ..writeln('2. Accept the permission prompt when shown.')
+      ..writeln(
+        '3. Once granted for your bundle identifier, subsequent "flutter run" '
+        'sessions',
+      )
+      ..writeln('   from your IDE will work.')
+      ..writeln()
+      ..writeln('See https://github.com/flutter/flutter/issues/70374 for more details.')
+      ..writeln('═' * 80);
+
+    logger.printError(message.toString());
+  }
 }

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -53,11 +53,7 @@ class MacOSDevice extends DesktopDevice {
   }) async {
     macosLogReader.bundlePath = null;
     if (package is MacOSApp) {
-      try {
-        macosLogReader.bundlePath = package.applicationBundle(debuggingOptions.buildInfo);
-      } on UnimplementedError {
-        // Can be thrown by test fakes that do not implement applicationBundle.
-      }
+      macosLogReader.bundlePath = package.applicationBundle(debuggingOptions.buildInfo);
     }
     return super.startApp(
       package,

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -249,46 +249,31 @@ class MacOSLogReader extends DesktopLogReader {
               'macos/Runner/Info.plist, ';
     final runCommand = bundlePath != null ? 'open "$bundlePath"' : 'open <path-to-app-bundle>';
 
-    final message = StringBuffer()
-      ..writeln()
-      ..writeln('═' * 80)
-      ..writeln('macOS Privacy Permission Crash Detected')
-      ..writeln('═' * 80)
-      ..write('The application crashed while requesting access to ')
-      ..writeln('privacy-sensitive data$keyNotice.')
-      ..writeln()
-      ..writeln(
-        'When launched from an IDE (such as VS Code or Android Studio) or '
-        'terminal via',
-      )
-      ..writeln(
-        '"flutter run", macOS Transparency, Consent, and Control (TCC) '
-        'attributes',
-      )
-      ..writeln(
-        'permission requests to the parent IDE or terminal process rather than '
-        'the',
-      )
-      ..writeln('application bundle.')
-      ..writeln()
-      ..write(keyDetail)
-      ..writeln('macOS terminates the process if the parent process lacks the usage')
-      ..writeln('description.')
-      ..writeln()
-      ..writeln('Workaround:')
-      ..writeln('1. Open the application bundle directly once from Terminal or Finder:')
-      ..writeln('   $runCommand')
-      ..writeln('   (or run the project directly from Xcode)')
-      ..writeln('2. Accept the permission prompt when shown.')
-      ..writeln(
-        '3. Once granted for your bundle identifier, subsequent "flutter run" '
-        'sessions',
-      )
-      ..writeln('   from your IDE will work.')
-      ..writeln()
-      ..writeln('See https://github.com/flutter/flutter/issues/70374 for more details.')
-      ..writeln('═' * 80);
+    logger.printError('''
 
-    logger.printError(message.toString());
+════════════════════════════════════════════════════════════════════════════════
+macOS Privacy Permission Crash Detected
+════════════════════════════════════════════════════════════════════════════════
+The application crashed while requesting access to privacy-sensitive data$keyNotice.
+
+When launched from an IDE (such as VS Code or Android Studio) or terminal via
+"flutter run", macOS Transparency, Consent, and Control (TCC) attributes
+permission requests to the parent IDE or terminal process rather than the
+application bundle.
+
+${keyDetail}macOS terminates the process if the parent process lacks the usage
+description.
+
+Workaround:
+1. Open the application bundle directly once from Terminal or Finder:
+   $runCommand
+   (or run the project directly from Xcode)
+2. Accept the permission prompt when shown.
+3. Once granted for your bundle identifier, subsequent "flutter run" sessions
+   from your IDE will work.
+
+See https://github.com/flutter/flutter/issues/70374 for more details.
+════════════════════════════════════════════════════════════════════════════════
+''');
   }
 }

--- a/packages/flutter_tools/templates/app/macos.tmpl/Runner/Info.plist
+++ b/packages/flutter_tools/templates/app/macos.tmpl/Runner/Info.plist
@@ -28,5 +28,12 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<!--
+	When developing privacy-sensitive features (e.g. camera, microphone, photos)
+	on macOS, launching via "flutter run" from an IDE attributes permission requests
+	to the parent IDE process instead of this app bundle. To grant permissions during
+	development, run the app bundle once directly via Finder, Terminal ("open <app>.app"),
+	or Xcode. See https://github.com/flutter/flutter/issues/70374 for more details.
+	-->
 </dict>
 </plist>

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -476,6 +476,32 @@ void main() {
 
       await subscription.cancel();
     });
+
+    testWithoutContext('forwards stderr errors to logLines without unhandled exceptions', () async {
+      final logReader = DesktopLogReader();
+      final receivedErrors = <Object>[];
+      final completer = Completer<void>();
+      final StreamSubscription<String> subscription = logReader.logLines.listen(
+        (_) {},
+        onError: (Object error) {
+          receivedErrors.add(error);
+          completer.complete();
+        },
+      );
+
+      final stderrController = StreamController<List<int>>();
+      final process = FakeProcess(stderr: stderrController.stream);
+      logReader.listenToProcessOutput(process);
+
+      stderrController.addError(Exception('test stderr error'));
+      await completer.future;
+
+      expect(receivedErrors, hasLength(1));
+      expect(receivedErrors.single, isA<Exception>());
+
+      await subscription.cancel();
+      logReader.dispose();
+    });
   });
 
   group('SingleLaunchLogReader', () {

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/macos/application_package.dart';
 import 'package:flutter_tools/src/macos/macos_device.dart';
@@ -18,7 +19,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
-import '../../src/fake_process_manager.dart';
+import '../../src/fake_process_manager.dart' hide FakeProcess;
 import '../../src/fakes.dart';
 
 final macOS = FakePlatform(operatingSystem: 'macos');
@@ -238,6 +239,185 @@ void main() {
     expect(device.executablePathForDevice(package, BuildInfo.profile), profilePath);
     expect(device.executablePathForDevice(package, BuildInfo.release), releasePath);
   });
+
+  group('MacOSLogReader', () {
+    testWithoutContext(
+      'detects privacy crash with key name and prints diagnostic with bundle path',
+      () {
+        final logger = BufferLogger.test();
+        final reader = MacOSLogReader(logger: logger)..bundlePath = '/path/to/MyFlutterApp.app';
+
+        const crashLine =
+            'This app has crashed because it attempted to access privacy-sensitive data '
+            "without a usage description.  The app's Info.plist must supply an "
+            'NSSpeechRecognitionUsageDescription key with a string value explaining to the user '
+            'how the app uses this data.';
+
+        reader.handleStderrLine(crashLine);
+
+        expect(logger.errorText, contains('macOS Privacy Permission Crash Detected'));
+        expect(logger.errorText, contains('requiring NSSpeechRecognitionUsageDescription'));
+        expect(
+          logger.errorText,
+          contains('Even if NSSpeechRecognitionUsageDescription is already present'),
+        );
+        expect(logger.errorText, contains('open "/path/to/MyFlutterApp.app"'));
+        expect(logger.errorText, contains('https://github.com/flutter/flutter/issues/70374'));
+      },
+    );
+
+    testWithoutContext(
+      'detects privacy crash with alternative phrasing and fallback bundle path',
+      () {
+        final logger = BufferLogger.test();
+        final reader = MacOSLogReader(logger: logger);
+
+        const crashLine =
+            'This app has crashed because it attempted to access privacy-sensitive data '
+            "without a usage description. The app's Info.plist must contain an "
+            'NSPhotoLibraryUsageDescription key with a string value explaining to the user '
+            'how the app uses this data.';
+
+        reader.handleStderrLine(crashLine);
+
+        expect(logger.errorText, contains('macOS Privacy Permission Crash Detected'));
+        expect(logger.errorText, contains('requiring NSPhotoLibraryUsageDescription'));
+        expect(logger.errorText, contains('open <path-to-app-bundle>'));
+      },
+    );
+
+    testWithoutContext('detects privacy crash without key name and prints fallback diagnostic', () {
+      final logger = BufferLogger.test();
+      final reader = MacOSLogReader(logger: logger);
+
+      const crashLine =
+          'This app has crashed because it attempted to access privacy-sensitive data '
+          'without a usage description.';
+
+      reader.handleStderrLine(crashLine);
+
+      expect(logger.errorText, contains('macOS Privacy Permission Crash Detected'));
+      expect(logger.errorText, contains('access to privacy-sensitive data.'));
+      expect(logger.errorText, isNot(contains('requiring')));
+      expect(
+        logger.errorText,
+        contains('Even if the usage description key is already present in macos/Runner/Info.plist'),
+      );
+    });
+
+    testWithoutContext(
+      'handles multi-byte UTF-8, split chunks, and unflushed trailing line',
+      () async {
+        final logger = BufferLogger.test();
+        final reader = MacOSLogReader(logger: logger);
+
+        final stderrController = StreamController<List<int>>();
+        final process = FakeProcess(stderr: stderrController.stream);
+        reader.listenToProcessOutput(process);
+
+        // Multi-byte UTF-8 character '€' (0xE2, 0x82, 0xAC) split across chunks.
+        const part1 = 'This app has crashed because it attempted to access privacy-sensitive data ';
+        const part2 =
+            "without a usage description. The app's Info.plist must contain an NSCameraUsageDescription key. €";
+
+        final List<int> bytes1 = utf8.encode(part1);
+        final List<int> bytes2 = utf8.encode(part2);
+
+        stderrController.add(bytes1);
+        stderrController.add(bytes2.sublist(0, bytes2.length - 2));
+        await pumpEventQueue();
+        expect(logger.errorText, isEmpty);
+
+        // Send remaining bytes of multi-byte character and complete stream without trailing newline.
+        stderrController.add(bytes2.sublist(bytes2.length - 2));
+        await stderrController.close();
+        await pumpEventQueue();
+
+        expect(logger.errorText, contains('macOS Privacy Permission Crash Detected'));
+        expect(logger.errorText, contains('requiring NSCameraUsageDescription'));
+      },
+    );
+
+    testWithoutContext('does not trigger diagnostic on unrelated stderr lines', () {
+      final logger = BufferLogger.test();
+      final reader = MacOSLogReader(logger: logger);
+
+      reader.handleStderrLine('Some standard stderr error message');
+      reader.handleStderrLine('Another line');
+
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext('only prints diagnostic once even if multiple crash lines are received', () {
+      final logger = BufferLogger.test();
+      final reader = MacOSLogReader(logger: logger);
+
+      const crashLine =
+          'This app has crashed because it attempted to access privacy-sensitive data '
+          "without a usage description. The app's Info.plist must supply an "
+          'NSMicrophoneUsageDescription key.';
+
+      reader.handleStderrLine(crashLine);
+      reader.handleStderrLine(crashLine);
+
+      final Iterable<RegExpMatch> matches = RegExp(
+        'macOS Privacy Permission Crash Detected',
+      ).allMatches(logger.errorText);
+      expect(matches.length, 1);
+    });
+  });
+
+  testWithoutContext('startApp sets bundlePath on macosLogReader', () async {
+    final fileSystem = MemoryFileSystem.test();
+    final logger = BufferLogger.test();
+    final device = MacOSDevice(
+      fileSystem: fileSystem,
+      logger: logger,
+      operatingSystemUtils: FakeOperatingSystemUtils(),
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>['release/executable']),
+      ]),
+    );
+    final package = FakeMacOSApp(bundlePath: '/path/to/CustomBundle.app');
+
+    await device.startApp(
+      package,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+      prebuiltApplication: true,
+    );
+
+    expect(device.macosLogReader.bundlePath, '/path/to/CustomBundle.app');
+  });
+
+  testWithoutContext('startApp clears stale bundlePath from previous launch', () async {
+    final fileSystem = MemoryFileSystem.test();
+    final logger = BufferLogger.test();
+    final device = MacOSDevice(
+      fileSystem: fileSystem,
+      logger: logger,
+      operatingSystemUtils: FakeOperatingSystemUtils(),
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>['release/executable']),
+        const FakeCommand(command: <String>['release/executable']),
+      ]),
+    );
+
+    final packageWithBundle = FakeMacOSApp(bundlePath: '/path/to/First.app');
+    await device.startApp(
+      packageWithBundle,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+      prebuiltApplication: true,
+    );
+    expect(device.macosLogReader.bundlePath, '/path/to/First.app');
+
+    final packageWithoutBundle = FakeMacOSApp(bundlePath: null);
+    await device.startApp(
+      packageWithoutBundle,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+      prebuiltApplication: true,
+    );
+    expect(device.macosLogReader.bundlePath, isNull);
+  });
 }
 
 FlutterProject setUpFlutterProject(Directory directory) {
@@ -249,6 +429,13 @@ FlutterProject setUpFlutterProject(Directory directory) {
 }
 
 class FakeMacOSApp extends Fake implements MacOSApp {
+  FakeMacOSApp({this.bundlePath = 'release/bundle.app'});
+
+  final String? bundlePath;
+
+  @override
+  String? applicationBundle(BuildInfo buildInfo) => bundlePath;
+
   @override
   String executable(BuildInfo buildInfo) {
     return switch (buildInfo) {


### PR DESCRIPTION
When developing macOS applications that access privacy-sensitive resources (e.g., Camera, Microphone, Speech Recognition, Photos), launching the application binary directly from an IDE (such as VS Code or Android Studio) or terminal via `flutter run` causes macOS Transparency, Consent, and Control (TCC) to attribute permission requests to the parent IDE/terminal process rather than the application bundle itself.

If the parent process does not declare the corresponding usage description key in its own `Info.plist`, macOS immediately terminates the application process on the first access attempt, even if the key is properly declared in the Flutter app bundle's `macos/Runner/Info.plist`.

### Changes
1. **`DesktopLogReader` Stderr Stream Processing**:
   - Refactored `DesktopLogReader.listenToProcessOutput` to transform `process.stderr` using `utf8AllowMalformedLineDecoder`, delegating decoding, multi-byte buffering, and line splitting to `utf8AllowMalformed` and `LineSplitter`.
   - Exposed `@protected void handleStderrLine(String line)` hook for subclasses to inspect output line by line.
   - Tied stream closure to `onDone` of `process.stderr` to prevent races with process exit and guarantee trailing lines are flushed.
2. **`MacOSLogReader` Diagnostic Detection**:
   - Subclassed `DesktopLogReader` to inspect stderr for the macOS TCC crash signature (`kMacOSPrivacyCrashPattern`).
   - Parses the missing usage description key name (e.g. `NSCameraUsageDescription`, `NSSpeechRecognitionUsageDescription`) if present.
   - Emits an actionable diagnostic message explaining the parent process attribution, the required key, and the terminal workaround (`open "<bundlePath>"`) or running once from Xcode.
   - Clears `bundlePath` on `MacOSDevice.startApp` to avoid leaking stale application bundle paths across multiple launches.
3. **Template Documentation**:
   - Added explanatory warning comment to `packages/flutter_tools/templates/app/macos.tmpl/Runner/Info.plist` explaining TCC attribution and how to run the app bundle directly to grant permissions during development.
4. **Tests**:
   - Added unit test coverage in `macos_device_test.dart` for crash detection, key extraction, fallback messaging, multi-byte UTF-8 chunk handling, and log reader state management across app launches.

Fixes https://github.com/flutter/flutter/issues/70374

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
