### PR TITLE
[Android] Fix the HCPP SurfaceControl transaction-list race and split the transaction entry points

### DIFF
--- a/engine/src/flutter/shell/platform/android/android_shell_holder_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/android_shell_holder_unittests.cc
@@ -101,7 +101,6 @@ class MockPlatformViewAndroidJNI : public PlatformViewAndroidJNI {
   MOCK_METHOD(void, FlutterViewDestroyOverlaySurfaces, (), (override));
   MOCK_METHOD(ASurfaceTransaction*, createTransaction, (), (override));
   MOCK_METHOD(void, swapTransaction, (), (override));
-  MOCK_METHOD(void, applyTransaction, (), (override));
   MOCK_METHOD(void, destroyOverlaySurface2, (), (override));
   MOCK_METHOD(std::unique_ptr<PlatformViewAndroidJNI::OverlayMetadata>,
               createOverlaySurface2,

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -1381,16 +1381,6 @@ public class FlutterJNI {
   @SuppressWarnings("unused")
   @SuppressLint("NewApi")
   @UiThread
-  public void applyTransactions() {
-    if (platformViewsController2 == null) {
-      throw new RuntimeException("");
-    }
-    platformViewsController2.applyTransactions();
-  }
-
-  @SuppressWarnings("unused")
-  @SuppressLint("NewApi")
-  @UiThread
   public void endFrame2() {
     if (platformViewsController2 == null) {
       throw new RuntimeException("");

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -1358,9 +1358,9 @@ public class FlutterJNI {
 
   // ----- New Platform Views ----------
 
+  // Called from the raster thread for AHB swapchain presentation.
   @SuppressWarnings("unused")
   @SuppressLint("NewApi")
-  @UiThread
   public SurfaceControl.Transaction createTransaction() {
     if (platformViewsController2 == null) {
       throw new RuntimeException("");

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -710,10 +710,6 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
       activePlatformTransaction = null;
     }
 
-    if (rasterTxs == null && platformTx == null) {
-      return;
-    }
-
     // This runs on the platform thread but is posted from the raster thread, so by the time it
     // runs the FlutterView may have been detached from the controller, or detached from its
     // window (in which case getRootSurfaceControl() returns null). Throwing here is fatal rather
@@ -747,8 +743,16 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
       }
     }
 
+    // Unconditional. applyTransactionOnDraw() merges into ViewRootImpl's pending transaction and
+    // applies it with the NEXT draw -- it does not schedule one. invalidate() is what guarantees
+    // that draw, so a frame with nothing of our own to apply is still the pump that flushes a
+    // transaction ViewRootImpl is already holding but has not drawn. See
+    // https://github.com/flutter/flutter/issues/175546 for the last time we assumed a frame was
+    // coming.
     flutterView.invalidate();
-    rootSurfaceControl.applyTransactionOnDraw(tx);
+    if (tx != null) {
+      rootSurfaceControl.applyTransactionOnDraw(tx);
+    }
   }
 
   // Called on the platform thread (UI thread) via the platform task runner.
@@ -756,10 +760,15 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   public void swapTransactions() {
     synchronized (transactionLock) {
       // Anything still active here belongs to a frame whose onEndFrame() never ran, so it will
-      // never be applied. Close it instead of just dropping the reference: raster transactions
-      // can already have buffers attached, and close() releases the native transaction and its
-      // buffer references deterministically rather than waiting for the GC to run the
-      // NativeAllocationRegistry cleaner.
+      // never be applied. Close it instead of just dropping the reference.
+      //
+      // This does not recycle any attached buffer. The completion callback is registered with
+      // libgui's process-global TransactionCompletedListener when it is *set*, not when the
+      // transaction is applied, and close() does not unregister it. SurfaceFlinger never learns
+      // about a transaction that was never applied, so that callback never fires and the buffer
+      // is not returned to the pool either way. What close() does release promptly is the
+      // native transaction and the acquire-fence file descriptor it owns -- the
+      // NativeAllocationRegistry cleaner frees those on no bounded schedule.
       for (int i = 0; i < activeRasterTransactions.size(); i++) {
         activeRasterTransactions.get(i).close();
       }
@@ -788,13 +797,19 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
       }
     }
 
-    // Raster thread (or non-platform thread): SurfaceControl.Transaction (and its native
-    // counterpart android::SurfaceComposerClient::Transaction in libgui.so) is NOT thread-safe
-    // and contains no internal mutexes. Concurrently mutating a single transaction from both
-    // the raster thread (e.g. ASurfaceTransaction_setBuffer) and the platform thread
-    // (e.g. setAlpha, setCrop) corrupts internal hash tables in libgui and causes a SIGSEGV.
-    // Therefore, raster presentations receive isolated transactions per presentation, which
-    // are transferred to the platform thread on swapTransactions() and merged in onEndFrame().
+    // Raster thread (or any non-platform thread): SurfaceControl.Transaction, and its native
+    // counterpart android::SurfaceComposerClient::Transaction in libgui.so, has no internal
+    // mutex. Each presentation therefore gets its own transaction rather than sharing the
+    // platform thread's, and ownership transfers to the platform thread at swapTransactions().
+    //
+    // This is not complete isolation, and the transaction objects are still raced. The AHB
+    // swapchain publishes the transaction here and only afterwards attaches the buffer and the
+    // completion callback to it (see Present() in ahb_swapchain_impl_vk.cc), so a concurrent
+    // merge() on the platform thread can touch a transaction the raster thread is mid-write on.
+    // That predates this change and cannot be closed from Java: past
+    // ASurfaceTransaction_fromJava() the raster thread mutates a raw native pointer and never
+    // re-enters Java. What the lock below does guarantee is that the *lists* stay consistent,
+    // which is the failure that reaches merge(null) and aborts the process.
     synchronized (transactionLock) {
       final SurfaceControl.Transaction tx = newTransaction();
       pendingRasterTransactions.add(tx);

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -11,7 +11,6 @@ import android.graphics.Path;
 import android.graphics.PixelFormat;
 import android.graphics.Rect;
 import android.graphics.RectF;
-import android.os.Looper;
 import android.util.SparseArray;
 import android.view.AttachedSurfaceControl;
 import android.view.Gravity;
@@ -621,7 +620,7 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
       return;
     }
     SurfaceControl.Transaction tx =
-        createTransaction().setAlpha(sc, opacity).setCrop(sc, screenRect);
+        platformTransaction().setAlpha(sc, opacity).setCrop(sc, screenRect);
   }
 
   @RequiresApi(API_LEVELS.API_34)
@@ -633,15 +632,10 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     return new SurfaceHolder.Callback() {
       @Override
       public void surfaceCreated(@NonNull SurfaceHolder holder) {
-        if (platformViews.get(viewId) == null) {
-          viewsWithPendingSurfaceCallback.remove(viewId);
-          surfaceView.getHolder().removeCallback(this);
-          return;
-        }
         SurfaceControl surfaceControl = surfaceView.getSurfaceControl();
         if (surfaceControl != null && surfaceControl.isValid()) {
           SurfaceControl.Transaction tx =
-              createTransaction()
+              platformTransaction()
                   .setAlpha(surfaceControl, opacity)
                   .setCrop(surfaceControl, screenRect);
         } else {
@@ -681,11 +675,6 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     parentView.setVisibility(View.GONE);
   }
 
-  private static boolean isPlatformThread() {
-    final Looper mainLooper = Looper.getMainLooper();
-    return mainLooper != null && Looper.myLooper() == mainLooper;
-  }
-
   @RequiresApi(API_LEVELS.API_34)
   public void onEndFrame() {
     final List<SurfaceControl.Transaction> rasterTxs;
@@ -706,6 +695,7 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
       tx = new SurfaceControl.Transaction();
       if (platformTx != null) {
         tx.merge(platformTx);
+        platformTx.close();
       }
       if (rasterTxs != null) {
         for (int i = 0; i < rasterTxs.size(); i++) {
@@ -740,8 +730,8 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   @RequiresApi(API_LEVELS.API_34)
   public void swapTransactions() {
     synchronized (transactionLock) {
-      // Preserve the existing lifetime of discarded raster transactions. Explicit close() must
-      // wait for a native producer-completion handoff; transactionLock only protects the lists.
+      // Normally onEndFrame() has already consumed the active transactions. Do not explicitly
+      // close raster inputs here; their native producers may still be using them.
       activeRasterTransactions.clear();
       activeRasterTransactions.addAll(pendingRasterTransactions);
       pendingRasterTransactions.clear();
@@ -754,22 +744,24 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     }
   }
 
+  @UiThread
+  @RequiresApi(API_LEVELS.API_34)
+  private SurfaceControl.Transaction platformTransaction() {
+    synchronized (transactionLock) {
+      if (pendingPlatformTransaction == null) {
+        pendingPlatformTransaction = newTransaction();
+      }
+      return pendingPlatformTransaction;
+    }
+  }
+
+  // Called from the raster thread through FlutterJNI.
   @RequiresApi(API_LEVELS.API_34)
   public SurfaceControl.Transaction createTransaction() {
-    if (isPlatformThread()) {
-      // Consolidate platform-thread mutations into one transaction per frame.
-      synchronized (transactionLock) {
-        if (pendingPlatformTransaction == null) {
-          pendingPlatformTransaction = newTransaction();
-        }
-        return pendingPlatformTransaction;
-      }
-    }
-
-    // Give each raster submission its own transaction. The lock prevents list corruption, but
-    // AHBSwapchainImplVK::Present still writes through a borrowed native pointer after publication
-    // here. Merging can race those writes; swapping lists does not transfer exclusive ownership.
-    // Resolving that pre-existing race requires a native producer-completion handoff.
+    // The lock protects the lists, but AHBSwapchainImplVK::Present writes through a borrowed native
+    // pointer after publication here. Merging can race those writes, and releasing Java references
+    // allows GC to free the transaction while native code still uses it. Both pre-existing hazards
+    // require native lifetime retention and publication after the producer finishes writing.
     synchronized (transactionLock) {
       final SurfaceControl.Transaction tx = newTransaction();
       pendingRasterTransactions.add(tx);
@@ -818,7 +810,7 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     if (overlaySurfaceControl == null) {
       return;
     }
-    SurfaceControl.Transaction tx = createTransaction();
+    SurfaceControl.Transaction tx = platformTransaction();
     tx.setVisibility(overlaySurfaceControl, /*visible=*/ true);
   }
 
@@ -827,7 +819,7 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     if (overlaySurfaceControl == null) {
       return;
     }
-    SurfaceControl.Transaction tx = createTransaction();
+    SurfaceControl.Transaction tx = platformTransaction();
     tx.setVisibility(overlaySurfaceControl, /*visible=*/ false);
   }
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -711,6 +711,23 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
       activePlatformTransaction = null;
     }
 
+    // Keep the merge destination separate from the raster transactions. The raster thread can
+    // still hold a borrowed native pointer after publishing a transaction (see
+    // createTransaction()).
+    // Closing an input here would free that pointer while the producer may still be using it.
+    SurfaceControl.Transaction tx = null;
+    if (platformTx != null || rasterTxs != null) {
+      tx = new SurfaceControl.Transaction();
+      if (platformTx != null) {
+        tx.merge(platformTx);
+      }
+      if (rasterTxs != null) {
+        for (int i = 0; i < rasterTxs.size(); i++) {
+          tx.merge(rasterTxs.get(i));
+        }
+      }
+    }
+
     // This runs on the platform thread but is posted from the raster thread, so by the time it
     // runs the FlutterView may have been detached from the controller, or detached from its
     // window (in which case getRootSurfaceControl() returns null). Throwing here is fatal rather
@@ -719,29 +736,10 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     final AttachedSurfaceControl rootSurfaceControl =
         flutterView == null ? null : flutterView.getRootSurfaceControl();
     if (rootSurfaceControl == null) {
-      if (platformTx != null) {
-        platformTx.close();
-      }
-      if (rasterTxs != null) {
-        for (int i = 0; i < rasterTxs.size(); i++) {
-          rasterTxs.get(i).close();
-        }
+      if (tx != null) {
+        tx.close();
       }
       return;
-    }
-
-    // Consolidate any raster and platform transactions into a single transaction for
-    // applyTransactionOnDraw. If both exist, this requires at most one merge.
-    SurfaceControl.Transaction tx = platformTx;
-    if (rasterTxs != null) {
-      for (int i = 0; i < rasterTxs.size(); i++) {
-        final SurfaceControl.Transaction rasterTx = rasterTxs.get(i);
-        if (tx == null) {
-          tx = rasterTx;
-        } else {
-          tx = tx.merge(rasterTx);
-        }
-      }
     }
 
     // Unconditional. applyTransactionOnDraw() merges into ViewRootImpl's pending transaction and
@@ -760,19 +758,8 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   @RequiresApi(API_LEVELS.API_34)
   public void swapTransactions() {
     synchronized (transactionLock) {
-      // Anything still active here belongs to a frame whose onEndFrame() never ran, so it will
-      // never be applied. Close it instead of just dropping the reference.
-      //
-      // This does not recycle any attached buffer. The completion callback is registered with
-      // libgui's process-global TransactionCompletedListener when it is *set*, not when the
-      // transaction is applied, and close() does not unregister it. SurfaceFlinger never learns
-      // about a transaction that was never applied, so that callback never fires and the buffer
-      // is not returned to the pool either way. What close() does release promptly is the
-      // native transaction and the acquire-fence file descriptor it owns -- the
-      // NativeAllocationRegistry cleaner frees those on no bounded schedule.
-      for (int i = 0; i < activeRasterTransactions.size(); i++) {
-        activeRasterTransactions.get(i).close();
-      }
+      // Preserve the existing lifetime of discarded raster transactions. Explicit close() must
+      // wait for a native producer-completion handoff; transactionLock only protects the lists.
       activeRasterTransactions.clear();
       activeRasterTransactions.addAll(pendingRasterTransactions);
       pendingRasterTransactions.clear();
@@ -801,7 +788,7 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     // Raster thread (or any non-platform thread): SurfaceControl.Transaction, and its native
     // counterpart android::SurfaceComposerClient::Transaction in libgui.so, has no internal
     // mutex. Each presentation therefore gets its own transaction rather than sharing the
-    // platform thread's, and ownership transfers to the platform thread at swapTransactions().
+    // platform thread's. swapTransactions() transfers list entries, not exclusive ownership.
     //
     // This is not complete isolation, and the transaction objects are still raced. The AHB
     // swapchain publishes the transaction here and only afterwards attaches the buffer and the

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -76,28 +76,16 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   private final SparseArray<FlutterMutatorView> platformViewParent;
   private final MotionEventTracker motionEventTracker;
 
-  // Transactions created on the raster thread (via JNI for AHB swapchain presentation).
-  // SurfaceControl.Transaction (and native android::SurfaceComposerClient::Transaction in
-  // libgui.so) is NOT thread-safe and contains no internal mutexes. Concurrently mutating a single
-  // transaction from both the raster thread (e.g. ASurfaceTransaction_setBuffer) and the platform
-  // thread (e.g. setAlpha, setCrop) corrupts libgui's internal data structures and causes a
-  // SIGSEGV.
-  // Therefore, raster presentations receive separate transactions per frame submission rather than
-  // sharing the platform thread's transaction, and list access is synchronized under
-  // transactionLock (see createTransaction() for residual native lifecycle nuances).
+  // AHB raster presentations receive separate transactions because native transactions are not
+  // thread-safe. See createTransaction() for the remaining native ownership race.
   private final ArrayList<SurfaceControl.Transaction> pendingRasterTransactions;
   private final ArrayList<SurfaceControl.Transaction> activeRasterTransactions;
 
-  // Consolidated transaction for mutations produced on the platform thread (UI thread),
-  // such as platform view clips and overlay surface visibility. All mutations on the UI thread
-  // in a frame accumulate into this single transaction, eliminating O(N) transaction allocations
-  // and intermediate merge loops.
+  // Platform-view clips and overlay visibility share one platform-thread transaction per frame.
   private SurfaceControl.Transaction pendingPlatformTransaction;
   private SurfaceControl.Transaction activePlatformTransaction;
 
-  // Protects mutation and transfer of transactions between the raster thread (where raster
-  // transactions are created) and the platform thread (where transactions are swapped into active
-  // state and merged for draw).
+  // Protects the lists and platform transaction slots, not native transaction contents.
   private final Object transactionLock = new Object();
   private Surface overlayerSurface = null;
   private SurfaceControl overlaySurfaceControl = null;
@@ -711,10 +699,8 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
       activePlatformTransaction = null;
     }
 
-    // Keep the merge destination separate from the raster transactions. The raster thread can
-    // still hold a borrowed native pointer after publishing a transaction (see
-    // createTransaction()).
-    // Closing an input here would free that pointer while the producer may still be using it.
+    // Use a separate destination: closing a raster input could free a native pointer still in use
+    // by its producer. See createTransaction().
     SurfaceControl.Transaction tx = null;
     if (platformTx != null || rasterTxs != null) {
       tx = new SurfaceControl.Transaction();
@@ -742,12 +728,8 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
       return;
     }
 
-    // Unconditional. applyTransactionOnDraw() merges into ViewRootImpl's pending transaction and
-    // applies it with the NEXT draw -- it does not schedule one. invalidate() is what guarantees
-    // that draw, so a frame with nothing of our own to apply is still the pump that flushes a
-    // transaction ViewRootImpl is already holding but has not drawn. See
-    // https://github.com/flutter/flutter/issues/175546 for the last time we assumed a frame was
-    // coming.
+    // applyTransactionOnDraw() does not schedule a draw. Invalidate even on empty frames to flush
+    // pending ViewRootImpl transactions. See https://github.com/flutter/flutter/issues/175546.
     flutterView.invalidate();
     if (tx != null) {
       rootSurfaceControl.applyTransactionOnDraw(tx);
@@ -775,8 +757,7 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   @RequiresApi(API_LEVELS.API_34)
   public SurfaceControl.Transaction createTransaction() {
     if (isPlatformThread()) {
-      // Platform thread: consolidate all clips and overlay mutations into a single transaction
-      // for this frame, eliminating O(N) transaction allocations and tx.merge() calls.
+      // Consolidate platform-thread mutations into one transaction per frame.
       synchronized (transactionLock) {
         if (pendingPlatformTransaction == null) {
           pendingPlatformTransaction = newTransaction();
@@ -785,19 +766,10 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
       }
     }
 
-    // Raster thread (or any non-platform thread): SurfaceControl.Transaction, and its native
-    // counterpart android::SurfaceComposerClient::Transaction in libgui.so, has no internal
-    // mutex. Each presentation therefore gets its own transaction rather than sharing the
-    // platform thread's. swapTransactions() transfers list entries, not exclusive ownership.
-    //
-    // This is not complete isolation, and the transaction objects are still raced. The AHB
-    // swapchain publishes the transaction here and only afterwards attaches the buffer and the
-    // completion callback to it (see Present() in ahb_swapchain_impl_vk.cc), so a concurrent
-    // merge() on the platform thread can touch a transaction the raster thread is mid-write on.
-    // That predates this change and cannot be closed from Java: past
-    // ASurfaceTransaction_fromJava() the raster thread mutates a raw native pointer and never
-    // re-enters Java. What the lock below does guarantee is that the *lists* stay consistent,
-    // which is the failure that reaches merge(null) and aborts the process.
+    // Give each raster submission its own transaction. The lock prevents list corruption, but
+    // AHBSwapchainImplVK::Present still writes through a borrowed native pointer after publication
+    // here. Merging can race those writes; swapping lists does not transfer exclusive ownership.
+    // Resolving that pre-existing race requires a native producer-completion handoff.
     synchronized (transactionLock) {
       final SurfaceControl.Transaction tx = newTransaction();
       pendingRasterTransactions.add(tx);
@@ -805,13 +777,7 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     }
   }
 
-  /**
-   * Allocates a new transaction.
-   *
-   * <p>Exists as a seam so tests can observe the transactions this controller retains. Overriding
-   * {@link #createTransaction()} is not sufficient, because the transaction handed back to the
-   * caller is not necessarily the one stored in the pending lists.
-   */
+  /** Allocates a transaction so tests can spy on the instance retained by the controller. */
   @VisibleForTesting
   @RequiresApi(API_LEVELS.API_34)
   SurfaceControl.Transaction newTransaction() {

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -78,12 +78,13 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
 
   // Transactions created on the raster thread (via JNI for AHB swapchain presentation).
   // SurfaceControl.Transaction (and native android::SurfaceComposerClient::Transaction in
-  // libgui.so)
-  // is NOT thread-safe and contains no internal mutexes. Concurrently mutating a single transaction
-  // from both the raster thread (e.g. ASurfaceTransaction_setBuffer) and the platform thread
-  // (e.g. setAlpha, setCrop) corrupts libgui's internal data structures and causes a SIGSEGV.
-  // Therefore, raster presentations receive isolated transactions per frame submission, which
-  // are protected by transactionLock when queued and swapped.
+  // libgui.so) is NOT thread-safe and contains no internal mutexes. Concurrently mutating a single
+  // transaction from both the raster thread (e.g. ASurfaceTransaction_setBuffer) and the platform
+  // thread (e.g. setAlpha, setCrop) corrupts libgui's internal data structures and causes a
+  // SIGSEGV.
+  // Therefore, raster presentations receive separate transactions per frame submission rather than
+  // sharing the platform thread's transaction, and list access is synchronized under
+  // transactionLock (see createTransaction() for residual native lifecycle nuances).
   private final ArrayList<SurfaceControl.Transaction> pendingRasterTransactions;
   private final ArrayList<SurfaceControl.Transaction> activeRasterTransactions;
 

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -816,28 +816,6 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   }
 
   @RequiresApi(API_LEVELS.API_34)
-  public void applyTransactions() {
-    final List<SurfaceControl.Transaction> rasterTxs;
-    final SurfaceControl.Transaction platformTx;
-    synchronized (transactionLock) {
-      rasterTxs =
-          pendingRasterTransactions.isEmpty() ? null : new ArrayList<>(pendingRasterTransactions);
-      pendingRasterTransactions.clear();
-
-      platformTx = pendingPlatformTransaction;
-      pendingPlatformTransaction = null;
-    }
-    if (platformTx != null) {
-      platformTx.apply();
-    }
-    if (rasterTxs != null) {
-      for (int i = 0; i < rasterTxs.size(); i++) {
-        rasterTxs.get(i).apply();
-      }
-    }
-  }
-
-  @RequiresApi(API_LEVELS.API_34)
   public FlutterOverlaySurface createOverlaySurface() {
     if (overlayerSurface == null) {
       final SurfaceControl.Builder surfaceControlBuilder = new SurfaceControl.Builder();

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -11,6 +11,7 @@ import android.graphics.Path;
 import android.graphics.PixelFormat;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.os.Looper;
 import android.util.SparseArray;
 import android.view.AttachedSurfaceControl;
 import android.view.Gravity;
@@ -75,8 +76,28 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   private final SparseArray<FlutterMutatorView> platformViewParent;
   private final MotionEventTracker motionEventTracker;
 
-  private final ArrayList<SurfaceControl.Transaction> pendingTransactions;
-  private final ArrayList<SurfaceControl.Transaction> activeTransactions;
+  // Transactions created on the raster thread (via JNI for AHB swapchain presentation).
+  // SurfaceControl.Transaction (and native android::SurfaceComposerClient::Transaction in
+  // libgui.so)
+  // is NOT thread-safe and contains no internal mutexes. Concurrently mutating a single transaction
+  // from both the raster thread (e.g. ASurfaceTransaction_setBuffer) and the platform thread
+  // (e.g. setAlpha, setCrop) corrupts libgui's internal data structures and causes a SIGSEGV.
+  // Therefore, raster presentations receive isolated transactions per frame submission, which
+  // are protected by transactionLock when queued and swapped.
+  private final ArrayList<SurfaceControl.Transaction> pendingRasterTransactions;
+  private final ArrayList<SurfaceControl.Transaction> activeRasterTransactions;
+
+  // Consolidated transaction for mutations produced on the platform thread (UI thread),
+  // such as platform view clips and overlay surface visibility. All mutations on the UI thread
+  // in a frame accumulate into this single transaction, eliminating O(N) transaction allocations
+  // and intermediate merge loops.
+  private SurfaceControl.Transaction pendingPlatformTransaction;
+  private SurfaceControl.Transaction activePlatformTransaction;
+
+  // Protects mutation and transfer of transactions between the raster thread (where raster
+  // transactions are created) and the platform thread (where transactions are swapped into active
+  // state and merged for draw).
+  private final Object transactionLock = new Object();
   private Surface overlayerSurface = null;
   private SurfaceControl overlaySurfaceControl = null;
 
@@ -86,8 +107,8 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     accessibilityEventsDelegate = new AccessibilityEventsDelegate();
     platformViews = new SparseArray<>();
     platformViewParent = new SparseArray<>();
-    pendingTransactions = new ArrayList<>();
-    activeTransactions = new ArrayList<>();
+    pendingRasterTransactions = new ArrayList<>();
+    activeRasterTransactions = new ArrayList<>();
     motionEventTracker = MotionEventTracker.getInstance();
   }
 
@@ -623,6 +644,11 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     return new SurfaceHolder.Callback() {
       @Override
       public void surfaceCreated(@NonNull SurfaceHolder holder) {
+        if (platformViews.get(viewId) == null) {
+          viewsWithPendingSurfaceCallback.remove(viewId);
+          surfaceView.getHolder().removeCallback(this);
+          return;
+        }
         SurfaceControl surfaceControl = surfaceView.getSurfaceControl();
         if (surfaceControl != null && surfaceControl.isValid()) {
           SurfaceControl.Transaction tx =
@@ -666,13 +692,27 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     parentView.setVisibility(View.GONE);
   }
 
+  private static boolean isPlatformThread() {
+    final Looper mainLooper = Looper.getMainLooper();
+    return mainLooper != null && Looper.myLooper() == mainLooper;
+  }
+
   @RequiresApi(API_LEVELS.API_34)
   public void onEndFrame() {
-    SurfaceControl.Transaction tx = new SurfaceControl.Transaction();
-    for (int i = 0; i < activeTransactions.size(); i++) {
-      tx = tx.merge(activeTransactions.get(i));
+    final List<SurfaceControl.Transaction> rasterTxs;
+    final SurfaceControl.Transaction platformTx;
+    synchronized (transactionLock) {
+      rasterTxs =
+          activeRasterTransactions.isEmpty() ? null : new ArrayList<>(activeRasterTransactions);
+      activeRasterTransactions.clear();
+
+      platformTx = activePlatformTransaction;
+      activePlatformTransaction = null;
     }
-    activeTransactions.clear();
+
+    if (rasterTxs == null && platformTx == null) {
+      return;
+    }
 
     // This runs on the platform thread but is posted from the raster thread, so by the time it
     // runs the FlutterView may have been detached from the controller, or detached from its
@@ -682,38 +722,94 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     final AttachedSurfaceControl rootSurfaceControl =
         flutterView == null ? null : flutterView.getRootSurfaceControl();
     if (rootSurfaceControl == null) {
-      tx.close();
+      if (platformTx != null) {
+        platformTx.close();
+      }
+      if (rasterTxs != null) {
+        for (int i = 0; i < rasterTxs.size(); i++) {
+          rasterTxs.get(i).close();
+        }
+      }
       return;
+    }
+
+    // Consolidate any raster and platform transactions into a single transaction for
+    // applyTransactionOnDraw. If both exist, this requires at most one merge.
+    SurfaceControl.Transaction tx = platformTx;
+    if (rasterTxs != null) {
+      for (int i = 0; i < rasterTxs.size(); i++) {
+        final SurfaceControl.Transaction rasterTx = rasterTxs.get(i);
+        if (tx == null) {
+          tx = rasterTx;
+        } else {
+          tx = tx.merge(rasterTx);
+        }
+      }
     }
 
     flutterView.invalidate();
     rootSurfaceControl.applyTransactionOnDraw(tx);
   }
 
-  // NOT called from UI thread.
-  public synchronized void swapTransactions() {
-    activeTransactions.clear();
-    activeTransactions.addAll(pendingTransactions);
-    pendingTransactions.clear();
+  // Called on the platform thread (UI thread) via the platform task runner.
+  public void swapTransactions() {
+    synchronized (transactionLock) {
+      activeRasterTransactions.clear();
+      activeRasterTransactions.addAll(pendingRasterTransactions);
+      pendingRasterTransactions.clear();
+
+      activePlatformTransaction = pendingPlatformTransaction;
+      pendingPlatformTransaction = null;
+    }
   }
 
-  // NOT called from UI thread.
   @RequiresApi(API_LEVELS.API_34)
   public SurfaceControl.Transaction createTransaction() {
-    SurfaceControl.Transaction tx = new SurfaceControl.Transaction();
-    pendingTransactions.add(tx);
-    return tx;
+    if (isPlatformThread()) {
+      // Platform thread: consolidate all clips and overlay mutations into a single transaction
+      // for this frame, eliminating O(N) transaction allocations and tx.merge() calls.
+      synchronized (transactionLock) {
+        if (pendingPlatformTransaction == null) {
+          pendingPlatformTransaction = new SurfaceControl.Transaction();
+        }
+        return pendingPlatformTransaction;
+      }
+    }
+
+    // Raster thread (or non-platform thread): SurfaceControl.Transaction (and its native
+    // counterpart android::SurfaceComposerClient::Transaction in libgui.so) is NOT thread-safe
+    // and contains no internal mutexes. Concurrently mutating a single transaction from both
+    // the raster thread (e.g. ASurfaceTransaction_setBuffer) and the platform thread
+    // (e.g. setAlpha, setCrop) corrupts internal hash tables in libgui and causes a SIGSEGV.
+    // Therefore, raster presentations receive isolated transactions per presentation, which
+    // are transferred to the platform thread on swapTransactions() and merged in onEndFrame().
+    synchronized (transactionLock) {
+      final SurfaceControl.Transaction tx = new SurfaceControl.Transaction();
+      pendingRasterTransactions.add(tx);
+      return tx;
+    }
   }
 
-  // NOT called from UI thread.
   @RequiresApi(API_LEVELS.API_34)
   public void applyTransactions() {
-    SurfaceControl.Transaction tx = new SurfaceControl.Transaction();
-    for (int i = 0; i < pendingTransactions.size(); i++) {
-      tx = tx.merge(pendingTransactions.get(i));
+    final List<SurfaceControl.Transaction> rasterTxs;
+    final SurfaceControl.Transaction platformTx;
+    synchronized (transactionLock) {
+      rasterTxs =
+          pendingRasterTransactions.isEmpty() ? null : new ArrayList<>(pendingRasterTransactions);
+      pendingRasterTransactions.clear();
+
+      platformTx = pendingPlatformTransaction;
+      pendingPlatformTransaction = null;
     }
-    tx.apply();
-    pendingTransactions.clear();
+    if (platformTx != null) {
+      platformTx.apply();
+    }
+    if (rasterTxs != null) {
+      for (int i = 0; i < rasterTxs.size(); i++) {
+        rasterTxs.get(i).apply();
+      }
+    }
   }
 
   @RequiresApi(API_LEVELS.API_34)

--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController2.java
@@ -752,12 +752,24 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
   }
 
   // Called on the platform thread (UI thread) via the platform task runner.
+  @RequiresApi(API_LEVELS.API_34)
   public void swapTransactions() {
     synchronized (transactionLock) {
+      // Anything still active here belongs to a frame whose onEndFrame() never ran, so it will
+      // never be applied. Close it instead of just dropping the reference: raster transactions
+      // can already have buffers attached, and close() releases the native transaction and its
+      // buffer references deterministically rather than waiting for the GC to run the
+      // NativeAllocationRegistry cleaner.
+      for (int i = 0; i < activeRasterTransactions.size(); i++) {
+        activeRasterTransactions.get(i).close();
+      }
       activeRasterTransactions.clear();
       activeRasterTransactions.addAll(pendingRasterTransactions);
       pendingRasterTransactions.clear();
 
+      if (activePlatformTransaction != null) {
+        activePlatformTransaction.close();
+      }
       activePlatformTransaction = pendingPlatformTransaction;
       pendingPlatformTransaction = null;
     }
@@ -770,7 +782,7 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
       // for this frame, eliminating O(N) transaction allocations and tx.merge() calls.
       synchronized (transactionLock) {
         if (pendingPlatformTransaction == null) {
-          pendingPlatformTransaction = new SurfaceControl.Transaction();
+          pendingPlatformTransaction = newTransaction();
         }
         return pendingPlatformTransaction;
       }
@@ -784,10 +796,23 @@ public class PlatformViewsController2 implements PlatformViewsAccessibilityDeleg
     // Therefore, raster presentations receive isolated transactions per presentation, which
     // are transferred to the platform thread on swapTransactions() and merged in onEndFrame().
     synchronized (transactionLock) {
-      final SurfaceControl.Transaction tx = new SurfaceControl.Transaction();
+      final SurfaceControl.Transaction tx = newTransaction();
       pendingRasterTransactions.add(tx);
       return tx;
     }
+  }
+
+  /**
+   * Allocates a new transaction.
+   *
+   * <p>Exists as a seam so tests can observe the transactions this controller retains. Overriding
+   * {@link #createTransaction()} is not sufficient, because the transaction handed back to the
+   * caller is not necessarily the one stored in the pending lists.
+   */
+  @VisibleForTesting
+  @RequiresApi(API_LEVELS.API_34)
+  SurfaceControl.Transaction newTransaction() {
+    return new SurfaceControl.Transaction();
   }
 
   @RequiresApi(API_LEVELS.API_34)

--- a/engine/src/flutter/shell/platform/android/jni/jni_mock.h
+++ b/engine/src/flutter/shell/platform/android/jni/jni_mock.h
@@ -127,8 +127,6 @@ class JNIMock final : public PlatformViewAndroidJNI {
 
   MOCK_METHOD(void, swapTransaction, (), (override));
 
-  MOCK_METHOD(void, applyTransaction, (), (override));
-
   MOCK_METHOD(void, destroyOverlaySurface2, (), (override));
 
   MOCK_METHOD(std::unique_ptr<PlatformViewAndroidJNI::OverlayMetadata>,

--- a/engine/src/flutter/shell/platform/android/jni/platform_view_android_jni.h
+++ b/engine/src/flutter/shell/platform/android/jni/platform_view_android_jni.h
@@ -233,8 +233,6 @@ class PlatformViewAndroidJNI {
 
   virtual void swapTransaction() = 0;
 
-  virtual void applyTransaction() = 0;
-
   virtual std::unique_ptr<PlatformViewAndroidJNI::OverlayMetadata>
   createOverlaySurface2() = 0;
 

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.cc
@@ -81,7 +81,6 @@ static jfieldID g_jni_shell_holder_field = nullptr;
   V(g_create_transaction_method, createTransaction,                           \
     "()Landroid/view/SurfaceControl$Transaction;")                            \
   V(g_swap_transaction_method, swapTransactions, "()V")                       \
-  V(g_apply_transaction_method, applyTransactions, "()V")                     \
   V(g_create_overlay_surface2_method, createOverlaySurface2,                  \
     "()Lio/flutter/embedding/engine/FlutterOverlaySurface;")                  \
   V(g_destroy_overlay_surface2_method, destroyOverlaySurface2, "()V")         \
@@ -2095,19 +2094,6 @@ void PlatformViewAndroidJNIImpl::swapTransaction() {
   }
 
   env->CallVoidMethod(java_object.obj(), g_swap_transaction_method);
-
-  FML_CHECK(fml::jni::CheckException(env));
-}
-
-void PlatformViewAndroidJNIImpl::applyTransaction() {
-  JNIEnv* env = fml::jni::AttachCurrentThread();
-
-  auto java_object = java_object_.get(env);
-  if (java_object.is_null()) {
-    return;
-  }
-
-  env->CallVoidMethod(java_object.obj(), g_apply_transaction_method);
 
   FML_CHECK(fml::jni::CheckException(env));
 }

--- a/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.h
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_jni_impl.h
@@ -132,8 +132,6 @@ class PlatformViewAndroidJNIImpl final : public PlatformViewAndroidJNI {
 
   void swapTransaction() override;
 
-  void applyTransaction() override;
-
   std::unique_ptr<PlatformViewAndroidJNI::OverlayMetadata>
   createOverlaySurface2() override;
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -555,6 +555,63 @@ public class PlatformViewsController2Test {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  public void createTransactionConsolidatesOnPlatformThread() {
+    PlatformViewsController2 controller = new PlatformViewsController2();
+    controller.setRegistry(new PlatformViewRegistryImpl());
+
+    // On the platform/test thread, repeated calls to createTransaction() return the same instance.
+    SurfaceControl.Transaction tx1 = controller.createTransaction();
+    SurfaceControl.Transaction tx2 = controller.createTransaction();
+    assertSame("Platform thread should reuse the consolidated transaction", tx1, tx2);
+
+    controller.swapTransactions();
+
+    // After swapping, a new frame gets a new consolidated transaction.
+    SurfaceControl.Transaction tx3 = controller.createTransaction();
+    assertNotSame("New frame on platform thread should get a fresh transaction", tx1, tx3);
+  }
+
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  public void createTransactionIsolatesRasterThreadTransactions() throws Exception {
+    PlatformViewsController2 controller = new PlatformViewsController2();
+    controller.setRegistry(new PlatformViewRegistryImpl());
+
+    // Transaction on platform thread:
+    SurfaceControl.Transaction platformTx = controller.createTransaction();
+
+    // Transactions created on a background/raster thread:
+    final SurfaceControl.Transaction[] rasterTxs = new SurfaceControl.Transaction[2];
+    Thread rasterThread =
+        new Thread(
+            () -> {
+              rasterTxs[0] = controller.createTransaction();
+              rasterTxs[1] = controller.createTransaction();
+            });
+    rasterThread.start();
+    rasterThread.join();
+
+    assertNotNull(rasterTxs[0]);
+    assertNotNull(rasterTxs[1]);
+    assertNotSame("Raster thread must not share platform transaction", platformTx, rasterTxs[0]);
+    assertNotSame(
+        "Raster thread submissions must receive isolated transactions", rasterTxs[0], rasterTxs[1]);
+
+    // Swapping and ending frame should merge both without crashing.
+    FlutterView mockFlutterView = mock(FlutterView.class);
+    AttachedSurfaceControl mockAttachedSurfaceControl = mock(AttachedSurfaceControl.class);
+    when(mockFlutterView.getRootSurfaceControl()).thenReturn(mockAttachedSurfaceControl);
+    controller.attachToView(mockFlutterView);
+
+    controller.swapTransactions();
+    controller.onEndFrame();
+
+    verify(mockAttachedSurfaceControl, times(1))
+        .applyTransactionOnDraw(any(SurfaceControl.Transaction.class));
+  }
+
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void onEndFrameIsANoopAfterDetachFromView() {
     PlatformViewsController2 controller = new PlatformViewsController2();
     controller.setRegistry(new PlatformViewRegistryImpl());

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -56,8 +56,8 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
@@ -665,6 +665,11 @@ public class PlatformViewsController2Test {
    * scheduling luck decides whether it catches an unsynchronized implementation, never whether it
    * fails a synchronized one. It reliably catches wholesale loss of the locking; it is not
    * guaranteed to catch a subtle partial regression.
+   *
+   * <p>It covers only the transaction <i>lists</i>, not the transaction objects. In production the
+   * raster thread keeps writing to a transaction after {@code createTransaction()} has published it
+   * -- the buffer and the completion callback are attached afterwards -- and that
+   * write-after-publish is out of scope here. See {@code createTransaction()} in the controller.
    */
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
@@ -678,20 +683,26 @@ public class PlatformViewsController2Test {
     // whether the race is observed at all; 8 presents per round detects it far less reliably.
     final int presentsPerRound = 64;
     final int rounds = 300;
-    // Rounds are cheap, but a run that completes almost none of them has proven nothing. Fail
-    // loudly instead of reporting green.
-    final int minRounds = rounds / 2;
     // Only a safety net: the cleanup below breaks the barrier explicitly, so a failing run does
     // not wait this out.
     final long timeoutMs = 30000;
+
+    // This test is only meaningful if isPlatformThread() classifies the test thread and the
+    // background threads differently. It is not asserted here because
+    // createTransactionConsolidatesOnPlatformThread and
+    // createTransactionIsolatesRasterThreadTransactions already assert exactly that, on exactly
+    // these two kinds of thread; if the classification broke, they would go red first.
 
     // Each round is barrier-synchronized so the raster threads' add()s land inside the platform
     // thread's swapTransactions(), instead of relying on two free-running loops happening to
     // overlap. Collision density is then a property of the test rather than of the machine.
     final CyclicBarrier roundStart = new CyclicBarrier(rasterThreadCount + 1);
-    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    // Two buckets, deliberately. A product failure is an assertion; a bot that could not schedule
+    // the threads is a skip. Collapsing them makes a slow machine indistinguishable from the
+    // crash this test is named after.
+    final AtomicReference<Throwable> raceFailure = new AtomicReference<>();
+    final AtomicReference<Throwable> harnessFailure = new AtomicReference<>();
     final AtomicBoolean running = new AtomicBoolean(true);
-    final AtomicInteger roundsCompleted = new AtomicInteger();
     final List<Thread> rasterThreads = new ArrayList<>();
 
     for (int i = 0; i < rasterThreadCount; i++) {
@@ -702,15 +713,19 @@ public class PlatformViewsController2Test {
                   for (int round = 0; round < rounds && running.get(); round++) {
                     roundStart.await(timeoutMs, TimeUnit.MILLISECONDS);
                     for (int present = 0; present < presentsPerRound; present++) {
-                      // The raster thread neither applies nor closes this: the platform thread
-                      // owns it from swapTransactions() onwards.
+                      // Unlike production, this thread is finished with the transaction as soon
+                      // as it is returned. The real raster thread goes on to attach a buffer and
+                      // a completion callback to it; that write-after-publish is out of scope
+                      // here (see the class doc above).
                       controller.createTransaction();
                     }
                   }
-                } catch (BrokenBarrierException | TimeoutException e) {
+                } catch (TimeoutException e) {
+                  harnessFailure.compareAndSet(null, e);
+                } catch (BrokenBarrierException e) {
                   // Another participant stopped early. Whichever one it was recorded why.
                 } catch (Throwable t) {
-                  failure.compareAndSet(null, t);
+                  raceFailure.compareAndSet(null, t);
                 } finally {
                   running.set(false);
                   // Release anyone parked on the barrier so a failure cannot turn into a hang.
@@ -736,11 +751,13 @@ public class PlatformViewsController2Test {
         // flutterView is null, so onEndFrame() drops the frame instead of applying it. It still
         // walks and merges the active transactions first, which is where the race shows up.
         controller.onEndFrame();
-
-        roundsCompleted.incrementAndGet();
       }
+    } catch (TimeoutException | BrokenBarrierException e) {
+      // Either this thread stalled, or a raster thread left the barrier. If it left because it
+      // hit a real failure, it recorded that in raceFailure, which is reported first below.
+      harnessFailure.compareAndSet(null, e);
     } catch (Throwable t) {
-      failure.compareAndSet(null, t);
+      raceFailure.compareAndSet(null, t);
     } finally {
       running.set(false);
       for (Thread rasterThread : rasterThreads) {
@@ -752,25 +769,43 @@ public class PlatformViewsController2Test {
           rasterThread.join(10);
         }
         if (rasterThread.isAlive()) {
-          failure.compareAndSet(
+          harnessFailure.compareAndSet(
               null, new AssertionError(rasterThread.getName() + " did not terminate"));
         }
       }
     }
 
-    if (failure.get() != null) {
+    if (raceFailure.get() != null) {
       throw new AssertionError(
           "Concurrent createTransaction()/swapTransactions() corrupted the transaction lists.",
-          failure.get());
+          raceFailure.get());
     }
+    Assume.assumeNoException(
+        "The harness could not complete a clean run on this machine; this is not a product "
+            + "failure.",
+        harnessFailure.get());
+  }
 
-    assertTrue(
-        "Only "
-            + roundsCompleted.get()
-            + " of "
-            + rounds
-            + " rounds ran, which is too few to have exercised the race.",
-        roundsCompleted.get() >= minRounds);
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  public void onEndFrameInvalidatesEvenWhenTheFrameProducedNoTransactions() {
+    PlatformViewsController2 controller = new PlatformViewsController2();
+    controller.setRegistry(new PlatformViewRegistryImpl());
+
+    FlutterView mockFlutterView = mock(FlutterView.class);
+    AttachedSurfaceControl mockAttachedSurfaceControl = mock(AttachedSurfaceControl.class);
+    when(mockFlutterView.getRootSurfaceControl()).thenReturn(mockAttachedSurfaceControl);
+    controller.attachToView(mockFlutterView);
+
+    controller.swapTransactions();
+    controller.onEndFrame();
+
+    // Nothing of our own to apply, but the invalidate is still owed: applyTransactionOnDraw()
+    // applies with the next draw and does not schedule one, so skipping the invalidate can
+    // strand a transaction ViewRootImpl is already holding.
+    verify(mockFlutterView, times(1)).invalidate();
+    verify(mockAttachedSurfaceControl, never())
+        .applyTransactionOnDraw(any(SurfaceControl.Transaction.class));
   }
 
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -46,6 +46,7 @@ import io.flutter.plugin.common.StandardMethodCodec;
 import io.flutter.plugin.localization.LocalizationPlugin;
 import io.flutter.view.TextureRegistry;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -608,6 +609,38 @@ public class PlatformViewsController2Test {
 
     verify(mockAttachedSurfaceControl, times(1))
         .applyTransactionOnDraw(any(SurfaceControl.Transaction.class));
+  }
+
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  public void swapTransactionsClosesTransactionsThatWereNeverApplied() throws Exception {
+    final List<SurfaceControl.Transaction> created = new ArrayList<>();
+    PlatformViewsController2 controller =
+        new PlatformViewsController2() {
+          @Override
+          SurfaceControl.Transaction newTransaction() {
+            SurfaceControl.Transaction tx = spy(super.newTransaction());
+            created.add(tx);
+            return tx;
+          }
+        };
+    controller.setRegistry(new PlatformViewRegistryImpl());
+
+    // Frame 1: one consolidated platform transaction and one isolated raster transaction.
+    controller.createTransaction();
+    Thread rasterThread = new Thread(controller::createTransaction);
+    rasterThread.start();
+    rasterThread.join();
+    assertEquals(2, created.size());
+
+    // Frame 1 is swapped into the active slots but onEndFrame() never runs, so frame 2's swap
+    // discards them. They must be closed rather than leaked.
+    controller.swapTransactions();
+    controller.swapTransactions();
+
+    for (SurfaceControl.Transaction tx : created) {
+      verify(tx, times(1)).close();
+    }
   }
 
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -749,7 +749,7 @@ public class PlatformViewsController2Test {
 
         controller.swapTransactions();
         // flutterView is null, so onEndFrame() drops the frame instead of applying it. It still
-        // walks and merges the active transactions first, which is where the race shows up.
+        // walks and closes the active transactions first, which is where the race shows up.
         controller.onEndFrame();
       }
     } catch (TimeoutException | BrokenBarrierException e) {

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -731,25 +731,12 @@ public class PlatformViewsController2Test {
   }
 
   /**
-   * Reproduces the HCPP transaction data race.
+   * Stress-tests HCPP transaction list synchronization. Concurrent add/clear operations can leave
+   * null entries, causing merge(null) to throw and abort the engine through JNI.
    *
-   * <p>With the AHB swapchain, the raster thread calls {@code createTransaction()} once per
-   * present, while the platform thread calls it once per SurfaceView platform view per frame and
-   * then runs {@code swapTransactions()} and {@code onEndFrame()}. If the lists holding those
-   * transactions are not synchronized, an {@code add()} racing a {@code clear()} leaves {@code
-   * null} at a live index, and {@code onEndFrame()} then calls {@code merge(null)}. On device that
-   * NPE unwinds into {@code onEndFrame2()}, where {@code FML_CHECK(fml::jni::CheckException(env))}
-   * turns it into an {@code abort()}.
-   *
-   * <p>This is a probabilistic detector, but a one-sided one: it has no timing assertions, so
-   * scheduling luck decides whether it catches an unsynchronized implementation, never whether it
-   * fails a synchronized one. It reliably catches wholesale loss of the locking; it is not
-   * guaranteed to catch a subtle partial regression.
-   *
-   * <p>It covers only the transaction <i>lists</i>, not the transaction objects. In production the
-   * raster thread keeps writing to a transaction after {@code createTransaction()} has published it
-   * -- the buffer and the completion callback are attached afterwards -- and that
-   * write-after-publish is out of scope here. See {@code createTransaction()} in the controller.
+   * <p>Detection is probabilistic. This does not exercise native writes after publication; see
+   * {@code createTransaction()} for that separate race. Thread classification is covered by the
+   * consolidation and isolation tests above.
    */
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
@@ -758,28 +745,15 @@ public class PlatformViewsController2Test {
     controller.setRegistry(new PlatformViewRegistryImpl());
 
     final int rasterThreadCount = 4;
-    // The pending list is what swapTransactions() has to walk, so its length sets how long the
-    // clear()/addAll() pair stays exposed to a concurrent add(). It is the dominant lever on
-    // whether the race is observed at all; 8 presents per round detects it far less reliably.
+    // Larger batches increase the opportunity for add() to overlap clear()/addAll().
     final int presentsPerRound = 64;
     final int rounds = 300;
-    // Only a safety net: the cleanup below breaks the barrier explicitly, so a failing run does
-    // not wait this out.
+    // Safety timeout; cleanup resets the barrier to release waiting threads sooner.
     final long timeoutMs = 30000;
 
-    // This test is only meaningful if isPlatformThread() classifies the test thread and the
-    // background threads differently. It is not asserted here because
-    // createTransactionConsolidatesOnPlatformThread and
-    // createTransactionIsolatesRasterThreadTransactions already assert exactly that, on exactly
-    // these two kinds of thread; if the classification broke, they would go red first.
-
-    // Each round is barrier-synchronized so the raster threads' add()s land inside the platform
-    // thread's swapTransactions(), instead of relying on two free-running loops happening to
-    // overlap. Collision density is then a property of the test rather than of the machine.
+    // Start producers and the frame swap together each round to encourage overlap.
     final CyclicBarrier roundStart = new CyclicBarrier(rasterThreadCount + 1);
-    // Two buckets, deliberately. A product failure is an assertion; a bot that could not schedule
-    // the threads is a skip. Collapsing them makes a slow machine indistinguishable from the
-    // crash this test is named after.
+    // Report product failures before skipping runs interrupted by harness timeouts or shutdown.
     final AtomicReference<Throwable> raceFailure = new AtomicReference<>();
     final AtomicReference<Throwable> harnessFailure = new AtomicReference<>();
     final AtomicBoolean running = new AtomicBoolean(true);
@@ -793,22 +767,18 @@ public class PlatformViewsController2Test {
                   for (int round = 0; round < rounds && running.get(); round++) {
                     roundStart.await(timeoutMs, TimeUnit.MILLISECONDS);
                     for (int present = 0; present < presentsPerRound; present++) {
-                      // Unlike production, this thread is finished with the transaction as soon
-                      // as it is returned. The real raster thread goes on to attach a buffer and
-                      // a completion callback to it; that write-after-publish is out of scope
-                      // here (see the class doc above).
                       controller.createTransaction();
                     }
                   }
                 } catch (TimeoutException e) {
                   harnessFailure.compareAndSet(null, e);
                 } catch (BrokenBarrierException e) {
-                  // Another participant stopped early. Whichever one it was recorded why.
+                  // The participant that stopped early recorded the cause.
                 } catch (Throwable t) {
                   raceFailure.compareAndSet(null, t);
                 } finally {
                   running.set(false);
-                  // Release anyone parked on the barrier so a failure cannot turn into a hang.
+                  // Release waiting participants on exit.
                   roundStart.reset();
                 }
               },
@@ -822,28 +792,23 @@ public class PlatformViewsController2Test {
       for (int round = 0; round < rounds; round++) {
         roundStart.await(timeoutMs, TimeUnit.MILLISECONDS);
 
-        // Stand-in for maybeApplyClipToSurfaceView(), which runs once per SurfaceView platform
-        // view in onDisplayPlatformView().
+        // Simulate platform-view clip transactions.
         controller.createTransaction();
         controller.createTransaction();
 
         controller.swapTransactions();
-        // flutterView is null, so onEndFrame() drops the frame instead of applying it. It still
-        // merges the active transactions first, which is where the race shows up.
+        // Without a FlutterView, this still merges the transactions before dropping the frame.
         controller.onEndFrame();
       }
     } catch (TimeoutException | BrokenBarrierException e) {
-      // Either this thread stalled, or a raster thread left the barrier. If it left because it
-      // hit a real failure, it recorded that in raceFailure, which is reported first below.
+      // Any producer failure is recorded separately and reported first below.
       harnessFailure.compareAndSet(null, e);
     } catch (Throwable t) {
       raceFailure.compareAndSet(null, t);
     } finally {
       running.set(false);
       for (Thread rasterThread : rasterThreads) {
-        // A raster thread can be parked on the barrier waiting for a participant that has already
-        // left, so keep breaking the barrier until it exits. Without this, a failing run waits out
-        // the barrier timeout before it reports, which is exactly when you want a fast answer.
+        // Repeat resets in case a producer enters await() after an earlier reset.
         for (int attempt = 0; attempt < 500 && rasterThread.isAlive(); attempt++) {
           roundStart.reset();
           rasterThread.join(10);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -51,6 +51,13 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
@@ -641,6 +648,129 @@ public class PlatformViewsController2Test {
     for (SurfaceControl.Transaction tx : created) {
       verify(tx, times(1)).close();
     }
+  }
+
+  /**
+   * Reproduces the HCPP transaction data race.
+   *
+   * <p>With the AHB swapchain, the raster thread calls {@code createTransaction()} once per
+   * present, while the platform thread calls it once per SurfaceView platform view per frame and
+   * then runs {@code swapTransactions()} and {@code onEndFrame()}. If the lists holding those
+   * transactions are not synchronized, an {@code add()} racing a {@code clear()} leaves {@code
+   * null} at a live index, and {@code onEndFrame()} then calls {@code merge(null)}. On device that
+   * NPE unwinds into {@code onEndFrame2()}, where {@code FML_CHECK(fml::jni::CheckException(env))}
+   * turns it into an {@code abort()}.
+   *
+   * <p>This is a probabilistic detector, but a one-sided one: it has no timing assertions, so
+   * scheduling luck decides whether it catches an unsynchronized implementation, never whether it
+   * fails a synchronized one. It reliably catches wholesale loss of the locking; it is not
+   * guaranteed to catch a subtle partial regression.
+   */
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  public void createTransactionIsSafeWhenRasterAndPlatformThreadsRaceOnFrames() throws Exception {
+    final PlatformViewsController2 controller = new PlatformViewsController2();
+    controller.setRegistry(new PlatformViewRegistryImpl());
+
+    final int rasterThreadCount = 4;
+    // The pending list is what swapTransactions() has to walk, so its length sets how long the
+    // clear()/addAll() pair stays exposed to a concurrent add(). It is the dominant lever on
+    // whether the race is observed at all; 8 presents per round detects it far less reliably.
+    final int presentsPerRound = 64;
+    final int rounds = 300;
+    // Rounds are cheap, but a run that completes almost none of them has proven nothing. Fail
+    // loudly instead of reporting green.
+    final int minRounds = rounds / 2;
+    // Only a safety net: the cleanup below breaks the barrier explicitly, so a failing run does
+    // not wait this out.
+    final long timeoutMs = 30000;
+
+    // Each round is barrier-synchronized so the raster threads' add()s land inside the platform
+    // thread's swapTransactions(), instead of relying on two free-running loops happening to
+    // overlap. Collision density is then a property of the test rather than of the machine.
+    final CyclicBarrier roundStart = new CyclicBarrier(rasterThreadCount + 1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final AtomicBoolean running = new AtomicBoolean(true);
+    final AtomicInteger roundsCompleted = new AtomicInteger();
+    final List<Thread> rasterThreads = new ArrayList<>();
+
+    for (int i = 0; i < rasterThreadCount; i++) {
+      final Thread rasterThread =
+          new Thread(
+              () -> {
+                try {
+                  for (int round = 0; round < rounds && running.get(); round++) {
+                    roundStart.await(timeoutMs, TimeUnit.MILLISECONDS);
+                    for (int present = 0; present < presentsPerRound; present++) {
+                      // The raster thread neither applies nor closes this: the platform thread
+                      // owns it from swapTransactions() onwards.
+                      controller.createTransaction();
+                    }
+                  }
+                } catch (BrokenBarrierException | TimeoutException e) {
+                  // Another participant stopped early. Whichever one it was recorded why.
+                } catch (Throwable t) {
+                  failure.compareAndSet(null, t);
+                } finally {
+                  running.set(false);
+                  // Release anyone parked on the barrier so a failure cannot turn into a hang.
+                  roundStart.reset();
+                }
+              },
+              "fake-raster-" + i);
+      rasterThread.setDaemon(true);
+      rasterThreads.add(rasterThread);
+      rasterThread.start();
+    }
+
+    try {
+      for (int round = 0; round < rounds; round++) {
+        roundStart.await(timeoutMs, TimeUnit.MILLISECONDS);
+
+        // Stand-in for maybeApplyClipToSurfaceView(), which runs once per SurfaceView platform
+        // view in onDisplayPlatformView().
+        controller.createTransaction();
+        controller.createTransaction();
+
+        controller.swapTransactions();
+        // flutterView is null, so onEndFrame() drops the frame instead of applying it. It still
+        // walks and merges the active transactions first, which is where the race shows up.
+        controller.onEndFrame();
+
+        roundsCompleted.incrementAndGet();
+      }
+    } catch (Throwable t) {
+      failure.compareAndSet(null, t);
+    } finally {
+      running.set(false);
+      for (Thread rasterThread : rasterThreads) {
+        // A raster thread can be parked on the barrier waiting for a participant that has already
+        // left, so keep breaking the barrier until it exits. Without this, a failing run waits out
+        // the barrier timeout before it reports, which is exactly when you want a fast answer.
+        for (int attempt = 0; attempt < 500 && rasterThread.isAlive(); attempt++) {
+          roundStart.reset();
+          rasterThread.join(10);
+        }
+        if (rasterThread.isAlive()) {
+          failure.compareAndSet(
+              null, new AssertionError(rasterThread.getName() + " did not terminate"));
+        }
+      }
+    }
+
+    if (failure.get() != null) {
+      throw new AssertionError(
+          "Concurrent createTransaction()/swapTransactions() corrupted the transaction lists.",
+          failure.get());
+    }
+
+    assertTrue(
+        "Only "
+            + roundsCompleted.get()
+            + " of "
+            + rounds
+            + " rounds ran, which is too few to have exercised the race.",
+        roundsCompleted.get() >= minRounds);
   }
 
   @Test

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -52,6 +52,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -620,34 +621,113 @@ public class PlatformViewsController2Test {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void swapTransactionsClosesTransactionsThatWereNeverApplied() throws Exception {
-    final List<SurfaceControl.Transaction> created = new ArrayList<>();
+  public void swapTransactionsDoesNotCloseRasterTransactionInUse() throws Exception {
+    assertRasterTransactionInUseIsNotClosed(false);
+  }
+
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  public void onEndFrameDoesNotCloseRasterTransactionInUseAfterDetach() throws Exception {
+    assertRasterTransactionInUseIsNotClosed(true);
+  }
+
+  private void assertRasterTransactionInUseIsNotClosed(boolean endFrame) throws Exception {
+    final SurfaceControl.Transaction rasterTx = spy(new SurfaceControl.Transaction());
     PlatformViewsController2 controller =
         new PlatformViewsController2() {
           @Override
           SurfaceControl.Transaction newTransaction() {
-            SurfaceControl.Transaction tx = spy(super.newTransaction());
-            created.add(tx);
-            return tx;
+            return rasterTx;
           }
         };
     controller.setRegistry(new PlatformViewRegistryImpl());
 
-    // Frame 1: one consolidated platform transaction and one isolated raster transaction.
-    controller.createTransaction();
-    Thread rasterThread = new Thread(controller::createTransaction);
+    FlutterView flutterView = mock(FlutterView.class);
+    controller.attachToView(flutterView);
+    controller.detachFromView();
+
+    final CountDownLatch published = new CountDownLatch(1);
+    final CountDownLatch releaseProducer = new CountDownLatch(1);
+    final AtomicReference<Throwable> producerFailure = new AtomicReference<>();
+    Thread rasterThread =
+        new Thread(
+            () -> {
+              try {
+                SurfaceControl.Transaction tx = controller.createTransaction();
+                published.countDown();
+                // Model native code retaining the borrowed transaction after createTransaction().
+                if (!releaseProducer.await(10, TimeUnit.SECONDS)) {
+                  throw new AssertionError("Platform thread did not release the producer");
+                }
+                verify(tx, never()).close();
+              } catch (Throwable t) {
+                producerFailure.set(t);
+              }
+            });
+    rasterThread.setDaemon(true);
     rasterThread.start();
-    rasterThread.join();
-    assertEquals(2, created.size());
-
-    // Frame 1 is swapped into the active slots but onEndFrame() never runs, so frame 2's swap
-    // discards them. They must be closed rather than leaked.
-    controller.swapTransactions();
-    controller.swapTransactions();
-
-    for (SurfaceControl.Transaction tx : created) {
-      verify(tx, times(1)).close();
+    try {
+      assertTrue("Producer did not publish a transaction", published.await(10, TimeUnit.SECONDS));
+      controller.swapTransactions();
+      if (endFrame) {
+        controller.onEndFrame();
+      } else {
+        // Discard an active frame while the producer is still using its transaction.
+        controller.swapTransactions();
+      }
+      verify(rasterTx, never()).close();
+    } finally {
+      releaseProducer.countDown();
+      rasterThread.join(10000);
     }
+    assertFalse("Producer did not terminate", rasterThread.isAlive());
+    if (producerFailure.get() != null) {
+      throw new AssertionError("Raster producer failed", producerFailure.get());
+    }
+  }
+
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  public void onEndFrameUsesSeparateMergeDestinationForRasterOnlyFrame() throws Exception {
+    PlatformViewsController2 controller = new PlatformViewsController2();
+    controller.setRegistry(new PlatformViewRegistryImpl());
+    FlutterView flutterView = mock(FlutterView.class);
+    AttachedSurfaceControl rootSurfaceControl = mock(AttachedSurfaceControl.class);
+    when(flutterView.getRootSurfaceControl()).thenReturn(rootSurfaceControl);
+    controller.attachToView(flutterView);
+
+    AtomicReference<SurfaceControl.Transaction> rasterTx = new AtomicReference<>();
+    Thread rasterThread = new Thread(() -> rasterTx.set(controller.createTransaction()));
+    rasterThread.setDaemon(true);
+    rasterThread.start();
+    rasterThread.join(10000);
+    assertFalse("Producer did not terminate", rasterThread.isAlive());
+    assertNotNull(rasterTx.get());
+
+    controller.swapTransactions();
+    controller.onEndFrame();
+
+    verify(rootSurfaceControl)
+        .applyTransactionOnDraw(argThat(tx -> tx != null && tx != rasterTx.get()));
+    verify(flutterView).invalidate();
+  }
+
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  public void swapTransactionsClosesDiscardedPlatformTransaction() {
+    final SurfaceControl.Transaction platformTx = spy(new SurfaceControl.Transaction());
+    PlatformViewsController2 controller =
+        new PlatformViewsController2() {
+          @Override
+          SurfaceControl.Transaction newTransaction() {
+            return platformTx;
+          }
+        };
+    controller.createTransaction();
+    controller.swapTransactions();
+    controller.swapTransactions();
+
+    verify(platformTx).close();
   }
 
   /**
@@ -749,7 +829,7 @@ public class PlatformViewsController2Test {
 
         controller.swapTransactions();
         // flutterView is null, so onEndFrame() drops the frame instead of applying it. It still
-        // walks and closes the active transactions first, which is where the race shows up.
+        // merges the active transactions first, which is where the race shows up.
         controller.onEndFrame();
       }
     } catch (TimeoutException | BrokenBarrierException e) {
@@ -819,6 +899,8 @@ public class PlatformViewsController2Test {
     when(mockFlutterView.getRootSurfaceControl()).thenReturn(mockAttachedSurfaceControl);
 
     controller.attachToView(mockFlutterView);
+    controller.createTransaction();
+    controller.swapTransactions();
     controller.detachFromView();
 
     // onEndFrame is posted from the raster thread, so it can run after the view was detached.
@@ -840,6 +922,8 @@ public class PlatformViewsController2Test {
     when(mockFlutterView.getRootSurfaceControl()).thenReturn(null);
 
     controller.attachToView(mockFlutterView);
+    controller.createTransaction();
+    controller.swapTransactions();
 
     controller.onEndFrame();
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsController2Test.java
@@ -517,106 +517,92 @@ public class PlatformViewsController2Test {
     verify(platformView, times(1)).dispose();
   }
 
-  // Class member variable
-  private SurfaceControl.Transaction mCapturedTx;
+  private static class TransactionTrackingController extends PlatformViewsController2 {
+    final List<SurfaceControl.Transaction> transactions = new ArrayList<>();
+
+    @Override
+    SurfaceControl.Transaction newTransaction() {
+      SurfaceControl.Transaction tx = spy(super.newTransaction());
+      transactions.add(tx);
+      return tx;
+    }
+  }
+
+  private AttachedSurfaceControl attachToViewWithOverlay(PlatformViewsController2 controller) {
+    controller.setRegistry(new PlatformViewRegistryImpl());
+    FlutterView flutterView = mock(FlutterView.class);
+    AttachedSurfaceControl rootSurfaceControl = mock(AttachedSurfaceControl.class);
+    when(flutterView.getRootSurfaceControl()).thenReturn(rootSurfaceControl);
+    when(rootSurfaceControl.buildReparentTransaction(any()))
+        .thenReturn(new SurfaceControl.Transaction());
+    controller.attachToView(flutterView);
+    controller.createOverlaySurface();
+    return rootSurfaceControl;
+  }
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void showOverlaySurfaceDefersTransactionUntilEndFrame() {
-
-    PlatformViewsController2 controller =
-        new PlatformViewsController2() {
-          @Override
-          public SurfaceControl.Transaction createTransaction() {
-            // Call super to ensure the real transaction is added to the private
-            // 'pendingTransactions' list
-            SurfaceControl.Transaction realTx = super.createTransaction();
-            // Spy on it so we can verify calls like 'apply()'
-            mCapturedTx = spy(realTx);
-            return mCapturedTx;
-          }
-        };
-
-    PlatformViewRegistryImpl registry = new PlatformViewRegistryImpl();
-    controller.setRegistry(registry);
-
-    // Mocks
-    FlutterView mockFlutterView = mock(FlutterView.class);
-    AttachedSurfaceControl mockAttachedSurfaceControl = mock(AttachedSurfaceControl.class);
-
-    when(mockFlutterView.getRootSurfaceControl()).thenReturn(mockAttachedSurfaceControl);
-    when(mockAttachedSurfaceControl.buildReparentTransaction(any()))
-        .thenReturn(new SurfaceControl.Transaction());
-
-    controller.attachToView(mockFlutterView);
-    controller.createOverlaySurface();
+    TransactionTrackingController controller = new TransactionTrackingController();
+    AttachedSurfaceControl rootSurfaceControl = attachToViewWithOverlay(controller);
 
     controller.showOverlaySurface();
-    assertNotNull("Transaction should have been created", mCapturedTx);
-    verify(mCapturedTx, never()).apply();
+    assertEquals(1, controller.transactions.size());
+    SurfaceControl.Transaction platformTx = controller.transactions.get(0);
+    verify(platformTx, never()).apply();
+    verify(platformTx, never()).close();
 
     controller.swapTransactions();
     controller.onEndFrame();
 
-    verify(mockAttachedSurfaceControl, times(1))
+    verify(rootSurfaceControl, times(1))
         .applyTransactionOnDraw(any(SurfaceControl.Transaction.class));
+    verify(platformTx).close();
   }
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createTransactionConsolidatesOnPlatformThread() {
-    PlatformViewsController2 controller = new PlatformViewsController2();
-    controller.setRegistry(new PlatformViewRegistryImpl());
+  public void overlayMutationsSharePlatformTransactionUntilSwap() {
+    TransactionTrackingController controller = new TransactionTrackingController();
+    attachToViewWithOverlay(controller);
 
-    // On the platform/test thread, repeated calls to createTransaction() return the same instance.
-    SurfaceControl.Transaction tx1 = controller.createTransaction();
-    SurfaceControl.Transaction tx2 = controller.createTransaction();
-    assertSame("Platform thread should reuse the consolidated transaction", tx1, tx2);
+    controller.showOverlaySurface();
+    controller.hideOverlaySurface();
+    assertEquals(1, controller.transactions.size());
+    SurfaceControl.Transaction platformTx = controller.transactions.get(0);
+    verify(platformTx).setVisibility(any(SurfaceControl.class), eq(true));
+    verify(platformTx).setVisibility(any(SurfaceControl.class), eq(false));
 
     controller.swapTransactions();
 
-    // After swapping, a new frame gets a new consolidated transaction.
-    SurfaceControl.Transaction tx3 = controller.createTransaction();
-    assertNotSame("New frame on platform thread should get a fresh transaction", tx1, tx3);
+    controller.showOverlaySurface();
+    assertEquals(2, controller.transactions.size());
+    assertNotSame(platformTx, controller.transactions.get(1));
   }
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createTransactionIsolatesRasterThreadTransactions() throws Exception {
-    PlatformViewsController2 controller = new PlatformViewsController2();
-    controller.setRegistry(new PlatformViewRegistryImpl());
+  public void createTransactionIsolatesRasterSubmissionsRegardlessOfCallingThread() {
+    TransactionTrackingController controller = new TransactionTrackingController();
+    AttachedSurfaceControl rootSurfaceControl = attachToViewWithOverlay(controller);
+    controller.showOverlaySurface();
+    SurfaceControl.Transaction platformTx = controller.transactions.get(0);
 
-    // Transaction on platform thread:
-    SurfaceControl.Transaction platformTx = controller.createTransaction();
-
-    // Transactions created on a background/raster thread:
-    final SurfaceControl.Transaction[] rasterTxs = new SurfaceControl.Transaction[2];
-    Thread rasterThread =
-        new Thread(
-            () -> {
-              rasterTxs[0] = controller.createTransaction();
-              rasterTxs[1] = controller.createTransaction();
-            });
-    rasterThread.start();
-    rasterThread.join();
-
-    assertNotNull(rasterTxs[0]);
-    assertNotNull(rasterTxs[1]);
-    assertNotSame("Raster thread must not share platform transaction", platformTx, rasterTxs[0]);
-    assertNotSame(
-        "Raster thread submissions must receive isolated transactions", rasterTxs[0], rasterTxs[1]);
-
-    // Swapping and ending frame should merge both without crashing.
-    FlutterView mockFlutterView = mock(FlutterView.class);
-    AttachedSurfaceControl mockAttachedSurfaceControl = mock(AttachedSurfaceControl.class);
-    when(mockFlutterView.getRootSurfaceControl()).thenReturn(mockAttachedSurfaceControl);
-    controller.attachToView(mockFlutterView);
+    // The JNI entry point always creates raster transactions, even on this test's main thread.
+    SurfaceControl.Transaction rasterTx1 = controller.createTransaction();
+    SurfaceControl.Transaction rasterTx2 = controller.createTransaction();
+    assertNotSame(platformTx, rasterTx1);
+    assertNotSame(platformTx, rasterTx2);
+    assertNotSame(rasterTx1, rasterTx2);
 
     controller.swapTransactions();
     controller.onEndFrame();
 
-    verify(mockAttachedSurfaceControl, times(1))
+    verify(rootSurfaceControl, times(1))
         .applyTransactionOnDraw(any(SurfaceControl.Transaction.class));
+    verify(platformTx).close();
+    verify(rasterTx1, never()).close();
+    verify(rasterTx2, never()).close();
   }
 
   @Test
@@ -688,7 +674,7 @@ public class PlatformViewsController2Test {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void onEndFrameUsesSeparateMergeDestinationForRasterOnlyFrame() throws Exception {
+  public void onEndFrameUsesSeparateMergeDestinationForRasterOnlyFrame() {
     PlatformViewsController2 controller = new PlatformViewsController2();
     controller.setRegistry(new PlatformViewRegistryImpl());
     FlutterView flutterView = mock(FlutterView.class);
@@ -696,38 +682,26 @@ public class PlatformViewsController2Test {
     when(flutterView.getRootSurfaceControl()).thenReturn(rootSurfaceControl);
     controller.attachToView(flutterView);
 
-    AtomicReference<SurfaceControl.Transaction> rasterTx = new AtomicReference<>();
-    Thread rasterThread = new Thread(() -> rasterTx.set(controller.createTransaction()));
-    rasterThread.setDaemon(true);
-    rasterThread.start();
-    rasterThread.join(10000);
-    assertFalse("Producer did not terminate", rasterThread.isAlive());
-    assertNotNull(rasterTx.get());
+    SurfaceControl.Transaction rasterTx = controller.createTransaction();
 
     controller.swapTransactions();
     controller.onEndFrame();
 
-    verify(rootSurfaceControl)
-        .applyTransactionOnDraw(argThat(tx -> tx != null && tx != rasterTx.get()));
+    verify(rootSurfaceControl).applyTransactionOnDraw(argThat(tx -> tx != null && tx != rasterTx));
     verify(flutterView).invalidate();
   }
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void swapTransactionsClosesDiscardedPlatformTransaction() {
-    final SurfaceControl.Transaction platformTx = spy(new SurfaceControl.Transaction());
-    PlatformViewsController2 controller =
-        new PlatformViewsController2() {
-          @Override
-          SurfaceControl.Transaction newTransaction() {
-            return platformTx;
-          }
-        };
-    controller.createTransaction();
+    TransactionTrackingController controller = new TransactionTrackingController();
+    attachToViewWithOverlay(controller);
+    controller.showOverlaySurface();
+    // Defensive coverage: production calls onEndFrame() between swaps.
     controller.swapTransactions();
     controller.swapTransactions();
 
-    verify(platformTx).close();
+    verify(controller.transactions.get(0)).close();
   }
 
   /**
@@ -735,14 +709,14 @@ public class PlatformViewsController2Test {
    * null entries, causing merge(null) to throw and abort the engine through JNI.
    *
    * <p>Detection is probabilistic. This does not exercise native writes after publication; see
-   * {@code createTransaction()} for that separate race. Thread classification is covered by the
-   * consolidation and isolation tests above.
+   * {@code createTransaction()} for that separate race. Barrier timeouts skip the run, so this is
+   * not a liveness test.
    */
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void createTransactionIsSafeWhenRasterAndPlatformThreadsRaceOnFrames() throws Exception {
     final PlatformViewsController2 controller = new PlatformViewsController2();
-    controller.setRegistry(new PlatformViewRegistryImpl());
+    attachToViewWithOverlay(controller);
 
     final int rasterThreadCount = 4;
     // Larger batches increase the opportunity for add() to overlap clear()/addAll().
@@ -792,12 +766,10 @@ public class PlatformViewsController2Test {
       for (int round = 0; round < rounds; round++) {
         roundStart.await(timeoutMs, TimeUnit.MILLISECONDS);
 
-        // Simulate platform-view clip transactions.
-        controller.createTransaction();
-        controller.createTransaction();
+        controller.showOverlaySurface();
+        controller.hideOverlaySurface();
 
         controller.swapTransactions();
-        // Without a FlutterView, this still merges the transactions before dropping the frame.
         controller.onEndFrame();
       }
     } catch (TimeoutException | BrokenBarrierException e) {
@@ -814,20 +786,17 @@ public class PlatformViewsController2Test {
           rasterThread.join(10);
         }
         if (rasterThread.isAlive()) {
-          harnessFailure.compareAndSet(
+          raceFailure.compareAndSet(
               null, new AssertionError(rasterThread.getName() + " did not terminate"));
         }
       }
     }
 
     if (raceFailure.get() != null) {
-      throw new AssertionError(
-          "Concurrent createTransaction()/swapTransactions() corrupted the transaction lists.",
-          raceFailure.get());
+      throw new AssertionError("Concurrent transaction processing failed.", raceFailure.get());
     }
     Assume.assumeNoException(
-        "The harness could not complete a clean run on this machine; this is not a product "
-            + "failure.",
+        "Stress run interrupted by a barrier failure; transaction failures are reported above.",
         harnessFailure.get());
   }
 


### PR DESCRIPTION
## Description

Fix the Android 14+ HCPP transaction-list race. The raster thread added to the pending transaction list while the platform thread swapped it, leaving null entries that made `merge(null)` throw and abort the engine through JNI.

- Guard the pending raster transaction list with one lock shared by raster-thread additions and platform-thread draining. The active raster transaction list and both platform transaction slots are confined to the platform thread.
- Split the entry points by caller rather than inferring the thread at runtime: `createTransaction()` is the raster/JNI entry and always returns an isolated transaction, while a private `platformTransaction()` consolidates platform-thread mutations (clips, overlay visibility) into one transaction per frame.
- Close platform transactions once they are merged or discarded. Raster transactions are not closed here, because their native producer may still be writing through them.
- Detached-view handling is unchanged: `onEndFrame()` still allocates a merge destination, merges, invalidates and applies on every frame, exactly as before.
- Remove the unused `applyTransactions()` JNI path, which nothing has ever called.

This fixes the Java-side list corruption only. Two pre-existing native ownership hazards remain, and both need the same follow-up:

1. `AHBSwapchainImplVK::Present` writes through the borrowed `ASurfaceTransaction*` after the transaction has been published to Java, so a merge on the platform thread can race those writes.
2. Once Java drops its last reference, the `NativeAllocationRegistry` cleaner can free the native transaction while native code is still using it. Avoiding an explicit `close()` narrows this window but does not close it.

Fixing either one properly requires the native side to retain the transaction and publish it only after the producer has finished writing. That is a separate change.

## Tests

Coverage includes platform consolidation, raster isolation, the separate merge destination, transactions still in use by a paused producer, discarded platform transactions, and detached frames. The tests drive platform mutations through their real call sites rather than calling `createTransaction()` directly.

Verified locally with a Robolectric harness built against these sources:

- 20/20 `PlatformViewsController2Test` tests pass.
- The stress test passes 10 consecutive runs with 0 skips (3.4s total).
- With the locks removed from a copy of the sources, the same test reports `NullPointerException: Cannot read field "mResizedSurfaces" because "other" is null` in 10/10 runs — the production stack trace, which `FML_CHECK(fml::jni::CheckException(env))` turns into an `abort()` on device.

Detection is probabilistic and one-sided: the test contains no timing assertions, so scheduling decides whether it catches an unsynchronized implementation, never whether it fails a synchronized one. A barrier timeout skips the run; a producer that fails to terminate fails it. It covers list corruption, not liveness, and does not exercise the native writes described above.

Java formatting and `git diff --check` pass.

---

*Portions of this change and this description were authored with AI assistance.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md



