### PR TITLE
[Impeller] Key the Vulkan framebuffer cache on the whole attachment set

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -171,11 +171,41 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   // attachment set are the same as before.
   const uint32_t cache_mip_level = color0.mip_level;
   const uint32_t cache_slice = color0.slice;
+  // And on the rest of the attachment set, which used to be assumed constant
+  // for a given color attachment. It is not: the same color texture paired with
+  // a different depth texture — a shadow atlas drawn with a pooled depth buffer
+  // is the ordinary case — otherwise hands back a framebuffer holding the
+  // previous depth's image view, and once that texture is released the view is
+  // dangling. Vulkan reports it as
+  // VUID-VkRenderPassBeginInfo-framebuffer-parameter and the driver then
+  // dereferences it.
+  uint64_t attachments_key = 0u;
+  {
+    auto mix = [&attachments_key](const std::shared_ptr<Texture>& texture) {
+      attachments_key = attachments_key * 1099511628211ull ^
+                        reinterpret_cast<uintptr_t>(texture.get());
+    };
+    render_target_.IterateAllColorAttachments(
+        [&mix](size_t index, const ColorAttachment& attachment) -> bool {
+          if (index != 0u) {
+            mix(attachment.texture);
+            mix(attachment.resolve_texture);
+          }
+          return true;
+        });
+    if (auto depth = render_target_.GetDepthAttachment(); depth.has_value()) {
+      mix(depth->texture);
+    }
+    if (auto stencil = render_target_.GetStencilAttachment();
+        stencil.has_value()) {
+      mix(stencil->texture);
+    }
+  }
   TextureVK& frame_data_texture = TextureVK::Cast(
       resolve_image_vk_ ? *resolve_image_vk_ : *color_image_vk_);
   is_swapchain = frame_data_texture.IsSwapchainImage();
   frame_data = frame_data_texture.GetCachedFrameData(
-      sample_count, cache_mip_level, cache_slice);
+      sample_count, cache_mip_level, cache_slice, attachments_key);
 
   const auto& target_size = render_target_.GetRenderTargetSize();
 
@@ -205,8 +235,8 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   frame_data.framebuffer = framebuffer;
   frame_data.render_pass = render_pass_;
 
-  frame_data_texture.SetCachedFrameData(frame_data, sample_count,
-                                        cache_mip_level, cache_slice);
+  frame_data_texture.SetCachedFrameData(
+      frame_data, sample_count, cache_mip_level, cache_slice, attachments_key);
 
   // If the resolve image exists and has mipmaps, transition mip levels besides
   // the base to shader read only in preparation for mipmap generation.

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/render_pass_vk_unittests.cc
@@ -5,6 +5,7 @@
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
 #include "gtest/gtest.h"
 #include "impeller/core/formats.h"
+#include "impeller/core/texture_descriptor.h"
 #include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/render_pass_builder_vk.h"
 #include "impeller/renderer/backend/vulkan/render_pass_vk.h"
