### PR TITLE
Move iOS compile benchmarks to Mac_benchmark and pin Mac_benchmark to M1

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5355,13 +5355,13 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: backdrop_filter_perf_ios__timeline_summary
 
-  - name: Mac_arm64_ios basic_material_app_ios__compile
+  - name: Mac_arm64 basic_material_app_ios__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "ios", "mac"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: basic_material_app_ios__compile
 
   - name: Mac channels_integration_test_ios
@@ -5461,13 +5461,17 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: flavors_test_ios
 
-  - name: Mac_arm64_ios flutter_gallery_ios__compile
+  - name: Mac_arm64 flutter_gallery_ios__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: flutter_gallery_ios__compile
 
   - name: Mac_ios flutter_gallery_ios__start_up
@@ -5488,22 +5492,22 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: flutter_view_ios__start_up
 
-  - name: Mac_arm64_ios hello_world_ios__compile
+  - name: Mac_arm64 hello_world_ios__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: hello_world_ios__compile
 
-  - name: Mac_arm64_ios imitation_game_flutter
+  - name: Mac_arm64 imitation_game_flutter
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: imitation_game_flutter__compile
 
   - name: Mac_arm64_ios imitation_game_swiftui


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/186414

This batch moves the 4 iOS compile benchmarks off physical-device bots and onto the pinned benchmark pool:
* `basic_material_app_ios__compile`
* `flutter_gallery_ios__compile`
* `hello_world_ios__compile`
* `imitation_game_flutter` (task: `imitation_game_flutter__compile`)

These tasks only run `flutter build ios` and never launch an app on the attached iPhone (details in [#186414 (comment)](https://github.com/flutter/flutter/issues/186414#issuecomment-5599492717)). On `Mac_arm64_ios` they tie up physical devices and, because that pool mixes M1 and M4 Pro hosts, every metric is split into two disconnected Skia Perf series (`device_type=iPhone_11` vs `iPhone_16_Pro`) with a ~40–60% timing gap.

Per [#186414 (comment)](https://github.com/flutter/flutter/issues/186414#issuecomment-5737235311), instead of moving them to the unpinned `Mac_arm64` pool:

**Changes**
- `platform_properties.mac_benchmark`: `mac_model` `"Macmini8,1"` (Intel, being turned down per [flutter.dev/go/macos-intel-deprecation](https://flutter.dev/go/macos-intel-deprecation)) → `"Macmini9,1"` (Apple Silicon M1 Mac mini), plus `cpu: arm64` and an `arm64` tag.
- Moved the 4 targets from `Mac_arm64_ios` to `Mac_benchmark` with `bringup: true`. They inherit `device_type: none` and `["devicelab", "hostonly", "mac", "arm64"]` from the platform; dropping the `ios` tag also stops the devicelab recipe from running `ideviceinfo` (which would fail on a host-only bot). `flutter_gallery_ios__compile` keeps the `ruby` dependency for CocoaPods, matching `flutter_gallery_macos__compile`.
- `imitation_game_swiftui` stays on `Mac_arm64_ios` — it runs `xcodebuild test` against a physical device.

**Heads-up for the metrics sheriff**
- All 13 existing `Mac_benchmark` macOS targets (`*_macos__compile`, `*_macos__start_up`, `complex_layout_scroll_perf_macos*`, `new_gallery_macos_impeller__transition_perf`, `flutter_tool_startup__macos`, …) move from Intel to M1 hardware with this change, so their baselines will shift (and the `arch` benchmark tag changes from `intel` to `arm`). Expect one-time step changes on Skia Perf rather than regressions.
- Host-only `Macmini9,1` capacity in `luci.flutter.prod` is ~56 bots (vs ~37 Intel `Macmini8,1`), shared with `Mac_arm64`; today that pool is all M1, so the pin mostly future-proofs against M4 Pros being added.

