### PR TITLE
Auto-generated backdrop groups in dl_dispatcher

### DIFF
--- a/engine/src/flutter/display_list/utils/dl_receiver_utils.h
+++ b/engine/src/flutter/display_list/utils/dl_receiver_utils.h
@@ -13,9 +13,14 @@
 //
 // IgnoreAttributeDispatchHelper:
 // IgnoreClipDispatchHelper:
-// IgnoreTransformDispatchHelper
+// IgnoreTransformDispatchHelper:
+// IgnoreDrawDispatchHelper:
 //     Empty overrides of all of the associated methods of DlOpReceiver
 //     for receivers that only track some of the rendering operations
+//
+// DrawHookDispatchHelper:
+//     Overrides of all draw methods of DlOpReceiver that forward to a
+//     virtual onDraw() hook for receivers that intercept draw operations
 
 namespace flutter {
 
@@ -74,53 +79,69 @@ class IgnoreTransformDispatchHelper : public virtual DlOpReceiver {
   void transformReset() override {}
 };
 
-class IgnoreDrawDispatchHelper : public virtual DlOpReceiver {
+// A utility class that intercepts all DlOpReceiver methods relating
+// to rendering/drawing operations and forwards them to a virtual onDraw() hook.
+class DrawHookDispatchHelper : public virtual DlOpReceiver {
  public:
-  void save() override {}
-  void saveLayer(const DlRect& bounds,
-                 const SaveLayerOptions options,
-                 const DlImageFilter* backdrop,
-                 std::optional<int64_t> backdrop_id) override {}
-  void restore() override {}
-  void drawColor(DlColor color, DlBlendMode mode) override {}
-  void drawPaint() override {}
-  void drawLine(const DlPoint& p0, const DlPoint& p1) override {}
+  virtual void onDraw() {}
+
+  void drawColor(DlColor color, DlBlendMode mode) override { onDraw(); }
+  void drawPaint() override { onDraw(); }
+  void drawLine(const DlPoint& p0, const DlPoint& p1) override { onDraw(); }
   void drawDashedLine(const DlPoint& p0,
                       const DlPoint& p1,
                       DlScalar on_length,
-                      DlScalar off_length) override {}
-  void drawRect(const DlRect& rect) override {}
-  void drawOval(const DlRect& bounds) override {}
-  void drawCircle(const DlPoint& center, DlScalar radius) override {}
-  void drawRoundRect(const DlRoundRect& rrect) override {}
+                      DlScalar off_length) override {
+    onDraw();
+  }
+  void drawRect(const DlRect& rect) override { onDraw(); }
+  void drawOval(const DlRect& bounds) override { onDraw(); }
+  void drawCircle(const DlPoint& center, DlScalar radius) override { onDraw(); }
+  void drawRoundRect(const DlRoundRect& rrect) override { onDraw(); }
   void drawDiffRoundRect(const DlRoundRect& outer,
-                         const DlRoundRect& inner) override {}
-  void drawRoundSuperellipse(const DlRoundSuperellipse& rse) override {}
-  void drawPath(const DlPath& path) override {}
+                         const DlRoundRect& inner) override {
+    onDraw();
+  }
+  void drawRoundSuperellipse(const DlRoundSuperellipse& rse) override {
+    onDraw();
+  }
+  void drawPath(const DlPath& path) override { onDraw(); }
   void drawArc(const DlRect& oval_bounds,
                DlScalar start_degrees,
                DlScalar sweep_degrees,
-               bool use_center) override {}
+               bool use_center) override {
+    onDraw();
+  }
   void drawPoints(DlPointMode mode,
                   uint32_t count,
-                  const DlPoint points[]) override {}
+                  const DlPoint points[]) override {
+    onDraw();
+  }
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
-                    DlBlendMode mode) override {}
+                    DlBlendMode mode) override {
+    onDraw();
+  }
   void drawImage(const sk_sp<DlImage> image,
                  const DlPoint& point,
                  DlImageSampling sampling,
-                 bool render_with_attributes) override {}
+                 bool render_with_attributes) override {
+    onDraw();
+  }
   void drawImageRect(const sk_sp<DlImage> image,
                      const DlRect& src,
                      const DlRect& dst,
                      DlImageSampling sampling,
                      bool render_with_attributes,
-                     DlSrcRectConstraint constraint) override {}
+                     DlSrcRectConstraint constraint) override {
+    onDraw();
+  }
   void drawImageNine(const sk_sp<DlImage> image,
                      const DlIRect& center,
                      const DlRect& dst,
                      DlFilterMode filter,
-                     bool render_with_attributes) override {}
+                     bool render_with_attributes) override {
+    onDraw();
+  }
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const DlRSTransform xform[],
                  const DlRect tex[],