@@ -88,6 +89,52 @@ TEST(RenderPassVK, SetViewportPropagatesAllUserSuppliedFields) {
   EXPECT_FLOAT_EQ(vp.height, -80.0f);
   EXPECT_FLOAT_EQ(vp.minDepth, 0.25f);
   EXPECT_FLOAT_EQ(vp.maxDepth, 0.75f);
+}
+
+// Regression guard: the framebuffer cache lives on color attachment zero's
+// texture, and a framebuffer holds image views of *every* attachment. Two
+// passes that share a color texture but bring different depth textures — a
+// shadow atlas drawn with a depth buffer from a pool is the ordinary case —
+// used to be handed the same framebuffer, which still referred to the first
+// pass's depth. Vulkan reports the stale view as
+// VUID-VkRenderPassBeginInfo-framebuffer-parameter, and the driver
+// dereferences it once that texture has been released.
+TEST(RenderPassVK, DoesNotReuseAFramebufferWithADifferentDepthAttachment) {
+  std::shared_ptr<ContextVK> context = MockVulkanContextBuilder().Build();
+  std::shared_ptr<Context> copy = context;
+  std::shared_ptr<CommandBuffer> cmd_buffer = context->CreateCommandBuffer();
+
+  RenderTargetAllocator allocator(context->GetResourceAllocator());
+  RenderTarget first = allocator.CreateOffscreen(*copy.get(), {4, 4}, 1);
+
+  // The same color texture, and whatever depth the allocator makes next.
+  RenderTarget second = allocator.CreateOffscreen(
+      *copy.get(),                                    //
+      {4, 4},                                         //
+      1,                                              //
+      "Offscreen",                                    //
+      RenderTarget::kDefaultColorAttachmentConfig,    //
+      RenderTarget::kDefaultStencilAttachmentConfig,  //
+      first.GetRenderTargetTexture()                  //
+  );
+
+  ASSERT_TRUE(first.GetDepthAttachment().has_value());
+  ASSERT_TRUE(second.GetDepthAttachment().has_value());
+  ASSERT_EQ(first.GetRenderTargetTexture(), second.GetRenderTargetTexture());
+  ASSERT_NE(first.GetDepthAttachment()->texture,
+            second.GetDepthAttachment()->texture);
+
+  ASSERT_TRUE(cmd_buffer->CreateRenderPass(first));
+  ASSERT_TRUE(cmd_buffer->CreateRenderPass(second));
+
+  // One framebuffer per attachment set. The render pass itself is compatible
+  // between the two and is cached separately, so the framebuffer is what says
+  // whether the entry was reused: before the key included the depth
+  // attachment, the second pass was handed the first's and only one was made.
+  auto called_functions = GetMockVulkanFunctions(context->GetDevice());
+  EXPECT_EQ(std::count(called_functions->begin(), called_functions->end(),
+                       "vkCreateFramebuffer"),
+            2);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -1044,6 +1044,8 @@ VkResult vkCreateFramebuffer(VkDevice device,
                              const VkFramebufferCreateInfo* pCreateInfo,
                              const VkAllocationCallbacks* pAllocator,
                              VkFramebuffer* pFramebuffer) {
+  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  mock_device->AddCalledFunction("vkCreateFramebuffer");
   *pFramebuffer = reinterpret_cast<VkFramebuffer>(new MockFramebuffer());
   return VK_SUCCESS;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.cc
@@ -61,24 +61,27 @@ fml::Status TextureSourceVK::SetLayout(const BarrierVK& barrier) const {
 void TextureSourceVK::SetCachedFrameData(const FramebufferAndRenderPass& data,
                                          SampleCount sample_count,
                                          uint32_t mip_level,
-                                         uint32_t slice) {
+                                         uint32_t slice,
+                                         uint64_t attachments_key) {
   for (auto& entry : frame_data_) {
     if (entry.sample_count == sample_count && entry.mip_level == mip_level &&
-        entry.slice == slice) {
+        entry.slice == slice && entry.attachments_key == attachments_key) {
       entry.data = data;
       return;
     }
   }
-  frame_data_.push_back({sample_count, mip_level, slice, data});
+  frame_data_.push_back(
+      {sample_count, mip_level, slice, attachments_key, data});
 }
 
 FramebufferAndRenderPass TextureSourceVK::GetCachedFrameData(
     SampleCount sample_count,
     uint32_t mip_level,
-    uint32_t slice) const {
+    uint32_t slice,
+    uint64_t attachments_key) const {
   for (const auto& entry : frame_data_) {
     if (entry.sample_count == sample_count && entry.mip_level == mip_level &&
-        entry.slice == slice) {
+        entry.slice == slice && entry.attachments_key == attachments_key) {
       return entry.data;
     }
   }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_source_vk.h
@@ -145,10 +145,18 @@ class TextureSourceVK {
   /// non-MSAA color) target of a render pass. By construction, the cached
   /// objects are compatible with any future render pass that targets the
   /// same subresource.
+  ///
+  /// [attachments_key] identifies the *rest* of the attachment set — the depth
+  /// and stencil textures, and any color attachment beyond the first. A
+  /// framebuffer holds image views of all of them, so a cache keyed on this
+  /// texture alone hands back a framebuffer referring to somebody else's
+  /// depth: valid while that texture lives, and a dangling view once it does
+  /// not.
   void SetCachedFrameData(const FramebufferAndRenderPass& data,
                           SampleCount sample_count,
                           uint32_t mip_level = 0u,
-                          uint32_t slice = 0u);
+                          uint32_t slice = 0u,
+                          uint64_t attachments_key = 0u);
 
   /// Retrieve the cached framebuffer and render pass for the given
   /// `(sample_count, mip_level, slice)` subresource.
@@ -156,9 +164,11 @@ class TextureSourceVK {
   /// An empty `FramebufferAndRenderPass` is returned when no cached entry
   /// exists for that key. Entries are populated lazily on first use and
   /// live for the lifetime of the texture.
-  FramebufferAndRenderPass GetCachedFrameData(SampleCount sample_count,
-                                              uint32_t mip_level = 0u,
-                                              uint32_t slice = 0u) const;
+  FramebufferAndRenderPass GetCachedFrameData(
+      SampleCount sample_count,
+      uint32_t mip_level = 0u,
+      uint32_t slice = 0u,
+      uint64_t attachments_key = 0u) const;
 
  protected:
   const TextureDescriptor desc_;
@@ -170,6 +180,7 @@ class TextureSourceVK {
     SampleCount sample_count;
     uint32_t mip_level;
     uint32_t slice;
+    uint64_t attachments_key;
     FramebufferAndRenderPass data;
   };
   // Linear-scanned because N is typically 1 and bounded by

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -201,14 +201,19 @@ vk::ImageView TextureVK::GetRenderTargetView(uint32_t mip_level,
 void TextureVK::SetCachedFrameData(const FramebufferAndRenderPass& data,
                                    SampleCount sample_count,
                                    uint32_t mip_level,
-                                   uint32_t slice) {
-  source_->SetCachedFrameData(data, sample_count, mip_level, slice);
+                                   uint32_t slice,
+                                   uint64_t attachments_key) {
+  source_->SetCachedFrameData(data, sample_count, mip_level, slice,
+                              attachments_key);
 }
 
-FramebufferAndRenderPass TextureVK::GetCachedFrameData(SampleCount sample_count,
-                                                       uint32_t mip_level,
-                                                       uint32_t slice) const {
-  return source_->GetCachedFrameData(sample_count, mip_level, slice);
+FramebufferAndRenderPass TextureVK::GetCachedFrameData(
+    SampleCount sample_count,
+    uint32_t mip_level,
+    uint32_t slice,
+    uint64_t attachments_key) const {
+  return source_->GetCachedFrameData(sample_count, mip_level, slice,
+                                     attachments_key);
 }
 
 void TextureVK::SetMipMapGenerated() {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/texture_vk.h
@@ -58,14 +58,17 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
   void SetCachedFrameData(const FramebufferAndRenderPass& data,
                           SampleCount sample_count,
                           uint32_t mip_level = 0u,
-                          uint32_t slice = 0u);
+                          uint32_t slice = 0u,
+                          uint64_t attachments_key = 0u);
 
   /// Retrieve the cached framebuffer and render pass for the given
   /// `(sample_count, mip_level, slice)` subresource. Returns an empty
   /// `FramebufferAndRenderPass` if no entry exists.
-  FramebufferAndRenderPass GetCachedFrameData(SampleCount sample_count,
-                                              uint32_t mip_level = 0u,
-                                              uint32_t slice = 0u) const;
+  FramebufferAndRenderPass GetCachedFrameData(
+      SampleCount sample_count,
+      uint32_t mip_level = 0u,
+      uint32_t slice = 0u,
+      uint64_t attachments_key = 0u) const;
 
  private:
   std::weak_ptr<Context> context_;


### PR DESCRIPTION
A framebuffer holds image views of every attachment, and `RenderPassVK` looks its
cached framebuffer up on color attachment zero's texture alone, keyed on that
attachment's `(sample_count, mip_level, slice)`. The comment beside the lookup
states the invariant this rests on — that the rest of the attachment set is the
same for a given color attachment — and nothing enforces it.

flutter_gpu lets an application break it in the ordinary way: a shadow atlas
whose color texture lives for the process's lifetime, drawn with a depth buffer
from a per-frame pool. The second pass is handed the framebuffer built for the
first, which still refers to the first pass's depth; once that texture is
released the view is dangling, Vulkan reports
`VUID-VkRenderPassBeginInfo-framebuffer-parameter`, and the driver dereferences
it.

The cache key now includes the identity of the other attachments — depth,
stencil, and any color attachment beyond index zero — so a pass that brings a
different depth gets its own framebuffer.

The mock Vulkan device records `vkCreateFramebuffer`, the way it already records
`vkCreateRenderPass`, so the test can count them. That is the one line of test
infrastructure this needs.

**Where it was verified.** At engine revision
`5f77625673248ee5846fbcaf5d3e1a3878386fd7` — the one the 3.47.0 SDK ships, and
the engine the affected device runs. `RenderPassVK.DoesNotReuseAFramebufferWithADifferentDepthAttachment`
counts one framebuffer without the change and two with it
(`out/host_debug/impeller_unittests --gtest_filter='RenderPassVK.*'`, 3/3). On
device, an application whose shadow atlas pairs one color texture with pooled
depth buffers is killed before the change and renders at 30 fps after it.

Fixes https://github.com/flutter/flutter/issues/192538

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
