### PR TITLE
Promote Windows gradient benchmark tests to non-bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -7270,7 +7270,6 @@ targets:
   - name: Windows windows_gradient_consistent_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >
@@ -7284,7 +7283,6 @@ targets:
   - name: Windows windows_gradient_dynamic_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >
@@ -7298,7 +7296,6 @@ targets:
   - name: Windows windows_gradient_static_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
They've been passing consistently for a while: https://flutter-dashboard.appspot.com/#/build?taskFilter=gradient&repo=flutter&branch=master