### PR TITLE
[Windows] Fix duplicated text when an IME composes on a non-composing model

### DIFF
--- a/engine/src/flutter/shell/platform/windows/text_input_plugin.cc
+++ b/engine/src/flutter/shell/platform/windows/text_input_plugin.cc
@@ -195,6 +195,17 @@ void TextInputPlugin::ComposeChangeHook(const std::u16string& text,
   if (active_model_ == nullptr) {
     return;
   }
+  // The IME can send composition updates while the model is not composing:
+  // the text client may be swapped mid-composition, and the engine's request
+  // to cancel the composition (ImmNotifyIME with CPS_CANCEL) is advisory, so
+  // an IME is free to ignore it. Re-enter composing at the caret; otherwise
+  // AddText and UpdateComposingText below both insert |text|, and the
+  // composing range stays anchored at offset 0, so subsequent updates
+  // overwrite the beginning of the text instead of the composing region.
+  // See https://github.com/flutter/flutter/issues/191196.
+  if (!active_model_->composing()) {
+    active_model_->BeginComposing();
+  }
   std::string text_before_change = active_model_->GetText();
   TextRange composing_before_change = active_model_->composing_range();
   active_model_->AddText(text);

--- a/engine/src/flutter/shell/platform/windows/text_input_plugin_unittest.cc
+++ b/engine/src/flutter/shell/platform/windows/text_input_plugin_unittest.cc
@@ -135,10 +135,14 @@ static TestBinaryMessenger::SendHandler RecordEditingState(
                                         BinaryReply reply) {
     auto method = JsonMethodCodec::GetInstance().DecodeMethodCall(
         std::vector<uint8_t>(message, message + size));
-    if (method->method_name() != kUpdateEditingStateMethod) {
+    if (!method || method->method_name() != kUpdateEditingStateMethod) {
       return;
     }
-    const auto& editing_state = (*method->arguments())[1];
+    const auto* arguments = method->arguments();
+    ASSERT_NE(arguments, nullptr);
+    ASSERT_TRUE(arguments->IsArray());
+    ASSERT_GE(arguments->Size(), 2u);
+    const auto& editing_state = (*arguments)[1];
     auto text = editing_state.FindMember(kTextKey);
     auto base = editing_state.FindMember(kSelectionBaseKey);
     ASSERT_NE(text, editing_state.MemberEnd());

--- a/engine/src/flutter/shell/platform/windows/text_input_plugin_unittest.cc
+++ b/engine/src/flutter/shell/platform/windows/text_input_plugin_unittest.cc
@@ -125,6 +125,31 @@ static std::unique_ptr<rapidjson::Document> EncodedEditingState(
   return arguments;
 }
 
+// Returns a send handler that records the text and the selection base of the
+// last TextInputClient.updateEditingState message sent to the framework.
+static TestBinaryMessenger::SendHandler RecordEditingState(
+    std::string* text_out,
+    int* selection_base_out) {
+  return [text_out, selection_base_out](const std::string& channel,
+                                        const uint8_t* message, size_t size,
+                                        BinaryReply reply) {
+    auto method = JsonMethodCodec::GetInstance().DecodeMethodCall(
+        std::vector<uint8_t>(message, message + size));
+    if (method->method_name() != kUpdateEditingStateMethod) {
+      return;
+    }
+    const auto& editing_state = (*method->arguments())[1];
+    auto text = editing_state.FindMember(kTextKey);
+    auto base = editing_state.FindMember(kSelectionBaseKey);
+    ASSERT_NE(text, editing_state.MemberEnd());
+    ASSERT_TRUE(text->value.IsString());
+    ASSERT_NE(base, editing_state.MemberEnd());
+    ASSERT_TRUE(base->value.IsInt());
+    *text_out = text->value.GetString();
+    *selection_base_out = base->value.GetInt();
+  };
+}
+
 class MockFlutterWindowsView : public FlutterWindowsView {
  public:
   MockFlutterWindowsView(FlutterWindowsEngine* engine,
@@ -617,6 +642,86 @@ TEST_F(TextInputPluginTest, CompositionCursorPos) {
 
   plugin.ComposeChangeHook(u"12", 2);
   EXPECT_EQ(selection_base, 5);
+}
+
+// Regression test for https://github.com/flutter/flutter/issues/191196.
+//
+// The composition is still pending when the text client is swapped. The new
+// model is not composing, but the IME is under no obligation to honor the
+// engine's cancellation request and keeps updating its composition.
+TEST_F(TextInputPluginTest, ComposeChangeAfterClientSwapDoesNotDuplicateText) {
+  UseEngineWithView();
+
+  std::string last_text;
+  int last_selection_base = -1;
+  TestBinaryMessenger messenger(
+      RecordEditingState(&last_text, &last_selection_base));
+  BinaryReply reply_handler = [](const uint8_t* reply, size_t size) {};
+
+  TextInputPlugin plugin(&messenger, engine());
+  auto& codec = JsonMethodCodec::GetInstance();
+  auto set_client = codec.EncodeMethodCall(
+      {kSetClientMethod,
+       EncodedClientConfig("TextInputType.text", "TextInputAction.done")});
+  EXPECT_TRUE(messenger.SimulateEngineMessage(
+      kChannelName, set_client->data(), set_client->size(), reply_handler));
+
+  plugin.ComposeBeginHook();
+  plugin.ComposeChangeHook(u"n", 1);
+  EXPECT_EQ(last_text, "n");
+
+  EXPECT_CALL(*view(), OnResetImeComposing());
+  auto clear_client =
+      codec.EncodeMethodCall({"TextInput.clearClient", nullptr});
+  EXPECT_TRUE(messenger.SimulateEngineMessage(
+      kChannelName, clear_client->data(), clear_client->size(), reply_handler));
+  EXPECT_TRUE(messenger.SimulateEngineMessage(
+      kChannelName, set_client->data(), set_client->size(), reply_handler));
+
+  plugin.ComposeChangeHook(u"ni", 2);
+
+  // The update is applied once, not inserted by both AddText and
+  // UpdateComposingText.
+  EXPECT_EQ(last_text, "ni");
+  EXPECT_EQ(last_selection_base, 2);
+}
+
+// An IME that reports the end of the composition and then keeps updating it
+// must not corrupt the text: the model restarts composing at the caret, so
+// updates keep replacing the composing region.
+TEST_F(TextInputPluginTest, ComposeChangeAfterComposeEndRestartsComposing) {
+  UseEngineWithView();
+
+  std::string last_text;
+  int last_selection_base = -1;
+  TestBinaryMessenger messenger(
+      RecordEditingState(&last_text, &last_selection_base));
+  BinaryReply reply_handler = [](const uint8_t* reply, size_t size) {};
+
+  TextInputPlugin plugin(&messenger, engine());
+  auto& codec = JsonMethodCodec::GetInstance();
+  auto set_client = codec.EncodeMethodCall(
+      {kSetClientMethod,
+       EncodedClientConfig("TextInputType.text", "TextInputAction.done")});
+  EXPECT_TRUE(messenger.SimulateEngineMessage(
+      kChannelName, set_client->data(), set_client->size(), reply_handler));
+
+  plugin.ComposeBeginHook();
+  plugin.ComposeChangeHook(u"n", 1);
+  plugin.ComposeEndHook();
+  EXPECT_EQ(last_text, "n");
+
+  // "n" was committed by ComposeEndHook, so the new composition is inserted
+  // once at the caret.
+  plugin.ComposeChangeHook(u"ni", 2);
+  EXPECT_EQ(last_text, "nni");
+  EXPECT_EQ(last_selection_base, 3);
+
+  // The next update replaces the composing region instead of overwriting the
+  // beginning of the text.
+  plugin.ComposeChangeHook(u"nihao", 5);
+  EXPECT_EQ(last_text, "nnihao");
+  EXPECT_EQ(last_selection_base, 6);
 }
 
 TEST_F(TextInputPluginTest, TransformCursorRect) {


### PR DESCRIPTION
`TextInputPlugin::ComposeChangeHook` applies an IME composition update even when
the model is not composing. In that state `TextInputModel::AddText` skips its
composing branch and inserts `text`, and `TextInputModel::UpdateComposingText`
then finds a collapsed composing range, falls back to the (also collapsed)
selection, and inserts the same `text` a second time. It also sets the composing
range's end while its start is still 0, so every subsequent update rewrites the
beginning of the text and places the caret near offset 0.

The model can be left not composing while the IME still is:

* The text client is swapped mid-composition (#191196). `TextInput.clearClient`
  followed by `TextInput.setClient` installs a fresh `TextInputModel`. The engine
  asks the IME to cancel the composition, but `ImmNotifyIME` with `CPS_CANCEL` is
  advisory and `TextInputManager::AbortComposing` also returns early when
  `ime_active_` is false.
* An IME reports `WM_IME_ENDCOMPOSITION` and then keeps updating its composition.
* `TextInput.setEditingState` arrives with an empty composing range while the IME
  is still composing.

This change makes the model re-enter composing at the caret when a composition
update arrives, which is what `ComposeBeginHook` already does for
`WM_IME_STARTCOMPOSITION`. `AddText` then replaces the composing region instead
of inserting in addition to `UpdateComposingText`, and the composing range is
anchored at the caret rather than at offset 0. Behavior is unchanged while the
model is composing.

This is complementary to #189968, which keeps `TextInput.setEditingState` from
dropping the composing range in the first place; this PR does not touch
`HandleMethodCall`.

Addresses #191196

This fixes the text corruption and the persistent bad state described there. It
does not stop a composition from carrying across a text-client swap: that
requires the IME to honor the cancellation, which is the `AbortComposing` /
`ime_active_` gap analysed in that issue. Measured with Sogou Pinyin, the
carry-over happens identically with and without this change. The reporter has
since confirmed both halves on a patched build with the IME from that issue: the
duplication is gone, the carry-over is unchanged —
https://github.com/flutter/flutter/issues/191196#issuecomment-5708302681

Built and tested on Windows with `flutter_windows_unittests` in
`host_debug_unopt`. Reverting only the guard makes both new tests fail: the
first records `"nini"` instead of `"ni"`, and the second records `"nnini"` with
the caret at 2 and then `"nihaonihaoini"` with the caret at 5.

Full suite, same machine and session, with and without the guard:

| | with the guard | guard reverted |
|---|---|---|
| passed | 399 / 401 | 397 / 401 |
| failed | `WindowsTest.Get{,Engine}GraphicsAdapterWithLowPowerPreference` | the same two, plus the two new tests |

The two `...WithLowPowerPreference` failures are unrelated to this change: they
fail identically with and without it, and they pass when run in isolation. This
machine has two GPUs and the test compares adapter LUIDs, so they appear to be
order-dependent on this hardware.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing (see the note above about the two pre-existing GPU-adapter failures on my machine).

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
