### PR TITLE
[flutter_tools] Properly detect unexpected process exit on Windows and fix leak-tracking flakes

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -6481,10 +6481,6 @@ targets:
     timeout: 120
     properties:
       test_timeout_secs: "3600" # 1 hour
-      dependencies: >-
-        [
-          {"dependency": "goldctl", "version": "git_revision:c845c41b9b81bfcb11f2f0ab17b5b2386d634c31"}
-        ]
       shard: framework_tests
       subshard: widgets
       tags: >

--- a/packages/flutter/test/widgets/navigator_restoration_test.dart
+++ b/packages/flutter/test/widgets/navigator_restoration_test.dart
@@ -1097,6 +1097,7 @@ void main() {
         (exception as AssertionError).message,
         contains('All routes returned by onGenerateInitialRoutes are not restorable.'),
       );
+      await tester.pumpWidget(const SizedBox());
     },
   );
 }

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -228,7 +228,9 @@ class FlutterTesterTestDevice extends TestDevice {
 
   @override
   Future<void> kill() async {
-    _killed = true;
+    if (!_exitCode.isCompleted) {
+      _killed = true;
+    }
     logger.printTrace('test $id: Terminating flutter_tester process');
     _process?.kill(io.ProcessSignal.sigkill);
 

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -73,6 +73,7 @@ class FlutterTesterTestDevice extends TestDevice {
   Process? _process;
   HttpServer? _server;
   DevtoolsLauncher? _devToolsLauncher;
+  bool _killed = false;
 
   /// Starts the device.
   ///
@@ -227,6 +228,7 @@ class FlutterTesterTestDevice extends TestDevice {
 
   @override
   Future<void> kill() async {
+    _killed = true;
     logger.printTrace('test $id: Terminating flutter_tester process');
     _process?.kill(io.ProcessSignal.sigkill);
 
@@ -242,8 +244,7 @@ class FlutterTesterTestDevice extends TestDevice {
   Future<void> get finished async {
     final int exitCode = await _exitCode.future;
 
-    // On Windows, the [exitCode] and the terminating signal have no correlation.
-    if (platform.isWindows) {
+    if (_killed) {
       return;
     }
 

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_tools/src/native_assets.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/test/flutter_tester_device.dart';
 import 'package:flutter_tools/src/test/font_config_manager.dart';
+import 'package:flutter_tools/src/test/test_device.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/fake.dart';
@@ -325,6 +326,107 @@ void main() {
       },
     );
   });
+
+  group('termination and finished', () {
+    testUsingContext('finished throws TestDeviceException on unexpected process exit on Windows', () async {
+      platform = FakePlatform(operatingSystem: 'windows');
+      processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>[
+            '/',
+            '--disable-vm-service',
+            '--ipv6',
+            '--enable-checked-mode',
+            '--verify-entry-points',
+            '--enable-software-rendering',
+            '--skia-deterministic-rendering',
+            '--enable-dart-profiling',
+            '--non-interactive',
+            '--use-test-fonts',
+            '--disable-asset-fonts',
+            '--packages=.dart_tool/package_config.json',
+            'example.dill',
+          ],
+          exitCode: 1,
+        ),
+      ]);
+      device = createDevice();
+      await device.start('example.dill');
+
+      await expectLater(device.finished, throwsA(isA<TestDeviceException>()));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Platform: () => platform,
+    });
+
+    testUsingContext('finished throws TestDeviceException on unexpected exit 0 on Windows', () async {
+      platform = FakePlatform(operatingSystem: 'windows');
+      processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>[
+            '/',
+            '--disable-vm-service',
+            '--ipv6',
+            '--enable-checked-mode',
+            '--verify-entry-points',
+            '--enable-software-rendering',
+            '--skia-deterministic-rendering',
+            '--enable-dart-profiling',
+            '--non-interactive',
+            '--use-test-fonts',
+            '--disable-asset-fonts',
+            '--packages=.dart_tool/package_config.json',
+            'example.dill',
+          ],
+        ),
+      ]);
+      device = createDevice();
+      await device.start('example.dill');
+
+      await expectLater(device.finished, throwsA(isA<TestDeviceException>()));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Platform: () => platform,
+    });
+
+    testUsingContext('finished completes normally when kill() is called on Windows', () async {
+      platform = FakePlatform(operatingSystem: 'windows');
+      final exitCompleter = Completer<int>();
+      processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: const <String>[
+            '/',
+            '--disable-vm-service',
+            '--ipv6',
+            '--enable-checked-mode',
+            '--verify-entry-points',
+            '--enable-software-rendering',
+            '--skia-deterministic-rendering',
+            '--enable-dart-profiling',
+            '--non-interactive',
+            '--use-test-fonts',
+            '--disable-asset-fonts',
+            '--packages=.dart_tool/package_config.json',
+            'example.dill',
+          ],
+          completer: exitCompleter,
+        ),
+      ]);
+      device = createDevice();
+      await device.start('example.dill');
+      final Future<void> killFuture = device.kill();
+      exitCompleter.complete(0);
+      await killFuture;
+
+      await expectLater(device.finished, completes);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Platform: () => platform,
+    });
+  });
 }
 
 /// A Flutter Tester device.
@@ -385,6 +487,9 @@ class TestFlutterTesterDevice extends FlutterTesterTestDevice {
 class FakeHttpServer extends Fake implements HttpServer {
   @override
   int get port => 0;
+
+  @override
+  Future<void> close({bool force = false}) async {}
 }
 
 class FakeNativeAssetsBuilder extends Fake implements TestCompilerNativeAssetsBuilder {


### PR DESCRIPTION
On Windows, `FlutterTesterTestDevice.finished` was returning cleanly on any process exit due to an outdated workaround intended only for intentional `kill()` invocations. When the test subprocess exited prematurely, `finished` resolved without error, causing `flutter_platform.dart` to close the test harness socket while test execution was still active.

Track intentional process termination with `_killed` in `FlutterTesterTestDevice` so that unexpected exits on Windows throw `TestDeviceException` as they do on POSIX. In addition, cleanly unmount the widget tree in `navigator_restoration_test.dart` following an assertion test, and remove the unnecessary `goldctl` dependency from `Windows framework_tests_widgets_leak_tracking` in `.ci.yaml` to prevent post-submit Skia Gold triage flakes on secondary builders.

Fixes #192469