### PR TITLE
[flutter_tools] Fix flutter drive device selection for unsupported project platforms

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -247,7 +247,7 @@ class DriveCommand extends RunCommandBase {
   String? get applicationBinaryPath => stringArg(FlutterOptions.kUseApplicationBinary);
 
   Future<Device?> get targetedDevice async {
-    return findTargetDevice(includeDevicesUnsupportedByProject: applicationBinaryPath == null);
+    return findTargetDevice(includeDevicesUnsupportedByProject: applicationBinaryPath != null);
   }
 
   // Wireless iOS devices need `publish-port` to be enabled because it requires mDNS.

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -178,6 +178,14 @@ class FlutterDriverService extends DriverService {
       buildInfo: buildInfo,
       applicationBinary: applicationBinary,
     );
+    if (_applicationPackage == null) {
+      var message = 'No application found for $targetPlatform.';
+      final String? hint = await getMissingPackageHintForPlatform(targetPlatform);
+      if (hint != null) {
+        message += '\n$hint';
+      }
+      throwToolExit(message);
+    }
     var attempt = 0;
     LaunchResult? result;
     var prebuiltApplication = applicationBinary != null;

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -951,6 +951,76 @@ void main() {}
       DeviceManager: () => fakeDeviceManager,
     },
   );
+
+  testUsingContext(
+    'ignores devices unsupported by the project when building from source',
+    () async {
+      final command = DriveCommand(
+        fileSystem: fileSystem,
+        logger: logger,
+        platform: platform,
+        terminal: terminal,
+        outputPreferences: outputPreferences,
+        signals: signals,
+      );
+
+      fileSystem.file('lib/main.dart').createSync(recursive: true);
+      fileSystem.file('test_driver/main_test.dart').createSync(recursive: true);
+      fileSystem.file('pubspec.yaml').createSync();
+
+      fakeDeviceManager.attachedDevices = <Device>[FakeUnsupportedDevice()];
+
+      await expectLater(
+        () => createTestCommandRunner(
+          command,
+        ).run(<String>['drive', '--no-pub', '-d', 'unsupported_device']),
+        throwsToolExit(),
+      );
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      Pub: () => FakePub(),
+      DeviceManager: () => fakeDeviceManager,
+    },
+  );
+
+  testUsingContext(
+    'includes devices unsupported by the project when using prebuilt application binary',
+    () async {
+      final capturingDriverService = CapturingDriverService();
+      final command = DriveCommand(
+        fileSystem: fileSystem,
+        logger: logger,
+        platform: platform,
+        terminal: terminal,
+        outputPreferences: outputPreferences,
+        signals: signals,
+        flutterDriverFactory: CapturingFlutterDriverFactory(capturingDriverService),
+      );
+
+      fileSystem.file('lib/main.dart').createSync(recursive: true);
+      fileSystem.file('test_driver/main_test.dart').createSync(recursive: true);
+      fileSystem.file('pubspec.yaml').createSync();
+      final File appBinary = fileSystem.file('app.apk')..createSync();
+
+      final unsupportedDevice = FakeUnsupportedDevice();
+      fakeDeviceManager.attachedDevices = <Device>[unsupportedDevice];
+
+      await createTestCommandRunner(
+        command,
+      ).run(<String>['drive', '--no-pub', '--use-application-binary', appBinary.path]);
+
+      expect(capturingDriverService.device, unsupportedDevice);
+      expect(capturingDriverService.applicationBinary?.path, appBinary.path);
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      Pub: () => FakePub(),
+      DeviceManager: () => fakeDeviceManager,
+    },
+  );
 }
 
 class ThrowingScreenshotDevice extends ScreenshotDevice {
@@ -991,7 +1061,13 @@ class ScreenshotDevice extends Fake implements Device {
   final id = 'fake_device';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android;
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.tester;
+
+  @override
+  Future<bool> isSupported() async => true;
+
+  @override
+  bool isSupportedForProject(FlutterProject flutterProject) => true;
 
   @override
   bool supportsScreenshot = true;
@@ -1100,6 +1176,8 @@ class FakeDriverService extends Fake implements DriverService {
 }
 
 class CapturingDriverService extends Fake implements DriverService {
+  Device? device;
+  File? applicationBinary;
   Map<String, Object>? platformArgs;
   Map<String, String>? webDefines;
 
@@ -1115,6 +1193,8 @@ class CapturingDriverService extends Fake implements DriverService {
     Map<String, Object> platformArgs = const <String, Object>{},
     Map<String, String> webDefines = const <String, String>{},
   }) async {
+    this.device = device;
+    this.applicationBinary = applicationBinary;
     this.platformArgs = platformArgs;
     this.webDefines = webDefines;
   }
@@ -1243,4 +1323,45 @@ class FakeSignals extends Fake implements Signals {
 
   @override
   Future<bool> removeHandler(ProcessSignal signal, Object token) async => true;
+}
+
+class FakeUnsupportedDevice extends Fake implements Device {
+  @override
+  final String id = 'unsupported_device';
+
+  @override
+  final String name = 'Unsupported Device';
+
+  @override
+  String get displayName => name;
+
+  @override
+  bool get isConnected => true;
+
+  @override
+  Category get category => Category.mobile;
+
+  @override
+  PlatformType get platformType => PlatformType.android;
+
+  @override
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
+
+  @override
+  Future<bool> isSupported() async => true;
+
+  @override
+  bool isSupportedForProject(FlutterProject flutterProject) => false;
+
+  @override
+  Future<LaunchResult> startApp(
+    ApplicationPackage? package, {
+    String? mainPath,
+    String? route,
+    DebuggingOptions? debuggingOptions,
+    Map<String, Object?> platformArgs = const <String, Object?>{},
+    bool prebuiltApplication = false,
+    bool ipv6 = false,
+    String? userIdentifier,
+  }) async => LaunchResult.succeeded();
 }

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -79,6 +79,22 @@ void main() {
     );
   });
 
