### PR TITLE
[Impeller] Let a render pass set the blend constant

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/test/recording_render_pass.cc
+++ b/engine/src/flutter/impeller/entity/contents/test/recording_render_pass.cc
@@ -40,6 +40,14 @@ void RecordingRenderPass::SetStencilReference(uint32_t value) {
 }
 
 // |RenderPass|
+void RecordingRenderPass::SetBlendColor(Color color) {
+  pending_.blend_color = color;
+  if (delegate_) {
+    delegate_->SetBlendColor(color);
+  }
+}
+
+// |RenderPass|
 void RecordingRenderPass::SetBaseVertex(uint64_t value) {
   pending_.base_vertex = value;
   if (delegate_) {

--- a/engine/src/flutter/impeller/entity/contents/test/recording_render_pass.h
+++ b/engine/src/flutter/impeller/entity/contents/test/recording_render_pass.h
@@ -28,6 +28,9 @@ class RecordingRenderPass : public RenderPass {
   void SetStencilReference(uint32_t value) override;
 
   // |RenderPass|
+  void SetBlendColor(Color color) override;
+
+  // |RenderPass|
   void SetBaseVertex(uint64_t value) override;
 
   // |RenderPass|

--- a/engine/src/flutter/impeller/geometry/color.h
+++ b/engine/src/flutter/impeller/geometry/color.h
@@ -169,6 +169,19 @@ struct Color {
            ScalarNearlyEqual(blue, c.blue) && ScalarNearlyEqual(alpha, c.alpha);
   }
 
+  //----------------------------------------------------------------------------
+  /// Whether two colours are the same value, as opposed to close enough to
+  /// each other. `operator==` is `ScalarNearlyEqual` with a 1e-3 tolerance,
+  /// which suits comparing a computed colour with an expected one and does
+  /// not suit a cache of what was last handed to a driver: comparing each
+  /// request against the last committed value under a tolerance drops a
+  /// sequence of small steps entirely, and the relation is not transitive.
+  ///
+  static constexpr bool ExactlyEqual(const Color& a, const Color& b) {
+    return a.red == b.red && a.green == b.green && a.blue == b.blue &&
+           a.alpha == b.alpha;
+  }
+
   constexpr inline Color operator+(const Color& c) const {
     return {red + c.red, green + c.green, blue + c.blue, alpha + c.alpha};
   }

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -156,6 +156,7 @@ struct GLProc {
   PROC(BindTexture);                         \
   PROC(BindVertexArray);                     \
   PROC(BlendEquationSeparate);               \
+  PROC(BlendColor);                          \
   PROC(BlendFuncSeparate);                   \
   PROC(BufferData);                          \
   PROC(BufferSubData);                       \

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -43,10 +43,39 @@ void RenderPassGLES::OnSetLabel(std::string_view label) {
   label_ = label;
 }
 
+/// Whether any of this attachment's factors reads the constant blend colour.
+static bool UsesBlendColor(const ColorAttachmentDescriptor* color) {
+  auto reads_constant = [](BlendFactor factor) {
+    switch (factor) {
+      case BlendFactor::kBlendColor:
+      case BlendFactor::kOneMinusBlendColor:
+      case BlendFactor::kBlendAlpha:
+      case BlendFactor::kOneMinusBlendAlpha:
+        return true;
+      default:
+        return false;
+    }
+  };
+  return reads_constant(color->src_color_blend_factor) ||
+         reads_constant(color->dst_color_blend_factor) ||
+         reads_constant(color->src_alpha_blend_factor) ||
+         reads_constant(color->dst_alpha_blend_factor);
+}
+
 void ConfigureBlending(const ProcTableGLES& gl,
-                       const ColorAttachmentDescriptor* color) {
+                       const ColorAttachmentDescriptor* color,
+                       const Color& blend_color) {
   if (color->blending_enabled) {
     gl.Enable(GL_BLEND);
+    // Only when one of the four constant factors actually reads it. The
+    // factors are already in hand, so the check is free, and this runs once
+    // per command in the encode loop where an unconditional call would be
+    // hundreds of redundant driver round-trips a frame — two each in debug,
+    // where every GL call is followed by glGetError.
+    if (UsesBlendColor(color)) {
+      gl.BlendColor(blend_color.red, blend_color.green, blend_color.blue,
+                    blend_color.alpha);
+    }
     gl.BlendFuncSeparate(
         ToBlendFactor(color->src_color_blend_factor),  // src color
         ToBlendFactor(color->dst_color_blend_factor),  // dst color
@@ -196,6 +225,10 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
   gl.DepthMask(GL_TRUE);
   gl.StencilMaskSeparate(GL_FRONT, 0xFFFFFFFF);
   gl.StencilMaskSeparate(GL_BACK, 0xFFFFFFFF);
+  // The blend constant belongs to the context, not the pass, so a pass that
+  // set one would otherwise hand it to whoever draws next — another pass, an
+  // embedder, a platform view.
+  gl.BlendColor(0.0f, 0.0f, 0.0f, 0.0f);
 }
 
 static void EncodeViewport(const ProcTableGLES& gl,
@@ -391,7 +424,7 @@ static void EncodeViewport(const ProcTableGLES& gl,
     //--------------------------------------------------------------------------
     /// Configure blending.
     ///
-    ConfigureBlending(gl, color_attachment);
+    ConfigureBlending(gl, color_attachment, command.blend_color);
 
     //--------------------------------------------------------------------------
     /// Setup stencil.

--- a/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.h
@@ -81,6 +81,10 @@ struct PassBindingsCacheMTL {
   ///        the current encoder state.
   void SetStencilRef(uint32_t stencil_ref);
 
+  /// @brief Set the encoder's blend constant if the value is different from
+  ///        the current encoder state.
+  void SetBlendColor(const Color& blend_color);
+
  private:
   struct BufferOffsetPair {
     id<MTLBuffer> buffer = nullptr;
@@ -99,6 +103,7 @@ struct PassBindingsCacheMTL {
   std::optional<Viewport> viewport_;
   std::optional<IRect32> scissor_;
   std::optional<uint32_t> stencil_ref_;
+  std::optional<Color> blend_color_;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.mm
@@ -171,4 +171,18 @@ void PassBindingsCacheMTL::SetStencilRef(uint32_t stencil_ref) {
   stencil_ref_ = stencil_ref;
 }
 
+void PassBindingsCacheMTL::SetBlendColor(const Color& blend_color) {
+  // Exact rather than `Color::operator==`, whose 1e-3 tolerance would drop a
+  // constant that moves in steps smaller than it, forever.
+  if (blend_color_.has_value() &&
+      Color::ExactlyEqual(blend_color_.value(), blend_color)) {
+    return;
+  }
+  [encoder_ setBlendColorRed:blend_color.red
+                       green:blend_color.green
+                        blue:blend_color.blue
+                       alpha:blend_color.alpha];
+  blend_color_ = blend_color;
+}
+
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -67,6 +67,9 @@ class RenderPassMTL final : public RenderPass {
   void SetStencilReference(uint32_t value) override;
 
   // |RenderPass|
+  void SetBlendColor(Color color) override;
+
+  // |RenderPass|
   void SetBaseVertex(uint64_t value) override;
 
   // |RenderPass|

--- a/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -265,6 +265,11 @@ void RenderPassMTL::SetStencilReference(uint32_t value) {
 }
 
 // |RenderPass|
+void RenderPassMTL::SetBlendColor(Color color) {
+  pass_bindings_.SetBlendColor(color);
+}
+
+// |RenderPass|
 void RenderPassMTL::SetBaseVertex(uint64_t value) {
   base_vertex_ = value;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_vk.cc
@@ -274,6 +274,7 @@ fml::StatusOr<vk::UniquePipeline> MakePipeline(
       vk::DynamicState::eViewport,
       vk::DynamicState::eScissor,
       vk::DynamicState::eStencilReference,
+      vk::DynamicState::eBlendConstants,
   };
   dynamic_create_state_info.setDynamicStates(dynamic_states);
   pipeline_info.setPDynamicState(&dynamic_create_state_info);

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -278,6 +278,14 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   command_buffer_vk_.setStencilReference(vk::StencilFaceFlagBits::eFrontAndBack,
                                          0u);
 
+  // Set the initial blend constant. Required, not tidiness: pipelines declare
+  // eBlendConstants dynamic, which makes the value in the pipeline's colour
+  // blend state ignored, and a dynamic state that no command sets is undefined
+  // at draw time. It also resynchronises the cache below, since blend
+  // constants belong to the command buffer and several passes share one.
+  const std::array<float, 4> initial_blend_color = {0.0f, 0.0f, 0.0f, 0.0f};
+  command_buffer_vk_.setBlendConstants(initial_blend_color.data());
+
   is_valid_ = true;
 }
 
@@ -400,6 +408,21 @@ void RenderPassVK::SetStencilReference(uint32_t value) {
   current_stencil_ = value;
   command_buffer_vk_.setStencilReference(vk::StencilFaceFlagBits::eFrontAndBack,
                                          value);
+}
+
+// |RenderPass|
+void RenderPassVK::SetBlendColor(Color color) {
+  // Deliberately not `Color::operator==`, which is `ScalarNearlyEqual` with a
+  // 1e-3 tolerance. Comparing each request against the last committed value
+  // under a tolerance loses a constant that ramps in steps smaller than it,
+  // and never commits any of them.
+  if (Color::ExactlyEqual(current_blend_color_, color)) {
+    return;
+  }
+  current_blend_color_ = color;
+  const std::array<float, 4> constants = {color.red, color.green, color.blue,
+                                          color.alpha};
+  command_buffer_vk_.setBlendConstants(constants.data());
 }
 
 // |RenderPass|

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -35,6 +35,13 @@ class RenderPassVK final : public RenderPass {
   std::shared_ptr<Texture> color_image_vk_;
   std::shared_ptr<Texture> resolve_image_vk_;
   uint32_t current_stencil_ = 0;
+  // Seeded to match what the constructor writes to the command buffer, not to
+  // any Vulkan default: a dynamic state has no initial value, which is why
+  // both of these are recorded explicitly when the pass opens. Blend
+  // constants belong to the command buffer rather than the pass, and passes
+  // share buffers, so without that write this cache would speak for state a
+  // previous pass had left behind.
+  Color current_blend_color_ = Color::BlackTransparent();
 
   // Per-command state.
   std::array<vk::DescriptorImageInfo, kMaxBindings> image_workspace_;
@@ -65,6 +72,9 @@ class RenderPassVK final : public RenderPass {
 
   // |RenderPass|
   void SetStencilReference(uint32_t value) override;
+
+  // |RenderPass|
+  void SetBlendColor(Color color) override;
 
   // |RenderPass|
   void SetBaseVertex(uint64_t value) override;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk_unittests.cc
@@ -50,6 +50,56 @@ TEST(RenderPassVK, DoesNotRedundantlySetStencil) {
             2);
 }
 
+TEST(RenderPassVK, DoesNotRedundantlySetBlendColor) {
+  std::shared_ptr<ContextVK> context = MockVulkanContextBuilder().Build();
+  std::shared_ptr<Context> copy = context;
+  auto cmd_buffer = context->CreateCommandBuffer();
+
+  RenderTargetAllocator allocator(context->GetResourceAllocator());
+  RenderTarget target = allocator.CreateOffscreenMSAA(*copy.get(), {1, 1}, 1);
+
+  std::shared_ptr<RenderPass> render_pass =
+      cmd_buffer->CreateRenderPass(target);
+
+  // Written once when the pass opens, for the same reason the stencil
+  // reference is: pipelines declare it dynamic, and a dynamic state nothing
+  // sets is undefined at draw time.
+  auto called_functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_EQ(std::count(called_functions->begin(), called_functions->end(),
+                       "vkCmdSetBlendConstants"),
+            1);
+
+  // Asking for the value that write left behind records nothing further.
+  render_pass->SetBlendColor(Color::BlackTransparent());
+  called_functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_EQ(std::count(called_functions->begin(), called_functions->end(),
+                       "vkCmdSetBlendConstants"),
+            1);
+
+  // A different colour reaches the command buffer.
+  render_pass->SetBlendColor(Color::Red());
+  called_functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_EQ(std::count(called_functions->begin(), called_functions->end(),
+                       "vkCmdSetBlendConstants"),
+            2);
+
+  // And repeating it does not.
+  render_pass->SetBlendColor(Color::Red());
+  render_pass->SetBlendColor(Color::Red());
+  called_functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_EQ(std::count(called_functions->begin(), called_functions->end(),
+                       "vkCmdSetBlendConstants"),
+            2);
+
+  // The channels arrive in the order the driver reads them. Counting calls
+  // alone would pass with the components permuted.
+  const auto& recorded = GetRecordedBlendConstants(
+      CommandBufferVK::Cast(*cmd_buffer).GetCommandBuffer());
+  ASSERT_EQ(recorded.size(), 2u);
+  EXPECT_EQ(recorded[0], (std::array<float, 4>{0.0f, 0.0f, 0.0f, 0.0f}));
+  EXPECT_EQ(recorded[1], (std::array<float, 4>{1.0f, 0.0f, 0.0f, 1.0f}));
+}
+
 // Regression guard for the bug where `RenderPassVK::SetViewport` silently
 // dropped the user's X and Y offsets and the depth range, only honoring
 // width and height.

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -29,6 +29,7 @@ struct MockCommandBuffer {
   std::shared_ptr<std::vector<std::string>> called_functions_;
   std::vector<VkImageMemoryBarrier> image_memory_barriers_;
   std::vector<VkViewport> recorded_viewports_;
+  std::vector<std::array<float, 4>> recorded_blend_constants_;
 };
 
 class MockQueue {
@@ -733,6 +734,16 @@ void vkCmdSetStencilReference(VkCommandBuffer commandBuffer,
   mock_command_buffer->called_functions_->push_back("vkCmdSetStencilReference");
 }
 
+void vkCmdSetBlendConstants(VkCommandBuffer commandBuffer,
+                            const float blendConstants[4]) {
+  MockCommandBuffer* mock_command_buffer =
+      reinterpret_cast<MockCommandBuffer*>(commandBuffer);
+  mock_command_buffer->called_functions_->push_back("vkCmdSetBlendConstants");
+  mock_command_buffer->recorded_blend_constants_.push_back(
+      {blendConstants[0], blendConstants[1], blendConstants[2],
+       blendConstants[3]});
+}
+
 void vkCmdSetScissor(VkCommandBuffer commandBuffer,
                      uint32_t firstScissor,
                      uint32_t scissorCount,
@@ -1203,6 +1214,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkCmdPipelineBarrier);
   } else if (strcmp("vkCmdSetStencilReference", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetStencilReference);
+  } else if (strcmp("vkCmdSetBlendConstants", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetBlendConstants);
   } else if (strcmp("vkCmdSetScissor", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkCmdSetScissor);
   } else if (strcmp("vkCmdSetViewport", pName) == 0) {
@@ -1356,6 +1369,13 @@ const std::vector<VkViewport>& GetRecordedViewports(VkCommandBuffer buffer) {
   MockCommandBuffer* mock_command_buffer =
       reinterpret_cast<MockCommandBuffer*>(buffer);
   return mock_command_buffer->recorded_viewports_;
+}
+
+const std::vector<std::array<float, 4>>& GetRecordedBlendConstants(
+    VkCommandBuffer buffer) {
+  MockCommandBuffer* mock_command_buffer =
+      reinterpret_cast<MockCommandBuffer*>(buffer);
+  return mock_command_buffer->recorded_blend_constants_;
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -175,6 +175,9 @@ std::vector<VkImageMemoryBarrier>& GetImageMemoryBarriers(
 ///        given command buffer, in call order.
 const std::vector<VkViewport>& GetRecordedViewports(VkCommandBuffer buffer);
 
+const std::vector<std::array<float, 4>>& GetRecordedBlendConstants(
+    VkCommandBuffer buffer);
+
 }  // namespace testing
 }  // namespace impeller
 

--- a/engine/src/flutter/impeller/renderer/command.h
+++ b/engine/src/flutter/impeller/renderer/command.h
@@ -15,6 +15,7 @@
 #include "impeller/core/sampler.h"
 #include "impeller/core/shader_types.h"
 #include "impeller/core/texture.h"
+#include "impeller/geometry/color.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/renderer/pipeline.h"
 
@@ -147,6 +148,26 @@ struct Command {
   /// @see         `PipelineDescriptor`
   ///
   uint32_t stencil_reference = 0u;
+
+  //----------------------------------------------------------------------------
+  /// The constant color read by `BlendFactor::kBlendColor` and the three
+  /// factors beside it. Which factors a pipeline uses is part of pipeline
+  /// setup; the constant they read is not, in the same way a stencil
+  /// operation is configured on the pipeline while its reference value is
+  /// set here.
+  ///
+  /// Defaults to transparent black. Note that this does not make the term
+  /// inert: the one-minus factors evaluate to one against it.
+  ///
+  /// Read per draw on OpenGL ES, where this member is the state. Metal and
+  /// Vulkan override `RenderPass::SetBlendColor` and write to the encoder
+  /// instead, so there the constant persists across draws until it is set
+  /// again. `stencil_reference` beside it is split the same way.
+  ///
+  /// @see         `BlendFactor`
+  /// @see         `ColorAttachmentDescriptor`
+  ///
+  Color blend_color = Color::BlackTransparent();
 
   //----------------------------------------------------------------------------
   /// The type of indices in the index buffer. The indices must be tightly

--- a/engine/src/flutter/impeller/renderer/render_pass.cc
+++ b/engine/src/flutter/impeller/renderer/render_pass.cc
@@ -104,6 +104,10 @@ void RenderPass::SetStencilReference(uint32_t value) {
   pending_.stencil_reference = value;
 }
 
+void RenderPass::SetBlendColor(Color color) {
+  pending_.blend_color = color;
+}
+
 void RenderPass::SetBaseVertex(uint64_t value) {
   pending_.base_vertex = value;
 }

--- a/engine/src/flutter/impeller/renderer/render_pass.h
+++ b/engine/src/flutter/impeller/renderer/render_pass.h
@@ -65,6 +65,23 @@ class RenderPass : public ResourceBinder {
   ///
   virtual void SetStencilReference(uint32_t value);
 
+  //----------------------------------------------------------------------------
+  /// The constant color that `BlendFactor::kBlendColor` and the three factors
+  /// beside it multiply by. Which factors are in use is part of pipeline
+  /// setup and can be read from the pipeline's descriptor; the constant they
+  /// read is set here, for the same reason a stencil reference is.
+  ///
+  /// Unset, the constant is transparent black, which is not the same as the
+  /// term being inert: `kBlendColor` and `kBlendAlpha` then evaluate to zero
+  /// and drop their term, while `kOneMinusBlendColor` and
+  /// `kOneMinusBlendAlpha` evaluate to one and pass theirs through at full
+  /// weight.
+  ///
+  /// @see         `BlendFactor`
+  /// @see         `ColorAttachmentDescriptor`
+  ///
+  virtual void SetBlendColor(Color color);
+
   virtual void SetBaseVertex(uint64_t value);
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/192397.

`BlendFactor` carries four factors that read a constant blend colour, and every backend already lowers them to the native equivalent: `MTLBlendFactorBlendColor`, `vk::BlendFactor::eConstantColor`, `GL_CONSTANT_COLOR`. Nothing could supply the constant they read, so a pipeline naming one of them multiplied by whatever the backend had left in place — transparent black in practice — and the term was dropped without an error. The issue has a reproduction and an independent confirmation.

## Shape

`RenderPass::SetBlendColor` is pass state, next to `SetStencilReference`, which the same argument splits the same way: the pipeline descriptor says which factors a draw uses, the pass says what value they read.

- **Metal** and **Vulkan** override it and write to the encoder, each with the redundancy check its stencil path already uses.
- **OpenGL ES** reads the value off the command while encoding, which is how it treats the stencil reference too, and calls `glBlendColor` only when one of the four factors actually reads it. `ResetGLState` returns the constant to zero, since it belongs to the context and would otherwise reach whoever draws next.
- **Vulkan** also declares `eBlendConstants` dynamic and records it when the pass opens. Both halves are load-bearing: declaring the state dynamic makes the value in the pipeline's colour blend state ignored, so without the write at pass open every draw would read an undefined constant and trip `VUID-vkCmdDraw-None-07835`.

The two caches compare colours exactly rather than through `Color::operator==`, which is `ScalarNearlyEqual` with a 1e-3 tolerance. Comparing each request against the last committed value under a tolerance never commits a constant that ramps in smaller steps, so `Color::ExactlyEqual` is added beside it.

## Tests

`RenderPassVK.DoesNotRedundantlySetBlendColor` covers the write at pass open, the elision of a repeat, and the channel order — the mock now records the constants rather than only the call name, so permuting the components fails the test instead of passing it silently.

Verified by breaking the code it covers: with the redundancy check removed the test goes red on every assertion, and with the channels swapped it goes red on the value comparison.

`impeller_unittests` on macOS under the CI filter: 2385 passed, 806 skipped, none failed. That is one test more than the same build before the change and no other movement.

## Not in this PR

Two questions I would rather answer in the issue than decide here, and neither blocks the fix:

1. **NaN.** `ExactlyEqual` uses `==`, so a NaN component never matches itself and the state setter would be re-recorded before every draw. A bitwise comparison fixes it at the cost of treating `+0.0` and `-0.0` as different values.
2. **Range.** `glBlendColor` clamps to [0, 1] when the value is specified; Vulkan and Metal store it as given. So a wide-gamut constant renders differently on GLES. Clamping in all three would settle it, and would mean saying that the constant is defined on [0, 1].

The Dart side of Flutter GPU is also absent deliberately: it needs the answer to the API-shape question on the issue first.
