### PR TITLE
Update packages, ensuring native_stack_traces is bumped to 0.7.0.

### DIFF
--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   # 'test' package, which change between versions, so when upgrading
   # this, make sure the tests are still running correctly.
   # See https://github.com/flutter/flutter/issues/185016
-  test_api: 0.7.13
+  test_api: 0.7.14
   matcher: 0.12.20
 
   # Used by golden file comparator
@@ -26,12 +26,12 @@ dependencies:
 
   # Testing utilities for dealing with async calls and time.
   fake_async: ^1.3.3
-  clock: ^1.1.2
+  clock: ^1.1.3
 
   # We import stack_trace because the test packages uses it and we
   # need to be able to unmangle the stack traces that it passed to
   # stack_trace. See https://github.com/dart-lang/test/issues/590
-  stack_trace: ^1.12.1
+  stack_trace: ^1.12.2
 
   # Used by globalToLocal et al.
   vector_math: ^2.4.2
@@ -48,4 +48,4 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
 
-# PUBSPEC CHECKSUM: iu3p08
+# PUBSPEC CHECKSUM: dod4ph

--- a/packages/flutter_tools/packages/flutter_tools_core/pubspec.yaml
+++ b/packages/flutter_tools/packages/flutter_tools_core/pubspec.yaml
@@ -9,6 +9,6 @@ dependencies:
   meta: 1.19.0
 
 dev_dependencies:
-  test: 1.31.2
+  test: 1.32.0
 
-# PUBSPEC CHECKSUM: 12mc60
+# PUBSPEC CHECKSUM: ua9vva

--- a/packages/flutter_tools/packages/flutter_tools_extension_linux_prototype/pubspec.yaml
+++ b/packages/flutter_tools/packages/flutter_tools_extension_linux_prototype/pubspec.yaml
@@ -13,6 +13,6 @@ dependencies:
     path: ../flutter_tools_extension
 
 dev_dependencies:
-  test: 1.31.2
+  test: 1.32.0
 
-# PUBSPEC CHECKSUM: mq6q80
+# PUBSPEC CHECKSUM: ln9fcj

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   dap_adapters: 1.0.0
   dds: 5.4.0
   dwds: 27.1.3
-  code_builder: 4.11.1
+  code_builder: 4.12.0
   collection: 1.19.1
   completion: 1.0.2
   coverage: 1.15.1
@@ -35,21 +35,21 @@ dependencies:
   flutter_tools_extension_linux_prototype:
     path: packages/flutter_tools_extension_linux_prototype
   flutter_template_images: 5.0.0
-  html: 0.15.6
+  html: 0.15.7
   http: 1.6.0
   intl: 0.20.3
   meta: 1.19.0
   multicast_dns: 0.3.3+1
   mustache_template: 2.0.5
   package_config: 2.2.0
-  process: 5.0.5
+  process: 5.0.6
   fake_async: 1.3.3
-  stack_trace: 1.12.1
+  stack_trace: 1.12.2
   webdriver: 3.1.0
   webkit_inspection_protocol: 1.2.1
   xml: 6.6.1
-  yaml: 3.1.3
-  native_stack_traces: 0.6.1
+  yaml: 3.1.4
+  native_stack_traces: 0.7.0
   shelf: 1.4.2
   vm_snapshot_analysis: 0.7.6
   uuid: 4.6.0
@@ -57,16 +57,16 @@ dependencies:
   stream_channel: 2.1.4
   shelf_web_socket: 3.0.0
   shelf_static: 1.1.3
-  pub_semver: 2.2.0
-  pool: 1.5.2
+  pub_semver: 2.2.1
+  pool: 1.5.3
   path: 1.9.1
-  mime: 2.0.0
+  mime: 2.1.0
   logging: 1.3.0
   http_multi_server: 3.2.2
   convert: 3.1.2
   async: 2.13.1
   unified_analytics: 8.0.18
-  pubspec_parse: 1.5.0
+  pubspec_parse: 1.6.0
 
   graphs: 2.3.2
   hooks_runner: 1.6.3
@@ -78,23 +78,23 @@ dependencies:
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so when upgrading
   # this, make sure the tests are still running correctly.
-  test_api: 0.7.13
-  test_core: 0.6.19
+  test_api: 0.7.14
+  test_core: 0.6.20
 
   vm_service: 15.3.0
 
   standard_message_codec: 0.0.1+5
 
