### PR TITLE
[macOS] Fix back buffer cache returning a wrong-size surface (Impeller null deref in Canvas::SetupRenderPass)

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
@@ -92,7 +92,9 @@
 @interface FlutterBackBufferCache : NSObject
 
 /**
- * Removes surface with given size from cache (if available) and returns it.
+ * Removes a surface with the given size from the cache and returns it, or nil
+ * if no idle surface of that exact size is cached. Cached surfaces of any
+ * other size are evicted. The returned surface is guaranteed to have `size`.
  */
 - (nullable FlutterSurface*)removeSurfaceForSize:(CGSize)size;
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
@@ -92,9 +92,9 @@
 @interface FlutterBackBufferCache : NSObject
 
 /**
- * Removes a surface with the given size from the cache and returns it, or nil
- * if no idle surface of that exact size is cached. Cached surfaces of any
- * other size are evicted. The returned surface is guaranteed to have `size`.
+ * Removes surface with given size from cache (if available) and returns it.
+ * All cached surfaces have the size of the last request; a request for a
+ * different size purges the cache first.
  */
 - (nullable FlutterSurface*)removeSurfaceForSize:(CGSize)size;
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -318,10 +318,16 @@ static const int kSurfaceEvictionAge = 30;
 
 - (nullable FlutterSurface*)removeSurfaceForSize:(CGSize)size {
   @synchronized(self) {
-    // Purge all cached surfaces if the size has changed.
-    if (_surfaces.firstObject != nil && !CGSizeEqualToSize(_surfaces.firstObject.size, size)) {
-      [_surfaces removeAllObjects];
-    }
+    // Surfaces of a different size can never be reused. Drop them so a later
+    // request cannot receive a surface whose Metal texture disagrees with the
+    // backing store size it was asked for (flutter/flutter#185394). This is
+    // checked per surface: the cache can hold mixed sizes when the front
+    // surfaces of a frame with a different size are returned while a surface
+    // of the current size is still held by the window server.
+    [_surfaces filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(FlutterSurface* surface,
+                                                                          NSDictionary* bindings) {
+                 return CGSizeEqualToSize(surface.size, size);
+               }]];
 
     FlutterSurface* res;
 
@@ -337,6 +343,7 @@ static const int kSurfaceEvictionAge = 30;
     if (res != nil) {
       [_surfaces removeObject:res];
     }
+    FML_DCHECK(res == nil || CGSizeEqualToSize(res.size, size));
     return res;
   }
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -324,10 +324,11 @@ static const int kSurfaceEvictionAge = 30;
     // checked per surface: the cache can hold mixed sizes when the front
     // surfaces of a frame with a different size are returned while a surface
     // of the current size is still held by the window server.
