### PR TITLE
[web] Respect text affinity in getLineBoundary at a soft wrap

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -974,7 +974,26 @@ class CkParagraph implements ui.Paragraph {
   ui.TextRange getLineBoundary(ui.TextPosition position) {
     assert(!_disposed, 'Paragraph has been disposed.');
     final List<SkLineMetrics> metrics = skiaObject.getLineMetrics();
-    final int offset = position.offset;
+    final ui.TextRange line = _lineBoundaryAtOffset(metrics, position.offset);
+
+    // A line's endIndex equals the next line's startIndex at a soft wrap, so
+    // the lookup above cannot tell the two apart on its own and always answers
+    // with the earlier line, as if the affinity were upstream. A downstream
+    // position sitting exactly on that seam belongs to the next line instead.
+    // This mirrors the native implementation in `lib/ui/text.dart`.
+    final ui.TextRange nextLine = _lineBoundaryAtOffset(metrics, position.offset + 1);
+    if (nextLine.isValid &&
+        position.affinity == ui.TextAffinity.downstream &&
+        line != nextLine &&
+        position.offset == line.end &&
+        line.end == nextLine.start) {
+      return nextLine;
+    }
+    return line;
+  }
+
+  // The line containing [offset], treating both line bounds as inclusive.
+  static ui.TextRange _lineBoundaryAtOffset(List<SkLineMetrics> metrics, int offset) {
     for (final metric in metrics) {
       if (offset >= metric.startIndex && offset <= metric.endIndex) {
         return ui.TextRange(start: metric.startIndex.toInt(), end: metric.endIndex.toInt());

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -247,10 +247,30 @@ class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Pa
 
   @override
   ui.TextRange getLineBoundary(ui.TextPosition position) {
-    final int offset = position.offset;
-    for (final SkwasmLineMetrics metrics in computeLineMetrics()) {
-      if (offset >= metrics.startIndex && offset <= metrics.endIndex) {
-        return ui.TextRange(start: metrics.startIndex, end: metrics.endIndex);
+    final List<SkwasmLineMetrics> metrics = computeLineMetrics();
+    final ui.TextRange line = _lineBoundaryAtOffset(metrics, position.offset);
+
+    // A line's endIndex equals the next line's startIndex at a soft wrap, so
+    // the lookup above cannot tell the two apart on its own and always answers
+    // with the earlier line, as if the affinity were upstream. A downstream
+    // position sitting exactly on that seam belongs to the next line instead.
+    // This mirrors the native implementation in `lib/ui/text.dart`.
+    final ui.TextRange nextLine = _lineBoundaryAtOffset(metrics, position.offset + 1);
+    if (nextLine.isValid &&
+        position.affinity == ui.TextAffinity.downstream &&
+        line != nextLine &&
+        position.offset == line.end &&
+        line.end == nextLine.start) {
+      return nextLine;
+    }
+    return line;
+  }
+
+  // The line containing [offset], treating both line bounds as inclusive.
+  static ui.TextRange _lineBoundaryAtOffset(List<SkwasmLineMetrics> metrics, int offset) {
+    for (final line in metrics) {
+      if (offset >= line.startIndex && offset <= line.endIndex) {
+        return ui.TextRange(start: line.startIndex, end: line.endIndex);
       }
     }
     return ui.TextRange.empty;

--- a/engine/src/flutter/lib/web_ui/test/ui/line_metrics_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/line_metrics_test.dart
@@ -141,6 +141,81 @@ Future<void> testMain() async {
     }
   });
 
+  test('getLineBoundary respects position affinity at a soft wrap', () {
+    const fontSize = 10.0;
+    final builder = ui.ParagraphBuilder(
+      ui.ParagraphStyle(fontSize: fontSize, fontFamily: 'FlutterTest'),
+    )..addText('Test Text');
+    final ui.Paragraph paragraph = builder.build();
+    // The test font is square, so five characters fit and the text wraps to
+    // 'Test ' and 'Text'.
+    paragraph.layout(const ui.ParagraphConstraints(width: fontSize * 5.0));
+    expect(paragraph.computeLineMetrics(), hasLength(2));
+
+    // Offset 5 is the seam: it is both the end of the first line and the start
+    // of the second, so only the affinity distinguishes the two. Downstream
+    // means the start of the second line.
+    expect(
+      paragraph.getLineBoundary(const ui.TextPosition(offset: 5)),
+      const ui.TextRange(start: 5, end: 9),
+    );
+
+    // Upstream means the end of the first line.
+    expect(
+      paragraph.getLineBoundary(
+        const ui.TextPosition(offset: 5, affinity: ui.TextAffinity.upstream),
+      ),
+      const ui.TextRange(start: 0, end: 5),
+    );
+
+    // Away from the seam the affinity makes no difference. Downstream at 0 and
+    // upstream at 2 both resolve to the first line.
+    expect(
+      paragraph.getLineBoundary(const ui.TextPosition(offset: 0)),
+      const ui.TextRange(start: 0, end: 5),
+    );
+    expect(
+      paragraph.getLineBoundary(
+        const ui.TextPosition(offset: 2, affinity: ui.TextAffinity.upstream),
+      ),
+      const ui.TextRange(start: 0, end: 5),
+    );
+
+    // The end of the last line has no following line to move to.
+    expect(
+      paragraph.getLineBoundary(const ui.TextPosition(offset: 9)),
+      const ui.TextRange(start: 5, end: 9),
+    );
+  });
+
+  test('getLineBoundary is unaffected by affinity at a hard line break', () {
+    const fontSize = 10.0;
+    final builder = ui.ParagraphBuilder(
+      ui.ParagraphStyle(fontSize: fontSize, fontFamily: 'FlutterTest'),
+    )..addText('Test\nText');
+    final ui.Paragraph paragraph = builder.build();
+    paragraph.layout(const ui.ParagraphConstraints(width: double.infinity));
+    expect(paragraph.computeLineMetrics(), hasLength(2));
+
+    // Unlike a soft wrap, the newline occupies an offset of its own, so the
+    // first line's end and the second line's start are not the same position
+    // and there is no seam for the affinity to disambiguate.
+    expect(
+      paragraph.getLineBoundary(const ui.TextPosition(offset: 4)),
+      const ui.TextRange(start: 0, end: 4),
+    );
+    expect(
+      paragraph.getLineBoundary(
+        const ui.TextPosition(offset: 4, affinity: ui.TextAffinity.upstream),
+      ),
+      const ui.TextRange(start: 0, end: 4),
+    );
+    expect(
+      paragraph.getLineBoundary(const ui.TextPosition(offset: 5)),
+      const ui.TextRange(start: 5, end: 9),
+    );
+  });
+
   group('when flutter tester emulation is enabled', () {
     setUp(() {
       ui_web.TestEnvironment.setUp(const ui_web.TestEnvironment.flutterTester());


### PR DESCRIPTION
Fixes #188874

**Problem**

When text wraps onto a second line, one offset sits in two places at once: the end of line 1 and the start of line 2. `TextPosition.affinity` is what says which of the two you mean. Web ignored it.

For `'Test Text'` wrapping after `'Test '`, asking about the start of line 2:

```
getLineBoundary(TextPosition(offset: 5))

native:  TextRange(5, 9)   line 2   correct
web:     TextRange(0, 5)   line 1   wrong
```

Skia reports line bounds inclusively, so line 1's `end` and line 2's `start` are both 5 and the lookup always matched line 1 first. Line 2 was unreachable from any caret position, which broke line navigation keys and triple-tap line selection on web. Both shipping web renderers, CanvasKit and skwasm, had the bug independently.

**Fix**

Ported the lookahead native has used since flutter/engine#28008. If the position is downstream and sits exactly where one line's `end` meets the next line's `start`, return the next line instead.

Hard line breaks are unaffected, because a newline takes an offset of its own so the two ranges never touch and the rule cannot fire. A test pins that.

**Demo**

Before: https://flutter-demo-60-before.web.app
After: https://flutter-demo-60-after.web.app

Repro steps:
1. Click in the text box, then drag the caret so it sits just before the `A` on the second line. The readout confirms offset 15.
2. The panel underneath follows the caret and shows the range `getLineBoundary` returns for that position.
3. Before: the caret is drawn on line 2, but the boundary comes back as `0..15`, which is line 1, so the panel reads MISMATCH.
4. After: the boundary comes back as `15..16` and the panel reads AGREE.

Every other offset behaves identically in both builds. Offset 15 with downstream affinity is the only input whose answer changes.