### PR TITLE
Include Wrap spacing in max intrinsic main-axis extent

### DIFF
--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -529,11 +529,9 @@ class RenderWrap extends RenderBox
     switch (direction) {
       case Axis.horizontal:
         var width = 0.0;
-        var childCount = 0;
         RenderBox? child = firstChild;
         while (child != null) {
           width += child.getMaxIntrinsicWidth(double.infinity);
-          childCount += 1;
           child = childAfter(child);
         }
         // Include inter-child spacing so IntrinsicWidth/PopupMenu sizing matches layout.
@@ -569,11 +567,9 @@ class RenderWrap extends RenderBox
         return getDryLayout(BoxConstraints(maxWidth: width)).height;
       case Axis.vertical:
         var height = 0.0;
-        var childCount = 0;
         RenderBox? child = firstChild;
         while (child != null) {
           height += child.getMaxIntrinsicHeight(double.infinity);
-          childCount += 1;
           child = childAfter(child);
         }
         if (childCount > 1) {

--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -529,10 +529,16 @@ class RenderWrap extends RenderBox
     switch (direction) {
       case Axis.horizontal:
         var width = 0.0;
+        var childCount = 0;
         RenderBox? child = firstChild;
         while (child != null) {
           width += child.getMaxIntrinsicWidth(double.infinity);
+          childCount += 1;
           child = childAfter(child);
+        }
+        // Include inter-child spacing so IntrinsicWidth/PopupMenu sizing matches layout.
+        if (childCount > 1) {
+          width += spacing * (childCount - 1);
         }
         return width;
       case Axis.vertical:
@@ -563,10 +569,15 @@ class RenderWrap extends RenderBox
         return getDryLayout(BoxConstraints(maxWidth: width)).height;
       case Axis.vertical:
         var height = 0.0;
+        var childCount = 0;
         RenderBox? child = firstChild;
         while (child != null) {
           height += child.getMaxIntrinsicHeight(double.infinity);
+          childCount += 1;
           child = childAfter(child);
+        }
+        if (childCount > 1) {
+          height += spacing * (childCount - 1);
         }
         return height;
     }

--- a/packages/flutter/test/rendering/wrap_test.dart
+++ b/packages/flutter/test/rendering/wrap_test.dart
@@ -180,6 +180,44 @@ void main() {
     expect(renderWrap.computeMinIntrinsicWidth(80), 80);
   });
 
+  test('Horizontal Wrap max intrinsic width includes spacing', () {
+    final children = <RenderBox>[
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints.tightFor(width: 25, height: 25),
+      ),
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints.tightFor(width: 100, height: 25),
+      ),
+    ];
+
+    final renderWrap = RenderWrap();
+    children.forEach(renderWrap.add);
+    renderWrap.spacing = 8;
+    renderWrap.direction = Axis.horizontal;
+
+    // Without spacing this would be 125; with spacing it must be 133 so
+    // IntrinsicWidth(stepWidth: 56) can expand to the next menu width step.
+    expect(renderWrap.computeMaxIntrinsicWidth(double.infinity), 133);
+  });
+
+  test('Vertical Wrap max intrinsic height includes spacing', () {
+    final children = <RenderBox>[
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints.tightFor(width: 25, height: 25),
+      ),
+      RenderConstrainedBox(
+        additionalConstraints: const BoxConstraints.tightFor(width: 25, height: 100),
+      ),
+    ];
+
+    final renderWrap = RenderWrap();
+    children.forEach(renderWrap.add);
+    renderWrap.spacing = 8;
+    renderWrap.direction = Axis.vertical;
+
+    expect(renderWrap.computeMaxIntrinsicHeight(double.infinity), 133);
+  });
+
   test('Wrap respects clipBehavior', () {
     const viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
     final context = TestClipPaintingContext();


### PR DESCRIPTION
Include `spacing` in `RenderWrap.computeMaxIntrinsicWidth` (horizontal) and `computeMaxIntrinsicHeight` (vertical).

`IntrinsicWidth` / `IntrinsicHeight` consumers (including `PopupMenu`) were under-sizing children that use `Wrap(spacing: ...)`, because max intrinsic main-axis extent ignored inter-child spacing.

Fixes https://github.com/flutter/flutter/issues/143372

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md