### PR TITLE
Fix ConcurrentModificationError when a Selectable unregisters during clear/selectAll dispatch

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2966,8 +2966,12 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   @protected
   SelectionResult handleSelectAll(SelectAllSelectionEvent event) {
     // Iterate over a snapshot: dispatching the event may cause a [Selectable]
-    // to unregister itself synchronously through [remove].
+    // to unregister itself synchronously through [remove]. Skip any
+    // [Selectable] that was unregistered by an earlier iteration.
     for (final selectable in List<Selectable>.of(selectables)) {
+      if (!selectables.contains(selectable)) {
+        continue;
+      }
       dispatchSelectionEventToChild(selectable, event);
     }
     currentSelectionStartIndex = 0;
@@ -3081,8 +3085,12 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   @protected
   SelectionResult handleClearSelection(ClearSelectionEvent event) {
     // Iterate over a snapshot: dispatching the event may cause a [Selectable]
-    // to unregister itself synchronously through [remove].
+    // to unregister itself synchronously through [remove]. Skip any
+    // [Selectable] that was unregistered by an earlier iteration.
     for (final selectable in List<Selectable>.of(selectables)) {
+      if (!selectables.contains(selectable)) {
+        continue;
+      }
       dispatchSelectionEventToChild(selectable, event);
     }
     currentSelectionEndIndex = -1;

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2965,7 +2965,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// Selects all contents of all [Selectable]s.
   @protected
   SelectionResult handleSelectAll(SelectAllSelectionEvent event) {
-    for (final Selectable selectable in selectables) {
+    // Iterate over a snapshot: dispatching the event may cause a [Selectable]
+    // to unregister itself synchronously through [remove].
+    for (final selectable in List<Selectable>.of(selectables)) {
       dispatchSelectionEventToChild(selectable, event);
     }
     currentSelectionStartIndex = 0;
@@ -3078,7 +3080,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// Removes the selection of all [Selectable]s this delegate manages.
   @protected
   SelectionResult handleClearSelection(ClearSelectionEvent event) {
-    for (final Selectable selectable in selectables) {
+    // Iterate over a snapshot: dispatching the event may cause a [Selectable]
+    // to unregister itself synchronously through [remove].
+    for (final selectable in List<Selectable>.of(selectables)) {
       dispatchSelectionEventToChild(selectable, event);
     }
     currentSelectionEndIndex = -1;

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1077,6 +1077,42 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('handleClearSelection skips selectables that unregistered during dispatch', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/192081.
+    final group = <RenderDisappearingSelectable>{};
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: _selectableRegion(
+          child: Column(
+            children: <Widget>[
+              DisappearingSelectable(group: group),
+              DisappearingSelectable(group: group),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(group, hasLength(2));
+
+    final SelectableRegionState state = tester.state<SelectableRegionState>(
+      find.byType(SelectableRegion),
+    );
+    state.selectAll();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    // Dispatching the clear event to the first member of the group unregisters
+    // both members, so the second member must not receive the event.
+    final Iterable<RenderDisappearingSelectable> cleared = group.where(
+      (RenderDisappearingSelectable selectable) =>
+          selectable.events.any((SelectionEvent event) => event.type == SelectionEventType.clear),
+    );
+    expect(cleared, hasLength(1));
+  });
+
   testWidgets('dragging handle or selecting word triggers haptic feedback on Android', (
     WidgetTester tester,
   ) async {
@@ -7107,12 +7143,22 @@ class RenderSelectionSpy extends RenderProxyBox with Selectable, SelectionRegist
 /// A [Selectable] whose content disappears as soon as it receives a
 /// [ClearSelectionEvent], mirroring a real [Selectable] being rebuilt or
 /// disposed mid-dispatch.
+///
+/// When [group] is provided, every member of the group disappears together, so
+/// dispatching an event to one member unregisters the others as a side effect.
 class DisappearingSelectable extends LeafRenderObjectWidget {
-  const DisappearingSelectable({super.key});
+  const DisappearingSelectable({super.key, this.group});
+
+  final Set<RenderDisappearingSelectable>? group;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    return RenderDisappearingSelectable(SelectionContainer.maybeOf(context));
+    final renderObject = RenderDisappearingSelectable(
+      SelectionContainer.maybeOf(context),
+      group: group,
+    );
+    group?.add(renderObject);
+    return renderObject;
   }
 
   @override
@@ -7122,9 +7168,14 @@ class DisappearingSelectable extends LeafRenderObjectWidget {
 }
 
 class RenderDisappearingSelectable extends RenderBox with Selectable, SelectionRegistrant {
-  RenderDisappearingSelectable(SelectionRegistrar? registrar) {
+  RenderDisappearingSelectable(SelectionRegistrar? registrar, {this.group}) {
     this.registrar = registrar;
   }
+
+  final Set<RenderDisappearingSelectable>? group;
+
+  /// The events this selectable has received, in order.
+  final List<SelectionEvent> events = <SelectionEvent>[];
 
   final Set<VoidCallback> _listeners = <VoidCallback>{};
 
@@ -7142,14 +7193,26 @@ class RenderDisappearingSelectable extends RenderBox with Selectable, SelectionR
   @override
   void removeListener(VoidCallback listener) => _listeners.remove(listener);
 
+  void _disappear() {
+    if (!_value.hasContent) {
+      return;
+    }
+    _value = const SelectionGeometry(status: SelectionStatus.none, hasContent: false);
+    // Notify a snapshot of the listeners: [SelectionRegistrant] reacts by
+    // calling [SelectionRegistrar.remove], which removes a listener.
+    for (final VoidCallback listener in _listeners.toList()) {
+      listener();
+    }
+  }
+
   @override
   SelectionResult dispatchSelectionEvent(SelectionEvent event) {
-    if (event.type == SelectionEventType.clear && _value.hasContent) {
-      _value = const SelectionGeometry(status: SelectionStatus.none, hasContent: false);
-      // Notify a snapshot of the listeners: [SelectionRegistrant] reacts by
-      // calling [SelectionRegistrar.remove], which removes a listener.
-      for (final VoidCallback listener in _listeners.toList()) {
-        listener();
+    events.add(event);
+    if (event.type == SelectionEventType.clear) {
+      final Set<RenderDisappearingSelectable> affected =
+          group ?? <RenderDisappearingSelectable>{this};
+      for (final selectable in affected) {
+        selectable._disappear();
       }
     }
     return SelectionResult.none;

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1046,6 +1046,37 @@ void main() {
     await tester.pump();
   });
 
+  testWidgets('handleClearSelection does not throw when a selectable unregisters during dispatch', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/192081.
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: _selectableRegion(
+          child: const Column(
+            children: <Widget>[DisappearingSelectable(), DisappearingSelectable()],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final SelectableRegionState state = tester.state<SelectableRegionState>(
+      find.byType(SelectableRegion),
+    );
+
+    // [SelectableRegionState.selectAll] dispatches a [ClearSelectionEvent]
+    // first. Each child drops its content while handling that event, so
+    // [SelectionRegistrant] unregisters it synchronously through
+    // [SelectionRegistrar.remove], mutating the list that
+    // [MultiSelectableSelectionContainerDelegate.handleClearSelection] is
+    // iterating.
+    state.selectAll();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('dragging handle or selecting word triggers haptic feedback on Android', (
     WidgetTester tester,
   ) async {
@@ -7071,6 +7102,81 @@ class RenderSelectionSpy extends RenderProxyBox with Selectable, SelectionRegist
 
   @override
   void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) {}
+}
+
+/// A [Selectable] whose content disappears as soon as it receives a
+/// [ClearSelectionEvent], mirroring a real [Selectable] being rebuilt or
+/// disposed mid-dispatch.
+class DisappearingSelectable extends LeafRenderObjectWidget {
+  const DisappearingSelectable({super.key});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return RenderDisappearingSelectable(SelectionContainer.maybeOf(context));
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderDisappearingSelectable renderObject) {
+    renderObject.registrar = SelectionContainer.maybeOf(context);
+  }
+}
+
+class RenderDisappearingSelectable extends RenderBox with Selectable, SelectionRegistrant {
+  RenderDisappearingSelectable(SelectionRegistrar? registrar) {
+    this.registrar = registrar;
+  }
+
+  final Set<VoidCallback> _listeners = <VoidCallback>{};
+
+  SelectionGeometry _value = const SelectionGeometry(
+    status: SelectionStatus.none,
+    hasContent: true,
+  );
+
+  @override
+  SelectionGeometry get value => _value;
+
+  @override
+  void addListener(VoidCallback listener) => _listeners.add(listener);
+
+  @override
+  void removeListener(VoidCallback listener) => _listeners.remove(listener);
+
+  @override
+  SelectionResult dispatchSelectionEvent(SelectionEvent event) {
+    if (event.type == SelectionEventType.clear && _value.hasContent) {
+      _value = const SelectionGeometry(status: SelectionStatus.none, hasContent: false);
+      // Notify a snapshot of the listeners: [SelectionRegistrant] reacts by
+      // calling [SelectionRegistrar.remove], which removes a listener.
+      for (final VoidCallback listener in _listeners.toList()) {
+        listener();
+      }
+    }
+    return SelectionResult.none;
+  }
+
+  @override
+  List<Rect> get boundingBoxes => <Rect>[paintBounds];
+
+  @override
+  int get contentLength => 1;
+
+  @override
+  SelectedContentRange? getSelection() => null;
+
+  @override
+  SelectedContent? getSelectedContent() => null;
+
+  @override
+  void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) {}
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    return constraints.constrain(const Size(10.0, 10.0));
+  }
+
+  @override
+  void performLayout() => size = computeDryLayout(constraints);
 }
 
 class SelectAllWidget extends SingleChildRenderObjectWidget {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

`MultiSelectableSelectionContainerDelegate.handleClearSelection` and `handleSelectAll` iterate `selectables` directly while dispatching the event to each child. `add` is deferred through `_additions` and flushed after the frame, but `remove` mutates `selectables` synchronously (`remove` → `_removeSelectable` → `selectables.removeAt`). If handling the event causes a child to unregister itself — which `SelectionRegistrant._updateSelectionRegistrarSubscription` does as soon as the child's `value.hasContent` becomes false — the `for-in` throws `ConcurrentModificationError`. In production this surfaces as recurring `FlutterError.onError` noise rather than a crash, because the framework catches it and drops the frame, which is why it has been hard to pin to a single gesture.

This PR iterates over a snapshot (`List<Selectable>.of(selectables)`) in both handlers. The rest of each method is unchanged; `handleSelectAll` still reads `selectables.length` after the loop, so a child that unregistered during dispatch is not counted.

It also adds a regression test in `test/widgets/selectable_region_test.dart` with a small `Selectable` (`DisappearingSelectable`) whose content disappears while it handles a `ClearSelectionEvent`, so `SelectionRegistrant` unregisters it mid-dispatch through the real `SelectionRegistrar.remove` path. Calling `SelectableRegionState.selectAll()` dispatches a clear first and hits the loop. The test fails on `master` with `ConcurrentModificationError` at `handleClearSelection` and passes with this change.

Note for reviewers: this is a different code path from #124624, which handled listeners removing themselves during a listener call; the loop in `handleClearSelection` was untouched by that change. `_clearSelectables` uses an index loop and cannot throw (it would skip an element instead), so I left it as is to keep this change minimal.

Verified on Flutter Web (wasm), where the issue was reported, with a small app that puts the same `DisappearingSelectable` inside a `SelectableRegion` and logs anything reaching `FlutterError.onError`, run with `flutter run -d chrome --wasm`.

Before — clicking "Select all" or single-clicking in the region reports `Concurrent modification during iteration`:

<img width="1917" height="1020" alt="image" src="https://github.com/user-attachments/assets/6b6e997a-0d17-440e-b0be-df5b77bfc18d" />

After — same interactions, no framework errors:

<img width="1917" height="1018" alt="image" src="https://github.com/user-attachments/assets/6a859696-90ee-4f76-b556-d1f73e0be172" />

Fixes https://github.com/flutter/flutter/issues/192081

No changes to flutter/tests were needed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md