-  dart_style: 3.1.12
+  dart_style: 3.1.13
 
   # The below dependencies are transitive and are here to pin them to a specific version.
   _fe_analyzer_shared: 107.0.0
   boolean_selector: 2.1.2
-  browser_launcher: 1.1.3
+  browser_launcher: 1.2.0
   built_collection: 5.1.1
-  built_value: 8.12.7
+  built_value: 8.13.0
   cli_config: 0.2.0
-  clock: 1.1.2
+  clock: 1.1.3
   csslib: 1.0.2
   dap: 1.4.0
   dds_service_extensions: 2.1.0
@@ -103,13 +103,13 @@ dependencies:
   extension_discovery: 2.1.0
   fixnum: 1.1.1
   frontend_server_client: 4.0.0
-  glob: 2.1.3
+  glob: 2.2.0
   http_parser: 4.1.2
-  io: 1.0.5
+  io: 1.1.0
   json_rpc_2: 4.1.0
   matcher: 0.12.20
   petitparser: 7.0.2
-  platform: 3.1.6
+  platform: 3.2.0
   shelf_packages_handler: 3.0.2
   shelf_proxy: 1.0.5
   source_map_stack_trace: 2.1.2
@@ -128,16 +128,16 @@ dependencies:
   yaml_edit: 2.2.4
 
 dev_dependencies:
-  file_testing: 3.0.2
+  file_testing: 3.1.0
 
   checked_yaml: 2.0.4
   js: 0.7.2
   json_annotation: 4.12.0
   node_preamble: 2.0.2
-  test: 1.31.2
+  test: 1.32.0
 
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: nnrahd
+# PUBSPEC CHECKSUM: eldlso

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,7 +13,7 @@ packages:
     dependency: "direct main"
     description:
       name: _fe_analyzer_shared
-      sha256: "fe18c7e37d5acb3b43224fa255281dec007970d6fd01f6d76fcd88ed3777a117"
+      sha256: fe18c7e37d5acb3b43224fa255281dec007970d6fd01f6d76fcd88ed3777a117
       url: "https://pub.dev"
     source: hosted
     version: "107.0.0"
@@ -29,7 +29,7 @@ packages:
     dependency: transitive
     description:
       name: analysis_server_plugin
-      sha256: "fc372bb4778b901afe4dea2e7f71ec74e6cbe772999d9961a4d8e382bc4fa49c"
+      sha256: fc372bb4778b901afe4dea2e7f71ec74e6cbe772999d9961a4d8e382bc4fa49c
       url: "https://pub.dev"
     source: hosted
     version: "0.3.22"
@@ -37,7 +37,7 @@ packages:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: "f2dde9e50c23fc95b846b4ef334e98c3ae8c0effd5d2453b02fc9fb3f8939791"
+      sha256: f2dde9e50c23fc95b846b4ef334e98c3ae8c0effd5d2453b02fc9fb3f8939791
       url: "https://pub.dev"
     source: hosted
     version: "14.3.0"
@@ -110,10 +110,10 @@ packages:
     dependency: transitive
     description:
       name: browser_launcher
-      sha256: ca2557663d3033845f2ef2b60f94fc249528324fd1affddccb7c63ac0ccd6c67
+      sha256: "3b81cb3b35dd3734952585c2dd78b7808fa2630b740ba0dfee17f057d406a990"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   built_collection:
     dependency: transitive
     description:
@@ -126,10 +126,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8"
+      sha256: f87ea98192116f7093cb214551ce1929caae0681fdba282b3d8b4462adee7bb7
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.7"
+    version: "8.13.0"
   characters:
     dependency: "direct main"
     description:
@@ -166,10 +166,10 @@ packages:
     dependency: "direct main"
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: e51d50bca3217c9a9fa2b41a30e4a38971133f5f9ec7a3d57bae095007f1d28e
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   code_assets:
     dependency: "direct main"
     description:
@@ -182,10 +182,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
+      sha256: aa5932e94c6c39c2f9ec4e5e06dfdd11a9430a61f6c41b6ba75b28ce0c481baf
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.1"
+    version: "4.12.0"
   collection:
     dependency: "direct main"
     description:
@@ -278,10 +278,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_style
-      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
+      sha256: "82ade9fc4273f29ed673e33166944465225b4f7fc5d4aaef48605cc751c18fc1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.12"
+    version: "3.1.13"
   data_assets:
     dependency: "direct main"
     description:
