### PR TITLE
Wrap routing in FocusScope in WidgetsApp.router

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1687,33 +1687,33 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
       );
     } else if (_usesNavigator) {
       assert(_navigator != null);
-      routing = FocusScope(
-        debugLabel: 'Navigator Scope',
-        autofocus: true,
-        child: Navigator(
-          clipBehavior: Clip.none,
-          restorationScopeId: 'nav',
-          key: _navigator,
-          initialRoute: _initialRouteName,
-          onGenerateRoute: _onGenerateRoute,
-          onGenerateInitialRoutes: widget.onGenerateInitialRoutes == null
-              ? Navigator.defaultGenerateInitialRoutes
-              : (NavigatorState navigator, String initialRouteName) {
-                  return widget.onGenerateInitialRoutes!(initialRouteName);
-                },
-          onUnknownRoute: _onUnknownRoute,
-          observers: widget.navigatorObservers!,
-          routeTraversalEdgeBehavior: kIsWeb
-              ? TraversalEdgeBehavior.leaveFlutterView
-              : TraversalEdgeBehavior.parentScope,
-          reportsRouteUpdateToEngine: true,
-        ),
+      routing = Navigator(
+        clipBehavior: Clip.none,
+        restorationScopeId: 'nav',
+        key: _navigator,
+        initialRoute: _initialRouteName,
+        onGenerateRoute: _onGenerateRoute,
+        onGenerateInitialRoutes: widget.onGenerateInitialRoutes == null
+            ? Navigator.defaultGenerateInitialRoutes
+            : (NavigatorState navigator, String initialRouteName) {
+                return widget.onGenerateInitialRoutes!(initialRouteName);
+              },
+        onUnknownRoute: _onUnknownRoute,
+        observers: widget.navigatorObservers!,
+        routeTraversalEdgeBehavior: kIsWeb
+            ? TraversalEdgeBehavior.leaveFlutterView
+            : TraversalEdgeBehavior.parentScope,
+        reportsRouteUpdateToEngine: true,
       );
     } else if (_usesRouterWithConfig) {
       routing = Router<Object>.withConfig(
         restorationScopeId: 'router',
         config: widget.routerConfig!,
       );
+    }
+
+    if (routing != null) {
+      routing = FocusScope(debugLabel: 'Navigator Scope', autofocus: true, child: routing);
     }
 
     Widget result;

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -806,7 +806,8 @@ class WidgetsApp extends StatefulWidget {
   /// [Localizations], consider [onGenerateTitle] instead.
   ///
   /// The [builder] callback is passed two arguments, the [BuildContext] (as
-  /// `context`) and a [Navigator] or [Router] widget (as `child`).
+  /// `context`) and a [FocusScope] widget enclosing the [Navigator] or [Router]
+  /// (as `child`).
   ///
   /// If no routes are provided to the regular [WidgetsApp] constructor using
   /// [home], [routes], [onGenerateRoute], or [onUnknownRoute], the `child` will

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -603,7 +603,88 @@ void main() {
       ),
     );
 
-    // FocusScope enclosing the routing introduces an explicit child semantics node.
+    // FocusScope's explicitChildNodes prevents WidgetsApp's Directionality from
+    // merging with the route's semantics node, ensuring the route remains an
+    // explicit child node even when it is the sole entry in the Navigator.
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  children: <TestSemantics>[
+                    TestSemantics(label: 'route content', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+        ignoreId: true,
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
+
+    // Inserting an overlay entry (such as Autocomplete options or a dialog) does
+    // not reparent the route's semantics node.
+    final entry = OverlayEntry(
+      builder: (BuildContext context) =>
+          const Text('overlay content', textDirection: TextDirection.ltr),
+    );
+    addTearDown(entry.remove);
+    delegate.navigatorKey.currentState!.overlay!.insert(entry);
+    await tester.pump();
+
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  children: <TestSemantics>[
+                    TestSemantics(label: 'route content', textDirection: TextDirection.ltr),
+                  ],
+                ),
+                TestSemantics(label: 'overlay content', textDirection: TextDirection.ltr),
+              ],
+            ),
+          ],
+        ),
+        ignoreId: true,
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
+
+    semantics.dispose();
+  });
+
+  testWidgets('WidgetsApp.router with routerConfig produces expected semantics tree structure', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final delegate = SimpleNavigatorRouterDelegate(
+      builder: (BuildContext context, RouteInformation information) {
+        return const Text('route content', textDirection: TextDirection.ltr);
+      },
+      onPopPage: (Route<Object?> route, Object? result, SimpleNavigatorRouterDelegate delegate) =>
+          true,
+    );
+    addTearDown(delegate.dispose);
+    delegate.routeInformation = RouteInformation(uri: Uri.parse('initial'));
+    final routerConfig = RouterConfig<RouteInformation>(routerDelegate: delegate);
+
+    await tester.pumpWidget(
+      WidgetsApp.router(routerConfig: routerConfig, color: const Color(0xFF123456)),
+    );
+
     expect(
       semantics,
       hasSemantics(

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -461,6 +461,82 @@ void main() {
     expect(find.text('/'), findsOneWidget);
   });
 
+  testWidgets('WidgetsApp.router wraps routing in FocusScope', (WidgetTester tester) async {
+    final delegate = SimpleNavigatorRouterDelegate(
+      builder: (BuildContext context, RouteInformation information) {
+        return Text(information.uri.toString());
+      },
+      onPopPage: (Route<Object?> route, Object? result, SimpleNavigatorRouterDelegate delegate) =>
+          true,
+    );
+    addTearDown(delegate.dispose);
+    await tester.pumpWidget(
+      WidgetsApp.router(
+        routeInformationParser: SimpleRouteInformationParser(),
+        routerDelegate: delegate,
+        color: const Color(0xFF123456),
+      ),
+    );
+
+    final Finder focusScopeFinder = find.byWidgetPredicate(
+      (Widget widget) => widget is FocusScope && widget.debugLabel == 'Navigator Scope',
+    );
+    expect(focusScopeFinder, findsOneWidget);
+
+    final FocusScope focusScope = tester.widget(focusScopeFinder);
+    expect(focusScope.autofocus, isTrue);
+  });
+
+  testWidgets('WidgetsApp.router with routerConfig wraps routing in FocusScope', (
+    WidgetTester tester,
+  ) async {
+    final delegate = SimpleNavigatorRouterDelegate(
+      builder: (BuildContext context, RouteInformation information) {
+        return Text(information.uri.toString());
+      },
+      onPopPage: (Route<Object?> route, Object? result, SimpleNavigatorRouterDelegate delegate) =>
+          true,
+    );
+    addTearDown(delegate.dispose);
+    delegate.routeInformation = RouteInformation(uri: Uri.parse('initial'));
+    final routerConfig = RouterConfig<RouteInformation>(routerDelegate: delegate);
+    await tester.pumpWidget(
+      WidgetsApp.router(routerConfig: routerConfig, color: const Color(0xFF123456)),
+    );
+
+    final Finder focusScopeFinder = find.byWidgetPredicate(
+      (Widget widget) => widget is FocusScope && widget.debugLabel == 'Navigator Scope',
+    );
+    expect(focusScopeFinder, findsOneWidget);
+
+    final FocusScope focusScope = tester.widget(focusScopeFinder);
+    expect(focusScope.autofocus, isTrue);
+  });
+
+  testWidgets('WidgetsApp wraps navigator in FocusScope', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: const Color(0xFF123456),
+        pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) {
+          return PageRouteBuilder<T>(
+            settings: settings,
+            pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) =>
+                builder(context),
+          );
+        },
+        home: const Placeholder(),
+      ),
+    );
+
+    final Finder focusScopeFinder = find.byWidgetPredicate(
+      (Widget widget) => widget is FocusScope && widget.debugLabel == 'Navigator Scope',
+    );
+    expect(focusScopeFinder, findsOneWidget);
+
+    final FocusScope focusScope = tester.widget(focusScopeFinder);
+    expect(focusScope.autofocus, isTrue);
+  });
+
   testWidgets('WidgetsApp has correct default ScrollBehavior', (WidgetTester tester) async {
     late BuildContext capturedContext;
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'semantics_tester.dart';
 import 'test_page_tester.dart';
 
 class TestIntent extends Intent {
@@ -579,6 +580,98 @@ void main() {
     final focusScope = capturedChild! as FocusScope;
     expect(focusScope.debugLabel, 'Navigator Scope');
     expect(focusScope.child, isA<Router<Object>>());
+  });
+
+  testWidgets('WidgetsApp.router produces expected semantics tree structure', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final delegate = SimpleNavigatorRouterDelegate(
+      builder: (BuildContext context, RouteInformation information) {
+        return const Text('route content', textDirection: TextDirection.ltr);
+      },
+      onPopPage: (Route<Object?> route, Object? result, SimpleNavigatorRouterDelegate delegate) =>
+          true,
+    );
+    addTearDown(delegate.dispose);
+
+    await tester.pumpWidget(
+      WidgetsApp.router(
+        routeInformationParser: SimpleRouteInformationParser(),
+        routerDelegate: delegate,
+        color: const Color(0xFF123456),
+      ),
+    );
+
+    // FocusScope enclosing the routing introduces an explicit child semantics node.
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  children: <TestSemantics>[
+                    TestSemantics(label: 'route content', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+        ignoreId: true,
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
+
+    semantics.dispose();
+  });
+
+  testWidgets('WidgetsApp with navigator produces expected semantics tree structure', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: const Color(0xFF123456),
+        pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) {
+          return PageRouteBuilder<T>(
+            settings: settings,
+            pageBuilder: (BuildContext context, Animation<double> _, Animation<double> _) =>
+                builder(context),
+          );
+        },
+        home: const Text('route content', textDirection: TextDirection.ltr),
+      ),
+    );
+
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  children: <TestSemantics>[
+                    TestSemantics(label: 'route content', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+        ignoreId: true,
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
+
+    semantics.dispose();
   });
 
   testWidgets('WidgetsApp has correct default ScrollBehavior', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -485,6 +485,11 @@ void main() {
 
     final FocusScope focusScope = tester.widget(focusScopeFinder);
     expect(focusScope.autofocus, isTrue);
+    expect(focusScope.child, isA<Router<Object>>());
+    expect(
+      delegate.navigatorKey.currentState!.focusNode.enclosingScope?.debugLabel,
+      'Navigator Scope',
+    );
   });
 
   testWidgets('WidgetsApp.router with routerConfig wraps routing in FocusScope', (
@@ -511,11 +516,18 @@ void main() {
 
     final FocusScope focusScope = tester.widget(focusScopeFinder);
     expect(focusScope.autofocus, isTrue);
+    expect(focusScope.child, isA<Router<Object>>());
+    expect(
+      delegate.navigatorKey.currentState!.focusNode.enclosingScope?.debugLabel,
+      'Navigator Scope',
+    );
   });
 
   testWidgets('WidgetsApp wraps navigator in FocusScope', (WidgetTester tester) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
     await tester.pumpWidget(
       WidgetsApp(
+        navigatorKey: navigatorKey,
         color: const Color(0xFF123456),
         pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) {
           return PageRouteBuilder<T>(
@@ -535,6 +547,38 @@ void main() {
 
     final FocusScope focusScope = tester.widget(focusScopeFinder);
     expect(focusScope.autofocus, isTrue);
+    expect(focusScope.child, isA<Navigator>());
+    expect(navigatorKey.currentState!.focusNode.enclosingScope?.debugLabel, 'Navigator Scope');
+  });
+
+  testWidgets('WidgetsApp.router passes FocusScope as child to builder', (
+    WidgetTester tester,
+  ) async {
+    final delegate = SimpleNavigatorRouterDelegate(
+      builder: (BuildContext context, RouteInformation information) {
+        return Text(information.uri.toString());
+      },
+      onPopPage: (Route<Object?> route, Object? result, SimpleNavigatorRouterDelegate delegate) =>
+          true,
+    );
+    addTearDown(delegate.dispose);
+    Widget? capturedChild;
+    await tester.pumpWidget(
+      WidgetsApp.router(
+        routeInformationParser: SimpleRouteInformationParser(),
+        routerDelegate: delegate,
+        builder: (BuildContext context, Widget? child) {
+          capturedChild = child;
+          return child!;
+        },
+        color: const Color(0xFF123456),
+      ),
+    );
+
+    expect(capturedChild, isA<FocusScope>());
+    final focusScope = capturedChild! as FocusScope;
+    expect(focusScope.debugLabel, 'Navigator Scope');
+    expect(focusScope.child, isA<Router<Object>>());
   });
 
   testWidgets('WidgetsApp has correct default ScrollBehavior', (WidgetTester tester) async {


### PR DESCRIPTION
In #109702, Navigator's internal `FocusScopeNode` was removed and hoisted into `WidgetsApp`, but only inside the `else if (_usesNavigator)` branch. As a result, apps using `WidgetsApp.router` (including `MaterialApp.router` and `CupertinoApp.router` with `RouterConfig` or `RouterDelegate`) lacked the enclosing `FocusScope(debugLabel: 'Navigator Scope', autofocus: true)`.

On Flutter Web with semantics enabled (`ensureSemantics()`), when widgets such as `Autocomplete` show an `OverlayPortal`, the semantics compiler reparents the route node under a newly synthesized container node. Without an enclosing `FocusScope`, moving the route's semantics node detaches it from its previous DOM parent, triggering a native browser blur event on any focused `<input>`. The text field loses focus immediately after typing a single character, causing the options overlay to dismiss.

This change wraps `routing` in `FocusScope` whenever `routing != null` in `WidgetsApp`, ensuring consistent focus scope hierarchy across `_usesNavigator`, `_usesRouterWithConfig`, and `_usesRouterWithDelegates`.

Fixes https://github.com/flutter/flutter/issues/187561

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
