### PR TITLE
RELAND: [devicelab] Clean up Chrome profile directories and trap abort signals in web benchmarks

### DIFF
--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -82,7 +82,7 @@ class Chrome {
     // If the Chrome process quits before it was asked to quit, notify the
     // error listener.
     _chromeProcess.exitCode.then((int exitCode) {
-      if (!_isStopped) {
+      if (!_isStopped && exitCode != 0) {
         _onError('Chrome process exited prematurely with exit code $exitCode');
       }
     });
@@ -92,7 +92,7 @@ class Chrome {
   ///
   /// The [onError] callback is called with an error message when the Chrome
   /// process encounters an error. In particular, [onError] is called when the
-  /// Chrome process exits prematurely, i.e. before [stop] is called.
+  /// Chrome process exits prematurely, i.e. before [stop] or [disconnect] is called.
   static Future<Chrome> launch(
     ChromeOptions options, {
     String? workingDirectory,
@@ -167,7 +167,7 @@ class Chrome {
   ///
   /// The [onError] callback is called with an error message when the Chrome
   /// process encounters an error. In particular, [onError] is called when the
-  /// Chrome process exits prematurely, i.e. before [stop] is called.
+  /// Chrome process exits prematurely, i.e. before [stop] or [disconnect] is called.
   static Future<Chrome> connect(
     io.Process chromeProcess,
     ChromeOptions options, {
@@ -270,10 +270,15 @@ class Chrome {
     await _debugConnection?.page.reload(ignoreCache: ignoreCache);
   }
 
-  /// Stops the Chrome process.
-  void stop() {
+  /// Disconnects from the Chrome process without killing it.
+  void disconnect() {
     _isStopped = true;
     _tracingSubscription?.cancel();
+  }
+
+  /// Stops the Chrome process.
+  void stop() {
+    disconnect();
     _chromeProcess.kill();
   }
 }

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -34,6 +34,28 @@ typedef WebBenchmarkOptions = ({
   String buildMode,
 });
 
+/// Deletes a directory with retry logic to handle file locks on various platforms.
+Future<void> deleteDirectoryWithRetry(
+  io.Directory dir, {
+  int maxAttempts = 10,
+  Duration delay = const Duration(milliseconds: 500),
+}) async {
+  for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      if (dir.existsSync()) {
+        await dir.delete(recursive: true);
+      }
+      return;
+    } on io.FileSystemException catch (e) {
+      if (attempt == maxAttempts) {
+        print('Warning: Failed to delete directory ${dir.path} after $maxAttempts attempts: $e');
+      } else {
+        await Future<void>.delayed(delay);
+      }
+    }
+  }
+}
+
 Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
   // Reduce logging level. Otherwise, package:webkit_inspection_protocol is way too spammy.
   Logger.root.level = Level.INFO;
@@ -43,198 +65,286 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
     'benchmarks',
     'macrobenchmarks',
   );
-  return inDirectory(macrobenchmarksDirectory, () async {
-    await flutter('clean');
-    // DDC runs the benchmarks suite with 'flutter run', attaching to its
-    // Chrome instance instead of starting a new one.
-    io.Process? flutterRunProcess;
-    if (benchmarkOptions.useDdc) {
-      final ddcAppReady = Completer<void>();
-      flutterRunProcess = await startFlutter(
-        'run',
-        options: <String>[
-          '-d',
-          'chrome',
-          '--web-port',
-          '$benchmarksAppPort',
-          '--web-browser-debug-port',
-          '$chromeDebugPort',
-          '--web-launch-url',
-          'http://localhost:$benchmarksAppPort/index.html',
-          '--debug',
-          '--web-run-headless',
-          '--no-web-enable-expression-evaluation',
-          '--web-browser-flag=--disable-popup-blocking',
-          '--web-browser-flag=--bwsi',
-          '--web-browser-flag=--no-first-run',
-          '--web-browser-flag=--no-default-browser-check',
-          '--web-browser-flag=--disable-default-apps',
-          '--web-browser-flag=--disable-translate',
-          '--web-browser-flag=--disable-background-timer-throttling',
-          '--web-browser-flag=--disable-backgrounding-occluded-windows',
-          '--web-browser-flag=--disable-renderer-backgrounding',
-          '--web-browser-flag=--disable-background-networking',
-          '--web-browser-flag=--disable-sync',
-          '--web-browser-flag=--disable-client-side-phishing-detection',
-          '--web-browser-flag=--disable-notifications',
-          ...kGcmDisabledFlags.map((String flag) => '--web-browser-flag=$flag'),
-          '--web-browser-flag=--headless=new',
-          '--web-browser-flag=--no-sandbox',
-          '--web-browser-flag=--password-store=basic',
-          if (io.Platform.isMacOS) '--web-browser-flag=--use-mock-keychain',
-          '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
-          if (!benchmarkOptions.withHotReload) '--no-web-experimental-hot-reload',
-          '--no-web-resources-cdn',
-          'lib/web_benchmarks_ddc.dart',
-        ],
-      );
-      flutterRunProcess.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((
-        String line,
-      ) {
-        if (!ddcAppReady.isCompleted && line.startsWith('Debug service listening on')) {
-          ddcAppReady.complete();
-        }
-        print('[CHROME STDOUT]: $line');
-      });
-      flutterRunProcess.stderr.transform(utf8.decoder).transform(const LineSplitter()).listen((
-        String line,
-      ) {
-        print('[CHROME STDERR]: $line');
-      });
-      // Wait for the app to load in DDC's Chrome instance before trying to
-      // connect the debugger.
-      await ddcAppReady.future;
-    } else {
-      await evalFlutter(
-        'build',
-        options: <String>[
-          'web',
-          '--no-tree-shake-icons', // local engine builds are frequently out of sync with the Dart Kernel version
-          if (benchmarkOptions.useWasm) ...<String>['--wasm', '--no-strip-wasm'],
-          '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
-          '--${benchmarkOptions.buildMode}',
-          '--no-web-resources-cdn',
-          '-t',
-          'lib/web_benchmarks.dart',
-        ],
-      );
+
+  io.HttpServer? server;
+  Chrome? chrome;
+  Future<Chrome>? whenChromeIsReady;
+  io.Process? flutterRunProcess;
+  String? userDataDir;
+
+  var isCleaningUp = false;
+  final cleanupCompleter = Completer<void>();
+
+  Future<void> performCleanup() async {
+    if (isCleaningUp) {
+      return cleanupCompleter.future;
     }
-    final profileData = Completer<List<Map<String, dynamic>>>();
-    final collectedProfiles = <Map<String, dynamic>>[];
-    List<String>? benchmarks;
-    late Iterator<String> benchmarkIterator;
-
-    // This future fixes a race condition between the web-page loading and
-    // asking to run a benchmark, and us connecting to Chrome's DevTools port.
-    // Sometime one wins. Other times, the other wins.
-    Future<Chrome>? whenChromeIsReady;
-    Chrome? chrome;
-    late io.HttpServer server;
-    var cascade = Cascade();
-    List<Map<String, dynamic>>? latestPerformanceTrace;
-    final requestHeaders = <String, List<String>>{
-      'Access-Control-Allow-Headers': <String>[
-        'Accept',
-        'Access-Control-Allow-Headers',
-        'Access-Control-Allow-Methods',
-        'Access-Control-Allow-Origin',
-        'Content-Type',
-        'Origin',
-      ],
-      'Access-Control-Allow-Methods': <String>['Post'],
-      'Access-Control-Allow-Origin': <String>['http://localhost:$benchmarksAppPort'],
-    };
-
-    cascade = cascade.add((Request request) async {
-      final String requestContents = await request.readAsString();
-      try {
-        chrome ??= await whenChromeIsReady;
-        if (request.method == 'OPTIONS') {
-          return Response.ok('', headers: requestHeaders);
-        }
-        if (request.requestedUri.path.endsWith('/profile-data')) {
-          final profile = json.decode(requestContents) as Map<String, dynamic>;
-          final benchmarkName = profile['name'] as String;
-          if (benchmarkName != benchmarkIterator.current) {
-            profileData.completeError(
-              Exception(
-                'Browser returned benchmark results from a wrong benchmark.\n'
-                'Requested to run benchmark ${benchmarkIterator.current}, but '
-                'got results for $benchmarkName.',
-              ),
-            );
-            unawaited(server.close());
-          }
-
-          // Trace data is null when the benchmark is not frame-based, such as RawRecorder.
-          if (latestPerformanceTrace != null) {
-            final BlinkTraceSummary traceSummary = BlinkTraceSummary.fromJson(
-              latestPerformanceTrace!,
-            )!;
-            profile['totalUiFrame.average'] = traceSummary.averageTotalUIFrameTime.inMicroseconds;
-            profile['scoreKeys'] ??= <dynamic>[]; // using dynamic for consistency with JSON
-            (profile['scoreKeys'] as List<dynamic>).add('totalUiFrame.average');
-            latestPerformanceTrace = null;
-          }
-          collectedProfiles.add(profile);
-          return Response.ok('Profile received', headers: requestHeaders);
-        } else if (request.requestedUri.path.endsWith('/start-performance-tracing')) {
-          latestPerformanceTrace = null;
-          await chrome!.beginRecordingPerformance(request.requestedUri.queryParameters['label']!);
-          return Response.ok('Started performance tracing', headers: requestHeaders);
-        } else if (request.requestedUri.path.endsWith('/stop-performance-tracing')) {
-          latestPerformanceTrace = await chrome!.endRecordingPerformance();
-          return Response.ok('Stopped performance tracing', headers: requestHeaders);
-        } else if (request.requestedUri.path.endsWith('/on-error')) {
-          final errorDetails = json.decode(requestContents) as Map<String, dynamic>;
-          unawaited(server.close());
-          // Keep the stack trace as a string. It's thrown in the browser, not this Dart VM.
-          profileData.completeError('${errorDetails['error']}\n${errorDetails['stackTrace']}');
-          return Response.ok('', headers: requestHeaders);
-        } else if (request.requestedUri.path.endsWith('/next-benchmark')) {
-          if (benchmarks == null) {
-            benchmarks = (json.decode(requestContents) as List<dynamic>).cast<String>();
-            benchmarkIterator = benchmarks!.iterator;
-          }
-          if (benchmarkIterator.moveNext()) {
-            final String nextBenchmark = benchmarkIterator.current;
-            print('Launching benchmark "$nextBenchmark"');
-            return Response.ok(nextBenchmark, headers: requestHeaders);
-          } else {
-            profileData.complete(collectedProfiles);
-            return Response.notFound('Finished running benchmarks.', headers: requestHeaders);
-          }
-        } else if (request.requestedUri.path.endsWith('/print-to-console')) {
-          // A passthrough used by
-          // `dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart`
-          // to print information.
-          final message = requestContents;
-          print('[APP] $message');
-          return Response.ok('Reported.', headers: requestHeaders);
-        } else {
-          return Response.notFound(
-            'This request is not handled by the profile-data handler.',
-            headers: requestHeaders,
-          );
-        }
-      } catch (error, stackTrace) {
-        profileData.completeError(error, stackTrace);
-        return Response.internalServerError(body: '$error', headers: requestHeaders);
-      }
-    });
-    // Macrobenchmarks using 'flutter build' serve files from their local build directory alongside the orchestration logic.
-    if (!benchmarkOptions.useDdc) {
-      cascade = cascade.add(
-        createBuildDirectoryHandler(path.join(macrobenchmarksDirectory, 'build', 'web')),
-      );
-    }
-
-    server = await io.HttpServer.bind('localhost', benchmarkServerPort);
+    isCleaningUp = true;
     try {
-      shelf_io.serveRequests(server, cascade.handler);
+      // 1. Close Shelf server
+      try {
+        await server?.close(force: true);
+      } catch (e) {
+        print('Warning: Error closing server: $e');
+      }
 
-      final String dartToolDirectory = path.join('$macrobenchmarksDirectory/.dart_tool');
-      final String userDataDir = io.Directory(
+      // 2. Stop Chrome (non-DDC mode only; in DDC mode Chrome is managed by flutterRunProcess)
+      if (!benchmarkOptions.useDdc) {
+        try {
+          final currentChrome = chrome;
+          final readyFuture = whenChromeIsReady;
+          if (currentChrome != null) {
+            currentChrome.stop();
+          } else if (readyFuture != null) {
+            final Chrome readyChrome = await readyFuture.timeout(
+              const Duration(seconds: 5),
+              onTimeout: () => throw TimeoutException('Chrome ready timeout during cleanup'),
+            );
+            readyChrome.stop();
+          }
+        } catch (e) {
+          print('Warning: Error stopping Chrome: $e');
+        }
+      }
+
+      // 3. Stop flutter run process if present
+      final process = flutterRunProcess;
+      if (process != null) {
+        try {
+          process.stdin.write('q');
+          await process.stdin.flush();
+        } catch (_) {
+          // Stdin pipe may already be closed if Chrome process was killed
+        }
+        await process.exitCode.timeout(
+          const Duration(seconds: 2),
+          onTimeout: () {
+            process.kill();
+            return 0;
+          },
+        );
+      }
+
+      // 4. Clean up temporary directory
+      final dirPath = userDataDir;
+      if (dirPath != null) {
+        await deleteDirectoryWithRetry(io.Directory(dirPath));
+      }
+    } finally {
+      cleanupCompleter.complete();
+    }
+  }
+
+  StreamSubscription<io.ProcessSignal>? sigintSub;
+  StreamSubscription<io.ProcessSignal>? sigtermSub;
+
+  try {
+    sigintSub = io.ProcessSignal.sigint.watch().listen((io.ProcessSignal signal) async {
+      print('\nReceived SIGINT. Cleaning up benchmark processes and temporary directories...');
+      await performCleanup();
+      io.exit(130);
+    });
+  } catch (e) {
+    print('Warning: Unable to watch SIGINT signal: $e');
+  }
+
+  if (!io.Platform.isWindows) {
+    try {
+      sigtermSub = io.ProcessSignal.sigterm.watch().listen((io.ProcessSignal signal) async {
+        print('\nReceived SIGTERM. Cleaning up benchmark processes and temporary directories...');
+        await performCleanup();
+        io.exit(143);
+      });
+    } catch (e) {
+      print('Warning: Unable to watch SIGTERM signal: $e');
+    }
+  }
+
+  try {
+    return await inDirectory(macrobenchmarksDirectory, () async {
+      await flutter('clean');
+      // DDC runs the benchmarks suite with 'flutter run', attaching to its
+      // Chrome instance instead of starting a new one.
+      if (benchmarkOptions.useDdc) {
+        final ddcAppReady = Completer<void>();
+        flutterRunProcess = await startFlutter(
+          'run',
+          options: <String>[
+            '-d',
+            'chrome',
+            '--web-port',
+            '$benchmarksAppPort',
+            '--web-browser-debug-port',
+            '$chromeDebugPort',
+            '--web-launch-url',
+            'http://localhost:$benchmarksAppPort/index.html',
+            '--debug',
+            '--web-run-headless',
+            '--no-web-enable-expression-evaluation',
+            '--web-browser-flag=--disable-popup-blocking',
+            '--web-browser-flag=--bwsi',
+            '--web-browser-flag=--no-first-run',
+            '--web-browser-flag=--no-default-browser-check',
+            '--web-browser-flag=--disable-default-apps',
+            '--web-browser-flag=--disable-translate',
+            '--web-browser-flag=--disable-background-timer-throttling',
+            '--web-browser-flag=--disable-backgrounding-occluded-windows',
+            '--web-browser-flag=--disable-renderer-backgrounding',
+            '--web-browser-flag=--disable-background-networking',
+            '--web-browser-flag=--disable-sync',
+            '--web-browser-flag=--disable-client-side-phishing-detection',
+            '--web-browser-flag=--disable-notifications',
+            ...kGcmDisabledFlags.map((String flag) => '--web-browser-flag=$flag'),
+            '--web-browser-flag=--headless=new',
+            '--web-browser-flag=--no-sandbox',
+            '--web-browser-flag=--password-store=basic',
+            if (io.Platform.isMacOS) '--web-browser-flag=--use-mock-keychain',
+            '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
+            if (!benchmarkOptions.withHotReload) '--no-web-experimental-hot-reload',
+            '--no-web-resources-cdn',
+            'lib/web_benchmarks_ddc.dart',
+          ],
+        );
+        flutterRunProcess!.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((
+          String line,
+        ) {
+          if (!ddcAppReady.isCompleted && line.startsWith('Debug service listening on')) {
+            ddcAppReady.complete();
+          }
+          print('[CHROME STDOUT]: $line');
+        });
+        flutterRunProcess!.stderr.transform(utf8.decoder).transform(const LineSplitter()).listen((
+          String line,
+        ) {
+          print('[CHROME STDERR]: $line');
+        });
+        // Wait for the app to load in DDC's Chrome instance before trying to
+        // connect the debugger.
+        await ddcAppReady.future;
+      } else {
+        await evalFlutter(
+          'build',
+          options: <String>[
+            'web',
+            '--no-tree-shake-icons', // local engine builds are frequently out of sync with the Dart Kernel version
+            if (benchmarkOptions.useWasm) ...<String>['--wasm', '--no-strip-wasm'],
+            '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
+            '--${benchmarkOptions.buildMode}',
+            '--no-web-resources-cdn',
+            '-t',
+            'lib/web_benchmarks.dart',
+          ],
+        );
+      }
+      final profileData = Completer<List<Map<String, dynamic>>>();
+      final collectedProfiles = <Map<String, dynamic>>[];
+      List<String>? benchmarks;
+      late Iterator<String> benchmarkIterator;
+
+      var cascade = Cascade();
+      List<Map<String, dynamic>>? latestPerformanceTrace;
+      final requestHeaders = <String, List<String>>{
+        'Access-Control-Allow-Headers': <String>[
+          'Accept',
+          'Access-Control-Allow-Headers',
+          'Access-Control-Allow-Methods',
+          'Access-Control-Allow-Origin',
+          'Content-Type',
+          'Origin',
+        ],
+        'Access-Control-Allow-Methods': <String>['Post'],
+        'Access-Control-Allow-Origin': <String>['http://localhost:$benchmarksAppPort'],
+      };
+
+      cascade = cascade.add((Request request) async {
+        final String requestContents = await request.readAsString();
+        try {
+          chrome ??= await whenChromeIsReady;
+          if (request.method == 'OPTIONS') {
+            return Response.ok('', headers: requestHeaders);
+          }
+          if (request.requestedUri.path.endsWith('/profile-data')) {
+            final profile = json.decode(requestContents) as Map<String, dynamic>;
+            final benchmarkName = profile['name'] as String;
+            if (benchmarkName != benchmarkIterator.current) {
+              profileData.completeError(
+                Exception(
+                  'Browser returned benchmark results from a wrong benchmark.\n'
+                  'Requested to run benchmark ${benchmarkIterator.current}, but '
+                  'got results for $benchmarkName.',
+                ),
+              );
+              unawaited(server!.close());
+            }
+
+            // Trace data is null when the benchmark is not frame-based, such as RawRecorder.
+            if (latestPerformanceTrace != null) {
+              final BlinkTraceSummary traceSummary = BlinkTraceSummary.fromJson(
+                latestPerformanceTrace!,
+              )!;
+              profile['totalUiFrame.average'] = traceSummary.averageTotalUIFrameTime.inMicroseconds;
+              profile['scoreKeys'] ??= <dynamic>[]; // using dynamic for consistency with JSON
+              (profile['scoreKeys'] as List<dynamic>).add('totalUiFrame.average');
+              latestPerformanceTrace = null;
+            }
+            collectedProfiles.add(profile);
+            return Response.ok('Profile received', headers: requestHeaders);
+          } else if (request.requestedUri.path.endsWith('/start-performance-tracing')) {
+            latestPerformanceTrace = null;
+            await chrome!.beginRecordingPerformance(request.requestedUri.queryParameters['label']!);
+            return Response.ok('Started performance tracing', headers: requestHeaders);
+          } else if (request.requestedUri.path.endsWith('/stop-performance-tracing')) {
+            latestPerformanceTrace = await chrome!.endRecordingPerformance();
+            return Response.ok('Stopped performance tracing', headers: requestHeaders);
+          } else if (request.requestedUri.path.endsWith('/on-error')) {
+            final errorDetails = json.decode(requestContents) as Map<String, dynamic>;
+            unawaited(server!.close());
+            // Keep the stack trace as a string. It's thrown in the browser, not this Dart VM.
+            profileData.completeError('${errorDetails['error']}\n${errorDetails['stackTrace']}');
+            return Response.ok('', headers: requestHeaders);
+          } else if (request.requestedUri.path.endsWith('/next-benchmark')) {
+            if (benchmarks == null) {
+              benchmarks = (json.decode(requestContents) as List<dynamic>).cast<String>();
+              benchmarkIterator = benchmarks!.iterator;
+            }
+            if (benchmarkIterator.moveNext()) {
+              final String nextBenchmark = benchmarkIterator.current;
+              print('Launching benchmark "$nextBenchmark"');
+              return Response.ok(nextBenchmark, headers: requestHeaders);
+            } else {
+              profileData.complete(collectedProfiles);
+              return Response.notFound('Finished running benchmarks.', headers: requestHeaders);
+            }
+          } else if (request.requestedUri.path.endsWith('/print-to-console')) {
+            // A passthrough used by
+            // `dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart`
+            // to print information.
+            final message = requestContents;
+            print('[APP] $message');
+            return Response.ok('Reported.', headers: requestHeaders);
+          } else {
+            return Response.notFound(
+              'This request is not handled by the profile-data handler.',
+              headers: requestHeaders,
+            );
+          }
+        } catch (error, stackTrace) {
+          profileData.completeError(error, stackTrace);
+          return Response.internalServerError(body: '$error', headers: requestHeaders);
+        }
+      });
+      // Macrobenchmarks using 'flutter build' serve files from their local build directory alongside the orchestration logic.
+      if (!benchmarkOptions.useDdc) {
+        cascade = cascade.add(
+          createBuildDirectoryHandler(path.join(macrobenchmarksDirectory, 'build', 'web')),
+        );
+      }
+
+      server = await io.HttpServer.bind('localhost', benchmarkServerPort);
+      shelf_io.serveRequests(server!, cascade.handler);
+
+      final String dartToolDirectory = path.join(macrobenchmarksDirectory, '.dart_tool');
+      userDataDir = io.Directory(
         dartToolDirectory,
       ).createTempSync('flutter_chrome_user_data.').path;
 
@@ -277,6 +387,7 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
           workingDirectory: cwd,
         );
       }
+      unawaited(whenChromeIsReady?.then((Chrome c) => chrome = c, onError: (_) {}));
 
       print('Waiting for the benchmark to report benchmark profile.');
       final taskResult = <String, dynamic>{};
@@ -317,27 +428,12 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
         }
       }
       return TaskResult.success(taskResult, benchmarkScoreKeys: benchmarkScoreKeys);
-    } finally {
-      unawaited(server.close());
-      chrome?.stop();
-      if (flutterRunProcess != null) {
-        // Sending a SIGINT/SIGTERM to the process here isn't reliable because [process] is
-        // the shell (flutter is a shell script) and doesn't pass the signal on.
-        // Sending a `q` is an instruction to quit using the console runner.
-        flutterRunProcess.stdin.write('q');
-        await flutterRunProcess.stdin.flush();
-        // Give the process a couple of seconds to exit and run shutdown hooks
-        // before sending kill signal.
-        await flutterRunProcess.exitCode.timeout(
-          const Duration(seconds: 2),
-          onTimeout: () {
-            flutterRunProcess!.kill(io.ProcessSignal.sigint);
-            return 0;
-          },
-        );
-      }
-    }
-  });
+    });
+  } finally {
+    await sigintSub?.cancel();
+    await sigtermSub?.cancel();
+    await performCleanup();
+  }
 }
 
 Handler createBuildDirectoryHandler(String buildDirectoryPath) {

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -89,37 +89,46 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
       }
 
       // 2. Stop or disconnect Chrome (in DDC mode Chrome is managed by flutterRunProcess)
-      if (!benchmarkOptions.useDdc) {
-        try {
-          final currentChrome = chrome;
-          final readyFuture = whenChromeIsReady;
-          if (currentChrome != null) {
-            currentChrome.stop();
-          } else if (readyFuture != null) {
-            final Chrome readyChrome = await readyFuture.timeout(
-              const Duration(seconds: 5),
-              onTimeout: () => throw TimeoutException('Chrome ready timeout during cleanup'),
-            );
-            readyChrome.stop();
-          }
-        } catch (e) {
-          print('Warning: Error stopping Chrome: $e');
+      void cleanChrome(Chrome c) {
+        if (benchmarkOptions.useDdc) {
+          c.disconnect();
+        } else {
+          c.stop();
         }
-      } else {
+      }
+
+      final currentChrome = chrome;
+      final readyFuture = whenChromeIsReady;
+      if (currentChrome != null) {
         try {
-          final currentChrome = chrome;
-          final readyFuture = whenChromeIsReady;
-          if (currentChrome != null) {
-            currentChrome.disconnect();
-          } else if (readyFuture != null) {
-            final Chrome readyChrome = await readyFuture.timeout(
-              const Duration(seconds: 5),
-              onTimeout: () => throw TimeoutException('Chrome ready timeout during cleanup'),
-            );
-            readyChrome.disconnect();
+          cleanChrome(currentChrome);
+        } catch (e) {
+          final action = benchmarkOptions.useDdc ? 'disconnecting' : 'stopping';
+          print('Warning: Error $action Chrome: $e');
+        }
+      } else if (readyFuture != null) {
+        try {
+          var cleanedUp = false;
+          unawaited(
+            readyFuture.then((Chrome readyChrome) {
+              if (!cleanedUp) {
+                cleanedUp = true;
+                cleanChrome(readyChrome);
+              }
+            }, onError: (_) {}),
+          );
+
+          final Chrome readyChrome = await readyFuture.timeout(
+            const Duration(seconds: 5),
+            onTimeout: () => throw TimeoutException('Chrome ready timeout during cleanup'),
+          );
+          if (!cleanedUp) {
+            cleanedUp = true;
+            cleanChrome(readyChrome);
           }
         } catch (e) {
-          print('Warning: Error disconnecting Chrome: $e');
+          final action = benchmarkOptions.useDdc ? 'disconnecting' : 'stopping';
+          print('Warning: Error $action Chrome: $e');
         }
       }
 
@@ -368,9 +377,11 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
       shelf_io.serveRequests(server!, cascade.handler);
 
       final String dartToolDirectory = path.join(macrobenchmarksDirectory, '.dart_tool');
-      userDataDir = io.Directory(
-        dartToolDirectory,
-      ).createTempSync('flutter_chrome_user_data.').path;
+      final dartToolDir = io.Directory(dartToolDirectory);
+      if (!dartToolDir.existsSync()) {
+        dartToolDir.createSync(recursive: true);
+      }
+      userDataDir = dartToolDir.createTempSync('flutter_chrome_user_data.').path;
 
       // TODO(yjbanov): temporarily disables headful Chrome until we get
       //                devicelab hardware that is able to run it. Our current

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -88,7 +88,7 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
         print('Warning: Error closing server: $e');
       }
 
-      // 2. Stop Chrome (non-DDC mode only; in DDC mode Chrome is managed by flutterRunProcess)
+      // 2. Stop or disconnect Chrome (in DDC mode Chrome is managed by flutterRunProcess)
       if (!benchmarkOptions.useDdc) {
         try {
           final currentChrome = chrome;
@@ -104,6 +104,22 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
           }
         } catch (e) {
           print('Warning: Error stopping Chrome: $e');
+        }
+      } else {
+        try {
+          final currentChrome = chrome;
+          final readyFuture = whenChromeIsReady;
+          if (currentChrome != null) {
+            currentChrome.disconnect();
+          } else if (readyFuture != null) {
+            final Chrome readyChrome = await readyFuture.timeout(
+              const Duration(seconds: 5),
+              onTimeout: () => throw TimeoutException('Chrome ready timeout during cleanup'),
+            );
+            readyChrome.disconnect();
+          }
+        } catch (e) {
+          print('Warning: Error disconnecting Chrome: $e');
         }
       }
 
@@ -267,13 +283,15 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
             final profile = json.decode(requestContents) as Map<String, dynamic>;
             final benchmarkName = profile['name'] as String;
             if (benchmarkName != benchmarkIterator.current) {
-              profileData.completeError(
-                Exception(
-                  'Browser returned benchmark results from a wrong benchmark.\n'
-                  'Requested to run benchmark ${benchmarkIterator.current}, but '
-                  'got results for $benchmarkName.',
-                ),
-              );
+              if (!profileData.isCompleted) {
+                profileData.completeError(
+                  Exception(
+                    'Browser returned benchmark results from a wrong benchmark.\n'
+                    'Requested to run benchmark ${benchmarkIterator.current}, but '
+                    'got results for $benchmarkName.',
+                  ),
+                );
+              }
               unawaited(server!.close());
             }
 
@@ -300,7 +318,9 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
             final errorDetails = json.decode(requestContents) as Map<String, dynamic>;
             unawaited(server!.close());
             // Keep the stack trace as a string. It's thrown in the browser, not this Dart VM.
-            profileData.completeError('${errorDetails['error']}\n${errorDetails['stackTrace']}');
+            if (!profileData.isCompleted) {
+              profileData.completeError('${errorDetails['error']}\n${errorDetails['stackTrace']}');
+            }
             return Response.ok('', headers: requestHeaders);
           } else if (request.requestedUri.path.endsWith('/next-benchmark')) {
             if (benchmarks == null) {
@@ -312,7 +332,9 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
               print('Launching benchmark "$nextBenchmark"');
               return Response.ok(nextBenchmark, headers: requestHeaders);
             } else {
-              profileData.complete(collectedProfiles);
+              if (!profileData.isCompleted) {
+                profileData.complete(collectedProfiles);
+              }
               return Response.notFound('Finished running benchmarks.', headers: requestHeaders);
             }
           } else if (request.requestedUri.path.endsWith('/print-to-console')) {
@@ -329,7 +351,9 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
             );
           }
         } catch (error, stackTrace) {
-          profileData.completeError(error, stackTrace);
+          if (!profileData.isCompleted) {
+            profileData.completeError(error, stackTrace);
+          }
           return Response.internalServerError(body: '$error', headers: requestHeaders);
         }
       });
