### PR TITLE
[tool] Defer app.restart until the app has finished starting

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1060,6 +1060,8 @@ class AppDomain extends Domain {
         }),
       );
     }
+    // Kept separate from [AppInstance.started]. Runners attach listeners to this
+    // completer that have no error handler, so it must only ever be completed.
     final appStartedCompleter = Completer<void>();
 
     // This future won't complete until the application has shutdown, so we don't want to
@@ -1085,18 +1087,31 @@ class AppDomain extends Domain {
       }
     });
 
-    await Future.any(<Future<void>>[
-      appStartedCompleter.future.then<void>((void value) {
-        _sendAppEvent(app, 'started');
-      }),
-      appRunFuture,
-    ]);
+    try {
+      await Future.any(<Future<void>>[
+        appStartedCompleter.future.then<void>((void value) {
+          app._markStarted();
+          _sendAppEvent(app, 'started');
+        }),
+        appRunFuture,
+      ]);
+    } on Object catch (error) {
+      // `appRunFuture` only converts an [Exception] into a `stop` event, so an
+      // [Error] thrown by the runner or by the `finally` above surfaces here.
+      // Settle anything waiting on [AppInstance.started] before it propagates,
+      // otherwise a deferred `app.restart` waits forever.
+      app._failedToStart(error);
+      rethrow;
+    }
 
     // If appRunFuture completes early due to a fatal initialization error
-    // without actually starting the app, we must explicitly throw an exception
-    // to prevent the IDE/client from hanging indefinitely.
+    // without actually starting the app, we must explicitly fail both this
+    // request and anything waiting on [AppInstance.started], to prevent the
+    // IDE/client from hanging indefinitely.
     if (!appStartedCompleter.isCompleted) {
-      throw DaemonException('App failed to start');
+      final failure = DaemonException('App failed to start');
+      app._failedToStart(failure);
+      throw failure;
     }
     return app;
   }
@@ -1119,6 +1134,14 @@ class AppDomain extends Domain {
     if (app == null) {
       throw DaemonException("app '$appId' not found");
     }
+
+    // The `app.start` event carries the app ID and is sent before the runner
+    // has finished starting up, so a client can ask for a restart while the
+    // initial compile is still in flight. Servicing it now would issue a
+    // recompile against a compiler that has not accepted its first compile
+    // yet. Defer instead of dropping it: the client may have edited a file
+    // that the initial compile did not pick up.
+    await app.started;
 
     return _queueAndDebounceReloadAction(
       app,
@@ -1833,12 +1856,41 @@ class AppInstance {
     required this.runner,
     this.logToStdout = false,
     required MachineOutputLogger logger,
-  }) : _logger = logger;
+  }) : _logger = logger {
+    // Nothing is obliged to await [started], so make sure a failure never
+    // surfaces as an unhandled async error.
+    _startedCompleter.future.ignore();
+  }
 
   final String id;
   final ResidentRunner runner;
   final bool logToStdout;
   final MachineOutputLogger _logger;
+
+  final _startedCompleter = Completer<void>();
+
+  /// Completes once [runner] reports the app has started, which is the same
+  /// signal the `app.started` event is sent from, or with an error if the app
+  /// exited before it got there.
+  ///
+  /// For a runner with an incremental compiler this is after the initial
+  /// compile was accepted, which is what makes it safe to ask for a reload. It
+  /// does not mean the VM service is connected: the web runner attaches that
+  /// asynchronously afterwards, so the VM service may still be unattached once
+  /// this completes.
+  Future<void> get started => _startedCompleter.future;
+
+  void _markStarted() {
+    _startedCompleter.complete();
+  }
+
+  void _failedToStart(Object error) {
+    // Reachable after [_markStarted] when sending the `app.started` event is
+    // what threw, so this cannot assume the completer is still pending.
+    if (!_startedCompleter.isCompleted) {
+      _startedCompleter.completeError(error);
+    }
+  }
 
   Future<OperationResult> restart({bool fullRestart = false, bool pause = false, String? reason}) {
     return runner.restart(fullRestart: fullRestart, pause: pause, reason: reason);

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1095,12 +1095,12 @@ class AppDomain extends Domain {
         }),
         appRunFuture,
       ]);
-    } on Object catch (error) {
+    } on Object catch (error, stackTrace) {
       // `appRunFuture` only converts an [Exception] into a `stop` event, so an
       // [Error] thrown by the runner or by the `finally` above surfaces here.
       // Settle anything waiting on [AppInstance.started] before it propagates,
       // otherwise a deferred `app.restart` waits forever.
-      app._failedToStart(error);
+      app._failedToStart(error, stackTrace);
       rethrow;
     }
 
@@ -1884,11 +1884,11 @@ class AppInstance {
     _startedCompleter.complete();
   }
 