+  testUsingContext('Exits if application package is null for target platform', () {
+    final DriverService driverService = setUpDriverService(
+      applicationPackageFactory: FakeApplicationPackageFactory(),
+    );
+    final Device device = FakeDevice(LaunchResult.succeeded());
+
+    expect(
+      () => driverService.start(
+        BuildInfo.profile,
+        device,
+        DebuggingOptions.enabled(BuildInfo.profile, ipv6: true),
+      ),
+      throwsToolExit(message: 'No application found for TargetPlatform.android_arm.'),
+    );
+  });
+
   testWithoutContext('Retries application launch if it fails the first time', () async {
     final fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[getVM]);
     final processManager = FakeProcessManager.list(<FakeCommand>[
@@ -451,15 +467,17 @@ void main() {
 }
 
 FlutterDriverService setUpDriverService({
+  ApplicationPackageFactory? applicationPackageFactory,
+  DevtoolsLauncher? devtoolsLauncher,
   Logger? logger,
   Platform? platform,
   ProcessManager? processManager,
   FlutterVmService? vmService,
-  DevtoolsLauncher? devtoolsLauncher,
 }) {
   logger ??= BufferLogger.test();
   return FlutterDriverService(
-    applicationPackageFactory: FakeApplicationPackageFactory(FakeApplicationPackage()),
+    applicationPackageFactory:
+        applicationPackageFactory ?? FakeApplicationPackageFactory(FakeApplicationPackage()),
     logger: logger,
     platform: platform ?? FakePlatform(),
     processUtils: ProcessUtils(
@@ -492,12 +510,12 @@ FlutterDriverService setUpDriverService({
 }
 
 class FakeApplicationPackageFactory extends Fake implements ApplicationPackageFactory {
-  FakeApplicationPackageFactory(this.applicationPackage);
+  FakeApplicationPackageFactory([this.applicationPackage]);
 
-  ApplicationPackage applicationPackage;
+  ApplicationPackage? applicationPackage;
 
   @override
-  Future<ApplicationPackage> getPackageForPlatform(
+  Future<ApplicationPackage?> getPackageForPlatform(
     TargetPlatform platform, {
     BuildInfo? buildInfo,
     File? applicationBinary,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/134073

### Summary of Changes

1. **`packages/flutter_tools/lib/src/commands/drive.dart`**:
   - Fixed an inverted boolean condition in `DriveCommand.targetedDevice` from `includeDevicesUnsupportedByProject: applicationBinaryPath == null` to `includeDevicesUnsupportedByProject: applicationBinaryPath != null`.
   - When building from source, devices unsupported by the source project (e.g., targeting iOS on a macOS-only project) are now properly excluded instead of included.
   - When targeting a prebuilt binary (`--use-application-binary`), devices unsupported by the local source directory structure are included as intended.

2. **`packages/flutter_tools/lib/src/drive/drive_service.dart`**:
   - Added a defensive null check on `_applicationPackage` in `DefaultDriverService.start` to exit cleanly via `throwToolExit` with `getMissingPackageHintForPlatform` instead of throwing an unhandled `_TypeError` crash.

3. **Tests**:
   - Added unit test in `packages/flutter_tools/test/general.shard/drive/drive_service_test.dart` verifying clean `ToolExit` when application package resolution returns `null`.
   - Added hermetic command tests in `packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart` verifying device filtering when building from source vs targeting prebuilt binaries.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://discord.gg/rflutter
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
