### PR TITLE
fix(web): hide --web-content-hash until content hashing is complete

### DIFF
--- a/packages/flutter_tools/lib/src/web/web_options.dart
+++ b/packages/flutter_tools/lib/src/web/web_options.dart
@@ -79,8 +79,13 @@ abstract final class WebOptions {
         'application.',
   );
 
+  // Hidden while content hashing is incomplete: only compiled entrypoints are
+  // hashed today. Un-hide once static assets (flutter/flutter#191915) and the
+  // service worker precache manifest (flutter/flutter#191916) are also hashed,
+  // so that enabling the flag covers everything a deploy caches.
   static const webContentHash = FlagOptionDescriptor(
     name: 'web-content-hash',
+    hide: true,
     help:
         'Include a content hash in the filenames of the compiled web '
         'entrypoints (for example, "main.dart.<hash>.js") so that browsers '

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -1179,6 +1179,9 @@ void main() {
       expectHidden('no-frequency-based-minification');
       expectHidden('enable-experiment');
 
+      // Incomplete features are hidden until they are fully implemented.
+      expectHidden('web-content-hash');
+
       // Standard options are visible.
       expectVisible('web-resources-cdn');
       expectVisible('optimization-level');
@@ -1230,6 +1233,9 @@ void main() {
       expectVisible('enable-wasm-deferred-loading');
       expectVisible('no-frequency-based-minification');
       expectVisible('enable-experiment');
+
+      // Incomplete features stay hidden even with verbose help.
+      expectHidden('web-content-hash');
 
       // Standard options remain visible.
       expectVisible('web-resources-cdn');


### PR DESCRIPTION
`--web-content-hash` currently hashes only the compiled entrypoints
(#191914). Static assets (#191915), the service worker precache manifest
(#191916), and deferred loading parts (#191917) are all still unhashed, so
a build with the flag enabled can continue to serve stale cached content.
Advertising the flag now sets an expectation the implementation does not
yet meet.

The flag has not shipped in any release. It landed on master in #190153 on
2026-09-10, after the flutter-3.48-candidate.0 fork, so hiding it costs
nothing today. It also avoids committing to the flag's boolean shape before
the remaining phases show whether granularity is needed.

Locks the behavior into the existing `flutter build web option visibility`
tests, including the verbose-help variant, so the flag stays hidden rather
than becoming verbose-only by accident.

Un-hide once #191915 and #191916 have landed.
