### PR TITLE
[flutter_tools] Do not mistake server-initiated requests for responses to client requests in AnalysisServer

### DIFF
--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -255,18 +255,6 @@ class AnalysisServer {
     final Object? response = json.decode(line);
 
     if (response is Map<String, Object?>) {
-      final Object? id = response['id'];
-      final Completer<Map<String, Object?>?>? completer = _outstandingRequests.remove(id);
-      if (completer != null) {
-        if (response case {'result': final Map<String, Object?>? result}) {
-          completer.complete(result);
-        } else if (response case {'error': final Map<String, Object?> error}) {
-          completer.completeError(error['message'] ?? error);
-        } else {
-          completer.completeError('Response for unknown request received: $response');
-        }
-      }
-
       final method = response['method'] as String?;
       if (method != null) {
         final Object? id = response['id'];
@@ -291,6 +279,18 @@ class AnalysisServer {
               _handleAnalysisIssues(paramsMap);
             case 'window/showMessage':
               _handleShowMessage(paramsMap);
+          }
+        }
+      } else {
+        final Object? id = response['id'];
+        final Completer<Map<String, Object?>?>? completer = _outstandingRequests.remove(id);
+        if (completer != null) {
+          if (response case {'result': final Map<String, Object?>? result}) {
+            completer.complete(result);
+          } else if (response case {'error': final Map<String, Object?> error}) {
+            completer.completeError(error['message'] ?? error);
+          } else {
+            completer.completeError('Response for unknown request received: $response');
           }
         }
       }

--- a/packages/flutter_tools/test/commands.shard/hermetic/analysis_server_mock.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analysis_server_mock.dart
@@ -68,7 +68,28 @@ class MockLspServerProcess extends test_process_manager.FakeProcess {
     _writeRawOutput('The Dart VM service is listening on http://127.0.0.1:65155/ZkxDXuYz2Aw=/\n');
   }
 
+  /// Starts simulated analysis on the server.
+  void startSimulatedAnalysis() {
+    _simulateAnalysisStart();
+  }
+
+  /// Ends simulated analysis on the server.
+  void endSimulatedAnalysis() {
+    _simulateAnalysisEnd();
+  }
+
+  /// Sends a request from the server to the client.
+  void sendServerRequest(String method, Map<String, Object?> params, {required Object id}) {
+    _writeAsLspToStdout(
+      jsonEncode(<String, Object?>{'jsonrpc': '2.0', 'id': id, 'method': method, 'params': params}),
+    );
+  }
+
+  /// Optional callback invoked when the mock receives a request on stdin.
+  void Function(Map<String, Object?> request)? onRequest;
+
   Future<void> _handleRequest(Map<String, Object?> request) async {
+    onRequest?.call(request);
     switch (request['method']) {
       case 'initialize':
         _initializeRequestCompleter.complete(request);

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -119,6 +119,76 @@ void main() {
     expect(processManager, hasNoRemainingExpectations);
   });
 
+  testUsingContext(
+    'AnalysisServer handles server-initiated requests with same ID as outstanding request',
+    () async {
+      final Directory tempDir = fileSystem.systemTempDirectory.createTempSync(
+        'flutter_analysis_test.',
+      );
+      createSampleProject(tempDir);
+
+      final process = MockLspServerProcess();
+      final processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            fileSystem.path.join('Artifact.engineDartSdkPath', 'bin', 'dart'),
+            'language-server',
+            '--dart-sdk',
+            'Artifact.engineDartSdkPath',
+            '--disable-server-feature-completion',
+            '--disable-server-feature-search',
+            '--suppress-analytics',
+          ],
+          process: process,
+        ),
+      ]);
+
+      final server = AnalysisServer(
+        'Artifact.engineDartSdkPath',
+        <String>[tempDir.path],
+        fileSystem: fileSystem,
+        platform: FakePlatform(),
+        processManager: processManager,
+        logger: logger,
+        terminal: terminal,
+        suppressAnalytics: true,
+      );
+
+      await server.start();
+      // Start simulated analysis so dart/workspace/analysis/complete will wait for it.
+      process.startSimulatedAnalysis();
+
+      final analysisCompleteReceived = Completer<int>();
+      process.onRequest = (Map<String, Object?> request) {
+        if (request['method'] == 'dart/workspace/analysis/complete') {
+          analysisCompleteReceived.complete(request['id']! as int);
+        }
+      };
+
+      // Start waiting for analysis. The client sends dart/workspace/analysis/complete.
+      final Future<void> waitFuture = server.waitForAnalysis(delay: Duration.zero);
+      final int requestId = await analysisCompleteReceived.future;
+
+      // Simulate server sending a request to the client (e.g. window/workDoneProgress/create)
+      // with the same ID while client request is still outstanding.
+      process.sendServerRequest('window/workDoneProgress/create', <String, Object?>{
+        'token': 'ANALYZING',
+      }, id: requestId);
+
+      await pumpEventQueue();
+
+      // Finish simulated analysis, allowing the server to respond to client request.
+      process.endSimulatedAnalysis();
+
+      // The client's waitForAnalysis future should complete successfully and not fail
+      // due to the server's request being mistaken for a response.
+      await expectLater(waitFuture, completes);
+
+      await server.dispose();
+      expect(processManager, hasNoRemainingExpectations);
+    },
+  );
+
   testUsingContext('AnalysisServer handles non-ASCII project path', () async {
     final Directory tempDir = fileSystem.systemTempDirectory.createTempSync(
       'flutter_analysis_test_’_dir.',


### PR DESCRIPTION
In JSON-RPC 2.0, server-to-client requests (such as `window/workDoneProgress/create`) include an ID allocated by the server along with a method. Previously, `AnalysisServer._handleServerResponse` checked `_outstandingRequests` for any message containing an ID before checking whether the message was a request or notification. If a server request happened to share an ID with an outstanding client request (e.g. `dart/workspace/analysis/complete` sent during `waitForAnalysis`), the server request was mistaken for an invalid response to the client request, causing an uncaught `StateError` that crashed the Flutter tool process and flaked tests in `widget_preview_detection_test.dart`.

This change separates the handling of incoming server messages (`method != null`) from responses to client requests (`method == null`), ensuring `_outstandingRequests` is only looked up for actual response messages.

Fixes #192471