### PR TITLE
[flutter_tools] validate placeholder type in gen-l10n

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -246,10 +246,19 @@ class Placeholder {
   List<String> get dateFormatParts => format?.split(_dateFormatPartsDelimiter) ?? <String>[];
   bool get hasValidDateFormat => dateFormatParts.every(validDateFormats.contains);
 
+  // Matches valid Dart type syntax:
+  // - Optional library or namespace prefixes, e.g. `prefix.`, `package.prefix.`
+  // - Leading Dart identifier for the type name (letters, numbers, underscores, $)
+  // - Optional generic type arguments enclosed in angle brackets, e.g. `<String, int>`
+  // - Optional trailing nullability operator `?`
+  //
+  // Enforcing full-string anchoring prevents code injection from crafted ARB placeholder types
+  // attempting to break out of generated method parameter declarations.
   static final RegExp _validTypeRegExp = RegExp(
     r'^([a-zA-Z_$][a-zA-Z0-9_$]*\.)*[a-zA-Z_$][a-zA-Z0-9_$]*(\s*<.*>)?\??$',
   );
 
+  /// Validates that [type] represents a syntactically valid Dart type identifier.
   static bool _isValidType(String type) {
     if (type.isEmpty) {
       return false;
@@ -257,6 +266,10 @@ class Placeholder {
     return _validTypeRegExp.hasMatch(type);
   }
 
+  /// Parses and validates the "type" attribute for placeholder [name].
+  ///
+  /// Throws an [L10nException] if the type is present but does not conform to
+  /// valid Dart type syntax.
   static String? _typeAttribute(String resourceId, String name, Map<String, Object?> attributes) {
     final String? type = _stringAttribute(resourceId, name, attributes, 'type');
     if (type == null) {

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -219,7 +219,7 @@ class OptionalParameter {
 class Placeholder {
   Placeholder(this.resourceId, this.name, Map<String, Object?> attributes)
     : example = _stringAttribute(resourceId, name, attributes, 'example'),
-      type = _stringAttribute(resourceId, name, attributes, 'type'),
+      type = _typeAttribute(resourceId, name, attributes),
       format = _stringAttribute(resourceId, name, attributes, 'format'),
       optionalParameters = _optionalParameters(resourceId, name, attributes),
       isCustomDateFormat = _boolAttribute(resourceId, name, attributes, 'isCustomDateFormat');
@@ -245,6 +245,31 @@ class Placeholder {
   // 'format' can contain a number of date time formats separated by `dateFormatPartsDelimiter`.
   List<String> get dateFormatParts => format?.split(_dateFormatPartsDelimiter) ?? <String>[];
   bool get hasValidDateFormat => dateFormatParts.every(validDateFormats.contains);
+
+  static final RegExp _validTypeRegExp = RegExp(
+    r'^([a-zA-Z_$][a-zA-Z0-9_$]*\.)*[a-zA-Z_$][a-zA-Z0-9_$]*(\s*<.*>)?\??$',
+  );
+
+  static bool _isValidType(String type) {
+    if (type.isEmpty) {
+      return false;
+    }
+    return _validTypeRegExp.hasMatch(type);
+  }
+
+  static String? _typeAttribute(String resourceId, String name, Map<String, Object?> attributes) {
+    final String? type = _stringAttribute(resourceId, name, attributes, 'type');
+    if (type == null) {
+      return null;
+    }
+    if (!_isValidType(type)) {
+      throw L10nException(
+        'Invalid placeholder type "$type" for placeholder "$name" in message "$resourceId". '
+        'Placeholder types must be valid Dart type names.',
+      );
+    }
+    return type;
+  }
 
   static String? _stringAttribute(
     String resourceId,

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -249,13 +249,13 @@ class Placeholder {
   // Matches valid Dart type syntax:
   // - Optional library or namespace prefixes, e.g. `prefix.`, `package.prefix.`
   // - Leading Dart identifier for the type name (letters, numbers, underscores, $)
-  // - Optional generic type arguments enclosed in angle brackets, e.g. `<String, int>`
+  // - Optional generic type arguments enclosed in angle brackets, restricted to valid type characters (letters, numbers, underscores, $, commas, spaces, nested angle brackets, and ?)
   // - Optional trailing nullability operator `?`
   //
-  // Enforcing full-string anchoring prevents code injection from crafted ARB placeholder types
-  // attempting to break out of generated method parameter declarations.
+  // Enforcing full-string anchoring and disallowing wildcard characters prevents code injection
+  // from crafted ARB placeholder types attempting to break out of generated method parameter declarations.
   static final RegExp _validTypeRegExp = RegExp(
-    r'^([a-zA-Z_$][a-zA-Z0-9_$]*\.)*[a-zA-Z_$][a-zA-Z0-9_$]*(\s*<.*>)?\??$',
+    r'^([a-zA-Z_$][a-zA-Z0-9_$]*\.)*[a-zA-Z_$][a-zA-Z0-9_$]*(\s*<[a-zA-Z0-9_$,\s<>?]+>)?\??$',
   );
 
   /// Validates that [type] represents a syntactically valid Dart type identifier.

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -3528,8 +3528,7 @@ String helloNameAndAge({required String name, required int age}) {
           }
         }
       }
-    }
-    ''';
+    }''';
 
     setupLocalizations(<String, String>{'en': en, 'da': da});
 
@@ -3537,6 +3536,31 @@ String helloNameAndAge({required String name, required int age}) {
     expect(
       localizationsFile,
       containsIgnoringWhitespace(r'''String get test => 'No placeholder in here'''),
+    );
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/192130.
+  testWithoutContext('throws an exception when placeholder type is invalid', () {
+    const maliciousArb = r'''
+{
+  "greeting": "Hello {user}",
+  "@greeting": {
+    "placeholders": {
+      "user": {
+        "type": "Object user) { print('bad'); return 'x'; } String injected("
+      }
+    }
+  }
+}''';
+    expect(
+      () => setupLocalizations(<String, String>{'en': maliciousArb}),
+      throwsA(
+        isA<L10nException>().having(
+          (L10nException e) => e.message,
+          'message',
+          contains('Invalid placeholder type'),
+        ),
+      ),
     );
   });
 }

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -3562,5 +3562,27 @@ String helloNameAndAge({required String name, required int age}) {
         ),
       ),
     );
+
+    const genericInjectionArb = r'''
+{
+  "greeting": "Hello {user}",
+  "@greeting": {
+    "placeholders": {
+      "user": {
+        "type": "dynamic> foo) { print('bad'); } void bar<dynamic>"
+      }
+    }
+  }
+}''';
+    expect(
+      () => setupLocalizations(<String, String>{'en': genericInjectionArb}),
+      throwsA(
+        isA<L10nException>().having(
+          (L10nException e) => e.message,
+          'message',
+          contains('Invalid placeholder type'),
+        ),
+      ),
+    );
   });
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/192130

In `flutter gen-l10n`, placeholder types specified in `.arb` files were previously parsed with `_stringAttribute` without validating whether the string is a valid Dart type identifier. When generating method parameter signatures in `generateMethodParameters`, `${placeholder.type} ${placeholder.name}` was directly interpolated, allowing crafted type strings to prematurely terminate the method declaration and inject arbitrary code.

This change:
1. Validates placeholder types during `Placeholder` parsing in `gen_l10n_types.dart` using `_isValidType`, ensuring only valid Dart type names (including generic type parameters, library prefixes, and nullable types) are accepted.
2. Throws an `L10nException` if an invalid type string is encountered.
3. Adds regression test in `generate_localizations_test.dart`.

## Related Issues
Fixes https://github.com/flutter/flutter/issues/192130

## Tests
- Added regression test in `packages/flutter_tools/test/general.shard/generate_localizations_test.dart`.
