### PR TITLE
[Impeller] Refuse a Vulkan render target with no color attachment

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -149,6 +149,16 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
                            const RenderTarget& target,
                            std::shared_ptr<CommandBufferVK> command_buffer)
     : RenderPass(context, target), command_buffer_(std::move(command_buffer)) {
+  // Everything below dereferences color attachment zero's texture, and
+  // `GetColorAttachment(0)` hands back a default-constructed attachment with a
+  // null texture when the target has none. `RenderTarget::IsValid()` is where
+  // that requirement is stated, and `RenderPassMTL` checks it in its own
+  // constructor; without the same check here a depth-only target — a shadow
+  // map — is a null dereference rather than a failed pass.
+  if (!render_target_.IsValid()) {
+    is_valid_ = false;
+    return;
+  }
   const ColorAttachment& color0 = render_target_.GetColorAttachment(0);
   color_image_vk_ = color0.texture;
   resolve_image_vk_ = color0.resolve_texture;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk_unittests.cc
@@ -4,7 +4,9 @@
 
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
 #include "gtest/gtest.h"
+#include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
+#include "impeller/core/texture_descriptor.h"
 #include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/render_pass_builder_vk.h"
 #include "impeller/renderer/backend/vulkan/render_pass_vk.h"
@@ -88,6 +90,35 @@ TEST(RenderPassVK, SetViewportPropagatesAllUserSuppliedFields) {
   EXPECT_FLOAT_EQ(vp.height, -80.0f);
   EXPECT_FLOAT_EQ(vp.minDepth, 0.25f);
   EXPECT_FLOAT_EQ(vp.maxDepth, 0.75f);
+}
+
+// Regression guard: a render target with no color attachment at index zero is
+// not a valid target — `RenderTarget::IsValid` says as much — and the Vulkan
+// backend used to read that attachment's texture while setting the pass up,
+// which is a null dereference rather than a refusal. A depth-only pass, which
+// is how a shadow map is drawn, is the way an application reaches it. The
+// Metal backend checks the target in its own constructor; both refuse it now.
+TEST(RenderPassVK, RefusesATargetWithNoColorAttachment) {
+  ScopedValidationDisable disable_validation;
+
+  std::shared_ptr<ContextVK> context = MockVulkanContextBuilder().Build();
+  std::shared_ptr<CommandBuffer> cmd_buffer = context->CreateCommandBuffer();
+
+  TextureDescriptor depth_desc;
+  depth_desc.storage_mode = StorageMode::kDeviceTransient;
+  depth_desc.format = PixelFormat::kD32FloatS8UInt;
+  depth_desc.size = ISize{1, 1};
+  depth_desc.usage = TextureUsage::kRenderTarget;
+  depth_desc.sample_count = SampleCount::kCount1;
+
+  DepthAttachment depth;
+  depth.texture = context->GetResourceAllocator()->CreateTexture(depth_desc);
+  ASSERT_TRUE(depth.texture);
+
+  RenderTarget target;
+  target.SetDepthAttachment(depth);
+
+  EXPECT_EQ(cmd_buffer->CreateRenderPass(target), nullptr);
 }
 
 }  // namespace testing


### PR DESCRIPTION
`RenderTarget::IsValid()` states that a render target must have a color
attachment at index zero, and `RenderPassMTL` checks it in its constructor.
`RenderPassVK` did not: it read color attachment zero — which
`GetColorAttachment(0)` hands back default-constructed, with a null texture,
when the target has none — and dereferenced that texture while working out the
pass's sample count.

A depth-only render target is how an application reaches this from
flutter_gpu; a shadow map is the ordinary case. On Metal such a target produces
`Failed to begin RenderPass`, which Dart can catch; on Vulkan the process died
with SIGSEGV inside libflutter, with nothing reported to Dart.

This adds the same check the Metal backend makes, so the two backends refuse
the target the same way.

**Where it was verified.** At engine revision
`5f77625673248ee5846fbcaf5d3e1a3878386fd7` — the one the 3.47.0 SDK ships —
because that is the engine the crashing device runs. No commit between that
revision and `main` touches either file, so the change applies to `main`
unchanged; CI is what checks it there.

**Verification.** The added test, `RenderPassVK.RefusesATargetWithNoColorAttachment`,
segfaults on the unpatched engine and passes with the change
(`out/host_debug/impeller_unittests --gtest_filter='RenderPassVK.*'`, 3/3). On
device — Samsung Galaxy A55, Android 16, Impeller Vulkan — a Flutter app that
begins such a pass is killed before the change and receives
`Exception: Failed to begin RenderPass` after it, matching macOS/Metal.

Fixes https://github.com/flutter/flutter/issues/192535

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