-  void _failedToStart(Object error) {
+  void _failedToStart(Object error, [StackTrace? stackTrace]) {
     // Reachable after [_markStarted] when sending the `app.started` event is
     // what threw, so this cannot assume the completer is still pending.
     if (!_startedCompleter.isCompleted) {
-      _startedCompleter.completeError(error);
+      _startedCompleter.completeError(error, stackTrace);
     }
   }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -1145,6 +1145,238 @@ void main() {
         ProcessManager: () => FakeProcessManager.any(),
       },
     );
+
+    testUsingContext(
+      'app.restart sent before the app has started waits for startup',
+      () async {
+        daemon = Daemon(
+          daemonConnection,
+          notifyingLogger: notifyingLogger,
+          featureFlags: featureFlags,
+          fileSystem: globals.fs,
+        );
+        final runner = FakeRestartableResidentRunner();
+        final startApp = Completer<void>();
+        final exitApp = Completer<void>();
+
+        final Future<AppInstance> launched = daemon.appDomain.launch(
+          runner,
+          ({
+            Completer<DebugConnectionInfo>? connectionInfoCompleter,
+            Completer<void>? appStartedCompleter,
+          }) async {
+            await startApp.future;
+            appStartedCompleter?.complete();
+            await exitApp.future;
+          },
+          FakeAndroidDevice(),
+          null, // projectDirectory
+          true, // enableHotReload
+          globals.fs.directory('/'), // cwd
+          LaunchMode.run,
+          MachineOutputLogger(parent: notifyingLogger),
+        );
+
+        // `app.start` is sent before the runner has finished starting up, so
+        // the client already has the app ID at this point.
+        final DaemonMessage startEvent = await daemonStreams.outputs.stream.firstWhere(
+          (DaemonMessage message) => message.data['event'] == 'app.start',
+        );
+        final appId = (startEvent.data['params']! as Map<String, Object?>)['appId']! as String;
+
+        final Future<OperationResult> restarted = daemon.appDomain.restart(<String, Object?>{
+          'appId': appId,
+        })!;
+
+        // The restart must not reach the runner while startup is in flight.
+        await pumpEventQueue();
+        expect(runner.restartCount, 0);
+
+        startApp.complete();
+        await launched;
+
+        expect(await restarted, OperationResult.ok);
+        expect(runner.restartCount, 1);
+
+        exitApp.complete();
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => MemoryFileSystem.test(),
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
+
+    testUsingContext(
+      'app.restart sent before the app has started reports an error if startup fails',
+      () async {
+        daemon = Daemon(
+          daemonConnection,
+          notifyingLogger: notifyingLogger,
+          featureFlags: featureFlags,
+          fileSystem: globals.fs,
+        );
+        final runner = FakeRestartableResidentRunner();
+        final exitApp = Completer<void>();
+
+        final Future<AppInstance> launched = daemon.appDomain.launch(
+          runner,
+          ({
+            Completer<DebugConnectionInfo>? connectionInfoCompleter,
+            Completer<void>? appStartedCompleter,
+          }) async {
+            // App exits without ever completing appStartedCompleter.
+            await exitApp.future;
+          },
+          FakeAndroidDevice(),
+          null, // projectDirectory
+          true, // enableHotReload
+          globals.fs.directory('/'), // cwd
+          LaunchMode.run,
+          MachineOutputLogger(parent: notifyingLogger),
+        );
+
+        final DaemonMessage startEvent = await daemonStreams.outputs.stream.firstWhere(
+          (DaemonMessage message) => message.data['event'] == 'app.start',
+        );
+        final appId = (startEvent.data['params']! as Map<String, Object?>)['appId']! as String;
+
+        final Future<OperationResult> restarted = daemon.appDomain.restart(<String, Object?>{
+          'appId': appId,
+        })!;
+
+        exitApp.complete();
+
+        final Matcher matcher = throwsA(
+          isA<DaemonException>().having(
+            (DaemonException e) => e.message,
+            'message',
+            'App failed to start',
+          ),
+        );
+        await expectLater(() => launched, matcher);
+        // The pending restart gets an error rather than hanging forever.
+        await expectLater(() => restarted, matcher);
+        expect(runner.restartCount, 0);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => MemoryFileSystem.test(),
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
+
+    testUsingContext(
+      'a pending app.restart gets an error when startup throws a non-Exception',
+      () async {
+        daemon = Daemon(
+          daemonConnection,
+          notifyingLogger: notifyingLogger,
+          featureFlags: featureFlags,
+          fileSystem: globals.fs,
+        );
+        final runner = FakeRestartableResidentRunner();
+        final failStartup = Completer<void>();
+
+        final Future<AppInstance> launched = daemon.appDomain.launch(
+          runner,
+          ({
+            Completer<DebugConnectionInfo>? connectionInfoCompleter,
+            Completer<void>? appStartedCompleter,
+          }) async {
+            await failStartup.future;
+            // An Error, not an Exception, so `launch` does not convert it into
+            // a `stop` event. The `finally` that assigns currentDirectory can
+            // throw a TypeError this way.
+            throw StateError('startup blew up');
+          },
+          FakeAndroidDevice(),
+          null, // projectDirectory
+          true, // enableHotReload
+          globals.fs.directory('/'), // cwd
+          LaunchMode.run,
+          MachineOutputLogger(parent: notifyingLogger),
+        );
+
+        final DaemonMessage startEvent = await daemonStreams.outputs.stream.firstWhere(
+          (DaemonMessage message) => message.data['event'] == 'app.start',
+        );
+        final appId = (startEvent.data['params']! as Map<String, Object?>)['appId']! as String;
+
+        final Future<OperationResult> restarted = daemon.appDomain.restart(<String, Object?>{
+          'appId': appId,
+        })!;
+
+        failStartup.complete();
+
+        await expectLater(() => launched, throwsStateError);
+        // Without settling `started` on this path the restart would hang.
+        await expectLater(() => restarted, throwsStateError);
+        expect(runner.restartCount, 0);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => MemoryFileSystem.test(),
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
+
+    testUsingContext(
+      'a failed start does not fault a runner listener that has no error handler',
+      () async {
+        daemon = Daemon(
+          daemonConnection,
+          notifyingLogger: notifyingLogger,
+          featureFlags: featureFlags,
+          fileSystem: globals.fs,
+        );
+        final exitApp = Completer<void>();
+        var listenerFired = false;
+
+        final Future<AppInstance> launched = daemon.appDomain.launch(
+          FakeRestartableResidentRunner(),
+          ({
+            Completer<DebugConnectionInfo>? connectionInfoCompleter,
+            Completer<void>? appStartedCompleter,
+          }) async {
+            // HotRunner.run attaches exactly this shape of listener for its
+            // startup analytics, with no onError. Completing the runner's
+            // completer with an error would fault it.
+            unawaited(
+              appStartedCompleter?.future.then((_) {
+                listenerFired = true;
+              }),
+            );
+            // App exits without ever completing appStartedCompleter.
+            await exitApp.future;
+          },
+          FakeAndroidDevice(),
+          null, // projectDirectory
+          true, // enableHotReload
+          globals.fs.directory('/'), // cwd
+          LaunchMode.run,
+          MachineOutputLogger(parent: notifyingLogger),
+        );
+
+        exitApp.complete();
+
+        await expectLater(
+          () => launched,
+          throwsA(
+            isA<DaemonException>().having(
+              (DaemonException e) => e.message,
+              'message',
+              'App failed to start',
+            ),
+          ),
+        );
+
+        // Let any unhandled async error reach the test zone.
+        await pumpEventQueue();
+        expect(listenerFired, isFalse);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => MemoryFileSystem.test(),
+        ProcessManager: () => FakeProcessManager.any(),
+      },
+    );
   });
 
   group('notifyingLogger', () {
@@ -1582,4 +1814,18 @@ class FakeResidentRunner extends Fake implements ResidentRunner {
 
   @override
   DebuggingOptions get debuggingOptions => DebuggingOptions.enabled(BuildInfo.debug);
+}
+
+class FakeRestartableResidentRunner extends FakeResidentRunner {
+  int restartCount = 0;
+
+  @override
+  Future<OperationResult> restart({
+    bool fullRestart = false,
+    bool pause = false,
+    String? reason,
+  }) async {
+    restartCount++;
+    return OperationResult.ok;
+  }
 }


### PR DESCRIPTION
Fixes #192227

**Problem**

`AppDomain.launch` sends the `app.start` event, which carries the app ID, before `ResidentRunner.run()` has compiled and called `generator.accept()`. A client that acts on that ID immediately can land an `app.restart` in the gap, producing a `recompile` against a compiler with no accepted baseline. `frontend_server` then crashes on `lastKnownGoodResult!`, and the app fails to start.

**Fix**

`AppDomain.restart` now waits on a new `AppInstance.started` before entering the debounce queue, so the compiler is never asked to recompile before it has a baseline. 

**Demo**

No URLs: the bug is in the `flutter run --machine` daemon protocol, not in rendered output, so a deployed build has no daemon to race.

Verified locally with a harness that sends `app.restart` during the initial compile, which is the window this closes. Before, it reproduces the exact trace from the issue and the app
dies:

    Null check operator used on a null value
    #0  FrontendCompiler.writeJavaScriptBundle (frontend_server.dart:1100)
    #1  FrontendCompiler.recompileDelta        (frontend_server.dart:1312)
    #2  listenAndCompile.<anonymous closure>   (frontend_server.dart:1806)
    App failed to start

After, the restart is held until `app.started` and returns `code: 0`.