### PR TITLE
[android] Isolate API-34 high contrast listener in AccessibilityBridge behind Api34Impl

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -418,18 +418,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
   private final AccessibilityManager.TouchExplorationStateChangeListener
       touchExplorationStateChangeListener;
 
-  // Listener that is notified when the high contrast mode is turned on/off.
-  private interface ContrastChangedListener {
-    void onContrastChanged(float contrast);
-  }
-
-  private final ContrastChangedListener highContrastObserver =
-      (Build.VERSION.SDK_INT >= API_LEVELS.API_34)
-          ? (ContrastChangedListener & UiModeManager.ContrastChangeListener)
-              contrast -> setHighContrastFlag()
-          : contrast -> {
-            /* no-op */
-          };
+  // Listener that is notified when the high contrast mode is turned on/off on API 34+.
+  // Stored as an Object to avoid class-verification issues on pre-API 34 devices.
+  private final Object highContrastObserver;
 
   // Listener that is notified when the invert colors flag is turned on/off.
   private final AccessibilityFeatureObserver invertColorsObserver;
@@ -612,8 +603,11 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
     // Initialize and register contrast listener
     if (Build.VERSION.SDK_INT >= API_LEVELS.API_34) {
+      highContrastObserver =
+          Api34Impl.registerHighContrastObserver(rootAccessibilityView.getContext(), this);
       setHighContrastFlag();
-      registerHighContrastObserver(rootAccessibilityView.getContext());
+    } else {
+      highContrastObserver = null;
     }
 
     platformViewsAccessibilityDelegate.attachAccessibilityBridge(this);
@@ -651,8 +645,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         touchExplorationStateChangeListener);
     contentResolver.unregisterContentObserver(animationScaleObserver);
     contentResolver.unregisterContentObserver(invertColorsObserver);
-    if (Build.VERSION.SDK_INT >= API_LEVELS.API_34) {
-      unregisterHighContrastObserver(rootAccessibilityView.getContext());
+    if (Build.VERSION.SDK_INT >= API_LEVELS.API_34 && highContrastObserver != null) {
+      Api34Impl.unregisterHighContrastObserver(
+          rootAccessibilityView.getContext(), highContrastObserver);
     }
     accessibilityChannel.setAccessibilityMessageHandler(null);
   }
@@ -721,24 +716,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
   }
 
   @RequiresApi(API_LEVELS.API_34)
-  private void registerHighContrastObserver(Context context) {
-    UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
-    if (uiModeManager != null) {
-      uiModeManager.addContrastChangeListener(
-          context.getMainExecutor(), (UiModeManager.ContrastChangeListener) highContrastObserver);
-    }
-  }
-
-  @RequiresApi(API_LEVELS.API_34)
-  private void unregisterHighContrastObserver(Context context) {
-    UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
-    if (uiModeManager != null) {
-      uiModeManager.removeContrastChangeListener(
-          (UiModeManager.ContrastChangeListener) highContrastObserver);
-    }
-  }
-
-  @RequiresApi(API_LEVELS.API_34)
   private void setHighContrastFlag() {
     Context context = rootAccessibilityView.getContext();
     UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
@@ -748,13 +725,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       return;
     }
 
-    float uiContrast = uiModeManager.getContrast();
     // TODO(https://github.com/flutter/flutter/issues/182863): Move contrast value to a separate API
     // as Android supports a range from -1.0 to 1.0, not just a boolean state.
-
-    // 0.0 (standard), 0.5 (medium), 1.0 (high)
-    // Any enhancement above standard is considered high contrast
-    boolean isHighContrastEnabled = uiContrast > 0.0f;
+    boolean isHighContrastEnabled = Api34Impl.isHighContrast(uiModeManager);
 
     updateAccessibilityFeature(AccessibilityFeature.HIGH_CONTRAST, isHighContrastEnabled);
   }
@@ -2997,6 +2970,44 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       int fontWeightAdjustment = configuration.fontWeightAdjustment;
       return fontWeightAdjustment != Configuration.FONT_WEIGHT_ADJUSTMENT_UNDEFINED
           && fontWeightAdjustment >= BOLD_TEXT_WEIGHT_ADJUSTMENT;
