### PR TITLE
Roll clang to 07d67299a15ce03b053736e2d31a668ee0576987

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -794,7 +794,7 @@ deps = {
     'packages': [
       {
         'package': 'flutter_internal/rbe/reclient_cfgs',
-        'version': '0vARzGeIZgIhW7zVfWuqIPQ_HXMLDccjAstykWZKjaEC',
+        'version': 'Vk7WiSKwQdBHbCrZ9PtRl3po2WpRFQZSag9M6-sxF_0C',
       }
     ],
     'condition': 'use_rbe',

--- a/DEPS
+++ b/DEPS
@@ -39,7 +39,7 @@ vars = {
   # updates to Clang Tidy will not turn the tree red.
   #
   # See https://github.com/flutter/flutter/wiki/Engine-pre‐submits-and-post‐submits#post-submit
-  'clang_version': 'git_revision:80743bd43fd5b38fedc503308e7a652e23d3ec93',
+  'clang_version': 'git_revision:07d67299a15ce03b053736e2d31a668ee0576987',
 
   'reclient_version': 're_client_version:0.185.0.db415f21-gomaip',
 

--- a/engine/src/build/config/BUILDCONFIG.gn
+++ b/engine/src/build/config/BUILDCONFIG.gn
@@ -532,6 +532,10 @@ if (!is_component_build) {
   }
 }
 
+# Applied by Skia's skia_* target templates. See
+# //flutter/third_party/skia/gn/skia.gni.
+skia_target_default_configs = [ "//flutter/build/config/skia:warnings" ]
+
 # Test defaults.
 set_defaults("test") {
   if (is_android) {

--- a/engine/src/build/config/compiler/BUILD.gn
+++ b/engine/src/build/config/compiler/BUILD.gn
@@ -637,9 +637,12 @@ config("runtime_library") {
       "-I" + _libcxxabi_include,
     ]
 
-    # Unwind seemes to be in these libraries in Linux.
-    if (!is_linux) {
-      ldflags += [ "-nostdlib++" ]
+    ldflags += [ "-nostdlib++" ]
+
+    if (is_linux) {
+      # Our custom libcxx doesn't include the unwinder, which is included in
+      # libc++.a. Link the libunwind directly.
+      ldflags += [ "--unwindlib=libunwind" ]
     }
   }
 

--- a/engine/src/flutter/build/config/skia/BUILD.gn
+++ b/engine/src/flutter/build/config/skia/BUILD.gn
@@ -1,0 +1,21 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Applied to Skia's targets only, via skia_target_default_configs in
+# //build/config/BUILDCONFIG.gn.
+config("warnings") {
+  cflags = []
+
+  if (is_fuchsia && is_clang) {
+    # Dead declarations in Skia that only warn against the libc++ headers
+    # bundled in the Fuchsia toolchain.
+    #
+    # Remove once fixed upstream in Skia.
+    # TODO(cbracken): https://github.com/flutter/flutter/issues/192609
+    cflags += [
+      "-Wno-unused-private-field",
+      "-Wno-unused-variable",
+    ]
+  }
+}

--- a/engine/src/flutter/build/secondary/flutter/third_party/libcxxabi/BUILD.gn
+++ b/engine/src/flutter/build/secondary/flutter/third_party/libcxxabi/BUILD.gn
@@ -41,18 +41,17 @@ source_set("libcxxabi") {
   configs += [ "//flutter/third_party/libcxx:src_include" ]
 
   # No translation units in the engine are built with exceptions. But, using
-  # Objective-C exceptions requires some infrastructure setup for exceptions.
-  # Build support for the same in cxxabi on Darwin.
-  if (is_mac || is_ios) {
+  # Objective-C exceptions requires some infrastructure setup for exceptions,
+  # as do the sanitizer runtimes on Linux, which reference __cxa_begin_catch
+  # and __gxx_personality_v0. Build support for the same in cxxabi there.
+  if (is_mac || is_ios || is_linux) {
     configs -= [ "//build/config/gcc:no_exceptions" ]
     sources += [
       "src/cxa_exception.cpp",
       "src/cxa_personality.cpp",
     ]
   } else {
-    if (!is_tsan) {
-      sources += [ "src/cxa_noexception.cpp" ]
-    }
+    sources += [ "src/cxa_noexception.cpp" ]
   }
 
   # Third party dependencies may depend on RTTI. Add support for the same in

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -1134,7 +1134,7 @@ TEST_F(DisplayListTest, DisplayListTransformResetHandling) {
 
 TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
   auto run_tests = [](const std::string& name,
-                      void build(DlCanvas & canvas, const DlPaint& paint),
+                      void build(DlCanvas& canvas, const DlPaint& paint),
                       bool expect_for_op, bool expect_with_kSrc) {
     {
       // First test is the draw op, by itself
@@ -3461,12 +3461,12 @@ TEST_F(DisplayListTest, DrawUnorderedRoundRectPathCCW) {
 
 TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
   auto run_tests = [](const std::string& name,
-                      void init(DisplayListBuilder & builder, DlPaint & paint),
+                      void init(DisplayListBuilder& builder, DlPaint& paint),
                       uint32_t expected_op_count = 0u,
                       uint32_t expected_total_depth = 0u) {
     auto run_one_test =
         [init](const std::string& name,
-               void build(DisplayListBuilder & builder, DlPaint & paint),
+               void build(DisplayListBuilder& builder, DlPaint& paint),
                uint32_t expected_op_count = 0u,
                uint32_t expected_total_depth = 0u) {
           DisplayListBuilder builder;

--- a/engine/src/flutter/display_list/geometry/dl_region_unittests.cc
+++ b/engine/src/flutter/display_list/geometry/dl_region_unittests.cc
@@ -343,6 +343,7 @@ TEST(DisplayListRegion, UnionEmpty) {
     std::vector<DlIRect> expected{
         DlIRect::MakeXYWH(0, 0, 20, 20),
     };
+    EXPECT_EQ(rects, expected);
   }
   {
     DlRegion region1({
@@ -355,6 +356,7 @@ TEST(DisplayListRegion, UnionEmpty) {
     std::vector<DlIRect> expected{
         DlIRect::MakeXYWH(0, 0, 20, 20),
     };
+    EXPECT_EQ(rects, expected);
   }
 }
 

--- a/engine/src/flutter/display_list/skia/dl_sk_conversions_unittests.cc
+++ b/engine/src/flutter/display_list/skia/dl_sk_conversions_unittests.cc
@@ -342,11 +342,12 @@ TEST(DisplayListSkConversions, MatrixColorFilterModifiesTransparency) {
     auto dl_filter = DlColorFilter::MakeMatrix(matrix);
     auto sk_filter = ToSk(filter);
     auto srgb = SkColorSpace::MakeSRGB();
-    EXPECT_EQ(dl_filter == nullptr, sk_filter == nullptr);
+    EXPECT_EQ(dl_filter == nullptr, sk_filter == nullptr) << desc;
     EXPECT_EQ(filter.modifies_transparent_black(),
               sk_filter && sk_filter->filterColor4f(SkColors::kTransparent,
                                                     srgb.get(), srgb.get()) !=
-                               SkColors::kTransparent);
+                               SkColors::kTransparent)
+        << desc;
   };
 
   // Tests identity (matrix[0] already == 1 in an identity filter)

--- a/engine/src/flutter/flow/layers/performance_overlay_layer_unittests.cc
+++ b/engine/src/flutter/flow/layers/performance_overlay_layer_unittests.cc
@@ -45,7 +45,6 @@ static std::string GetGoldenFilePath(int refresh_rate, bool is_new) {
 
 static void TestPerformanceOverlayLayerGold(int refresh_rate) {
   std::string golden_file_path = GetGoldenFilePath(refresh_rate, false);
-  std::string new_golden_file_path = GetGoldenFilePath(refresh_rate, true);
 
   FixedRefreshRateStopwatch mock_stopwatch(
       fml::RefreshRateToFrameBudget(refresh_rate));
@@ -107,6 +106,7 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
 #else
   const bool golden_data_matches = golden_data->equals(snapshot_data.get());
   if (!golden_data_matches) {
+    std::string new_golden_file_path = GetGoldenFilePath(refresh_rate, true);
     SkFILEWStream wstream(new_golden_file_path.c_str());
     wstream.write(snapshot_data->data(), snapshot_data->size());
     wstream.flush();

--- a/engine/src/flutter/fml/command_line_unittest.cc
+++ b/engine/src/flutter/fml/command_line_unittest.cc
@@ -300,6 +300,7 @@ TEST(CommandLineTest, OddArguments) {
     EXPECT_EQ(std::string(), cl.argv0());
     std::vector<CommandLine::Option> expected_options = {
         CommandLine::Option("flag", "value")};
+    EXPECT_EQ(expected_options, cl.options());
     std::vector<std::string> expected_positional_args = {"--not-a-flag", "arg",
                                                          "--"};
     EXPECT_EQ(expected_positional_args, cl.positional_args());
@@ -313,6 +314,7 @@ TEST(CommandLineTest, MultipleOccurrencesOfOption) {
       CommandLine::Option("flag1", "value1"),
       CommandLine::Option("flag2", "value2"),
       CommandLine::Option("flag1", "value3")};
+  EXPECT_EQ(expected_options, cl.options());
   EXPECT_EQ("value3", cl.GetOptionValueWithDefault("flag1", "nope"));
   EXPECT_EQ("value2", cl.GetOptionValueWithDefault("flag2", "nope"));
   std::vector<std::string_view> values = cl.GetOptionValues("flag1");

--- a/engine/src/flutter/fml/platform/win/command_line_win.cc
+++ b/engine/src/flutter/fml/platform/win/command_line_win.cc
@@ -29,7 +29,7 @@ std::optional<CommandLine> CommandLineFromPlatform() {
   wchar_t* command_line = GetCommandLineW();
   int unicode_argc;
   std::unique_ptr<wchar_t*[], decltype(::LocalFree)*> unicode_argv(
-      CommandLineToArgvW(command_line, &unicode_argc), ::LocalFree);
+      CommandLineToArgvW(command_line, & unicode_argc), ::LocalFree);
   if (!unicode_argv) {
     return std::nullopt;
   }

--- a/engine/src/flutter/impeller/display_list/canvas.cc
+++ b/engine/src/flutter/impeller/display_list/canvas.cc
@@ -185,7 +185,7 @@ static const constexpr RenderTarget::AttachmentConfig kDefaultStencilConfig =
         .storage_mode = StorageMode::kDeviceTransient,
         .load_action = LoadAction::kDontCare,
         .store_action = StoreAction::kDontCare,
-    };
+};
 
 static std::unique_ptr<EntityPassTarget> CreateRenderTarget(
     ContentContext& renderer,

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -6,6 +6,7 @@
 
 #include "GLES3/gl3.h"
 #include "fml/logging.h"
+#include "impeller/base/thread_safety.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 #include "impeller/renderer/backend/gles/test/mock_gles.h"
 
@@ -469,7 +470,7 @@ static_assert(CheckSameSignature<decltype(mockVertexAttribDivisor),  //
                                  decltype(glVertexAttribDivisor)>::value);
 
 // static
-std::shared_ptr<MockGLES> MockGLES::Init(
+IPLR_NO_THREAD_SAFETY_ANALYSIS std::shared_ptr<MockGLES> MockGLES::Init(
     std::unique_ptr<MockGLESImpl> impl,
     const std::optional<std::vector<const char*>>& extensions,
     const char* version_string) {
@@ -490,7 +491,7 @@ std::shared_ptr<MockGLES> MockGLES::Init(
   return mock_gles;
 }
 
-std::shared_ptr<MockGLES> MockGLES::Init(
+IPLR_NO_THREAD_SAFETY_ANALYSIS std::shared_ptr<MockGLES> MockGLES::Init(
     const std::optional<std::vector<const char*>>& extensions,
     const char* version_string,
     ProcTableGLES::Resolver resolver) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -24,7 +24,7 @@ static const constexpr DescriptorPoolSize kDefaultBindingSize =
         .texture_bindings = 256u,  // Texture Bindings
         .storage_bindings = 32,
         .subpass_bindings = 4u  // Subpass Bindings
-    };
+};
 
 DescriptorPoolVK::DescriptorPoolVK(std::weak_ptr<const ContextVK> context)
     : context_(std::move(context)) {}

--- a/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
@@ -38,12 +38,12 @@ fml::AutoResetWaitableEvent message_latch;
 class MockSyncSwitch {
  public:
   struct Handlers {
-    Handlers& SetIfTrue(const std::function<void()>& handler) {
-      true_handler = handler;
+    Handlers& SetIfTrue(std::function<void()> handler) {
+      true_handler = std::move(handler);
       return *this;
     }
-    Handlers& SetIfFalse(const std::function<void()>& handler) {
-      false_handler = handler;
+    Handlers& SetIfFalse(std::function<void()> handler) {
+      false_handler = std::move(handler);
       return *this;
     }
     std::function<void()> true_handler = [] {};

--- a/engine/src/flutter/lib/ui/painting/image_generator_apng.h
+++ b/engine/src/flutter/lib/ui/painting/image_generator_apng.h
@@ -10,16 +10,16 @@
 #include "flutter/fml/endianness.h"
 #include "flutter/fml/logging.h"
 
-#define PNG_FIELD(T, name)                \
- private:                                 \
-  T name;                                 \
-                                          \
- public:                                  \
-  T get_##name() const {                  \
-    return fml::BigEndianToArch<T>(name); \
-  }                                       \
-  void set_##name(T n) {                  \
-    name = fml::BigEndianToArch<T>(n);    \
+#define PNG_FIELD(T, name)                   \
+ private:                                    \
+  T name##_;                                 \
+                                             \
+ public:                                     \
+  T get_##name() const {                     \
+    return fml::BigEndianToArch<T>(name##_); \
+  }                                          \
+  void set_##name(T n) {                     \
+    name##_ = fml::BigEndianToArch<T>(n);    \
   }
 
 namespace flutter {

--- a/engine/src/flutter/runtime/dart_vm.cc
+++ b/engine/src/flutter/runtime/dart_vm.cc
@@ -79,7 +79,7 @@ static std::string DartFileRecorderArgs(const std::string& path) {
 
 // "Microtask" is included in all argument strings below, but "Microtask" stream
 // events will only be recorded by the VM's timeline recorders when
-// |Switch::ProfileMicrotasks| is set.
+// |Switch::kProfileMicrotasks| is set.
 
 [[maybe_unused]]
 static const char* kDartDefaultTraceStreamsArgs[]{

--- a/engine/src/flutter/shell/common/switch_defs.h
+++ b/engine/src/flutter/shell/common/switch_defs.h
@@ -20,279 +20,279 @@ namespace flutter {
 // clang-format on
 
 DEF_SWITCHES_START
-DEF_SWITCH(AotSharedLibraryName,
+DEF_SWITCH(kAotSharedLibraryName,
            "aot-shared-library-name",
            "Name of the *.so containing AOT compiled Dart assets.")
-DEF_SWITCH(AotVMServiceSharedLibraryName,
+DEF_SWITCH(kAotVmServiceSharedLibraryName,
            "aot-vmservice-shared-library-name",
            "Name of the *.so containing AOT compiled Dart assets for "
            "launching the service isolate.")
-DEF_SWITCH(SnapshotAssetPath,
+DEF_SWITCH(kSnapshotAssetPath,
            "snapshot-asset-path",
            "Path to the directory containing the four files specified by "
            "VmSnapshotData, VmSnapshotInstructions, "
            "VmSnapshotInstructions and IsolateSnapshotInstructions.")
-DEF_SWITCH(VmSnapshotData,
+DEF_SWITCH(kVmSnapshotData,
            "vm-snapshot-data",
            "The VM snapshot data that will be memory mapped as read-only. "
            "SnapshotAssetPath must be present.")
-DEF_SWITCH(VmSnapshotInstructions,
+DEF_SWITCH(kVmSnapshotInstructions,
            "vm-snapshot-instr",
            "The VM instructions snapshot that will be memory mapped as read "
            "and executable. SnapshotAssetPath must be present.")
-DEF_SWITCH(IsolateSnapshotData,
+DEF_SWITCH(kIsolateSnapshotData,
            "isolate-snapshot-data",
            "The isolate snapshot data that will be memory mapped as read-only. "
            "SnapshotAssetPath must be present.")
-DEF_SWITCH(IsolateSnapshotInstructions,
+DEF_SWITCH(kIsolateSnapshotInstructions,
            "isolate-snapshot-instr",
            "The isolate instructions snapshot that will be memory mapped as "
            "read and executable. SnapshotAssetPath must be present.")
-DEF_SWITCH(CacheDirPath,
+DEF_SWITCH(kCacheDirPath,
            "cache-dir-path",
            "Path to the cache directory. "
            "This is different from the persistent_cache_path in embedder.h, "
            "which is used for Skia shader cache.")
-DEF_SWITCH(ICUDataFilePath, "icu-data-file-path", "Path to the ICU data file.")
-DEF_SWITCH(ICUSymbolPrefix,
+DEF_SWITCH(kIcuDataFilePath, "icu-data-file-path", "Path to the ICU data file.")
+DEF_SWITCH(kIcuSymbolPrefix,
            "icu-symbol-prefix",
            "Prefix for the symbols representing ICU data linked into the "
            "Flutter library.")
-DEF_SWITCH(ICUNativeLibPath,
+DEF_SWITCH(kIcuNativeLibPath,
            "icu-native-lib-path",
            "Path to the library file that exports the ICU data.")
-DEF_SWITCH(DartFlags,
+DEF_SWITCH(kDartFlags,
            "dart-flags",
            "Flags passed directly to the Dart VM without being interpreted "
            "by the Flutter shell.")
-DEF_SWITCH(DeviceVMServiceHost,
+DEF_SWITCH(kDeviceVmServiceHost,
            "vm-service-host",
            "The hostname/IP address on which the Dart VM Service should "
            "be served. If not set, defaults to 127.0.0.1 or ::1 depending on "
            "whether --ipv6 is specified.")
-DEF_SWITCH(DeviceVMServicePort,
+DEF_SWITCH(kDeviceVmServicePort,
            "vm-service-port",
            "A custom Dart VM Service port. The default is to pick a randomly "
            "available open port.")
 DEF_SWITCH(
-    DisableVMService,
+    kDisableVmService,
     "disable-vm-service",
     "Disable the Dart VM Service. The Dart VM Service is never available "
     "in release mode.")
-DEF_SWITCH(DisableVMServicePublication,
+DEF_SWITCH(kDisableVmServicePublication,
            "disable-vm-service-publication",
            "Disable mDNS Dart VM Service publication.")
-DEF_SWITCH(IPv6,
+DEF_SWITCH(kIPv6,
            "ipv6",
            "Bind to the IPv6 localhost address for the Dart VM Service. "
            "Ignored if --vm-service-host is set.")
-DEF_SWITCH(EnableDartProfiling,
+DEF_SWITCH(kEnableDartProfiling,
            "enable-dart-profiling",
            "Enable Dart profiling. Profiling information can be viewed from "
            "Dart / Flutter DevTools.")
 DEF_SWITCH(
-    ProfileStartup,
+    kProfileStartup,
     "profile-startup",
     "Make the profiler discard new samples once the profiler sample buffer is "
     "full. When this flag is not set, the profiler sample buffer is used as a "
     "ring buffer, meaning that once it is full, new samples start overwriting "
     "the oldest ones. This switch is only meaningful when set in conjunction "
     "with --enable-dart-profiling.")
-DEF_SWITCH(EndlessTraceBuffer,
+DEF_SWITCH(kEndlessTraceBuffer,
            "endless-trace-buffer",
            "Enable an endless trace buffer. The default is a ring buffer. "
            "This is useful when very old events need to viewed. For example, "
            "during application launch. Memory usage will continue to grow "
            "indefinitely however.")
-DEF_SWITCH(EnableSoftwareRendering,
+DEF_SWITCH(kEnableSoftwareRendering,
            "enable-software-rendering",
            "Enable rendering using the Skia software backend. This is useful "
            "when testing Flutter on emulators. By default, Flutter will "
            "attempt to either use OpenGL, Metal, or Vulkan.")
-DEF_SWITCH(Route,
+DEF_SWITCH(kRoute,
            "route",
            "Start app with an specific route defined on the framework")
-DEF_SWITCH(SkiaDeterministicRendering,
+DEF_SWITCH(kSkiaDeterministicRendering,
            "skia-deterministic-rendering",
            "Skips the call to SkGraphics::Init(), thus avoiding swapping out "
            "some Skia function pointers based on available CPU features. This "
            "is used to obtain 100% deterministic behavior in Skia rendering.")
-DEF_SWITCH(FlutterAssetsDir,
+DEF_SWITCH(kFlutterAssetsDir,
            "flutter-assets-dir",
            "Path to the Flutter assets directory.")
-DEF_SWITCH(Help, "help", "Display this help text.")
-DEF_SWITCH(LogTag, "log-tag", "Tag associated with log messages.")
-DEF_SWITCH(DisableServiceAuthCodes,
+DEF_SWITCH(kHelp, "help", "Display this help text.")
+DEF_SWITCH(kLogTag, "log-tag", "Tag associated with log messages.")
+DEF_SWITCH(kDisableServiceAuthCodes,
            "disable-service-auth-codes",
            "Disable the requirement for authentication codes for communicating"
            " with the VM service.")
-DEF_SWITCH(DisableServiceOriginCheck,
+DEF_SWITCH(kDisableServiceOriginCheck,
            "disable-service-origin-check",
            "Disable the WebSocket origin check for the VM service.")
-DEF_SWITCH(EnableServicePortFallback,
+DEF_SWITCH(kEnableServicePortFallback,
            "enable-service-port-fallback",
            "Allow the VM service to fallback to automatic port selection if"
            " binding to a specified port fails.")
-DEF_SWITCH(StartPaused,
+DEF_SWITCH(kStartPaused,
            "start-paused",
            "Start the application paused in the Dart debugger.")
-DEF_SWITCH(EnableCheckedMode, "enable-checked-mode", "Enable checked mode.")
-DEF_SWITCH(TraceStartup,
+DEF_SWITCH(kEnableCheckedMode, "enable-checked-mode", "Enable checked mode.")
+DEF_SWITCH(kTraceStartup,
            "trace-startup",
            "Trace early application lifecycle. Automatically switches to an "
            "endless trace buffer.")
-DEF_SWITCH(TraceSkia,
+DEF_SWITCH(kTraceSkia,
            "trace-skia",
            "Trace Skia calls. This is useful when debugging the GPU threed."
            "By default, Skia tracing is not enabled to reduce the number of "
            "traced events")
-DEF_SWITCH(TraceSkiaAllowlist,
+DEF_SWITCH(kTraceSkiaAllowlist,
            "trace-skia-allowlist",
            "Filters out all Skia trace event categories except those that are "
            "specified in this comma separated list.")
 DEF_SWITCH(
-    TraceAllowlist,
+    kTraceAllowlist,
     "trace-allowlist",
     "Filters out all trace events except those that are specified in this "
     "comma separated list of allowed prefixes.")
-DEF_SWITCH(DumpSkpOnShaderCompilation,
+DEF_SWITCH(kDumpSkpOnShaderCompilation,
            "dump-skp-on-shader-compilation",
            "Automatically dump the skp that triggers new shader compilations. "
            "This is useful for writing custom ShaderWarmUp to reduce jank. "
            "By default, this is not enabled to reduce the overhead. ")
-DEF_SWITCH(CacheSkSL,
+DEF_SWITCH(kCacheSkSl,
            "cache-sksl",
            "Only cache the shader in SkSL instead of binary or GLSL. This "
            "should only be used during development phases. The generated SkSLs "
            "can later be used in the release build for shader precompilation "
            "at launch in order to eliminate the shader-compile jank.")
-DEF_SWITCH(PurgePersistentCache,
+DEF_SWITCH(kPurgePersistentCache,
            "purge-persistent-cache",
            "Remove all existing persistent cache. This is mainly for debugging "
            "purposes such as reproducing the shader compilation jank.")
 DEF_SWITCH(
-    TraceSystrace,
+    kTraceSystrace,
     "trace-systrace",
     "Trace to the system tracer (instead of the timeline) on platforms where "
     "such a tracer is available. Currently only supported on Android and "
     "Fuchsia.")
-DEF_SWITCH(TraceToFile,
+DEF_SWITCH(kTraceToFile,
            "trace-to-file",
            "Write the timeline trace to a file at the specified path. The file "
            "will be in Perfetto's proto format; it will be possible to load "
            "the file into Perfetto's trace viewer.")
-DEF_SWITCH(ProfileMicrotasks,
+DEF_SWITCH(kProfileMicrotasks,
            "profile-microtasks",
            "Enable collection of information about each microtask. Information "
            "about completed microtasks will be written to the \"Microtask\" "
            "timeline stream. Information about queued microtasks will be "
            "accessible from Dart / Flutter DevTools.")
-DEF_SWITCH(UseTestFonts,
+DEF_SWITCH(kUseTestFonts,
            "use-test-fonts",
            "Running tests that layout and measure text will not yield "
            "consistent results across various platforms. Enabling this option "
            "will make font resolution default to the Ahem test font on all "
            "platforms (See https://www.w3.org/Style/CSS/Test/Fonts/Ahem/). "
            "This option is only available on the desktop test shells.")
-DEF_SWITCH(DisableAssetFonts,
+DEF_SWITCH(kDisableAssetFonts,
            "disable-asset-fonts",
            "Prevents usage of any non-test fonts unless they were explicitly "
            "Loaded via dart:ui font APIs. This option is only available on the "
            "desktop test shells.")
-DEF_SWITCH(PrefetchedDefaultFontManager,
+DEF_SWITCH(kPrefetchedDefaultFontManager,
            "prefetched-default-font-manager",
            "Indicates whether the embedding started a prefetch of the "
            "default font manager before creating the engine.")
-DEF_SWITCH(VerboseLogging,
+DEF_SWITCH(kVerboseLogging,
            "verbose-logging",
            "By default, only errors are logged. This flag enabled logging at "
            "all severity levels. This is NOT a per shell flag and affect log "
            "levels for all shells in the process.")
-DEF_SWITCH(RunForever,
+DEF_SWITCH(kRunForever,
            "run-forever",
            "In non-interactive mode, keep the shell running after the Dart "
            "script has completed.")
-DEF_SWITCH(DisableDartAsserts,
+DEF_SWITCH(kDisableDartAsserts,
            "disable-dart-asserts",
            "Dart code runs with assertions enabled when the runtime mode is "
            "debug. In profile and release product modes, assertions are "
            "disabled. This flag may be specified if the user wishes to run "
            "with assertions disabled in the debug product mode (i.e. with JIT "
            "or DBC).")
-DEF_SWITCH(DisallowInsecureConnections,
+DEF_SWITCH(kDisallowInsecureConnections,
            "disallow-insecure-connections",
            "By default, dart:io allows all socket connections. If this switch "
            "is set, all insecure connections are rejected.")
-DEF_SWITCH(DomainNetworkPolicy,
+DEF_SWITCH(kDomainNetworkPolicy,
            "domain-network-policy",
            "JSON encoded network policy per domain. This overrides the "
            "DisallowInsecureConnections switch. Embedder can specify whether "
            "to allow or disallow insecure connections at a domain level.")
 DEF_SWITCH(
-    ForceMultithreading,
+    kForceMultithreading,
     "force-multithreading",
     "Uses separate threads for the platform, UI, GPU and IO task runners. "
     "By default, a single thread is used for all task runners. Only available "
     "in the flutter_tester.")
-DEF_SWITCH(OldGenHeapSize,
+DEF_SWITCH(kOldGenHeapSize,
            "old-gen-heap-size",
            "The size limit in megabytes for the Dart VM old gen heap space.")
 
-DEF_SWITCH(ResourceCacheMaxBytesThreshold,
+DEF_SWITCH(kResourceCacheMaxBytesThreshold,
            "resource-cache-max-bytes-threshold",
            "The max bytes threshold of resource cache, or 0 for unlimited.")
-DEF_SWITCH(EnableImpeller,
+DEF_SWITCH(kEnableImpeller,
            "enable-impeller",
            "Enable the Impeller renderer on supported platforms. Ignored if "
            "Impeller is not supported on the platform.")
-DEF_SWITCH(ImpellerBackend,
+DEF_SWITCH(kImpellerBackend,
            "impeller-backend",
            "Requests a particular Impeller backend on platforms that support "
            "multiple backends. (ex `opengles` or `vulkan`)")
-DEF_SWITCH(EnableVulkanValidation,
+DEF_SWITCH(kEnableVulkanValidation,
            "enable-vulkan-validation",
            "Enable loading Vulkan validation layers. The layers must be "
            "available to the application and loadable. On non-Vulkan backends, "
            "this flag does nothing.")
-DEF_SWITCH(EnableOpenGLGPUTracing,
+DEF_SWITCH(kEnableOpenGlgpuTracing,
            "enable-opengl-gpu-tracing",
            "Enable tracing of GPU execution time when using the Impeller "
            "OpenGLES backend.")
-DEF_SWITCH(EnableVulkanGPUTracing,
+DEF_SWITCH(kEnableVulkanGpuTracing,
            "enable-vulkan-gpu-tracing",
            "Enable tracing of GPU execution time when using the Impeller "
            "Vulkan backend.")
-DEF_SWITCH(LeakVM,
+DEF_SWITCH(kLeakVm,
            "leak-vm",
            "When the last shell shuts down, the shared VM is leaked by default "
            "(the leak_vm in VM settings is true). To clean up the leak VM, set "
            "this value to false.")
-DEF_SWITCH(EnableEmbedderAPI,
+DEF_SWITCH(kEnableEmbedderApi,
            "enable-embedder-api",
            "Enable the embedder api. Defaults to false. iOS only.")
-DEF_SWITCH(EnablePlatformIsolates,
+DEF_SWITCH(kEnablePlatformIsolates,
            "enable-platform-isolates",
            "Enable support for isolates that run on the platform thread.")
-DEF_SWITCH(MergedPlatformUIThread,
+DEF_SWITCH(kMergedPlatformUiThread,
            "merged-platform-ui-thread",
            "Sets whether the ui thread and platform thread should be merged.")
 // This is a legacy flag that has been superseded by merged-platform-ui-thread.
 // TODO(163064): remove this when users have been migrated.
-DEF_SWITCH(DisableMergedPlatformUIThread,
+DEF_SWITCH(kDisableMergedPlatformUiThread,
            "no-enable-merged-platform-ui-thread",
            "Disables merging of the UI and platform threads.")
-DEF_SWITCH(EnableAndroidHcppAndSurfaceControl,
+DEF_SWITCH(kEnableAndroidHcppAndSurfaceControl,
            "enable-hcpp-and-surface-control",
            "Enable the HCPP platform view mode and SurfaceControl backed "
            "swapchain when supported.")
-DEF_SWITCH(EnableFlutterGPU,
+DEF_SWITCH(kEnableFlutterGpu,
            "enable-flutter-gpu",
            "Whether Flutter GPU is enabled.")
-DEF_SWITCH(ImpellerLazyShaderMode,
+DEF_SWITCH(kImpellerLazyShaderMode,
            "impeller-lazy-shader-mode",
            "Whether to defer initialization of all required PSOs for the "
            "Impeller backend. Defaults to false.")
-DEF_SWITCH(ImpellerUseSDFs,
+DEF_SWITCH(kImpellerUseSdFs,
            "impeller-use-sdfs",
            "Whether to use SDFs for rendering in Impeller.")
 DEF_SWITCHES_END

--- a/engine/src/flutter/shell/common/switches.cc
+++ b/engine/src/flutter/shell/common/switches.cc
@@ -238,27 +238,27 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
 
   // Enable the VM Service
   settings.enable_vm_service =
-      !command_line.HasOption(FlagForSwitch(Switch::DisableVMService));
+      !command_line.HasOption(FlagForSwitch(Switch::kDisableVmService));
 
   // Enable mDNS VM Service Publication
   settings.enable_vm_service_publication = !command_line.HasOption(
-      FlagForSwitch(Switch::DisableVMServicePublication));
+      FlagForSwitch(Switch::kDisableVmServicePublication));
 
   // Set VM Service Host
-  if (command_line.HasOption(FlagForSwitch(Switch::DeviceVMServiceHost))) {
-    command_line.GetOptionValue(FlagForSwitch(Switch::DeviceVMServiceHost),
+  if (command_line.HasOption(FlagForSwitch(Switch::kDeviceVmServiceHost))) {
+    command_line.GetOptionValue(FlagForSwitch(Switch::kDeviceVmServiceHost),
                                 &settings.vm_service_host);
   }
   // Default the VM Service port based on --ipv6 if not set.
   if (settings.vm_service_host.empty()) {
     settings.vm_service_host =
-        command_line.HasOption(FlagForSwitch(Switch::IPv6)) ? "::1"
-                                                            : "127.0.0.1";
+        command_line.HasOption(FlagForSwitch(Switch::kIPv6)) ? "::1"
+                                                             : "127.0.0.1";
   }
 
   // Set VM Service Port
-  if (command_line.HasOption(FlagForSwitch(Switch::DeviceVMServicePort))) {
-    if (!GetSwitchValue(command_line, Switch::DeviceVMServicePort,
+  if (command_line.HasOption(FlagForSwitch(Switch::kDeviceVmServicePort))) {
+    if (!GetSwitchValue(command_line, Switch::kDeviceVmServicePort,
                         &settings.vm_service_port)) {
       FML_LOG(INFO)
           << "VM Service port specified was malformed. Will default to "
@@ -267,59 +267,59 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
   }
 
   settings.may_insecurely_connect_to_all_domains = !command_line.HasOption(
-      FlagForSwitch(Switch::DisallowInsecureConnections));
+      FlagForSwitch(Switch::kDisallowInsecureConnections));
 
-  command_line.GetOptionValue(FlagForSwitch(Switch::DomainNetworkPolicy),
+  command_line.GetOptionValue(FlagForSwitch(Switch::kDomainNetworkPolicy),
                               &settings.domain_network_policy);
 
   // Disable need for authentication codes for VM service communication, if
   // specified.
   settings.disable_service_auth_codes =
-      command_line.HasOption(FlagForSwitch(Switch::DisableServiceAuthCodes));
+      command_line.HasOption(FlagForSwitch(Switch::kDisableServiceAuthCodes));
 
   // Disable WebSocket origin checks for the VM service, if specified.
   settings.disable_service_origin_check =
-      command_line.HasOption(FlagForSwitch(Switch::DisableServiceOriginCheck));
+      command_line.HasOption(FlagForSwitch(Switch::kDisableServiceOriginCheck));
 
   // Allow fallback to automatic port selection if binding to a specified port
   // fails.
   settings.enable_service_port_fallback =
-      command_line.HasOption(FlagForSwitch(Switch::EnableServicePortFallback));
+      command_line.HasOption(FlagForSwitch(Switch::kEnableServicePortFallback));
 
   // Checked mode overrides.
   settings.disable_dart_asserts =
-      command_line.HasOption(FlagForSwitch(Switch::DisableDartAsserts));
+      command_line.HasOption(FlagForSwitch(Switch::kDisableDartAsserts));
 
   settings.start_paused =
-      command_line.HasOption(FlagForSwitch(Switch::StartPaused));
+      command_line.HasOption(FlagForSwitch(Switch::kStartPaused));
 
   settings.enable_checked_mode =
-      command_line.HasOption(FlagForSwitch(Switch::EnableCheckedMode));
+      command_line.HasOption(FlagForSwitch(Switch::kEnableCheckedMode));
 
   settings.enable_dart_profiling =
-      command_line.HasOption(FlagForSwitch(Switch::EnableDartProfiling));
+      command_line.HasOption(FlagForSwitch(Switch::kEnableDartProfiling));
 
   settings.profile_startup =
-      command_line.HasOption(FlagForSwitch(Switch::ProfileStartup));
+      command_line.HasOption(FlagForSwitch(Switch::kProfileStartup));
 
   settings.enable_software_rendering =
-      command_line.HasOption(FlagForSwitch(Switch::EnableSoftwareRendering));
+      command_line.HasOption(FlagForSwitch(Switch::kEnableSoftwareRendering));
 
   settings.endless_trace_buffer =
-      command_line.HasOption(FlagForSwitch(Switch::EndlessTraceBuffer));
+      command_line.HasOption(FlagForSwitch(Switch::kEndlessTraceBuffer));
 
   settings.trace_startup =
-      command_line.HasOption(FlagForSwitch(Switch::TraceStartup));
+      command_line.HasOption(FlagForSwitch(Switch::kTraceStartup));
 
 #if !FLUTTER_RELEASE
   settings.trace_skia = true;
 
-  if (command_line.HasOption(FlagForSwitch(Switch::TraceSkia))) {
+  if (command_line.HasOption(FlagForSwitch(Switch::kTraceSkia))) {
     // If --trace-skia is specified, then log all Skia events.
     settings.trace_skia_allowlist.reset();
   } else {
     std::string trace_skia_allowlist;
-    command_line.GetOptionValue(FlagForSwitch(Switch::TraceSkiaAllowlist),
+    command_line.GetOptionValue(FlagForSwitch(Switch::kTraceSkiaAllowlist),
                                 &trace_skia_allowlist);
     if (trace_skia_allowlist.size()) {
       settings.trace_skia_allowlist = ParseCommaDelimited(trace_skia_allowlist);
@@ -330,59 +330,60 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
 #endif  // !FLUTTER_RELEASE
 
   std::string trace_allowlist;
-  command_line.GetOptionValue(FlagForSwitch(Switch::TraceAllowlist),
+  command_line.GetOptionValue(FlagForSwitch(Switch::kTraceAllowlist),
                               &trace_allowlist);
   settings.trace_allowlist = ParseCommaDelimited(trace_allowlist);
 
   settings.trace_systrace =
-      command_line.HasOption(FlagForSwitch(Switch::TraceSystrace));
+      command_line.HasOption(FlagForSwitch(Switch::kTraceSystrace));
 
-  command_line.GetOptionValue(FlagForSwitch(Switch::TraceToFile),
+  command_line.GetOptionValue(FlagForSwitch(Switch::kTraceToFile),
                               &settings.trace_to_file);
 
   settings.profile_microtasks =
-      command_line.HasOption(FlagForSwitch(Switch::ProfileMicrotasks));
+      command_line.HasOption(FlagForSwitch(Switch::kProfileMicrotasks));
 
-  settings.skia_deterministic_rendering_on_cpu =
-      command_line.HasOption(FlagForSwitch(Switch::SkiaDeterministicRendering));
+  settings.skia_deterministic_rendering_on_cpu = command_line.HasOption(
+      FlagForSwitch(Switch::kSkiaDeterministicRendering));
 
   settings.verbose_logging =
-      command_line.HasOption(FlagForSwitch(Switch::VerboseLogging));
+      command_line.HasOption(FlagForSwitch(Switch::kVerboseLogging));
 
-  command_line.GetOptionValue(FlagForSwitch(Switch::FlutterAssetsDir),
+  command_line.GetOptionValue(FlagForSwitch(Switch::kFlutterAssetsDir),
                               &settings.assets_path);
 
   std::vector<std::string_view> aot_shared_library_name =
-      command_line.GetOptionValues(FlagForSwitch(Switch::AotSharedLibraryName));
+      command_line.GetOptionValues(
+          FlagForSwitch(Switch::kAotSharedLibraryName));
 
   std::vector<std::string_view> vmservice_shared_library_name =
       command_line.GetOptionValues(
-          FlagForSwitch(Switch::AotVMServiceSharedLibraryName));
+          FlagForSwitch(Switch::kAotVmServiceSharedLibraryName));
   for (auto path : vmservice_shared_library_name) {
     settings.vmservice_snapshot_library_path.emplace_back(path);
   }
 
   std::string snapshot_asset_path;
-  command_line.GetOptionValue(FlagForSwitch(Switch::SnapshotAssetPath),
+  command_line.GetOptionValue(FlagForSwitch(Switch::kSnapshotAssetPath),
                               &snapshot_asset_path);
 
   std::string vm_snapshot_data_filename;
-  command_line.GetOptionValue(FlagForSwitch(Switch::VmSnapshotData),
+  command_line.GetOptionValue(FlagForSwitch(Switch::kVmSnapshotData),
                               &vm_snapshot_data_filename);
 
-  command_line.GetOptionValue(FlagForSwitch(Switch::Route), &settings.route);
+  command_line.GetOptionValue(FlagForSwitch(Switch::kRoute), &settings.route);
 
   std::string vm_snapshot_instr_filename;
-  command_line.GetOptionValue(FlagForSwitch(Switch::VmSnapshotInstructions),
+  command_line.GetOptionValue(FlagForSwitch(Switch::kVmSnapshotInstructions),
                               &vm_snapshot_instr_filename);
 
   std::string isolate_snapshot_data_filename;
-  command_line.GetOptionValue(FlagForSwitch(Switch::IsolateSnapshotData),
+  command_line.GetOptionValue(FlagForSwitch(Switch::kIsolateSnapshotData),
                               &isolate_snapshot_data_filename);
 
   std::string isolate_snapshot_instr_filename;
   command_line.GetOptionValue(
-      FlagForSwitch(Switch::IsolateSnapshotInstructions),
+      FlagForSwitch(Switch::kIsolateSnapshotInstructions),
       &isolate_snapshot_instr_filename);
 
   if (!aot_shared_library_name.empty()) {
@@ -400,21 +401,21 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
         {snapshot_asset_path, isolate_snapshot_instr_filename});
   }
 
-  command_line.GetOptionValue(FlagForSwitch(Switch::CacheDirPath),
+  command_line.GetOptionValue(FlagForSwitch(Switch::kCacheDirPath),
                               &settings.temp_directory_path);
 
   bool leak_vm = "true" == command_line.GetOptionValueWithDefault(
-                               FlagForSwitch(Switch::LeakVM), "true");
+                               FlagForSwitch(Switch::kLeakVm), "true");
   settings.leak_vm = leak_vm;
 
   if (settings.icu_initialization_required) {
-    command_line.GetOptionValue(FlagForSwitch(Switch::ICUDataFilePath),
+    command_line.GetOptionValue(FlagForSwitch(Switch::kIcuDataFilePath),
                                 &settings.icu_data_path);
-    if (command_line.HasOption(FlagForSwitch(Switch::ICUSymbolPrefix))) {
+    if (command_line.HasOption(FlagForSwitch(Switch::kIcuSymbolPrefix))) {
       std::string icu_symbol_prefix, native_lib_path;
-      command_line.GetOptionValue(FlagForSwitch(Switch::ICUSymbolPrefix),
+      command_line.GetOptionValue(FlagForSwitch(Switch::kIcuSymbolPrefix),
                                   &icu_symbol_prefix);
-      command_line.GetOptionValue(FlagForSwitch(Switch::ICUNativeLibPath),
+      command_line.GetOptionValue(FlagForSwitch(Switch::kIcuNativeLibPath),
                                   &native_lib_path);
 
 #if FML_OS_ANDROID
@@ -428,9 +429,9 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
   }
 
   settings.use_test_fonts =
-      command_line.HasOption(FlagForSwitch(Switch::UseTestFonts));
+      command_line.HasOption(FlagForSwitch(Switch::kUseTestFonts));
   settings.use_asset_fonts =
-      !command_line.HasOption(FlagForSwitch(Switch::DisableAssetFonts));
+      !command_line.HasOption(FlagForSwitch(Switch::kDisableAssetFonts));
 
 #if FML_OS_IOS || FML_OS_IOS_SIMULATOR || SLIMPELLER
 // On these configurations, the Impeller flags are completely ignored with the
@@ -438,7 +439,7 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
 #else   // FML_OS_IOS && !FML_OS_IOS_SIMULATOR
   {
     std::string enable_impeller_value;
-    if (command_line.GetOptionValue(FlagForSwitch(Switch::EnableImpeller),
+    if (command_line.GetOptionValue(FlagForSwitch(Switch::kEnableImpeller),
                                     &enable_impeller_value)) {
       settings.enable_impeller =
           enable_impeller_value.empty() || "true" == enable_impeller_value;
@@ -448,7 +449,7 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
 
   {
     std::string impeller_backend_value;
-    if (command_line.GetOptionValue(FlagForSwitch(Switch::ImpellerBackend),
+    if (command_line.GetOptionValue(FlagForSwitch(Switch::kImpellerBackend),
                                     &impeller_backend_value)) {
       if (!impeller_backend_value.empty()) {
         settings.requested_rendering_backend = impeller_backend_value;
@@ -457,20 +458,20 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
   }
 
   settings.enable_vulkan_validation =
-      command_line.HasOption(FlagForSwitch(Switch::EnableVulkanValidation));
+      command_line.HasOption(FlagForSwitch(Switch::kEnableVulkanValidation));
   settings.enable_opengl_gpu_tracing =
-      command_line.HasOption(FlagForSwitch(Switch::EnableOpenGLGPUTracing));
+      command_line.HasOption(FlagForSwitch(Switch::kEnableOpenGlgpuTracing));
   settings.enable_vulkan_gpu_tracing =
-      command_line.HasOption(FlagForSwitch(Switch::EnableVulkanGPUTracing));
+      command_line.HasOption(FlagForSwitch(Switch::kEnableVulkanGpuTracing));
 
   settings.enable_embedder_api =
-      command_line.HasOption(FlagForSwitch(Switch::EnableEmbedderAPI));
+      command_line.HasOption(FlagForSwitch(Switch::kEnableEmbedderApi));
 
   settings.prefetched_default_font_manager = command_line.HasOption(
-      FlagForSwitch(Switch::PrefetchedDefaultFontManager));
+      FlagForSwitch(Switch::kPrefetchedDefaultFontManager));
 
   std::string all_dart_flags;
-  if (command_line.GetOptionValue(FlagForSwitch(Switch::DartFlags),
+  if (command_line.GetOptionValue(FlagForSwitch(Switch::kDartFlags),
                                   &all_dart_flags)) {
     // Assume that individual flags are comma separated.
     std::vector<std::string> flags = ParseCommaDelimited(all_dart_flags);
@@ -483,42 +484,43 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
   }
 
 #if !FLUTTER_RELEASE
-  command_line.GetOptionValue(FlagForSwitch(Switch::LogTag), &settings.log_tag);
+  command_line.GetOptionValue(FlagForSwitch(Switch::kLogTag),
+                              &settings.log_tag);
 #endif
 
-  settings.dump_skp_on_shader_compilation =
-      command_line.HasOption(FlagForSwitch(Switch::DumpSkpOnShaderCompilation));
+  settings.dump_skp_on_shader_compilation = command_line.HasOption(
+      FlagForSwitch(Switch::kDumpSkpOnShaderCompilation));
 
   settings.cache_sksl =
-      command_line.HasOption(FlagForSwitch(Switch::CacheSkSL));
+      command_line.HasOption(FlagForSwitch(Switch::kCacheSkSl));
 
   settings.purge_persistent_cache =
-      command_line.HasOption(FlagForSwitch(Switch::PurgePersistentCache));
+      command_line.HasOption(FlagForSwitch(Switch::kPurgePersistentCache));
 
-  if (command_line.HasOption(FlagForSwitch(Switch::OldGenHeapSize))) {
+  if (command_line.HasOption(FlagForSwitch(Switch::kOldGenHeapSize))) {
     std::string old_gen_heap_size;
-    command_line.GetOptionValue(FlagForSwitch(Switch::OldGenHeapSize),
+    command_line.GetOptionValue(FlagForSwitch(Switch::kOldGenHeapSize),
                                 &old_gen_heap_size);
     settings.old_gen_heap_size = std::stoi(old_gen_heap_size);
   }
 
   if (command_line.HasOption(
-          FlagForSwitch(Switch::ResourceCacheMaxBytesThreshold))) {
+          FlagForSwitch(Switch::kResourceCacheMaxBytesThreshold))) {
     std::string resource_cache_max_bytes_threshold;
     command_line.GetOptionValue(
-        FlagForSwitch(Switch::ResourceCacheMaxBytesThreshold),
+        FlagForSwitch(Switch::kResourceCacheMaxBytesThreshold),
         &resource_cache_max_bytes_threshold);
     settings.resource_cache_max_bytes_threshold =
         std::stoi(resource_cache_max_bytes_threshold);
   }
 
   settings.enable_platform_isolates =
-      command_line.HasOption(FlagForSwitch(Switch::EnablePlatformIsolates));
+      command_line.HasOption(FlagForSwitch(Switch::kEnablePlatformIsolates));
 
   {
     std::string enable_surface_control_value;
     if (command_line.GetOptionValue(
-            FlagForSwitch(Switch::EnableAndroidHcppAndSurfaceControl),
+            FlagForSwitch(Switch::kEnableAndroidHcppAndSurfaceControl),
             &enable_surface_control_value)) {
       settings.enable_surface_control = enable_surface_control_value.empty() ||
                                         "true" == enable_surface_control_value;
@@ -529,17 +531,17 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
   constexpr std::string_view kMergedThreadDisabled = "disabled";
   constexpr std::string_view kMergedThreadMergeAfterLaunch = "mergeAfterLaunch";
   if (command_line.HasOption(
-          FlagForSwitch(Switch::DisableMergedPlatformUIThread))) {
+          FlagForSwitch(Switch::kDisableMergedPlatformUiThread))) {
     FML_CHECK(!require_merged_platform_ui_thread)
         << "This platform does not support the "
-        << FlagForSwitch(Switch::DisableMergedPlatformUIThread) << " flag";
+        << FlagForSwitch(Switch::kDisableMergedPlatformUiThread) << " flag";
 
     settings.merged_platform_ui_thread =
         Settings::MergedPlatformUIThread::kDisabled;
   } else if (command_line.HasOption(
-                 FlagForSwitch(Switch::MergedPlatformUIThread))) {
+                 FlagForSwitch(Switch::kMergedPlatformUiThread))) {
     std::string merged_platform_ui;
-    command_line.GetOptionValue(FlagForSwitch(Switch::MergedPlatformUIThread),
+    command_line.GetOptionValue(FlagForSwitch(Switch::kMergedPlatformUiThread),
                                 &merged_platform_ui);
     if (merged_platform_ui == kMergedThreadEnabled) {
       settings.merged_platform_ui_thread =
@@ -547,7 +549,7 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
     } else if (merged_platform_ui == kMergedThreadDisabled) {
       FML_CHECK(!require_merged_platform_ui_thread)
           << "This platform does not support the "
-          << FlagForSwitch(Switch::MergedPlatformUIThread) << "="
+          << FlagForSwitch(Switch::kMergedPlatformUiThread) << "="
           << kMergedThreadDisabled << " flag";
 
       settings.merged_platform_ui_thread =
@@ -559,11 +561,11 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line,
   }
 
   settings.enable_flutter_gpu =
-      command_line.HasOption(FlagForSwitch(Switch::EnableFlutterGPU));
+      command_line.HasOption(FlagForSwitch(Switch::kEnableFlutterGpu));
   settings.impeller_enable_lazy_shader_mode =
-      command_line.HasOption(FlagForSwitch(Switch::ImpellerLazyShaderMode));
+      command_line.HasOption(FlagForSwitch(Switch::kImpellerLazyShaderMode));
   settings.impeller_use_sdfs =
-      command_line.HasOption(FlagForSwitch(Switch::ImpellerUseSDFs));
+      command_line.HasOption(FlagForSwitch(Switch::kImpellerUseSdFs));
 
   return settings;
 }

--- a/engine/src/flutter/shell/platform/android/android_context_gl_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_gl_impeller.cc
@@ -191,8 +191,7 @@ AndroidContextGLImpeller::AndroidContextGLImpeller(
   }
   // Setup context listeners.
   impeller::egl::Context::LifecycleListener listener =
-      [worker =
-           reactor_worker_](impeller::egl ::Context::LifecycleEvent event) {
+      [worker = reactor_worker_](impeller::egl::Context::LifecycleEvent event) {
         switch (event) {
           case impeller::egl::Context::LifecycleEvent::kDidMakeCurrent:
             worker->SetReactionsAllowedOnCurrentThread(true);

--- a/engine/src/flutter/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/engine/src/flutter/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -315,7 +315,7 @@ FLUTTER_ASSERT_ARC
   skiaTextureInfo.fTexture.retain((__bridge GrMTLHandle)rgbaTex);
 
   GrBackendTexture skiaBackendTexture =
-      GrBackendTextures::MakeMtl(width, height, skgpu::Mipmapped ::kNo, skiaTextureInfo);
+      GrBackendTextures::MakeMtl(width, height, skgpu::Mipmapped::kNo, skiaTextureInfo);
 
   return SkImages::BorrowTextureFrom(grContext, skiaBackendTexture, kTopLeft_GrSurfaceOrigin,
                                      kBGRA_8888_SkColorType, kPremul_SkAlphaType,

--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -411,7 +411,7 @@ copy("copy_asan_runtime_dylib") {
   # TODO(cbracken): https://github.com/flutter/flutter/issues/186668
   # Eliminate clang toolchain hardcoding.
   _libclang_base_path =
-      "$buildtools_path/mac-${host_cpu}/clang/lib/clang/23/lib/darwin/"
+      "$buildtools_path/mac-${host_cpu}/clang/lib/clang/24/lib/darwin/"
 
   if (defined(use_ios_simulator) && use_ios_simulator) {
     _dylib_name = "libclang_rt.asan_iossim_dynamic.dylib"

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponder.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponder.mm
@@ -31,20 +31,20 @@ typedef NS_OPTIONS(NSInteger, kKeyboardModifier) {
   kKeyboardModifierLeftCommand = 0x08,
   kKeyboardModifierRightCommand = 0x10,
   kKeyboardModifierNumericPad = 0x200000,
-  kKeyboardModifierMask = kKeyboardModifierAlphaShift |    //
-                          kKeyboardModifierShift |         //
-                          kKeyboardModifierLeftShift |     //
-                          kKeyboardModifierRightShift |    //
-                          kKeyboardModifierControl |       //
-                          kKeyboardModifierLeftControl |   //
-                          kKeyboardModifierRightControl |  //
-                          kKeyboardModifierOption |        //
-                          kKeyboardModifierLeftOption |    //
-                          kKeyboardModifierRightOption |   //
-                          kKeyboardModifierCommand |       //
-                          kKeyboardModifierLeftCommand |   //
-                          kKeyboardModifierRightCommand |  //
-                          kKeyboardModifierNumericPad,
+  kKeyboardModifierMask = kKeyboardModifierAlphaShift |  //
+      kKeyboardModifierShift |                           //
+      kKeyboardModifierLeftShift |                       //
+      kKeyboardModifierRightShift |                      //
+      kKeyboardModifierControl |                         //
+      kKeyboardModifierLeftControl |                     //
+      kKeyboardModifierRightControl |                    //
+      kKeyboardModifierOption |                          //
+      kKeyboardModifierLeftOption |                      //
+      kKeyboardModifierRightOption |                     //
+      kKeyboardModifierCommand |                         //
+      kKeyboardModifierLeftCommand |                     //
+      kKeyboardModifierRightCommand |                    //
+      kKeyboardModifierNumericPad,
 };
 
 /**

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -530,11 +530,11 @@ void HandleResponse(bool handled, void* user_data);
   NSAssert(guardedCallback.handled, @"The callback returned without being handled.");
   NSAssert(
       (_lastModifierFlagsOfInterest & ~kModifierFlagCapsLock) ==
-          ([self adjustModifiers:press] & (_modifierFlagOfInterestMask & ~kModifierFlagCapsLock)),
+          ([self adjustModifiers:press] & (_modifierFlagOfInterestMask& ~kModifierFlagCapsLock)),
       @"The modifier flags are not properly updated: recorded 0x%lx, event with mask 0x%lx",
       static_cast<unsigned long>(_lastModifierFlagsOfInterest & ~kModifierFlagCapsLock),
       static_cast<unsigned long>([self adjustModifiers:press] &
-                                 (_modifierFlagOfInterestMask & ~kModifierFlagCapsLock)));
+                                 (_modifierFlagOfInterestMask& ~kModifierFlagCapsLock)));
 }
 
 #pragma mark - Private

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -1765,14 +1765,14 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 static BOOL FLTFlutterPluginRespondsToLegacyAppLifecycleSelectors(
     NSObject<FlutterPlugin>* delegate) {
   SEL selectors[] = {
-    @selector(applicationDidBecomeActive:),
-    @selector(applicationWillResignActive:),
-    @selector(applicationWillEnterForeground:),
-    @selector(applicationDidEnterBackground:),
-    @selector(application:continueUserActivity:restorationHandler:),
-    @selector(application:performActionForShortcutItem:completionHandler:),
-    @selector(application:openURL:options:),
-    @selector(application:performFetchWithCompletionHandler:),
+      @selector(applicationDidBecomeActive:),
+      @selector(applicationWillResignActive:),
+      @selector(applicationWillEnterForeground:),
+      @selector(applicationDidEnterBackground:),
+      @selector(application:continueUserActivity:restorationHandler:),
+      @selector(application:performActionForShortcutItem:completionHandler:),
+      @selector(application:openURL:options:),
+      @selector(application:performFetchWithCompletionHandler:),
   };
   for (SEL sel : selectors) {
     if ([delegate respondsToSelector:sel]) {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -1507,9 +1507,11 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
     bridge->AccessibilityObjectDidBecomeFocused(123);
 
     NSDictionary<NSString*, id>* annotatedEvent = @{@"type" : @"didGainFocus", @"nodeId" : @123};
-    NSData* encodedMessage = [[FlutterStandardMessageCodec sharedInstance] encode:annotatedEvent];
-
-    OCMVerify([messenger sendOnChannel:@"flutter/accessibility" message:encodedMessage]);
+    OCMVerify([messenger sendOnChannel:@"flutter/accessibility"
+                               message:[OCMArg checkWithBlock:^BOOL(NSData* message) {
+                                 return [[[FlutterStandardMessageCodec sharedInstance]
+                                     decode:message] isEqual:annotatedEvent];
+                               }]]);
     latch.Signal();
   });
   latch.Wait();

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -631,7 +631,7 @@ TEST_F(FlutterEngineTest, DartEntrypointArguments) {
   engine.embedderAPI.Initialize = MOCK_ENGINE_PROC(
       Initialize, ([&called, &original_init](size_t version, const FlutterRendererConfig* config,
                                              const FlutterProjectArgs* args, void* user_data,
-                                             FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                                             FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         called = true;
         EXPECT_EQ(args->dart_entrypoint_argc, 2);
         NSString* arg1 = [[NSString alloc] initWithCString:args->dart_entrypoint_argv[0]

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManagerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManagerTest.mm
@@ -629,7 +629,7 @@ TEST(FlutterKeyboardManagerUnittests, ShouldNotHoldStrongReferenceToDelegate) {
 
   NSDictionary* pressingRecords = [tester.manager getPressedState];
   EXPECT_EQ([pressingRecords count], 1u);
-  EXPECT_EQ(pressingRecords[@(kPhysicalKeyA)], @(kLogicalKeyA));
+  EXPECT_EQ([pressingRecords[@(kPhysicalKeyA)] unsignedLongLongValue], kLogicalKeyA);
 
   return true;
 }
@@ -652,7 +652,7 @@ TEST(FlutterKeyboardManagerUnittests, ShouldNotHoldStrongReferenceToDelegate) {
   id decoded = [[FlutterStandardMethodCodec sharedInstance] decodeEnvelope:encodedResult];
 
   EXPECT_EQ([decoded count], 1u);
-  EXPECT_EQ(decoded[@(kPhysicalKeyA)], @(kLogicalKeyA));
+  EXPECT_EQ([decoded[@(kPhysicalKeyA)] unsignedLongLongValue], kLogicalKeyA);
 
   return true;
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -52,6 +52,18 @@
 }
 @end
 
+// Matches an encoded JSON message whose content equals that of |expected|.
+//
+// The encoded bytes are not comparable directly: clang emits constant
+// dictionaries for literals, which order their keys differently to the
+// dictionaries the plugins build at runtime.
+static id JSONMessageWithContentOf(NSData* expected) {
+  id expectedContent = [[FlutterJSONMessageCodec sharedInstance] decode:expected];
+  return [OCMArg checkWithBlock:^BOOL(NSData* message) {
+    return [[[FlutterJSONMessageCodec sharedInstance] decode:message] isEqual:expectedContent];
+  }];
+}
+
 @interface FlutterInputPluginTestObjc : NSObject
 - (bool)testEmptyCompositionRange;
 - (bool)testClearClientDuringComposing;
@@ -217,11 +229,13 @@ static const FlutterViewIdentifier kViewId = 1;
                                           arguments:@[ @(1), expectedState ]]];
 
   OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
-      [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+      [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                 message:JSONMessageWithContentOf(updateCall)]);
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -287,11 +301,13 @@ static const FlutterViewIdentifier kViewId = 1;
                                           arguments:@[ @(1), expectedState ]]];
 
   OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
-      [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+      [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                 message:JSONMessageWithContentOf(updateCall)]);
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1255,7 +1271,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1285,7 +1302,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1315,7 +1333,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1374,7 +1393,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1404,7 +1424,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1434,7 +1455,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1464,7 +1486,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1494,7 +1517,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1524,7 +1548,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1554,7 +1579,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1628,7 +1654,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -1992,7 +2019,8 @@ static const FlutterViewIdentifier kViewId = 1;
                                           arguments:@[ @(1), expectedState ]]];
 
   OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
-      [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+      [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                 message:JSONMessageWithContentOf(updateCall)]);
 
   [plugin handleMethodCall:call
                     result:^(id){
@@ -2008,7 +2036,8 @@ static const FlutterViewIdentifier kViewId = 1;
   // Input action should be notified.
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:performActionCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(performActionCall)]);
   } @catch (...) {
     return false;
   }
@@ -2031,7 +2060,8 @@ static const FlutterViewIdentifier kViewId = 1;
   // Verify that editing state was not be updated.
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
     return false;
   } @catch (...) {
     // Expected.
@@ -2092,7 +2122,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(updateCall)]);
   } @catch (...) {
     return false;
   }
@@ -2159,7 +2190,8 @@ static const FlutterViewIdentifier kViewId = 1;
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:performSelectorCall]);
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput"
+                                   message:JSONMessageWithContentOf(performSelectorCall)]);
   } @catch (...) {
     return false;
   }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -97,6 +97,14 @@ static const FlutterKeyEvent kDefaultFlutterKeyEvent = {};
 }
 @end
 
+// Matches an encoded JSON message whose content equals that of |expected|.
+static id JSONMessageWithContentOf(NSData* expected) {
+  id expectedContent = [[FlutterJSONMessageCodec sharedInstance] decode:expected];
+  return [OCMArg checkWithBlock:^BOOL(NSData* message) {
+    return [[[FlutterJSONMessageCodec sharedInstance] decode:message] isEqual:expectedContent];
+  }];
+}
+
 @interface FlutterViewControllerTestObjC : NSObject
 - (bool)testKeyEventsAreSentToFramework:(id)mockEngine;
 - (bool)testKeyEventsArePropagatedIfNotHandled:(id)mockEngine;
@@ -384,7 +392,7 @@ TEST_F(FlutterViewControllerTest, testViewControllerIsReleased) {
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
         [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                   message:encodedKeyEvent
+                                   message:JSONMessageWithContentOf(encodedKeyEvent)
                                binaryReply:[OCMArg any]]);
   } @catch (...) {
     return false;
@@ -536,7 +544,7 @@ TEST_F(FlutterViewControllerTest, testViewControllerIsReleased) {
   NSEvent* event = [NSEvent eventWithCGEvent:cgEvent];
   OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
       [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                 message:encodedKeyEvent
+                                 message:JSONMessageWithContentOf(encodedKeyEvent)
                              binaryReply:[OCMArg any]])
       .andDo((^(NSInvocation* invocation) {
         FlutterBinaryReply handler;
@@ -554,7 +562,7 @@ TEST_F(FlutterViewControllerTest, testViewControllerIsReleased) {
         [responderMock keyDown:[OCMArg any]]);
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
         [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                   message:encodedKeyEvent
+                                   message:JSONMessageWithContentOf(encodedKeyEvent)
                                binaryReply:[OCMArg any]]);
   } @catch (...) {
     return false;
@@ -612,7 +620,7 @@ TEST_F(FlutterViewControllerTest, testViewControllerIsReleased) {
   NSEvent* event = [NSEvent eventWithCGEvent:cgEvent];
   OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
       [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                 message:encodedKeyEvent
+                                 message:JSONMessageWithContentOf(encodedKeyEvent)
                              binaryReply:[OCMArg any]])
       .andDo((^(NSInvocation* invocation) {
         FlutterBinaryReply handler;
@@ -628,7 +636,7 @@ TEST_F(FlutterViewControllerTest, testViewControllerIsReleased) {
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
         [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                   message:encodedKeyEvent
+                                   message:JSONMessageWithContentOf(encodedKeyEvent)
                                binaryReply:[OCMArg any]]);
   } @catch (NSException* e) {
     NSLog(@"%@", e.reason);
@@ -669,7 +677,7 @@ TEST_F(FlutterViewControllerTest, testViewControllerIsReleased) {
   NSEvent* event = [NSEvent eventWithCGEvent:cgEvent];
   OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
       [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                 message:encodedKeyEvent
+                                 message:JSONMessageWithContentOf(encodedKeyEvent)
                              binaryReply:[OCMArg any]])
       .andDo((^(NSInvocation* invocation) {
         FlutterBinaryReply handler;
@@ -687,7 +695,7 @@ TEST_F(FlutterViewControllerTest, testViewControllerIsReleased) {
         never(), [responderMock keyDown:[OCMArg any]]);
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
         [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                   message:encodedKeyEvent
+                                   message:JSONMessageWithContentOf(encodedKeyEvent)
                                binaryReply:[OCMArg any]]);
   } @catch (...) {
     return false;

--- a/engine/src/flutter/shell/platform/embedder/embedder.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder.cc
@@ -575,7 +575,7 @@ InferMetalPlatformViewCreationCallback(
           metal_dispatch_table = {
               .present = metal_present,
               .get_texture = metal_get_texture,
-          };
+      };
       impeller::Flags impeller_flags;
       impeller_flags.use_sdfs = shell.GetSettings().impeller_use_sdfs;
       embedder_surface =
@@ -590,7 +590,7 @@ InferMetalPlatformViewCreationCallback(
           metal_dispatch_table = {
               .present = metal_present,
               .get_texture = metal_get_texture,
-          };
+      };
       embedder_surface = std::make_unique<flutter::EmbedderSurfaceMetalSkia>(
           const_cast<flutter::GPUMTLDeviceHandle>(config->metal.device),
           const_cast<flutter::GPUMTLCommandQueueHandle>(
@@ -675,7 +675,7 @@ InferVulkanPlatformViewCreationCallback(
                 reinterpret_cast<PFN_vkGetInstanceProcAddr>(proc_addr),
             .get_next_image = vulkan_get_next_image,
             .present_image = vulkan_present_image_callback,
-        };
+    };
 
     std::unique_ptr<flutter::EmbedderSurfaceVulkanImpeller> embedder_surface =
         std::make_unique<flutter::EmbedderSurfaceVulkanImpeller>(
@@ -710,7 +710,7 @@ InferVulkanPlatformViewCreationCallback(
                 reinterpret_cast<PFN_vkGetInstanceProcAddr>(proc_addr),
             .get_next_image = vulkan_get_next_image,
             .present_image = vulkan_present_image_callback,
-        };
+    };
 
     std::unique_ptr<flutter::EmbedderSurfaceVulkan> embedder_surface =
         std::make_unique<flutter::EmbedderSurfaceVulkan>(
@@ -800,7 +800,7 @@ InferSoftwarePlatformViewCreationCallback(
   flutter::EmbedderSurfaceSoftware::SoftwareDispatchTable
       software_dispatch_table = {
           software_present_backing_store,  // required
-      };
+  };
 
   return fml::MakeCopyable(
       [software_dispatch_table, platform_dispatch_table,
@@ -2315,7 +2315,7 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
           on_pre_engine_restart_callback,             //
           channel_update_callback,                    //
           view_focus_change_request_callback,         //
-      };
+  };
 
   impeller::Flags impeller_flags;
   impeller_flags.use_sdfs = settings.impeller_use_sdfs;

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h
@@ -14,7 +14,13 @@
 #include <lib/async/cpp/wait.h>
 #include <lib/fdio/namespace.h>
 #include <lib/fidl/cpp/binding.h>
+// TODO(cbracken): https://github.com/flutter/flutter/issues/192609
+// Remove once the Fuchsia SDK marks bindings_local as maybe_unused in
+// BindingSet::CloseAll.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
 #include <lib/fidl/cpp/binding_set.h>
+#pragma clang diagnostic pop
 #include <lib/sys/cpp/component_context.h>
 #include <lib/sys/cpp/service_directory.h>
 #include <lib/zx/timer.h>

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
@@ -6,7 +6,13 @@
 #include <gtest/gtest.h>
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/async-loop/default.h>
+// TODO(cbracken): https://github.com/flutter/flutter/issues/192609
+// Remove once the Fuchsia SDK marks bindings_local as maybe_unused in
+// BindingSet::CloseAll.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
 #include <lib/fidl/cpp/binding_set.h>
+#pragma clang diagnostic pop
 #include <lib/zx/eventpair.h>
 
 #include "flutter/shell/platform/fuchsia/flutter/focus_delegate.h"

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/runner_tzdata_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/runner_tzdata_unittest.cc
@@ -17,7 +17,7 @@ TEST(RunnerTZDataTest, LoadsWithTZDataPresent) {
   setenv("ICU_TIMEZONE_FILES_DIR", "/pkg/data/tzdata", true);
 
   UErrorCode err = U_ZERO_ERROR;
-  const auto version_before = std::string(icu::TimeZone::getTZDataVersion(err));
+  icu::TimeZone::getTZDataVersion(err);
   ASSERT_EQ(U_ZERO_ERROR, err) << "unicode error: " << u_errorName(err);
 
   // This loads the tzdata. In Fuchsia, we force the data from this package

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
@@ -7,6 +7,7 @@
 #include <zircon/types.h>
 
 #include <algorithm>  // For std::remove_if
+#include <cmath>
 #include <memory>
 
 #include "flutter/fml/logging.h"
@@ -244,7 +245,8 @@ void FakeFlatland::SetScale(fuchsia::ui::composition::TransformId transform_id,
     return;
   }
 
-  if (isinf(scale.x) || isinf(scale.y) || isnan(scale.x) || isnan(scale.y)) {
+  if (std::isinf(scale.x) || std::isinf(scale.y) || std::isnan(scale.x) ||
+      std::isnan(scale.y)) {
     FML_CHECK(false) << "SetScale failed, invalid scale values (" << scale.x
                      << ", " << scale.y << " ).";
     return;

--- a/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine_test.cc
@@ -342,7 +342,7 @@ TEST_F(FlEngineTest, OnPreEngineRestart) {
       Initialize, ([&callback, &callback_user_data, &called](
                        size_t version, const FlutterRendererConfig* config,
                        const FlutterProjectArgs* args, void* user_data,
-                       FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                       FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         called = true;
         callback = args->on_pre_engine_restart_callback;
         callback_user_data = user_data;
@@ -388,7 +388,7 @@ TEST_F(FlEngineTest, DartEntrypointArgs) {
       Initialize, ([&called, &set_args = args](
                        size_t version, const FlutterRendererConfig* config,
                        const FlutterProjectArgs* args, void* user_data,
-                       FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                       FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         called = true;
         EXPECT_NE(set_args, args->dart_entrypoint_argv);
         EXPECT_EQ(args->dart_entrypoint_argc, 3);
@@ -409,7 +409,7 @@ TEST_F(FlEngineTest, EngineId) {
       Initialize,
       ([&engine_id](size_t version, const FlutterRendererConfig* config,
                     const FlutterProjectArgs* args, void* user_data,
-                    FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                    FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         engine_id = args->engine_id;
         return kSuccess;
       }));
@@ -431,7 +431,7 @@ TEST_F(FlEngineTest, UIIsolateDefaultThreadPolicy) {
       Initialize,
       ([&same_task_runner](size_t version, const FlutterRendererConfig* config,
                            const FlutterProjectArgs* args, void* user_data,
-                           FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                           FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         same_task_runner = args->custom_task_runners->platform_task_runner ==
                            args->custom_task_runners->ui_task_runner;
         return kSuccess;
@@ -453,7 +453,7 @@ TEST_F(FlEngineTest, UIIsolateOnPlatformTaskRunner) {
       Initialize,
       ([&same_task_runner](size_t version, const FlutterRendererConfig* config,
                            const FlutterProjectArgs* args, void* user_data,
-                           FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                           FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         same_task_runner = args->custom_task_runners->platform_task_runner ==
                            args->custom_task_runners->ui_task_runner;
         return kSuccess;
@@ -475,7 +475,7 @@ TEST_F(FlEngineTest, UIIsolateOnSeparateThread) {
       Initialize,
       ([&separate_thread](size_t version, const FlutterRendererConfig* config,
                           const FlutterProjectArgs* args, void* user_data,
-                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                          FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         separate_thread = args->custom_task_runners->ui_task_runner == nullptr;
         return kSuccess;
       }));
@@ -964,7 +964,7 @@ TEST_F(FlEngineTest, EnableImpellerDefault) {
       Initialize,
       ([&called](size_t version, const FlutterRendererConfig* config,
                  const FlutterProjectArgs* args, void* user_data,
-                 FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                 FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         called = true;
         bool has_impeller_switch = false;
         for (int i = 0; i < args->command_line_argc; i++) {
@@ -990,7 +990,7 @@ TEST_F(FlEngineTest, DisableImpeller) {
       Initialize,
       ([&called](size_t version, const FlutterRendererConfig* config,
                  const FlutterProjectArgs* args, void* user_data,
-                 FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                 FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         called = true;
         bool has_impeller_switch = false;
         for (int i = 0; i < args->command_line_argc; i++) {
@@ -1016,7 +1016,7 @@ TEST_F(FlEngineTest, EnableFlutterGpuDefault) {
       Initialize,
       ([&called](size_t version, const FlutterRendererConfig* config,
                  const FlutterProjectArgs* args, void* user_data,
-                 FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                 FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         called = true;
         bool has_flutter_gpu_switch = false;
         for (int i = 0; i < args->command_line_argc; i++) {
@@ -1042,7 +1042,7 @@ TEST_F(FlEngineTest, EnableFlutterGpu) {
       Initialize,
       ([&called](size_t version, const FlutterRendererConfig* config,
                  const FlutterProjectArgs* args, void* user_data,
-                 FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                 FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         called = true;
         bool has_flutter_gpu_switch = false;
         for (int i = 0; i < args->command_line_argc; i++) {
@@ -1075,7 +1075,7 @@ void test_impeller_backing_store(FlEngine* engine,
       Initialize,
       ([&compositor](size_t version, const FlutterRendererConfig* config,
                      const FlutterProjectArgs* args, void* user_data,
-                     FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                     FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         if (args->compositor != nullptr) {
           compositor = *args->compositor;
         }

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -199,7 +199,7 @@ TEST_F(FlutterWindowsEngineTest, RunDoesExpectedInitialization) {
       Run, ([&run_called, engine_instance = engine.get()](
                 size_t version, const FlutterRendererConfig* config,
                 const FlutterProjectArgs* args, void* user_data,
-                FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         run_called = true;
         *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
 
@@ -341,7 +341,7 @@ TEST_F(FlutterWindowsEngineTest, RunSkiaWithoutANGLEUsesSoftware) {
       Run, ([&run_called, engine_instance = engine.get()](
                 size_t version, const FlutterRendererConfig* config,
                 const FlutterProjectArgs* args, void* user_data,
-                FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         run_called = true;
         *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
         // We don't have an EGL Manager, so we should be using software.
@@ -442,7 +442,7 @@ TEST_F(FlutterWindowsEngineTest, RunWithDefaultEnablesImpeller) {
       Run, ([&run_called, engine_instance = engine.get()](
                 size_t version, const FlutterRendererConfig* config,
                 const FlutterProjectArgs* args, void* user_data,
-                FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         run_called = true;
         *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
 
@@ -503,7 +503,7 @@ TEST_F(FlutterWindowsEngineTest, RunWithProjectFlagEnableImpeller) {
   modifier.embedder_api().Run = MOCK_ENGINE_PROC(
       Run, ([&run_called](size_t version, const FlutterRendererConfig* config,
                           const FlutterProjectArgs* args, void* user_data,
-                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                          FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         run_called = true;
         *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
 
@@ -564,7 +564,7 @@ TEST_F(FlutterWindowsEngineTest, RunWithProjectFlagEnableFlutterGpu) {
   modifier.embedder_api().Run = MOCK_ENGINE_PROC(
       Run, ([&run_called](size_t version, const FlutterRendererConfig* config,
                           const FlutterProjectArgs* args, void* user_data,
-                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                          FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         run_called = true;
         *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
 
@@ -618,7 +618,7 @@ TEST_F(FlutterWindowsEngineTest, RunWithoutProjectFlagEnableFlutterGpu) {
   modifier.embedder_api().Run = MOCK_ENGINE_PROC(
       Run, ([&run_called](size_t version, const FlutterRendererConfig* config,
                           const FlutterProjectArgs* args, void* user_data,
-                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                          FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         run_called = true;
         *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
 
@@ -673,7 +673,7 @@ TEST_F(FlutterWindowsEngineTest, RunWithProjectFlagDisableImpeller) {
   modifier.embedder_api().Run = MOCK_ENGINE_PROC(
       Run, ([&run_called](size_t version, const FlutterRendererConfig* config,
                           const FlutterProjectArgs* args, void* user_data,
-                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                          FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         run_called = true;
         *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
 
@@ -725,7 +725,7 @@ TEST_F(FlutterWindowsEngineTest, RunWithCommandLineDisableImpeller) {
   modifier.embedder_api().Run = MOCK_ENGINE_PROC(
       Run, ([&run_called](size_t version, const FlutterRendererConfig* config,
                           const FlutterProjectArgs* args, void* user_data,
-                          FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+                          FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         run_called = true;
         *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
 

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -114,7 +114,7 @@ std::unique_ptr<FlutterWindowsEngine> GetTestEngine(
   modifier.embedder_api().Run = MOCK_ENGINE_PROC(
       Run, ([](size_t version, const FlutterRendererConfig* config,
                const FlutterProjectArgs* args, void* user_data,
-               FLUTTER_API_SYMBOL(FlutterEngine) * engine) {
+               FLUTTER_API_SYMBOL(FlutterEngine)* engine) {
         *engine =
             reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(0x12345678);
         return kSuccess;

--- a/engine/src/flutter/shell/platform/windows/testing/test_keyboard.cc
+++ b/engine/src/flutter/shell/platform/windows/testing/test_keyboard.cc
@@ -176,7 +176,7 @@ void MockEmbedderApiForKeyboard(
   modifier.embedder_api().Run =
       [](size_t version, const FlutterRendererConfig* config,
          const FlutterProjectArgs* args, void* user_data,
-         FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+         FLUTTER_API_SYMBOL(FlutterEngine)* engine_out) {
         *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
 
         return kSuccess;

--- a/engine/src/flutter/shell/testing/tester_main.cc
+++ b/engine/src/flutter/shell/testing/tester_main.cc
@@ -570,7 +570,7 @@ int main(int argc, char* argv[]) {
 
   auto command_line = fml::CommandLineFromPlatformOrArgcArgv(argc, argv);
 
-  if (command_line.HasOption(flutter::FlagForSwitch(flutter::Switch::Help))) {
+  if (command_line.HasOption(flutter::FlagForSwitch(flutter::Switch::kHelp))) {
     flutter::PrintUsage("flutter_tester");
     return EXIT_SUCCESS;
   }
@@ -632,7 +632,7 @@ int main(int argc, char* argv[]) {
 
   return flutter::RunTester(settings,
                             command_line.HasOption(flutter::FlagForSwitch(
-                                flutter::Switch::RunForever)),
+                                flutter::Switch::kRunForever)),
                             command_line.HasOption(flutter::FlagForSwitch(
-                                flutter::Switch::ForceMultithreading)));
+                                flutter::Switch::kForceMultithreading)));
 }


### PR DESCRIPTION
This rolls clang to pick up https://github.com/llvm/llvm-project/commit/b8007a8e4020b8bca2b12e941660e10bf5bf6716

Xcode 27 Release Candidate 1 includes a new target architecture in the MacOS SDK .tbd stub files: `arm64e.x1`. The linker in our toolchain errors out, complaining about the unknown architecture and claiming the .tbd is malformed. The fix was landed in the above clang commit. This rolls the updated Fuchsia clang toolchain with the upstream fix.

```
ld64.lld: error: could not load TAPI file at ../../flutter/prebuilts/SDKs/MacOSX27.0.sdk/usr/lib/libSystem.tbd: malformed file
./engine/src/flutter/prebuilts/SDKs/MacOSX27.0.sdk/usr/lib/libSystem.tbd:4:20: error: unknown architecture
                   arm64e.x1-macos, arm64e.x1-maccatalyst ]
                   ^~~~~~~~~~~~~~~
```

It's been above six months since the last roll. Clang now catches two new unused identifier warnings (which we promote to errors) in Skia:
* `SkSL::Program::ElementsCollection::iterator::fOwnedEnd` in `src/sksl/ir/SkSLProgram.h:113` identified due to `-Wunused-private-field`. Assigned in the iterator's ctor init list at line 110 but never read.
* `skia::textlayout::ParagraphImpl::getEllipsis()` contains an unused local `ellipsis16` at `modules/skparagraph/src/ParagraphImpl.cpp:1090` identified due to `-Wunused-variable`; the `else` branch calls `fParagraphStyle.getEllipsisUtf16()` again instead of using it.

I've added Skia-specific suppression for those two, and a TODO. I'll send patches upstream to clean these up. Once they land and Skia rolls back in, we'll remove the suppression.

This also triggers a warning about `g_test_lock` acquired in `MockGLES::Init`. This is test-only code either way, but the mutex is always released in the dtor so the code as written is safe. Added an annotation to silence that warning.

Issue: https://github.com/flutter/flutter/issues/192609

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant in-code documentation (doc comments with `///`).
- [X] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