@@ -374,7 +398,9 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
           flutterRunProcess!,
           options,
           onError: (String error) {
-            profileData.completeError(Exception(error));
+            if (!profileData.isCompleted) {
+              profileData.completeError(Exception(error));
+            }
           },
           workingDirectory: cwd,
         );
@@ -382,7 +408,9 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
         whenChromeIsReady = Chrome.launch(
           options,
           onError: (String error) {
-            profileData.completeError(Exception(error));
+            if (!profileData.isCompleted) {
+              profileData.completeError(Exception(error));
+            }
           },
           workingDirectory: cwd,
         );

--- a/dev/devicelab/test/framework/browser_test.dart
+++ b/dev/devicelab/test/framework/browser_test.dart
@@ -244,91 +244,90 @@ void main() {
 
         immediateCrashProcess.completeExit(1);
         await pumpEventQueue();
-        expect(immediateCrashErrors, <String>['Chrome process exited prematurely with exit code 1']);
+        expect(immediateCrashErrors, <String>[
+          'Chrome process exited prematurely with exit code 1',
+        ]);
       },
     );
 
-    test(
-      'handles rapid disposal and immediate process exit in the same microtask turn',
-      () async {
-        // 1. Process exits in the same microtask turn as disconnect()
-        final process1 = FakeProcess();
-        final errors1 = <String>[];
+    test('handles rapid disposal and immediate process exit in the same microtask turn', () async {
+      // 1. Process exits in the same microtask turn as disconnect()
+      final process1 = FakeProcess();
+      final errors1 = <String>[];
 
-        final Chrome chrome1 = await Chrome.connect(
-          process1,
-          ChromeOptions(),
-          onError: (String error) {
-            errors1.add(error);
-          },
-        );
+      final Chrome chrome1 = await Chrome.connect(
+        process1,
+        ChromeOptions(),
+        onError: (String error) {
+          errors1.add(error);
+        },
+      );
 
-        // Exit and disconnect within the same synchronous turn
-        process1.completeExit(1);
-        chrome1.disconnect();
+      // Exit and disconnect within the same synchronous turn
+      process1.completeExit(1);
+      chrome1.disconnect();
 
-        await pumpEventQueue();
-        expect(errors1, isEmpty);
-        expect(process1.wasKilled, isFalse);
+      await pumpEventQueue();
+      expect(errors1, isEmpty);
+      expect(process1.wasKilled, isFalse);
 
-        // 2. Disconnect called first, then process exits in the same synchronous turn
-        final process2 = FakeProcess();
-        final errors2 = <String>[];
+      // 2. Disconnect called first, then process exits in the same synchronous turn
+      final process2 = FakeProcess();
+      final errors2 = <String>[];
 
-        final Chrome chrome2 = await Chrome.connect(
-          process2,
-          ChromeOptions(),
-          onError: (String error) {
-            errors2.add(error);
-          },
-        );
+      final Chrome chrome2 = await Chrome.connect(
+        process2,
+        ChromeOptions(),
+        onError: (String error) {
+          errors2.add(error);
+        },
+      );
 
-        chrome2.disconnect();
-        process2.completeExit(1);
+      chrome2.disconnect();
+      process2.completeExit(1);
 
-        await pumpEventQueue();
-        expect(errors2, isEmpty);
-        expect(process2.wasKilled, isFalse);
+      await pumpEventQueue();
+      expect(errors2, isEmpty);
+      expect(process2.wasKilled, isFalse);
 
-        // 3. Process exits in the same microtask turn as stop()
-        final process3 = FakeProcess();
-        final errors3 = <String>[];
+      // 3. Process exits in the same microtask turn as stop()
+      final process3 = FakeProcess();
+      final errors3 = <String>[];
 
-        final Chrome chrome3 = await Chrome.connect(
-          process3,
-          ChromeOptions(),
-          onError: (String error) {
-            errors3.add(error);
-          },
-        );
+      final Chrome chrome3 = await Chrome.connect(
+        process3,
+        ChromeOptions(),
+        onError: (String error) {
+          errors3.add(error);
+        },
+      );
 
-        // stop() calls disconnect() and kills process in the same turn
-        chrome3.stop();
+      // stop() calls disconnect() and kills process in the same turn
+      chrome3.stop();
 
-        await pumpEventQueue();
-        expect(errors3, isEmpty);
-        expect(process3.wasKilled, isTrue);
+      await pumpEventQueue();
+      expect(errors3, isEmpty);
+      expect(process3.wasKilled, isTrue);
 
-        // 4. Process exits with non-zero exit code immediately before stop() in same turn
-        final process4 = FakeProcess();
-        final errors4 = <String>[];
+      // 4. Process exits with non-zero exit code immediately before stop() in same turn
+      final process4 = FakeProcess();
+      final errors4 = <String>[];
 
-        final Chrome chrome4 = await Chrome.connect(
-          process4,
-          ChromeOptions(),
-          onError: (String error) {
-            errors4.add(error);
-          },
-        );
+      final Chrome chrome4 = await Chrome.connect(
+        process4,
+        ChromeOptions(),
+        onError: (String error) {
+          errors4.add(error);
+        },
+      );
 
-        process4.completeExit(1);
-        chrome4.stop();
+      process4.completeExit(1);
+      chrome4.stop();
 
-        await pumpEventQueue();
-        expect(errors4, isEmpty);
-        expect(process4.wasKilled, isTrue);
-      },
-    );
+      await pumpEventQueue();
+      expect(errors4, isEmpty);
+      expect(process4.wasKilled, isTrue);
+    });
   });
 }
 

