### PR TITLE
[Android] Implement ADPF hint sessions for API 35+ with AWorkDuration

### DIFF
--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -45,6 +45,7 @@ executable("flutter_shell_native_unittests") {
   sources = [
     "android_context_gl_impeller_unittests.cc",
     "android_image_generator_unittests.cc",
+    "android_performance_hint_manager_unittests.cc",
     "android_shell_holder_unittests.cc",
     "apk_asset_provider_unittests.cc",
     "flutter_shell_native_unittests.cc",
@@ -98,6 +99,8 @@ source_set("flutter_shell_native_src") {
     "android_egl_surface.h",
     "android_environment_gl.cc",
     "android_environment_gl.h",
+    "android_performance_hint_manager.cc",
+    "android_performance_hint_manager.h",
     "android_shell_holder.cc",
     "android_shell_holder.h",
     "android_surface_dynamic_impeller.cc",

--- a/engine/src/flutter/shell/platform/android/android_performance_hint_manager.cc
+++ b/engine/src/flutter/shell/platform/android/android_performance_hint_manager.cc
@@ -1,0 +1,284 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/android/android_performance_hint_manager.h"
+
+#include <android/api-level.h>
+#include <dlfcn.h>
+#include <cerrno>
+#include <mutex>
+#include <optional>
+
+#include "flutter/fml/logging.h"
+#include "flutter/fml/native_library.h"
+
+namespace flutter {
+
+// Opaque handles matching NDK <android/performance_hint.h>
+struct APerformanceHintManager;
+struct APerformanceHintSession;
+struct AWorkDuration;
+
+using APerformanceHint_getManager_fn = APerformanceHintManager* (*)();
+using APerformanceHint_createSession_fn =
+    APerformanceHintSession* (*)(APerformanceHintManager*,
+                                 const int32_t*,
+                                 size_t,
+                                 int64_t);
+using APerformanceHint_reportActualWorkDuration2_fn =
+    int (*)(APerformanceHintSession*, AWorkDuration*);
+using APerformanceHint_updateTargetWorkDuration_fn =
+    int (*)(APerformanceHintSession*, int64_t);
+using APerformanceHint_closeSession_fn = void (*)(APerformanceHintSession*);
+
+using AWorkDuration_create_fn = AWorkDuration* (*)();
+using AWorkDuration_release_fn = void (*)(AWorkDuration*);
+using AWorkDuration_setWorkPeriodStartTimestampNanos_fn =
+    void (*)(AWorkDuration*, int64_t);
+using AWorkDuration_setActualTotalDurationNanos_fn = void (*)(AWorkDuration*,
+                                                              int64_t);
+using AWorkDuration_setActualCpuDurationNanos_fn = void (*)(AWorkDuration*,
+                                                            int64_t);
+using AWorkDuration_setActualGpuDurationNanos_fn = void (*)(AWorkDuration*,
+                                                            int64_t);
+
+struct AndroidPerformanceHintManager::Impl {
+  mutable std::mutex mutex;
+  fml::RefPtr<fml::NativeLibrary> lib_android;
+  APerformanceHintSession* session = nullptr;
+  AWorkDuration* work_duration = nullptr;
+  int64_t applied_target_duration_ns = 0;
+
+  APerformanceHint_reportActualWorkDuration2_fn report_actual_work_duration2 =
+      nullptr;
+  APerformanceHint_updateTargetWorkDuration_fn update_target_work_duration =
+      nullptr;
+  APerformanceHint_closeSession_fn close_session = nullptr;
+
+  AWorkDuration_release_fn release_work_duration = nullptr;
+  AWorkDuration_setWorkPeriodStartTimestampNanos_fn set_work_period_start =
+      nullptr;
+  AWorkDuration_setActualTotalDurationNanos_fn set_actual_total_duration =
+      nullptr;
+  AWorkDuration_setActualCpuDurationNanos_fn set_actual_cpu_duration = nullptr;
+  AWorkDuration_setActualGpuDurationNanos_fn set_actual_gpu_duration = nullptr;
+
+  ~Impl() {
+    std::lock_guard<std::mutex> lock(mutex);
+    CloseSessionLocked();
+  }
+
+  void CloseSessionLocked() {
+    if (session && close_session) {
+      close_session(session);
+      session = nullptr;
+    }
+    if (work_duration && release_work_duration) {
+      release_work_duration(work_duration);
+      work_duration = nullptr;
+    }
+  }
+};
+
+std::unique_ptr<AndroidPerformanceHintManager>
+AndroidPerformanceHintManager::Create(const std::vector<int32_t>& tids,
+                                      int64_t target_duration_ns) {
+  if (tids.empty() || target_duration_ns <= 0) {
+    return nullptr;
+  }
+
+  // Gate to Android 15+ (API 35+), where AWorkDuration and
+  // APerformanceHint_reportActualWorkDuration2 were introduced to accurately
+  // report decomposed CPU work durations and total frame turnaround time
+  // without relying on heuristics for multi-threaded thread groups.
+  if (android_get_device_api_level() < 35) {
+    return nullptr;
+  }
+
+  fml::RefPtr<fml::NativeLibrary> lib_android =
+      fml::NativeLibrary::Create("libandroid.so");
+  if (!lib_android) {
+    return nullptr;
+  }
+
+  const std::optional<APerformanceHint_getManager_fn> get_manager =
+      lib_android->ResolveFunction<APerformanceHint_getManager_fn>(
+          "APerformanceHint_getManager");
+  const std::optional<APerformanceHint_createSession_fn> create_session =
+      lib_android->ResolveFunction<APerformanceHint_createSession_fn>(
+          "APerformanceHint_createSession");
+  const std::optional<APerformanceHint_reportActualWorkDuration2_fn>
+      report_actual2 =
+          lib_android
+              ->ResolveFunction<APerformanceHint_reportActualWorkDuration2_fn>(
+                  "APerformanceHint_reportActualWorkDuration2");
+  const std::optional<APerformanceHint_updateTargetWorkDuration_fn>
+      update_target =
+          lib_android
+              ->ResolveFunction<APerformanceHint_updateTargetWorkDuration_fn>(
+                  "APerformanceHint_updateTargetWorkDuration");
+  const std::optional<APerformanceHint_closeSession_fn> close_session =
+      lib_android->ResolveFunction<APerformanceHint_closeSession_fn>(
+          "APerformanceHint_closeSession");
+
+  const std::optional<AWorkDuration_create_fn> work_duration_create =
+      lib_android->ResolveFunction<AWorkDuration_create_fn>(
+          "AWorkDuration_create");
+  const std::optional<AWorkDuration_release_fn> work_duration_release =
+      lib_android->ResolveFunction<AWorkDuration_release_fn>(
+          "AWorkDuration_release");
+  const std::optional<AWorkDuration_setWorkPeriodStartTimestampNanos_fn>
+      set_work_period_start = lib_android->ResolveFunction<
+          AWorkDuration_setWorkPeriodStartTimestampNanos_fn>(
+          "AWorkDuration_setWorkPeriodStartTimestampNanos");
+  const std::optional<AWorkDuration_setActualTotalDurationNanos_fn>
+      set_actual_total_duration =
+          lib_android
+              ->ResolveFunction<AWorkDuration_setActualTotalDurationNanos_fn>(
+                  "AWorkDuration_setActualTotalDurationNanos");
+  const std::optional<AWorkDuration_setActualCpuDurationNanos_fn>
+      set_actual_cpu_duration =
+          lib_android
+              ->ResolveFunction<AWorkDuration_setActualCpuDurationNanos_fn>(
+                  "AWorkDuration_setActualCpuDurationNanos");
+  const std::optional<AWorkDuration_setActualGpuDurationNanos_fn>
+      set_actual_gpu_duration =
+          lib_android
+              ->ResolveFunction<AWorkDuration_setActualGpuDurationNanos_fn>(
+                  "AWorkDuration_setActualGpuDurationNanos");
+
+  if (!get_manager.has_value() || !create_session.has_value() ||
+      !report_actual2.has_value() || !update_target.has_value() ||
+      !close_session.has_value() || !work_duration_create.has_value() ||
+      !work_duration_release.has_value() ||
+      !set_work_period_start.has_value() ||
+      !set_actual_total_duration.has_value() ||
+      !set_actual_cpu_duration.has_value() ||
+      !set_actual_gpu_duration.has_value()) {
+    FML_LOG(WARNING)
+        << "ADPF PerformanceHint APIs not available in libandroid.so";
+    return nullptr;
+  }
+
+  APerformanceHintManager* manager = get_manager.value()();
+  if (!manager) {
+    FML_LOG(WARNING) << "APerformanceHint_getManager returned nullptr";
+    return nullptr;
+  }
+
+  APerformanceHintSession* session = create_session.value()(
+      manager, tids.data(), tids.size(), target_duration_ns);
+  if (!session) {
+    FML_LOG(WARNING) << "Failed to create APerformanceHintSession for "
+                     << tids.size() << " threads";
+    return nullptr;
+  }
+
+  AWorkDuration* work_duration = work_duration_create.value()();
+  if (!work_duration) {
+    FML_LOG(WARNING) << "Failed to allocate AWorkDuration";
+    close_session.value()(session);
+    return nullptr;
+  }
+
+  std::unique_ptr<Impl> impl = std::make_unique<Impl>();
+  impl->lib_android = std::move(lib_android);
+  impl->session = session;
+  impl->work_duration = work_duration;
+  impl->applied_target_duration_ns = target_duration_ns;
+  impl->report_actual_work_duration2 = report_actual2.value();
+  impl->update_target_work_duration = update_target.value();
+  impl->close_session = close_session.value();
+  impl->release_work_duration = work_duration_release.value();
+  impl->set_work_period_start = set_work_period_start.value();
+  impl->set_actual_total_duration = set_actual_total_duration.value();
+  impl->set_actual_cpu_duration = set_actual_cpu_duration.value();
+  impl->set_actual_gpu_duration = set_actual_gpu_duration.value();
+
+  FML_DLOG(INFO) << "Created ADPF PerformanceHintSession with target "
+                 << target_duration_ns << " ns (" << (1e9 / target_duration_ns)
+                 << " Hz) for " << tids.size() << " threads";
+
+  return std::unique_ptr<AndroidPerformanceHintManager>(
+      new AndroidPerformanceHintManager(std::move(impl)));
+}
+
+AndroidPerformanceHintManager::AndroidPerformanceHintManager(
+    std::unique_ptr<Impl> impl)
+    : impl_(std::move(impl)) {}
+
+AndroidPerformanceHintManager::~AndroidPerformanceHintManager() = default;
+
+void AndroidPerformanceHintManager::ReportActualWorkDuration(
+    int64_t work_period_start_ns,
+    int64_t actual_total_duration_ns,
+    int64_t actual_cpu_duration_ns,
+    int64_t actual_gpu_duration_ns) {
+  if (!impl_ || work_period_start_ns <= 0 || actual_total_duration_ns <= 0 ||
+      actual_cpu_duration_ns < 0 || actual_gpu_duration_ns < 0 ||
+      (actual_cpu_duration_ns == 0 && actual_gpu_duration_ns == 0)) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  if (impl_->session && impl_->work_duration &&
+      impl_->report_actual_work_duration2) {
+    impl_->set_work_period_start(impl_->work_duration, work_period_start_ns);
+    impl_->set_actual_total_duration(impl_->work_duration,
+                                     actual_total_duration_ns);
+    impl_->set_actual_cpu_duration(impl_->work_duration,
+                                   actual_cpu_duration_ns);
+    impl_->set_actual_gpu_duration(impl_->work_duration,
+                                   actual_gpu_duration_ns);
+
+    int result = impl_->report_actual_work_duration2(impl_->session,
+                                                     impl_->work_duration);
+    if (result != 0) {
+      if (result == EPIPE) {
+        FML_LOG(WARNING)
+            << "ADPF session disconnected (EPIPE). Closing session.";
+        impl_->CloseSessionLocked();
+      } else {
+        FML_DLOG(WARNING)
+            << "APerformanceHint_reportActualWorkDuration2 returned " << result;
+      }
+    }
+  }
+}
+
+void AndroidPerformanceHintManager::UpdateTargetWorkDuration(
+    int64_t target_duration_ns) {
+  if (!impl_ || target_duration_ns <= 0) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  if (impl_->applied_target_duration_ns == target_duration_ns) {
+    return;
+  }
+  if (impl_->session && impl_->update_target_work_duration) {
+    int result =
+        impl_->update_target_work_duration(impl_->session, target_duration_ns);
+    if (result != 0) {
+      if (result == EPIPE) {
+        FML_LOG(WARNING)
+            << "ADPF session disconnected (EPIPE). Closing session.";
+        impl_->CloseSessionLocked();
+      } else {
+        FML_DLOG(WARNING)
+            << "APerformanceHint_updateTargetWorkDuration returned " << result;
+      }
+    } else {
+      impl_->applied_target_duration_ns = target_duration_ns;
+    }
+  }
+}
+
+int64_t AndroidPerformanceHintManager::GetTargetWorkDuration() const {
+  if (!impl_) {
+    return 0;
+  }
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  return impl_->applied_target_duration_ns;
+}
+
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/android_performance_hint_manager.h
+++ b/engine/src/flutter/shell/platform/android/android_performance_hint_manager.h
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_PERFORMANCE_HINT_MANAGER_H_
+#define FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_PERFORMANCE_HINT_MANAGER_H_
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "flutter/fml/macros.h"
+
+namespace flutter {
+
+//------------------------------------------------------------------------------
+/// @brief      Manages an Android Dynamic Performance Framework (ADPF)
+///             APerformanceHintSession for communicating frame target and
+///             actual work durations directly to the Android vendor PowerHAL.
+///
+///             This informs the system PowerHAL of workload deadlines, enabling
+///             proactive DVFS frequency scaling and thread scheduling
+///             adjustments for Flutter's UI and Raster threads.
+///
+class AndroidPerformanceHintManager {
+ public:
+  static std::unique_ptr<AndroidPerformanceHintManager> Create(
+      const std::vector<int32_t>& tids,
+      int64_t target_duration_ns);
+
+  ~AndroidPerformanceHintManager();
+
+  void ReportActualWorkDuration(int64_t work_period_start_ns,
+                                int64_t actual_total_duration_ns,
+                                int64_t actual_cpu_duration_ns,
+                                int64_t actual_gpu_duration_ns = 0);
+
+  void UpdateTargetWorkDuration(int64_t target_duration_ns);
+
+  int64_t GetTargetWorkDuration() const;
+
+ private:
+  struct Impl;
+  explicit AndroidPerformanceHintManager(std::unique_ptr<Impl> impl);
+
+  std::unique_ptr<Impl> impl_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AndroidPerformanceHintManager);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_PERFORMANCE_HINT_MANAGER_H_

--- a/engine/src/flutter/shell/platform/android/android_performance_hint_manager_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/android_performance_hint_manager_unittests.cc
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/android/android_performance_hint_manager.h"
+
+#include <android/api-level.h>
+#include <unistd.h>
+
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+TEST(AndroidPerformanceHintManagerTest, RejectsInvalidArguments) {
+  // Empty TIDs.
+  EXPECT_EQ(AndroidPerformanceHintManager::Create({}, 16666666), nullptr);
+
+  // Negative or zero target duration.
+  EXPECT_EQ(AndroidPerformanceHintManager::Create({gettid()}, 0), nullptr);
+  EXPECT_EQ(AndroidPerformanceHintManager::Create({gettid()}, -100), nullptr);
+}
+
+TEST(AndroidPerformanceHintManagerTest, LifecycleOnSupportedDevice) {
+  if (android_get_device_api_level() < 35) {
+    GTEST_SKIP() << "ADPF PerformanceHint requires Android API level 35+";
+  }
+
+  constexpr int64_t target_ns = 16666666;  // ~60 Hz
+  std::unique_ptr<AndroidPerformanceHintManager> manager =
+      AndroidPerformanceHintManager::Create({gettid()}, target_ns);
+
+  // If the OS / PowerHAL supports ADPF, verify the methods execute cleanly.
+  if (manager) {
+    EXPECT_EQ(manager->GetTargetWorkDuration(), target_ns);
+
+    // Test reporting actual duration with AWorkDuration parameters.
+    manager->ReportActualWorkDuration(1000000000, 12000000, 8000000, 0);
+
+    // Test updating target duration (e.g. 120 Hz).
+    int64_t new_target_ns = 8333333;
+    manager->UpdateTargetWorkDuration(new_target_ns);
+    EXPECT_EQ(manager->GetTargetWorkDuration(), new_target_ns);
+  }
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/android/android_shell_holder.cc
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder.cc
@@ -7,6 +7,8 @@
 #include <pthread.h>
 #include <sys/resource.h>
 #include <sys/time.h>
+#include <algorithm>
+#include <atomic>
 #include <memory>
 #include <optional>
 
@@ -23,6 +25,7 @@
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/platform/android/android_display.h"
 #include "flutter/shell/platform/android/android_image_generator.h"
+#include "flutter/shell/platform/android/android_performance_hint_manager.h"
 #include "flutter/shell/platform/android/android_rendering_selector.h"
 #include "flutter/shell/platform/android/android_shell_holder.h"
 #include "flutter/shell/platform/android/context/android_context.h"
@@ -95,8 +98,20 @@ AndroidShellHolder::AndroidShellHolder(
     mask |= ThreadHost::Type::kUi;
   }
 
-  flutter::ThreadHost::ThreadHostConfig host_config(
-      thread_label, mask, AndroidPlatformThreadConfigSetter);
+  std::atomic<int32_t> ui_tid{0};
+  std::atomic<int32_t> raster_tid{0};
+  auto thread_config_setter =
+      [&ui_tid, &raster_tid](const fml::Thread::ThreadConfig& config) {
+        AndroidPlatformThreadConfigSetter(config);
+        if (config.priority == fml::Thread::ThreadPriority::kDisplay) {
+          ui_tid.store(gettid());
+        } else if (config.priority == fml::Thread::ThreadPriority::kRaster) {
+          raster_tid.store(gettid());
+        }
+      };
+
+  flutter::ThreadHost::ThreadHostConfig host_config(thread_label, mask,
+                                                    thread_config_setter);
   host_config.ui_config = fml::Thread::ThreadConfig(
       flutter::ThreadHost::ThreadHostConfig::MakeThreadName(
           flutter::ThreadHost::Type::kUi, thread_label),
@@ -111,6 +126,80 @@ AndroidShellHolder::AndroidShellHolder(
       fml::Thread::ThreadPriority::kNormal);
 
   thread_host_ = std::make_shared<ThreadHost>(host_config);
+
+  std::vector<int32_t> tids;
+  if (settings.merged_platform_ui_thread ==
+      Settings::MergedPlatformUIThread::kMergeAfterLaunch) {
+    // MergedPlatformUIThread::kMergeAfterLaunch dynamically migrates the UI
+    // task queue to the platform thread during Engine::Run. Skip ADPF session
+    // creation until dynamic thread migration can be represented.
+  } else {
+    if (ui_tid.load() > 0) {
+      tids.push_back(ui_tid.load());
+    } else if (settings.merged_platform_ui_thread ==
+               Settings::MergedPlatformUIThread::kEnabled) {
+      tids.push_back(gettid());
+    }
+    if (raster_tid.load() > 0) {
+      tids.push_back(raster_tid.load());
+    }
+  }
+
+  // Use a provisional end-to-end frame-work target of 75% of the display
+  // interval. This leaves scheduling slack because GPU duration is presently
+  // unmeasured. The ratio must be validated with device traces.
+  constexpr double kTargetFrameWorkRatio = 0.75;
+
+  double refresh_rate = jni_facade->GetDisplayRefreshRate();
+  if (refresh_rate <= 0) {
+    refresh_rate = 60.0;
+  }
+  int64_t target_duration_ns =
+      static_cast<int64_t>((1e9 / refresh_rate) * kTargetFrameWorkRatio);
+
+  if (!tids.empty()) {
+    performance_hint_manager_ =
+        AndroidPerformanceHintManager::Create(tids, target_duration_ns);
+  }
+
+  flutter::Settings shell_settings = settings_;
+  if (performance_hint_manager_) {
+    FrameRasterizedCallback prev_callback =
+        shell_settings.frame_rasterized_callback;
+    shell_settings.frame_rasterized_callback = [perf_hint =
+                                                    performance_hint_manager_,
+                                                prev_callback](
+                                                   const FrameTiming& timing) {
+      if (prev_callback) {
+        prev_callback(timing);
+      }
+      int64_t vsync_start_ns =
+          timing.Get(FrameTiming::kVsyncStart).ToEpochDelta().ToNanoseconds();
+      int64_t total_duration_ns = 0;
+      if (vsync_start_ns > 0) {
+        total_duration_ns = (timing.Get(FrameTiming::kRasterFinish) -
+                             timing.Get(FrameTiming::kVsyncStart))
+                                .ToNanoseconds();
+      } else {
+        vsync_start_ns =
+            timing.Get(FrameTiming::kBuildStart).ToEpochDelta().ToNanoseconds();
+        total_duration_ns = (timing.Get(FrameTiming::kRasterFinish) -
+                             timing.Get(FrameTiming::kBuildStart))
+                                .ToNanoseconds();
+      }
+      int64_t build_ns = (timing.Get(FrameTiming::kBuildFinish) -
+                          timing.Get(FrameTiming::kBuildStart))
+                             .ToNanoseconds();
+      int64_t raster_ns = (timing.Get(FrameTiming::kRasterFinish) -
+                           timing.Get(FrameTiming::kRasterStart))
+                              .ToNanoseconds();
+      int64_t cpu_duration_ns = build_ns + raster_ns;
+      if (vsync_start_ns > 0 && total_duration_ns > 0 && cpu_duration_ns > 0) {
+        perf_hint->ReportActualWorkDuration(vsync_start_ns, total_duration_ns,
+                                            cpu_duration_ns, 0);
+      }
+    };
+  }
 
   fml::WeakPtr<PlatformViewAndroid> weak_platform_view;
   AndroidRenderingAPI rendering_api = android_rendering_api_;
@@ -158,7 +247,7 @@ AndroidShellHolder::AndroidShellHolder(
   shell_ =
       Shell::Create(GetDefaultPlatformData(),  // window data
                     task_runners,              // task runners
-                    settings_,                 // settings
+                    shell_settings,            // settings
                     on_create_platform_view,   // platform view create callback
                     on_create_rasterizer       // rasterizer create callback
       );
@@ -362,6 +451,15 @@ void AndroidShellHolder::UpdateDisplayMetrics() {
   std::vector<std::unique_ptr<Display>> displays;
   displays.push_back(std::make_unique<AndroidDisplay>(jni_facade_));
   shell_->OnDisplayUpdates(std::move(displays));
+
+  if (performance_hint_manager_ && jni_facade_) {
+    double refresh_rate = jni_facade_->GetDisplayRefreshRate();
+    if (refresh_rate > 0) {
+      constexpr double kTargetFrameWorkRatio = 0.75;
+      performance_hint_manager_->UpdateTargetWorkDuration(
+          static_cast<int64_t>((1e9 / refresh_rate) * kTargetFrameWorkRatio));
+    }
+  }
 }
 
 bool AndroidShellHolder::IsSurfaceControlEnabled() {

--- a/engine/src/flutter/shell/platform/android/android_shell_holder.h
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder.h
@@ -18,6 +18,8 @@
 
 namespace flutter {
 
+class AndroidPerformanceHintManager;
+
 //----------------------------------------------------------------------------
 /// @brief      This is the Android owner of the core engine Shell.
 ///
@@ -119,6 +121,7 @@ class AndroidShellHolder {
   uint64_t next_pointer_flow_id_ = 0;
   std::unique_ptr<APKAssetProvider> apk_asset_provider_;
   const AndroidRenderingAPI android_rendering_api_;
+  std::shared_ptr<AndroidPerformanceHintManager> performance_hint_manager_;
 
   //----------------------------------------------------------------------------
   /// @brief      Constructor with its components injected.


### PR DESCRIPTION
- Gate ADPF hint session creation to Android 15+ (API 35+).
- Dynamically resolve AWorkDuration APIs and APerformanceHint_reportActualWorkDuration2 from libandroid.so.
- Report aggregate elapsed duration of CPU build and raster phases (build_ns + raster_ns), work period start timestamp, and total frame duration.
- Exclude MergedPlatformUIThread::kMergeAfterLaunch to avoid tracking stale UI thread after dynamic task queue migration.
- Manage reusable AWorkDuration instance synchronized under std::mutex with APerformanceHintSession.
- Fix target duration state caching to only update upon successful native PowerHAL return.
- Apply provisional 75% target frame-work ratio to leave scheduling slack while GPU duration is unmeasured.
- De-duplicate updateTargetWorkDuration calls to prevent redundant Binder IPC.
- Check NDK return codes, log warnings, and close session cleanly on EPIPE disconnects.
- Switch session creation log to FML_DLOG to avoid logcat pollution.
- Use explicit types instead of auto per Google C++ style and Flutter reviewer preference.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
