### PR TITLE
Ensure no extraction conflicts and unpack all Dart SDK archive artifacts

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -18,7 +18,6 @@ $flutterRoot = (Get-Item $progName).parent.parent.FullName
 
 $cachePath = "$flutterRoot\bin\cache"
 $dartSdkPath = "$cachePath\dart-sdk"
-$dartSdkLicense = "$cachePath\LICENSE.dart_sdk_archive.md"
 $engineStamp = "$cachePath\engine-dart-sdk.stamp"
 $engineVersion = (Get-Content "$flutterRoot\bin\cache\engine.stamp")
 $engineRealm = (Get-Content "$flutterRoot\bin\cache\engine.realm")
@@ -97,23 +96,23 @@ Catch {
 If (Get-Command 7z -errorAction SilentlyContinue) {
     Write-Host "Expanding downloaded archive with 7z..."
     # The built-in unzippers are painfully slow. Use 7-Zip, if available.
-    & 7z x $dartSdkZip "-o$dartSdkPathTemp" -bd | Out-Null
+    & 7z x $dartSdkZip "-o$dartSdkPathTemp" -aoa -bd | Out-Null
 } ElseIf (Get-Command 7za -errorAction SilentlyContinue) {
     Write-Host "Expanding downloaded archive with 7za..."
     # Use 7-Zip's standalone version 7za.exe, if available.
-    & 7za x $dartSdkZip "-o$dartSdkPathTemp" -bd | Out-Null
+    & 7za x $dartSdkZip "-o$dartSdkPathTemp" -aoa -bd | Out-Null
 } ElseIf (Get-Command Microsoft.PowerShell.Archive\Expand-Archive -errorAction SilentlyContinue) {
     Write-Host "Expanding downloaded archive with PowerShell..."
     # Use PowerShell's built-in unzipper, if available (requires PowerShell 5+).
     $global:ProgressPreference='SilentlyContinue'
-    Microsoft.PowerShell.Archive\Expand-Archive $dartSdkZip -DestinationPath $dartSdkPathTemp
+    Microsoft.PowerShell.Archive\Expand-Archive $dartSdkZip -DestinationPath $dartSdkPathTemp -Force
 } Else {
     Write-Host "Expanding downloaded archive with Windows..."
     # As last resort: fall back to the Windows GUI.
     $shell = New-Object -com shell.application
     $zip = $shell.NameSpace($dartSdkZip)
     foreach($item in $zip.items()) {
-        $shell.Namespace($dartSdkPathTemp).copyhere($item)
+        $shell.Namespace($dartSdkPathTemp).copyhere($item, 16)
     }
 }
 
@@ -126,35 +125,28 @@ if (-not (Test-Path "$dartSdkPathTemp\dart-sdk")) {
 }
 
 # Move old SDK to a new location instead of deleting it in case it is still in use (e.g. by IntelliJ).
-if ((Test-Path $dartSdkPath) -or (Test-Path $dartSdkLicense)) {
+if (Test-Path $dartSdkPath) {
     $oldDartSdkSuffix = 1
     while (Test-Path "$cachePath\$oldDartSdkPrefix$oldDartSdkSuffix") { $oldDartSdkSuffix++ }
-
-    if (Test-Path $dartSdkPath) {
-        Rename-Item $dartSdkPath "$oldDartSdkPrefix$oldDartSdkSuffix" -ErrorAction Stop
-    }
-
-    if (Test-Path $dartSdkLicense) {
-        Rename-Item $dartSdkLicense "$oldDartSdkPrefix$oldDartSdkSuffix.LICENSE.md" -ErrorAction Stop
-    }
-}
-
-# The unzip might have extracted LICENSE.dart_sdk_archive.md to the temp dir
-$tempLicense = "$dartSdkPathTemp\LICENSE.dart_sdk_archive.md"
-if (Test-Path $tempLicense) {
-    if (Test-Path $dartSdkLicense) {
-        Remove-Item $dartSdkLicense -Force -ErrorAction Stop
-    }
-    Move-Item $tempLicense $dartSdkLicense -ErrorAction Stop
+    Rename-Item $dartSdkPath "$oldDartSdkPrefix$oldDartSdkSuffix" -ErrorAction Stop
 }
 
 # Move the extracted SDK to the final location
 try {
     Move-Item "$dartSdkPathTemp\dart-sdk" $dartSdkPath -ErrorAction Stop
+
+    # Move all other files/directories extracted from archive into $cachePath
+    Get-ChildItem -Path $dartSdkPathTemp | ForEach-Object {
+        $dest = Join-Path $cachePath $_.Name
+        if (Test-Path $dest) {
+            Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        Move-Item $_.FullName $dest -Force -ErrorAction Stop
+    }
 } finally {
     Remove-Item $dartSdkPathTemp -Recurse -Force -ErrorAction SilentlyContinue
 }
 $engineVersion | Out-File $engineStamp -Encoding ASCII
 
-# Try to delete all old SDKs and license files.
+# Try to delete all old SDKs.
 Get-ChildItem -Path $cachePath | Where {$_.BaseName.StartsWith($oldDartSdkPrefix)} | Remove-Item -Recurse -ErrorAction SilentlyContinue

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -210,7 +210,11 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != "$(< "$ENGINE_STAMP")" ]; 
     if [ -e "$item" ]; then
       dest="$FLUTTER_ROOT/bin/cache/$(basename "$item")"
       rm -rf "$dest"
-      mv -f "$item" "$dest"
+      mv -f "$item" "$dest" || {
+        >&2 echo "Failed to move $item to $dest"
+        rm -rf -- "$DART_SDK_PATH_TEMP"
+        exit 1
+      }
     fi
   done
 

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -189,11 +189,6 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != "$(< "$ENGINE_STAMP")" ]; 
     exit 1
   fi
 
-  # The unzip might have extracted LICENSE.dart_sdk_archive.md to the temp dir
-  if [ -f "$DART_SDK_PATH_TEMP/LICENSE.dart_sdk_archive.md" ]; then
-    mv "$DART_SDK_PATH_TEMP/LICENSE.dart_sdk_archive.md" "$FLUTTER_ROOT/bin/cache/LICENSE.dart_sdk_archive.md"
-  fi
-
   $FIND "$DART_SDK_PATH_TEMP/dart-sdk" -type d -exec chmod 755 {} +
   $FIND "$DART_SDK_PATH_TEMP/dart-sdk" -type f $IS_USER_EXECUTABLE -exec chmod a+x,a+r {} +
 
@@ -209,6 +204,16 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != "$(< "$ENGINE_STAMP")" ]; 
     rm -rf -- "$DART_SDK_PATH_TEMP"
     exit 1
   }
