### PR TITLE
Format TestWidgetsApp route callbacks

### DIFF
--- a/packages/flutter_test/lib/src/test_widgets_app.dart
+++ b/packages/flutter_test/lib/src/test_widgets_app.dart
@@ -299,14 +299,18 @@ class TestWidgetsApp extends StatelessWidget {
             BuildContext context,
             Animation<double> animation,
             Animation<double> secondaryAnimation,
-          ) => builder(context),
+          ) {
+            return builder(context);
+          },
       transitionsBuilder:
           (
             BuildContext context,
             Animation<double> animation,
             Animation<double> secondaryAnimation,
             Widget child,
-          ) => child,
+          ) {
+            return child;
+          },
     );
   }
 


### PR DESCRIPTION
## Description

Use block bodies for the `pageBuilder` and `transitionsBuilder` callbacks in `TestWidgetsApp`’s default route builder. This keeps the formatting readable when the callback parameter lists are expanded.

Follow-up to the nit in #186624.

## Tests

- `./bin/flutter analyze --no-pub packages/flutter_test/lib/src/test_widgets_app.dart`
- `./bin/flutter test packages/flutter_test/test/test_widgets_app_test.dart`
