### PR TITLE
[Impeller] Fix the text benchmark on Impeller backends

### DIFF
--- a/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
+++ b/engine/src/flutter/display_list/benchmarking/dl_benchmarks.cc
@@ -11,6 +11,9 @@
 #include "flutter/display_list/skia/dl_sk_canvas.h"
 #include "flutter/display_list/testing/dl_test_snippets.h"
 #include "flutter/testing/display_list_testing.h"
+#ifdef IMPELLER_SUPPORTS_RENDERING
+#include "flutter/impeller/display_list/dl_text_impeller.h"  // nogncheck
+#endif  // IMPELLER_SUPPORTS_RENDERING
 
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkImage.h"
@@ -1547,9 +1550,19 @@ void BM_DrawTextBlob(benchmark::State& state,
   state.counters["GlyphCount"] = draw_calls;
   char character[2] = {'A', '\0'};
 
+#ifdef IMPELLER_SUPPORTS_RENDERING
+  const bool targets_impeller = surface_provider->TargetsImpeller();
+#endif  // IMPELLER_SUPPORTS_RENDERING
+
   for (size_t i = 0; i < draw_calls; i++) {
     character[0] = 'A' + (i % 26);
     auto blob = SkTextBlob::MakeFromString(character, CreateTestFontOfSize(20));
+#ifdef IMPELLER_SUPPORTS_RENDERING
+    if (targets_impeller) {
+      builder.DrawText(DlTextImpeller::MakeFromBlob(blob), 50.0f, 50.0f, paint);
+      continue;
+    }
+#endif  // IMPELLER_SUPPORTS_RENDERING
     builder.DrawText(DlTextSkia::Make(blob), 50.0f, 50.0f, paint);
   }
 


### PR DESCRIPTION
The DrawTextBlob benchmark always built a DlTextSkia, whose text frame is null on Impeller backends. The dispatcher FML_CHECKs that frame and aborts.

This is a local macOS/iOS benchmark crash. The text benchmark is compiled into display_list_benchmarks via DISPLAY_LIST_BENCHMARK_ALL_OPS (primitive_rendering_benchmarks omits text benchmarks); the Impeller Metal variants are built only when ENABLE_METAL_BENCHMARKS is set. Linux CI does not run those backends.

Build a DlTextImpeller when the surface provider targets Impeller. The backend check is outside the timed loop.

Fixes #192671

test-exempt: benchmark-only crash fix

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

Made with [Cursor](https://cursor.com)
