### PR TITLE
[flutter_tools] Support custom asset bundle paths

### DIFF
--- a/dev/integration_tests/flavors/README.md
+++ b/dev/integration_tests/flavors/README.md
@@ -1,3 +1,17 @@
 # flavors
 
 Integration test of build flavors (Android product flavors, Xcode schemes).
+
+The `free` and `paid` flavors each select a different configuration file from
+`configs/`, using `bundle_path: assets/branch-config.json`. The integration test
+checks that Dart's `rootBundle` and the Android/iOS native asset APIs read the
+same selected file at that fixed key. The fixtures contain no SDK keys and do
+not initialize the Branch SDK.
+
+Run the full integration test with the `paid` flavor, or just the configuration
+lookup test with either flavor:
+
+```sh
+flutter test integration_test/integration_test.dart --flavor paid -d <device>
+flutter test integration_test/integration_test.dart --flavor free -d <device> --plain-name 'loads the selected configuration'
+```

--- a/dev/integration_tests/flavors/android/app/src/main/java/com/yourcompany/flavors/MainActivity.java
+++ b/dev/integration_tests/flavors/android/app/src/main/java/com/yourcompany/flavors/MainActivity.java
@@ -4,6 +4,41 @@
 
 package com.yourcompany.flavors;
 
+import androidx.annotation.NonNull;
+import io.flutter.FlutterInjector;
 import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.plugin.common.MethodChannel;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
-public class MainActivity extends FlutterActivity {}
+public class MainActivity extends FlutterActivity {
+  @Override
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    super.configureFlutterEngine(flutterEngine);
+    new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), "flavor")
+        .setMethodCallHandler(
+            (call, result) -> {
+              if (!call.method.equals("loadBranchConfig")) {
+                result.notImplemented();
+                return;
+              }
+              String key =
+                  FlutterInjector.instance()
+                      .flutterLoader()
+                      .getLookupKeyForAsset("assets/branch-config.json");
+              try (InputStream input = getAssets().open(key);
+                  ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+                byte[] buffer = new byte[1024];
+                int count;
+                while ((count = input.read(buffer)) != -1) {
+                  output.write(buffer, 0, count);
+                }
+                result.success(output.toString("UTF-8"));
+              } catch (IOException exception) {
+                result.error("asset-read", exception.getMessage(), null);
+              }
+            });
+  }
+}

--- a/dev/integration_tests/flavors/configs/free/branch-config.json
+++ b/dev/integration_tests/flavors/configs/free/branch-config.json
@@ -1,0 +1,1 @@
+{"flavor":"free"}

--- a/dev/integration_tests/flavors/configs/paid/branch-config.json
+++ b/dev/integration_tests/flavors/configs/paid/branch-config.json
@@ -1,0 +1,1 @@
+{"flavor":"paid"}

--- a/dev/integration_tests/flavors/integration_test/integration_test.dart
+++ b/dev/integration_tests/flavors/integration_test/integration_test.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flavors/main.dart' as app;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -11,6 +14,25 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('Flavor Test', () {
+    testWidgets('loads the selected configuration through Dart and native asset APIs', (
+      WidgetTester tester,
+    ) async {
+      const key = 'assets/branch-config.json';
+      final String dartConfig = await rootBundle.loadString(key);
+      expect(jsonDecode(dartConfig), <String, Object?>{'flavor': appFlavor});
+      final AssetManifest manifest = await AssetManifest.loadFromAssetBundle(rootBundle);
+      expect(manifest.listAssets(), contains(key));
+      expect(manifest.listAssets(), isNot(contains('configs/$appFlavor/branch-config.json')));
+      if (!kIsWeb &&
+          (defaultTargetPlatform == TargetPlatform.android ||
+              defaultTargetPlatform == TargetPlatform.iOS)) {
+        final String? nativeConfig = await const MethodChannel(
+          'flavor',
+        ).invokeMethod<String>('loadBranchConfig');
+        expect(nativeConfig, dartConfig);
+      }
+    });
+
     testWidgets('check flavor', (WidgetTester tester) async {
       app.runMainApp();
       await tester.pumpAndSettle();

--- a/dev/integration_tests/flavors/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/flavors/ios/Runner/AppDelegate.m
@@ -14,9 +14,28 @@
 - (void)didInitializeImplicitFlutterEngine:(NSObject<FlutterImplicitEngineBridge>*)engineBridge {
   [GeneratedPluginRegistrant registerWithRegistry:engineBridge.pluginRegistry];
 
+  NSObject<FlutterPluginRegistrar>* assetRegistrar =
+      [engineBridge.pluginRegistry registrarForPlugin:@"FlavorAssetLookup"];
+
   FlutterMethodChannel* flavorChannel = [FlutterMethodChannel methodChannelWithName:@"flavor" binaryMessenger:engineBridge.applicationRegistrar.messenger];
 
   [flavorChannel setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
+    if ([call.method isEqualToString:@"loadBranchConfig"]) {
+      NSString* key = [assetRegistrar lookupKeyForAsset:@"assets/branch-config.json"];
+      NSString* path = [[NSBundle mainBundle] pathForResource:key ofType:nil];
+      NSError* error = nil;
+      NSString* config = path == nil ? nil : [NSString stringWithContentsOfFile:path
+                                                                   encoding:NSUTF8StringEncoding
+                                                                      error:&error];
+      if (config == nil) {
+        result([FlutterError errorWithCode:@"asset-read"
+                                  message:error.localizedDescription ?: @"Asset not found"
+                                  details:nil]);
+      } else {
+        result(config);
+      }
+      return;
+    }
     NSString* flavor = (NSString*)[[NSBundle mainBundle].infoDictionary valueForKey:@"Flavor"];
     result(flavor);
   }];

--- a/dev/integration_tests/flavors/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/flavors/ios/Runner/AppDelegate.m
@@ -11,20 +11,20 @@
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
-- (void)didInitializeImplicitFlutterEngine:(NSObject<FlutterImplicitEngineBridge>*)engineBridge {
+- (void)didInitializeImplicitFlutterEngine:(NSObject<FlutterImplicitEngineBridge> *)engineBridge {
   [GeneratedPluginRegistrant registerWithRegistry:engineBridge.pluginRegistry];
 
-  NSObject<FlutterPluginRegistrar>* assetRegistrar =
+  NSObject<FlutterPluginRegistrar> *assetRegistrar =
       [engineBridge.pluginRegistry registrarForPlugin:@"FlavorAssetLookup"];
 
-  FlutterMethodChannel* flavorChannel = [FlutterMethodChannel methodChannelWithName:@"flavor" binaryMessenger:engineBridge.applicationRegistrar.messenger];
+  FlutterMethodChannel *flavorChannel = [FlutterMethodChannel methodChannelWithName:@"flavor" binaryMessenger:engineBridge.applicationRegistrar.messenger];
 
   [flavorChannel setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
     if ([call.method isEqualToString:@"loadBranchConfig"]) {
-      NSString* key = [assetRegistrar lookupKeyForAsset:@"assets/branch-config.json"];
-      NSString* path = [[NSBundle mainBundle] pathForResource:key ofType:nil];
-      NSError* error = nil;
-      NSString* config = path == nil ? nil : [NSString stringWithContentsOfFile:path
+      NSString *key = [assetRegistrar lookupKeyForAsset:@"assets/branch-config.json"];
+      NSString *path = [[NSBundle mainBundle] pathForResource:key ofType:nil];
+      NSError *error = nil;
+      NSString *config = path == nil ? nil : [NSString stringWithContentsOfFile:path
                                                                    encoding:NSUTF8StringEncoding
                                                                       error:&error];
       if (config == nil) {
@@ -36,7 +36,7 @@
       }
       return;
     }
-    NSString* flavor = (NSString*)[[NSBundle mainBundle].infoDictionary valueForKey:@"Flavor"];
+    NSString *flavor = (NSString *)[[NSBundle mainBundle].infoDictionary valueForKey:@"Flavor"];
     result(flavor);
   }];
 }

--- a/dev/integration_tests/flavors/pubspec.yaml
+++ b/dev/integration_tests/flavors/pubspec.yaml
@@ -31,5 +31,11 @@ flutter:
     - path: assets/free/
       flavors:
         - free
+    - path: configs/free/branch-config.json
+      flavors: [free]
+      bundle_path: assets/branch-config.json
+    - path: configs/paid/branch-config.json
+      flavors: [paid]
+      bundle_path: assets/branch-config.json
 
 # PUBSPEC CHECKSUM: rnq93o

--- a/docs/tool/Asset-bundle-paths.md
+++ b/docs/tool/Asset-bundle-paths.md
@@ -1,0 +1,78 @@
+# Asset bundle paths
+
+An asset declaration can use `bundle_path` to choose its location and runtime
+lookup key inside the Flutter asset bundle. `path` still identifies the source
+relative to `pubspec.yaml`. When `bundle_path` is omitted, the existing asset
+path behavior is unchanged.
+
+For example, a plugin that always reads `assets/branch-config.json` can receive
+a different configuration for each build flavor:
+
+```yaml
+flutter:
+  assets:
+    - path: configs/dev/branch-config.json
+      flavors: [dev]
+      bundle_path: assets/branch-config.json
+    - path: configs/prod/branch-config.json
+      flavors: [prod]
+      bundle_path: assets/branch-config.json
+```
+
+A build with `--flavor dev` includes the development file at
+`assets/branch-config.json`. A build with `--flavor prod` includes the production
+file at the same location. Existing flavor selection rules apply, including
+omitting flavor-restricted entries when no matching flavor is selected. The
+source files are not copied over each other or modified.
+
+Dart code uses the bundle path:
+
+```dart
+final String config = await rootBundle.loadString('assets/branch-config.json');
+```
+
+Native code uses that same key with Android's `getLookupKeyForAsset` or iOS's
+`lookupKeyForAsset`, then opens the returned path with the platform's asset or
+bundle API. No plugin changes are needed when the plugin already uses those
+APIs with this key. This does not place files in Android's top-level `assets/`
+directory or iOS's top-level application bundle.
+
+## Other asset features
+
+- Directory declarations must end both `path` and `bundle_path` with `/`. The
+  bundle path replaces the directory prefix. Directory traversal remains
+  non-recursive, apart from the existing image resolution variant discovery.
+- Image variants follow the rewritten path and filename. For example,
+  `source/logo.png` mapped to `images/brand.png` also maps
+  `source/2.0x/logo.png` to `images/2.0x/brand.png`. A missing base image remains
+  supported when resolution variants exist.
+- Assets declared by dependencies retain the `packages/<package>/` prefix.
+  An application can also map an explicit `packages/<package>/...` source.
+- Platform filtering, asset transformers, shaders, and deferred-component
+  asset declarations retain their existing behavior. Transformers and shader
+  compilation read the source file and write to the mapped destination.
+- Dependency files track source files. Editing the selected source or changing
+  the flavor causes subsequent builds to use the selected contents. Directory
+  mappings retain the existing wildcard rebuild behavior.
+- Asset manifests expose the rewritten keys. Existing URI escaping applies to
+  special characters in bundle filenames.
+
+## Validation and limits
+
+`bundle_path` must be a non-empty relative path using forward slashes. Absolute
+paths, drive prefixes, backslashes, control characters, empty path segments,
+and `.` or `..` segments are rejected. File declarations cannot target a
+directory, and directory declarations cannot target a file.
+
+Flutter checks destination conflicts after flavor and platform filtering,
+including image variants, package assets, hook assets, fonts, and deferred
+components. Two selected sources cannot write the same destination, and a file
+cannot also be used as a directory. Existing duplicate declarations of the same
+source with the same processing configuration remain allowed. Generated Flutter
+asset names cannot be used as mapped destinations.
+
+This field does not introduce fallback precedence between declarations. An
+unconditional asset and a matching flavor-specific asset at the same destination
+conflict. Flavor support is unchanged for each build target. Third-party asset
+code generators must support this field before they can generate the rewritten
+keys; build hooks remain available for configurations that need custom logic.

--- a/docs/tool/README.md
+++ b/docs/tool/README.md
@@ -30,6 +30,8 @@ to the Flutter SDK controlled `flutter` and `dart` binaries.
 
 Markdown documentation can be found for some commands in [flutter/packages/flutter_tools/doc/](https://github.com/flutter/flutter/tree/main/packages/flutter_tools/doc).
 
+See [Asset bundle paths](Asset-bundle-paths.md) for mapping asset sources to runtime lookup keys.
+
 ## Analysis
 
 To run dart analysis on the Flutter tool codebase, run:

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -766,11 +766,12 @@ class ManifestAssetBundle implements AssetBundle {
     AssetBundleEntry entry,
   ) {
     final AssetBundleEntry? existingEntry = entryMap[key];
+    final DevFSContent content = entry.content;
+    final DevFSContent? existingContent = existingEntry?.content;
     if (existingEntry == null ||
-        (entry.content is DevFSFileContent &&
-            existingEntry.content is DevFSFileContent &&
-            (entry.content as DevFSFileContent).file.path !=
-                (existingEntry.content as DevFSFileContent).file.path) ||
+        (content is DevFSFileContent &&
+            existingContent is DevFSFileContent &&
+            content.file.path != existingContent.file.path) ||
         !entry.hasEquivalentConfigurationWith(existingEntry)) {
       entryMap[key] = entry;
     }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -557,6 +557,13 @@ class ManifestAssetBundle implements AssetBundle {
       assetVariants[asset] = <_Asset>[asset];
     }
 
+    final materialAndFrameworkAssets = <_Asset>[
+      if (flutterManifest.usesMaterialDesign) ..._getMaterialFonts(),
+      // For all platforms, include the shaders unconditionally. They are
+      // small, and whether they're used is determined only by the app source
+      // code and not by the Flutter manifest.
+      ..._getFrameworkShaders(),
+    ];
     final selectedAssets = <_Asset>[
       for (final Map<_Asset, List<_Asset>> assets in <Map<_Asset, List<_Asset>>>[
         assetVariants,
@@ -566,8 +573,7 @@ class ManifestAssetBundle implements AssetBundle {
           entry.key,
           ...entry.value,
         ],
-      if (flutterManifest.usesMaterialDesign) ..._getMaterialFonts(),
-      ..._getFrameworkShaders(),
+      ...materialAndFrameworkAssets,
     ];
     _checkForBundlePathConflicts(selectedAssets);
 
@@ -647,13 +653,6 @@ class ManifestAssetBundle implements AssetBundle {
         }
       }
     }
-    final materialAndFrameworkAssets = <_Asset>[
-      if (flutterManifest.usesMaterialDesign) ..._getMaterialFonts(),
-      // For all platforms, include the shaders unconditionally. They are
-      // small, and whether they're used is determined only by the app source
-      // code and not by the Flutter manifest.
-      ..._getFrameworkShaders(),
-    ];
     for (final asset in materialAndFrameworkAssets) {
       final File assetFile = asset.lookupAssetFile(_fileSystem);
       assert(assetFile.existsSync(), 'Missing ${assetFile.path}');
@@ -711,11 +710,17 @@ class ManifestAssetBundle implements AssetBundle {
     }
     _setIfChanged(kFontManifestJson, fontManifest, AssetKind.regular);
     _setLicenseIfChanged(licenseResult.combinedLicenses, targetPlatform);
-    final Set<String> selectedKeys = selectedAssets
-        .map((_Asset asset) => asset.entryUri.path)
-        .toSet();
+    // A manifest key can remain even when its base image is absent. Only the
+    // selected files belong in the bundle; the manifest still lists variants.
+    final Iterable<_Asset> bundledAssets = assetVariants.values.expand(
+      (List<_Asset> variants) => variants,
+    );
+    final selectedKeys = <String>{
+      for (final asset in bundledAssets) asset.entryUri.path,
+      for (final asset in materialAndFrameworkAssets) asset.entryUri.path,
+    };
     _bundlePathKeys.difference(selectedKeys).forEach(entries.remove);
-    _bundlePathKeys = selectedAssets
+    _bundlePathKeys = bundledAssets
         .where((_Asset asset) => asset.hasBundlePath)
         .map((_Asset asset) => asset.entryUri.path)
         .toSet();

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -264,6 +264,8 @@ class ManifestAssetBundle implements AssetBundle {
   // the current project.
   final _wildcardDirectories = <Uri, Directory>{};
 
+  Set<String> _bundlePathKeys = <String>{};
+
   DateTime? _lastBuildTimestamp;
 
   FlutterHookResult _lastHookResult;
@@ -555,6 +557,20 @@ class ManifestAssetBundle implements AssetBundle {
       assetVariants[asset] = <_Asset>[asset];
     }
 
+    final selectedAssets = <_Asset>[
+      for (final Map<_Asset, List<_Asset>> assets in <Map<_Asset, List<_Asset>>>[
+        assetVariants,
+        ...deferredComponentsAssetVariants.values,
+      ])
+        for (final MapEntry<_Asset, List<_Asset>> entry in assets.entries) ...<_Asset>[
+          entry.key,
+          ...entry.value,
+        ],
+      if (flutterManifest.usesMaterialDesign) ..._getMaterialFonts(),
+      ..._getFrameworkShaders(),
+    ];
+    _checkForBundlePathConflicts(selectedAssets);
+
     // Save the contents of each image, image variant, and font
     // asset in [entries].
     for (final _Asset asset in assetVariants.keys) {
@@ -695,6 +711,14 @@ class ManifestAssetBundle implements AssetBundle {
     }
     _setIfChanged(kFontManifestJson, fontManifest, AssetKind.regular);
     _setLicenseIfChanged(licenseResult.combinedLicenses, targetPlatform);
+    final Set<String> selectedKeys = selectedAssets
+        .map((_Asset asset) => asset.entryUri.path)
+        .toSet();
+    _bundlePathKeys.difference(selectedKeys).forEach(entries.remove);
+    _bundlePathKeys = selectedAssets
+        .where((_Asset asset) => asset.hasBundlePath)
+        .map((_Asset asset) => asset.entryUri.path)
+        .toSet();
     return 0;
   }
 
@@ -737,7 +761,12 @@ class ManifestAssetBundle implements AssetBundle {
     AssetBundleEntry entry,
   ) {
     final AssetBundleEntry? existingEntry = entryMap[key];
-    if (existingEntry == null || !entry.hasEquivalentConfigurationWith(existingEntry)) {
+    if (existingEntry == null ||
+        (entry.content is DevFSFileContent &&
+            existingEntry.content is DevFSFileContent &&
+            (entry.content as DevFSFileContent).file.path !=
+                (existingEntry.content as DevFSFileContent).file.path) ||
+        !entry.hasEquivalentConfigurationWith(existingEntry)) {
       entryMap[key] = entry;
     }
   }
@@ -901,6 +930,7 @@ class ManifestAssetBundle implements AssetBundle {
             cache,
             componentAssets,
             assetsEntry.uri,
+            bundleUri: assetsEntry.bundleUri,
             flavors: assetsEntry.flavors,
             platforms: assetsEntry.platforms,
             transformers: assetsEntry.transformers,
@@ -913,6 +943,7 @@ class ManifestAssetBundle implements AssetBundle {
             cache,
             componentAssets,
             assetsEntry.uri,
+            bundleUri: assetsEntry.bundleUri,
             flavors: assetsEntry.flavors,
             platforms: assetsEntry.platforms,
             transformers: assetsEntry.transformers,
@@ -1084,6 +1115,7 @@ class ManifestAssetBundle implements AssetBundle {
           assetsEntry.uri,
           packageName: packageName,
           attributedPackage: attributedPackage,
+          bundleUri: assetsEntry.bundleUri,
           flavors: assetsEntry.flavors,
           platforms: assetsEntry.platforms,
           transformers: assetsEntry.transformers,
@@ -1098,6 +1130,7 @@ class ManifestAssetBundle implements AssetBundle {
           assetsEntry.uri,
           packageName: packageName,
           attributedPackage: attributedPackage,
+          bundleUri: assetsEntry.bundleUri,
           flavors: assetsEntry.flavors,
           platforms: assetsEntry.platforms,
           transformers: assetsEntry.transformers,
@@ -1137,6 +1170,7 @@ class ManifestAssetBundle implements AssetBundle {
         packageName: packageName,
         attributedPackage: attributedPackage,
         assetKind: AssetKind.shader,
+        bundleUri: shaderEntry.bundleUri,
         flavors: shaderEntry.flavors,
         platforms: shaderEntry.platforms,
         transformers: shaderEntry.transformers,
@@ -1199,6 +1233,7 @@ class ManifestAssetBundle implements AssetBundle {
     _AssetDirectoryCache cache,
     Map<_Asset, List<_Asset>> result,
     Uri assetUri, {
+    Uri? bundleUri,
     String? packageName,
     Package? attributedPackage,
     required Set<String> flavors,
@@ -1273,6 +1308,7 @@ class ManifestAssetBundle implements AssetBundle {
         packageName: packageName,
         attributedPackage: attributedPackage,
         originUri: assetUri,
+        bundleUri: bundleUri?.resolveUri(Uri(pathSegments: <String>[uri.pathSegments.last])),
         flavors: flavors,
         platforms: platforms,
         transformers: transformers,
@@ -1288,6 +1324,7 @@ class ManifestAssetBundle implements AssetBundle {
     Map<_Asset, List<_Asset>> result,
     Uri assetUri, {
     Uri? originUri,
+    Uri? bundleUri,
     String? packageName,
     Package? attributedPackage,
     AssetKind assetKind = AssetKind.regular,
@@ -1308,7 +1345,12 @@ class ManifestAssetBundle implements AssetBundle {
       transformers: transformers,
     );
 
-    _checkForFlavorConflicts(asset, result.keys.toList());
+    if (bundleUri == null) {
+      _checkForFlavorConflicts(
+        asset,
+        result.keys.where((_Asset asset) => !asset.hasBundlePath).toList(),
+      );
+    }
 
     final variants = <_Asset>[];
     final File assetFile = asset.lookupAssetFile(_fileSystem);
@@ -1335,7 +1377,29 @@ class ManifestAssetBundle implements AssetBundle {
       }
     }
 
-    result[asset] = variants;
+    if (bundleUri == null) {
+      result[asset] = variants;
+    } else {
+      final Uri entryUri = packageName == null
+          ? bundleUri
+          : Uri(pathSegments: <String>['packages', packageName, ...bundleUri.pathSegments]);
+      result[asset.withBundleUri(entryUri)] = <_Asset>[
+        for (final _Asset variant in variants)
+          variant.withBundleUri(
+            variant.relativeUri == asset.relativeUri
+                ? entryUri
+                : entryUri.resolveUri(
+                    Uri(
+                      pathSegments: <String>[
+                        variant.relativeUri.pathSegments[variant.relativeUri.pathSegments.length -
+                            2],
+                        entryUri.pathSegments.last,
+                      ],
+                    ),
+                  ),
+          ),
+      ];
+    }
   }
 
   // Since it is not clear how overlapping asset declarations should work in the
@@ -1407,6 +1471,62 @@ class ManifestAssetBundle implements AssetBundle {
     }
 
     throwToolExit(errorMessage.toString());
+  }
+
+  // Run after flavor and platform filtering and after combining package and hook
+  // assets. Legacy duplicate declarations keep their existing behavior.
+  void _checkForBundlePathConflicts(List<_Asset> assets) {
+    final destinations = <String, _Asset>{};
+    const generatedPaths = <String>{
+      _kAssetManifestBinFilename,
+      _kAssetManifestBinJsonFilename,
+      kFontManifestJson,
+      _kNoticeFile,
+      _kNoticeZippedFile,
+      'kernel_blob.bin',
+      'isolate_snapshot_data',
+      'vm_snapshot_data',
+      'NativeAssetsManifest.json',
+    };
+    for (final asset in assets) {
+      final String key = asset.entryUri.normalizePath().path;
+      if (asset.hasBundlePath &&
+          generatedPaths.any((String path) => key == path || key.startsWith('$path/'))) {
+        throwToolExit(
+          'The bundle_path "$key" of asset "${asset.originUri}" '
+          'is reserved for a generated Flutter asset.',
+        );
+      }
+      final _Asset? previous = destinations[key];
+      if (previous != null &&
+          (asset.hasBundlePath || previous.hasBundlePath) &&
+          (asset.baseDir != previous.baseDir ||
+              asset.relativeUri != previous.relativeUri ||
+              asset.kind != previous.kind ||
+              !listEquals(asset.transformers, previous.transformers))) {
+        throwToolExit(
+          'Conflicting assets at bundle path "$key": '
+          '"${previous.originUri}" and "${asset.originUri}" are both selected for this build.',
+        );
+      }
+      // Keep the mapped declaration so a later legacy duplicate cannot hide it.
+      if (previous == null || asset.hasBundlePath) {
+        destinations[key] = asset;
+      }
+    }
+    for (final MapEntry<String, _Asset> entry in destinations.entries) {
+      final List<String> segments = entry.key.split('/');
+      for (var index = 1; index < segments.length; index += 1) {
+        final String parent = segments.take(index).join('/');
+        final _Asset? parentAsset = destinations[parent];
+        if (parentAsset != null && (entry.value.hasBundlePath || parentAsset.hasBundlePath)) {
+          throwToolExit(
+            'Conflicting assets at bundle paths "$parent" and "${entry.key}": '
+            'a file cannot also be used as a directory.',
+          );
+        }
+      }
+    }
   }
 
   void _ensureAssetPathIsValid({
@@ -1554,6 +1674,7 @@ class _Asset {
     required this.entryUri,
     required this.package,
     this.kind = AssetKind.regular,
+    this.hasBundlePath = false,
     Set<String>? flavors,
     Set<String>? platforms,
     List<AssetTransformerEntry>? transformers,
@@ -1578,6 +1699,21 @@ class _Asset {
   final Uri entryUri;
 
   final AssetKind kind;
+
+  final bool hasBundlePath;
+
+  _Asset withBundleUri(Uri uri) => _Asset(
+    baseDir: baseDir,
+    originUri: originUri,
+    relativeUri: relativeUri,
+    entryUri: uri,
+    package: package,
+    kind: kind,
+    hasBundlePath: true,
+    flavors: flavors,
+    platforms: platforms,
+    transformers: transformers,
+  );
 
   final Set<String> flavors;
 
@@ -1643,13 +1779,23 @@ class _Asset {
         other.relativeUri == relativeUri &&
         other.entryUri == entryUri &&
         other.kind == kind &&
+        other.hasBundlePath == hasBundlePath &&
+        (!hasBundlePath || listEquals(other.transformers, transformers)) &&
         hasEquivalentFlavorsWith(other) &&
         hasEquivalentPlatformsWith(other);
   }
 
   @override
-  int get hashCode =>
-      Object.hashAll(<Object>[baseDir, relativeUri, entryUri, kind, ...flavors, ...platforms]);
+  int get hashCode => Object.hashAll(<Object>[
+    baseDir,
+    relativeUri,
+    entryUri,
+    kind,
+    hasBundlePath,
+    if (hasBundlePath) ...transformers,
+    ...flavors,
+    ...platforms,
+  ]);
 }
 
 // Given an assets directory like this:

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -789,22 +789,32 @@ void _validateFonts(YamlList fonts, List<String> errors) {
 class AssetsEntry {
   const AssetsEntry({
     required this.uri,
+    this.bundleUri,
     this.flavors = const <String>{},
     this.platforms = const <String>{},
     this.transformers = const <AssetTransformerEntry>[],
   });
 
   final Uri uri;
+
+  /// The path and runtime lookup key inside the asset bundle.
+  ///
+  /// When omitted, [uri] determines both the source and bundle paths. Directory
+  /// entries rewrite the directory prefix, preserving filenames and image variants.
+  /// Package declarations retain their `packages/<package>/` namespace.
+  final Uri? bundleUri;
+
   final Set<String> flavors;
   final Set<String> platforms;
   final List<AssetTransformerEntry> transformers;
 
   Object? get descriptor {
-    if (transformers.isEmpty && flavors.isEmpty && platforms.isEmpty) {
+    if (bundleUri == null && transformers.isEmpty && flavors.isEmpty && platforms.isEmpty) {
       return uri.toString();
     }
     return <String, Object?>{
       _pathKey: uri.toString(),
+      if (bundleUri != null) _bundlePathKey: bundleUri!.toFilePath(windows: false),
       if (flavors.isNotEmpty) _flavorKey: flavors.toList(),
       if (platforms.isNotEmpty) _platformsKey: platforms.toList(),
       if (transformers.isNotEmpty)
@@ -813,6 +823,7 @@ class AssetsEntry {
   }
 
   static const _pathKey = 'path';
+  static const _bundlePathKey = 'bundle_path';
   static const _flavorKey = 'flavors';
   static const _platformsKey = 'platforms';
   static const _transformersKey = 'transformers';
@@ -859,6 +870,36 @@ class AssetsEntry {
         );
       }
 
+      Uri? bundleUri;
+      if (yaml.containsKey(_bundlePathKey)) {
+        final Object? bundlePath = yaml[_bundlePathKey];
+        if (bundlePath is! String || bundlePath.isEmpty) {
+          return (null, 'The bundle_path of asset "$path" must be a non-empty string.');
+        }
+        final List<String> segments = bundlePath.split('/');
+        final Iterable<String> names = bundlePath.endsWith('/')
+            ? segments.take(segments.length - 1)
+            : segments;
+        if (names.any((String segment) => segment.isEmpty || segment == '.' || segment == '..') ||
+            bundlePath.contains(r'\') ||
+            bundlePath.contains(':') ||
+            bundlePath.runes.any((int rune) => rune < 32 || rune == 127)) {
+          return (
+            null,
+            'The bundle_path of asset "$path" must be a relative path with '
+                'forward slashes and no empty, ".", or ".." segments.',
+          );
+        }
+        if (path.endsWith('/') != bundlePath.endsWith('/')) {
+          return (
+            null,
+            'The path and bundle_path of asset "$path" must either both '
+                'end with "/" for directories, or neither for files.',
+          );
+        }
+        bundleUri = Uri(pathSegments: segments);
+      }
+
       final (List<String>? flavors, List<String> flavorsErrors) = _parseFlavorsSection(
         yaml[_flavorKey],
       );
@@ -882,6 +923,7 @@ class AssetsEntry {
       return (
         AssetsEntry(
           uri: Uri(pathSegments: path.split('/')),
+          bundleUri: bundleUri,
           flavors: Set<String>.from(flavors ?? <String>[]),
           platforms: Set<String>.from(platforms ?? <String>[]),
           transformers: transformers ?? <AssetTransformerEntry>[],
@@ -981,6 +1023,7 @@ class AssetsEntry {
     }
 
     return uri == other.uri &&
+        bundleUri == other.bundleUri &&
         setEquals(flavors, other.flavors) &&
         setEquals(platforms, other.platforms);
   }
@@ -988,6 +1031,7 @@ class AssetsEntry {
   @override
   int get hashCode => Object.hashAll(<Object?>[
     uri.hashCode,
+    bundleUri,
     Object.hashAllUnordered(flavors),
     Object.hashAllUnordered(platforms),
     Object.hashAll(transformers),
@@ -995,7 +1039,7 @@ class AssetsEntry {
 
   @override
   String toString() =>
-      'AssetsEntry(uri: $uri, flavors: $flavors, platforms: $platforms, transformers: $transformers)';
+      'AssetsEntry(uri: $uri, bundleUri: $bundleUri, flavors: $flavors, platforms: $platforms, transformers: $transformers)';
 }
 
 /// Represents an entry in the "transformers" section of an asset.

--- a/packages/flutter_tools/test/general.shard/asset_bundle_path_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_path_test.dart
@@ -129,6 +129,20 @@ void main() {
     },
   );
 
+  testWithoutContext('removes a mapped base image when only resolution variants remain', () async {
+    writeManifest('    - path: source/logo.png\n      bundle_path: images/brand.png');
+    writeFile('source/logo.png');
+    writeFile('source/2.0x/logo.png');
+    expect(await build(), 0);
+    expect(bundle.entries, contains('images/brand.png'));
+
+    fileSystem.file('source/logo.png').deleteSync();
+    expect(await build(), 0);
+    expect(bundle.entries, isNot(contains('images/brand.png')));
+    expect(bundle.entries, contains('images/2.0x/brand.png'));
+    expect((await manifest()).keys, contains('images/brand.png'));
+  });
+
   testWithoutContext('removes mapped entries when their flavor is no longer selected', () async {
     writeManifest('    - path: dev.json\n      flavors: [dev]\n      bundle_path: config.json');
     writeFile('dev.json');

--- a/packages/flutter_tools/test/general.shard/asset_bundle_path_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_path_test.dart
@@ -1,0 +1,437 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/asset.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/devfs.dart';
+import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:standard_message_codec/standard_message_codec.dart';
+
+import '../src/common.dart';
+import '../src/package_config.dart';
+
+void main() {
+  late MemoryFileSystem fileSystem;
+  late BufferLogger logger;
+  late ManifestAssetBundle bundle;
+
+  void writeFile(String path, [String contents = 'contents']) {
+    fileSystem.file(fileSystem.path.fromUri(Uri(path: path)))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(contents);
+  }
+
+  void writeManifest(String assets, {String extra = ''}) {
+    writeFile('pubspec.yaml', 'name: example\nflutter:\n  assets:\n$assets\n$extra');
+  }
+
+  Future<int> build({
+    String? flavor,
+    TargetPlatform platform = TargetPlatform.android_arm64,
+    bool deferred = false,
+    FlutterHookResult? hooks,
+  }) => bundle.build(
+    packageConfigPath: '.dart_tool/package_config.json',
+    flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+    flavor: flavor,
+    targetPlatform: platform,
+    deferredComponentsEnabled: deferred,
+    flutterHookResult: hooks,
+  );
+
+  Future<Map<Object?, Object?>> manifest() async =>
+      const StandardMessageCodec().decodeMessage(
+            ByteData.sublistView(
+              Uint8List.fromList(await bundle.entries['AssetManifest.bin']!.contentsAsBytes()),
+            ),
+          )!
+          as Map<Object?, Object?>;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    logger = BufferLogger.test();
+    writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'example');
+    bundle = ManifestAssetBundle(
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: FakePlatform(),
+      flutterRoot: '/flutter',
+      splitDeferredAssets: true,
+    );
+  });
+
+  for (final flavor in <String?>['dev', 'prod', null, 'other']) {
+    testWithoutContext('selects Branch configuration for flavor $flavor', () async {
+      writeManifest('''
+    - path: configs/dev/branch-config.json
+      flavors: [dev]
+      bundle_path: assets/branch-config.json
+    - path: configs/prod/branch-config.json
+      flavors: [prod]
+      bundle_path: assets/branch-config.json''');
+      writeFile('configs/dev/branch-config.json', '{"environment":"dev"}');
+      writeFile('configs/prod/branch-config.json', '{"environment":"prod"}');
+      expect(await build(flavor: flavor), 0);
+      expect(bundle.entries.keys, isNot(contains(startsWith('configs/'))));
+      if (flavor == 'dev' || flavor == 'prod') {
+        expect(
+          utf8.decode(await bundle.entries['assets/branch-config.json']!.contentsAsBytes()),
+          '{"environment":"$flavor"}',
+        );
+        expect((await manifest()).keys, contains('assets/branch-config.json'));
+        expect(
+          bundle.inputFiles.map((File file) => file.path),
+          contains('/configs/$flavor/branch-config.json'),
+        );
+      } else {
+        expect(bundle.entries, isNot(contains('assets/branch-config.json')));
+      }
+    });
+  }
+
+  testWithoutContext(
+    'updates the source when rebuilding the same bundle for another flavor',
+    () async {
+      writeManifest('''
+    - path: dev.json
+      flavors: [dev]
+      bundle_path: assets/branch-config.json
+    - path: prod.json
+      flavors: [prod]
+      bundle_path: assets/branch-config.json''');
+      writeFile('dev.json', 'dev');
+      writeFile('prod.json', 'prod');
+      expect(await build(flavor: 'dev'), 0);
+      final AssetBundleEntry first = bundle.entries['assets/branch-config.json']!;
+      expect(await build(flavor: 'dev'), 0);
+      expect(bundle.entries['assets/branch-config.json'], same(first));
+      expect(await build(flavor: 'prod'), 0);
+      expect(
+        utf8.decode(await bundle.entries['assets/branch-config.json']!.contentsAsBytes()),
+        'prod',
+      );
+      writeFile('prod.json', 'updated');
+      expect(await build(flavor: 'prod'), 0);
+      expect(
+        utf8.decode(await bundle.entries['assets/branch-config.json']!.contentsAsBytes()),
+        'updated',
+      );
+      expect(fileSystem.file('dev.json').readAsStringSync(), 'dev');
+    },
+  );
+
+  testWithoutContext('removes mapped entries when their flavor is no longer selected', () async {
+    writeManifest('    - path: dev.json\n      flavors: [dev]\n      bundle_path: config.json');
+    writeFile('dev.json');
+    expect(await build(flavor: 'dev'), 0);
+    expect(bundle.entries, contains('config.json'));
+    expect(await build(), 0);
+    expect(bundle.entries, isNot(contains('config.json')));
+  });
+
+  testWithoutContext('removes the previous destination after a pubspec edit', () async {
+    writeManifest('    - path: config.json\n      bundle_path: old.json');
+    writeFile('config.json');
+    expect(await build(), 0);
+    writeManifest('    - path: config.json\n      bundle_path: new.json');
+    expect(await build(), 0);
+    expect(bundle.entries, contains('new.json'));
+    expect(bundle.entries, isNot(contains('old.json')));
+  });
+
+  testWithoutContext('keeps duplicate declarations of the same source', () async {
+    writeManifest('''
+    - path: source.json
+      bundle_path: config.json
+    - path: source.json
+      bundle_path: config.json
+''');
+    writeFile('source.json');
+    expect(await build(), 0);
+    expect((await manifest()).keys, <String>['config.json']);
+  });
+
+  testWithoutContext('rejects different transformers for the same mapped source', () async {
+    writeManifest('''
+    - path: source.json
+      bundle_path: config.json
+      transformers:
+        - package: first
+    - path: source.json
+      bundle_path: config.json
+      transformers:
+        - package: second
+''');
+    writeFile('source.json');
+    await expectLater(build(), throwsToolExit(message: 'Conflicting assets at bundle path'));
+  });
+
+  testWithoutContext('uses portable bundle keys on Windows', () async {
+    fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+    fileSystem.currentDirectory = fileSystem.systemTempDirectory.createTempSync('bundle_path.');
+    writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'example');
+    bundle = ManifestAssetBundle(
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: FakePlatform(operatingSystem: 'windows'),
+      flutterRoot: r'C:\flutter',
+    );
+    writeManifest('    - path: source/\n      bundle_path: images/');
+    writeFile('source/logo.png');
+    writeFile('source/2.0x/logo.png');
+    expect(await build(platform: TargetPlatform.windows_x64), 0);
+    expect(logger.errorText, isEmpty);
+    expect(bundle.entries.keys, containsAll(<String>['images/logo.png', 'images/2.0x/logo.png']));
+  });
+
+  testWithoutContext('normalizes legacy destinations when checking conflicts', () async {
+    writeManifest('''
+    - path: source.json
+      bundle_path: config.json
+    - assets/../config.json
+''');
+    writeFile('source.json');
+    writeFile('config.json');
+    fileSystem.directory('assets').createSync();
+    await expectLater(build(), throwsToolExit(message: 'Conflicting assets at bundle path'));
+  });
+
+  testWithoutContext('reports missing mapped source files', () async {
+    writeManifest('    - path: missing.json\n      bundle_path: config.json');
+    expect(await build(), 1);
+    expect(logger.errorText, contains('No file or variants found'));
+  });
+
+  for (final reverse in <bool>[false, true]) {
+    testWithoutContext(
+      'rejects file-directory destination collisions (reverse: $reverse)',
+      () async {
+        final declarations = <String>[
+          '    - path: source.json\n      bundle_path: assets',
+          '    - assets/config.json',
+        ];
+        writeManifest((reverse ? declarations.reversed : declarations).join('\n'));
+        writeFile('source.json');
+        writeFile('assets/config.json');
+        await expectLater(
+          build(),
+          throwsToolExit(message: 'a file cannot also be used as a directory'),
+        );
+      },
+    );
+  }
+
+  testWithoutContext('detects a destination collision with hook assets', () async {
+    writeManifest('    - path: source.json\n      bundle_path: packages/example/config.json');
+    writeFile('source.json');
+    writeFile('hook.json');
+    final hooks = FlutterHookResult(
+      buildStart: DateTime(2026),
+      buildEnd: DateTime(2026),
+      dependencies: <Uri>[],
+      dataAssets: <HookAsset>[
+        HookAsset(file: Uri.file('/hook.json'), name: 'config.json', package: 'example'),
+      ],
+    );
+    await expectLater(
+      build(hooks: hooks),
+      throwsToolExit(message: 'Conflicting assets at bundle path'),
+    );
+  });
+
+  testWithoutContext('detects a destination collision with fonts', () async {
+    writeManifest(
+      '    - path: source.ttf\n      bundle_path: fonts/font.ttf',
+      extra: '''
+  fonts:
+    - family: Test
+      fonts:
+        - asset: fonts/font.ttf
+''',
+    );
+    writeFile('source.ttf');
+    writeFile('fonts/font.ttf');
+    await expectLater(build(), throwsToolExit(message: 'Conflicting assets at bundle path'));
+  });
+
+  testWithoutContext('preserves shader kind and source under a mapped destination', () async {
+    writeManifest(
+      '    - common.txt',
+      extra: '''
+  shaders:
+    - path: source.frag
+      bundle_path: shaders/renamed.frag
+''',
+    );
+    writeFile('common.txt');
+    writeFile('source.frag');
+    expect(await build(), 0);
+    final AssetBundleEntry entry = bundle.entries['shaders/renamed.frag']!;
+    expect(entry.kind, AssetKind.shader);
+    expect((entry.content as DevFSFileContent).file.path, '/source.frag');
+  });
+
+  testWithoutContext('filters platforms before checking destination conflicts', () async {
+    writeManifest('''
+    - path: android.json
+      platforms: [android]
+      bundle_path: config.json
+    - path: ios.json
+      platforms: [ios]
+      bundle_path: config.json''');
+    writeFile('android.json', 'android');
+    writeFile('ios.json', 'ios');
+    expect(await build(), 0);
+    expect(utf8.decode(await bundle.entries['config.json']!.contentsAsBytes()), 'android');
+  });
+
+  for (final second in <String>[
+    '    - path: other.json\n      bundle_path: config.json',
+    '    - config.json',
+    '    - path: other.json\n      flavors: [dev]\n      bundle_path: config.json',
+  ]) {
+    testWithoutContext('rejects selected destination conflict with $second', () async {
+      writeManifest('''
+    - path: dev.json
+      flavors: [dev]
+      bundle_path: config.json
+$second''');
+      writeFile('dev.json');
+      writeFile('other.json');
+      writeFile('config.json');
+      await expectLater(
+        build(flavor: 'dev'),
+        throwsToolExit(message: 'Conflicting assets at bundle path "config.json"'),
+      );
+    });
+  }
+
+  for (final key in <String>[
+    'AssetManifest.bin',
+    'FontManifest.json',
+    'NOTICES.Z',
+    'kernel_blob.bin',
+  ]) {
+    testWithoutContext('rejects generated destination $key', () async {
+      writeManifest('    - path: source.json\n      bundle_path: $key');
+      writeFile('source.json');
+      await expectLater(build(), throwsToolExit(message: 'reserved for a generated Flutter asset'));
+    });
+  }
+
+  testWithoutContext('rewrites directory prefixes and image variants without recursing', () async {
+    writeManifest('    - path: source/\n      bundle_path: images/');
+    writeFile('source/logo.png');
+    writeFile('source/2.0x/logo.png', '2x');
+    writeFile('source/nested/ignored.png');
+    expect(await build(), 0);
+    expect(bundle.entries.keys, containsAll(<String>['images/logo.png', 'images/2.0x/logo.png']));
+    expect(bundle.entries.keys, isNot(contains('images/nested/ignored.png')));
+    expect((await manifest())['images/logo.png'], <Object?>[
+      <String, Object?>{'asset': 'images/logo.png'},
+      <String, Object?>{'asset': 'images/2.0x/logo.png', 'dpr': 2.0},
+    ]);
+  });
+
+  testWithoutContext('renames image variants when the base image is missing', () async {
+    writeManifest('    - path: source/logo.png\n      bundle_path: images/brand.png');
+    writeFile('source/2.0x/logo.png');
+    expect(await build(), 0);
+    expect(bundle.entries.keys, contains('images/2.0x/brand.png'));
+    expect((await manifest()).keys, contains('images/brand.png'));
+  });
+
+  testWithoutContext('detects a collision with an image variant', () async {
+    writeManifest('''
+    - path: source/logo.png
+      bundle_path: images/logo.png
+    - images/2.0x/logo.png''');
+    writeFile('source/logo.png');
+    writeFile('source/2.0x/logo.png');
+    writeFile('images/2.0x/logo.png');
+    await expectLater(
+      build(),
+      throwsToolExit(message: 'Conflicting assets at bundle path "images/2.0x/logo.png"'),
+    );
+  });
+
+  testWithoutContext('preserves package namespaces and transformer configuration', () async {
+    writePackageConfigFiles(
+      directory: fileSystem.currentDirectory,
+      mainLibName: 'example',
+      packages: <String, String>{'foo': '/foo/'},
+    );
+    writeFile('pubspec.yaml', 'name: example\ndependencies:\n  foo:\n    path: foo\n');
+    writeFile('foo/pubspec.yaml', '''
+name: foo
+flutter:
+  assets:
+    - path: config.json
+      bundle_path: assets/config.json
+      transformers:
+        - package: transformer
+          args: [--example]
+''');
+    writeFile('foo/config.json');
+    expect(await build(), 0);
+    final AssetBundleEntry entry = bundle.entries['packages/foo/assets/config.json']!;
+    expect((entry.content as DevFSFileContent).file.path, '/foo/config.json');
+    expect(entry.transformers, <AssetTransformerEntry>[
+      const AssetTransformerEntry(package: 'transformer', args: <String>['--example']),
+    ]);
+  });
+
+  testWithoutContext('resolves explicitly declared package files from their source', () async {
+    writePackageConfigFiles(
+      directory: fileSystem.currentDirectory,
+      mainLibName: 'example',
+      packages: <String, String>{'foo': '/foo/'},
+    );
+    writeManifest('    - path: packages/foo/config.json\n      bundle_path: assets/config.json');
+    writeFile('foo/lib/config.json', 'package config');
+    expect(await build(), 0);
+    expect(
+      utf8.decode(await bundle.entries['assets/config.json']!.contentsAsBytes()),
+      'package config',
+    );
+  });
+
+  testWithoutContext('rewrites deferred component assets', () async {
+    writeManifest(
+      '    - common.txt',
+      extra: '''
+  deferred-components:
+    - name: feature
+      assets:
+        - path: config.json
+          bundle_path: assets/config.json
+''',
+    );
+    writeFile('common.txt');
+    writeFile('config.json');
+    expect(await build(deferred: true), 0);
+    expect(bundle.deferredComponentsEntries['feature'], contains('assets/config.json'));
+    expect((await manifest()).keys, contains('assets/config.json'));
+  });
+
+  testWithoutContext(
+    'encodes special characters for web output and decodes manifest keys',
+    () async {
+      writeManifest('    - path: source.json\n      bundle_path: "assets/config #1%.json"');
+      writeFile('source.json');
+      expect(await build(platform: TargetPlatform.web_javascript), 0);
+      expect(bundle.entries, contains('assets/config%20%231%25.json'));
+      expect((await manifest()).keys, contains('assets/config #1%.json'));
+      expect(bundle.entries, contains('AssetManifest.bin.json'));
+    },
+  );
+}

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -64,6 +64,58 @@ flutter:
   });
 
   testUsingContext(
+    'tracks source files while copying to bundle_path across incremental builds',
+    () async {
+      writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'example');
+      fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: example
+flutter:
+  assets:
+    - path: configs/dev.json
+      flavors: [dev]
+      bundle_path: assets/branch-config.json
+    - path: configs/prod.json
+      flavors: [prod]
+      bundle_path: assets/branch-config.json
+''');
+      fileSystem.file('configs/dev.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('dev');
+      fileSystem.file('configs/prod.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('prod');
+      final File output = environment.buildDir
+          .childDirectory('flutter_assets')
+          .childDirectory('assets')
+          .childFile('branch-config.json');
+      for (final flavor in <String>['dev', 'prod', 'dev']) {
+        environment.defines[kFlavor] = flavor;
+        await const CopyAssets().build(environment);
+        expect(output.readAsStringSync(), flavor);
+        final Depfile dependencies = environment.depFileService.parse(
+          environment.buildDir.childFile('flutter_assets.d'),
+        );
+        expect(
+          dependencies.inputs.map((File file) => file.path),
+          contains('/configs/$flavor.json'),
+        );
+        expect(
+          dependencies.inputs.map((File file) => file.path),
+          isNot(contains('/assets/branch-config.json')),
+        );
+        expect(dependencies.outputs.map((File file) => file.path), contains(output.path));
+      }
+      fileSystem.file('configs/dev.json').writeAsStringSync('updated');
+      await const CopyAssets().build(environment);
+      expect(output.readAsStringSync(), 'updated');
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+    },
+  );
+
+  testUsingContext(
     'includes LICENSE file inputs in dependencies',
     () async {
       writePackageConfigFiles(

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -2,12 +2,55 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:yaml/yaml.dart';
 
 import '../src/common.dart';
 
 void main() {
+  testWithoutContext('bundle_path is optional and round trips through the descriptor', () {
+    final AssetsEntry entry = AssetsEntry.parseFromYaml(<String, Object>{
+      'path': 'configs/dev.json',
+      'bundle_path': 'assets/config #1.json',
+      'flavors': YamlList.wrap(<String>['dev']),
+    })!;
+    expect(entry.uri, Uri.parse('configs/dev.json'));
+    expect(entry.bundleUri, Uri(path: 'assets/config #1.json'));
+    expect(AssetsEntry.parseFromYaml(loadYaml(jsonEncode(entry.descriptor))), entry);
+    final AssetsEntry legacy = AssetsEntry.parseFromYaml('config.json')!;
+    expect(legacy.bundleUri, isNull);
+    expect(legacy.descriptor, 'config.json');
+    expect(entry, isNot(AssetsEntry(uri: entry.uri, flavors: entry.flavors)));
+  });
+
+  for (final path in <Object?>[
+    null,
+    '',
+    1,
+    <String>[],
+    '/absolute.json',
+    '../escape.json',
+    'assets/../escape.json',
+    './config.json',
+    'assets//config.json',
+    r'assets\config.json',
+    'C:/config.json',
+    'file:config.json',
+    'assets/',
+  ]) {
+    testWithoutContext('rejects invalid bundle_path $path', () {
+      final (AssetsEntry? entry, String? error) = AssetsEntry.parseFromYamlSafe(<String, Object?>{
+        'path': 'config.json',
+        'bundle_path': path,
+      });
+      expect(entry, isNull);
+      expect(error, contains('bundle_path'));
+    });
+  }
+
   group('parsing of assets section in flutter manifests', () {
     testWithoutContext('ignores empty list of assets', () {
       final logger = BufferLogger.test();


### PR DESCRIPTION
Some plugins load configuration from a fixed asset key. For example, the Branch SDK expects `assets/branch-config.json`, so selecting a different source file by flavor is only useful if it can keep that key in the built app.

This adds an optional `bundle_path` to asset declarations:

```yaml
flutter:
  assets:
    - path: configs/dev/branch-config.json
      flavors: [dev]
      bundle_path: assets/branch-config.json
    - path: configs/prod/branch-config.json
      flavors: [prod]
      bundle_path: assets/branch-config.json
```

`path` remains the source and build dependency. `bundle_path` becomes the output location and runtime key. Omitting it preserves existing behavior. The implementation reuses the existing flavor and platform filtering, then checks selected destinations for conflicts, including variants, package assets, hook assets, fonts, and deferred components. It also updates cached entries when a flavor switch changes the source behind the same key.

Directory prefixes and image variants follow the mapping, and dependency assets keep their package namespace. The tool documentation covers lookup APIs, path validation, and interactions with the existing asset features.

Fixes #151342. Related: #192497 (closed as a duplicate of #151342) and #171627.

## Validation

- 242 focused tool tests passed across asset bundling, flavors, variants, packages, fonts, manifests, transformer declarations, and asset copying. New cases cover conflicts, Windows paths, generated destinations, source dependency tracking, repeated builds after source/flavor changes, and removing a base image while retaining its resolution variants.
- Static analysis passed for all modified Dart files.
- The flavors integration test passed on an Android emulator and an iOS simulator, with both `paid` and `free`. Dart's `rootBundle` and the native asset lookup APIs read the same configuration at `assets/branch-config.json`.

## Scope and remaining validation

The integration fixtures exercise the lookup pattern used by Branch; they do not initialize the Branch SDK or contain SDK keys. This changes paths inside the Flutter asset bundle, not the platform application's top-level resources. It adds no fallback precedence or new flavor support for build targets. Third-party asset generators need their own support for the new field.

The full repository suite and release/device-lab builds were not run locally. Full CI is awaiting the maintainer-controlled `CICD` label. Website documentation is tracked in https://github.com/flutter/website/issues/13868; the proposed API and release availability should be confirmed before those docs are published.

## Pre-launch Checklist

- [x] Read the contributor guide, contribution policies, Tree Hygiene, and Flutter Style Guide.
- [x] CLA check passed for this PR.
- [x] Listed the issue addressed by this change.
- [x] Added in-code and tool documentation.
- [x] Linked a flutter/website documentation issue: https://github.com/flutter/website/issues/13868.
- [x] Added focused tests and ran the relevant existing tests.
- [x] Checked compatibility when `bundle_path` is omitted; no migration is required.