@@ -374,10 +374,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_testing
-      sha256: eb0c85fd118ddc0d41c295c09f64e0924c256b071087cdc9828d5372c80d554d
+      sha256: e2f5285a9b0fad6e06350aa33f53413529bba39703f79e94d74c9de77446c7b4
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   fixnum:
     dependency: "direct main"
     description:
@@ -474,10 +474,10 @@ packages:
     dependency: "direct main"
     description:
       name: glob
-      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      sha256: "218aeb56050c714f62a3182775320dfa04602b55074873e24e31bbd39bda96fb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.0"
   google_cloud:
     dependency: transitive
     description:
@@ -554,10 +554,10 @@ packages:
     dependency: "direct main"
     description:
       name: html
-      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      sha256: "43b67b8f43321ab066817dfac5619596c98bb1b61624e77203bb4351785f9699"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.6"
+    version: "0.15.7"
   http:
     dependency: "direct main"
     description:
@@ -602,10 +602,10 @@ packages:
     dependency: "direct main"
     description:
       name: io
-      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
+      sha256: "2635216ca6a737e60de577ffa1a48a0bec76ca8a62917cfc1bb88c14c570646f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   isolate:
     dependency: "direct main"
     description:
@@ -754,10 +754,10 @@ packages:
     dependency: "direct main"
     description:
       name: mime
-      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      sha256: bd47de35f07e27267e69c8c8b22edf9473bfee170a60d60fcc93730c5144b7f6
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   multicast_dns:
     dependency: transitive
     description:
@@ -778,10 +778,10 @@ packages:
     dependency: transitive
     description:
       name: native_stack_traces
-      sha256: d34cf916db87b14d39465b3e3b4b4a8ee1f304bde6ed7605571e34802e3d6a11
+      sha256: "2117de75654627ac1ccbf325f70b0777ec3f4d20822a0e44ff7994d2fb1b19d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   native_toolchain_c:
     dependency: "direct main"
     description:
@@ -890,10 +890,10 @@ packages:
     dependency: "direct main"
     description:
       name: platform
-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      sha256: a36d119c13416516a7b5913fbe8af8531e11633d784c550b2125f76c758524ec
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.6"
+    version: "3.2.0"
   plugin_platform_interface:
     dependency: "direct main"
     description:
@@ -906,18 +906,18 @@ packages:
     dependency: "direct main"
     description:
       name: pool
-      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
+      sha256: "4177f68c237ea2128d1bee66ac17b2ce05ba3dbaafcbdd54c5d40a39d0b6b11c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.2"
+    version: "1.5.3"
   process:
     dependency: "direct main"
     description:
       name: process
-      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      sha256: "4242ba3508d37e01808bdf71ad1d5bb93a8d671bf2e7450e6b1b353fb0808891"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.5"
+    version: "5.0.6"
   process_runner:
     dependency: "direct main"
     description:
@@ -938,18 +938,18 @@ packages:
     dependency: "direct main"
     description:
       name: pub_semver
-      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      sha256: "261236774e8b1d69cfc6b9eabbc96c40f25e7a2d6b171f3385d4f65d5734fb24"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   pubspec_parse:
     dependency: "direct main"
     description:
       name: pubspec_parse
-      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      sha256: c38b81cbf34450b67e0265d73433569d12e34782e30ed769c9cc99c9d5f2e796
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   quiver:
     dependency: "direct main"
     description:
@@ -1095,10 +1095,10 @@ packages:
     dependency: "direct main"
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "277654b3034d17ac6f9f1cb5595db011b1d5d41e8806866db28e0abaa101c490"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.12.2"
   standard_message_codec:
     dependency: "direct main"
     description:
@@ -1143,26 +1143,26 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "0d5ba5602ec3baa28c8ce365e1efc5575969c765f45c554a3e167dc7945b9c30"
+      sha256: de5d145b0afff7921e5e788a880f52d7e5f3ae24068a202f6fd3b58e4ba26323
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.2"
+    version: "1.32.0"
   test_api:
     dependency: "direct main"
     description:
       name: test_api
-      sha256: "475610b2aa23c19687cce2961e44b0cc57cafe220f67c2b80201231b2a07fbe7"
+      sha256: "0a10344e901e5b2e63819567951cb6a06673ed6b84f40462188ff5a0c41f371f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.13"
+    version: "0.7.14"
   test_core:
     dependency: "direct main"
     description:
       name: test_core
