### PR TITLE
feat(flutter_tools): add IntOptionDescriptor and DefaultedIntOptionDescriptor

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -134,8 +134,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   @protected
   Future<DebuggingOptions> createDebuggingOptions({WebDevServerConfig? webDevServerConfig}) async {
     final BuildInfo buildInfo = await getBuildInfo();
-    final int? webBrowserDebugPort =
-        featureFlags.isWebEnabled && wasParsed(WebOptions.webBrowserDebugPort)
+    final int? webBrowserDebugPort = featureFlags.isWebEnabled
         ? getValue(WebOptions.webBrowserDebugPort)
         : null;
     final List<String> webBrowserFlags = featureFlags.isWebEnabled

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -136,7 +136,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
     final BuildInfo buildInfo = await getBuildInfo();
     final int? webBrowserDebugPort =
         featureFlags.isWebEnabled && wasParsed(WebOptions.webBrowserDebugPort)
-        ? int.parse(getValue(WebOptions.webBrowserDebugPort)!)
+        ? getValue(WebOptions.webBrowserDebugPort)
         : null;
     final List<String> webBrowserFlags = featureFlags.isWebEnabled
         ? getValue(WebOptions.webBrowserFlags)
@@ -263,8 +263,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
       logger: globals.logger,
     );
 
