### PR TITLE
[flutter_tools] Use super parameters in more places

### DIFF
--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -99,13 +99,12 @@ class AssembleCommand extends FlutterCommand {
   AssembleCommand({
     required BuildSystem buildSystem,
     required FeatureFlags featureFlags,
-    required ToolContext toolContext,
+    required ToolContext super.toolContext,
     bool verboseHelp = false,
   }) : _buildSystem = buildSystem,
        _featureFlags = featureFlags,
        _toolContext = toolContext,
-       _verboseHelp = verboseHelp,
-       super(toolContext: toolContext) {
+       _verboseHelp = verboseHelp {
     requiresPubspecYaml();
     argParser.addMultiOption(
       'define',

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -906,12 +906,12 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
   _BuildIOSSubCommand({
     required AppleContext appleContext,
     required BuildSystem buildSystem,
-    required ToolContext toolContext,
+    required ToolContext super.toolContext,
     required bool verboseHelp,
   }) : _appleContext = appleContext,
        _buildSystem = buildSystem,
        _toolContext = toolContext,
-       super(logger: toolContext.logger, toolContext: toolContext, verboseHelp: verboseHelp) {
+       super(logger: toolContext.logger, verboseHelp: verboseHelp) {
     addTreeShakeIconsFlag();
     addSplitDebugInfoOption();
     addBuildModeFlags(verboseHelp: verboseHelp);

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -907,11 +907,11 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
     required AppleContext appleContext,
     required BuildSystem buildSystem,
     required ToolContext super.toolContext,
-    required bool verboseHelp,
+    required super.verboseHelp,
   }) : _appleContext = appleContext,
        _buildSystem = buildSystem,
        _toolContext = toolContext,
-       super(logger: toolContext.logger, verboseHelp: verboseHelp) {
+       super(logger: toolContext.logger) {
     addTreeShakeIconsFlag();
     addSplitDebugInfoOption();
     addBuildModeFlags(verboseHelp: verboseHelp);

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -23,12 +23,11 @@ class BuildMacosCommand extends BuildSubCommand {
   BuildMacosCommand({
     required this.buildSystem,
     required this.featureFlags,
-    required ToolContext toolContext,
+    required ToolContext super.toolContext,
     required bool verboseHelp,
   }) : super(
          logger: toolContext.logger,
          outputPreferences: toolContext.outputPreferences,
-         toolContext: toolContext,
          verboseHelp: verboseHelp,
        ) {
     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -24,11 +24,10 @@ class BuildMacosCommand extends BuildSubCommand {
     required this.buildSystem,
     required this.featureFlags,
     required ToolContext super.toolContext,
-    required bool verboseHelp,
+    required super.verboseHelp,
   }) : super(
          logger: toolContext.logger,
          outputPreferences: toolContext.outputPreferences,
-         verboseHelp: verboseHelp,
        ) {
     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
     usesFlavorOption();

--- a/packages/flutter_tools/lib/src/commands/build_windows.dart
+++ b/packages/flutter_tools/lib/src/commands/build_windows.dart
@@ -24,7 +24,7 @@ import 'build.dart';
 class BuildWindowsCommand extends BuildSubCommand {
   BuildWindowsCommand({
     required this.buildSystem,
-    required ToolContext toolContext,
+    required ToolContext super.toolContext,
     required bool verboseHelp,
     required FeatureFlags featureFlags,
     required VisualStudio visualStudio,
@@ -33,7 +33,6 @@ class BuildWindowsCommand extends BuildSubCommand {
        super(
          logger: toolContext.logger,
          outputPreferences: toolContext.outputPreferences,
-         toolContext: toolContext,
          verboseHelp: verboseHelp,
        ) {
     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -15,7 +15,7 @@ import '../version.dart';
 import 'upgrade.dart' show precacheArtifacts;
 
 class ChannelCommand extends FlutterCommand {
-  ChannelCommand({required ToolContext super.toolContext, bool verboseHelp = false})
+  ChannelCommand({required ToolContext super.toolContext, super.verboseHelp = false})
     : _toolContext = toolContext {
     argParser.addFlag(
       'all',

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -15,9 +15,8 @@ import '../version.dart';
 import 'upgrade.dart' show precacheArtifacts;
 
 class ChannelCommand extends FlutterCommand {
-  ChannelCommand({required ToolContext toolContext, bool verboseHelp = false})
-    : _toolContext = toolContext,
-      super(toolContext: toolContext) {
+  ChannelCommand({required ToolContext super.toolContext, bool verboseHelp = false})
+    : _toolContext = toolContext {
     argParser.addFlag(
       'all',
       abbr: 'a',

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -19,15 +19,14 @@ import '../runner/flutter_command.dart';
 
 class CleanCommand extends FlutterCommand {
   CleanCommand({
-    required ToolContext toolContext,
+    required ToolContext super.toolContext,
     required Xcode xcode,
     required XcodeProjectInterpreter xcodeProjectInterpreter,
     bool verbose = false,
   }) : _toolContext = toolContext,
        _xcode = xcode,
        _xcodeProjectInterpreter = xcodeProjectInterpreter,
-       _verbose = verbose,
-       super(toolContext: toolContext) {
+       _verbose = verbose {
     requiresPubspecYaml();
     argParser.addOption(
       'scheme',

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -28,15 +28,14 @@ import '../runner/flutter_command_runner.dart';
 class ConfigCommand extends FlutterCommand with ExtensionArgParserMixin {
   ConfigCommand({
     required AndroidContext androidContext,
-    required ToolContext toolContext,
+    required ToolContext super.toolContext,
     required this.featureFlags,
     bool verboseHelp = false,
     ExtensionManager? extensionManager,
   }) : _androidContext = androidContext,
        _toolContext = toolContext,
        _extensionManager = extensionManager,
-       _verboseHelp = verboseHelp,
-       super(toolContext: toolContext);
+       _verboseHelp = verboseHelp;
 
   final AndroidContext _androidContext;
   final ToolContext _toolContext;

--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -78,8 +78,7 @@ Requires the custom devices feature to be enabled. You can enable it using "flut
 /// to the subcommands, like backing up the config file & checking if the
 /// feature is enabled.
 abstract class CustomDevicesCommandBase extends FlutterCommand {
-  CustomDevicesCommandBase({required this.featureFlags, required ToolContext toolContext})
-    : super(toolContext: toolContext);
+  CustomDevicesCommandBase({required this.featureFlags, required ToolContext super.toolContext});
 
   @override
   ToolContext get toolContext => super.toolContext!;

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -19,11 +19,10 @@ class EmulatorsCommand extends FlutterCommand {
   EmulatorsCommand({
     required Doctor doctor,
     required EmulatorManager emulatorManager,
-    required ToolContext toolContext,
+    required ToolContext super.toolContext,
     super.verboseHelp,
   }) : _doctor = doctor,
-       _emulatorManager = emulatorManager,
-       super(toolContext: toolContext) {
+       _emulatorManager = emulatorManager {
     argParser.addOption('launch', help: 'The full or partial ID of the emulator to launch.');
     argParser.addFlag(
       'cold',

--- a/packages/flutter_tools/lib/src/commands/generate.dart
+++ b/packages/flutter_tools/lib/src/commands/generate.dart
@@ -6,9 +6,7 @@ import '../context/tool_context.dart';
 import '../runner/flutter_command.dart';
 
 class GenerateCommand extends FlutterCommand {
-  GenerateCommand({required ToolContext toolContext})
-    : _toolContext = toolContext,
-      super(toolContext: toolContext) {
+  GenerateCommand({required ToolContext super.toolContext}) : _toolContext = toolContext {
     usesTargetOption();
   }
 

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -20,9 +20,8 @@ import '../runner/flutter_command.dart';
 /// For a more comprehensive tutorial on the tool, please see the
 /// [internationalization guide](https://flutter.dev/to/internationalization).
 class GenerateLocalizationsCommand extends FlutterCommand {
-  GenerateLocalizationsCommand({required ToolContext toolContext})
-    : _toolContext = toolContext,
-      super(toolContext: toolContext) {
+  GenerateLocalizationsCommand({required ToolContext super.toolContext})
+    : _toolContext = toolContext {
     argParser.addOption(
       'arb-dir',
       help: 'The directory where the template and translated arb files are located.',

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -13,8 +13,7 @@ import '../device.dart';
 import '../runner/flutter_command.dart';
 
 class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
-  InstallCommand({required ToolContext toolContext, required super.verboseHelp})
-    : super(toolContext: toolContext) {
+  InstallCommand({required ToolContext super.toolContext, required super.verboseHelp}) {
     addBuildModeFlags(verboseHelp: verboseHelp);
     requiresPubspecYaml();
     usesApplicationBinaryOption();

--- a/packages/flutter_tools/lib/src/commands/symbolize.dart
+++ b/packages/flutter_tools/lib/src/commands/symbolize.dart
@@ -26,11 +26,10 @@ const rootLoadingUnitId = 1;
 /// over stdout.
 class SymbolizeCommand extends FlutterCommand {
   SymbolizeCommand({
-    required ToolContext toolContext,
+    required ToolContext super.toolContext,
     DwarfSymbolizationService dwarfSymbolizationService = const DwarfSymbolizationService(),
   }) : _toolContext = toolContext,
-       _dwarfSymbolizationService = dwarfSymbolizationService,
-       super(toolContext: toolContext) {
+       _dwarfSymbolizationService = dwarfSymbolizationService {
     argParser.addOption(
       'debug-info',
       abbr: 'd',


### PR DESCRIPTION
This is work towards https://github.com/dart-lang/sdk/issues/59226

The lint rule use_super_parameters has a bug such that it didn't previously report these cases. But they will be reported soon.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