--- a/dev/devicelab/test/framework/browser_test.dart
+++ b/dev/devicelab/test/framework/browser_test.dart
@@ -138,7 +138,7 @@ void main() {
     );
   });
 
-  group('Chrome hostile lifecycle stress tests', () {
+  group('Chrome lifecycle edge cases', () {
     test(
       're-entrant and redundant lifecycle calls do not throw and kill process on stop',
       () async {

--- a/dev/devicelab/test/framework/browser_test.dart
+++ b/dev/devicelab/test/framework/browser_test.dart
@@ -50,44 +50,50 @@ void main() {
   });
 
   group('Chrome.connect lifecycle', () {
-    test('does not report premature exit when wrapped process exits cleanly with exitCode 0', () async {
-      final fakeProcess = FakeProcess();
-      final errors = <String>[];
+    test(
+      'does not report premature exit when wrapped process exits cleanly with exitCode 0',
+      () async {
+        final fakeProcess = FakeProcess();
+        final errors = <String>[];
 
-      await Chrome.connect(
-        fakeProcess,
-        ChromeOptions(),
-        onError: (String error) {
-          errors.add(error);
-        },
-      );
+        await Chrome.connect(
+          fakeProcess,
+          ChromeOptions(),
+          onError: (String error) {
+            errors.add(error);
+          },
+        );
 
-      fakeProcess.completeExit(0);
-      await pumpEventQueue();
+        fakeProcess.completeExit(0);
+        await pumpEventQueue();
 
-      expect(errors, isEmpty);
-    });
+        expect(errors, isEmpty);
+      },
+    );
 
-    test('does not throw Future already completed when wrapped process terminates after completer completes', () async {
-      final fakeProcess = FakeProcess();
-      final profileData = Completer<List<Map<String, dynamic>>>();
+    test(
+      'does not throw Future already completed when wrapped process terminates after completer completes',
+      () async {
+        final fakeProcess = FakeProcess();
+        final profileData = Completer<List<Map<String, dynamic>>>();
 
-      await Chrome.connect(
-        fakeProcess,
-        ChromeOptions(),
-        onError: (String error) {
-          profileData.completeError(Exception(error));
-        },
-      );
+        await Chrome.connect(
+          fakeProcess,
+          ChromeOptions(),
+          onError: (String error) {
+            profileData.completeError(Exception(error));
+          },
+        );
 
-      // Simulate benchmark completion
-      profileData.complete(<Map<String, dynamic>>[]);
-      await profileData.future;
+        // Simulate benchmark completion
+        profileData.complete(<Map<String, dynamic>>[]);
+        await profileData.future;
 
-      // Simulate graceful shutdown of the wrapped process (e.g. sending 'q' to flutter run)
-      fakeProcess.completeExit(0);
-      await pumpEventQueue();
-    });
+        // Simulate graceful shutdown of the wrapped process (e.g. sending 'q' to flutter run)
+        fakeProcess.completeExit(0);
+        await pumpEventQueue();
+      },
+    );
 
     test('reports premature exit when wrapped process crashes with non-zero exitCode', () async {
       final fakeProcess = FakeProcess();
@@ -106,6 +112,30 @@ void main() {
 
       expect(errors, <String>['Chrome process exited prematurely with exit code 1']);
     });
+
+    test(
+      'does not report premature exit after disconnect even if wrapped process crashes',
+      () async {
+        final fakeProcess = FakeProcess();
+        final errors = <String>[];
+
+        final Chrome chrome = await Chrome.connect(
+          fakeProcess,
+          ChromeOptions(),
+          onError: (String error) {
+            errors.add(error);
+          },
+        );
+
+        chrome.disconnect();
+
+        fakeProcess.completeExit(1);
+        await pumpEventQueue();
+
+        expect(errors, isEmpty);
+        expect(fakeProcess.wasKilled, isFalse);
+      },
+    );
   });
 }
 

--- a/dev/devicelab/test/framework/browser_test.dart
+++ b/dev/devicelab/test/framework/browser_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:io' as io;
+
 import 'package:flutter_devicelab/framework/browser.dart';
 
 import '../common.dart';
@@ -45,4 +48,98 @@ void main() {
       expect(anotherUnrelated.isEndMeasuredFrame, isFalse);
     });
   });
+
+  group('Chrome.connect lifecycle', () {
+    test('does not report premature exit when wrapped process exits cleanly with exitCode 0', () async {
+      final fakeProcess = FakeProcess();
+      final errors = <String>[];
+
+      await Chrome.connect(
+        fakeProcess,
+        ChromeOptions(),
+        onError: (String error) {
+          errors.add(error);
+        },
+      );
+
+      fakeProcess.completeExit(0);
+      await pumpEventQueue();
+
+      expect(errors, isEmpty);
+    });
+
+    test('does not throw Future already completed when wrapped process terminates after completer completes', () async {
+      final fakeProcess = FakeProcess();
+      final profileData = Completer<List<Map<String, dynamic>>>();
+
+      await Chrome.connect(
+        fakeProcess,
+        ChromeOptions(),
+        onError: (String error) {
+          profileData.completeError(Exception(error));
+        },
+      );
+
+      // Simulate benchmark completion
+      profileData.complete(<Map<String, dynamic>>[]);
+      await profileData.future;
+
+      // Simulate graceful shutdown of the wrapped process (e.g. sending 'q' to flutter run)
+      fakeProcess.completeExit(0);
+      await pumpEventQueue();
+    });
+
+    test('reports premature exit when wrapped process crashes with non-zero exitCode', () async {
+      final fakeProcess = FakeProcess();
+      final errors = <String>[];
+
+      await Chrome.connect(
+        fakeProcess,
+        ChromeOptions(),
+        onError: (String error) {
+          errors.add(error);
+        },
+      );
+
+      fakeProcess.completeExit(1);
+      await pumpEventQueue();
+
+      expect(errors, <String>['Chrome process exited prematurely with exit code 1']);
+    });
+  });
+}
+
+class FakeProcess implements io.Process {
+  final Completer<int> _exitCodeCompleter = Completer<int>();
+  bool wasKilled = false;
+
+  @override
+  Future<int> get exitCode => _exitCodeCompleter.future;
+
+  @override
+  bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]) {
+    wasKilled = true;
+    if (!_exitCodeCompleter.isCompleted) {
+      _exitCodeCompleter.complete(-1);
+    }
+    return true;
+  }
+
+  void completeExit(int code) {
+    if (!_exitCodeCompleter.isCompleted) {
+      _exitCodeCompleter.complete(code);
+    }
+  }
+
+  @override
+  int get pid => 12345;
+
+  @override
+  Stream<List<int>> get stderr => const Stream<List<int>>.empty();
+
+  @override
+  Stream<List<int>> get stdout => const Stream<List<int>>.empty();
+
+  @override
+  io.IOSink get stdin => throw UnimplementedError();
 }

