### PR TITLE
[Impeller] Reduce Metal per-command binding and state overhead

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.h
+++ b/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.h
@@ -7,6 +7,12 @@
 
 #include <Metal/Metal.h>
 
+#include <array>
+#include <optional>
+#include <vector>
+
+#include "impeller/core/formats.h"
+#include "impeller/core/shader_types.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
 
@@ -39,7 +45,9 @@ struct PassBindingsCacheMTL {
   ///
   /// If this matches the previous render pipeline state, no update
   /// is performed.
-  void SetRenderPipelineState(id<MTLRenderPipelineState> pipeline);
+  ///
+  /// @returns true if the pipeline state changed.
+  bool SetRenderPipelineState(id<MTLRenderPipelineState> pipeline);
 
   /// @brief Set the depth and stencil state for the current encoder.
   ///
@@ -81,24 +89,55 @@ struct PassBindingsCacheMTL {
   ///        the current encoder state.
   void SetStencilRef(uint32_t stencil_ref);
 
+  /// @brief Set the encoder front-facing winding if it differs from the
+  ///        current encoder state.
+  void SetWindingOrder(WindingOrder winding);
+
+  /// @brief Set the encoder cull mode if it differs from the current encoder
+  ///        state.
+  void SetCullMode(CullMode cull_mode);
+
+  /// @brief Set the encoder triangle fill mode if it differs from the current
+  ///        encoder state.
+  void SetPolygonMode(PolygonMode polygon_mode);
+
  private:
   struct BufferOffsetPair {
     id<MTLBuffer> buffer = nullptr;
     size_t offset = 0u;
   };
-  using BufferMap = std::map<uint64_t, BufferOffsetPair>;
-  using TextureMap = std::map<uint64_t, id<MTLTexture>>;
-  using SamplerMap = std::map<uint64_t, id<MTLSamplerState>>;
+
+  // Shader argument table binding indices are small, dense integers, so
+  // per-stage vectors indexed by the binding index avoid the allocation and
+  // lookup costs of a node-based map on the per-command hot path.
+  static constexpr size_t kShaderStageCount = 4u;
+  static_assert(kShaderStageCount ==
+                static_cast<size_t>(ShaderStage::kCompute) + 1u);
+  static constexpr uint64_t kMaxBindingIndex = 512u;
+
+  using BufferBindings =
+      std::array<std::vector<BufferOffsetPair>, kShaderStageCount>;
+  using TextureBindings =
+      std::array<std::vector<id<MTLTexture>>, kShaderStageCount>;
+  using SamplerBindings =
+      std::array<std::vector<id<MTLSamplerState>>, kShaderStageCount>;
+
+  static bool IsCacheableStage(ShaderStage stage) {
+    return stage == ShaderStage::kVertex || stage == ShaderStage::kFragment;
+  }
 
   id<MTLRenderCommandEncoder> encoder_;
   id<MTLRenderPipelineState> pipeline_ = nullptr;
   id<MTLDepthStencilState> depth_stencil_ = nullptr;
-  std::map<ShaderStage, BufferMap> buffers_;
-  std::map<ShaderStage, TextureMap> textures_;
-  std::map<ShaderStage, SamplerMap> samplers_;
+  BufferBindings buffers_;
+  TextureBindings textures_;
+  SamplerBindings samplers_;
   std::optional<Viewport> viewport_;
   std::optional<IRect32> scissor_;
   std::optional<uint32_t> stencil_ref_;
+  std::optional<WindingOrder> winding_;
+  std::optional<CullMode> cull_mode_;
+  std::optional<PolygonMode> polygon_mode_;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/pass_bindings_cache_mtl.mm
@@ -4,19 +4,22 @@
 
 #include "impeller/renderer/backend/metal/pass_bindings_cache_mtl.h"
 
+#include "impeller/renderer/backend/metal/formats_mtl.h"
+
 namespace impeller {
 
 void PassBindingsCacheMTL::SetEncoder(id<MTLRenderCommandEncoder> encoder) {
   encoder_ = encoder;
 }
 
-void PassBindingsCacheMTL::SetRenderPipelineState(
+bool PassBindingsCacheMTL::SetRenderPipelineState(
     id<MTLRenderPipelineState> pipeline) {
   if (pipeline == pipeline_) {
-    return;
+    return false;
   }
   pipeline_ = pipeline;
   [encoder_ setRenderPipelineState:pipeline_];
+  return true;
 }
 
 void PassBindingsCacheMTL::SetDepthStencilState(
@@ -38,17 +41,25 @@ bool PassBindingsCacheMTL::SetBuffer(ShaderStage stage,
     // index to Metal, which has no bounds check and would crash.
     return true;
   }
-  auto& buffers_map = buffers_[stage];
-  auto found = buffers_map.find(index);
-  if (found != buffers_map.end() && found->second.buffer == buffer) {
+  if (!IsCacheableStage(stage) || index >= kMaxBindingIndex) {
+    VALIDATION_LOG << "Cannot bind buffer to an unknown stage or out of range "
+                      "binding index.";
+    return false;
+  }
+  auto& slots = buffers_[static_cast<size_t>(stage)];
+  if (index >= slots.size()) {
+    slots.resize(index + 1);
+  }
+  BufferOffsetPair& slot = slots[index];
+  if (slot.buffer == buffer) {
     // The right buffer is bound. Check if its offset needs to be updated.
-    if (found->second.offset == offset) {
+    if (slot.offset == offset) {
       // Buffer and its offset is identical. Nothing to do.
       return true;
     }
 
     // Only the offset needs to be updated.
-    found->second.offset = offset;
+    slot.offset = offset;
 
     switch (stage) {
       case ShaderStage::kVertex:
@@ -58,12 +69,10 @@ bool PassBindingsCacheMTL::SetBuffer(ShaderStage stage,
         [encoder_ setFragmentBufferOffset:offset atIndex:index];
         return true;
       default:
-        VALIDATION_LOG << "Cannot update buffer offset of an unknown stage.";
-        return false;
+        break;
     }
-    return true;
   }
-  buffers_map[index] = {buffer, static_cast<size_t>(offset)};
+  slot = {buffer, static_cast<size_t>(offset)};
   switch (stage) {
     case ShaderStage::kVertex:
       [encoder_ setVertexBuffer:buffer offset:offset atIndex:index];
@@ -72,8 +81,7 @@ bool PassBindingsCacheMTL::SetBuffer(ShaderStage stage,
       [encoder_ setFragmentBuffer:buffer offset:offset atIndex:index];
       return true;
     default:
-      VALIDATION_LOG << "Cannot bind buffer to unknown shader stage.";
-      return false;
+      break;
   }
   return false;
 }
@@ -85,13 +93,20 @@ bool PassBindingsCacheMTL::SetTexture(ShaderStage stage,
     // See SetBuffer: a dead-code-eliminated sampler has no argument-table slot.
     return true;
   }
-  auto& texture_map = textures_[stage];
-  auto found = texture_map.find(index);
-  if (found != texture_map.end() && found->second == texture) {
+  if (!IsCacheableStage(stage) || index >= kMaxBindingIndex) {
+    VALIDATION_LOG << "Cannot bind texture to an unknown stage or out of range "
+                      "binding index.";
+    return false;
+  }
+  auto& slots = textures_[static_cast<size_t>(stage)];
+  if (index >= slots.size()) {
+    slots.resize(index + 1);
+  }
+  if (slots[index] == texture) {
     // Already bound.
     return true;
   }
-  texture_map[index] = texture;
+  slots[index] = texture;
   switch (stage) {
     case ShaderStage::kVertex:
       [encoder_ setVertexTexture:texture atIndex:index];
@@ -100,8 +115,7 @@ bool PassBindingsCacheMTL::SetTexture(ShaderStage stage,
       [encoder_ setFragmentTexture:texture atIndex:index];
       return true;
     default:
-      VALIDATION_LOG << "Cannot bind buffer to unknown shader stage.";
-      return false;
+      break;
   }
   return false;
 }
@@ -113,13 +127,20 @@ bool PassBindingsCacheMTL::SetSampler(ShaderStage stage,
     // See SetBuffer: a dead-code-eliminated sampler has no argument-table slot.
     return true;
   }
-  auto& sampler_map = samplers_[stage];
-  auto found = sampler_map.find(index);
-  if (found != sampler_map.end() && found->second == sampler) {
+  if (!IsCacheableStage(stage) || index >= kMaxBindingIndex) {
+    VALIDATION_LOG << "Cannot bind sampler to an unknown stage or out of range "
+                      "binding index.";
+    return false;
+  }
+  auto& slots = samplers_[static_cast<size_t>(stage)];
+  if (index >= slots.size()) {
+    slots.resize(index + 1);
+  }
+  if (slots[index] == sampler) {
     // Already bound.
     return true;
   }
-  sampler_map[index] = sampler;
+  slots[index] = sampler;
   switch (stage) {
     case ShaderStage::kVertex:
       [encoder_ setVertexSamplerState:sampler atIndex:index];
@@ -128,8 +149,7 @@ bool PassBindingsCacheMTL::SetSampler(ShaderStage stage,
       [encoder_ setFragmentSamplerState:sampler atIndex:index];
       return true;
     default:
-      VALIDATION_LOG << "Cannot bind buffer to unknown shader stage.";
-      return false;
+      break;
   }
   return false;
 }
@@ -169,6 +189,32 @@ void PassBindingsCacheMTL::SetStencilRef(uint32_t stencil_ref) {
   }
   [encoder_ setStencilReferenceValue:stencil_ref];
   stencil_ref_ = stencil_ref;
+}
+
+void PassBindingsCacheMTL::SetWindingOrder(WindingOrder winding) {
+  if (winding_.has_value() && winding_.value() == winding) {
+    return;
+  }
+  [encoder_ setFrontFacingWinding:winding == WindingOrder::kClockwise
+                                      ? MTLWindingClockwise
+                                      : MTLWindingCounterClockwise];
+  winding_ = winding;
+}
+
+void PassBindingsCacheMTL::SetCullMode(CullMode cull_mode) {
+  if (cull_mode_.has_value() && cull_mode_.value() == cull_mode) {
+    return;
+  }
+  [encoder_ setCullMode:ToMTLCullMode(cull_mode)];
+  cull_mode_ = cull_mode;
+}
+
+void PassBindingsCacheMTL::SetPolygonMode(PolygonMode polygon_mode) {
+  if (polygon_mode_.has_value() && polygon_mode_.value() == polygon_mode) {
+    return;
+  }
+  [encoder_ setTriangleFillMode:ToMTLTriangleFillMode(polygon_mode)];
+  polygon_mode_ = polygon_mode;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/engine/src/flutter/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -238,13 +238,12 @@ void RenderPassMTL::SetPipeline(PipelineRef pipeline) {
   pass_bindings_.SetDepthStencilState(
       PipelineMTL::Cast(*pipeline).GetMTLDepthStencilState());
 
-  [encoder_ setFrontFacingWinding:pipeline_desc.GetWindingOrder() ==
-                                          WindingOrder::kClockwise
-                                      ? MTLWindingClockwise
-                                      : MTLWindingCounterClockwise];
-  [encoder_ setCullMode:ToMTLCullMode(pipeline_desc.GetCullMode())];
-  [encoder_ setTriangleFillMode:ToMTLTriangleFillMode(
-                                    pipeline_desc.GetPolygonMode())];
+  // Winding, cull, and triangle fill live on the encoder, not in the PSO.
+  // Cache them independently of pipeline identity so a future PSO intern
+  // that ignored these fields cannot skip a needed encoder update.
+  pass_bindings_.SetWindingOrder(pipeline_desc.GetWindingOrder());
+  pass_bindings_.SetCullMode(pipeline_desc.GetCullMode());
+  pass_bindings_.SetPolygonMode(pipeline_desc.GetPolygonMode());
   has_valid_pipeline_ = true;
 }
 


### PR DESCRIPTION
Two CPU-side changes in the immediate-mode Metal encoder, which runs per draw command:

- PassBindingsCacheMTL used std::map keyed on the argument table slot, allocating nodes and tree-searching on every bound buffer, texture, and sampler. Argument table slots are small dense integers, so store per-stage vectors indexed by slot instead.
- Winding, cull, and triangle fill live on the encoder, not in MTLRenderPipelineState. Cache them independently of pipeline identity and set them only when they change.

Fixes #192674
Related to #164607

test-exempt: Metal encoder binding/raster-state cache; no semantic change

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

Made with [Cursor](https://cursor.com)