### PR TITLE
Fix NestedScrollView fling velocity jumps with BouncingScrollPhysics

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -487,9 +487,11 @@ class NestedScrollViewState extends State<NestedScrollView> {
   @override
   Widget build(BuildContext context) {
     final ScrollPhysics scrollPhysics =
-        widget.physics?.applyTo(const ClampingScrollPhysics()) ??
-        widget.scrollBehavior?.getScrollPhysics(context).applyTo(const ClampingScrollPhysics()) ??
-        const ClampingScrollPhysics();
+        widget.physics?.applyTo(const _NestedScrollViewPhysics()) ??
+        widget.scrollBehavior
+            ?.getScrollPhysics(context)
+            .applyTo(const _NestedScrollViewPhysics()) ??
+        const _NestedScrollViewPhysics();
 
     return _InheritedNestedScrollView(
       state: this,
@@ -518,6 +520,23 @@ class NestedScrollViewState extends State<NestedScrollView> {
         },
       ),
     );
+  }
+}
+
+// The outer position must stay within its scroll extents, but its ballistic
+// simulation should follow the inherited physics so that it stays in sync with
+// the inner position when scrolling across the header boundary.
+class _NestedScrollViewPhysics extends ScrollPhysics {
+  const _NestedScrollViewPhysics({super.parent});
+
+  @override
+  _NestedScrollViewPhysics applyTo(ScrollPhysics? ancestor) {
+    return _NestedScrollViewPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  double applyBoundaryConditions(ScrollMetrics position, double value) {
+    return const ClampingScrollPhysics().applyBoundaryConditions(position, value);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -523,9 +523,11 @@ class NestedScrollViewState extends State<NestedScrollView> {
   }
 }
 
-// The outer position must stay within its scroll extents, but its ballistic
-// simulation should follow the inherited physics so that it stays in sync with
-// the inner position when scrolling across the header boundary.
+/// Clamps the outer scroll position while inheriting ballistic simulations.
+///
+/// The outer position must stay within its scroll extents, but its ballistic
+/// simulation should follow the inherited physics so that it stays in sync with
+/// the inner position when scrolling across the header boundary.
 class _NestedScrollViewPhysics extends ScrollPhysics {
   const _NestedScrollViewPhysics({super.parent});
 

--- a/packages/flutter/test/widgets/nested_scroll_view_ballistic_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_ballistic_test.dart
@@ -1,0 +1,163 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart' show Drag, DragEndDetails, DragStartDetails, Velocity;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _buildTestWidget(GlobalKey<NestedScrollViewState> key) {
+  return MaterialApp(
+    home: Scaffold(
+      body: NestedScrollView(
+        key: key,
+        headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+          return <Widget>[const SliverAppBar(pinned: true, expandedHeight: 200.0)];
+        },
+        body: ListView.builder(
+          itemExtent: 50.0,
+          itemCount: 100,
+          itemBuilder: (BuildContext context, int index) => Text('Item $index'),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  for (final velocity in <double>[1000.0, -1000.0]) {
+    testWidgets('NestedScrollView inherits the platform ballistic simulation ($velocity)', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/73864.
+      final key = GlobalKey<NestedScrollViewState>();
+      await tester.pumpWidget(_buildTestWidget(key));
+
+      final ScrollPosition outer = key.currentState!.outerController.position;
+      final ScrollPosition inner = key.currentState!.innerController.position;
+      final metrics = FixedScrollMetrics(
+        minScrollExtent: 0.0,
+        maxScrollExtent: 1000.0,
+        pixels: 500.0,
+        viewportDimension: outer.viewportDimension,
+        axisDirection: outer.axisDirection,
+        devicePixelRatio: outer.devicePixelRatio,
+      );
+      final Simulation outerSimulation = outer.physics.createBallisticSimulation(
+        metrics,
+        velocity,
+      )!;
+      final Simulation innerSimulation = inner.physics.createBallisticSimulation(
+        metrics,
+        velocity,
+      )!;
+
+      for (final time in <double>[0.016, 0.1, 0.2]) {
+        expect(outerSimulation.x(time), moreOrLessEquals(innerSimulation.x(time), epsilon: 0.01));
+        expect(outerSimulation.dx(time), moreOrLessEquals(innerSimulation.dx(time), epsilon: 0.01));
+      }
+    }, variant: TargetPlatformVariant.all());
+
+    testWidgets('NestedScrollView crosses the header boundary in order ($velocity)', (
+      WidgetTester tester,
+    ) async {
+      final key = GlobalKey<NestedScrollViewState>();
+      await tester.pumpWidget(_buildTestWidget(key));
+
+      final ScrollPosition outer = key.currentState!.outerController.position;
+      final ScrollPosition inner = key.currentState!.innerController.position;
+      if (velocity < 0.0) {
+        key.currentState!.outerController.jumpTo(outer.maxScrollExtent);
+        key.currentState!.innerController.jumpTo(100.0);
+      } else {
+        // Start close enough to the boundary to cross it on every platform.
+        key.currentState!.outerController.jumpTo(outer.maxScrollExtent - 100.0);
+      }
+      await tester.pumpAndSettle();
+
+      final Drag drag = inner.drag(DragStartDetails(), () {});
+      drag.end(
+        DragEndDetails(
+          primaryVelocity: -velocity,
+          velocity: Velocity(pixelsPerSecond: Offset(0.0, -velocity)),
+        ),
+      );
+      await tester.pump();
+      double previousPixels = outer.pixels + inner.pixels;
+      for (var frame = 0; frame < 16; frame += 1) {
+        await tester.pump(const Duration(milliseconds: 16));
+        final double pixels = outer.pixels + inner.pixels;
+        expect(pixels, velocity > 0.0 ? greaterThan(previousPixels) : lessThan(previousPixels));
+        previousPixels = pixels;
+        expect(outer.pixels, inInclusiveRange(outer.minScrollExtent, outer.maxScrollExtent));
+        if (inner.pixels > inner.minScrollExtent) {
+          expect(outer.pixels, outer.maxScrollExtent);
+        }
+      }
+      if (velocity > 0.0) {
+        expect(outer.pixels, outer.maxScrollExtent);
+        expect(inner.pixels, greaterThan(inner.minScrollExtent));
+      } else {
+        expect(inner.pixels, inner.minScrollExtent);
+        expect(outer.pixels, lessThan(outer.maxScrollExtent));
+      }
+      await tester.pumpAndSettle();
+    }, variant: TargetPlatformVariant.all());
+
+    testWidgets(
+      'NestedScrollView follows one ballistic trajectory across the header boundary on iOS '
+      '($velocity)',
+      (WidgetTester tester) async {
+        final key = GlobalKey<NestedScrollViewState>();
+        await tester.pumpWidget(_buildTestWidget(key));
+
+        final ScrollPosition outer = key.currentState!.outerController.position;
+        final ScrollPosition inner = key.currentState!.innerController.position;
+        if (velocity < 0.0) {
+          key.currentState!.outerController.jumpTo(outer.maxScrollExtent);
+          key.currentState!.innerController.jumpTo(100.0);
+        } else {
+          key.currentState!.outerController.jumpTo(outer.maxScrollExtent - 100.0);
+        }
+        await tester.pumpAndSettle();
+        final Simulation simulation = inner.physics.createBallisticSimulation(
+          FixedScrollMetrics(
+            minScrollExtent: outer.minScrollExtent,
+            maxScrollExtent: outer.maxScrollExtent + inner.maxScrollExtent,
+            pixels: outer.pixels + inner.pixels,
+            viewportDimension: outer.viewportDimension,
+            axisDirection: outer.axisDirection,
+            devicePixelRatio: outer.devicePixelRatio,
+          ),
+          velocity,
+        )!;
+
+        final Drag drag = inner.drag(DragStartDetails(), () {});
+        drag.end(
+          DragEndDetails(
+            primaryVelocity: -velocity,
+            velocity: Velocity(pixelsPerSecond: Offset(0.0, -velocity)),
+          ),
+        );
+        await tester.pump();
+        for (var frame = 1; frame <= 16; frame += 1) {
+          await tester.pump(const Duration(milliseconds: 16));
+          expect(
+            outer.pixels + inner.pixels,
+            moreOrLessEquals(simulation.x(frame * 0.016), epsilon: 0.01),
+            reason: 'The header and body should follow one trajectory at frame $frame.',
+          );
+        }
+        if (velocity > 0.0) {
+          expect(outer.pixels, outer.maxScrollExtent);
+          expect(inner.pixels, greaterThan(inner.minScrollExtent));
+        } else {
+          expect(inner.pixels, inner.minScrollExtent);
+          expect(outer.pixels, lessThan(outer.maxScrollExtent));
+        }
+        await tester.pumpAndSettle();
+      },
+      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
+    );
+  }
+}


### PR DESCRIPTION
The default physics used by `NestedScrollView` on iOS applies different ballistic simulations to its outer and inner scroll positions.

The outer position uses a clamping simulation while the inner position inherits the platform's bouncing simulation. During a fling, their different deceleration rates cause a speed discontinuity when scrolling crosses the header boundary.

This PR adds private outer scroll physics that delegates only boundary conditions to `ClampingScrollPhysics`. Ballistic simulation creation continues through the inherited platform physics. This keeps the outer position within its scroll extents while allowing the outer and inner positions to follow the same ballistic trajectory.

Explicit `physics` and `scrollBehavior` retain their existing precedence. This change does not add a public API.

Fixes #73864.

## Before and after

I ran the original reproduction from #73864 on an iPhone 17 Pro iOS 26.3 Simulator using the same scripted gestures before and after the change.

Before | After
:--:|:--:
<video src="https://github.com/user-attachments/assets/659b7da8-a6e6-40f1-bd2e-e311146e04aa" width="300" /> | <video src="https://github.com/user-attachments/assets/9961942f-e4b3-4c21-a25c-8e40ccd77944" width="300" />
The outer and inner ballistic velocities differed by up to 401.86 px/s. The combined scroll speed increased while crossing the header boundary. | The outer and inner ballistic velocities remained equal within floating-point rounding error, and the scroll continued decelerating across the boundary. Overscroll recovery and tab navigation also completed without exceptions.

## Tests

The regression tests perform forward and reverse flings and separately verify:

- the outer and inner positions select the same inherited ballistic simulation on all target platforms;
- the scroll crosses the header boundary in the correct order while the outer position stays within its extents on all target platforms; and
- the combined position follows the inherited ballistic simulation across the header boundary on iOS.

Without the implementation change, the inherited-simulation tests fail on iOS and macOS, and the trajectory tests fail on iOS. The dedicated `nested_scroll_view_ballistic_test.dart` tests and the existing `nested_scroll_view_test.dart` suite pass with this change.

## Scope

The fast bouncing simulation used on macOS has a separate restart limitation tracked by #120340. This PR verifies inherited simulation selection and boundary ordering on all platforms, while the end-to-end reference trajectory across the boundary is tested on iOS. It does not attempt to address #120340.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