--- a/dev/devicelab/test/framework/browser_test.dart
+++ b/dev/devicelab/test/framework/browser_test.dart
@@ -137,6 +137,199 @@ void main() {
       },
     );
   });
+
+  group('Chrome hostile lifecycle stress tests', () {
+    test(
+      're-entrant and redundant lifecycle calls do not throw and kill process on stop',
+      () async {
+        final fakeProcess = FakeProcess();
+        final errors = <String>[];
+
+        final Chrome chrome = await Chrome.connect(
+          fakeProcess,
+          ChromeOptions(),
+          onError: (String error) {
+            errors.add(error);
+          },
+        );
+
+        // Multiple disconnect calls sequentially should not throw
+        expect(() {
+          chrome.disconnect();
+          chrome.disconnect();
+          chrome.disconnect();
+        }, returnsNormally);
+
+        expect(fakeProcess.wasKilled, isFalse);
+
+        // Calling stop after disconnect should not throw and should kill underlying process
+        expect(() {
+          chrome.stop();
+          chrome.stop();
+        }, returnsNormally);
+
+        expect(fakeProcess.wasKilled, isTrue);
+
+        // Redundant disconnect after stop should not throw
+        expect(() {
+          chrome.disconnect();
+        }, returnsNormally);
+
+        await pumpEventQueue();
+        expect(errors, isEmpty);
+      },
+    );
+
+    test(
+      'pre-exited process boundary handles exitCode 0 without error and exitCode 1 with error',
+      () async {
+        // 1. Process that has already exited with exitCode 0 before connection
+        final cleanProcess = FakeProcess()..completeExit(0);
+        final cleanErrors = <String>[];
+
+        await Chrome.connect(
+          cleanProcess,
+          ChromeOptions(),
+          onError: (String error) {
+            cleanErrors.add(error);
+          },
+        );
+
+        await pumpEventQueue();
+        expect(cleanErrors, isEmpty);
+
+        // 2. Process that has already exited with exitCode 1 before connection
+        final crashedProcess = FakeProcess()..completeExit(1);
+        final crashErrors = <String>[];
+
+        await Chrome.connect(
+          crashedProcess,
+          ChromeOptions(),
+          onError: (String error) {
+            crashErrors.add(error);
+          },
+        );
+
+        await pumpEventQueue();
+        expect(crashErrors, <String>['Chrome process exited prematurely with exit code 1']);
+
+        // 3. Process that completes exitCode 0 immediately upon connection
+        final immediateCleanProcess = FakeProcess();
+        final immediateCleanErrors = <String>[];
+
+        final Chrome immediateCleanChrome = await Chrome.connect(
+          immediateCleanProcess,
+          ChromeOptions(),
+          onError: (String error) {
+            immediateCleanErrors.add(error);
+          },
+        );
+
+        immediateCleanProcess.completeExit(0);
+        await pumpEventQueue();
+        expect(immediateCleanErrors, isEmpty);
+        immediateCleanChrome.disconnect();
+
+        // 4. Process that completes exitCode 1 immediately upon connection
+        final immediateCrashProcess = FakeProcess();
+        final immediateCrashErrors = <String>[];
+
+        await Chrome.connect(
+          immediateCrashProcess,
+          ChromeOptions(),
+          onError: (String error) {
+            immediateCrashErrors.add(error);
+          },
+        );
+
+        immediateCrashProcess.completeExit(1);
+        await pumpEventQueue();
+        expect(immediateCrashErrors, <String>['Chrome process exited prematurely with exit code 1']);
+      },
+    );
+
+    test(
+      'handles rapid disposal and immediate process exit in the same microtask turn',
+      () async {
+        // 1. Process exits in the same microtask turn as disconnect()
+        final process1 = FakeProcess();
+        final errors1 = <String>[];
+
+        final Chrome chrome1 = await Chrome.connect(
+          process1,
+          ChromeOptions(),
+          onError: (String error) {
+            errors1.add(error);
+          },
+        );
+
+        // Exit and disconnect within the same synchronous turn
+        process1.completeExit(1);
+        chrome1.disconnect();
+
+        await pumpEventQueue();
+        expect(errors1, isEmpty);
+        expect(process1.wasKilled, isFalse);
+
+        // 2. Disconnect called first, then process exits in the same synchronous turn
+        final process2 = FakeProcess();
+        final errors2 = <String>[];
+
+        final Chrome chrome2 = await Chrome.connect(
+          process2,
+          ChromeOptions(),
+          onError: (String error) {
+            errors2.add(error);
+          },
+        );
+
+        chrome2.disconnect();
+        process2.completeExit(1);
+
+        await pumpEventQueue();
+        expect(errors2, isEmpty);
+        expect(process2.wasKilled, isFalse);
+
+        // 3. Process exits in the same microtask turn as stop()
+        final process3 = FakeProcess();
+        final errors3 = <String>[];
+
+        final Chrome chrome3 = await Chrome.connect(
+          process3,
+          ChromeOptions(),
+          onError: (String error) {
+            errors3.add(error);
+          },
+        );
+
+        // stop() calls disconnect() and kills process in the same turn
+        chrome3.stop();
+
+        await pumpEventQueue();
+        expect(errors3, isEmpty);
+        expect(process3.wasKilled, isTrue);
+
+        // 4. Process exits with non-zero exit code immediately before stop() in same turn
+        final process4 = FakeProcess();
+        final errors4 = <String>[];
+
+        final Chrome chrome4 = await Chrome.connect(
+          process4,
+          ChromeOptions(),
+          onError: (String error) {
+            errors4.add(error);
+          },
+        );
+
+        process4.completeExit(1);
+        chrome4.stop();
+
+        await pumpEventQueue();
+        expect(errors4, isEmpty);
+        expect(process4.wasKilled, isTrue);
+      },
+    );
+  });
 }
 
 class FakeProcess implements io.Process {


### PR DESCRIPTION
Ensures temporary Chrome user profile directories created during web benchmarks are reliably deleted, and ensures benchmark child processes (Chrome, Shelf, and `flutter run`) are cleaned up when benchmarks complete or when interrupted with SIGINT/SIGTERM.

Part of #191316

_Tip for reviewers: Recommend viewing with "Hide whitespace" enabled (`?w=1`), as wrapping the task body in `try ... finally` re-indents the inner block._

I fixed the issue with the Chrome lifecycle that caused the original revert.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
