### PR TITLE
Specify non-obvious types in pattern variable declarations

### DIFF
--- a/dev/integration_tests/record_use_test_package/hook/link.dart
+++ b/dev/integration_tests/record_use_test_package/hook/link.dart
@@ -68,7 +68,7 @@ Set<String> _extractUsedPhrases(Recordings recordings) {
   for (final CallReference call in recordings.calls[translateDef] ?? const <CallReference>[]) {
     switch (call) {
       case CallWithArguments(
-          positionalArguments: [StringConstant(:final value), ...],
+          positionalArguments: [StringConstant(:final String value), ...],
         ):
         usedPhrases.add(value);
       case _:

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -197,7 +197,7 @@ abstract class Action<T extends Intent> with Diagnosticable {
   bool _debugCanHandleIntent<I extends Intent>(I? intent) {
     final Object? badIntentString = switch (intent) {
       T() => null,
-      Object(:final runtimeType) => runtimeType,
+      Object(:final Type runtimeType) => runtimeType,
       // The List literal is needed to reify the type I.
       // ignore: literal_only_boolean_expressions
       null when <I>[] is List<T> => null,

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2990,8 +2990,8 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       'This method should only be given selection events that select text boundaries.',
     );
     final Offset effectiveGlobalPosition = switch (event) {
-      SelectWordSelectionEvent(:final globalPosition) => globalPosition,
-      SelectParagraphSelectionEvent(:final globalPosition) => globalPosition,
+      SelectWordSelectionEvent(:final Offset globalPosition) => globalPosition,
+      SelectParagraphSelectionEvent(:final Offset globalPosition) => globalPosition,
       _ => throw ArgumentError('Unsupported selection event: $event'),
     };
     SelectionResult? lastSelectionResult;

--- a/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
@@ -393,11 +393,11 @@ extension on DartObject {
     return switch (variable) {
       FieldElement(
         isEnumConstant: true,
-        displayName: final enumValue,
-        enclosingElement: EnumElement(displayName: final enumName),
+        displayName: final String enumValue,
+        enclosingElement: EnumElement(displayName: final String enumName),
       ) =>
         cb.refer('$enumName.$enumValue', _elementToLibraryIdentifier(variable)),
-      PropertyInducingElement(:final displayName) => cb.refer(
+      PropertyInducingElement(:final String displayName) => cb.refer(
         displayName,
         _elementToLibraryIdentifier(variable),
       ),


### PR DESCRIPTION
Preemptively fixes static analysis warnings reported by newer Dart SDK builds under `specify_nonobvious_local_variable_types`.

Adds explicit types to pattern variable declarations in:
- `dev/integration_tests/record_use_test_package/hook/link.dart`
- `packages/flutter/lib/src/widgets/actions.dart`
- `packages/flutter/lib/src/widgets/selectable_region.dart`
- `packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart`