### PR TITLE
[flutter_tools] Verify local engine option propagation across tool commands and DI

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -303,28 +303,28 @@ abstract class Artifacts {
     required ToolContext toolContext,
   }) {
     final ToolContext(
-      cache: Cache targetCache,
-      fs: FileSystem targetFileSystem,
-      os: OperatingSystemUtils targetOs,
-      platform: Platform targetPlatform,
-      processManager: ProcessManager targetProcessManager,
+      :Cache cache,
+      :FileSystem fs,
+      :OperatingSystemUtils os,
+      :Platform platform,
+      :ProcessManager processManager,
     ) = toolContext;
 
     Artifacts artifacts = CachedArtifacts(
-      fileSystem: targetFileSystem,
-      platform: targetPlatform,
-      cache: targetCache,
-      operatingSystemUtils: targetOs,
+      fileSystem: fs,
+      platform: platform,
+      cache: cache,
+      operatingSystemUtils: os,
     );
     if (engineBuildPaths.hostEngine != null && engineBuildPaths.targetEngine != null) {
       artifacts = CachedLocalEngineArtifacts(
         engineBuildPaths.hostEngine!,
         engineOutPath: engineBuildPaths.targetEngine!,
-        cache: targetCache,
-        fileSystem: targetFileSystem,
-        processManager: targetProcessManager,
-        platform: targetPlatform,
-        operatingSystemUtils: targetOs,
+        cache: cache,
+        fileSystem: fs,
+        processManager: processManager,
+        platform: platform,
+        operatingSystemUtils: os,
         parent: artifacts,
       );
     }
@@ -332,9 +332,9 @@ abstract class Artifacts {
       artifacts = CachedLocalWebSdkArtifacts(
         parent: artifacts,
         webSdkPath: engineBuildPaths.webSdk!,
-        fileSystem: targetFileSystem,
-        platform: targetPlatform,
-        operatingSystemUtils: targetOs,
+        fileSystem: fs,
+        platform: platform,
+        operatingSystemUtils: os,
       );
     }
     return artifacts;

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -303,11 +303,11 @@ abstract class Artifacts {
     required ToolContext toolContext,
   }) {
     final ToolContext(
-      cache: targetCache,
-      fs: targetFileSystem,
-      os: targetOs,
-      platform: targetPlatform,
-      processManager: targetProcessManager,
+      cache: Cache targetCache,
+      fs: FileSystem targetFileSystem,
+      os: OperatingSystemUtils targetOs,
+      platform: Platform targetPlatform,
+      processManager: ProcessManager targetProcessManager,
     ) = toolContext;
 
     Artifacts artifacts = CachedArtifacts(

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -14,6 +14,7 @@ import 'base/user_messages.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
 import 'cache.dart';
+import 'context/tool_context.dart';
 import 'globals.dart' as globals;
 
 //////////////////////////////////////////////////////////////////////
@@ -299,27 +300,31 @@ abstract class Artifacts {
 
   static Artifacts getLocalEngine(
     EngineBuildPaths engineBuildPaths, {
-    required Cache cache,
-    required FileSystem fileSystem,
-    required OperatingSystemUtils operatingSystemUtils,
-    required Platform platform,
-    required ProcessManager processManager,
+    required ToolContext toolContext,
   }) {
+    final ToolContext(
+      cache: targetCache,
+      fs: targetFileSystem,
+      os: targetOs,
+      platform: targetPlatform,
+      processManager: targetProcessManager,
+    ) = toolContext;
+
     Artifacts artifacts = CachedArtifacts(
-      fileSystem: fileSystem,
-      platform: platform,
-      cache: cache,
-      operatingSystemUtils: operatingSystemUtils,
+      fileSystem: targetFileSystem,
+      platform: targetPlatform,
+      cache: targetCache,
+      operatingSystemUtils: targetOs,
     );
     if (engineBuildPaths.hostEngine != null && engineBuildPaths.targetEngine != null) {
       artifacts = CachedLocalEngineArtifacts(
         engineBuildPaths.hostEngine!,
         engineOutPath: engineBuildPaths.targetEngine!,
-        cache: cache,
-        fileSystem: fileSystem,
-        processManager: processManager,
-        platform: platform,
-        operatingSystemUtils: operatingSystemUtils,
+        cache: targetCache,
+        fileSystem: targetFileSystem,
+        processManager: targetProcessManager,
+        platform: targetPlatform,
+        operatingSystemUtils: targetOs,
         parent: artifacts,
       );
     }
@@ -327,9 +332,9 @@ abstract class Artifacts {
       artifacts = CachedLocalWebSdkArtifacts(
         parent: artifacts,
         webSdkPath: engineBuildPaths.webSdk!,
-        fileSystem: fileSystem,
-        platform: platform,
-        operatingSystemUtils: operatingSystemUtils,
+        fileSystem: targetFileSystem,
+        platform: targetPlatform,
+        operatingSystemUtils: targetOs,
       );
     }
     return artifacts;

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -297,22 +297,29 @@ abstract class Artifacts {
     return _TestLocalEngine(localEngine, localEngineHost, fileSystem ?? MemoryFileSystem.test());
   }
 
-  static Artifacts getLocalEngine(EngineBuildPaths engineBuildPaths) {
+  static Artifacts getLocalEngine(
+    EngineBuildPaths engineBuildPaths, {
+    required Cache cache,
+    required FileSystem fileSystem,
+    required OperatingSystemUtils operatingSystemUtils,
+    required Platform platform,
+    required ProcessManager processManager,
+  }) {
     Artifacts artifacts = CachedArtifacts(
-      fileSystem: globals.fs,
-      platform: globals.platform,
-      cache: globals.cache,
-      operatingSystemUtils: globals.os,
+      fileSystem: fileSystem,
+      platform: platform,
+      cache: cache,
+      operatingSystemUtils: operatingSystemUtils,
     );
     if (engineBuildPaths.hostEngine != null && engineBuildPaths.targetEngine != null) {
       artifacts = CachedLocalEngineArtifacts(
         engineBuildPaths.hostEngine!,
         engineOutPath: engineBuildPaths.targetEngine!,
-        cache: globals.cache,
-        fileSystem: globals.fs,
-        processManager: globals.processManager,
-        platform: globals.platform,
-        operatingSystemUtils: globals.os,
+        cache: cache,
+        fileSystem: fileSystem,
+        processManager: processManager,
+        platform: platform,
+        operatingSystemUtils: operatingSystemUtils,
         parent: artifacts,
       );
     }
@@ -320,9 +327,9 @@ abstract class Artifacts {
       artifacts = CachedLocalWebSdkArtifacts(
         parent: artifacts,
         webSdkPath: engineBuildPaths.webSdk!,
-        fileSystem: globals.fs,
-        platform: globals.platform,
-        operatingSystemUtils: globals.os,
+        fileSystem: fileSystem,
+        platform: platform,
+        operatingSystemUtils: operatingSystemUtils,
       );
     }
     return artifacts;

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -564,11 +564,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
     if (engineBuildPaths != null) {
       final Artifacts localArtifacts = Artifacts.getLocalEngine(
         engineBuildPaths,
-        cache: _toolContext.cache,
-        fileSystem: _toolContext.fs,
-        operatingSystemUtils: _toolContext.os,
-        platform: _toolContext.platform,
-        processManager: _toolContext.processManager,
+        toolContext: _toolContext,
       );
       contextOverrides.addAll(<Type, Object?>{Artifacts: localArtifacts});
       // Update the artifacts the commands were created with.

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -562,7 +562,14 @@ class FlutterCommandRunner extends CommandRunner<void> {
       packagePath: topLevelResults[FlutterGlobalOptions.kPackagesOption] as String?,
     );
     if (engineBuildPaths != null) {
-      final Artifacts localArtifacts = Artifacts.getLocalEngine(engineBuildPaths);
+      final Artifacts localArtifacts = Artifacts.getLocalEngine(
+        engineBuildPaths,
+        cache: _toolContext.cache,
+        fileSystem: _toolContext.fs,
+        operatingSystemUtils: _toolContext.os,
+        platform: _toolContext.platform,
+        processManager: _toolContext.processManager,
+      );
       contextOverrides.addAll(<Type, Object?>{Artifacts: localArtifacts});
       // Update the artifacts the commands were created with.
       if (_toolContext.artifacts case final DeferredArtifacts artifacts) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -438,7 +438,7 @@ void main() {
             expect(environment.artifacts.usesLocalArtifacts, isTrue);
             expect(
               environment.artifacts.localEngineInfo?.targetOutPath,
-              endsWith('engine/src/out/host_debug'),
+              endsWith(fileSystem.path.join('engine', 'src', 'out', 'host_debug')),
             );
             expect(environment.engineVersion, isNull);
           }),

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -410,6 +410,54 @@ void main() {
   );
 
   testWithoutContext(
+    'flutter assemble propagates local-engine flags to environment when passed via CLI with DeferredArtifacts',
+    () async {
+      fileSystem
+          .directory('engine')
+          .childDirectory('src')
+          .childDirectory('out')
+          .childDirectory('host_debug')
+          .createSync(recursive: true);
+      final deferredArtifacts = DeferredArtifacts(artifacts);
+      final localToolContext = FakeToolContext(
+        artifacts: deferredArtifacts,
+        cache: cache,
+        fs: fileSystem,
+        logger: logger,
+        processManager: FakeProcessManager.any(),
+      );
+      var buildInvoked = false;
+      final CommandRunner<void> commandRunner = createTestCommandRunner(
+        AssembleCommand(
+          featureFlags: TestFeatureFlags(),
+          buildSystem: TestBuildSystem.all(BuildResult(success: true), (
+            Target target,
+            Environment environment,
+          ) {
+            buildInvoked = true;
+            expect(environment.artifacts.usesLocalArtifacts, isTrue);
+            expect(
+              environment.artifacts.localEngineInfo?.targetOutPath,
+              endsWith('engine/src/out/host_debug'),
+            );
+            expect(environment.engineVersion, isNull);
+          }),
+          toolContext: localToolContext,
+        ),
+      );
+      await commandRunner.run(<String>[
+        '--local-engine=host_debug',
+        '--local-engine-host=host_debug',
+        '--local-engine-src-path=./engine/src',
+        'assemble',
+        '-o Output',
+        'debug_macos_bundle_flutter_assets',
+      ]);
+      expect(buildInvoked, isTrue);
+    },
+  );
+
+  testWithoutContext(
     'flutter assemble only writes input and output files when the values change',
     () async {
       final BuildSystem buildSystem = TestBuildSystem.list(<BuildResult>[

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/common.dart';
@@ -628,6 +629,54 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
       Artifacts: () => Artifacts.test(),
+    },
+  );
+
+  testUsingContext(
+    'ios build config-only writes Generated.xcconfig with local engine options',
+    () async {
+      fileSystem
+          .directory('engine')
+          .childDirectory('src')
+          .childDirectory('out')
+          .childDirectory('ios_debug')
+          .childDirectory('Flutter.xcframework')
+          .childDirectory('ios-arm64')
+          .childDirectory('Flutter.framework')
+          .createSync(recursive: true);
+      fileSystem
+          .directory('engine')
+          .childDirectory('src')
+          .childDirectory('out')
+          .childDirectory('host_debug')
+          .createSync(recursive: true);
+      createMinimalMockProjectFiles();
+
+      final BuildCommand command = createBuildCommand();
+
+      await createTestCommandRunner(command).run(const <String>[
+        '--local-engine=ios_debug',
+        '--local-engine-host=host_debug',
+        '--local-engine-src-path=engine/src',
+        'build',
+        'ios',
+        '--config-only',
+        '--no-pub',
+      ]);
+
+      final File configFile = fileSystem.file('ios/Flutter/Generated.xcconfig');
+      expect(configFile, exists);
+      final String configContent = configFile.readAsStringSync();
+      expect(configContent, contains('LOCAL_ENGINE=ios_debug'));
+      expect(configContent, contains('LOCAL_ENGINE_HOST=host_debug'));
+      expect(configContent, contains('FLUTTER_ENGINE=engine/src'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+      Platform: () => macosPlatform,
+      XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
     },
   );
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -176,7 +176,7 @@ void main() {
       projectFactory: FlutterProjectFactory(fileSystem: fileSystem, logger: effectiveLogger),
     );
     return BuildLinuxCommand(
-            buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
       featureFlags: effectiveFeatureFlags,
       toolContext: toolContext,
       verboseHelp: verboseHelp,
@@ -235,7 +235,8 @@ void main() {
       expect(
         createTestCommandRunner(command).run(const <String>['build', 'linux', '--no-pub']),
         throwsToolExit(
-          message: '"build linux" is not currently supported. To enable, run "flutter config --enable-linux-desktop".',
+          message:
+              '"build linux" is not currently supported. To enable, run "flutter config --enable-linux-desktop".',
         ),
       );
     },
@@ -309,6 +310,44 @@ void main() {
   );
 
   testUsingContext(
+    'Linux build config-only writes CMake configuration with local engine options',
+    () async {
+      fileSystem
+          .directory('engine')
+          .childDirectory('src')
+          .childDirectory('out')
+          .childDirectory('host_debug')
+          .createSync(recursive: true);
+      final BuildCommand command = createBuildCommand();
+      setUpMockProjectFilesForBuild();
+      processManager.addCommands(<FakeCommand>[cmakeCommand('release')]);
+
+      await createTestCommandRunner(command).run(const <String>[
+        '--local-engine=host_debug',
+        '--local-engine-host=host_debug',
+        '--local-engine-src-path=./engine/src',
+        'build',
+        'linux',
+        '--config-only',
+        '--no-pub',
+      ]);
+      final File configFile = fileSystem.file('linux/flutter/ephemeral/generated_config.cmake');
+      expect(configFile, exists);
+      final String configContent = configFile.readAsStringSync();
+      expect(configContent, contains(r'"LOCAL_ENGINE=host_debug"'));
+      expect(configContent, contains(r'"LOCAL_ENGINE_HOST=host_debug"'));
+      expect(configContent, contains(r'"FLUTTER_ENGINE=engine/src"'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Platform: () => linuxPlatform,
+      FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
+      OperatingSystemUtils: () => FakeOperatingSystemUtils(),
+    },
+  );
+
+  testUsingContext(
     'Handles missing cmake',
     () async {
       setUpMockProjectFilesForBuild();
@@ -369,8 +408,9 @@ void main() {
         ninjaCommand('debug', stdout: 'STDOUT STUFF'),
       ]);
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--debug', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--debug', '--no-pub']);
       expect(testLogger.statusText, isNot(contains('STDOUT STUFF')));
       expect(testLogger.warningText, isNot(contains('STDOUT STUFF')));
       expect(testLogger.errorText, isNot(contains('STDOUT STUFF')));
@@ -453,8 +493,9 @@ ERROR: No file or variants found for asset: images/a_dot_burr.jpeg
         ),
       ]);
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--debug', '-v', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--debug', '-v', '--no-pub']);
       expect(testLogger.statusText, contains('STDOUT STUFF'));
       expect(testLogger.traceText, isNot(contains('STDOUT STUFF')));
       expect(testLogger.warningText, isNot(contains('STDOUT STUFF')));
@@ -477,8 +518,9 @@ ERROR: No file or variants found for asset: images/a_dot_burr.jpeg
       setUpMockProjectFilesForBuild();
       processManager.addCommands(<FakeCommand>[cmakeCommand('debug'), ninjaCommand('debug')]);
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--debug', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--debug', '--no-pub']);
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -502,8 +544,9 @@ ERROR: No file or variants found for asset: images/a_dot_burr.jpeg
         ninjaCommand('debug', target: 'arm64'),
       ]);
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--debug', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--debug', '--no-pub']);
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -525,8 +568,9 @@ ERROR: No file or variants found for asset: images/a_dot_burr.jpeg
         ninjaCommand('debug', target: 'riscv64'),
       ]);
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--debug', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--debug', '--no-pub']);
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -543,8 +587,9 @@ ERROR: No file or variants found for asset: images/a_dot_burr.jpeg
       setUpMockProjectFilesForBuild();
       processManager.addCommands(<FakeCommand>[cmakeCommand('profile'), ninjaCommand('profile')]);
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--profile', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--profile', '--no-pub']);
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -567,8 +612,9 @@ ERROR: No file or variants found for asset: images/a_dot_burr.jpeg
         ninjaCommand('profile', target: 'arm64'),
       ]);
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--profile', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--profile', '--no-pub']);
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -590,8 +636,9 @@ ERROR: No file or variants found for asset: images/a_dot_burr.jpeg
         ninjaCommand('profile', target: 'riscv64'),
       ]);
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--profile', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--profile', '--no-pub']);
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -609,8 +656,9 @@ ERROR: No file or variants found for asset: images/a_dot_burr.jpeg
       );
 
       expect(
-        createTestCommandRunner(command)
-            .run(const <String>['build', 'linux', '--no-pub', '--target-platform=linux-x64']),
+        createTestCommandRunner(
+          command,
+        ).run(const <String>['build', 'linux', '--no-pub', '--target-platform=linux-x64']),
         throwsToolExit(),
       );
     },
@@ -779,8 +827,9 @@ set(BINARY_NAME "fizz_bar")
         ..createSync(recursive: true)
         ..writeAsBytesSync(List<int>.filled(10000, 0));
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--no-pub', '--analyze-size']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--no-pub', '--analyze-size']);
 
       expect(
         testLogger.statusText,
@@ -834,8 +883,9 @@ set(BINARY_NAME "fizz_bar")
         ..createSync(recursive: true)
         ..writeAsBytesSync(List<int>.filled(10000, 0));
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--no-pub', '--analyze-size']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--no-pub', '--analyze-size']);
 
       // check if libapp.so of "build/linux/arm64/release" directory can be referenced.
       expect(testLogger.statusText, contains('libapp.so (Dart AOT)'));
@@ -888,8 +938,9 @@ set(BINARY_NAME "fizz_bar")
         ..createSync(recursive: true)
         ..writeAsBytesSync(List<int>.filled(10000, 0));
 
-      await createTestCommandRunner(command)
-          .run(const <String>['build', 'linux', '--no-pub', '--analyze-size']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['build', 'linux', '--no-pub', '--analyze-size']);
 
       // check if libapp.so of "build/linux/riscv64/release" directory can be referenced.
       expect(testLogger.statusText, contains('libapp.so (Dart AOT)'));

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -646,6 +646,55 @@ STDERR STUFF
   );
 
   testUsingContext(
+    'macOS build config-only writes Flutter-Generated.xcconfig with local engine options',
+    () async {
+      fileSystem
+          .directory('engine')
+          .childDirectory('src')
+          .childDirectory('out')
+          .childDirectory('host_debug_arm64')
+          .createSync(recursive: true);
+      createMinimalMockProjectFiles();
+
+      final BuildCommand command = createFakeBuildCommand(
+        fileSystem: fileSystem,
+        logger: logger,
+        osUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64),
+        platform: macosPlatform,
+        featureFlags: TestFeatureFlags(isMacOSEnabled: true),
+        xcodeProjectInterpreter: FakeXcodeProjectInterpreterWithBuildSettings(),
+      );
+
+      await createTestCommandRunner(command).run(const <String>[
+        '--local-engine=host_debug_arm64',
+        '--local-engine-host=host_debug_arm64',
+        '--local-engine-src-path=engine/src',
+        'build',
+        'macos',
+        '--config-only',
+        '--no-pub',
+      ]);
+
+      final File configFile = fileSystem.file('macos/Flutter/ephemeral/Flutter-Generated.xcconfig');
+      expect(configFile, exists);
+      final String configContent = configFile.readAsStringSync();
+      expect(configContent, contains('LOCAL_ENGINE=host_debug_arm64'));
+      expect(configContent, contains('LOCAL_ENGINE_HOST=host_debug_arm64'));
+      expect(configContent, contains('FLUTTER_ENGINE=engine/src'));
+      expect(configContent, contains('ARCHS=arm64'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      Platform: () => macosPlatform,
+      Pub: ThrowingPub.new,
+      FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+      XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64),
+    },
+  );
+
+  testUsingContext(
     'macOS build invokes xcode build (profile)',
     () async {
       final BuildCommand command = createFakeBuildCommand(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -684,6 +684,56 @@ void main() {
     },
   );
 
+  var buildInvoked = false;
+  testUsingContext(
+    'Web build propagates local engine options to build system Environment',
+    () async {
+      buildInvoked = false;
+      fileSystem
+          .directory('engine')
+          .childDirectory('src')
+          .childDirectory('out')
+          .childDirectory('wasm_release')
+          .createSync(recursive: true);
+      fileSystem
+          .directory('engine')
+          .childDirectory('src')
+          .childDirectory('out')
+          .childDirectory('host_release')
+          .createSync(recursive: true);
+
+      final buildCommand = TestWebBuildCommand(fileSystem: fileSystem);
+      final CommandRunner<void> runner = createTestCommandRunner(buildCommand);
+      setupFileSystemForEndToEndTest(fileSystem);
+
+      await runner.run(<String>[
+        '--local-engine=wasm_release',
+        '--local-engine-host=host_release',
+        '--local-engine-src-path=engine/src',
+        'build',
+        'web',
+        '--no-pub',
+      ]);
+
+      expect(buildInvoked, isTrue);
+    },
+    overrides: <Type, Generator>{
+      Platform: () => fakePlatform,
+      FileSystem: () => fileSystem,
+      FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
+      ProcessManager: () => processManager,
+      BuildSystem: () =>
+          TestBuildSystem.all(BuildResult(success: true), (Target target, Environment environment) {
+            buildInvoked = true;
+            expect(environment.artifacts.usesLocalArtifacts, isTrue);
+            expect(environment.artifacts.localEngineInfo, isNotNull);
+            expect(environment.artifacts.localEngineInfo?.localTargetName, 'wasm_release');
+            expect(environment.artifacts.localEngineInfo?.localHostName, 'host_release');
+            expect(environment.engineVersion, isNull);
+          }),
+    },
+  );
+
   testUsingContext(
     'Passes minify to only wasm when minify-wasm specified',
     () async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -109,7 +109,7 @@ void main() {
       projectFactory: FlutterProjectFactory(fileSystem: fileSystem, logger: effectiveLogger),
     );
     return BuildWindowsCommand(
-            buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
       featureFlags: effectiveFeatureFlags,
       toolContext: toolContext,
       verboseHelp: verboseHelp,
@@ -241,7 +241,8 @@ void main() {
       expect(
         createTestCommandRunner(command).run(const <String>['windows', '--no-pub']),
         throwsToolExit(
-          message: '"build windows" is not currently supported. To enable, run "flutter config --enable-windows-desktop".',
+          message:
+              '"build windows" is not currently supported. To enable, run "flutter config --enable-windows-desktop".',
         ),
       );
     },
@@ -314,6 +315,40 @@ void main() {
       Platform: () => windowsPlatform,
       FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
       Analytics: () => fakeAnalytics,
+    },
+  );
+
+  testUsingContext(
+    'Windows build config-only writes CMake configuration with local engine options',
+    () async {
+      fileSystem.directory(r'C:\engine\src\out\host_debug').createSync(recursive: true);
+      final fakeVisualStudio = FakeVisualStudio();
+      setUpMockProjectFilesForBuild();
+      processManager = FakeProcessManager.list(<FakeCommand>[cmakeGenerationCommand()]);
+
+      final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
+      await createTestCommandRunner(command).run(const <String>[
+        r'--local-engine=host_debug',
+        r'--local-engine-host=host_debug',
+        r'--local-engine-src-path=C:\engine\src',
+        'windows',
+        '--config-only',
+        '--no-pub',
+      ]);
+      final File configFile = fileSystem.file(
+        r'C:\windows\flutter\ephemeral\generated_config.cmake',
+      );
+      expect(configFile, exists);
+      final String configContent = configFile.readAsStringSync();
+      expect(configContent, contains(r'"LOCAL_ENGINE=host_debug"'));
+      expect(configContent, contains(r'"LOCAL_ENGINE_HOST=host_debug"'));
+      expect(configContent, contains(r'"FLUTTER_ENGINE=C:\\engine\\src"'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Platform: () => windowsPlatform,
+      FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
     },
   );
 
@@ -627,8 +662,9 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ]);
 
       final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
-      await createTestCommandRunner(command)
-          .run(const <String>['windows', '--profile', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['windows', '--profile', '--no-pub']);
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -650,8 +686,9 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ]);
 
       final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
-      await createTestCommandRunner(command)
-          .run(const <String>['windows', '--release', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['windows', '--release', '--no-pub']);
       expect(testLogger.statusText, contains(r'✓ Built build\windows\x64\runner\Release'));
     },
     overrides: <Type, Generator>{
@@ -675,8 +712,9 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ]);
 
       final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
-      await createTestCommandRunner(command)
-          .run(const <String>['windows', '--release', '--no-pub']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['windows', '--release', '--no-pub']);
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -745,8 +783,9 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ]);
 
       final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
-      await createTestCommandRunner(command)
-          .run(const <String>['windows', '--no-pub', '--build-name=1.2.3', '--build-number=4']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['windows', '--no-pub', '--build-name=1.2.3', '--build-number=4']);
 
       final File cmakeConfig = fileSystem.currentDirectory
           .childDirectory('windows')
@@ -793,8 +832,9 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ]);
 
       final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
-      await createTestCommandRunner(command)
-          .run(const <String>['windows', '--no-pub', '--build-name=1.2.3']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['windows', '--no-pub', '--build-name=1.2.3']);
 
       final File cmakeConfig = fileSystem.currentDirectory
           .childDirectory('windows')
@@ -841,8 +881,9 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ]);
 
       final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
-      await createTestCommandRunner(command)
-          .run(const <String>['windows', '--no-pub', '--build-number=4']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['windows', '--no-pub', '--build-number=4']);
 
       final File cmakeConfig = fileSystem.currentDirectory
           .childDirectory('windows')
@@ -889,8 +930,9 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ]);
 
       final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
-      await createTestCommandRunner(command)
-          .run(const <String>['windows', '--no-pub', '--build-name=1.2.3', '--build-number=4']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['windows', '--no-pub', '--build-name=1.2.3', '--build-number=4']);
 
       final File cmakeConfig = fileSystem.currentDirectory
           .childDirectory('windows')
@@ -933,8 +975,9 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ]);
 
       final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
-      await createTestCommandRunner(command)
-          .run(const <String>['windows', '--no-pub', '--build-name=1.2.3', '--build-number=hello']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['windows', '--no-pub', '--build-name=1.2.3', '--build-number=hello']);
 
       final File cmakeConfig = fileSystem.currentDirectory
           .childDirectory('windows')
@@ -986,8 +1029,9 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ]);
 
       final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
-      await createTestCommandRunner(command)
-          .run(const <String>['windows', '--no-pub', '--build-name=1.2.3', '--build-number=4.5']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['windows', '--no-pub', '--build-name=1.2.3', '--build-number=4.5']);
 
       final File cmakeConfig = fileSystem.currentDirectory
           .childDirectory('windows')
@@ -1092,8 +1136,9 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ]);
 
       final BuildWindowsCommand command = createCommand(visualStudio: fakeVisualStudio);
-      await createTestCommandRunner(command)
-          .run(const <String>['windows', '--no-pub', '--analyze-size']);
+      await createTestCommandRunner(
+        command,
+      ).run(const <String>['windows', '--no-pub', '--analyze-size']);
 
       expect(
         testLogger.statusText,

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -65,6 +65,47 @@ void main() {
     },
   );
 
+  testUsingContext(
+    'BundleBuilder propagates local engine options to build system Environment',
+    () async {
+      late Environment capturedEnvironment;
+      final BuildSystem buildSystem = TestBuildSystem.all(BuildResult(success: true), (
+        Target target,
+        Environment environment,
+      ) {
+        capturedEnvironment = environment;
+        environment.outputDir.childFile('kernel_blob.bin').createSync(recursive: true);
+        environment.outputDir.childFile('isolate_snapshot_data').createSync();
+        environment.outputDir.childFile('vm_snapshot_data').createSync();
+        environment.outputDir.childFile('LICENSE').createSync(recursive: true);
+      });
+
+      await BundleBuilder().build(
+        platform: TargetPlatform.ios,
+        buildInfo: BuildInfo.debug,
+        project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
+        mainPath: globals.fs.path.join('lib', 'main.dart'),
+        assetDirPath: 'example',
+        depfilePath: 'example.d',
+        buildSystem: buildSystem,
+      );
+
+      expect(capturedEnvironment.artifacts.usesLocalArtifacts, isTrue);
+      expect(capturedEnvironment.artifacts.localEngineInfo, isNotNull);
+      expect(capturedEnvironment.artifacts.localEngineInfo?.localTargetName, 'ios_debug');
+      expect(capturedEnvironment.artifacts.localEngineInfo?.localHostName, 'host_debug');
+      expect(capturedEnvironment.engineVersion, isNull);
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+      Artifacts: () => Artifacts.testLocalEngine(
+        localEngine: 'engine/src/out/ios_debug',
+        localEngineHost: 'engine/src/out/host_debug',
+      ),
+    },
+  );
+
   testWithoutContext(
     'writeBundle applies transformations to any assets that have them defined',
     () async {

--- a/packages/flutter_tools/test/general.shard/context/dependency_injection_test.dart
+++ b/packages/flutter_tools/test/general.shard/context/dependency_injection_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/android_studio.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -149,6 +150,33 @@ void main() {
       );
 
       expect(dependencies.featureFlags, same(mockFeatureFlags));
+    });
+
+    testUsingContext('resolves DeferredArtifacts to local engine artifacts', () async {
+      final ToolDependencies dependencies = await ToolDependencies.bootstrap(
+        fs: fs,
+        logger: logger,
+        platform: platform,
+        processManager: processManager,
+      );
+
+      if (dependencies.toolContext.artifacts case final DeferredArtifacts artifacts) {
+        expect(artifacts.usesLocalArtifacts, isFalse);
+
+        final localArtifacts = Artifacts.testLocalEngine(
+          localEngine: 'out/host_debug',
+          localEngineHost: 'out/host_debug',
+        );
+        artifacts.resolve(localArtifacts);
+
+        expect(artifacts.usesLocalArtifacts, isTrue);
+        expect(artifacts.localEngineInfo, isNotNull);
+        expect(artifacts.localEngineInfo?.localTargetName, 'host_debug');
+        // Verifies dependent context instances created with DeferredArtifacts remain intact.
+        expect(dependencies.appleContext.xcdevice, isNotNull);
+      } else {
+        fail('Expected dependencies.toolContext.artifacts to be DeferredArtifacts');
+      }
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -5,9 +5,11 @@
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -666,6 +668,55 @@ void main() {
             FeatureFlags: () => TestFeatureFlags(),
           },
         );
+
+        testUsingContext(
+          'propagates local engine options to DeferredArtifacts and context Artifacts',
+          () async {
+            fileSystem
+                .directory('engine')
+                .childDirectory('src')
+                .childDirectory('out')
+                .childDirectory('host_debug')
+                .createSync(recursive: true);
+            final deferredArtifacts = DeferredArtifacts(Artifacts.test());
+            final localToolContext = FakeToolContext(
+              artifacts: deferredArtifacts,
+              fs: fileSystem,
+              logger: BufferLogger.test(),
+              platform: platform,
+              processManager: FakeProcessManager.any(),
+            );
+            final fakeCommand = FakeFlutterCommand();
+            final runner =
+                createTestCommandRunner(fakeCommand, null, localToolContext)
+                    as FlutterCommandRunner;
+
+            Artifacts? artifactsInsideCommand;
+            fakeCommand.onRun = () {
+              artifactsInsideCommand = globals.artifacts;
+            };
+
+            await runner.run(<String>[
+              '--local-engine=host_debug',
+              '--local-engine-host=host_debug',
+              '--local-engine-src-path=./engine/src',
+              'fake',
+            ]);
+
+            expect(deferredArtifacts.usesLocalArtifacts, isTrue);
+            expect(deferredArtifacts.localEngineInfo?.localTargetName, 'host_debug');
+            expect(deferredArtifacts.localEngineInfo?.localHostName, 'host_debug');
+            expect(artifactsInsideCommand, isNotNull);
+            expect(artifactsInsideCommand!.usesLocalArtifacts, isTrue);
+            expect(artifactsInsideCommand!.localEngineInfo?.localTargetName, 'host_debug');
+            expect(artifactsInsideCommand!.localEngineInfo?.localHostName, 'host_debug');
+          },
+          overrides: <Type, Generator>{
+            FileSystem: () => fileSystem,
+            ProcessManager: () => FakeProcessManager.any(),
+            Platform: () => platform,
+          },
+        );
       });
     });
   });
@@ -674,11 +725,13 @@ void main() {
 class FakeFlutterCommand extends FlutterCommand {
   bool ran = false;
   late OutputPreferences preferences;
+  void Function()? onRun;
 
   @override
   Future<FlutterCommandResult> runCommand() {
     ran = true;
     preferences = globals.outputPreferences;
+    onRun?.call();
     return Future<FlutterCommandResult>.value(const FlutterCommandResult(ExitStatus.success));
   }
 

--- a/packages/flutter_tools/test/integration.shard/build_linux_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_linux_config_only_test.dart
@@ -6,6 +6,7 @@ import 'dart:ffi';
 
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 
 import '../src/common.dart';
 import 'test_utils.dart';
@@ -73,6 +74,72 @@ void main() {
       expect(appLibrary, isNot(exists));
       expect(exe, isNot(exists));
       expect(bundleExe, isNot(exists));
+    },
+    skip: !platform.isLinux, // [intended] Linux builds only work on Linux.
+  );
+
+  test(
+    'flutter build linux --config-only propagates local engine options to generated_config.cmake',
+    () async {
+      final Directory tempDir = createResolvedTempDirectorySync('local_engine_test.');
+      final Directory engineSrc = tempDir.childDirectory('engine').childDirectory('src');
+      engineSrc.childDirectory('out').childDirectory('host_debug').createSync(recursive: true);
+
+      final String workingDirectory = fileSystem.path.join(
+        getFlutterRoot(),
+        'dev',
+        'integration_tests',
+        'flutter_gallery',
+      );
+
+      try {
+        final buildCommand = <String>[
+          flutterBin,
+          '--local-engine=host_debug',
+          '--local-engine-host=host_debug',
+          '--local-engine-src-path=${engineSrc.path}',
+          'build',
+          'linux',
+          '--config-only',
+          '--no-pub',
+          '-v',
+        ];
+        final ProcessResult result = await processManager.run(
+          buildCommand,
+          workingDirectory: workingDirectory,
+        );
+
+        expect(
+          result.exitCode,
+          0,
+          reason:
+              'Command failed with exitCode ${result.exitCode}.\n'
+              'STDOUT:\n${result.stdout}\n'
+              'STDERR:\n${result.stderr}',
+        );
+
+        final File generatedConfig = fileSystem.file(
+          fileSystem.path.join(
+            workingDirectory,
+            'linux',
+            'flutter',
+            'ephemeral',
+            'generated_config.cmake',
+          ),
+        );
+        expect(generatedConfig, exists);
+        final String content = generatedConfig.readAsStringSync();
+        expect(content, contains('"LOCAL_ENGINE=host_debug"'));
+        expect(content, contains('"LOCAL_ENGINE_HOST=host_debug"'));
+        expect(content, contains('"FLUTTER_ENGINE=${engineSrc.path}"'));
+      } finally {
+        tryToDelete(tempDir);
+        tryToDelete(
+          fileSystem.directory(
+            fileSystem.path.join(workingDirectory, 'linux', 'flutter', 'ephemeral'),
+          ),
+        );
+      }
     },
     skip: !platform.isLinux, // [intended] Linux builds only work on Linux.
   );


### PR DESCRIPTION
## Description

Adds comprehensive tests to verify that local engine options specified via CLI flags or artifacts are properly propagated to where they are needed across the flutter tool, addressing https://github.com/flutter/flutter/pull/192361#issuecomment-5594678667.

### Changes
- **`Artifacts.getLocalEngine`**: Refactored to make `cache`, `fileSystem`, `operatingSystemUtils`, `platform`, and `processManager` required named parameters, eliminating ambient context (`globals.*`) fallbacks.
- **`FlutterCommandRunner`**: Passes its `ToolContext` dependencies directly into `Artifacts.getLocalEngine`.
- **Hermetic Unit Tests**:
  - `AssembleCommand` (`assemble_test.dart`): verifies `--local-engine` CLI flags with `DeferredArtifacts` propagate `usesLocalArtifacts`, `localEngineInfo`, and reset `engineVersion` in the build `Environment`.
  - `BuildLinuxCommand` (`build_linux_test.dart`): verifies `flutter build linux --config-only` writes `LOCAL_ENGINE`, `LOCAL_ENGINE_HOST`, and `FLUTTER_ENGINE` to `generated_config.cmake`.
  - `BuildWindowsCommand` (`build_windows_test.dart`): verifies `flutter build windows --config-only` writes `LOCAL_ENGINE`, `LOCAL_ENGINE_HOST`, and `FLUTTER_ENGINE` to `generated_config.cmake`.
  - `BuildMacOSCommand` (`build_macos_test.dart`): verifies `flutter build macos --config-only` writes `LOCAL_ENGINE`, `LOCAL_ENGINE_HOST`, `FLUTTER_ENGINE`, and `ARCHS` to `Flutter-Generated.xcconfig`.
  - `BuildIOSCommand` (`build_ios_test.dart`): verifies `flutter build ios --config-only` writes `LOCAL_ENGINE`, `LOCAL_ENGINE_HOST`, and `FLUTTER_ENGINE` to `Generated.xcconfig`.
  - `BuildWebCommand` (`build_web_test.dart`): verifies `flutter build web` propagates `usesLocalArtifacts` and `localEngineInfo` to the build `Environment`.
  - `BundleBuilder` (`bundle_builder_test.dart`): verifies bundle build propagates local engine artifacts to the build `Environment`.
  - `ToolDependencies.bootstrap` (`dependency_injection_test.dart`): verifies `DeferredArtifacts` initializes and resolves to local engine artifacts cleanly without breaking dependent contexts.
  - `FlutterCommandRunner` (`flutter_command_runner_test.dart`): verifies global `--local-engine` CLI flags resolve `DeferredArtifacts` on `ToolContext` and populate context `Artifacts`.
- **Integration Test**:
  - `build_linux_config_only_test.dart`: verifies `flutter build linux --config-only` generates `ephemeral/generated_config.cmake` with `LOCAL_ENGINE`, `LOCAL_ENGINE_HOST`, and `FLUTTER_ENGINE`.

## Related Issues
- Follow-up to [#192361](https://github.com/flutter/flutter/pull/192361)

## Tests
- `packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart`
- `packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart`
- `packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart`
- `packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart`
- `packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart`
- `packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart`
- `packages/flutter_tools/test/general.shard/bundle_builder_test.dart`
- `packages/flutter_tools/test/general.shard/context/dependency_injection_test.dart`
- `packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart`
- `packages/flutter_tools/test/integration.shard/build_linux_config_only_test.dart`