@@ -129,17 +150,38 @@ class IgnoreDrawDispatchHelper : public virtual DlOpReceiver {
                  DlBlendMode mode,
                  DlImageSampling sampling,
                  const DlRect* cull_rect,
-                 bool render_with_attributes) override {}
+                 bool render_with_attributes) override {
+    onDraw();
+  }
   void drawDisplayList(const sk_sp<DisplayList> display_list,
-                       DlScalar opacity) override {}
+                       DlScalar opacity) override {
+    onDraw();
+  }
   void drawText(const std::shared_ptr<DlText>& text,
                 DlScalar x,
-                DlScalar y) override {}
+                DlScalar y) override {
+    onDraw();
+  }
   void drawShadow(const DlPath& path,
                   const DlColor color,
                   const DlScalar elevation,
                   bool transparent_occluder,
-                  DlScalar dpr) override {}
+                  DlScalar dpr) override {
+    onDraw();
+  }
+};
+
+// A utility class that will ignore all DlOpReceiver methods relating
+// to rendering/drawing operations and canvas save/restore/saveLayer stack
+// management.
+class IgnoreDrawDispatchHelper : public virtual DrawHookDispatchHelper {
+ public:
+  void save() override {}
+  void saveLayer(const DlRect& bounds,
+                 const SaveLayerOptions options,
+                 const DlImageFilter* backdrop,
+                 std::optional<int64_t> backdrop_id) override {}
+  void restore() override {}
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/display_list/utils/dl_receiver_utils.h
+++ b/engine/src/flutter/display_list/utils/dl_receiver_utils.h
@@ -79,6 +79,77 @@ class IgnoreTransformDispatchHelper : public virtual DlOpReceiver {
   void transformReset() override {}
 };
 
+// A utility class that will ignore all DlOpReceiver methods relating
+// to rendering/drawing operations and canvas save/restore/saveLayer stack
+// management.
+class IgnoreDrawDispatchHelper : public virtual DlOpReceiver {
+ public:
+  void save() override {}
+  void saveLayer(const DlRect& bounds,
+                 const SaveLayerOptions options,
+                 const DlImageFilter* backdrop,
+                 std::optional<int64_t> backdrop_id) override {}
+  void restore() override {}
+  void drawColor(DlColor color, DlBlendMode mode) override {}
+  void drawPaint() override {}
+  void drawLine(const DlPoint& p0, const DlPoint& p1) override {}
+  void drawDashedLine(const DlPoint& p0,
+                      const DlPoint& p1,
+                      DlScalar on_length,
+                      DlScalar off_length) override {}
+  void drawRect(const DlRect& rect) override {}
+  void drawOval(const DlRect& bounds) override {}
+  void drawCircle(const DlPoint& center, DlScalar radius) override {}
+  void drawRoundRect(const DlRoundRect& rrect) override {}
+  void drawDiffRoundRect(const DlRoundRect& outer,
+                         const DlRoundRect& inner) override {}
+  void drawRoundSuperellipse(const DlRoundSuperellipse& rse) override {}
+  void drawPath(const DlPath& path) override {}
+  void drawArc(const DlRect& oval_bounds,
+               DlScalar start_degrees,
+               DlScalar sweep_degrees,
+               bool use_center) override {}
+  void drawPoints(DlPointMode mode,
+                  uint32_t count,
+                  const DlPoint points[]) override {}
+  void drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                    DlBlendMode mode) override {}
+  void drawImage(const sk_sp<DlImage> image,
+                 const DlPoint& point,
+                 DlImageSampling sampling,
+                 bool render_with_attributes) override {}
+  void drawImageRect(const sk_sp<DlImage> image,
+                     const DlRect& src,
+                     const DlRect& dst,
+                     DlImageSampling sampling,
+                     bool render_with_attributes,
+                     DlSrcRectConstraint constraint) override {}
+  void drawImageNine(const sk_sp<DlImage> image,
+                     const DlIRect& center,
+                     const DlRect& dst,
+                     DlFilterMode filter,
+                     bool render_with_attributes) override {}
+  void drawAtlas(const sk_sp<DlImage> atlas,
+                 const DlRSTransform xform[],
+                 const DlRect tex[],
+                 const DlColor colors[],
+                 int count,
+                 DlBlendMode mode,
+                 DlImageSampling sampling,
+                 const DlRect* cull_rect,
+                 bool render_with_attributes) override {}
+  void drawDisplayList(const sk_sp<DisplayList> display_list,
+                       DlScalar opacity) override {}
+  void drawText(const std::shared_ptr<DlText>& text,
+                DlScalar x,
+                DlScalar y) override {}
+  void drawShadow(const DlPath& path,
+                  const DlColor color,
+                  const DlScalar elevation,
+                  bool transparent_occluder,
+                  DlScalar dpr) override {}
+};
+
 // A utility class that intercepts all DlOpReceiver methods relating
 // to rendering/drawing operations and forwards them to a virtual onDraw() hook.
 class DrawHookDispatchHelper : public virtual DlOpReceiver {
@@ -169,19 +240,6 @@ class DrawHookDispatchHelper : public virtual DlOpReceiver {
                   DlScalar dpr) override {
     onDraw();
   }
-};
-
-// A utility class that will ignore all DlOpReceiver methods relating
-// to rendering/drawing operations and canvas save/restore/saveLayer stack
-// management.
-class IgnoreDrawDispatchHelper : public virtual DrawHookDispatchHelper {
- public:
-  void save() override {}
-  void saveLayer(const DlRect& bounds,
-                 const SaveLayerOptions options,
-                 const DlImageFilter* backdrop,
-                 std::optional<int64_t> backdrop_id) override {}
-  void restore() override {}
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -1909,6 +1909,11 @@ void Canvas::SaveLayer(const Paint& paint,
   std::shared_ptr<FilterContents> backdrop_filter_contents;
   Point local_position = Point(0, 0);
   if (backdrop_filter) {
+    if (!backdrop_id.has_value() && !generated_backdrop_ids_.empty()) {
+      backdrop_id = generated_backdrop_ids_.front();
+      generated_backdrop_ids_.pop_front();
+    }
+
     local_position = subpass_coverage.GetOrigin() - GetGlobalPassPosition();
 
     std::shared_ptr<Texture> input_texture;
@@ -2528,9 +2533,11 @@ RenderPass& Canvas::GetCurrentRenderPass() const {
 
 void Canvas::SetBackdropData(
     std::unordered_map<int64_t, BackdropData> backdrop_data,
-    size_t backdrop_count) {
+    size_t backdrop_count,
+    std::deque<int64_t> generated_backdrop_ids) {
   backdrop_data_ = std::move(backdrop_data);
   backdrop_count_ = backdrop_count;
+  generated_backdrop_ids_ = std::move(generated_backdrop_ids);
 }
 
 std::shared_ptr<Texture> Canvas::FlipBackdrop(Point global_pass_position,
@@ -2731,6 +2738,7 @@ void Canvas::EndReplay() {
   render_passes_.back().GetInlinePassContext()->EndPass(
       /*is_onscreen=*/!requires_readback_ && is_onscreen_);
   backdrop_data_.clear();
+  generated_backdrop_ids_.clear();
 
   // If requires_readback_ was true, then we rendered to an offscreen texture
   // instead of to the onscreen provided in the render target. Now we need to

--- a/engine/src/flutter/impeller/display_list/canvas.h
+++ b/engine/src/flutter/impeller/display_list/canvas.h
@@ -145,7 +145,8 @@ class Canvas {
   /// @brief Update the backdrop data used to group together backdrop filters
   ///        within the same layer
   void SetBackdropData(std::unordered_map<int64_t, BackdropData> backdrop_data,
-                       size_t backdrop_count);
+                       size_t backdrop_count,
+                       std::deque<int64_t> generated_backdrop_ids = {});
 
   const std::unordered_map<int64_t, BackdropData>& GetBackdropData() const {
     return backdrop_data_;
@@ -330,6 +331,11 @@ class Canvas {
   /// This optimization is disabled on devices that do not support framebuffer
   /// fetch (iOS Simulator and certain OpenGLES devices).
   size_t backdrop_count_ = 0u;
+
+  /// Ordered queue of synthesized backdrop group IDs collected during display
+  /// list preprocessing. Consumed in sequence by [SaveLayer] when a backdrop
+  /// filter does not specify an explicit backdrop ID.
+  std::deque<int64_t> generated_backdrop_ids_;
 
   // All geometry objects created for regular draws can be stack allocated,
   // but clip geometries must be cached for record/replay for backdrop filters

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -971,8 +971,10 @@ void CanvasDlDispatcher::drawVertices(
 
 void CanvasDlDispatcher::SetBackdropData(
     std::unordered_map<int64_t, BackdropData> backdrop,
-    size_t backdrop_count) {
-  GetCanvas().SetBackdropData(std::move(backdrop), backdrop_count);
+    size_t backdrop_count,
+    std::deque<int64_t> generated_backdrop_ids) {
+  GetCanvas().SetBackdropData(std::move(backdrop), backdrop_count,
+                              std::move(generated_backdrop_ids));
 }
 
 //// Text Frame Dispatcher
@@ -992,7 +994,10 @@ FirstPassDispatcher::~FirstPassDispatcher() {
 }
 
 void FirstPassDispatcher::save() {
-  stack_.push_back(stack_.back());
+  stack_.push_back(SaveFrame{
+      .matrix = stack_.back().matrix,
+      .cull_rect = stack_.back().cull_rect,
+  });
 }
 
 namespace {
@@ -1029,6 +1034,7 @@ void FirstPassDispatcher::saveLayer(const DlRect& bounds,
   SaveFrame frame = {
       .matrix = stack_.back().matrix,
       .cull_rect = stack_.back().cull_rect,
+      .is_save_layer = true,
   };
 
   const bool has_layer_bounds =
@@ -1036,7 +1042,34 @@ void FirstPassDispatcher::saveLayer(const DlRect& bounds,
       (!bounds.IsEmpty() || options.bounds_from_caller());
 
   backdrop_count_ += (backdrop == nullptr ? 0 : 1);
-  if (backdrop != nullptr && backdrop_id.has_value()) {
+  if (backdrop != nullptr) {
+    if (backdrop_id.has_value()) {
+      // saveLayer called with an explicit backdrop_id. Invalidate any active
+      // generated backdrop group.
+      active_generated_backdrop_group_ = std::nullopt;
+    } else {
+      // saveLayer called with no explicit backdrop_id.
+      // The currently active backdrop group ID can be reused if:
+      // 1. There is a currently active generated backdrop group, and
+      // 2. This layer is at the same saveLayer depth as the active
+      //    backdrop group, and
+      // 3. The backdrop filter parameters are equal to the active group's.
+      // If these conditions are not all met, generate a new backdrop group.
+      if (!(active_generated_backdrop_group_.has_value() &&
+            active_generated_backdrop_group_->save_layer_depth ==
+                save_layer_depth_ &&
+            *active_generated_backdrop_group_->filter == *backdrop)) {
+        active_generated_backdrop_group_ = GeneratedBackdropGroup{
+            .id = --next_generated_backdrop_id_,
+            .save_layer_depth = save_layer_depth_,
+            .filter = backdrop->shared(),
+        };
+      }
+      backdrop_id = active_generated_backdrop_group_->id;
+      frame.is_generated_backdrop = true;
+      generated_backdrop_ids_.push_back(active_generated_backdrop_group_->id);
+    }
+
     Rect layer_coverage = frame.cull_rect;
     if (has_layer_bounds) {
       layer_coverage = layer_coverage.IntersectionOrEmpty(
@@ -1056,10 +1089,38 @@ void FirstPassDispatcher::saveLayer(const DlRect& bounds,
   }
 
   stack_.push_back(std::move(frame));
+  save_layer_depth_++;
 }
 
 void FirstPassDispatcher::restore() {
+  SaveFrame frame = stack_.back();
   stack_.pop_back();
+
+  if (frame.is_save_layer) {
+    save_layer_depth_--;
+    if (!frame.is_generated_backdrop) {
+      // Restoring a non-generated saveLayer (e.g. non-backdrop saveLayer or
+      // backdrop with an explicit ID) composites onto the parent canvas and
+      // invalidates the active generated backdrop group.
+      active_generated_backdrop_group_ = std::nullopt;
+    }
+    if (active_generated_backdrop_group_.has_value() &&
+        active_generated_backdrop_group_->save_layer_depth >
+            save_layer_depth_) {
+      // The parent layer of the active backdrop group was restored, so
+      // invalidate the active group.
+      active_generated_backdrop_group_ = std::nullopt;
+    }
+  }
+}
+
+void FirstPassDispatcher::onDraw() {
+  // Drawing on the current canvas mutates its backdrop and invalidates any
+  // active generated backdrop group at this saveLayer depth.
+  if (active_generated_backdrop_group_.has_value() &&
+      active_generated_backdrop_group_->save_layer_depth == save_layer_depth_) {
+    active_generated_backdrop_group_ = std::nullopt;
+  }
 }
 
 namespace {
@@ -1162,6 +1223,7 @@ void FirstPassDispatcher::transformReset() {
 void FirstPassDispatcher::drawText(const std::shared_ptr<flutter::DlText>& text,
                                    DlScalar x,
                                    DlScalar y) {
+  flutter::DrawHookDispatchHelper::drawText(text, x, y);
   GlyphProperties properties;
   auto text_frame = text->GetTextFrame();
   if (text_frame == nullptr) {
@@ -1287,11 +1349,12 @@ bool PixelFormatSupportsMSAA(std::optional<PixelFormat> pixel_format) {
 }
 }  // namespace
 
-std::pair<std::unordered_map<int64_t, BackdropData>, size_t>
+std::tuple<std::unordered_map<int64_t, BackdropData>,
+           size_t,
+           std::deque<int64_t>>
 FirstPassDispatcher::TakeBackdropData() {
-  std::unordered_map<int64_t, BackdropData> temp;
-  std::swap(temp, backdrop_data_);
-  return std::make_pair(temp, backdrop_count_);
+  return {std::move(backdrop_data_), backdrop_count_,
+          std::move(generated_backdrop_ids_)};
 }
 
 std::shared_ptr<Texture> DisplayListToTexture(
@@ -1356,8 +1419,9 @@ std::shared_ptr<Texture> DisplayListToTexture(
       display_list->max_root_blend_mode(),       //
       impeller::IRect32::MakeSize(size)          //
   );
-  const auto& [data, count] = collector.TakeBackdropData();
-  impeller_dispatcher.SetBackdropData(data, count);
+  const auto& [data, count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  impeller_dispatcher.SetBackdropData(data, count, generated_backdrop_ids);
   context.GetTextShadowCache().MarkFrameStart();
   fml::ScopedCleanupClosure cleanup([&] {
     if (reset_host_buffer) {
@@ -1404,8 +1468,9 @@ bool RenderToTarget(ContentContext& context,
       display_list->max_root_blend_mode(),       //
       IRect32::RoundOut(cull_rect)               //
   );
-  const auto& [data, count] = collector.TakeBackdropData();
-  impeller_dispatcher.SetBackdropData(data, count);
+  const auto& [data, count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  impeller_dispatcher.SetBackdropData(data, count, generated_backdrop_ids);
   context.GetTextShadowCache().MarkFrameStart();
   fml::ScopedCleanupClosure cleanup([&] {
     if (reset_host_buffer) {

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -12,6 +12,7 @@
 
 #include "display_list/dl_sampling_options.h"
 #include "display_list/effects/dl_image_filter.h"
+#include "display_list/effects/image_filters/dl_blur_image_filter.h"
 #include "flutter/fml/logging.h"
 #include "fml/closure.h"
 #include "impeller/core/formats.h"
@@ -1001,6 +1002,25 @@ void FirstPassDispatcher::save() {
 }
 
 namespace {
+bool CanShareBackdropId(const flutter::DlImageFilter* a,
+                        const flutter::DlImageFilter* b) {
+  if (a == b) {
+    return true;
+  }
+  if (a == nullptr || b == nullptr) {
+    return false;
+  }
+  if (a->type() == flutter::DlImageFilterType::kBlur &&
+      b->type() == flutter::DlImageFilterType::kBlur) {
+    const auto* blur_a = a->asBlur();
+    const auto* blur_b = b->asBlur();
+    return flutter::DlScalarNearlyEqual(blur_a->sigma_x(), blur_b->sigma_x()) &&
+           flutter::DlScalarNearlyEqual(blur_a->sigma_y(), blur_b->sigma_y()) &&
+           blur_a->tile_mode() == blur_b->tile_mode();
+  }
+  return *a == *b;
+}
+
 void RecordBackdropData(
     std::unordered_map<int64_t, BackdropData>* backdrop_data,
     int64_t backdrop_id,
@@ -1053,12 +1073,14 @@ void FirstPassDispatcher::saveLayer(const DlRect& bounds,
       // 1. There is a currently active generated backdrop group, and
       // 2. This layer is at the same saveLayer depth as the active
       //    backdrop group, and
-      // 3. The backdrop filter parameters are equal to the active group's.
+      // 3. The backdrop filter parameters are compatible with the active
+      //    group's (e.g. matching blur parameters even if local bounds differ).
       // If these conditions are not all met, generate a new backdrop group.
       if (!(active_generated_backdrop_group_.has_value() &&
             active_generated_backdrop_group_->save_layer_depth ==
                 save_layer_depth_ &&
-            *active_generated_backdrop_group_->filter == *backdrop)) {
+            CanShareBackdropId(active_generated_backdrop_group_->filter.get(),
+                               backdrop))) {
         active_generated_backdrop_group_ = GeneratedBackdropGroup{
             .id = --next_generated_backdrop_id_,
             .save_layer_depth = save_layer_depth_,
@@ -1088,7 +1110,7 @@ void FirstPassDispatcher::saveLayer(const DlRect& bounds,
         bounds.TransformBounds(frame.matrix));
   }
 
-  stack_.push_back(std::move(frame));
+  stack_.push_back(frame);
   save_layer_depth_++;
 }
 

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -980,17 +980,19 @@ void CanvasDlDispatcher::SetBackdropData(
 FirstPassDispatcher::FirstPassDispatcher(const ContentContext& renderer,
                                          const Matrix& initial_matrix,
                                          const Rect cull_rect)
-    : renderer_(renderer), matrix_(initial_matrix) {
-  cull_rect_state_.push_back(cull_rect);
+    : renderer_(renderer) {
+  stack_.push_back({
+      .matrix = initial_matrix,
+      .cull_rect = cull_rect,
+  });
 }
 
 FirstPassDispatcher::~FirstPassDispatcher() {
-  FML_DCHECK(cull_rect_state_.size() == 1);
+  FML_DCHECK(stack_.size() == 1);
 }
 
 void FirstPassDispatcher::save() {
-  stack_.emplace_back(matrix_);
-  cull_rect_state_.push_back(cull_rect_state_.back());
+  stack_.push_back(stack_.back());
 }
 
 namespace {
@@ -1024,7 +1026,10 @@ void FirstPassDispatcher::saveLayer(const DlRect& bounds,
                                     const flutter::SaveLayerOptions options,
                                     const flutter::DlImageFilter* backdrop,
                                     std::optional<int64_t> backdrop_id) {
-  save();
+  SaveFrame frame = {
+      .matrix = stack_.back().matrix,
+      .cull_rect = stack_.back().cull_rect,
+  };
 
   const bool has_layer_bounds =
       !bounds.IsMaximum() &&
@@ -1032,41 +1037,38 @@ void FirstPassDispatcher::saveLayer(const DlRect& bounds,
 
   backdrop_count_ += (backdrop == nullptr ? 0 : 1);
   if (backdrop != nullptr && backdrop_id.has_value()) {
-    Rect layer_coverage = cull_rect_state_.back();
+    Rect layer_coverage = frame.cull_rect;
     if (has_layer_bounds) {
-      layer_coverage =
-          layer_coverage.IntersectionOrEmpty(bounds.TransformBounds(matrix_));
+      layer_coverage = layer_coverage.IntersectionOrEmpty(
+          bounds.TransformBounds(frame.matrix));
     }
-    RecordBackdropData(&backdrop_data_, backdrop_id.value(), backdrop->shared(),
+    RecordBackdropData(&backdrop_data_, *backdrop_id, backdrop->shared(),
                        layer_coverage);
   }
 
   // This dispatcher does not track enough state to accurately compute
   // cull rects with image filters.
-  auto global_cull_rect = cull_rect_state_.back();
-  if (has_image_filter_ || global_cull_rect.IsMaximum()) {
-    cull_rect_state_.back() = Rect::MakeMaximum();
+  if (has_image_filter_ || frame.cull_rect.IsMaximum()) {
+    frame.cull_rect = Rect::MakeMaximum();
   } else if (has_layer_bounds) {
-    cull_rect_state_.back() =
-        global_cull_rect.IntersectionOrEmpty(bounds.TransformBounds(matrix_));
+    frame.cull_rect = frame.cull_rect.IntersectionOrEmpty(
+        bounds.TransformBounds(frame.matrix));
   }
+
+  stack_.push_back(std::move(frame));
 }
 
 void FirstPassDispatcher::restore() {
-  matrix_ = stack_.back();
   stack_.pop_back();
-  cull_rect_state_.pop_back();
 }
 
 namespace {
-void Clip(std::vector<Rect>& cull_rect_state,
-          const Matrix& matrix,
+void Clip(FirstPassDispatcher::SaveFrame& frame,
           const DlRect& bounds,
           flutter::DlClipOp clip_op) {
   if (clip_op == flutter::DlClipOp::kIntersect) {
-    auto global_rect = bounds.TransformBounds(matrix);
-    cull_rect_state.back() =
-        cull_rect_state.back().IntersectionOrEmpty(global_rect);
+    auto global_rect = bounds.TransformBounds(frame.matrix);
+    frame.cull_rect = frame.cull_rect.IntersectionOrEmpty(global_rect);
   }
 }
 }  // namespace
@@ -1075,51 +1077,52 @@ void Clip(std::vector<Rect>& cull_rect_state,
 void FirstPassDispatcher::clipRect(const DlRect& rect,
                                    flutter::DlClipOp clip_op,
                                    bool is_aa) {
-  Clip(cull_rect_state_, matrix_, rect, clip_op);
+  Clip(stack_.back(), rect, clip_op);
 }
 
 // |flutter::DlOpReceiver|
 void FirstPassDispatcher::clipOval(const DlRect& bounds,
                                    flutter::DlClipOp clip_op,
                                    bool is_aa) {
-  Clip(cull_rect_state_, matrix_, bounds, clip_op);
+  Clip(stack_.back(), bounds, clip_op);
 }
 
 // |flutter::DlOpReceiver|
 void FirstPassDispatcher::clipRoundRect(const DlRoundRect& rrect,
                                         flutter::DlClipOp clip_op,
                                         bool is_aa) {
-  Clip(cull_rect_state_, matrix_, rrect.GetBounds(), clip_op);
+  Clip(stack_.back(), rrect.GetBounds(), clip_op);
 }
 
 // |flutter::DlOpReceiver|
 void FirstPassDispatcher::clipPath(const DlPath& path,
                                    flutter::DlClipOp clip_op,
                                    bool is_aa) {
-  Clip(cull_rect_state_, matrix_, path.GetBounds(), clip_op);
+  Clip(stack_.back(), path.GetBounds(), clip_op);
 }
 
 // |flutter::DlOpReceiver|
 void FirstPassDispatcher::clipRoundSuperellipse(const DlRoundSuperellipse& rse,
                                                 flutter::DlClipOp clip_op,
                                                 bool is_aa) {
-  Clip(cull_rect_state_, matrix_, rse.GetBounds(), clip_op);
+  Clip(stack_.back(), rse.GetBounds(), clip_op);
 }
 
 void FirstPassDispatcher::translate(DlScalar tx, DlScalar ty) {
-  matrix_ = matrix_.Translate({tx, ty});
+  stack_.back().matrix = stack_.back().matrix.Translate({tx, ty});
 }
 
 void FirstPassDispatcher::scale(DlScalar sx, DlScalar sy) {
-  matrix_ = matrix_.Scale({sx, sy, 1.0f});
+  stack_.back().matrix = stack_.back().matrix.Scale({sx, sy, 1.0f});
 }
 
 void FirstPassDispatcher::rotate(DlScalar degrees) {
-  matrix_ = matrix_ * Matrix::MakeRotationZ(Degrees(degrees));
+  stack_.back().matrix =
+      stack_.back().matrix * Matrix::MakeRotationZ(Degrees(degrees));
 }
 
 void FirstPassDispatcher::skew(DlScalar sx, DlScalar sy) {
-  matrix_ = matrix_ * Matrix::MakeSkew(sx, sy);
+  stack_.back().matrix = stack_.back().matrix * Matrix::MakeSkew(sx, sy);
 }
 
 // clang-format off
@@ -1127,7 +1130,7 @@ void FirstPassDispatcher::skew(DlScalar sx, DlScalar sy) {
 void FirstPassDispatcher::transform2DAffine(
     DlScalar mxx, DlScalar mxy, DlScalar mxt,
     DlScalar myx, DlScalar myy, DlScalar myt) {
-  matrix_ = matrix_ * Matrix::MakeColumn(
+  stack_.back().matrix = stack_.back().matrix * Matrix::MakeColumn(
       mxx,  myx,  0.0f, 0.0f,
       mxy,  myy,  0.0f, 0.0f,
       0.0f, 0.0f, 1.0f, 0.0f,
@@ -1143,7 +1146,7 @@ void FirstPassDispatcher::transformFullPerspective(
     DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
     DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
     DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) {
-  matrix_ = matrix_ * Matrix::MakeColumn(
+  stack_.back().matrix = stack_.back().matrix * Matrix::MakeColumn(
       mxx, myx, mzx, mwx,
       mxy, myy, mzy, mwy,
       mxz, myz, mzz, mwz,
@@ -1153,7 +1156,7 @@ void FirstPassDispatcher::transformFullPerspective(
 // clang-format on
 
 void FirstPassDispatcher::transformReset() {
-  matrix_ = Matrix();
+  stack_.back().matrix = Matrix();
 }
 
 void FirstPassDispatcher::drawText(const std::shared_ptr<flutter::DlText>& text,
@@ -1175,17 +1178,17 @@ void FirstPassDispatcher::drawText(const std::shared_ptr<flutter::DlText>& text,
     properties.tone_or_color = GlyphProperties::ComputeTone(paint_.color);
   }
 
-  renderer_.GetLazyGlyphAtlas()->AddTextFrame(text_frame,   //
-                                              Point(x, y),  //
-                                              matrix_,      //
-                                              properties    //
+  renderer_.GetLazyGlyphAtlas()->AddTextFrame(text_frame,            //
+                                              Point(x, y),           //
+                                              stack_.back().matrix,  //
+                                              properties             //
   );
 }
 
 const Rect FirstPassDispatcher::GetCurrentLocalCullingBounds() const {
-  auto cull_rect = cull_rect_state_.back();
+  auto cull_rect = stack_.back().cull_rect;
   if (!cull_rect.IsEmpty() && !cull_rect.IsMaximum()) {
-    Matrix inverse = matrix_.Invert();
+    Matrix inverse = stack_.back().matrix.Invert();
     cull_rect = cull_rect.TransformBounds(inverse);
   }
   return cull_rect;
@@ -1201,7 +1204,7 @@ void FirstPassDispatcher::drawDisplayList(
   bool old_has_image_filter = has_image_filter_;
   has_image_filter_ = false;
 
-  if (matrix_.HasPerspective()) {
+  if (stack_.back().matrix.HasPerspective()) {
     display_list->Dispatch(*this);
   } else {
     Rect local_cull_bounds = GetCurrentLocalCullingBounds();

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.cc
@@ -1098,18 +1098,20 @@ void FirstPassDispatcher::restore() {
 
   if (frame.is_save_layer) {
     save_layer_depth_--;
-    if (!frame.is_generated_backdrop) {
-      // Restoring a non-generated saveLayer (e.g. non-backdrop saveLayer or
-      // backdrop with an explicit ID) composites onto the parent canvas and
-      // invalidates the active generated backdrop group.
-      active_generated_backdrop_group_ = std::nullopt;
-    }
-    if (active_generated_backdrop_group_.has_value() &&
-        active_generated_backdrop_group_->save_layer_depth >
-            save_layer_depth_) {
-      // The parent layer of the active backdrop group was restored, so
-      // invalidate the active group.
-      active_generated_backdrop_group_ = std::nullopt;
+    if (active_generated_backdrop_group_.has_value()) {
+      if (active_generated_backdrop_group_->save_layer_depth >
+          save_layer_depth_) {
+        // The parent layer of the active backdrop group was restored, so
+        // invalidate the active group.
+        active_generated_backdrop_group_ = std::nullopt;
+      } else if (active_generated_backdrop_group_->save_layer_depth ==
+                     save_layer_depth_ &&
+                 !frame.is_generated_backdrop) {
+        // Restoring a non-generated saveLayer (e.g. non-backdrop saveLayer or
+        // backdrop with an explicit ID) composites onto the parent canvas and
+        // invalidates the active generated backdrop group at this depth.
+        active_generated_backdrop_group_ = std::nullopt;
+      }
     }
   }
 }

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.h
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.h
@@ -5,8 +5,10 @@
 #ifndef FLUTTER_IMPELLER_DISPLAY_LIST_DL_DISPATCHER_H_
 #define FLUTTER_IMPELLER_DISPLAY_LIST_DL_DISPATCHER_H_
 
+#include <deque>
 #include <map>
 #include <memory>
+#include <tuple>
 
 #include "flutter/display_list/dl_op_receiver.h"
 #include "flutter/display_list/geometry/dl_geometry_types.h"
@@ -318,7 +320,8 @@ class CanvasDlDispatcher : public DlDispatcherBase {
   ~CanvasDlDispatcher() = default;
 
   void SetBackdropData(std::unordered_map<int64_t, BackdropData> backdrop,
-                       size_t backdrop_count);
+                       size_t backdrop_count,
+                       std::deque<int64_t> generated_backdrop_ids = {});
 
   // |flutter::DlOpReceiver|
   void save() override {
@@ -357,12 +360,14 @@ class CanvasDlDispatcher : public DlDispatcherBase {
 /// that will be useful in a second pass by the CanvasDlDispatcher.
 /// This class collects things like text frames and backdrop filters.
 class FirstPassDispatcher : public flutter::IgnoreAttributeDispatchHelper,
-                            public flutter::IgnoreDrawDispatchHelper {
+                            public flutter::DrawHookDispatchHelper {
  public:
   struct SaveFrame {
     Matrix matrix;
     // Note: cull rects are always in the global coordinate space.
     Rect cull_rect;
+    bool is_save_layer = false;
+    bool is_generated_backdrop = false;
   };
 
   FirstPassDispatcher(const ContentContext& renderer,
@@ -379,6 +384,9 @@ class FirstPassDispatcher : public flutter::IgnoreAttributeDispatchHelper,
                  std::optional<int64_t> backdrop_id) override;
 
   void restore() override;
+
+  // |flutter::DrawHookDispatchHelper|
+  void onDraw() override;
 
   // |flutter::DlOpReceiver|
   void clipRect(const DlRect& rect,
@@ -458,15 +466,42 @@ class FirstPassDispatcher : public flutter::IgnoreAttributeDispatchHelper,
   // |flutter::DlOpReceiver|
   void setImageFilter(const flutter::DlImageFilter* filter) override;
 
-  std::pair<std::unordered_map<int64_t, BackdropData>, size_t>
+  std::tuple<std::unordered_map<int64_t, BackdropData>,
+             size_t,
+             std::deque<int64_t>>
   TakeBackdropData();
 
  private:
+  struct GeneratedBackdropGroup {
+    int64_t id;
+    size_t save_layer_depth;
+    std::shared_ptr<flutter::DlImageFilter> filter;
+  };
+
   const Rect GetCurrentLocalCullingBounds() const;
 
   const ContentContext& renderer_;
   std::vector<SaveFrame> stack_;
   std::unordered_map<int64_t, BackdropData> backdrop_data_;
+
+  // Automatic backdrop grouping state. Used to automatically synthesize
+  // backdrop IDs to group sibling backdrop layers that are not in explicit
+  // user-specified backdrop groups. Sibling backdrop layers with matching
+  // filter configurations and without an intervening draw mutation can share a
+  // generated backdrop group.
+
+  /// The active generated backdrop group, if one is currently active.
+  std::optional<GeneratedBackdropGroup> active_generated_backdrop_group_ =
+      std::nullopt;
+  /// Tracks the current saveLayer nesting depth.
+  size_t save_layer_depth_ = 0;
+  /// Monotonically decreasing negative counter for generating unique backdrop
+  /// IDs.
+  int64_t next_generated_backdrop_id_ = 0;
+  /// Synthesized backdrop IDs generated during display list preprocessing, in
+  /// encounter order.
+  std::deque<int64_t> generated_backdrop_ids_;
+
   bool has_image_filter_ = false;
   size_t backdrop_count_ = 0;
   Paint paint_;

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.h
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.h
@@ -486,7 +486,7 @@ class FirstPassDispatcher : public flutter::IgnoreAttributeDispatchHelper,
 
   // Automatic backdrop grouping state. Used to automatically synthesize
   // backdrop IDs to group sibling backdrop layers that are not in explicit
-  // user-specified backdrop groups. Sibling backdrop layers with matching
+  // user-specified backdrop groups. Sibling backdrop layers with compatible
   // filter configurations and without an intervening draw mutation can share a
   // generated backdrop group.
 

--- a/engine/src/flutter/impeller/display_list/dl_dispatcher.h
+++ b/engine/src/flutter/impeller/display_list/dl_dispatcher.h
@@ -359,6 +359,12 @@ class CanvasDlDispatcher : public DlDispatcherBase {
 class FirstPassDispatcher : public flutter::IgnoreAttributeDispatchHelper,
                             public flutter::IgnoreDrawDispatchHelper {
  public:
+  struct SaveFrame {
+    Matrix matrix;
+    // Note: cull rects are always in the global coordinate space.
+    Rect cull_rect;
+  };
+
   FirstPassDispatcher(const ContentContext& renderer,
                       const Matrix& initial_matrix,
                       const Rect cull_rect);
@@ -459,11 +465,8 @@ class FirstPassDispatcher : public flutter::IgnoreAttributeDispatchHelper,
   const Rect GetCurrentLocalCullingBounds() const;
 
   const ContentContext& renderer_;
-  Matrix matrix_;
-  std::vector<Matrix> stack_;
+  std::vector<SaveFrame> stack_;
   std::unordered_map<int64_t, BackdropData> backdrop_data_;
-  // note: cull rects are always in the global coordinate space.
-  std::vector<Rect> cull_rect_state_;
   bool has_image_filter_ = false;
   size_t backdrop_count_ = 0;
   Paint paint_;

--- a/engine/src/flutter/impeller/display_list/dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_unittests.cc
@@ -1749,7 +1749,8 @@ TEST_P(DisplayListTest, FirstPassDispatcherBackdropCoverageUnion) {
                                 Rect::MakeLTRB(0, 0, 1000, 1000));
   display_list->Dispatch(collector);
 
-  auto [backdrop_data, backdrop_count] = collector.TakeBackdropData();
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
   EXPECT_EQ(backdrop_count, 2u);
   auto it = backdrop_data.find(1);
   ASSERT_TRUE(it != backdrop_data.end());
@@ -1784,7 +1785,8 @@ TEST_P(DisplayListTest, FirstPassDispatcherBackdropCoverageUnionClippedOut) {
                                 Rect::MakeLTRB(0, 0, 1000, 1000));
   display_list->Dispatch(collector);
 
-  auto [backdrop_data, backdrop_count] = collector.TakeBackdropData();
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
   EXPECT_EQ(backdrop_count, 2u);
   auto it = backdrop_data.find(1);
   ASSERT_TRUE(it != backdrop_data.end());
@@ -1820,7 +1822,8 @@ TEST_P(DisplayListTest,
                                 Rect::MakeLTRB(0, 0, 1000, 1000));
   display_list->Dispatch(collector);
 
-  auto [backdrop_data, backdrop_count] = collector.TakeBackdropData();
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
   EXPECT_EQ(backdrop_count, 2u);
   auto it = backdrop_data.find(1);
   ASSERT_TRUE(it != backdrop_data.end());
@@ -1851,7 +1854,8 @@ TEST_P(DisplayListTest,
                                 Rect::MakeLTRB(0, 0, 1000, 1000));
   display_list->Dispatch(collector);
 
-  auto [backdrop_data, backdrop_count] = collector.TakeBackdropData();
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
   EXPECT_EQ(backdrop_count, 2u);
   auto it = backdrop_data.find(1);
   ASSERT_TRUE(it != backdrop_data.end());
@@ -1883,12 +1887,350 @@ TEST_P(DisplayListTest,
   collector.restore();
   collector.restore();
 
-  auto [backdrop_data, backdrop_count] = collector.TakeBackdropData();
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
   EXPECT_EQ(backdrop_count, 1u);
   auto it = backdrop_data.find(1);
   ASSERT_TRUE(it != backdrop_data.end());
   EXPECT_FALSE(it->second.coverage_union.IsEmpty());
   EXPECT_EQ(it->second.coverage_union, Rect::MakeLTRB(0, 0, 1000, 1000));
+}
+
+TEST_P(DisplayListTest, FirstPassDispatcherGeneratedBackdropGrouping) {
+  flutter::DisplayListBuilder builder;
+  auto blur =
+      flutter::DlImageFilter::MakeBlur(10, 10, flutter::DlTileMode::kClamp);
+  flutter::DlPaint save_paint;
+
+  // Sibling SaveLayer 1
+  builder.SaveLayer(DlRect::MakeLTRB(10, 20, 60, 80), &save_paint, blur.get());
+  builder.Restore();
+  // Sibling SaveLayer 2 with matching blur filter
+  builder.SaveLayer(DlRect::MakeLTRB(100, 120, 160, 180), &save_paint,
+                    blur.get());
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 2u);
+  EXPECT_EQ(generated_backdrop_ids.size(), 2u);
+  // Both sibling layers share the first generated backdrop ID (-1).
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  EXPECT_EQ(generated_backdrop_ids[1], -1);
+
+  auto it = backdrop_data.find(-1);
+  ASSERT_TRUE(it != backdrop_data.end());
+  EXPECT_EQ(it->second.backdrop_count, 2u);
+  EXPECT_TRUE(it->second.all_filters_equal);
+  EXPECT_EQ(it->second.coverage_union, Rect::MakeLTRB(10, 20, 160, 180));
+}
+
+TEST_P(DisplayListTest,
+       FirstPassDispatcherGeneratedBackdropNotGroupedWhenInterveningDraw) {
+  flutter::DisplayListBuilder builder;
+  auto blur =
+      flutter::DlImageFilter::MakeBlur(10, 10, flutter::DlTileMode::kClamp);
+  flutter::DlPaint save_paint;
+
+  // Sibling SaveLayer 1
+  builder.SaveLayer(DlRect::MakeLTRB(10, 20, 60, 80), &save_paint, blur.get());
+  builder.Restore();
+  // Intervening draw directly on the canvas invalidates active generated group
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 50, 50), flutter::DlPaint());
+  // Sibling SaveLayer 2
+  builder.SaveLayer(DlRect::MakeLTRB(100, 120, 160, 180), &save_paint,
+                    blur.get());
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 2u);
+  EXPECT_EQ(generated_backdrop_ids.size(), 2u);
+  // Due to intervening draw, layers receive distinct generated backdrop IDs.
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  EXPECT_EQ(generated_backdrop_ids[1], -2);
+
+  auto it1 = backdrop_data.find(-1);
+  ASSERT_TRUE(it1 != backdrop_data.end());
+  EXPECT_EQ(it1->second.backdrop_count, 1u);
+
+  auto it2 = backdrop_data.find(-2);
+  ASSERT_TRUE(it2 != backdrop_data.end());
+  EXPECT_EQ(it2->second.backdrop_count, 1u);
+}
+
+TEST_P(DisplayListTest,
+       FirstPassDispatcherGeneratedBackdropNotGroupedWhenDifferentFilters) {
+  flutter::DisplayListBuilder builder;
+  auto blur1 =
+      flutter::DlImageFilter::MakeBlur(10, 10, flutter::DlTileMode::kClamp);
+  auto blur2 =
+      flutter::DlImageFilter::MakeBlur(20, 20, flutter::DlTileMode::kClamp);
+  flutter::DlPaint save_paint;
+
+  // SaveLayer 1 with sigma 10
+  builder.SaveLayer(DlRect::MakeLTRB(10, 20, 60, 80), &save_paint, blur1.get());
+  builder.Restore();
+  // SaveLayer 2 with sigma 20
+  builder.SaveLayer(DlRect::MakeLTRB(100, 120, 160, 180), &save_paint,
+                    blur2.get());
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 2u);
+  EXPECT_EQ(generated_backdrop_ids.size(), 2u);
+  // Different filter parameters receive distinct generated backdrop IDs.
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  EXPECT_EQ(generated_backdrop_ids[1], -2);
+
+  auto it1 = backdrop_data.find(-1);
+  ASSERT_TRUE(it1 != backdrop_data.end());
+  EXPECT_EQ(it1->second.backdrop_count, 1u);
+
+  auto it2 = backdrop_data.find(-2);
+  ASSERT_TRUE(it2 != backdrop_data.end());
+  EXPECT_EQ(it2->second.backdrop_count, 1u);
+}
+
+TEST_P(DisplayListTest,
+       FirstPassDispatcherGeneratedBackdropNestedSiblingsAndScopeReset) {
+  flutter::DisplayListBuilder builder;
+  auto blur_parent =
+      flutter::DlImageFilter::MakeBlur(10, 10, flutter::DlTileMode::kClamp);
+  auto blur_child =
+      flutter::DlImageFilter::MakeBlur(20, 20, flutter::DlTileMode::kClamp);
+  flutter::DlPaint save_paint;
+
+  // 1. Parent SaveLayer (Blur 10)
+  builder.SaveLayer(DlRect::MakeLTRB(0, 0, 500, 500), &save_paint,
+                    blur_parent.get());
+
+  // 2. Child Layer 1 (Blur 20) inside Parent Layer
+  builder.SaveLayer(DlRect::MakeLTRB(10, 10, 100, 100), &save_paint,
+                    blur_child.get());
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 100, 100), flutter::DlPaint());
+  builder.Restore();
+
+  // 3. Child Layer 2 (Blur 20) inside Parent Layer - Sibling of Child Layer 1
+  builder.SaveLayer(DlRect::MakeLTRB(120, 10, 210, 100), &save_paint,
+                    blur_child.get());
+  builder.DrawRect(DlRect::MakeLTRB(120, 10, 210, 100), flutter::DlPaint());
+  builder.Restore();
+
+  // 4. Parent SaveLayer finishes and restores
+  builder.Restore();
+
+  // 5. Root-level SaveLayer (Blur 20) - after Parent SaveLayer restored
+  builder.SaveLayer(DlRect::MakeLTRB(250, 10, 350, 100), &save_paint,
+                    blur_child.get());
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 4u);
+  EXPECT_EQ(generated_backdrop_ids.size(), 4u);
+
+  // Parent Layer gets -1
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  // Child Layer 1 and Child Layer 2 are siblings inside Parent Layer and share
+  // -2
+  EXPECT_EQ(generated_backdrop_ids[1], -2);
+  EXPECT_EQ(generated_backdrop_ids[2], -2);
+  // Root Layer gets -3 because Parent Layer restored and reset the group scope
+  EXPECT_EQ(generated_backdrop_ids[3], -3);
+
+  auto it_parent = backdrop_data.find(-1);
+  ASSERT_TRUE(it_parent != backdrop_data.end());
+  EXPECT_EQ(it_parent->second.backdrop_count, 1u);
+
+  auto it_child = backdrop_data.find(-2);
+  ASSERT_TRUE(it_child != backdrop_data.end());
+  EXPECT_EQ(it_child->second.backdrop_count, 2u);
+
+  auto it_root = backdrop_data.find(-3);
+  ASSERT_TRUE(it_root != backdrop_data.end());
+  EXPECT_EQ(it_root->second.backdrop_count, 1u);
+}
+
+TEST_P(DisplayListTest,
+       FirstPassDispatcherGeneratedBackdropInterleavedExplicitBackdrop) {
+  flutter::DisplayListBuilder builder;
+  auto blur =
+      flutter::DlImageFilter::MakeBlur(10, 10, flutter::DlTileMode::kClamp);
+  flutter::DlPaint save_paint;
+
+  // 1. Enclosing explicit backdrop layer (Blur 10, explicit ID 100)
+  builder.SaveLayer(DlRect::MakeLTRB(0, 0, 500, 500), &save_paint, blur.get(),
+                    /*backdrop_id=*/100);
+
+  // 2. Child Auto SaveLayer 1 inside Explicit Layer (Blur 10, generated ID)
+  builder.SaveLayer(DlRect::MakeLTRB(10, 10, 100, 100), &save_paint,
+                    blur.get());
+  builder.Restore();
+
+  // 3. Child Auto SaveLayer 2 inside Explicit Layer (Blur 10, generated ID)
+  builder.SaveLayer(DlRect::MakeLTRB(120, 10, 210, 100), &save_paint,
+                    blur.get());
+  builder.Restore();
+
+  // 4. Enclosing explicit backdrop layer restores
+  builder.Restore();
+
+  // 5. Root Auto SaveLayer 3 (Blur 10, generated ID)
+  builder.SaveLayer(DlRect::MakeLTRB(250, 10, 350, 100), &save_paint,
+                    blur.get());
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 4u);
+  // generated_backdrop_ids only collects entries for generated backdrops (3
+  // generated backdrops total)
+  EXPECT_EQ(generated_backdrop_ids.size(), 3u);
+
+  // Child 1 and Child 2 are siblings and share generated ID -1
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  EXPECT_EQ(generated_backdrop_ids[1], -1);
+  // Root Auto Layer 3 gets -2 because explicit layer restored and reset scope
+  EXPECT_EQ(generated_backdrop_ids[2], -2);
+
+  auto it_auto1 = backdrop_data.find(-1);
+  ASSERT_TRUE(it_auto1 != backdrop_data.end());
+  EXPECT_EQ(it_auto1->second.backdrop_count, 2u);
+
+  auto it_auto2 = backdrop_data.find(-2);
+  ASSERT_TRUE(it_auto2 != backdrop_data.end());
+  EXPECT_EQ(it_auto2->second.backdrop_count, 1u);
+
+  auto it_explicit = backdrop_data.find(100);
+  ASSERT_TRUE(it_explicit != backdrop_data.end());
+  EXPECT_EQ(it_explicit->second.backdrop_count, 1u);
+}
+
+TEST_P(DisplayListTest,
+       FirstPassDispatcherGeneratedBackdropNestedInterveningDrawOnParent) {
+  flutter::DisplayListBuilder builder;
+  auto blur_parent =
+      flutter::DlImageFilter::MakeBlur(10, 10, flutter::DlTileMode::kClamp);
+  auto blur_child =
+      flutter::DlImageFilter::MakeBlur(20, 20, flutter::DlTileMode::kClamp);
+  flutter::DlPaint save_paint;
+
+  // 1. Parent Layer (Blur 10)
+  builder.SaveLayer(DlRect::MakeLTRB(0, 0, 500, 500), &save_paint,
+                    blur_parent.get());
+
+  // 2. Child Layer 1 (Blur 20)
+  builder.SaveLayer(DlRect::MakeLTRB(10, 10, 100, 100), &save_paint,
+                    blur_child.get());
+  builder.Restore();
+
+  // 3. Draw on Parent Layer (mutates canvas between child 1 and child 2)
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 100, 100), flutter::DlPaint());
+
+  // 4. Child Layer 2 (Blur 20) inside Parent Layer
+  builder.SaveLayer(DlRect::MakeLTRB(120, 10, 210, 100), &save_paint,
+                    blur_child.get());
+  builder.Restore();
+
+  // 5. Parent Layer finishes and restores
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 3u);
+  EXPECT_EQ(generated_backdrop_ids.size(), 3u);
+
+  // Parent Layer gets -1
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  // Child 1 gets -2
+  EXPECT_EQ(generated_backdrop_ids[1], -2);
+  // Child 2 gets -3 because the intervening draw on the parent layer
+  // invalidated group -2
+  EXPECT_EQ(generated_backdrop_ids[2], -3);
+
+  auto it1 = backdrop_data.find(-1);
+  ASSERT_TRUE(it1 != backdrop_data.end());
+  EXPECT_EQ(it1->second.backdrop_count, 1u);
+
+  auto it2 = backdrop_data.find(-2);
+  ASSERT_TRUE(it2 != backdrop_data.end());
+  EXPECT_EQ(it2->second.backdrop_count, 1u);
+
+  auto it3 = backdrop_data.find(-3);
+  ASSERT_TRUE(it3 != backdrop_data.end());
+  EXPECT_EQ(it3->second.backdrop_count, 1u);
+}
+
+TEST_P(
+    DisplayListTest,
+    FirstPassDispatcherGeneratedBackdropInternalSaveRestoreDoesNotInvalidate) {
+  flutter::DisplayListBuilder builder;
+  auto blur =
+      flutter::DlImageFilter::MakeBlur(10, 10, flutter::DlTileMode::kClamp);
+  flutter::DlPaint save_paint;
+
+  // 1. SaveLayer 1 with internal save() / restore() and draws inside
+  builder.SaveLayer(DlRect::MakeLTRB(0, 0, 100, 100), &save_paint, blur.get());
+  builder.Save();
+  builder.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), flutter::DlPaint());
+  builder.Restore();
+  builder.Restore();
+
+  // 2. SaveLayer 2 immediately following SaveLayer 1 with same filter
+  builder.SaveLayer(DlRect::MakeLTRB(120, 0, 220, 100), &save_paint,
+                    blur.get());
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 2u);
+  EXPECT_EQ(generated_backdrop_ids.size(), 2u);
+
+  // SaveLayer 1 and SaveLayer 2 both share -1 because the internal
+  // save()/draw occurred within SaveLayer 1's layer
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  EXPECT_EQ(generated_backdrop_ids[1], -1);
+
+  auto it = backdrop_data.find(-1);
+  ASSERT_TRUE(it != backdrop_data.end());
+  EXPECT_EQ(it->second.backdrop_count, 2u);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/display_list/dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_unittests.cc
@@ -2320,5 +2320,88 @@ TEST_P(
   EXPECT_EQ(it2->second.backdrop_count, 1u);
 }
 
+TEST_P(
+    DisplayListTest,
+    FirstPassDispatcherGeneratedBackdropBoundedBlursWithDifferentBoundsShareId) {
+  flutter::DisplayListBuilder builder;
+  auto blur1 = flutter::DlBlurImageFilter::Make(
+      10, 10, flutter::DlTileMode::kClamp, DlRect::MakeLTRB(0, 0, 100, 100));
+  auto blur2 = flutter::DlBlurImageFilter::Make(
+      10, 10, flutter::DlTileMode::kClamp, DlRect::MakeLTRB(120, 0, 220, 100));
+  flutter::DlPaint save_paint;
+
+  // Sibling SaveLayer 1 with bounded blur
+  builder.SaveLayer(DlRect::MakeLTRB(0, 0, 100, 100), &save_paint, blur1.get());
+  builder.Restore();
+
+  // Sibling SaveLayer 2 with bounded blur having different bounds
+  builder.SaveLayer(DlRect::MakeLTRB(120, 0, 220, 100), &save_paint,
+                    blur2.get());
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 2u);
+  EXPECT_EQ(generated_backdrop_ids.size(), 2u);
+
+  // Both bounded blur layers share the generated ID -1 because their sigma
+  // and tile mode match.
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  EXPECT_EQ(generated_backdrop_ids[1], -1);
+
+  auto it = backdrop_data.find(-1);
+  ASSERT_TRUE(it != backdrop_data.end());
+  EXPECT_EQ(it->second.backdrop_count, 2u);
+  // Bounds differ between blur1 and blur2, so all_filters_equal is false.
+  EXPECT_FALSE(it->second.all_filters_equal);
+  EXPECT_EQ(it->second.coverage_union, Rect::MakeLTRB(0, 0, 220, 100));
+}
+
+TEST_P(DisplayListTest,
+       FirstPassDispatcherGeneratedBackdropBoundedAndUnboundedBlursShareId) {
+  flutter::DisplayListBuilder builder;
+  auto blur_unbounded =
+      flutter::DlImageFilter::MakeBlur(10, 10, flutter::DlTileMode::kClamp);
+  auto blur_bounded = flutter::DlBlurImageFilter::Make(
+      10, 10, flutter::DlTileMode::kClamp, DlRect::MakeLTRB(120, 0, 220, 100));
+  flutter::DlPaint save_paint;
+
+  // Sibling SaveLayer 1 with unbounded blur
+  builder.SaveLayer(DlRect::MakeLTRB(0, 0, 100, 100), &save_paint,
+                    blur_unbounded.get());
+  builder.Restore();
+
+  // Sibling SaveLayer 2 with bounded blur
+  builder.SaveLayer(DlRect::MakeLTRB(120, 0, 220, 100), &save_paint,
+                    blur_bounded.get());
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 2u);
+  EXPECT_EQ(generated_backdrop_ids.size(), 2u);
+
+  // Both layers share generated ID -1 because blur parameters match.
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  EXPECT_EQ(generated_backdrop_ids[1], -1);
+
+  auto it = backdrop_data.find(-1);
+  ASSERT_TRUE(it != backdrop_data.end());
+  EXPECT_EQ(it->second.backdrop_count, 2u);
+  // Unbounded vs bounded blur filters are not equal.
+  EXPECT_FALSE(it->second.all_filters_equal);
+  EXPECT_EQ(it->second.coverage_union, Rect::MakeLTRB(0, 0, 220, 100));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/display_list/dl_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/dl_unittests.cc
@@ -2233,5 +2233,92 @@ TEST_P(
   EXPECT_EQ(it->second.backdrop_count, 2u);
 }
 
+TEST_P(
+    DisplayListTest,
+    FirstPassDispatcherGeneratedBackdropNestedNonBackdropSaveLayerDoesNotInvalidate) {
+  flutter::DisplayListBuilder builder;
+  auto blur =
+      flutter::DlImageFilter::MakeBlur(10, 10, flutter::DlTileMode::kClamp);
+  flutter::DlPaint save_paint;
+
+  // 1. Card 1 (Blur 10) with internal non-backdrop SaveLayer (e.g.
+  // clip/opacity)
+  builder.SaveLayer(DlRect::MakeLTRB(0, 0, 100, 100), &save_paint, blur.get());
+  builder.SaveLayer(DlRect::MakeLTRB(10, 10, 90, 90), &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 90, 90), flutter::DlPaint());
+  builder.Restore();  // restores inner non-backdrop SaveLayer
+  builder.Restore();  // restores Card 1
+
+  // 2. Card 2 (Blur 10) immediately following Card 1 at root level
+  builder.SaveLayer(DlRect::MakeLTRB(120, 0, 220, 100), &save_paint,
+                    blur.get());
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 2u);
+  EXPECT_EQ(generated_backdrop_ids.size(), 2u);
+
+  // Card 1 and Card 2 should share ID -1 because the nested non-backdrop
+  // SaveLayer only composited onto Card 1's layer, not the root canvas
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  EXPECT_EQ(generated_backdrop_ids[1], -1);
+
+  auto it = backdrop_data.find(-1);
+  ASSERT_TRUE(it != backdrop_data.end());
+  EXPECT_EQ(it->second.backdrop_count, 2u);
+}
+
+TEST_P(
+    DisplayListTest,
+    FirstPassDispatcherGeneratedBackdropInterveningNonBackdropSaveLayerInvalidates) {
+  flutter::DisplayListBuilder builder;
+  auto blur =
+      flutter::DlImageFilter::MakeBlur(10, 10, flutter::DlTileMode::kClamp);
+  flutter::DlPaint save_paint;
+
+  // 1. Card 1 (Blur 10) at root level
+  builder.SaveLayer(DlRect::MakeLTRB(0, 0, 100, 100), &save_paint, blur.get());
+  builder.Restore();
+
+  // 2. Intervening non-backdrop SaveLayer at root level
+  builder.SaveLayer(DlRect::MakeLTRB(50, 0, 150, 100), &save_paint);
+  builder.DrawRect(DlRect::MakeLTRB(50, 0, 150, 100), flutter::DlPaint());
+  builder.Restore();  // compositing this layer mutates the root canvas
+
+  // 3. Card 2 (Blur 10) at root level
+  builder.SaveLayer(DlRect::MakeLTRB(120, 0, 220, 100), &save_paint,
+                    blur.get());
+  builder.Restore();
+
+  auto display_list = builder.Build();
+  FirstPassDispatcher collector(GetContentContext(), Matrix(),
+                                Rect::MakeLTRB(0, 0, 1000, 1000));
+  display_list->Dispatch(collector);
+
+  auto [backdrop_data, backdrop_count, generated_backdrop_ids] =
+      collector.TakeBackdropData();
+  EXPECT_EQ(backdrop_count, 2u);
+  EXPECT_EQ(generated_backdrop_ids.size(), 2u);
+
+  // Card 1 gets -1 and Card 2 gets -2 because the intervening non-backdrop
+  // layer at root level composited onto the root canvas
+  EXPECT_EQ(generated_backdrop_ids[0], -1);
+  EXPECT_EQ(generated_backdrop_ids[1], -2);
+
+  auto it1 = backdrop_data.find(-1);
+  ASSERT_TRUE(it1 != backdrop_data.end());
+  EXPECT_EQ(it1->second.backdrop_count, 1u);
+
+  auto it2 = backdrop_data.find(-2);
+  ASSERT_TRUE(it2 != backdrop_data.end());
+  EXPECT_EQ(it2->second.backdrop_count, 1u);
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
This change automatically groups backdrop filter `SaveLayer`s in `FirstPassDispatcher`. When `saveLayer` is called without an explicit backdrop_id, a generated ID is assigned for the layer. Compatible sibling `saveLayer` calls will reuse generated backdrop IDs.

This PR includes https://github.com/flutter/flutter/pull/192594, which is no-op refactor that I factored out of this PR.

I only have a Windows virtual machine with no GPU to test this on.

Before:
```
=== Windows bounded BackdropFilter A/B/C/D/E/F/G/H comparison ===
mode=profile speed=800px/s order=A/B/C/D/E/F/G/H
A — scroll, ungrouped, unbounded | frames=55 fps=13.50 | ui p50/p95=2.237/3.246ms | raster p50/p90/p95/p99/max=19.154/194.493/199.454/203.735/203.808ms | raster_over_budget=55/55 (100.0%)
B — scroll, ungrouped, bounded | frames=55 fps=13.50 | ui p50/p95=2.195/2.793ms | raster p50/p90/p95/p99/max=18.654/191.071/193.694/202.903/207.869ms | raster_over_budget=55/55 (100.0%)
C — scroll, grouped, unbounded | frames=165 fps=41.00 | ui p50/p95=2.481/3.551ms | raster p50/p90/p95/p99/max=23.876/25.291/26.029/31.610/38.215ms | raster_over_budget=165/165 (100.0%)
D — scroll, grouped, bounded | frames=186 fps=46.25 | ui p50/p95=2.704/3.887ms | raster p50/p90/p95/p99/max=17.137/38.680/54.796/85.069/92.163ms | raster_over_budget=186/186 (100.0%)
E — translated, ungrouped, unbounded | frames=55 fps=13.50 | ui p50/p95=2.316/3.322ms | raster p50/p90/p95/p99/max=20.090/193.463/198.423/205.022/209.373ms | raster_over_budget=55/55 (100.0%)
F — translated, ungrouped, bounded | frames=56 fps=13.75 | ui p50/p95=2.428/3.492ms | raster p50/p90/p95/p99/max=20.097/189.802/192.267/197.408/200.413ms | raster_over_budget=56/56 (100.0%)
G — translated, grouped, unbounded | frames=167 fps=41.50 | ui p50/p95=2.619/3.430ms | raster p50/p90/p95/p99/max=23.903/25.055/26.068/34.341/38.036ms | raster_over_budget=167/167 (100.0%)
H — translated, grouped, bounded | frames=187 fps=46.50 | ui p50/p95=2.976/4.173ms | raster p50/p90/p95/p99/max=16.936/29.797/58.252/89.942/108.133ms | raster_over_budget=187/187 (100.0%)
================================================================
```

After:

```
=== Windows bounded BackdropFilter A/B/C/D/E/F/G/H comparison ===
mode=profile speed=800px/s order=A/B/C/D/E/F/G/H
A — scroll, ungrouped, unbounded | frames=162 fps=40.25 | ui p50/p95=2.388/3.204ms | raster p50/p90/p95/p99/max=24.486/26.126/26.512/28.065/28.367ms | raster_over_budget=162/162 (100.0%)
B — scroll, ungrouped, bounded | frames=181 fps=45.00 | ui p50/p95=2.857/4.064ms | raster p50/p90/p95/p99/max=17.208/29.842/73.951/90.301/94.384ms | raster_over_budget=181/181 (100.0%)
C — scroll, grouped, unbounded | frames=160 fps=39.75 | ui p50/p95=2.511/3.281ms | raster p50/p90/p95/p99/max=25.060/26.576/27.057/29.035/30.127ms | raster_over_budget=160/160 (100.0%)
D — scroll, grouped, bounded | frames=178 fps=44.25 | ui p50/p95=2.784/4.040ms | raster p50/p90/p95/p99/max=17.578/29.865/70.420/92.476/97.546ms | raster_over_budget=178/178 (100.0%)
E — translated, ungrouped, unbounded | frames=165 fps=41.00 | ui p50/p95=2.564/3.279ms | raster p50/p90/p95/p99/max=24.180/25.556/25.790/26.880/27.087ms | raster_over_budget=165/165 (100.0%)
F — translated, ungrouped, bounded | frames=182 fps=45.25 | ui p50/p95=2.876/4.082ms | raster p50/p90/p95/p99/max=17.482/28.497/68.912/89.556/93.816ms | raster_over_budget=182/182 (100.0%)
G — translated, grouped, unbounded | frames=162 fps=40.25 | ui p50/p95=2.544/3.354ms | raster p50/p90/p95/p99/max=24.514/25.977/26.413/27.196/28.575ms | raster_over_budget=162/162 (100.0%)
H — translated, grouped, bounded | frames=182 fps=45.25 | ui p50/p95=2.978/3.965ms | raster p50/p90/p95/p99/max=17.602/30.275/72.898/90.172/96.144ms | raster_over_budget=182/182 (100.0%)
================================================================
```

The ungrouped configurations now perform significantly better, specifically in their p90+ raster times. Their performance becomes on par with the grouped configurations.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
