### PR TITLE
[Impeller] Avoid heap-allocating std::function captures per draw

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/circle_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/circle_contents.cc
@@ -62,6 +62,8 @@ bool CircleContents::Render(const ContentContext& renderer,
       this, geometry_.get(), renderer, entity, pass, pipeline_callback,
       frame_info,
       /*bind_fragment_callback=*/
+      // DrawGeometry invokes this before returning, so capturing locals by
+      // reference is safe.
       [&frag_info, &data_host_buffer](RenderPass& pass) {
         FS::BindFragInfo(pass, data_host_buffer.EmplaceUniform(frag_info));
         pass.SetCommandLabel("Circle");
@@ -69,10 +71,11 @@ bool CircleContents::Render(const ContentContext& renderer,
       },
       /*force_stencil=*/false,
       /*create_geom_callback=*/
-      [geometry_result = std::move(geometry_result)](
-          const ContentContext& renderer, const Entity& entity,
-          RenderPass& pass,
-          const Geometry* geometry) { return geometry_result; });
+      // DrawGeometry invokes this before returning, so capturing
+      // geometry_result by reference is safe.
+      [&geometry_result](const ContentContext& renderer, const Entity& entity,
+                         RenderPass& pass,
+                         const Geometry* geometry) { return geometry_result; });
 }
 
 std::optional<Rect> CircleContents::GetCoverage(const Entity& entity) const {

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.cc
@@ -165,8 +165,9 @@ bool UberSDFContents::Render(const ContentContext& renderer,
       this, GetGeometry(), renderer, entity, pass, pipeline_callback,
       frame_info,
       /*bind_fragment_callback=*/
-      [&frag_info, &data_host_buffer,
-       sampler_binding = std::move(sampler_binding)](RenderPass& pass) {
+      // DrawGeometry invokes this before returning, so capturing locals by
+      // reference is safe.
+      [&frag_info, &data_host_buffer, &sampler_binding](RenderPass& pass) {
         FS::BindColorSourceSampler(pass, sampler_binding.texture,
                                    sampler_binding.sampler);
         FS::BindFragInfo(pass, data_host_buffer.EmplaceUniform(frag_info));
@@ -175,10 +176,11 @@ bool UberSDFContents::Render(const ContentContext& renderer,
       },
       /*force_stencil=*/false,
       /*create_geom_callback=*/
-      [geometry_result = std::move(geometry_result)](
-          const ContentContext& renderer, const Entity& entity,
-          RenderPass& pass,
-          const Geometry* geometry) { return geometry_result; });
+      // DrawGeometry invokes this before returning, so capturing
+      // geometry_result by reference is safe.
+      [&geometry_result](const ContentContext& renderer, const Entity& entity,
+                         RenderPass& pass,
+                         const Geometry* geometry) { return geometry_result; });
 }
 
 std::optional<Rect> UberSDFContents::GetCoverage(const Entity& entity) const {

--- a/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.h
+++ b/engine/src/flutter/impeller/entity/contents/uber_sdf_contents.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_ENTITY_CONTENTS_UBER_SDF_CONTENTS_H_
 
 #include <memory>
+#include <optional>
 
 #include "flutter/impeller/entity/contents/color_source_contents.h"
 #include "flutter/impeller/entity/contents/contents.h"


### PR DESCRIPTION
UberSDF and circle contents build per-draw callbacks that capture the sampler binding and geometry result by value. Those captures exceed the std::function small-buffer optimization and heap-allocate on every draw.

DrawGeometry invokes the callbacks before returning, so capturing by reference is valid and removes those allocations.

Fixes #192673
Related to #164607

test-exempt: capture-by-ref only; DrawGeometry remains synchronous

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

Made with [Cursor](https://cursor.com)