-      sha256: a39c204a4fc7a7ccb04a2b985e359fda3cc37e45e0b8ac61c3fb1a05aa832132
+      sha256: "80f3fb49087454e07e7e07c67578cfdd156c8c3a5227d8b3f47c7b2d019c2e93"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.19"
+    version: "0.6.20"
   test_reflective_loader:
     dependency: transitive
     description:
@@ -1199,34 +1199,34 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher_android
-      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      sha256: "611e87fb320b70d1dd721dc46af89c98aceccea9b31fde49e084591414e0c610"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.32"
+    version: "6.3.33"
   url_launcher_ios:
     dependency: "direct main"
     description:
       name: url_launcher_ios
-      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      sha256: "8faa1aab294f1ab4040b43660c887b0418d5fa4f0cffef76a484e6aa1092eb4a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "6.4.2"
   url_launcher_linux:
     dependency: "direct main"
     description:
       name: url_launcher_linux
-      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      sha256: "10f86fef4c2c43563fa6c211ff9cf757adf4d3ab762c56bd430664a947d70cd0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   url_launcher_macos:
     dependency: "direct main"
     description:
       name: url_launcher_macos
-      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      sha256: "5e835a3b869c2d70325349c81c5a45c28e20791265b67b2669da6b08c5cd5201"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.5"
+    version: "3.2.6"
   url_launcher_platform_interface:
     dependency: "direct main"
     description:
@@ -1247,10 +1247,10 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher_windows
-      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      sha256: "6c5ad3f22cd4c38e089b81963b3cd7bb83b111b2df5dce008bb066162f42e429"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   uuid:
     dependency: transitive
     description:
@@ -1279,18 +1279,18 @@ packages:
     dependency: "direct main"
     description:
       name: video_player_android
-      sha256: e229676f8fade3e0124482495aaa2b548872cc4018b6268adfca4868be16aa74
+      sha256: d27054dea34d748a44f06d433a57005d2aac69944485b0abbaed3303dbcfa3f1
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.12.2"
   video_player_avfoundation:
     dependency: "direct main"
     description:
       name: video_player_avfoundation
-      sha256: c238f5f0a26845cd0bcc2956049b63065a4d3c40ddfc22c3414cd170bef7fff9
+      sha256: "2fc56e537324a19eb649fca991aa308ac961b5406292876fa657b062de461fd8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   video_player_platform_interface:
     dependency: "direct main"
     description:
@@ -1391,10 +1391,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_android
-      sha256: b98656fa4461f8cc05c48a778b4d4883e60ec63e1778348f363f9bb9a477745d
+      sha256: "4de8b3d1ff4ebe1bdb42e68a5e4f809194a3cb0117a8f495f590004f00da3964"
       url: "https://pub.dev"
     source: hosted
-    version: "4.14.0"
+    version: "4.14.1"
   webview_flutter_platform_interface:
     dependency: "direct main"
     description:
@@ -1407,10 +1407,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
-      sha256: c879dd64b87c452aa84381b244d5469da57ba7e8cca6884c7b1e0d406372c12d
+      sha256: fe359c7fac1002124b5b9e2ba3a41906bbb9b2d029ccb4a0067404d8f3704730
       url: "https://pub.dev"
     source: hosted
-    version: "3.26.0"
+    version: "3.26.1"
   xdg_directories:
     dependency: "direct main"
     description:
@@ -1431,10 +1431,10 @@ packages:
     dependency: "direct main"
     description:
       name: yaml
-      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      sha256: f67cdd8e07d3c6329146aaef1ba043542b3134c12489f553ca9a7435d1068aea
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
   yaml_edit:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,7 +99,7 @@ dependencies:
   characters: ^1.4.1
   checked_yaml: 2.0.4
   cli_config: 0.2.0
-  clock: ^1.1.2
+  clock: ^1.1.3
   code_assets: 2.0.0
   collection: ^1.19.1
   convert: 3.1.2
@@ -116,7 +116,7 @@ dependencies:
   flutter_staggered_grid_view: 0.7.0
   frontend_server_client: 4.0.0
   gcloud: 0.8.19
-  glob: 2.1.3
+  glob: 2.2.0
   google_fonts: 6.3.3
   google_identity_services_web: 0.3.3+1
   google_mobile_ads: 8.0.0
@@ -125,12 +125,12 @@ dependencies:
   hooks: 2.2.0
   data_assets: 0.20.0
   record_use: 1.1.1
