### PR TITLE
[tool] Migrate PackagesCommand and Pub to modular dependency injection

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -333,7 +333,11 @@ List<FlutterCommand> generateCommands({
   GenerateLocalizationsCommand(toolContext: toolDependencies.toolContext),
   InstallCommand(toolContext: toolDependencies.toolContext, verboseHelp: verboseHelp),
   LogsCommand(toolContext: toolDependencies.toolContext),
-  PackagesCommand(),
+  PackagesCommand(
+    buildSystem: toolDependencies.buildSystem,
+    toolContext: toolDependencies.toolContext,
+    verboseHelp: verboseHelp,
+  ),
   PrecacheCommand(
     verboseHelp: verboseHelp,
     cache: toolDependencies.toolContext.cache,

--- a/packages/flutter_tools/lib/src/commands/build_swift_package.dart
+++ b/packages/flutter_tools/lib/src/commands/build_swift_package.dart
@@ -310,7 +310,7 @@ class BuildSwiftPackage extends BuildSubCommand {
       throwToolExit('--build-mode is required.');
     }
 
-    final List<Plugin> plugins = await findPlugins(project);
+    final List<Plugin> plugins = await findPlugins(project, logger: logger);
     plugins.sort((Plugin left, Plugin right) => left.name.compareTo(right.name));
     await pluginSwiftDependencies.processPlugins(
       cacheDirectory: cacheDirectory,

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -10,48 +10,73 @@ import 'package:pool/pool.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../base/common.dart';
+import '../base/file_system.dart';
+import '../base/logger.dart';
 import '../base/os.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../build_system/build_system.dart';
 import '../build_system/targets/localizations.dart';
 import '../cache.dart';
+import '../context/tool_context.dart';
 import '../dart/package_map.dart';
 import '../dart/pub.dart';
 import '../flutter_plugins.dart';
-import '../globals.dart' as globals;
 import '../package_graph.dart';
 import '../plugins.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart';
 
 class PackagesCommand extends FlutterCommand {
-  PackagesCommand() {
+  PackagesCommand({
+    required BuildSystem buildSystem,
+    required ToolContext toolContext,
+    super.verboseHelp,
+  }) : _buildSystem = buildSystem,
+       _toolContext = toolContext,
+       super(toolContext: toolContext) {
     addSubcommand(
-      PackagesGetCommand('get', "Get the current package's dependencies.", PubContext.pubGet),
+      PackagesGetCommand(
+        'get',
+        "Get the current package's dependencies.",
+        PubContext.pubGet,
+        buildSystem: _buildSystem,
+        toolContext: _toolContext,
+      ),
     );
     addSubcommand(
       PackagesGetCommand(
         'upgrade',
         "Upgrade the current package's dependencies to latest versions.",
         PubContext.pubUpgrade,
+        buildSystem: _buildSystem,
+        toolContext: _toolContext,
       ),
     );
     addSubcommand(
-      PackagesGetCommand('add', 'Add a dependency to pubspec.yaml.', PubContext.pubAdd),
+      PackagesGetCommand(
+        'add',
+        'Add a dependency to pubspec.yaml.',
+        PubContext.pubAdd,
+        buildSystem: _buildSystem,
+        toolContext: _toolContext,
+      ),
     );
     addSubcommand(
       PackagesGetCommand(
         'remove',
         'Removes a dependency from the current package.',
         PubContext.pubRemove,
+        buildSystem: _buildSystem,
+        toolContext: _toolContext,
       ),
     );
-    addSubcommand(PackagesTestCommand());
+    addSubcommand(PackagesTestCommand(toolContext: _toolContext));
     addSubcommand(
       PackagesForwardCommand(
         'publish',
         'Publish the current package to pub.dartlang.org.',
+        toolContext: _toolContext,
         requiresPubspec: true,
       ),
     );
@@ -59,33 +84,61 @@ class PackagesCommand extends FlutterCommand {
       PackagesForwardCommand(
         'downgrade',
         'Downgrade packages in a Flutter project.',
+        toolContext: _toolContext,
         requiresPubspec: true,
       ),
     );
     addSubcommand(
-      PackagesForwardCommand('deps', 'Print package dependencies.'),
+      PackagesForwardCommand('deps', 'Print package dependencies.', toolContext: _toolContext),
     ); // path to package can be specified with --directory argument
     addSubcommand(
-      PackagesForwardCommand('run', 'Run an executable from a package.', requiresPubspec: true),
+      PackagesForwardCommand(
+        'run',
+        'Run an executable from a package.',
+        toolContext: _toolContext,
+        requiresPubspec: true,
+      ),
     );
-    addSubcommand(PackagesForwardCommand('cache', 'Work with the Pub system cache.'));
-    addSubcommand(PackagesForwardCommand('version', 'Print Pub version.'));
-    addSubcommand(PackagesForwardCommand('uploader', 'Manage uploaders for a package on pub.dev.'));
-    addSubcommand(PackagesForwardCommand('login', 'Log into pub.dev.'));
-    addSubcommand(PackagesForwardCommand('logout', 'Log out of pub.dev.'));
-    addSubcommand(PackagesForwardCommand('global', 'Work with Pub global packages.'));
+    addSubcommand(
+      PackagesForwardCommand('cache', 'Work with the Pub system cache.', toolContext: _toolContext),
+    );
+    addSubcommand(
+      PackagesForwardCommand('version', 'Print Pub version.', toolContext: _toolContext),
+    );
+    addSubcommand(
+      PackagesForwardCommand(
+        'uploader',
+        'Manage uploaders for a package on pub.dev.',
+        toolContext: _toolContext,
+      ),
+    );
+    addSubcommand(PackagesForwardCommand('login', 'Log into pub.dev.', toolContext: _toolContext));
+    addSubcommand(
+      PackagesForwardCommand('logout', 'Log out of pub.dev.', toolContext: _toolContext),
+    );
+    addSubcommand(
+      PackagesForwardCommand('global', 'Work with Pub global packages.', toolContext: _toolContext),
+    );
     addSubcommand(
       PackagesForwardCommand(
         'outdated',
         'Analyze dependencies to find which ones can be upgraded.',
+        toolContext: _toolContext,
         requiresPubspec: true,
       ),
     );
     addSubcommand(
-      PackagesForwardCommand('token', 'Manage authentication tokens for hosted pub repositories.'),
+      PackagesForwardCommand(
+        'token',
+        'Manage authentication tokens for hosted pub repositories.',
+        toolContext: _toolContext,
+      ),
     );
-    addSubcommand(PackagesPassthroughCommand());
+    addSubcommand(PackagesPassthroughCommand(toolContext: _toolContext));
   }
+
+  final ToolContext _toolContext;
+  final BuildSystem _buildSystem;
 
   @override
   final name = 'pub';
@@ -104,41 +157,53 @@ class PackagesCommand extends FlutterCommand {
 }
 
 class PackagesTestCommand extends FlutterCommand {
-  PackagesTestCommand() {
+  PackagesTestCommand({required ToolContext toolContext})
+    : _toolContext = toolContext,
+      super(toolContext: toolContext) {
     requiresPubspecYaml();
   }
+
+  final ToolContext _toolContext;
+
+  late final Pub _pub = _createPub(_toolContext);
 
   @override
   String get name => 'test';
 
   @override
-  String get description {
-    return 'Run the "test" package.\n'
-        'This is similar to "flutter test", but instead of hosting the tests in the '
-        'flutter environment it hosts the tests in a pure Dart environment. The main '
-        'differences are that the "dart:ui" library is not available and that tests '
-        'run faster. This is helpful for testing libraries that do not depend on any '
-        'packages from the Flutter SDK. It is equivalent to "dart test".';
-  }
+  final description = 'Run the test runner for the current package.';
+
+  @override
+  ArgParser argParser = ArgParser.allowAnything();
 
   @override
   String get invocation {
-    return '${runner!.executableName} pub test [<tests...>]';
+    return '${runner!.executableName} pub test [<arguments...>]';
   }
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    await pub.batch(<String>['run', 'test', ...argResults!.rest], context: PubContext.runTest);
+    await _pub.batch(<String>['run', 'test', ...argResults!.rest], context: PubContext.runTest);
     return FlutterCommandResult.success();
   }
 }
 
 class PackagesForwardCommand extends FlutterCommand {
-  PackagesForwardCommand(this._commandName, this._description, {bool requiresPubspec = false}) {
+  PackagesForwardCommand(
+    this._commandName,
+    this._description, {
+    required ToolContext toolContext,
+    bool requiresPubspec = false,
+  }) : _toolContext = toolContext,
+       super(toolContext: toolContext) {
     if (requiresPubspec) {
       requiresPubspecYaml();
     }
   }
+
+  final ToolContext _toolContext;
+
+  late final Pub _pub = _createPub(_toolContext);
 
   PubContext context = PubContext.pubForward;
 
@@ -166,27 +231,34 @@ class PackagesForwardCommand extends FlutterCommand {
   Future<FlutterCommandResult> runCommand() async {
     final List<String> subArgs = argResults!.rest.toList()
       ..removeWhere((String arg) => arg == '--');
-    await pub.interactively(
+    await _pub.interactively(
       <String>[_commandName, ...subArgs],
-      context: context,
       command: _commandName,
+      context: context,
     );
     return FlutterCommandResult.success();
   }
 }
 
 class PackagesPassthroughCommand extends FlutterCommand {
+  PackagesPassthroughCommand({required ToolContext toolContext})
+    : _toolContext = toolContext,
+      super(toolContext: toolContext);
+
+  final ToolContext _toolContext;
+
   @override
   ArgParser argParser = ArgParser.allowAnything();
+
+  late final Pub _pub = _createPub(_toolContext);
 
   @override
   String get name => 'pub';
 
   @override
-  String get description {
-    return 'Pass the remaining arguments to Dart\'s "pub" tool.\n'
-        'This runs the "pub" tool in a Flutter context.';
-  }
+  final String description =
+      'Pass the remaining arguments to Dart\'s "pub" tool.\n'
+      'This runs the "pub" tool in a Flutter context.';
 
   @override
   String get invocation {
@@ -197,14 +269,25 @@ class PackagesPassthroughCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    await pub.interactively(command: 'pub', argResults!.rest, context: _context);
+    await _pub.interactively(argResults!.rest, command: 'pub', context: _context);
     return FlutterCommandResult.success();
   }
 }
 
 /// Represents the pub sub-commands that makes package-resolutions.
 class PackagesGetCommand extends FlutterCommand {
-  PackagesGetCommand(this._commandName, this._description, this._context);
+  PackagesGetCommand(
+    this._commandName,
+    this._description,
+    this._context, {
+    required BuildSystem buildSystem,
+    required ToolContext toolContext,
+  }) : _buildSystem = buildSystem,
+       _toolContext = toolContext,
+       super(toolContext: toolContext);
+
+  final ToolContext _toolContext;
+  final BuildSystem _buildSystem;
 
   @override
   ArgParser argParser = ArgParser.allowAnything();
@@ -228,6 +311,8 @@ class PackagesGetCommand extends FlutterCommand {
   String get invocation {
     return '${runner!.executableName} pub $_commandName [<arguments...>]';
   }
+
+  late final Pub _pub = _createPub(_toolContext);
 
   /// An [ArgParser] that accepts all options and flags that the
   ///
@@ -277,11 +362,15 @@ class PackagesGetCommand extends FlutterCommand {
     } on ArgParserException {
       // Let pub give the error message.
     }
+    final FileSystem fs = _toolContext.fs;
+    final Logger logger = _toolContext.logger;
+    final FlutterProjectFactory projectFactory = _toolContext.projectFactory;
+
     String? target;
     FlutterProject? rootProject;
 
     if (!isHelp) {
-      target = findProjectRoot(globals.fs, directoryOption);
+      target = findProjectRoot(fs, directoryOption);
       if (target == null) {
         if (directoryOption == null) {
           throwToolExit('Expected to find project root in current working directory.');
@@ -290,15 +379,15 @@ class PackagesGetCommand extends FlutterCommand {
         }
       }
 
-      rootProject = FlutterProject.fromDirectory(globals.fs.directory(target));
+      rootProject = projectFactory.fromDirectory(fs.directory(target));
       _rootProject = rootProject;
     }
-    final String? relativeTarget = target == null ? null : globals.fs.path.relative(target);
+    final String? relativeTarget = target == null ? null : fs.path.relative(target);
 
     final List<String> subArgs = rest.toList()..removeWhere((String arg) => arg == '--');
     final timer = Stopwatch()..start();
     try {
-      await pub.interactively(
+      await _pub.interactively(
         <String>[
           name,
           ...subArgs,
@@ -342,14 +431,14 @@ class PackagesGetCommand extends FlutterCommand {
       // tooling if needed.
       final PackageConfig packageConfig = await loadPackageConfigWithLogging(
         rootProject.packageConfig,
-        logger: globals.logger,
+        logger: logger,
       );
       final PackageGraph graph = PackageGraph.load(rootProject);
 
       // Build a cache of all pubspec.yaml contents once, keyed by package root
       // URI. This avoids re-reading the same files for every workspace package
       // during post-processing.
-      final PubspecCache pubspecCache = await buildPubspecCache(packageConfig);
+      final PubspecCache pubspecCache = await buildPubspecCache(packageConfig, fileSystem: fs);
       // Process workspace root packages concurrently, capped to 64 to
       // saturate I/O without exhausting file descriptors or system resources.
       await Pool(64).forEach<String, void>(graph.roots, (String workspaceRootName) async {
@@ -357,26 +446,26 @@ class PackagesGetCommand extends FlutterCommand {
         assert(rootPackage != null);
         final Uri rootUri = rootPackage!.root;
 
-        final FlutterProject project = FlutterProject.fromDirectory(globals.fs.directory(rootUri));
+        final FlutterProject project = projectFactory.fromDirectory(fs.directory(rootUri));
 
         if (project.manifest.generateLocalizations) {
           final environment = Environment(
-            artifacts: globals.artifacts!,
-            logger: globals.logger,
-            cacheDir: globals.cache.getRoot(),
-            engineVersion: globals.flutterVersion.engineRevision,
-            fileSystem: globals.fs,
-            flutterRootDir: globals.fs.directory(Cache.flutterRoot),
-            outputDir: globals.fs.directory(getBuildDirectory()),
-            processManager: globals.processManager,
-            platform: globals.platform,
+            artifacts: _toolContext.artifacts,
+            logger: logger,
+            cacheDir: _toolContext.cache.getRoot(),
+            engineVersion: _toolContext.flutterVersion.engineRevision,
+            fileSystem: fs,
+            flutterRootDir: fs.directory(Cache.flutterRoot),
+            outputDir: fs.directory(getBuildDirectory(_toolContext.config, fs)),
+            processManager: _toolContext.processManager,
+            platform: _toolContext.platform,
             analytics: analytics,
             projectDir: project.directory,
             packageConfigPath: packageConfigPath(),
             generateDartPluginRegistry: true,
           );
           // If localizations were enabled, but we are not using synthetic packages.
-          final BuildResult result = await globals.buildSystem.build(
+          final BuildResult result = await _buildSystem.build(
             const GenerateLocalizationsTarget(),
             environment,
           );
@@ -460,7 +549,7 @@ class PackagesGetCommand extends FlutterCommand {
       return <Plugin>[];
     }
 
-    return findPlugins(rootProject, throwOnError: false);
+    return findPlugins(rootProject, logger: _toolContext.logger, throwOnError: false);
   })();
 
   late final String? _androidEmbeddingVersion = _rootProject?.android
@@ -501,3 +590,12 @@ class PackagesGetCommand extends FlutterCommand {
     );
   }
 }
+
+Pub _createPub(ToolContext toolContext) => Pub(
+  botDetector: toolContext.botDetector,
+  fileSystem: toolContext.fs,
+  logger: toolContext.logger,
+  platform: toolContext.platform,
+  processManager: toolContext.processManager,
+  stdio: toolContext.stdio,
+);

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -32,16 +32,14 @@ class PackagesCommand extends FlutterCommand {
     required BuildSystem buildSystem,
     required ToolContext toolContext,
     super.verboseHelp,
-  }) : _buildSystem = buildSystem,
-       _toolContext = toolContext,
-       super(toolContext: toolContext) {
+  }) : super(toolContext: toolContext) {
     addSubcommand(
       PackagesGetCommand(
         'get',
         "Get the current package's dependencies.",
         PubContext.pubGet,
-        buildSystem: _buildSystem,
-        toolContext: _toolContext,
+        buildSystem: buildSystem,
+        toolContext: toolContext,
       ),
     );
     addSubcommand(
@@ -49,8 +47,8 @@ class PackagesCommand extends FlutterCommand {
         'upgrade',
         "Upgrade the current package's dependencies to latest versions.",
         PubContext.pubUpgrade,
-        buildSystem: _buildSystem,
-        toolContext: _toolContext,
+        buildSystem: buildSystem,
+        toolContext: toolContext,
       ),
     );
     addSubcommand(
@@ -58,8 +56,8 @@ class PackagesCommand extends FlutterCommand {
         'add',
         'Add a dependency to pubspec.yaml.',
         PubContext.pubAdd,
-        buildSystem: _buildSystem,
-        toolContext: _toolContext,
+        buildSystem: buildSystem,
+        toolContext: toolContext,
       ),
     );
     addSubcommand(
@@ -67,16 +65,16 @@ class PackagesCommand extends FlutterCommand {
         'remove',
         'Removes a dependency from the current package.',
         PubContext.pubRemove,
-        buildSystem: _buildSystem,
-        toolContext: _toolContext,
+        buildSystem: buildSystem,
+        toolContext: toolContext,
       ),
     );
-    addSubcommand(PackagesTestCommand(toolContext: _toolContext));
+    addSubcommand(PackagesTestCommand(toolContext: toolContext));
     addSubcommand(
       PackagesForwardCommand(
         'publish',
         'Publish the current package to pub.dartlang.org.',
-        toolContext: _toolContext,
+        toolContext: toolContext,
         requiresPubspec: true,
       ),
     );
@@ -84,46 +82,46 @@ class PackagesCommand extends FlutterCommand {
       PackagesForwardCommand(
         'downgrade',
         'Downgrade packages in a Flutter project.',
-        toolContext: _toolContext,
+        toolContext: toolContext,
         requiresPubspec: true,
       ),
     );
     addSubcommand(
-      PackagesForwardCommand('deps', 'Print package dependencies.', toolContext: _toolContext),
+      PackagesForwardCommand('deps', 'Print package dependencies.', toolContext: toolContext),
     ); // path to package can be specified with --directory argument
     addSubcommand(
       PackagesForwardCommand(
         'run',
         'Run an executable from a package.',
-        toolContext: _toolContext,
+        toolContext: toolContext,
         requiresPubspec: true,
       ),
     );
     addSubcommand(
-      PackagesForwardCommand('cache', 'Work with the Pub system cache.', toolContext: _toolContext),
+      PackagesForwardCommand('cache', 'Work with the Pub system cache.', toolContext: toolContext),
     );
     addSubcommand(
-      PackagesForwardCommand('version', 'Print Pub version.', toolContext: _toolContext),
+      PackagesForwardCommand('version', 'Print Pub version.', toolContext: toolContext),
     );
     addSubcommand(
       PackagesForwardCommand(
         'uploader',
         'Manage uploaders for a package on pub.dev.',
-        toolContext: _toolContext,
+        toolContext: toolContext,
       ),
     );
-    addSubcommand(PackagesForwardCommand('login', 'Log into pub.dev.', toolContext: _toolContext));
+    addSubcommand(PackagesForwardCommand('login', 'Log into pub.dev.', toolContext: toolContext));
     addSubcommand(
-      PackagesForwardCommand('logout', 'Log out of pub.dev.', toolContext: _toolContext),
+      PackagesForwardCommand('logout', 'Log out of pub.dev.', toolContext: toolContext),
     );
     addSubcommand(
-      PackagesForwardCommand('global', 'Work with Pub global packages.', toolContext: _toolContext),
+      PackagesForwardCommand('global', 'Work with Pub global packages.', toolContext: toolContext),
     );
     addSubcommand(
       PackagesForwardCommand(
         'outdated',
         'Analyze dependencies to find which ones can be upgraded.',
-        toolContext: _toolContext,
+        toolContext: toolContext,
         requiresPubspec: true,
       ),
     );
@@ -131,14 +129,11 @@ class PackagesCommand extends FlutterCommand {
       PackagesForwardCommand(
         'token',
         'Manage authentication tokens for hosted pub repositories.',
-        toolContext: _toolContext,
+        toolContext: toolContext,
       ),
     );
-    addSubcommand(PackagesPassthroughCommand(toolContext: _toolContext));
+    addSubcommand(PackagesPassthroughCommand(toolContext: toolContext));
   }
-
-  final ToolContext _toolContext;
-  final BuildSystem _buildSystem;
 
   @override
   final name = 'pub';
@@ -171,14 +166,18 @@ class PackagesTestCommand extends FlutterCommand {
   String get name => 'test';
 
   @override
-  final description = 'Run the test runner for the current package.';
-
-  @override
-  ArgParser argParser = ArgParser.allowAnything();
+  String get description {
+    return 'Run the "test" package.\n'
+        'This is similar to "flutter test", but instead of hosting the tests in the '
+        'flutter environment it hosts the tests in a pure Dart environment. The main '
+        'differences are that the "dart:ui" library is not available and that tests '
+        'run faster. This is helpful for testing libraries that do not depend on any '
+        'packages from the Flutter SDK. It is equivalent to "dart test".';
+  }
 
   @override
   String get invocation {
-    return '${runner!.executableName} pub test [<arguments...>]';
+    return '${runner!.executableName} pub test [<tests...>]';
   }
 
   @override
@@ -362,9 +361,8 @@ class PackagesGetCommand extends FlutterCommand {
     } on ArgParserException {
       // Let pub give the error message.
     }
-    final FileSystem fs = _toolContext.fs;
-    final Logger logger = _toolContext.logger;
-    final FlutterProjectFactory projectFactory = _toolContext.projectFactory;
+    final ToolContext(:FileSystem fs, :Logger logger, :FlutterProjectFactory projectFactory) =
+        _toolContext;
 
     String? target;
     FlutterProject? rootProject;

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
+
 import '../base/bot_detector.dart';
 import '../base/common.dart';
 import '../base/context.dart';
@@ -109,21 +110,40 @@ enum PubOutputMode {
 abstract class Pub {
   /// Create a default [Pub] instance.
   factory Pub({
+    required BotDetector botDetector,
     required FileSystem fileSystem,
     required Logger logger,
-    required ProcessManager processManager,
     required Platform platform,
-    required BotDetector botDetector,
-  }) = _DefaultPub;
+    required ProcessManager processManager,
+    Stdio? stdio,
+  }) {
+    if (stdio != null) {
+      return _DefaultPub.test(
+        fileSystem: fileSystem,
+        logger: logger,
+        processManager: processManager,
+        platform: platform,
+        botDetector: botDetector,
+        stdio: stdio,
+      );
+    }
+    return _DefaultPub(
+      fileSystem: fileSystem,
+      logger: logger,
+      processManager: processManager,
+      platform: platform,
+      botDetector: botDetector,
+    );
+  }
 
   /// Create a [Pub] instance with a mocked [stdio].
   @visibleForTesting
   factory Pub.test({
+    required BotDetector botDetector,
     required FileSystem fileSystem,
     required Logger logger,
-    required ProcessManager processManager,
     required Platform platform,
-    required BotDetector botDetector,
+    required ProcessManager processManager,
     required Stdio stdio,
   }) = _DefaultPub.test;
 
@@ -147,13 +167,13 @@ abstract class Pub {
   Future<void> get({
     required PubContext context,
     required FlutterProject project,
-    bool upgrade = false,
-    bool offline = false,
-    String? flutterRootOverride,
     bool checkUpToDate = false,
-    bool shouldSkipThirdPartyGenerator = true,
     bool enforceLockfile = false,
+    String? flutterRootOverride,
+    bool offline = false,
     PubOutputMode outputMode = PubOutputMode.all,
+    bool shouldSkipThirdPartyGenerator = true,
+    bool upgrade = false,
   });
 
   /// Runs pub in 'batch' mode.
@@ -188,21 +208,21 @@ abstract class Pub {
   /// create a new `.dart_tool/package_config.json` file.
   Future<void> interactively(
     List<String> arguments, {
-    FlutterProject? project,
-    required PubContext context,
     required String command,
-    bool touchesPackageConfig = false,
+    required PubContext context,
     PubOutputMode outputMode = PubOutputMode.all,
+    FlutterProject? project,
+    bool touchesPackageConfig = false,
   });
 }
 
 class _DefaultPub implements Pub {
   _DefaultPub({
+    required BotDetector botDetector,
     required FileSystem fileSystem,
     required Logger logger,
-    required ProcessManager processManager,
     required Platform platform,
-    required BotDetector botDetector,
+    required ProcessManager processManager,
   }) : _fileSystem = fileSystem,
        _logger = logger,
        _platform = platform,
@@ -215,11 +235,11 @@ class _DefaultPub implements Pub {
 
   @visibleForTesting
   _DefaultPub.test({
+    required BotDetector botDetector,
     required FileSystem fileSystem,
     required Logger logger,
-    required ProcessManager processManager,
     required Platform platform,
-    required BotDetector botDetector,
+    required ProcessManager processManager,
     required Stdio stdio,
   }) : _fileSystem = fileSystem,
        _logger = logger,
@@ -244,18 +264,72 @@ class _DefaultPub implements Pub {
   Future<void> get({
     required PubContext context,
     required FlutterProject project,
-    bool upgrade = false,
-    bool offline = false,
-    String? flutterRootOverride,
     bool checkUpToDate = false,
-    bool shouldSkipThirdPartyGenerator = true,
     bool enforceLockfile = false,
+    String? flutterRootOverride,
+    bool offline = false,
     PubOutputMode outputMode = PubOutputMode.all,
+    bool shouldSkipThirdPartyGenerator = true,
+    bool upgrade = false,
   }) async {
     final String directory = project.directory.path;
-    if (shouldSkipThirdPartyGenerator) {
-      final File? packageConfigFile = findPackageConfigFile(project.directory);
-      if (packageConfigFile != null && packageConfigFile.existsSync()) {
+
+    // Here we use pub's private helper file to locate the package_config.
+    // In pub workspaces pub will generate a `.dart_tool/pub/workspace_ref.json`
+    // inside each workspace-package that refers to the workspace root where
+    // .dart_tool/package_config.json is located.
+    //
+    // By checking for this file instead of iterating parent directories until
+    // finding .dart_tool/package_config.json we will not mistakenly find a
+    // package_config.json from outside the workspace.
+    //
+    // TODO(sigurdm): avoid relying on pubs implementation details somehow?
+    final File workspaceRefFile = project.dartTool
+        .childDirectory('pub')
+        .childFile('workspace_ref.json');
+    final File packageConfigFile;
+    if (workspaceRefFile.existsSync()) {
+      Object? decoded;
+      try {
+        decoded = jsonDecode(workspaceRefFile.readAsStringSync());
+      } on FormatException {
+        // Fall through to default.
+      }
+      switch (decoded) {
+        case {'workspaceRoot': final String workspaceRoot}:
+          packageConfigFile = _fileSystem.file(
+            _fileSystem.path.join(
+              workspaceRefFile.parent.path,
+              workspaceRoot,
+              '.dart_tool',
+              'package_config.json',
+            ),
+          );
+        default:
+          // The workspace_ref.json file was malformed. Attempt to load the
+          // regular .dart_tool/package_config.json
+          //
+          // Most likely this doesn't exist, and we will get a new pub
+          // resolution.
+          //
+          // Alternatively this is a stray file somehow, and it can be ignored.
+          packageConfigFile = project.dartTool.childFile('package_config.json');
+      }
+    } else {
+      packageConfigFile = project.dartTool.childFile('package_config.json');
+    }
+
+    if (packageConfigFile.existsSync()) {
+      final Directory workspaceRoot = packageConfigFile.parent.parent;
+      final File lastVersion = workspaceRoot.childDirectory('.dart_tool').childFile('version');
+      final versionFromFile = FlutterVersion(
+        flutterRoot: Cache.flutterRoot!,
+        fs: _fileSystem,
+        git: _git,
+        platform: _platform,
+      );
+
+      if (shouldSkipThirdPartyGenerator) {
         Map<String, Object?> packageConfigMap;
         try {
           packageConfigMap =
@@ -272,30 +346,17 @@ class _DefaultPub implements Pub {
           return;
         }
       }
-    }
 
-    var versionMatch = false;
-    if (checkUpToDate) {
-      final File? packageConfigFile = findPackageConfigFile(project.directory);
-      if (packageConfigFile != null && packageConfigFile.existsSync()) {
-        final Directory workspaceRoot = packageConfigFile.parent.parent;
-        final File lastVersion = workspaceRoot.childDirectory('.dart_tool').childFile('version');
-        final versionFromFile = FlutterVersion(
-          flutterRoot: Cache.flutterRoot!,
-          fs: _fileSystem,
-          git: _git,
-        );
-        versionMatch =
-            lastVersion.existsSync() &&
-            lastVersion.readAsStringSync() == versionFromFile.frameworkVersion;
+      final bool versionMatch =
+          lastVersion.existsSync() &&
+          lastVersion.readAsStringSync() == versionFromFile.frameworkVersion;
+
+      if (checkUpToDate &&
+          versionMatch &&
+          await _checkResolutionUpToDate(directory, context, flutterRootOverride)) {
+        _logger.printTrace('Skipping pub get: resolution up-to-date.');
+        return;
       }
-    }
-
-    if (checkUpToDate &&
-        versionMatch &&
-        await _checkResolutionUpToDate(directory, context, flutterRootOverride)) {
-      _logger.printTrace('Skipping pub get: resolution up-to-date.');
-      return;
     }
 
     final command = upgrade ? 'upgrade' : 'get';
@@ -541,12 +602,12 @@ class _DefaultPub implements Pub {
   @override
   Future<void> interactively(
     List<String> arguments, {
-    FlutterProject? project,
-    required PubContext context,
     required String command,
-    bool touchesPackageConfig = false,
+    required PubContext context,
     bool generateSyntheticPackage = false,
     PubOutputMode outputMode = PubOutputMode.all,
+    FlutterProject? project,
+    bool touchesPackageConfig = false,
   }) async {
     await _runWithStdioInherited(
       arguments,
@@ -679,6 +740,7 @@ class _DefaultPub implements Pub {
       flutterRoot: Cache.flutterRoot!,
       fs: _fileSystem,
       git: _git,
+      platform: _platform,
     );
     lastVersion.writeAsStringSync(versionFromFile.frameworkVersion);
 

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -292,7 +292,7 @@ class _DefaultPub implements Pub {
       Object? decoded;
       try {
         decoded = jsonDecode(workspaceRefFile.readAsStringSync());
-      } on FormatException {
+      } on Exception {
         // Fall through to default.
       }
       switch (decoded) {
@@ -320,8 +320,7 @@ class _DefaultPub implements Pub {
     }
 
     if (packageConfigFile.existsSync()) {
-      final Directory workspaceRoot = packageConfigFile.parent.parent;
-      final File lastVersion = workspaceRoot.childDirectory('.dart_tool').childFile('version');
+      final File lastVersion = packageConfigFile.parent.childFile('version');
       final versionFromFile = FlutterVersion(
         flutterRoot: Cache.flutterRoot!,
         fs: _fileSystem,

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -13,6 +13,7 @@ import 'android/gradle.dart';
 import 'base/common.dart';
 import 'base/error_handling_io.dart';
 import 'base/file_system.dart';
+import 'base/logger.dart';
 import 'base/os.dart';
 import 'base/platform.dart';
 import 'base/template.dart';
@@ -161,10 +162,11 @@ Future<Plugin?> _pluginFromPackage(
 /// If [throwOnError] is `true`, an empty package configuration is an error.
 Future<List<Plugin>> findPlugins(
   FlutterProject project, {
-  bool throwOnError = true,
-  PubspecCache? pubspecCache,
-  PackageGraph? packageGraph,
+  Logger? logger,
   PackageConfig? packageConfig,
+  PackageGraph? packageGraph,
+  PubspecCache? pubspecCache,
+  bool throwOnError = true,
 }) async {
   final plugins = <Plugin>[];
   final FileSystem fs = project.directory.fileSystem;
@@ -183,7 +185,7 @@ Future<List<Plugin>> findPlugins(
     final File packageConfigFile = findPackageConfigFileOrDefault(project.directory);
     resolvedPackageConfig = await loadPackageConfigWithLogging(
       packageConfigFile,
-      logger: globals.logger,
+      logger: logger ?? globals.logger,
       throwOnError: throwOnError,
     );
   }
@@ -199,7 +201,7 @@ Future<List<Plugin>> findPlugins(
       if (throwOnError) {
         throwToolExit('Could not locate package:$packageName. Try running `flutter pub get`');
       } else {
-        globals.logger.printTrace('Could not locate package:$packageName');
+        (logger ?? globals.logger).printTrace('Could not locate package:$packageName');
         continue;
       }
     }

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -162,7 +162,7 @@ Future<Plugin?> _pluginFromPackage(
 /// If [throwOnError] is `true`, an empty package configuration is an error.
 Future<List<Plugin>> findPlugins(
   FlutterProject project, {
-  Logger? logger,
+  required Logger logger,
   PackageConfig? packageConfig,
   PackageGraph? packageGraph,
   PubspecCache? pubspecCache,
@@ -185,7 +185,7 @@ Future<List<Plugin>> findPlugins(
     final File packageConfigFile = findPackageConfigFileOrDefault(project.directory);
     resolvedPackageConfig = await loadPackageConfigWithLogging(
       packageConfigFile,
-      logger: logger ?? globals.logger,
+      logger: logger,
       throwOnError: throwOnError,
     );
   }
@@ -201,7 +201,7 @@ Future<List<Plugin>> findPlugins(
       if (throwOnError) {
         throwToolExit('Could not locate package:$packageName. Try running `flutter pub get`');
       } else {
-        (logger ?? globals.logger).printTrace('Could not locate package:$packageName');
+        logger.printTrace('Could not locate package:$packageName');
         continue;
       }
     }
@@ -1305,6 +1305,7 @@ Future<void> refreshPluginsList(
 }) async {
   final List<Plugin> plugins = await findPlugins(
     project,
+    logger: globals.logger,
     pubspecCache: pubspecCache,
     packageGraph: packageGraph,
     packageConfig: packageConfig,
@@ -1363,7 +1364,7 @@ Future<void> injectBuildTimePluginFilesForWebPlatform(
   FlutterProject project, {
   required Directory destination,
 }) async {
-  final List<Plugin> plugins = await findPlugins(project);
+  final List<Plugin> plugins = await findPlugins(project, logger: globals.logger);
   final Map<String, List<Plugin>> pluginsByPlatform = _resolvePluginImplementations(
     plugins,
     pluginResolutionType: _PluginResolutionType.nativeOrDart,
@@ -1402,6 +1403,7 @@ Future<void> injectPlugins(
 }) async {
   final List<Plugin> plugins = await findPlugins(
     project,
+    logger: globals.logger,
     pubspecCache: pubspecCache,
     packageGraph: packageGraph,
     packageConfig: packageConfig,
@@ -1940,7 +1942,7 @@ Future<void> generateMainDartWithPluginRegistrant(
   PackageConfig packageConfig,
   File mainFile,
 ) async {
-  final List<Plugin> plugins = await findPlugins(rootProject);
+  final List<Plugin> plugins = await findPlugins(rootProject, logger: globals.logger);
   final List<PluginInterfaceResolution> resolutions = resolvePlatformImplementation(
     plugins,
     selectDartPluginsOnly: true,

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -85,6 +85,7 @@ class WebBuilder {
 
     final bool hasWebPlugins = (await findPlugins(
       flutterProject,
+      logger: _logger,
     )).any((Plugin p) => p.platforms.containsKey(WebPlugin.kConfigKey));
     final Directory outputDirectory = outputDirectoryPath == null
         ? _fileSystem.directory(

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -88,7 +88,7 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform {
   /// On the first call, this will find plugins in the project.
   /// On subsequent calls, this will return the cached list of plugins.
   Future<List<Plugin>> getPlugins() async {
-    _plugins ??= await findPlugins(parent);
+    _plugins ??= await findPlugins(parent, logger: globals.logger);
     return _plugins!;
   }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/pub_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/pub_test.dart
@@ -7,7 +7,9 @@ import 'dart:convert';
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart' as io;
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/packages.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
@@ -15,8 +17,11 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
-import '../../src/context.dart';
+import '../../src/common.dart';
+import '../../src/fake_process_manager.dart';
+import '../../src/fakes.dart' hide FakeProcess;
 import '../../src/package_config.dart';
+import '../../src/test_build_system.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 const minimalV2EmbeddingManifest = r'''
@@ -32,13 +37,13 @@ const minimalV2EmbeddingManifest = r'''
 
 void main() {
   late FileSystem fileSystem;
-  late FakePub pub;
+  late _PubTestProcessManager processManager;
   late BufferLogger logger;
 
   setUp(() {
     Cache.disableLocking();
     fileSystem = MemoryFileSystem.test();
-    pub = FakePub();
+    processManager = _PubTestProcessManager(fileSystem);
     logger = BufferLogger.test();
   });
 
@@ -46,8 +51,31 @@ void main() {
     Cache.enableLocking();
   });
 
-  testUsingContext('pub shows help', () async {
-    final command = PackagesCommand();
+  PackagesGetCommand createPackagesGetCommand(
+    String commandName,
+    String description,
+    PubContext context,
+  ) {
+    final toolContext = FakeToolContext(
+      fs: fileSystem,
+      logger: logger,
+      processManager: processManager,
+    );
+    return PackagesGetCommand(
+      commandName,
+      description,
+      context,
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      toolContext: toolContext,
+    );
+  }
+
+  testWithoutContext('pub shows help', () async {
+    final toolContext = FakeToolContext(fs: fileSystem, logger: logger);
+    final command = PackagesCommand(
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      toolContext: toolContext,
+    );
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['pub']);
 
@@ -58,9 +86,9 @@ void main() {
         contains('Usage: flutter pub <subcommand> [arguments]'),
       ),
     );
-  }, overrides: <Type, Generator>{Logger: () => logger});
+  });
 
-  testUsingContext(
+  testWithoutContext(
     'pub get usage values are resilient to missing package config files before running "pub get"',
     () async {
       fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
@@ -70,7 +98,7 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync(minimalV2EmbeddingManifest);
 
-      final command = PackagesGetCommand('get', '', PubContext.pubGet);
+      final PackagesGetCommand command = createPackagesGetCommand('get', '', PubContext.pubGet);
       final CommandRunner<void> commandRunner = createTestCommandRunner(command);
 
       await commandRunner.run(<String>['get']);
@@ -86,14 +114,9 @@ void main() {
         ),
       );
     },
-    overrides: <Type, Generator>{
-      Pub: () => pub,
-      ProcessManager: () => FakeProcessManager.any(),
-      FileSystem: () => fileSystem,
-    },
   );
 
-  testUsingContext(
+  testWithoutContext(
     'pub get usage values are resilient to poorly formatted package config before "pub get"',
     () async {
       fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
@@ -106,7 +129,7 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync(minimalV2EmbeddingManifest);
 
-      final command = PackagesGetCommand('get', '', PubContext.pubGet);
+      final PackagesGetCommand command = createPackagesGetCommand('get', '', PubContext.pubGet);
       final CommandRunner<void> commandRunner = createTestCommandRunner(command);
 
       await commandRunner.run(<String>['get']);
@@ -122,114 +145,86 @@ void main() {
         ),
       );
     },
-    overrides: <Type, Generator>{
-      Pub: () => pub,
-      ProcessManager: () => FakeProcessManager.any(),
-      FileSystem: () => fileSystem,
-    },
   );
 
-  testUsingContext(
-    'pub get on target directory',
-    () async {
-      fileSystem.currentDirectory.childDirectory('target').createSync();
-      final Directory targetDirectory = fileSystem.currentDirectory.childDirectory('target');
-      targetDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
+  testWithoutContext('pub get on target directory', () async {
+    fileSystem.currentDirectory.childDirectory('target').createSync();
+    final Directory targetDirectory = fileSystem.currentDirectory.childDirectory('target');
+    targetDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
 
-      final command = PackagesGetCommand('get', '', PubContext.pubGet);
-      final CommandRunner<void> commandRunner = createTestCommandRunner(command);
+    final PackagesGetCommand command = createPackagesGetCommand('get', '', PubContext.pubGet);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
 
-      await commandRunner.run(<String>['get', '--directory=${targetDirectory.path}']);
-      final FlutterProject rootProject = FlutterProject.fromDirectory(targetDirectory);
-      final File packageConfigFile = rootProject.dartTool.childFile('package_config.json');
+    await commandRunner.run(<String>['get', '--directory=${targetDirectory.path}']);
+    final FlutterProject rootProject = FlutterProject.fromDirectoryTest(targetDirectory, logger);
+    final File packageConfigFile = rootProject.dartTool.childFile('package_config.json');
 
-      expect(packageConfigFile.existsSync(), true);
-      expect(json.decode(packageConfigFile.readAsStringSync()), <String, Object>{
-        'configVersion': 2,
-        'packages': <Object?>[
-          <String, Object?>{
-            'name': 'my_app',
-            'rootUri': '../',
-            'packageUri': 'lib/',
-            'languageVersion': '3.7',
-          },
-        ],
-      });
-    },
-    overrides: <Type, Generator>{
-      Pub: () => pub,
-      ProcessManager: () => FakeProcessManager.any(),
-      FileSystem: () => fileSystem,
-    },
-  );
+    expect(packageConfigFile.existsSync(), true);
+    expect(json.decode(packageConfigFile.readAsStringSync()), <String, Object>{
+      'configVersion': 2,
+      'packages': <Object?>[
+        <String, Object?>{
+          'name': 'my_app',
+          'rootUri': '../',
+          'packageUri': 'lib/',
+          'languageVersion': '3.7',
+        },
+      ],
+    });
+  });
 
-  testUsingContext(
-    "pub get doesn't treat unknown flag as directory",
-    () async {
-      fileSystem.currentDirectory.childDirectory('target').createSync();
-      fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
-      final command = PackagesGetCommand('get', '', PubContext.pubGet);
-      final CommandRunner<void> commandRunner = createTestCommandRunner(command);
-      pub.expectedArguments = <String>['get', '--unknown-flag', '--example', '--directory', '.'];
-      await commandRunner.run(<String>['get', '--unknown-flag']);
-    },
-    overrides: <Type, Generator>{
-      Pub: () => pub,
-      ProcessManager: () => FakeProcessManager.any(),
-      FileSystem: () => fileSystem,
-    },
-  );
+  testWithoutContext("pub get doesn't treat unknown flag as directory", () async {
+    fileSystem.currentDirectory.childDirectory('target').createSync();
+    fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
+    final PackagesGetCommand command = createPackagesGetCommand('get', '', PubContext.pubGet);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
+    await commandRunner.run(<String>['get', '--unknown-flag']);
+    expect(
+      processManager.lastCommand,
+      containsAllInOrder(<String>['get', '--unknown-flag', '--example', '--directory', '.']),
+    );
+  });
 
-  testUsingContext(
-    "pub get doesn't treat -v as directory",
-    () async {
-      fileSystem.currentDirectory.childDirectory('target').createSync();
-      fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
-      final command = PackagesGetCommand('get', '', PubContext.pubGet);
-      final CommandRunner<void> commandRunner = createTestCommandRunner(command);
-      pub.expectedArguments = <String>['get', '-v', '--example', '--directory', '.'];
-      await commandRunner.run(<String>['get', '-v']);
-    },
-    overrides: <Type, Generator>{
-      Pub: () => pub,
-      ProcessManager: () => FakeProcessManager.any(),
-      FileSystem: () => fileSystem,
-    },
-  );
+  testWithoutContext("pub get doesn't treat -v as directory", () async {
+    fileSystem.currentDirectory.childDirectory('target').createSync();
+    fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
+    final PackagesGetCommand command = createPackagesGetCommand('get', '', PubContext.pubGet);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
+    await commandRunner.run(<String>['get', '-v']);
+    expect(
+      processManager.lastCommand,
+      containsAllInOrder(<String>['get', '-v', '--example', '--directory', '.']),
+    );
+  });
 
   // Regression test for https://github.com/flutter/flutter/issues/144898
   // Regression test for https://github.com/flutter/flutter/issues/160145
-  testUsingContext(
-    "pub add doesn't treat dependency syntax as directory",
-    () async {
-      fileSystem.currentDirectory.childDirectory('target').createSync();
-      fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
-      fileSystem.currentDirectory.childDirectory('example').createSync(recursive: true);
-      fileSystem.currentDirectory.childDirectory('android').childFile('AndroidManifest.xml')
-        ..createSync(recursive: true)
-        ..writeAsStringSync(minimalV2EmbeddingManifest);
+  testWithoutContext("pub add doesn't treat dependency syntax as directory", () async {
+    fileSystem.currentDirectory.childDirectory('target').createSync();
+    fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
+    fileSystem.currentDirectory.childDirectory('example').createSync(recursive: true);
+    fileSystem.currentDirectory.childDirectory('android').childFile('AndroidManifest.xml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(minimalV2EmbeddingManifest);
 
-      final command = PackagesGetCommand('add', '', PubContext.pubAdd);
-      final CommandRunner<void> commandRunner = createTestCommandRunner(command);
-      const availableSyntax = <String>[
-        'foo:{"path":"../foo"}',
-        'foo:{"hosted":"my-pub.dev"}',
-        'foo:{"sdk":"flutter"}',
-        'foo:{"git":"https://github.com/foo/foo"}',
-      ];
-      for (final syntax in availableSyntax) {
-        pub.expectedArguments = <String>['add', syntax, '--example', '--directory', '.'];
-        await commandRunner.run(<String>['add', syntax]);
-      }
-    },
-    overrides: <Type, Generator>{
-      Pub: () => pub,
-      ProcessManager: () => FakeProcessManager.any(),
-      FileSystem: () => fileSystem,
-    },
-  );
+    final PackagesGetCommand command = createPackagesGetCommand('add', '', PubContext.pubAdd);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
+    const availableSyntax = <String>[
+      'foo:{"path":"../foo"}',
+      'foo:{"hosted":"my-pub.dev"}',
+      'foo:{"sdk":"flutter"}',
+      'foo:{"git":"https://github.com/foo/foo"}',
+    ];
+    for (final syntax in availableSyntax) {
+      await commandRunner.run(<String>['add', syntax]);
+      expect(
+        processManager.lastCommand,
+        containsAllInOrder(<String>['add', syntax, '--example', '--directory', '.']),
+      );
+    }
+  });
 
-  testUsingContext(
+  testWithoutContext(
     "pub get skips example directory if it doesn't contain a pubspec.yaml",
     () async {
       fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
@@ -238,7 +233,7 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync(minimalV2EmbeddingManifest);
 
-      final command = PackagesGetCommand('get', '', PubContext.pubGet);
+      final PackagesGetCommand command = createPackagesGetCommand('get', '', PubContext.pubGet);
       final CommandRunner<void> commandRunner = createTestCommandRunner(command);
 
       await commandRunner.run(<String>['get']);
@@ -254,50 +249,95 @@ void main() {
         ),
       );
     },
-    overrides: <Type, Generator>{
-      Pub: () => pub,
-      ProcessManager: () => FakeProcessManager.any(),
-      FileSystem: () => fileSystem,
-    },
   );
 
-  testUsingContext(
-    'pub get throws error on missing directory',
-    () async {
-      final command = PackagesGetCommand('get', '', PubContext.pubGet);
-      final CommandRunner<void> commandRunner = createTestCommandRunner(command);
+  testWithoutContext('pub get throws error on missing directory', () async {
+    final PackagesGetCommand command = createPackagesGetCommand('get', '', PubContext.pubGet);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
 
-      try {
-        await commandRunner.run(<String>['get', '--directory=missing_dir']);
-        fail('expected an exception');
-      } on Exception catch (e) {
-        expect(e.toString(), contains('Expected to find project root in missing_dir'));
-      }
-    },
-    overrides: <Type, Generator>{
-      Pub: () => pub,
-      ProcessManager: () => FakeProcessManager.any(),
-      FileSystem: () => fileSystem,
+    try {
+      await commandRunner.run(<String>['get', '--directory=missing_dir']);
+      fail('expected an exception');
+    } on Exception catch (e) {
+      expect(e.toString(), contains('Expected to find project root in missing_dir'));
+    }
+  });
+
+  testWithoutContext(
+    'packages forward command forwards command name and arguments to pub',
+    () async {
+      final toolContext = FakeToolContext(
+        fs: fileSystem,
+        logger: logger,
+        processManager: processManager,
+      );
+      fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
+      final command = PackagesCommand(
+        buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+        toolContext: toolContext,
+      );
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+      await runner.run(<String>['pub', 'outdated', '--json']);
+      expect(
+        processManager.lastCommand,
+        containsAllInOrder(<String>['pub', '--suppress-analytics', 'outdated', '--json']),
+      );
     },
   );
 }
 
-class FakePub extends Fake implements Pub {
-  FakePub();
+class _PubTestProcessManager extends Fake implements ProcessManager {
+  _PubTestProcessManager(this.fileSystem);
 
-  List<String>? expectedArguments;
+  final FileSystem fileSystem;
+  List<String>? lastCommand;
 
   @override
-  Future<void> interactively(
-    List<String> arguments, {
-    FlutterProject? project,
-    required PubContext context,
-    required String command,
-    bool touchesPackageConfig = false,
-    PubOutputMode outputMode = PubOutputMode.all,
+  bool canRun(Object? executable, {String? workingDirectory}) => true;
+
+  @override
+  Future<io.Process> start(
+    List<Object> command, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    io.ProcessStartMode mode = io.ProcessStartMode.normal,
   }) async {
-    if (project != null) {
-      writePackageConfigFiles(directory: project.directory, mainLibName: 'my_app');
+    final stringCommand = <String>[for (final e in command) e.toString()];
+    lastCommand = stringCommand;
+    String? dir;
+    const directoryFlagPrefix = '--directory=';
+    for (final (index, arg) in stringCommand.indexed) {
+      if (arg == '--directory' && index + 1 < stringCommand.length) {
+        dir = stringCommand[index + 1];
+        break;
+      }
+      if (arg.startsWith(directoryFlagPrefix)) {
+        dir = arg.substring(directoryFlagPrefix.length);
+        break;
+      }
     }
+    final Directory targetDir = dir != null
+        ? fileSystem.directory(dir)
+        : fileSystem.currentDirectory;
+    writePackageConfigFiles(directory: targetDir, mainLibName: 'my_app');
+    return FakeProcess();
+  }
+
+  @override
+  io.ProcessResult runSync(
+    List<Object> command, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    covariant Object? stdoutEncoding = io.systemEncoding,
+    covariant Object? stderrEncoding = io.systemEncoding,
+  }) {
+    if (command.contains('tag')) {
+      return io.ProcessResult(1, 0, '1.2.3', '');
+    }
+    return io.ProcessResult(1, 0, '1234567890abcdef', '');
   }
 }

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/file_system.dart' hide IOSink;
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/packages.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
@@ -24,6 +25,7 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
+import '../../src/test_build_system.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -75,7 +77,10 @@ void main() {
       List<String>? args,
       List<String>? globalArgs,
     }) async {
-      final command = PackagesCommand();
+      final command = PackagesCommand(
+        buildSystem: globals.buildSystem,
+        toolContext: DelegatingToolContext(),
+      );
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>[
         ...?globalArgs,
@@ -847,7 +852,12 @@ flutter:
             ],
           ),
         );
-        await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
+        await createTestCommandRunner(
+          PackagesCommand(
+            buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+            toolContext: DelegatingToolContext(),
+          ),
+        ).run(<String>['packages', 'test']);
 
         expect(processManager, hasNoRemainingExpectations);
       },
@@ -885,7 +895,12 @@ flutter:
             ],
           ),
         );
-        await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
+        await createTestCommandRunner(
+          PackagesCommand(
+            buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+            toolContext: DelegatingToolContext(),
+          ),
+        ).run(<String>['packages', 'test']);
 
         expect(processManager, hasNoRemainingExpectations);
       },
@@ -926,7 +941,10 @@ flutter:
           ),
         );
         await createTestCommandRunner(
-          PackagesCommand(),
+          PackagesCommand(
+            buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+            toolContext: DelegatingToolContext(),
+          ),
         ).run(<String>['packages', '--verbose', 'pub', 'run', '--foo', 'bar']);
 
         expect(processManager, hasNoRemainingExpectations);
@@ -966,7 +984,10 @@ flutter:
           ),
         );
         await createTestCommandRunner(
-          PackagesCommand(),
+          PackagesCommand(
+            buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+            toolContext: DelegatingToolContext(),
+          ),
         ).run(<String>['packages', '--verbose', 'pub', 'token', 'list']);
 
         expect(processManager, hasNoRemainingExpectations);
@@ -1003,7 +1024,12 @@ flutter:
             stdin: IOSink(StreamController<List<int>>().sink),
           ),
         );
-        await createTestCommandRunner(PackagesCommand()).run(<String>['pub', 'upgrade', '-h']);
+        await createTestCommandRunner(
+          PackagesCommand(
+            buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+            toolContext: DelegatingToolContext(),
+          ),
+        ).run(<String>['pub', 'upgrade', '-h']);
 
         expect(processManager, hasNoRemainingExpectations);
       },

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -497,7 +497,10 @@ dependencies:
               .writeAsBytesSync(Uint8List.fromList(<int>[0xff, 0xfe, 0xfd]));
 
           // The tool must not crash when a plugin's pubspec.yaml cannot be read.
-          final Future<List<Plugin>> pluginsFuture = findPlugins(flutterProject);
+          final Future<List<Plugin>> pluginsFuture = findPlugins(
+            flutterProject,
+            logger: BufferLogger.test(),
+          );
           await expectLater(pluginsFuture, completes);
 
           // The unreadable plugin is skipped, but the readable one is still found.


### PR DESCRIPTION
Migrates PackagesCommand, its subcommands, and Pub to modular dependency injection with ToolContext. Stacked before PR #190787.