+    }
+  }
+
+  /**
+   * Isolates API-34 references so that ART's class verifier does not attempt to resolve them when
+   * loading {@link AccessibilityBridge} on older API levels. Without this separation, the verifier
+   * attempts to resolve {@link UiModeManager.ContrastChangeListener} at class-load time, causing a
+   * {@link NoClassDefFoundError} crash on pre-API 34 devices (issue #192231).
+   */
+  @RequiresApi(API_LEVELS.API_34)
+  private static class Api34Impl {
+    @DoNotInline
+    static Object registerHighContrastObserver(
+        @NonNull Context context, @NonNull AccessibilityBridge bridge) {
+      UiModeManager uiModeManager =
+          (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
+      if (uiModeManager == null) {
+        return null;
+      }
+      UiModeManager.ContrastChangeListener listener = contrast -> bridge.setHighContrastFlag();
+      uiModeManager.addContrastChangeListener(context.getMainExecutor(), listener);
+      return listener;
+    }
+
+    @DoNotInline
+    static void unregisterHighContrastObserver(@NonNull Context context, @NonNull Object observer) {
+      UiModeManager uiModeManager =
+          (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
+      if (uiModeManager != null && observer instanceof UiModeManager.ContrastChangeListener) {
+        uiModeManager.removeContrastChangeListener((UiModeManager.ContrastChangeListener) observer);
+      }
+    }
+
+    @DoNotInline
+    static boolean isHighContrast(@NonNull UiModeManager uiModeManager) {
+      // 0.0 (standard), 0.5 (medium), 1.0 (high)
+      // Any enhancement above standard is considered high contrast
+      return uiModeManager.getContrast() > 0.0f;
     }
   }
 }

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1579,6 +1579,40 @@ public class AccessibilityBridgeTest {
     assertEquals(ACCESSIBILITY_FEATURE_NO_ANNOUNCE, featuresCaptor.getValue().intValue());
   }
 
+  @Config(sdk = API_LEVELS.API_34)
+  @TargetApi(API_LEVELS.API_34)
+  @Test
+  public void itUnregistersHighContrastObserverOnRelease() {
+    AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    View mockRootView = mock(View.class);
+    Context context = mock(Context.class);
+    UiModeManager mockUiModeManager = mock(UiModeManager.class);
+
+    when(mockRootView.getContext()).thenReturn(context);
+    when(context.getSystemService(Context.UI_MODE_SERVICE)).thenReturn(mockUiModeManager);
+    when(context.getMainExecutor())
+        .thenReturn(RuntimeEnvironment.getApplication().getMainExecutor());
+
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(
+            /* rootAccessibilityView= */ mockRootView,
+            /* accessibilityChannel= */ mockChannel,
+            /* accessibilityManager= */ mockManager,
+            /* contentResolver= */ null,
+            /* accessibilityViewEmbedder= */ null,
+            /* platformViewsAccessibilityDelegate= */ null);
+
+    ArgumentCaptor<UiModeManager.ContrastChangeListener> listenerCaptor =
+        ArgumentCaptor.forClass(UiModeManager.ContrastChangeListener.class);
+    verify(mockUiModeManager).addContrastChangeListener(any(), listenerCaptor.capture());
+    UiModeManager.ContrastChangeListener listener = listenerCaptor.getValue();
+
+    accessibilityBridge.release();
+
+    verify(mockUiModeManager).removeContrastChangeListener(listener);
+  }
+
   @Config(sdk = API_LEVELS.API_33)
   @TargetApi(API_LEVELS.API_33)
   @Test


### PR DESCRIPTION
Isolates API-34 `UiModeManager.ContrastChangeListener` and related contrast calls in `AccessibilityBridge` inside an `@RequiresApi(API_LEVELS.API_34)` static holder class (`Api34Impl`) with `@DoNotInline`.

### Background / Root Cause

On Android 12 and 13 (API < 34), `AccessibilityBridge` previously evaluated a ternary merge point in `<init>` between a lambda cast to `(ContrastChangedListener & UiModeManager.ContrastChangeListener)` and a no-op fallback. D8 desugars this intersection cast into a synthetic class implementing `UiModeManager.ContrastChangeListener`. Because this ternary join occurs in `<init>`, the ART verifier attempts to resolve the synthetic class and its unimplemented interface when loading `AccessibilityBridge`, failing with `NoClassDefFoundError: Failed resolution of: Lt2;` (`ClassNotFoundException: android.app.UiModeManager$ContrastChangeListener`).

By moving all references to `UiModeManager.ContrastChangeListener` into `Api34Impl` and holding the observer as an `Object` reference on `AccessibilityBridge`, ART never attempts to load or verify the API-34 types on devices with API < 34.

Fixes https://github.com/flutter/flutter/issues/192231

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

---

*This pull request was generated with Gemini / AI assistance.*