-    final String? webPortArg = getValue(WebOptions.webPort);
-    final int? webPort = webPortArg != null ? int.tryParse(webPortArg) : null;
+    final int? webPort = getValue(WebOptions.webPort);
 
     // Determine HTTPS config with CLI > file precedence
     final HttpsConfig? httpsConfig = HttpsConfig.parse(

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -549,7 +549,7 @@ abstract class FlutterCommand extends Command<void> {
       return _tryParseHostVmservicePort();
     } else if (wasParsed(DebuggingOptionDescriptors.ddsPort)) {
       // If an explicit DDS port is provided, use dds-port for DDS.
-      return int.tryParse(getValue(DebuggingOptionDescriptors.ddsPort)!) ?? 0;
+      return getValue(DebuggingOptionDescriptors.ddsPort) ?? 0;
     }
     // Otherwise, DDS can bind to a random port.
     return 0;

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -547,12 +547,8 @@ abstract class FlutterCommand extends Command<void> {
     if (!wasParsed(DebuggingOptionDescriptors.ddsPort) && _hostVmServicePortProvided) {
       // If an explicit DDS port is _not_ provided, use the host-vmservice-port for DDS.
       return _tryParseHostVmservicePort();
-    } else if (wasParsed(DebuggingOptionDescriptors.ddsPort)) {
-      // If an explicit DDS port is provided, use dds-port for DDS.
-      return getValue(DebuggingOptionDescriptors.ddsPort) ?? 0;
     }
-    // Otherwise, DDS can bind to a random port.
-    return 0;
+    return getValue(DebuggingOptionDescriptors.ddsPort);
   }
 
   Uri? get devToolsServerAddress {

--- a/packages/flutter_tools/lib/src/runner/options/common_options.dart
+++ b/packages/flutter_tools/lib/src/runner/options/common_options.dart
@@ -443,7 +443,7 @@ abstract final class DebuggingOptionDescriptors {
         'not already connected to the target application.',
   );
 
-  static const ddsPort = StringOptionDescriptor(
+  static const ddsPort = IntOptionDescriptor(
     name: 'dds-port',
     help:
         'When this value is provided, the Dart Development Service (DDS) will be '

--- a/packages/flutter_tools/lib/src/runner/options/common_options.dart
+++ b/packages/flutter_tools/lib/src/runner/options/common_options.dart
@@ -443,8 +443,9 @@ abstract final class DebuggingOptionDescriptors {
         'not already connected to the target application.',
   );
 
-  static const ddsPort = IntOptionDescriptor(
+  static const ddsPort = DefaultedIntOptionDescriptor(
     name: 'dds-port',
+    defaultsTo: 0,
     help:
         'When this value is provided, the Dart Development Service (DDS) will be '
         'bound to the provided port.\n'

--- a/packages/flutter_tools/lib/src/runner/options/option_descriptor.dart
+++ b/packages/flutter_tools/lib/src/runner/options/option_descriptor.dart
@@ -237,6 +237,115 @@ class DefaultedStringOptionDescriptor extends OptionDescriptor<String> {
   }
 }
 
+/// A private base class providing shared integer parsing and registration infrastructure
+/// for [IntOptionDescriptor] and [DefaultedIntOptionDescriptor].
+abstract class _IntOptionDescriptorBase<R> extends OptionDescriptor<R> {
+  const _IntOptionDescriptorBase({
+    required super.name,
+    required super.help,
+    super.abbr,
+    super.valueHelp,
+    super.defaultsTo,
+    this.aliases = const <String>[],
+    super.allowed,
+    super.allowedHelp,
+    super.scope,
+    super.hide,
+    super.verboseOnly,
+  });
+
+  /// Alternative names for this option.
+  final List<String> aliases;
+
+  @override
+  void addTo(ArgParser parser, {bool verboseHelp = false, bool? hideOverride}) {
+    if (_isAlreadyRegistered(parser)) {
+      return;
+    }
+
+    parser.addOption(
+      name,
+      abbr: abbr,
+      aliases: aliases,
+      help: help,
+      valueHelp: valueHelp,
+      defaultsTo: defaultsTo?.toString(),
+      allowed: allowed,
+      allowedHelp: allowedHelp,
+      hide: _computeEffectiveHide(verboseHelp: verboseHelp, hideOverride: hideOverride),
+    );
+    _recordRegistration(parser);
+  }
+}
+
+/// A descriptor for single-value integer options.
+class IntOptionDescriptor extends _IntOptionDescriptorBase<int?> {
+  const IntOptionDescriptor({
+    required super.name,
+    required super.help,
+    super.abbr,
+    super.valueHelp,
+    super.defaultsTo,
+    super.aliases,
+    super.allowed,
+    super.allowedHelp,
+    super.scope,
+    super.hide,
+    super.verboseOnly,
+  });
+
+  @override
+  int? getValue(ArgResults? results, {ArgResults? globalResults}) {
+    final ArgResults? target = _resolveTargetResults(results, globalResults);
+    if (target != null && target.options.contains(name)) {
+      final raw = target[name] as String?;
+      if (raw == null) {
+        return defaultsTo;
+      }
+      final int? parsed = int.tryParse(raw);
+      if (parsed == null) {
+        throw FormatException('Invalid integer value "$raw" for "--$name".');
+      }
+      return parsed;
+    }
+    return defaultsTo;
+  }
+}
+
+/// A descriptor for single-value integer options that have a non-null default value.
+class DefaultedIntOptionDescriptor extends _IntOptionDescriptorBase<int> {
+  const DefaultedIntOptionDescriptor({
+    required super.name,
+    required super.help,
+    required int super.defaultsTo,
+    super.abbr,
+    super.valueHelp,
+    super.aliases,
+    super.allowed,
+    super.allowedHelp,
+    super.scope,
+    super.hide,
+    super.verboseOnly,
+  });
+
+  @override
+  int getValue(ArgResults? results, {ArgResults? globalResults}) {
+    final ArgResults? target = _resolveTargetResults(results, globalResults);
+    if (target != null && target.options.contains(name)) {
+      final raw = target[name] as String?;
+      if (raw == null) {
+        return defaultsTo!;
+      }
+      final int? parsed = int.tryParse(raw);
+      if (parsed == null) {
+        throw FormatException('Invalid integer value "$raw" for "--$name".');
+      }
+      return parsed;
+    }
+    return defaultsTo!;
+  }
+}
+
 /// A descriptor for boolean flags with a concrete default value.
 class FlagOptionDescriptor extends OptionDescriptor<bool> {
   const FlagOptionDescriptor({

--- a/packages/flutter_tools/lib/src/runner/options/option_descriptor.dart
+++ b/packages/flutter_tools/lib/src/runner/options/option_descriptor.dart
@@ -276,6 +276,24 @@ abstract class _IntOptionDescriptorBase<R> extends OptionDescriptor<R> {
     );
     _recordRegistration(parser);
   }
+
+  /// Resolves and parses the integer option value from [results] or [globalResults],
+  /// throwing a [FormatException] if the provided string is not a valid integer.
+  int? _parseValue(ArgResults? results, {ArgResults? globalResults}) {
+    final ArgResults? target = _resolveTargetResults(results, globalResults);
+    if (target != null && target.options.contains(name)) {
+      final raw = target[name] as String?;
+      if (raw == null) {
+        return defaultsTo as int?;
+      }
+      final int? parsed = int.tryParse(raw);
+      if (parsed == null) {
+        throw FormatException('Invalid integer value "$raw" for "--$name".');
+      }
+      return parsed;
+    }
+    return defaultsTo as int?;
+  }
 }
 
 /// A descriptor for single-value integer options.
@@ -295,21 +313,8 @@ class IntOptionDescriptor extends _IntOptionDescriptorBase<int?> {
   });
 
   @override
-  int? getValue(ArgResults? results, {ArgResults? globalResults}) {
-    final ArgResults? target = _resolveTargetResults(results, globalResults);
-    if (target != null && target.options.contains(name)) {
-      final raw = target[name] as String?;
-      if (raw == null) {
-        return defaultsTo;
-      }
-      final int? parsed = int.tryParse(raw);
-      if (parsed == null) {
-        throw FormatException('Invalid integer value "$raw" for "--$name".');
-      }
-      return parsed;
-    }
-    return defaultsTo;
-  }
+  int? getValue(ArgResults? results, {ArgResults? globalResults}) =>
+      _parseValue(results, globalResults: globalResults);
 }
 
 /// A descriptor for single-value integer options that have a non-null default value.
@@ -329,21 +334,8 @@ class DefaultedIntOptionDescriptor extends _IntOptionDescriptorBase<int> {
   });
 
   @override
-  int getValue(ArgResults? results, {ArgResults? globalResults}) {
-    final ArgResults? target = _resolveTargetResults(results, globalResults);
-    if (target != null && target.options.contains(name)) {
-      final raw = target[name] as String?;
-      if (raw == null) {
-        return defaultsTo!;
-      }
-      final int? parsed = int.tryParse(raw);
-      if (parsed == null) {
-        throw FormatException('Invalid integer value "$raw" for "--$name".');
-      }
-      return parsed;
-    }
-    return defaultsTo!;
-  }
+  int getValue(ArgResults? results, {ArgResults? globalResults}) =>
+      _parseValue(results, globalResults: globalResults)!;
 }
 
 /// A descriptor for boolean flags with a concrete default value.

--- a/packages/flutter_tools/lib/src/runner/options/safe_arg_results.dart
+++ b/packages/flutter_tools/lib/src/runner/options/safe_arg_results.dart
@@ -2,13 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../../base/common.dart';
 import '../flutter_command.dart';
 
 /// Type-safe argument extraction extension for [FlutterCommand].
 extension SafeArgResults on FlutterCommand {
   /// Returns the resolved value for [descriptor], falling back to its default value.
-  T getValue<T>(OptionDescriptor<T> descriptor) =>
-      descriptor.getValue(argResults, globalResults: globalResults);
+  T getValue<T>(OptionDescriptor<T> descriptor) {
+    try {
+      return descriptor.getValue(argResults, globalResults: globalResults);
+    } on FormatException catch (e) {
+      throwToolExit(e.message);
+    }
+  }
 
   /// Returns whether [descriptor] was explicitly provided on the command line.
   bool wasProvided(OptionDescriptor<Object?> descriptor) =>

--- a/packages/flutter_tools/lib/src/web/web_options.dart
+++ b/packages/flutter_tools/lib/src/web/web_options.dart
@@ -176,7 +176,7 @@ abstract final class WebOptions {
         'IPV4 for either the Chrome or web-server device.',
   );
 
-  static const webPort = StringOptionDescriptor(
+  static const webPort = IntOptionDescriptor(
     name: 'web-port',
     verboseOnly: true,
     help:
@@ -250,7 +250,7 @@ abstract final class WebOptions {
         'supports this option.',
   );
 
-  static const webBrowserDebugPort = StringOptionDescriptor(
+  static const webBrowserDebugPort = IntOptionDescriptor(
     name: 'web-browser-debug-port',
     verboseOnly: true,
     help:

--- a/packages/flutter_tools/test/general.shard/runner/options/option_descriptor_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/options/option_descriptor_test.dart
@@ -273,6 +273,80 @@ void main() {
     });
   });
 
+  group('IntOptionDescriptor', () {
+    test('returns null when omitted without default', () {
+      const descriptor = IntOptionDescriptor(name: 'port', help: 'Port number');
+      final parser = ArgParser();
+      descriptor.addTo(parser);
+
+      final ArgResults results = parser.parse(<String>[]);
+      expect(descriptor.wasProvided(results), isFalse);
+      expect(descriptor.getValue(results), isNull);
+    });
+
+    test('parses valid integer string', () {
+      const descriptor = IntOptionDescriptor(name: 'port', help: 'Port number');
+      final parser = ArgParser();
+      descriptor.addTo(parser);
+
+      final ArgResults results = parser.parse(<String>['--port=8080']);
+      expect(descriptor.wasProvided(results), isTrue);
+      expect(descriptor.getValue(results), 8080);
+    });
+
+    test('throws FormatException on invalid integer string', () {
+      const descriptor = IntOptionDescriptor(name: 'port', help: 'Port number');
+      final parser = ArgParser();
+      descriptor.addTo(parser);
+
+      final ArgResults results = parser.parse(<String>['--port=not-an-int']);
+      expect(() => descriptor.getValue(results), throwsA(isA<FormatException>()));
+    });
+  });
+
+  group('DefaultedIntOptionDescriptor', () {
+    test('returns default value when omitted', () {
+      const descriptor = DefaultedIntOptionDescriptor(
+        name: 'timeout',
+        defaultsTo: 30,
+        help: 'Timeout in seconds',
+      );
+      final parser = ArgParser();
+      descriptor.addTo(parser);
+
+      final ArgResults results = parser.parse(<String>[]);
+      expect(descriptor.wasProvided(results), isFalse);
+      expect(descriptor.getValue(results), 30);
+    });
+
+    test('returns parsed integer when provided', () {
+      const descriptor = DefaultedIntOptionDescriptor(
+        name: 'timeout',
+        defaultsTo: 30,
+        help: 'Timeout in seconds',
+      );
+      final parser = ArgParser();
+      descriptor.addTo(parser);
+
+      final ArgResults results = parser.parse(<String>['--timeout=60']);
+      expect(descriptor.wasProvided(results), isTrue);
+      expect(descriptor.getValue(results), 60);
+    });
+
+    test('throws FormatException on invalid integer string', () {
+      const descriptor = DefaultedIntOptionDescriptor(
+        name: 'timeout',
+        defaultsTo: 30,
+        help: 'Timeout in seconds',
+      );
+      final parser = ArgParser();
+      descriptor.addTo(parser);
+
+      final ArgResults results = parser.parse(<String>['--timeout=abc']);
+      expect(() => descriptor.getValue(results), throwsA(isA<FormatException>()));
+    });
+  });
+
   group('EnumOptionDescriptor', () {
     test('derives allowed from enum values and returns null when omitted', () {
       const descriptor = EnumOptionDescriptor<_TestEnum>(

--- a/packages/flutter_tools/test/general.shard/runner/options/option_descriptor_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/options/option_descriptor_test.dart
@@ -508,6 +508,24 @@ void main() {
       expect(command.wasProvided(stringOpt), isTrue);
     });
 
+    testUsingContext('converts FormatException from IntOptionDescriptor into ToolExit', () async {
+      const intOpt = IntOptionDescriptor(name: 'port', help: 'Server port');
+      const bundle = _SimpleBundle(descriptors: <OptionDescriptor<Object?>>[intOpt]);
+      final command = _FakeCommand(
+        name: 'serve',
+        description: 'Serve command',
+        bundles: const <OptionBundle>[bundle],
+      );
+
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+      await runner.run(<String>['serve', '--port=not-a-number']);
+
+      expect(
+        () => command.getValue(intOpt),
+        throwsToolExit(message: 'Invalid integer value "not-a-number" for "--port".'),
+      );
+    });
+
     testUsingContext('renders section separator titles in command usage', () {
       const bundle = _TitledBundle();
       final command = _FakeCommand(


### PR DESCRIPTION
Adds IntOptionDescriptor (OptionDescriptor<int?>) and DefaultedIntOptionDescriptor (OptionDescriptor<int>) to option_descriptor.dart.

- Parses single-value integer CLI options and throws a descriptive FormatException on invalid numeric strings.
- Migrates DebuggingOptionDescriptors.ddsPort, WebOptions.webPort, and WebOptions.webBrowserDebugPort from StringOptionDescriptor to IntOptionDescriptor.
- Eliminates redundant manual int.tryParse / int.parse call sites in FlutterCommand.ddsPort and RunCommand.
- Adds comprehensive unit tests in option_descriptor_test.dart.
