### PR TITLE
[ios]disable user interaction for visual effect view

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -602,6 +602,9 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
         CGFloat blurRadius = (*iter)->GetFilterMutation().GetFilter().asBlur()->sigma_x();
         UIVisualEffectView* visualEffectView = [[UIVisualEffectView alloc]
             initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleLight]];
+        // The visual effect shouldn't swallow touches.
+        // See: https://github.com/flutter/flutter/issues/191203
+        visualEffectView.userInteractionEnabled = NO;
 
         // TODO(https://github.com/flutter/flutter/issues/179126)
         CGFloat cornerRadius = 0.0;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -616,6 +616,11 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
     }
   }
   XCTAssertEqual(numberOfExpectedVisualEffectView, 1u);
+
+  // The visual effect view shouldn't swallow touches.
+  // See: https://github.com/flutter/flutter/issues/191203
+  UIView* hitView = [childClippingView hitTest:CGPointMake(5, 5) withEvent:nil];
+  XCTAssertEqual(hitView, gMockPlatformView.superview);
 }
 
 - (void)testApplyBackdropFilterWithCorrectFrame {
@@ -1732,6 +1737,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertEqual(visualEffectView.layer.cornerRadius, radii.top_left.width);
   XCTAssertEqual(visualEffectView.layer.cornerCurve, kCACornerCurveCircular);
+  XCTAssertFalse(visualEffectView.userInteractionEnabled);
 }
 
 - (void)testApplyBackdropFilterRespectsClipRSuperellipse {
@@ -1810,6 +1816,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
 
   XCTAssertEqual(visualEffectView.layer.cornerRadius, radii.top_left.width);
   XCTAssertEqual(visualEffectView.layer.cornerCurve, kCACornerCurveContinuous);
+  XCTAssertFalse(visualEffectView.userInteractionEnabled);
 }
 
 - (void)testBackdropFilterVisualEffectSubviewBackgroundColor {
@@ -4909,6 +4916,7 @@ static UIGestureRecognizer* FindForwardingGestureRecognizer(UIView* view) {
                       expectedFrame:(CGRect)frame
                         inputRadius:(CGFloat)inputRadius {
   XCTAssertTrue(CGRectEqualToRect(visualEffectView.frame, frame));
+  XCTAssertFalse(visualEffectView.userInteractionEnabled);
   for (UIView* view in visualEffectView.subviews) {
     if (![NSStringFromClass([view class]) hasSuffix:@"BackdropView"]) {
       continue;


### PR DESCRIPTION
The visual effect view shouldn't be involved in any user interaction since it's visual only. 

Fixes https://github.com/flutter/flutter/issues/191203

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [ ] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