-  html: 0.15.6
+  html: 0.15.7
   http: 1.6.0
   http_multi_server: 3.2.2
   http_parser: 4.1.2
   intl: ^0.20.3
-  io: 1.0.5
+  io: 1.1.0
   isolate: 2.1.1
   js: 0.7.2
   json_annotation: 4.12.0
@@ -142,7 +142,7 @@ dependencies:
   material_color_utilities: 0.13.0
   meta: ^1.19.0
   metrics_center: 1.0.15
-  mime: 2.0.0
+  mime: 2.1.0
   native_toolchain_c: 0.19.4
   nested: 1.0.0
   node_preamble: 2.0.2
@@ -155,14 +155,14 @@ dependencies:
   path_provider_platform_interface: 2.1.3
   path_provider_windows: 2.3.0
   petitparser: 7.0.2
-  platform: 3.1.6
+  platform: 3.2.0
   plugin_platform_interface: 2.1.8
-  pool: 1.5.2
-  process: 5.0.5
+  pool: 1.5.3
+  process: 5.0.6
   process_runner: 4.2.4
   provider: 6.1.5+1
-  pub_semver: 2.2.0
-  pubspec_parse: 1.5.0
+  pub_semver: 2.2.1
+  pubspec_parse: 1.6.0
   rally_assets: 3.0.1
   retry: 3.1.2
   scoped_model: 2.0.0
@@ -174,28 +174,28 @@ dependencies:
   source_map_stack_trace: 2.1.2
   source_maps: 0.10.14
   source_span: 1.10.2
-  stack_trace: ^1.12.1
+  stack_trace: ^1.12.2
   standard_message_codec: 0.0.1+5
   stream_channel: ^2.1.4
   string_scanner: 1.4.1
   sync_http: 0.3.1
   term_glyph: 1.2.2
-  test: 1.31.2
-  test_api: 0.7.13
-  test_core: 0.6.19
+  test: 1.32.0
+  test_api: 0.7.14
+  test_core: 0.6.20
   typed_data: 1.4.0
   url_launcher: 6.3.2
-  url_launcher_android: 6.3.32
-  url_launcher_ios: 6.4.1
-  url_launcher_linux: 3.2.2
-  url_launcher_macos: 3.2.5
+  url_launcher_android: 6.3.33
+  url_launcher_ios: 6.4.2
+  url_launcher_linux: 3.2.3
+  url_launcher_macos: 3.2.6
   url_launcher_platform_interface: 2.3.2
   url_launcher_web: 2.4.3
-  url_launcher_windows: 3.1.5
+  url_launcher_windows: 3.1.6
   vector_math: ^2.4.2
   video_player: 2.14.0
-  video_player_android: 2.12.0
-  video_player_avfoundation: 2.11.0
+  video_player_android: 2.12.2
+  video_player_avfoundation: 2.12.0
   video_player_platform_interface: 6.9.0
   video_player_web: 2.4.0
   vm_service: 15.3.0
@@ -207,15 +207,15 @@ dependencies:
   webdriver: 3.1.0
   webkit_inspection_protocol: 1.2.1
   webview_flutter: 4.14.1
-  webview_flutter_android: 4.14.0
+  webview_flutter_android: 4.14.1
   webview_flutter_platform_interface: 2.15.1
-  webview_flutter_wkwebview: 3.26.0
+  webview_flutter_wkwebview: 3.26.1
   xdg_directories: 1.1.0
   xml: 6.6.1
-  yaml: 3.1.3
+  yaml: 3.1.4
   cli_util: 0.4.2
-  dart_style: 3.1.12
-  file_testing: 3.0.2
+  dart_style: 3.1.13
+  file_testing: 3.1.0
   flutter_lints: 6.0.0
   lints: 6.1.0
   quiver: 3.2.2
@@ -224,4 +224,4 @@ dependencies:
 dev_dependencies:
   ffigen: 20.1.1
 
-# PUBSPEC CHECKSUM: 4h4hgm
+# PUBSPEC CHECKSUM: r8nvvh


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Recent changes to Dart to remove the VM isolate also updated `package/native_stack_traces` to handle this change. Without those changes, using `flutter symbolize` fails with newer snapshots. This PR updates the Flutter package dependencies, including a bump of `native_stack_traces` from 0.6.1 to 0.7.0. 

Fixes: https://github.com/flutter/flutter/issues/191879

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant in-code documentation (doc comments with `///`).
- [X] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.