-    [_surfaces filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(FlutterSurface* surface,
-                                                                          NSDictionary* bindings) {
-                 return CGSizeEqualToSize(surface.size, size);
-               }]];
+    for (NSInteger i = static_cast<NSInteger>(_surfaces.count) - 1; i >= 0; i--) {
+      if (!CGSizeEqualToSize(_surfaces[i].size, size)) {
+        [_surfaces removeObjectAtIndex:i];
+      }
+    }
 
     FlutterSurface* res;
 

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -318,16 +318,9 @@ static const int kSurfaceEvictionAge = 30;
 
 - (nullable FlutterSurface*)removeSurfaceForSize:(CGSize)size {
   @synchronized(self) {
-    // Surfaces of a different size can never be reused. Drop them so a later
-    // request cannot receive a surface whose Metal texture disagrees with the
-    // backing store size it was asked for (flutter/flutter#185394). This is
-    // checked per surface: the cache can hold mixed sizes when the front
-    // surfaces of a frame with a different size are returned while a surface
-    // of the current size is still held by the window server.
-    for (NSInteger i = static_cast<NSInteger>(_surfaces.count) - 1; i >= 0; i--) {
-      if (!CGSizeEqualToSize(_surfaces[i].size, size)) {
-        [_surfaces removeObjectAtIndex:i];
-      }
+    // Purge all cached surfaces if the size has changed.
+    if (_surfaces.firstObject != nil && !CGSizeEqualToSize(_surfaces.firstObject.size, size)) {
+      [_surfaces removeAllObjects];
     }
 
     FlutterSurface* res;
@@ -344,13 +337,20 @@ static const int kSurfaceEvictionAge = 30;
     if (res != nil) {
       [_surfaces removeObject:res];
     }
-    FML_DCHECK(res == nil || CGSizeEqualToSize(res.size, size));
     return res;
   }
 }
 
 - (void)returnSurfaces:(nonnull NSArray<FlutterSurface*>*)returnedSurfaces {
   @synchronized(self) {
+    if (_surfaces.count > 0 && returnedSurfaces.count > 0 &&
+        !CGSizeEqualToSize(returnedSurfaces.firstObject.size, _surfaces.firstObject.size)) {
+      // Any cached surface size will match last requested size (see removeSurfaceForSize:). If the
+      // size of incoming surfaces don't match cached surface size it means they are stale and
+      // should be discarded. Keeping them would let removeSurfaceForSize: hand out a surface of
+      // the wrong size (https://github.com/flutter/flutter/issues/185394).
+      return;
+    }
     for (FlutterSurface* surface in returnedSurfaces) {
       [self setAge:0 forSurface:surface];
     }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
@@ -198,6 +198,58 @@ TEST(FlutterSurfaceManager, BackingStoreCacheSurfaceStuckInUse) {
   EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
 }
 
+// Regression test for https://github.com/flutter/flutter/issues/185394.
+//
+// The cache purged itself only when the *first* cached surface had a different
+// size than the request, then returned the youngest idle surface without
+// checking *that* surface's size. A size flip-flop (A -> B -> A) while the
+// previous A surface is still held by the window server leaves a mixed-size
+// cache, and the next request for A gets the B surface. Impeller then wraps a
+// Metal texture whose real size disagrees with the descriptor, the texture
+// invalidates itself, the color attachment is dropped, and the raster thread
+// crashes in impeller::Canvas::SetupRenderPass.
+TEST(FlutterSurfaceManager, BackBufferCacheNeverReturnsSurfaceOfDifferentSize) {
+  TestView* testView = [[TestView alloc] init];
+  FlutterSurfaceManager* surfaceManager = CreateSurfaceManager(testView);
+
+  const CGSize sizeA = CGSizeMake(100, 100);
+  const CGSize sizeB = CGSizeMake(50, 50);
+
+  // Frame 1 at A.
+  auto surfaceA1 = [surfaceManager surfaceForSize:sizeA];
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surfaceA1) ] atTime:0 notify:nil];
+
+  // Frame 2 at B: A1 returns to the cache.
+  auto surfaceB1 = [surfaceManager surfaceForSize:sizeB];
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surfaceB1) ] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
+
+  // The window server is still displaying A1, so it cannot be recycled yet.
+  surfaceA1.isInUseOverride = YES;
+
+  // Frame 3 at A: cache head is A1 (size matches, no purge), A1 is busy, so a
+  // fresh A surface is created and A1 stays cached.
+  auto surfaceA2 = [surfaceManager surfaceForSize:sizeA];
+  EXPECT_NE(surfaceA2, surfaceA1);
+  EXPECT_TRUE(CGSizeEqualToSize(surfaceA2.size, sizeA));
+  // Presenting returns B1 into a cache whose head is A1 -> mixed sizes.
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surfaceA2) ] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 2ul);
+
+  surfaceA1.isInUseOverride = NO;
+
+  // Frame 4 at A must never receive the B surface.
+  auto surfaceA3 = [surfaceManager surfaceForSize:sizeA];
+  EXPECT_TRUE(CGSizeEqualToSize(surfaceA3.size, sizeA))
+      << "cache returned " << surfaceA3.size.width << "x" << surfaceA3.size.height << " for a "
+      << sizeA.width << "x" << sizeA.height << " request";
+  EXPECT_NE(surfaceA3, surfaceB1);
+
+  // Every surface the cache hands out must match the request, whatever is cached.
+  auto surfaceB2 = [surfaceManager surfaceForSize:sizeB];
+  EXPECT_TRUE(CGSizeEqualToSize(surfaceB2.size, sizeB));
+}
+
 inline bool operator==(const CGRect& lhs, const CGRect& rhs) {
   return CGRectEqualToRect(lhs, rhs);
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
@@ -200,14 +200,14 @@ TEST(FlutterSurfaceManager, BackingStoreCacheSurfaceStuckInUse) {
 
 // Regression test for https://github.com/flutter/flutter/issues/185394.
 //
-// The cache purged itself only when the *first* cached surface had a different
-// size than the request, then returned the youngest idle surface without
-// checking *that* surface's size. A size flip-flop (A -> B -> A) while the
-// previous A surface is still held by the window server leaves a mixed-size
-// cache, and the next request for A gets the B surface. Impeller then wraps a
-// Metal texture whose real size disagrees with the descriptor, the texture
-// invalidates itself, the color attachment is dropped, and the raster thread
-// crashes in impeller::Canvas::SetupRenderPass.
+// The cache is meant to hold surfaces of a single size (the last requested
+// one), but returnSurfaces: appended the previous front surfaces without
+// checking their size. A size flip-flop (A -> B -> A) while the previous A
+// surface is still held by the window server therefore left a mixed-size
+// cache, and the next request for A got the B surface. Impeller then wrapped a
+// Metal texture whose real size disagreed with the descriptor, the texture
+// invalidated itself, the color attachment was dropped, and the raster thread
+// crashed in impeller::Canvas::SetupRenderPass.
 TEST(FlutterSurfaceManager, BackBufferCacheNeverReturnsSurfaceOfDifferentSize) {
   TestView* testView = [[TestView alloc] init];
   FlutterSurfaceManager* surfaceManager = CreateSurfaceManager(testView);
@@ -232,9 +232,10 @@ TEST(FlutterSurfaceManager, BackBufferCacheNeverReturnsSurfaceOfDifferentSize) {
   auto surfaceA2 = [surfaceManager surfaceForSize:sizeA];
   EXPECT_NE(surfaceA2, surfaceA1);
   EXPECT_TRUE(CGSizeEqualToSize(surfaceA2.size, sizeA));
-  // Presenting returns B1 into a cache whose head is A1 -> mixed sizes.
+  // Presenting A2 returns B1, whose size differs from the cached A1. The cache
+  // must drop it rather than hold two sizes.
   [surfaceManager presentSurfaces:@[ CreatePresentInfo(surfaceA2) ] atTime:0 notify:nil];
-  EXPECT_EQ(surfaceManager.backBufferCache.count, 2ul);
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
 
   surfaceA1.isInUseOverride = NO;
 

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -1265,8 +1265,15 @@ MakeRenderTargetFromBackingStoreImpeller(
       resolve_tex_desc, metal->texture.texture,
       [callback = metal->texture.destruction_callback,
        user_data = metal->texture.user_data]() { callback(user_data); });
-  if (!resolve_tex) {
-    FML_LOG(ERROR) << "Could not wrap embedder supplied Metal render texture.";
+  if (!resolve_tex || !resolve_tex->IsValid()) {
+    // A wrapped texture is invalid when the embedder's texture disagrees with
+    // the requested backing store size. Rendering into it would leave the
+    // render target without a color attachment and crash the raster thread
+    // (https://github.com/flutter/flutter/issues/185394); skip the layer.
+    FML_LOG(ERROR) << "Could not wrap embedder supplied Metal render texture "
+                      "(requested "
+                   << size.width << "x" << size.height
+                   << ", texture is invalid or has a different size).";
     return nullptr;
   }
 
@@ -1286,7 +1293,7 @@ MakeRenderTargetFromBackingStoreImpeller(
   auto msaa_tex =
       aiks_context->GetContext()->GetResourceAllocator()->CreateTexture(
           msaa_tex_desc);
-  if (!msaa_tex) {
+  if (!msaa_tex || !msaa_tex->IsValid()) {
     FML_LOG(ERROR) << "Could not allocate MSAA color texture.";
     return nullptr;
   }

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_metal_unittests.mm
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_metal_unittests.mm
@@ -560,6 +560,76 @@ TEST_F(EmbedderTest, CreateInvalidBackingstoreMetalTexture) {
   latch.Wait();
 }
 
+// Regression test for https://github.com/flutter/flutter/issues/185394.
+//
+// An embedder that hands back a Metal texture whose size does not match the
+// requested backing store size must not crash the raster thread. Before the
+// fix, the wrapped TextureMTL silently invalidated itself because its size
+// disagreed with the descriptor, RenderTarget::SetColorAttachment dropped the
+// invalid attachment, and impeller::Canvas::SetupRenderPass dereferenced the
+// missing color texture.
+TEST_F(EmbedderTest, WrongSizeMetalBackingStoreDoesNotCrashImpeller) {
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
+  EmbedderConfigBuilder builder(context);
+  builder.AddCommandLineArgument("--enable-impeller");
+  builder.SetSurface(DlISize(800, 600));
+  builder.SetCompositor();
+  builder.SetRenderTargetType(EmbedderTestBackingStoreProducer::RenderTargetType::kMetalTexture);
+  builder.SetDartEntrypoint("invalid_backingstore");
+
+  builder.GetCompositor().create_backing_store_callback =
+      [](const FlutterBackingStoreConfig* config,  //
+         FlutterBackingStore* backing_store_out,   //
+         void* user_data                           //
+      ) {
+        // Deliberately hand back a texture that is half the requested size.
+        id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+        MTLTextureDescriptor* descriptor = [MTLTextureDescriptor
+            texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+                                         width:static_cast<NSUInteger>(config->size.width / 2)
+                                        height:static_cast<NSUInteger>(config->size.height / 2)
+                                     mipmapped:NO];
+        descriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+        id<MTLTexture> texture = [device newTextureWithDescriptor:descriptor];
+
+        backing_store_out->type = kFlutterBackingStoreTypeMetal;
+        backing_store_out->user_data = nullptr;
+        backing_store_out->metal.struct_size = sizeof(FlutterMetalBackingStore);
+        backing_store_out->metal.texture.struct_size = sizeof(FlutterMetalTexture);
+        backing_store_out->metal.texture.texture = (__bridge void*)texture;
+        // The retain taken here is balanced in the destruction callback.
+        backing_store_out->metal.texture.user_data = (__bridge_retained void*)texture;
+        backing_store_out->metal.texture.destruction_callback = [](void* user_data) {
+          id<MTLTexture> released = (__bridge_transfer id<MTLTexture>)user_data;
+          released = nil;
+        };
+        return true;
+      };
+
+  // The fixture signals after every frame; the assertion here is on the
+  // compositor side, so the signal is only consumed.
+  context.AddFfiNativeCallback("SignalNativeTest", CREATE_FFI_LAMBDA([]() {}));
+
+  // The layer is dropped, but the frame is still presented (with no layers)
+  // and the engine must survive it.
+  fml::AutoResetWaitableEvent latch;
+  context.GetCompositor().AddOnPresentCallback([&latch]() { latch.Signal(); });
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+
+  // Send a window metrics events so frames may be scheduled.
+  FlutterWindowMetricsEvent event = {};
+  event.struct_size = sizeof(event);
+  event.width = 800;
+  event.height = 600;
+  event.pixel_ratio = 1.0;
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event), kSuccess);
+
+  latch.Wait();
+  engine.reset();
+}
+
 TEST_F(EmbedderTest, ExternalTextureMetalRefreshedTooOften) {
   auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
 


### PR DESCRIPTION
On macOS with Impeller, the raster thread can crash in `impeller::Canvas::SetupRenderPass()` (`color0.texture->GetSize()` on a null texture) via `EmbedderExternalViewEmbedder::SubmitFlutterView`. It reproduces reliably in a video-player app by toggling native fullscreen (`NSWindow toggleFullScreen:`) while a `Texture` widget is on screen, and has been reported upstream on foregrounding, display hot-plug and window drag.

## Root cause

`-[FlutterBackBufferCache removeSurfaceForSize:]` only compared the requested size with the **first** cached surface, then returned the youngest idle surface without checking that surface's size. When frame sizes flip-flop (A → B → A) while the previous A surface is still held by the window server (`IOSurfaceIsInUse`), the cache ends up holding both sizes and the next request for A receives the B surface.

`MakeRenderTargetFromBackingStoreImpeller` then wraps an `MTLTexture` whose real size disagrees with the requested backing-store size. The failure is silent all the way down:

1. `TextureMTL` invalidates itself (`The texture and its descriptor disagree about its size.` — a `VALIDATION_LOG`, compiled out in release).
2. `RenderTarget::SetColorAttachment` drops the invalid attachment without logging.
3. `Canvas::SetupRenderPass` reads `GetColorAttachment(0)` (a default `ColorAttachment{}`) and dereferences the null texture.

## Fix

1. **`FlutterSurfaceManager.mm`** — `returnSurfaces:` discards returned surfaces whose size differs from what the cache already holds. The cache only ever contains one size (the last requested one, since `removeSurfaceForSize:` purges on a size change), so surfaces coming back with another size are stale by definition. This keeps the existing single-size invariant instead of adding a size check on the take side (approach suggested in review by @knopp; the doc comment on `removeSurfaceForSize:` now states the invariant).
2. **`embedder.cc`** — the Impeller Metal backing-store wrapper rejects invalid (not just null) wrapped textures. A bad backing store now drops that layer for one frame through the existing null-target path (`Layer::RenderFlutterContents` guards it, the target never enters the render-target cache, the next frame gets a fresh backing store) and logs the requested size, instead of taking the process down.

## Tests

- `FlutterSurfaceManager.BackBufferCacheNeverReturnsSurfaceOfDifferentSize` (`flutter_desktop_darwin_unittests`) — constructs the A → B → A / in-use sequence against a real `FlutterSurfaceManager`. Fails before fix 1 (`cache returned 50x50 for a 100x100 request`), passes after; also asserts the stale surface never enters the cache (count stays 1).
- `EmbedderTest.WrongSizeMetalBackingStoreDoesNotCrashImpeller` (`embedder_unittests`) — the compositor hands the engine a Metal texture half the requested size under `--enable-impeller`. Before fix 2 the raster thread dies (`SIGABRT` on the size `DCHECK` in `Layer::RenderFlutterContentsImpeller` in unopt builds; the null dereference above in release); after, the frame is presented without the layer and the engine shuts down cleanly.
- `flutter_desktop_darwin_unittests` (236) and `embedder_unittests` `EmbedderTest.*` (96 + 8 skipped) pass locally on `host_debug_unopt_arm64`.

## Reproduction

Standalone app: https://github.com/abdelaziz-mahdy/flutter-macos-backbuffer-repro (stock `flutter create` macOS app; a Swift timer shrinks the window by 1 px and restores it synchronously every 2.5 s, which yields frame sizes A → B → A with one frame at B while the window server still holds the previous A surface). Run on `host_debug_unopt_arm64`, Apple M2 Pro, macOS 26.6.2:

| Engine | Result |
|---|---|
| `4e6768eca70` (master, unfixed) | 3/3 runs crash on the second flip within 7 s: `The texture and its descriptor disagree about its size.` then `Check failed: render_target_->GetRenderTargetSize() == c->GetRenderSurfaceSize()` on `io.flutter.raster`. With a temporary log in `surfaceForSize:` the handoff is visible: `req=1600x1200 REUSED got=1598x1198`. |
| this branch (`a8073db1e1d`) | 3 × 60 s runs (23–24 flips each) plus one 4-minute run (97 flips): 0 validation lines, 0 crashes. Same result on the earlier take-side version (`cec7d27aa2c`). |

Plain fullscreen toggling (the trigger we hit in production, with a video `Texture` on screen) produces monotonic sizes during the animation and only crashes occasionally; the flip is the same A → B → A pattern reduced to one frame.

Fixes https://github.com/flutter/flutter/issues/185394

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

