### PR TITLE
Make SelectableRegion selection geometry accessors null-safe

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1786,19 +1786,39 @@ class SelectableRegionState extends State<SelectableRegion>
   }
 
   /// The line height at the start of the current selection.
+  ///
+  /// The selection points can be null when they are queried while the selection
+  /// is being cleared, for example when the selected content is disposed or
+  /// scrolled out of the viewport. Falls back to the other selection point, and
+  /// to zero when there is no selection at all, so that callers such as
+  /// [contextMenuAnchors] do not crash in that window.
   double get startGlyphHeight {
-    return _selectionDelegate.value.startSelectionPoint!.lineHeight;
+    final SelectionPoint? start = _selectionDelegate.value.startSelectionPoint;
+    final SelectionPoint? end = _selectionDelegate.value.endSelectionPoint;
+    return (start ?? end)?.lineHeight ?? 0;
   }
 
   /// The line height at the end of the current selection.
+  ///
+  /// Falls back to the other selection point, and to zero when there is no
+  /// selection at all. See [startGlyphHeight].
   double get endGlyphHeight {
-    return _selectionDelegate.value.endSelectionPoint!.lineHeight;
+    final SelectionPoint? start = _selectionDelegate.value.startSelectionPoint;
+    final SelectionPoint? end = _selectionDelegate.value.endSelectionPoint;
+    return (end ?? start)?.lineHeight ?? 0;
   }
 
   /// Returns the local coordinates of the endpoints of the current selection.
+  ///
+  /// Returns an empty list when there is no selection, which can happen when
+  /// this is queried while the selection is being cleared. See
+  /// [startGlyphHeight].
   List<TextSelectionPoint> get selectionEndpoints {
     final SelectionPoint? start = _selectionDelegate.value.startSelectionPoint;
     final SelectionPoint? end = _selectionDelegate.value.endSelectionPoint;
+    if (start == null && end == null) {
+      return const <TextSelectionPoint>[];
+    }
     late List<TextSelectionPoint> points;
     final Offset startLocalPosition = start?.localPosition ?? end!.localPosition;
     final Offset endLocalPosition = end?.localPosition ?? start!.localPosition;

--- a/packages/flutter/lib/src/widgets/text_selection_toolbar_anchors.dart
+++ b/packages/flutter/lib/src/widgets/text_selection_toolbar_anchors.dart
@@ -78,6 +78,10 @@ class TextSelectionToolbarAnchors {
       return Rect.zero;
     }
 
+    if (selectionEndpoints.isEmpty) {
+      return Rect.zero;
+    }
+
     final bool isMultiline =
         selectionEndpoints.last.point.dy - selectionEndpoints.first.point.dy > endGlyphHeight / 2;
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -998,6 +998,44 @@ void main() {
       );
       expect(tester.getSize(find.byType(SelectableRegion)), Size.zero);
     });
+
+    testWidgets('context menu anchors do not crash when the selection has been cleared', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/124078.
+      //
+      // The selection points can become null between the gesture that requests
+      // the context menu and the menu being built, for example when the
+      // selected content scrolled out of the viewport or was disposed. Reading
+      // the anchors for the context menu must not crash in that window.
+      const text = 'Hello world, how are you today?';
+      await tester.pumpWidget(
+        TestWidgetsApp(home: _selectableRegion(child: const Text(text))),
+      );
+      await tester.pumpAndSettle();
+
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+        find.descendant(of: find.text(text), matching: find.byType(RichText)),
+      );
+
+      // Long press to select a word and show the context menu.
+      await tester.longPressAt(textOffsetToPosition(paragraph, 7));
+      await tester.pumpAndSettle();
+      expect(paragraph.selections, isNotEmpty);
+
+      // Clear the selection to simulate the race where the selection points
+      // are no longer available while the context menu is being built.
+      final SelectableRegionState state = tester.state<SelectableRegionState>(
+        find.byType(SelectableRegion),
+      );
+      state.clearSelection();
+      await tester.pumpAndSettle();
+
+      // Before the fix this threw a "Null check operator used on a null value"
+      // exception from startGlyphHeight.
+      final TextSelectionToolbarAnchors anchors = state.contextMenuAnchors;
+      expect(anchors.primaryAnchor, isNotNull);
+    });
   });
 
   testWidgets('Can extend StaticSelectionContainerDelegate', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Fixes #124078 (picked up from the abandoned #183261, which the framework team asked whether the author still wanted to work on).

The selection points stored by `SelectableRegionState` can become null while they are still being queried. This happens in production when the gesture that shows the context menu races with the selection being cleared — for example the selected content scrolled out of the viewport (`ListView` + `select all`, as in the issue) or was disposed (dialog closing / list refresh), per crash reports such as the stack in #124078:

```
SelectableRegionState.startGlyphHeight        <- Null check operator used on a null value
SelectableRegionState.contextMenuAnchors
AdaptiveTextSelectionToolbar.selectableRegion
SelectionArea._defaultContextMenuBuilder
SelectableRegionState._showToolbar
```

In that window three accessors were unsafe:

- `startGlyphHeight` / `endGlyphHeight` used `!` on the selection points when read through `contextMenuAnchors` by the default context menu builder.
- `selectionEndpoints` used `end!` / `start!` fallbacks when both points were null.
- `TextSelectionToolbarAnchors.getSelectionRect` assumed a non-empty endpoint list (`selectionEndpoints.last` / `.first`).

## Changes

This PR makes no behavior change when a selection exists:

- `startGlyphHeight` / `endGlyphHeight` now fall back to the other selection point, then to `0` — mirroring the existing `start?.lineHeight ?? end!.lineHeight` pattern used in `_createSelectionOverlay`.
- `selectionEndpoints` returns an empty list when there is no selection.
- `TextSelectionToolbarAnchors.getSelectionRect` returns `Rect.zero` for an empty endpoint list, which the existing `fromSelection` factory already handles by falling back to `primaryAnchor: Offset.zero`.

## Test plan

Added a regression test in `selectable_region_test.dart` that selects a word via long press, clears the selection, then reads `contextMenuAnchors`. Verified it fails on unpatched `master` with the exact production crash (`Null check operator used on a null value` at `startGlyphHeight`) and passes with this change.

Ran locally, all green:

- `test/widgets/selectable_region_test.dart` (228 tests)
- `test/widgets/selectable_region_context_menu_test.dart` + `test/material/selection_area_test.dart`
- `test/widgets/selection_container_test.dart` + `test/widgets/text_selection_test.dart`
- `test/material/adaptive_text_selection_toolbar_test.dart` + cupertino toolbar suites