### PR TITLE
[Impeller] Add a fast path for small host buffer emplaces

### DIFF
--- a/engine/src/flutter/impeller/core/host_buffer.cc
+++ b/engine/src/flutter/impeller/core/host_buffer.cc
@@ -16,8 +16,6 @@
 
 namespace impeller {
 
-constexpr size_t kAllocatorBlockSize = 1024000;  // 1024 Kb.
-
 std::shared_ptr<HostBuffer> HostBuffer::Create(
     const std::shared_ptr<Allocator>& allocator,
     const std::shared_ptr<const IdleWaiter>& idle_waiter,
@@ -45,6 +43,7 @@ HostBuffer::HostBuffer(
     FML_CHECK(device_buffer) << "Failed to allocate device buffer.";
     device_buffers_[i].push_back(device_buffer);
   }
+  RefreshCurrentBuffer();
 }
 
 HostBuffer::~HostBuffer() {
@@ -55,9 +54,9 @@ HostBuffer::~HostBuffer() {
   }
 };
 
-BufferView HostBuffer::Emplace(const void* buffer,
-                               size_t length,
-                               size_t align) {
+BufferView HostBuffer::EmplaceSlow(const void* buffer,
+                                   size_t length,
+                                   size_t align) {
   auto [range, device_buffer, raw_device_buffer] =
       EmplaceInternal(buffer, length, align);
   if (device_buffer) {
@@ -117,6 +116,7 @@ bool HostBuffer::MaybeCreateNewBuffer() {
     device_buffers_[frame_index_].push_back(std::move(buffer));
   }
   offset_ = 0;
+  RefreshCurrentBuffer();
   return true;
 }
 
@@ -159,13 +159,12 @@ HostBuffer::EmplaceInternal(size_t length,
   }
 
   const std::shared_ptr<DeviceBuffer>& current_buffer = GetCurrentBuffer();
-  auto contents = current_buffer->OnGetContents();
-  cb(contents + offset_);
+  cb(current_contents_ + offset_);
   Range output_range(offset_, length);
   current_buffer->Flush(output_range);
 
   offset_ += length;
-  return std::make_tuple(output_range, nullptr, current_buffer.get());
+  return std::make_tuple(output_range, nullptr, current_raw_buffer_);
 }
 
 std::tuple<Range, std::shared_ptr<DeviceBuffer>, DeviceBuffer*>
@@ -199,14 +198,13 @@ HostBuffer::EmplaceInternal(const void* buffer, size_t length) {
   old_length = GetLength();
 
   const std::shared_ptr<DeviceBuffer>& current_buffer = GetCurrentBuffer();
-  auto contents = current_buffer->OnGetContents();
   if (buffer) {
-    ::memmove(contents + old_length, buffer, length);
+    ::memmove(current_contents_ + old_length, buffer, length);
     current_buffer->Flush(Range{old_length, length});
   }
   offset_ += length;
   return std::make_tuple(Range{old_length, length}, nullptr,
-                         current_buffer.get());
+                         current_raw_buffer_);
 }
 
 std::tuple<Range, std::shared_ptr<DeviceBuffer>, DeviceBuffer*>
@@ -231,6 +229,12 @@ const std::shared_ptr<DeviceBuffer>& HostBuffer::GetCurrentBuffer() const {
   return device_buffers_[frame_index_][current_buffer_];
 }
 
+void HostBuffer::RefreshCurrentBuffer() {
+  const std::shared_ptr<DeviceBuffer>& buffer = GetCurrentBuffer();
+  current_raw_buffer_ = buffer.get();
+  current_contents_ = buffer->OnGetContents();
+}
+
 void HostBuffer::Reset() {
   // When resetting the host buffer state at the end of the frame, check if
   // there are any unused buffers and remove them.
@@ -248,6 +252,7 @@ void HostBuffer::Reset() {
   frame_index_ = (frame_index_ + 1) % kHostBufferArenaSize;
 
   if (!submission_tracker_) {
+    RefreshCurrentBuffer();
     return;
   }
   uint64_t completed = submission_tracker_->CompletedThrough();
@@ -258,6 +263,7 @@ void HostBuffer::Reset() {
   });
 
   if (entry_stamps_[frame_index_] <= completed) {
+    RefreshCurrentBuffer();
     return;
   }
 
@@ -270,6 +276,7 @@ void HostBuffer::Reset() {
   std::shared_ptr<DeviceBuffer> buffer = allocator_->CreateBuffer(desc);
   if (!buffer) {
     VALIDATION_LOG << "Failed to replace an in-flight host buffer entry.";
+    RefreshCurrentBuffer();
     return;
   }
   retired_buffers_.emplace_back(entry_stamps_[frame_index_],
@@ -277,6 +284,7 @@ void HostBuffer::Reset() {
   device_buffers_[frame_index_].clear();
   device_buffers_[frame_index_].push_back(std::move(buffer));
   entry_stamps_[frame_index_] = 0;
+  RefreshCurrentBuffer();
 }
 
 size_t HostBuffer::GetMinimumUniformAlignment() const {

--- a/engine/src/flutter/impeller/core/host_buffer.h
+++ b/engine/src/flutter/impeller/core/host_buffer.h
@@ -7,17 +7,24 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <cstring>
 #include <functional>
 #include <memory>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "impeller/core/allocator.h"
 #include "impeller/core/buffer_view.h"
+#include "impeller/core/device_buffer.h"
 #include "impeller/core/gpu_submission_tracker.h"
 
 namespace impeller {
+
+/// The size of each host buffer arena allocation.
+inline constexpr size_t kAllocatorBlockSize = 1024000;  // 1024 Kb.
 
 /// Approximately the same size as the max frames in flight.
 static const constexpr size_t kHostBufferArenaSize = 4u;
@@ -109,7 +116,29 @@ class HostBuffer {
 
   [[nodiscard]] BufferView Emplace(const void* buffer,
                                    size_t length,
-                                   size_t align);
+                                   size_t align) {
+    // Fast path: the vast majority of emplaces are small and fit in the
+    // current buffer without rolling over.
+    if (current_contents_ != nullptr) {
+      size_t offset = offset_;
+      if (align > 0u) {
+        const size_t misalignment = offset % align;
+        if (misalignment != 0u) {
+          offset += align - misalignment;
+        }
+      }
+      if (length <= kAllocatorBlockSize &&
+          offset <= kAllocatorBlockSize - length) {
+        if (buffer != nullptr) {
+          ::memcpy(current_contents_ + offset, buffer, length);
+        }
+        offset_ = offset + length;
+        current_raw_buffer_->Flush(Range{offset, length});
+        return BufferView(current_raw_buffer_, Range{offset, length});
+      }
+    }
+    return EmplaceSlow(buffer, length, align);
+  }
 
   using EmplaceProc = std::function<void(uint8_t* buffer)>;
 
@@ -146,6 +175,10 @@ class HostBuffer {
   TestStateQuery GetStateForTest();
 
  private:
+  [[nodiscard]] BufferView EmplaceSlow(const void* buffer,
+                                       size_t length,
+                                       size_t align);
+
   [[nodiscard]] std::tuple<Range, std::shared_ptr<DeviceBuffer>, DeviceBuffer*>
   EmplaceInternal(const void* buffer, size_t length);
 
@@ -164,6 +197,12 @@ class HostBuffer {
   [[nodiscard]] bool MaybeCreateNewBuffer();
 
   const std::shared_ptr<DeviceBuffer>& GetCurrentBuffer() const;
+
+  // Refresh the cached raw pointer and host visible contents of the current
+  // buffer. Must be called whenever |current_buffer_| or |frame_index_|
+  // changes, and whenever the buffer object at that slot is replaced (the
+  // in-flight |Reset| path).
+  void RefreshCurrentBuffer();
 
   [[nodiscard]] BufferView Emplace(const void* buffer, size_t length);
 
@@ -193,6 +232,10 @@ class HostBuffer {
   size_t offset_ = 0u;
   size_t frame_index_ = 0u;
   size_t minimum_uniform_alignment_ = 0u;
+  // Cached raw pointer and host visible contents of the current buffer to
+  // avoid a virtual call and a shared_ptr dereference per emplace.
+  DeviceBuffer* current_raw_buffer_ = nullptr;
+  uint8_t* current_contents_ = nullptr;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/core/host_buffer.h
+++ b/engine/src/flutter/impeller/core/host_buffer.h
@@ -131,9 +131,9 @@ class HostBuffer {
           offset <= kAllocatorBlockSize - length) {
         if (buffer != nullptr) {
           ::memcpy(current_contents_ + offset, buffer, length);
+          current_raw_buffer_->Flush(Range{offset, length});
         }
         offset_ = offset + length;
-        current_raw_buffer_->Flush(Range{offset, length});
         return BufferView(current_raw_buffer_, Range{offset, length});
       }
     }

--- a/engine/src/flutter/impeller/entity/contents/host_buffer_unittests.cc
+++ b/engine/src/flutter/impeller/entity/contents/host_buffer_unittests.cc
@@ -288,5 +288,78 @@ TEST_P(HostBufferTest, EmplaceWithFailingAllocationDoesntCrash) {
   EXPECT_EQ(view.GetRange().length, 0u);
 }
 
+TEST_P(HostBufferTest, FastPathProducesCorrectRangesAndContent) {
+  auto buffer = HostBuffer::Create(GetContext()->GetResourceAllocator(),
+                                   GetContext()->GetIdleWaiter(), 256);
+
+  struct alignas(16) Align16 {
+    uint8_t data[16];
+  };
+
+  std::vector<BufferView> views;
+  for (size_t i = 0; i < 64; i++) {
+    Align16 block;
+    std::fill(block.data, block.data + 16, static_cast<uint8_t>(i));
+    views.push_back(buffer->Emplace(block));
+  }
+  for (size_t i = 0; i < views.size(); i++) {
+    ASSERT_TRUE(views[i]);
+    ASSERT_EQ(views[i].GetRange(), Range(i * 16u, 16u));
+    const uint8_t* contents =
+        views[i].GetBuffer()->OnGetContents() + views[i].GetRange().offset;
+    for (size_t j = 0; j < 16; j++) {
+      EXPECT_EQ(contents[j], static_cast<uint8_t>(i));
+    }
+  }
+}
+
+TEST_P(HostBufferTest, FastPathHandlesBufferRollover) {
+  auto buffer = HostBuffer::Create(GetContext()->GetResourceAllocator(),
+                                   GetContext()->GetIdleWaiter(), 256);
+
+  const size_t big_size = kAllocatorBlockSize - 4096;
+  std::vector<uint8_t> big(big_size, 0xAB);
+  auto first = buffer->Emplace(big.data(), big.size(), 0);
+  ASSERT_TRUE(first);
+  ASSERT_EQ(first.GetRange().offset, 0u);
+
+  // The remaining 4096 bytes can't hold this allocation, so it must move to
+  // a fresh buffer at offset 0.
+  std::vector<uint8_t> next(8192, 0xCD);
+  auto second = buffer->Emplace(next.data(), next.size(), 0);
+  ASSERT_TRUE(second);
+  ASSERT_EQ(second.GetRange().offset, 0u);
+  EXPECT_NE(first.GetBuffer(), second.GetBuffer());
+  const uint8_t* contents =
+      second.GetBuffer()->OnGetContents() + second.GetRange().offset;
+  EXPECT_EQ(std::vector<uint8_t>(contents, contents + next.size()), next);
+}
+
+TEST_P(HostBufferTest, FastPathResetDoesNotClobberPreviousFrame) {
+  auto buffer = HostBuffer::Create(GetContext()->GetResourceAllocator(),
+                                   GetContext()->GetIdleWaiter(), 256);
+
+  std::vector<uint8_t> first_bytes(64, 0xAA);
+  auto first = buffer->Emplace(first_bytes.data(), first_bytes.size(), 0);
+  ASSERT_TRUE(first);
+  const DeviceBuffer* first_buffer = first.GetBuffer();
+  const size_t first_offset = first.GetRange().offset;
+
+  buffer->Reset();
+
+  std::vector<uint8_t> second_bytes(64, 0xBB);
+  auto second = buffer->Emplace(second_bytes.data(), second_bytes.size(), 0);
+  ASSERT_TRUE(second);
+
+  const uint8_t* previous = first_buffer->OnGetContents() + first_offset;
+  EXPECT_EQ(std::vector<uint8_t>(previous, previous + first_bytes.size()),
+            first_bytes);
+
+  const uint8_t* current =
+      second.GetBuffer()->OnGetContents() + second.GetRange().offset;
+  EXPECT_EQ(std::vector<uint8_t>(current, current + second_bytes.size()),
+            second_bytes);
+}
+
 }  // namespace  testing
 }  // namespace impeller


### PR DESCRIPTION
HostBuffer is used for every uniform and vertex upload. Cache the current host visible mapping and raw device buffer so the common small emplace path avoids a virtual OnGetContents call, an out-of-line EmplaceInternal call, and std::tuple construction.

Take the fast path only when length <= kAllocatorBlockSize and offset <= kAllocatorBlockSize - length. Refresh whenever the current buffer or frame index changes, and whenever Reset replaces an in-flight buffer object.

Existing HostBuffer tests cover the fast path (FastPath* passed locally on Metal). Tests also check full payloads, rollover contents, and that Reset does not write through a stale mapping into the previous frame.

Fixes #192672
Related to #164607

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

Made with [Cursor](https://cursor.com)