### PR TITLE
[ci] Sort integration tests and restore Mac test_timeout_secs

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4789,6 +4789,7 @@ targets:
       subshard: "1_10"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -4816,6 +4817,7 @@ targets:
       subshard: "2_10"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -4843,6 +4845,7 @@ targets:
       subshard: "3_10"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -4870,6 +4873,7 @@ targets:
       subshard: "4_10"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -4897,6 +4901,7 @@ targets:
       subshard: "5_10"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -4924,6 +4929,7 @@ targets:
       subshard: "6_10"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -4951,6 +4957,7 @@ targets:
       subshard: "7_10"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -4978,6 +4985,7 @@ targets:
       subshard: "8_10"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -5005,6 +5013,7 @@ targets:
       subshard: "9_10"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -5032,6 +5041,7 @@ targets:
       subshard: "10_10"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**

--- a/dev/bots/suite_runners/run_add_to_app_life_cycle_tests.dart
+++ b/dev/bots/suite_runners/run_add_to_app_life_cycle_tests.dart
@@ -10,7 +10,7 @@ import '../run_command.dart';
 import '../utils.dart';
 
 Future<void> addToAppLifeCycleRunner() async {
-  if (Platform.isMacOS) {
+  if (Platform.isMacOS || dryRun) {
     printProgress('${green}Running add-to-app life cycle iOS integration tests$reset...');
     final String addToAppDir = path.join(
       flutterRoot,

--- a/dev/bots/suite_runners/run_android_java17_integration_tool_tests.dart
+++ b/dev/bots/suite_runners/run_android_java17_integration_tool_tests.dart
@@ -31,7 +31,8 @@ Future<void> androidJava17IntegrationToolTestsRunner() async {
           .whereType<File>()
           .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: toolsPath))
           .where((String testPath) => path.basename(testPath).endsWith('_test.dart'))
-          .toList();
+          .toList()
+        ..sort();
 
   await runDartTest(
     toolsPath,

--- a/dev/bots/suite_runners/run_android_preview_integration_tool_tests.dart
+++ b/dev/bots/suite_runners/run_android_preview_integration_tool_tests.dart
@@ -17,7 +17,8 @@ Future<void> androidPreviewIntegrationToolTestsRunner() async {
           .whereType<File>()
           .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: toolsPath))
           .where((String testPath) => path.basename(testPath).endsWith('_test.dart'))
-          .toList();
+          .toList()
+        ..sort();
 
   await runDartTest(
     toolsPath,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -277,7 +277,7 @@ Future<void> _runSnippetsTests() async {
       Directory(path.join(snippetsPath, 'test'))
           .listSync(recursive: true)
           .whereType<File>()
-          .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
+          .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: snippetsPath))
           .where((String testPath) => path.basename(testPath).endsWith('_test.dart'))
           .toList()
         ..sort();

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -204,6 +204,7 @@ Future<void> _runCommandsToolTests() async {
       allTests.add(file.path);
     }
   }
+  allTests.sort();
 
   await runDartTest(
     _toolsPath,
@@ -222,6 +223,8 @@ Future<void> _runWebToolTests() async {
       allTests.add(file.path);
     }
   }
+  allTests.sort();
+
   await runDartTest(
     _toolsPath,
     forceSingleCore: true,
@@ -234,12 +237,14 @@ Future<void> _runWebToolTests() async {
 Future<void> _runToolHostCrossArchTests() async {}
 
 Future<void> _runIntegrationToolTests() async {
-  final List<String> allTests = Directory(path.join(_toolsPath, 'test', 'integration.shard'))
-      .listSync(recursive: true)
-      .whereType<File>()
-      .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
-      .where((String testPath) => path.basename(testPath).endsWith('_test.dart'))
-      .toList();
+  final List<String> allTests =
+      Directory(path.join(_toolsPath, 'test', 'integration.shard'))
+          .listSync(recursive: true)
+          .whereType<File>()
+          .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
+          .where((String testPath) => path.basename(testPath).endsWith('_test.dart'))
+          .toList()
+        ..sort();
 
   await runDartTest(
     _toolsPath,
@@ -268,12 +273,14 @@ Future<void> _runToolTests() async {
 
 Future<void> _runSnippetsTests() async {
   final String snippetsPath = path.join(flutterRoot, 'dev', 'snippets');
-  final List<String> allTests = Directory(path.join(snippetsPath, 'test'))
-      .listSync(recursive: true)
-      .whereType<File>()
-      .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
-      .where((String testPath) => path.basename(testPath).endsWith('_test.dart'))
-      .toList();
+  final List<String> allTests =
+      Directory(path.join(snippetsPath, 'test'))
+          .listSync(recursive: true)
+          .whereType<File>()
+          .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
+          .where((String testPath) => path.basename(testPath).endsWith('_test.dart'))
+          .toList()
+        ..sort();
 
   await runDartTest(
     snippetsPath,

--- a/dev/bots/test/ci_yaml_validation_test.dart
+++ b/dev/bots/test/ci_yaml_validation_test.dart
@@ -39,6 +39,22 @@ void main() {
 
     expect(properties['leak_tracking'], anyOf('true', 'false', isNull));
     expect(properties['test_randomization_off'], anyOf('true', 'false', isNull));
+
+    if (properties['shard'] == 'tool_integration_tests') {
+      final timeoutSecs = properties['test_timeout_secs'] as String?;
+      expect(
+        timeoutSecs,
+        isNotNull,
+        reason: '${target.name} must specify test_timeout_secs (e.g. "2700") to avoid hitting the 30-minute step execution timeout.',
+      );
+      if (timeoutSecs != null) {
+        expect(
+          int.parse(timeoutSecs),
+          greaterThanOrEqualTo(2700),
+          reason: '${target.name} test_timeout_secs should be at least 2700s (45 minutes).',
+        );
+      }
+    }
   }
 
   group('framework', () {

--- a/dev/bots/test/ci_yaml_validation_test.dart
+++ b/dev/bots/test/ci_yaml_validation_test.dart
@@ -41,15 +41,21 @@ void main() {
     expect(properties['test_randomization_off'], anyOf('true', 'false', isNull));
 
     if (properties['shard'] == 'tool_integration_tests') {
-      final timeoutSecs = properties['test_timeout_secs'] as String?;
+      final Object? timeoutSecsValue = properties['test_timeout_secs'];
       expect(
-        timeoutSecs,
+        timeoutSecsValue,
         isNotNull,
         reason: '${target.name} must specify test_timeout_secs (e.g. "2700") to avoid hitting the 30-minute step execution timeout.',
       );
-      if (timeoutSecs != null) {
+      if (timeoutSecsValue != null) {
+        final int? timeoutSecs = int.tryParse(timeoutSecsValue.toString());
         expect(
-          int.parse(timeoutSecs),
+          timeoutSecs,
+          isNotNull,
+          reason: '${target.name} test_timeout_secs must be a valid integer, got "$timeoutSecsValue".',
+        );
+        expect(
+          timeoutSecs!,
           greaterThanOrEqualTo(2700),
           reason: '${target.name} test_timeout_secs should be at least 2700s (45 minutes).',
         );

--- a/dev/bots/test/test_test.dart
+++ b/dev/bots/test/test_test.dart
@@ -186,10 +186,11 @@ void main() {
       }, <String>['--dry-run']);
       expectExitCode(result, 0);
 
+      final String prefix = path.join('test', 'integration.shard');
       final List<String> lines = (result.stdout as String).split('\n');
       final List<String> testLines = lines
           .map((String line) => line.trim())
-          .where((String line) => line.startsWith('test/integration.shard/') && line.endsWith('_test.dart'))
+          .where((String line) => (line.startsWith(prefix) || line.startsWith('test/integration.shard/')) && line.endsWith('_test.dart'))
           .toList();
 
       expect(testLines, isNotEmpty);

--- a/dev/bots/test/test_test.dart
+++ b/dev/bots/test/test_test.dart
@@ -178,6 +178,28 @@ void main() {
       expectExitCode(result, 0);
       expect(result.stdout, contains('|> bin/flutter'));
     }, testOn: 'posix');
+
+    test('tool_integration_tests runs tests in sorted order with --dry-run', () async {
+      final ProcessResult result = await runScript(<String, String>{
+        'SHARD': 'tool_integration_tests',
+        'SUBSHARD': '7_10',
+      }, <String>['--dry-run']);
+      expectExitCode(result, 0);
+
+      final List<String> lines = (result.stdout as String).split('\n');
+      final List<String> testLines = lines
+          .map((String line) => line.trim())
+          .where((String line) => line.startsWith('test/integration.shard/') && line.endsWith('_test.dart'))
+          .toList();
+
+      expect(testLines, isNotEmpty);
+      final sortedTestLines = List<String>.of(testLines)..sort();
+      expect(
+        testLines,
+        equals(sortedTestLines),
+        reason: 'Tests in tool_integration_tests must be sorted deterministically to prevent uneven clustering across platforms.',
+      );
+    });
   });
 
   test('selectTestsForSubShard distributes tests amongst subshards correctly', () async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,7 +13,7 @@ packages:
     dependency: "direct main"
     description:
       name: _fe_analyzer_shared
-      sha256: "fe18c7e37d5acb3b43224fa255281dec007970d6fd01f6d76fcd88ed3777a117"
+      sha256: fe18c7e37d5acb3b43224fa255281dec007970d6fd01f6d76fcd88ed3777a117
       url: "https://pub.dev"
     source: hosted
     version: "107.0.0"
@@ -29,7 +29,7 @@ packages:
     dependency: transitive
     description:
       name: analysis_server_plugin
-      sha256: "fc372bb4778b901afe4dea2e7f71ec74e6cbe772999d9961a4d8e382bc4fa49c"
+      sha256: fc372bb4778b901afe4dea2e7f71ec74e6cbe772999d9961a4d8e382bc4fa49c
       url: "https://pub.dev"
     source: hosted
     version: "0.3.22"
@@ -37,7 +37,7 @@ packages:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: "f2dde9e50c23fc95b846b4ef334e98c3ae8c0effd5d2453b02fc9fb3f8939791"
+      sha256: f2dde9e50c23fc95b846b4ef334e98c3ae8c0effd5d2453b02fc9fb3f8939791
       url: "https://pub.dev"
     source: hosted
     version: "14.3.0"


### PR DESCRIPTION
Because integration test discovery relied on `Directory.listSync()`, the order of tests was non-deterministic and depended on filesystem directory iteration. On macOS, this caused multiple long-running tests (`break_on_framework_exceptions_test.dart` and `deferred_components_test.dart`) to cluster together in subshard `7_10`, consuming almost 30 minutes.

Additionally, commit 43754916b41 inadvertently omitted `test_timeout_secs: "2700"` from the Mac `tool_integration_tests` targets in `.ci.yaml`, causing the LUCI step execution timeout to default to 30 minutes (1800s). Under bot congestion, subshard `7_10` exceeded 30 minutes and was killed with SIGTERM.

This change:
- Sorts integration tests lexicographically before sharding so tests are deterministically distributed across shards and platforms, separating the heaviest tests into different subshards.
- Restores `test_timeout_secs: "2700"` for all 10 Mac `tool_integration_tests` targets.
- Adds regression tests in `ci_yaml_validation_test.dart` and `test_test.dart`.

Fixes #192470