### PR TITLE
Migrate ios driver tests batch 4 to simulators

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5427,13 +5427,18 @@ targets:
   #
   # Also, rename this to "external_textures_integration_test" to be consistent
   # with the Android test, but that can wait until we've figured out the flake.
-  - name: Mac_ios external_ui_integration_test_ios
+  - name: Mac external_ui_integration_test_ios
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac"]
+        ["devicelab", "hostonly", "mac"]
       task_name: external_textures_integration_test_ios
       ignore_flakiness: "true"
 
@@ -5668,13 +5673,18 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: ios_defines_test
 
-  - name: Mac_ios hello_world_impeller_ios_sdfs
+  - name: Mac hello_world_impeller_ios_sdfs
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac"]
+        ["devicelab", "hostonly", "mac"]
       task_name: hello_world_impeller_ios_sdfs
 
   - name: Mac_ios large_image_changer_perf_ios

--- a/dev/devicelab/bin/tasks/external_textures_integration_test_ios.dart
+++ b/dev/devicelab/bin/tasks/external_textures_integration_test_ios.dart
@@ -4,9 +4,29 @@
 
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/ios.dart';
+import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
-  await task(createExternalTexturesFrameRateIntegrationTest());
+  await task(() async {
+    String? simulatorDeviceId;
+    TaskResult? result;
+    try {
+      await testWithNewIOSSimulator('external_textures_integration_test_ios', (
+        String deviceId,
+      ) async {
+        simulatorDeviceId = deviceId;
+        result = await createExternalTexturesFrameRateIntegrationTest(
+          deviceIdOverride: deviceId,
+        ).call();
+      });
+    } finally {
+      if (simulatorDeviceId != null) {
+        await removeIOSSimulator(simulatorDeviceId);
+      }
+    }
+    return result ?? TaskResult.failure('Simulator creation failed');
+  });
 }

--- a/dev/devicelab/lib/tasks/integration_tests.dart
+++ b/dev/devicelab/lib/tasks/integration_tests.dart
@@ -53,11 +53,13 @@ TaskFunction createIntegrationTestFlavorsTest({
 
 TaskFunction createExternalTexturesFrameRateIntegrationTest({
   List<String> extraOptions = const <String>[],
+  String? deviceIdOverride,
 }) {
   return DriverTest(
     '${flutterDirectory.path}/dev/integration_tests/external_textures',
     'lib/frame_rate_main.dart',
     extraOptions: extraOptions,
+    deviceIdOverride: deviceIdOverride,
   ).call;
 }
 

--- a/dev/integration_tests/external_textures/ios/Runner/AppDelegate.h
+++ b/dev/integration_tests/external_textures/ios/Runner/AppDelegate.h
@@ -5,5 +5,5 @@
 #import <UIKit/UIKit.h>
 #import <Flutter/Flutter.h>
 
-@interface AppDelegate : FlutterAppDelegate
+@interface AppDelegate : FlutterAppDelegate <FlutterImplicitEngineDelegate>
 @end

--- a/dev/integration_tests/external_textures/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/external_textures/ios/Runner/AppDelegate.m
@@ -5,4 +5,15 @@
 #import "AppDelegate.h"
 
 @implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application
+    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  return [super application:application
+      didFinishLaunchingWithOptions:launchOptions];
+}
+
+- (void)didInitializeImplicitFlutterEngine:
+    (NSObject<FlutterImplicitEngineBridge> *)engineBridge {
+}
+
 @end

--- a/examples/hello_world/ios/Runner/AppDelegate.h
+++ b/examples/hello_world/ios/Runner/AppDelegate.h
@@ -5,6 +5,6 @@
 #import <UIKit/UIKit.h>
 #import <Flutter/Flutter.h>
 
-@interface AppDelegate : FlutterAppDelegate
+@interface AppDelegate : FlutterAppDelegate <FlutterImplicitEngineDelegate>
 
 @end

--- a/examples/hello_world/ios/Runner/AppDelegate.m
+++ b/examples/hello_world/ios/Runner/AppDelegate.m
@@ -7,9 +7,14 @@
 
 @implementation AppDelegate
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  [GeneratedPluginRegistrant registerWithRegistry:self];
-  // Override point for customization after application launch.
-  return [super application:application didFinishLaunchingWithOptions:launchOptions];
+- (BOOL)application:(UIApplication *)application
+    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  return [super application:application
+      didFinishLaunchingWithOptions:launchOptions];
+}
+
+- (void)didInitializeImplicitFlutterEngine:
+    (NSObject<FlutterImplicitEngineBridge> *)engineBridge {
+  [GeneratedPluginRegistrant registerWithRegistry:engineBridge.pluginRegistry];
 }
 @end

--- a/examples/hello_world/ios/Runner/Info.plist
+++ b/examples/hello_world/ios/Runner/Info.plist
@@ -43,5 +43,26 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/186414

This batch migrates 2 Devicelab tests to simulators:
* `external_ui_integration_test_ios` (`external_textures_integration_test_ios`)
* `hello_world_impeller_ios_sdfs`

Changes:
- Moved targets in `.ci.yaml` from `Mac_ios` to `Mac` (Simulator) with `bringup: true` and injected `ruby` dependency.
- Changed tags to `["devicelab", "hostonly", "mac"]`.
- Wrapped `external_textures_integration_test_ios` Devicelab task with `testWithNewIOSSimulator`.
- Migrated `dev/integration_tests/external_textures` and `examples/hello_world` iOS projects to adopt `UIScene` .