+
+  # Move all other extracted files/directories (e.g., license files, metadata) to bin/cache/
+  for item in "$DART_SDK_PATH_TEMP"/*; do
+    if [ -e "$item" ]; then
+      dest="$FLUTTER_ROOT/bin/cache/$(basename "$item")"
+      rm -rf "$dest"
+      mv -f "$item" "$dest"
+    fi
+  done
+
   rm -rf -- "$DART_SDK_PATH_TEMP"
 
   echo "$ENGINE_VERSION" > "$ENGINE_STAMP"

--- a/dev/tools/test/update_dart_sdk_test.dart
+++ b/dev/tools/test/update_dart_sdk_test.dart
@@ -1,0 +1,304 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:archive/archive.dart';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:platform/platform.dart';
+import 'package:test/test.dart';
+
+const String _kInitialEngineVersion = 'engine-version-initial';
+const String _kUpdatedEngineVersion = 'engine-version-updated';
+const String _kExtraFileName = 'extra_file.txt';
+const String _kAnotherFileName = 'another_new_file.txt';
+const String _kLicenseFileName = 'LICENSE.dart_sdk_archive.md';
+
+void main() {
+  final usePowershellOnPosix = io.Platform.environment['FORCE_POWERSHELL'] == 'true';
+
+  const FileSystem localFs = LocalFileSystem();
+  final flutterRoot = _FlutterRootUnderTest.findWithin(forcePowershell: usePowershellOnPosix);
+
+  late Directory tmpDir;
+  late _FlutterRootUnderTest testRoot;
+  late Map<String, String> environment;
+  late io.HttpServer mockStorageServer;
+  late Map<String, List<int>> serverFiles;
+
+  void printIfNotEmpty(String prefix, String string) {
+    if (string.isNotEmpty) {
+      for (final String s in string.split(io.Platform.lineTerminator)) {
+        print('$prefix:>$s<');
+      }
+    }
+  }
+
+  Future<io.ProcessResult> run(String executable, List<String> args, {String? workingPath}) async {
+    print('Running "$executable ${args.join(" ")}"${workingPath != null ? ' $workingPath' : ''}');
+    final io.ProcessResult result = await io.Process.run(
+      executable,
+      args,
+      environment: <String, String>{...io.Platform.environment, ...environment},
+      workingDirectory: workingPath ?? testRoot.root.absolute.path,
+    );
+    if (result.exitCode != 0) {
+      fail(
+        'Failed running "$executable $args" (exit code = ${result.exitCode}),'
+        '\nstdout: ${result.stdout}'
+        '\nstderr: ${result.stderr}',
+      );
+    }
+    printIfNotEmpty('stdout', (result.stdout as String).trim());
+    printIfNotEmpty('stderr', (result.stderr as String).trim());
+    return result;
+  }
+
+  setUpAll(() async {
+    if (usePowershellOnPosix) {
+      final io.ProcessResult result = io.Process.runSync('pwsh', <String>['--version']);
+      print('Using Powershell (${result.stdout}) on POSIX for local debugging and testing');
+    }
+  });
+
+  setUp(() async {
+    tmpDir = localFs.systemTempDirectory.createTempSync('update_dart_sdk_test.');
+    testRoot = _FlutterRootUnderTest.fromPath(
+      tmpDir.childDirectory('flutter').path,
+      forcePowershell: usePowershellOnPosix,
+    );
+
+    serverFiles = <String, List<int>>{};
+    mockStorageServer = await io.HttpServer.bind(io.InternetAddress.loopbackIPv4, 0);
+    mockStorageServer.listen((io.HttpRequest request) async {
+      await request.drain<void>();
+      final String path = request.uri.path;
+      for (final MapEntry(:key, :value) in serverFiles.entries) {
+        if (path.contains(key)) {
+          request.response.headers.contentType = io.ContentType.binary;
+          request.response.headers.contentLength = value.length;
+          request.response.add(value);
+          await request.response.close();
+          return;
+        }
+      }
+      request.response.statusCode = io.HttpStatus.notFound;
+      await request.response.close();
+    });
+
+    environment = <String, String>{
+      'FLUTTER_STORAGE_BASE_URL':
+          'http://${mockStorageServer.address.host}:${mockStorageServer.port}',
+    };
+
+    flutterRoot.binInternalUpdateDartSdk.copySyncRecursive(testRoot.binInternalUpdateDartSdk.path);
+
+    testRoot.binCacheEngineStamp.parent.createSync(recursive: true);
+    testRoot.binCacheEngineRealm.writeAsStringSync('');
+  });
+
+  tearDown(() async {
+    await mockStorageServer.close(force: true);
+    if (tmpDir.existsSync()) {
+      tmpDir.deleteSync(recursive: true);
+    }
+  });
+
+  Future<io.ProcessResult> runUpdateDartSdk() {
+    final String executable;
+    final List<String> args;
+    if (const LocalPlatform().isWindows) {
+      executable = 'powershell';
+      args = <String>[testRoot.binInternalUpdateDartSdk.path];
+    } else if (usePowershellOnPosix) {
+      executable = 'pwsh';
+      args = <String>[testRoot.binInternalUpdateDartSdk.path];
+    } else {
+      executable = testRoot.binInternalUpdateDartSdk.path;
+      args = <String>[];
+    }
+    return run(executable, args);
+  }
+
+  List<int> createDartSdkZip(Map<String, String> files) {
+    final archive = Archive();
+    for (final MapEntry(:key, :value) in files.entries) {
+      final List<int> data = utf8.encode(value);
+      archive.addFile(ArchiveFile(key, data.length, data));
+    }
+    return ZipEncoder().encode(archive)!;
+  }
+
+  test('extracts all archive contents and updates without conflicts', () async {
+    testRoot.binCacheEngineStamp.writeAsStringSync(_kInitialEngineVersion);
+
+    final List<int> initialZip = createDartSdkZip(<String, String>{
+      'dart-sdk/bin/dart': 'initial dart binary',
+      'dart-sdk/version': '3.0.0',
+      _kLicenseFileName: 'initial license content',
+      _kExtraFileName: 'initial extra content',
+      'extra_dir/file.txt': 'initial directory file content',
+    });
+
+    serverFiles[_kInitialEngineVersion] = initialZip;
+    serverFiles['dart-sdk-'] = initialZip;
+
+    await runUpdateDartSdk();
+
+    expect(testRoot.binCacheEngineDartSdkStamp.existsSync(), isTrue);
+    expect(testRoot.binCacheEngineDartSdkStamp.readAsStringSync().trim(), _kInitialEngineVersion);
+    expect(testRoot.binCacheDartSdk.childDirectory('bin').childFile('dart').existsSync(), isTrue);
+    expect(
+      testRoot.binCacheDartSdk.childDirectory('bin').childFile('dart').readAsStringSync(),
+      'initial dart binary',
+    );
+    expect(testRoot.binCache.childFile(_kLicenseFileName).existsSync(), isTrue);
+    expect(
+      testRoot.binCache.childFile(_kLicenseFileName).readAsStringSync(),
+      'initial license content',
+    );
+    expect(testRoot.binCache.childFile(_kExtraFileName).existsSync(), isTrue);
+    expect(
+      testRoot.binCache.childFile(_kExtraFileName).readAsStringSync(),
+      'initial extra content',
+    );
+    expect(
+      testRoot.binCache.childDirectory('extra_dir').childFile('file.txt').existsSync(),
+      isTrue,
+    );
+    expect(
+      testRoot.binCache.childDirectory('extra_dir').childFile('file.txt').readAsStringSync(),
+      'initial directory file content',
+    );
+
+    // Now simulate an update with a new engine version and updated/additional files.
+    testRoot.binCacheEngineStamp.writeAsStringSync(_kUpdatedEngineVersion);
+
+    final List<int> updatedZip = createDartSdkZip(<String, String>{
+      'dart-sdk/bin/dart': 'updated dart binary',
+      'dart-sdk/version': '3.1.0',
+      _kLicenseFileName: 'updated license content',
+      _kExtraFileName: 'updated extra content',
+      'extra_dir/file.txt': 'updated directory file content',
+      _kAnotherFileName: 'another file content',
+    });
+
+    serverFiles[_kUpdatedEngineVersion] = updatedZip;
+    serverFiles['dart-sdk-'] = updatedZip;
+
+    await runUpdateDartSdk();
+
+    expect(testRoot.binCacheEngineDartSdkStamp.existsSync(), isTrue);
+    expect(testRoot.binCacheEngineDartSdkStamp.readAsStringSync().trim(), _kUpdatedEngineVersion);
+    expect(testRoot.binCacheDartSdk.childDirectory('bin').childFile('dart').existsSync(), isTrue);
+    expect(
+      testRoot.binCacheDartSdk.childDirectory('bin').childFile('dart').readAsStringSync(),
+      'updated dart binary',
+    );
+    expect(testRoot.binCache.childFile(_kLicenseFileName).existsSync(), isTrue);
+    expect(
+      testRoot.binCache.childFile(_kLicenseFileName).readAsStringSync(),
+      'updated license content',
+    );
+    expect(testRoot.binCache.childFile(_kExtraFileName).existsSync(), isTrue);
+    expect(
+      testRoot.binCache.childFile(_kExtraFileName).readAsStringSync(),
+      'updated extra content',
+    );
+    expect(
+      testRoot.binCache.childDirectory('extra_dir').childFile('file.txt').existsSync(),
+      isTrue,
+    );
+    expect(
+      testRoot.binCache.childDirectory('extra_dir').childFile('file.txt').readAsStringSync(),
+      'updated directory file content',
+    );
+    expect(testRoot.binCache.childFile(_kAnotherFileName).existsSync(), isTrue);
+    expect(
+      testRoot.binCache.childFile(_kAnotherFileName).readAsStringSync(),
+      'another file content',
+    );
+
+    // Ensure no leftover .old files remain in cache
+    final List<FileSystemEntity> leftoverOld = testRoot.binCache
+        .listSync()
+        .where((FileSystemEntity entity) => entity.basename.contains('.old'))
+        .toList();
+    expect(leftoverOld, isEmpty);
+  });
+}
+
+final class _FlutterRootUnderTest {
+  factory _FlutterRootUnderTest.fromPath(
+    String path, {
+    FileSystem fileSystem = const LocalFileSystem(),
+    Platform platform = const LocalPlatform(),
+    bool forcePowershell = false,
+  }) {
+    final Directory root = fileSystem.directory(path);
+    return _FlutterRootUnderTest._(
+      root,
+      binCache: root.childDirectory(fileSystem.path.join('bin', 'cache')),
+      binCacheDartSdk: root.childDirectory(fileSystem.path.join('bin', 'cache', 'dart-sdk')),
+      binCacheEngineStamp: root.childFile(fileSystem.path.join('bin', 'cache', 'engine.stamp')),
+      binCacheEngineRealm: root.childFile(fileSystem.path.join('bin', 'cache', 'engine.realm')),
+      binCacheEngineDartSdkStamp: root.childFile(
+        fileSystem.path.join('bin', 'cache', 'engine-dart-sdk.stamp'),
+      ),
+      binInternalUpdateDartSdk: root.childFile(
+        fileSystem.path.join(
+          'bin',
+          'internal',
+          'update_dart_sdk.${platform.isWindows || forcePowershell ? 'ps1' : 'sh'}',
+        ),
+      ),
+    );
+  }
+
+  factory _FlutterRootUnderTest.findWithin({
+    String? path,
+    FileSystem fileSystem = const LocalFileSystem(),
+    bool forcePowershell = false,
+  }) {
+    path ??= fileSystem.currentDirectory.path;
+    Directory current = fileSystem.directory(path);
+    while (!current.childFile('DEPS').existsSync()) {
+      if (current.path == current.parent.path) {
+        throw ArgumentError.value(path, 'path', 'Could not resolve flutter root');
+      }
+      current = current.parent;
+    }
+    return _FlutterRootUnderTest.fromPath(current.path, forcePowershell: forcePowershell);
+  }
+
+  const _FlutterRootUnderTest._(
+    this.root, {
+    required this.binCache,
+    required this.binCacheDartSdk,
+    required this.binCacheEngineStamp,
+    required this.binCacheEngineRealm,
+    required this.binCacheEngineDartSdkStamp,
+    required this.binInternalUpdateDartSdk,
+  });
+
+  final Directory root;
+  final Directory binCache;
+  final Directory binCacheDartSdk;
+  final File binCacheEngineStamp;
+  final File binCacheEngineRealm;
+  final File binCacheEngineDartSdkStamp;
+  final File binInternalUpdateDartSdk;
+}
+
+extension on File {
+  void copySyncRecursive(String newPath) {
+    fileSystem.directory(fileSystem.path.dirname(newPath)).createSync(recursive: true);
+    copySync(newPath);
+  }
+}

--- a/dev/tools/test/update_dart_sdk_test.dart
+++ b/dev/tools/test/update_dart_sdk_test.dart
@@ -34,7 +34,7 @@ void main() {
 
   void printIfNotEmpty(String prefix, String string) {
     if (string.isNotEmpty) {
-      for (final String s in string.split(io.Platform.lineTerminator)) {
+      for (final String s in LineSplitter.split(string)) {
         print('$prefix:>$s<');
       }
     }


### PR DESCRIPTION
Fixes [#132702](https://github.com/flutter/flutter/issues/132702)

### Summary

When downloading and extracting the Dart SDK archive during Flutter bootstrap/upgrade (`update_dart_sdk.sh` and `update_dart_sdk.ps1`), archives containing files outside `dart-sdk/` (e.g. `LICENSE.dart_sdk_archive.md` or future metadata/artifacts) previously caused extraction issues:

1. **Extraction prompt hangs on Windows**:
   In [#132592](https://github.com/flutter/flutter/issues/132592), adding `LICENSE.dart_sdk_archive.md` to the archive root caused 7-Zip (`7z`/`7za`) to prompt interactively on stdout/stdin when overwriting an existing file, which PowerShell hides from background processes, resulting in an indefinite hang.
   Workaround in [#132777](https://github.com/flutter/flutter/pull/132777) only targeted the single license file without addressing the general overwrite conflict during extraction.

2. **Discarded archive artifacts**:
   Both `update_dart_sdk.sh` and `update_dart_sdk.ps1` previously hardcoded moving only `LICENSE.dart_sdk_archive.md`. Any other top-level files or directories in the Dart SDK archive were discarded during cleanup of the temporary extraction directory.

### Solution

- **`bin/internal/update_dart_sdk.ps1`**:
  - Add `-aoa` overwrite switch to `7z` and `7za`.
  - Add `-Force` switch to `Microsoft.PowerShell.Archive\Expand-Archive`.
  - Add flag `16` (`FOF_NOCONFIRMATION`) to COM `copyhere($item, 16)`.
  - Replace hardcoded license logic with a generic traversal of all extracted files and directories, safely moving them into `bin/cache/`.
- **`bin/internal/update_dart_sdk.sh`**:
  - Replace hardcoded license logic with a generic loop over all items in `$DART_SDK_PATH_TEMP/*`, safely removing preexisting destination items and moving extracted artifacts into `bin/cache/`.

### Tests

- Added automated test in `dev/tools/test/update_dart_sdk_test.dart` testing mock SDK download, multi-file/directory extraction, version upgrades, and non-interactive overwrite handling.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/