### PR TITLE
[Impeller] Cache fill path tessellations on second use

### DIFF
--- a/engine/src/flutter/display_list/geometry/dl_path.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path.cc
@@ -256,6 +256,10 @@ bool DlPath::IsConvex() const {
   return data_->sk_path.isConvex();
 }
 
+std::shared_ptr<const void> DlPath::GetCacheIdentity() const {
+  return data_;
+}
+
 DlPath DlPath::operator+(const DlPath& other) const {
   SkPathBuilder path = SkPathBuilder(GetSkPath());
   path.addPath(other.GetSkPath());

--- a/engine/src/flutter/display_list/geometry/dl_path.h
+++ b/engine/src/flutter/display_list/geometry/dl_path.h
@@ -96,6 +96,9 @@ class DlPath : public impeller::PathSource {
   bool IsVolatile() const;
   bool IsConvex() const override;
 
+  // |impeller::PathSource|
+  std::shared_ptr<const void> GetCacheIdentity() const override;
+
   DlPath operator+(const DlPath& other) const;
 
  private:

--- a/engine/src/flutter/display_list/geometry/dl_path_unittests.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path_unittests.cc
@@ -843,5 +843,22 @@ TEST(DisplayListPath, CannotConstructFromSkiaInverseEvenOdd) {
 }
 #endif
 
+TEST(DisplayListPath, CacheIdentityIsSharedForCopies) {
+  DlPath path = DlPath::MakeRect(DlRect::MakeWH(10, 10));
+  ASSERT_NE(path.GetCacheIdentity(), nullptr);
+  // Copies share the same cache identity.
+  EXPECT_EQ(path.GetCacheIdentity(), DlPath(path).GetCacheIdentity());
+
+  DlPath other = DlPath::MakeRect(DlRect::MakeWH(20, 20));
+  ASSERT_NE(other.GetCacheIdentity(), nullptr);
+  EXPECT_NE(path.GetCacheIdentity(), other.GetCacheIdentity());
+
+  // A separately created path with identical geometry has a distinct
+  // identity so cached data is never shared between unrelated paths.
+  DlPath recreated = DlPath::MakeRect(DlRect::MakeWH(10, 10));
+  ASSERT_NE(recreated.GetCacheIdentity(), nullptr);
+  EXPECT_NE(path.GetCacheIdentity(), recreated.GetCacheIdentity());
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/impeller/geometry/path_source.h
+++ b/engine/src/flutter/impeller/geometry/path_source.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_IMPELLER_GEOMETRY_PATH_SOURCE_H_
 #define FLUTTER_IMPELLER_GEOMETRY_PATH_SOURCE_H_
 
+#include <memory>
+
 #include "impeller/geometry/point.h"
 #include "impeller/geometry/rect.h"
 
@@ -59,6 +61,19 @@ class PathSource {
   virtual Rect GetBounds() const = 0;
   virtual bool IsConvex() const = 0;
   virtual void Dispatch(PathReceiver& receiver) const = 0;
+
+  /// @brief  An opaque, stable identity for this source that can be used to
+  ///         cache derived data such as tessellations.
+  ///
+  /// Returns nullptr when the source has no stable identity and therefore
+  /// cannot be cached. The returned shared pointer keeps the identity alive
+  /// for as long as the caller retains it, which prevents address reuse by
+  /// newly created sources. Tessellation caches insert on second use of a
+  /// key; a recycled address with no live cache entry may cache on first
+  /// use of the new path.
+  virtual std::shared_ptr<const void> GetCacheIdentity() const {
+    return nullptr;
+  }
 };
 
 /// @brief A PathSource object that provides path iteration for any TRect.

--- a/engine/src/flutter/impeller/tessellator/tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator.cc
@@ -5,7 +5,14 @@
 #include "impeller/tessellator/tessellator.h"
 #include <cstdint>
 #include <cstring>
+#include <deque>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
+#include "flutter/fml/hash_combine.h"
 #include "flutter/impeller/core/device_buffer.h"
 #include "flutter/impeller/tessellator/path_tessellator.h"
 
@@ -334,50 +341,181 @@ class ConvexTessellatorImpl : public Tessellator::ConvexTessellator {
                                 Scalar tolerance,
                                 bool supports_primitive_restart,
                                 bool supports_triangle_fan) override {
-    if (supports_primitive_restart) {
-      // Primitive Restart.
-      const auto [point_count, contour_count] =
-          PathTessellator::CountFillStorage(path, tolerance);
-      BufferView point_buffer = data_host_buffer.Emplace(
-          nullptr, sizeof(Point) * point_count, alignof(Point));
-      BufferView index_buffer = indexes_host_buffer.Emplace(
-          nullptr, sizeof(IndexT) * (point_count + contour_count),
-          alignof(IndexT));
+    std::shared_ptr<const void> identity = path.GetCacheIdentity();
+    const CacheKey key = {
+        /*identity=*/identity.get(),
+        /*tolerance=*/tolerance,
+        /*restart=*/supports_primitive_restart,
+        /*fan=*/supports_triangle_fan,
+    };
 
-      auto* points_ptr =
-          reinterpret_cast<Point*>(point_buffer.GetBuffer()->OnGetContents() +
-                                   point_buffer.GetRange().offset);
-      auto* indices_ptr =
-          reinterpret_cast<IndexT*>(index_buffer.GetBuffer()->OnGetContents() +
-                                    index_buffer.GetRange().offset);
-
-      auto tessellate_path = [&](auto& writer) {
-        PathTessellator::PathToFilledVertices(path, writer, tolerance);
-        FML_DCHECK(writer.GetPointCount() <= point_count);
-        FML_DCHECK(writer.GetIndexCount() <= (point_count + contour_count));
-        point_buffer.GetBuffer()->Flush(point_buffer.GetRange());
-        index_buffer.GetBuffer()->Flush(index_buffer.GetRange());
-
-        return VertexBuffer{
-            .vertex_buffer = std::move(point_buffer),
-            .index_buffer = std::move(index_buffer),
-            .vertex_count = writer.GetIndexCount(),
-            .index_type = IndexTypeFor<IndexT>(),
-        };
-      };
-
-      if (supports_triangle_fan) {
-        FanPathVertexWriter writer(points_ptr, indices_ptr);
-        return tessellate_path(writer);
-      } else {
-        StripPathVertexWriter writer(points_ptr, indices_ptr);
-        return tessellate_path(writer);
+    if (identity != nullptr) {
+      auto found = cache_.find(key);
+      if (found != cache_.end()) {
+        return Upload(found->second.points, found->second.indices,
+                      data_host_buffer, indexes_host_buffer);
       }
     }
 
-    DoTessellateConvexInternal(path, point_buffer_, index_buffer_, tolerance);
+    // Unique paths stay on the existing direct / GLES path. Cache only after
+    // the same key is seen a second time so one-shot DlPaths keep zero-copy
+    // uploads. The seen set stores raw keys (no shared_ptr); a recycled
+    // address may therefore cache on first use of a new path.
+    const bool cacheable = identity != nullptr;
+    const bool second_use = cacheable && seen_.find(key) != seen_.end();
+    if (!second_use) {
+      if (cacheable) {
+        RecordSeen(key);
+      }
+      if (supports_primitive_restart) {
+        return TessellateConvexDirect(
+            path, data_host_buffer, indexes_host_buffer, tolerance,
+            supports_primitive_restart, supports_triangle_fan);
+      }
+      DoTessellateConvexInternal(path, point_buffer_, index_buffer_, tolerance);
+      return Upload(point_buffer_, index_buffer_, data_host_buffer,
+                    indexes_host_buffer);
+    }
 
-    if (point_buffer_.empty()) {
+    if (supports_primitive_restart) {
+      TessellateConvexIntoVectors(path, tolerance, supports_triangle_fan);
+    } else {
+      DoTessellateConvexInternal(path, point_buffer_, index_buffer_, tolerance);
+    }
+
+    VertexBuffer result = Upload(point_buffer_, index_buffer_, data_host_buffer,
+                                 indexes_host_buffer);
+    if (!point_buffer_.empty() && point_buffer_.size() <= kMaxPointsPerEntry) {
+      CacheEntry entry;
+      entry.identity = std::move(identity);
+      entry.points.swap(point_buffer_);
+      entry.indices.swap(index_buffer_);
+      point_buffer_.reserve(2048);
+      index_buffer_.reserve(2048);
+      InsertCacheEntry(key, std::move(entry));
+    }
+    return result;
+  }
+
+  size_t GetCacheSizeForTesting() const override { return cache_.size(); }
+
+ private:
+  // The maximum number of tessellations retained per tessellator, and the
+  // total number of points across all retained tessellations. These bounds
+  // keep the memory used by the cache predictable for applications that draw
+  // many distinct paths. Keep these eviction bounds in sync with the stroke
+  // tessellation cache.
+  static constexpr size_t kMaxCacheEntries = 256u;
+  static constexpr size_t kMaxCachedPoints = 1u << 18;
+  static constexpr size_t kMaxPointsPerEntry = 1u << 14;
+
+  VertexBuffer TessellateConvexDirect(const PathSource& path,
+                                      HostBuffer& data_host_buffer,
+                                      HostBuffer& indexes_host_buffer,
+                                      Scalar tolerance,
+                                      bool supports_primitive_restart,
+                                      bool supports_triangle_fan) {
+    FML_DCHECK(supports_primitive_restart);
+    const auto [point_count, contour_count] =
+        PathTessellator::CountFillStorage(path, tolerance);
+    BufferView point_buffer = data_host_buffer.Emplace(
+        nullptr, sizeof(Point) * point_count, alignof(Point));
+    BufferView index_buffer = indexes_host_buffer.Emplace(
+        nullptr, sizeof(IndexT) * (point_count + contour_count),
+        alignof(IndexT));
+
+    auto* points_ptr =
+        reinterpret_cast<Point*>(point_buffer.GetBuffer()->OnGetContents() +
+                                 point_buffer.GetRange().offset);
+    auto* indices_ptr =
+        reinterpret_cast<IndexT*>(index_buffer.GetBuffer()->OnGetContents() +
+                                  index_buffer.GetRange().offset);
+
+    auto tessellate_path = [&](auto& writer) {
+      PathTessellator::PathToFilledVertices(path, writer, tolerance);
+      FML_DCHECK(writer.GetPointCount() <= point_count);
+      FML_DCHECK(writer.GetIndexCount() <= (point_count + contour_count));
+      point_buffer.GetBuffer()->Flush(point_buffer.GetRange());
+      index_buffer.GetBuffer()->Flush(index_buffer.GetRange());
+
+      return VertexBuffer{
+          .vertex_buffer = std::move(point_buffer),
+          .index_buffer = std::move(index_buffer),
+          .vertex_count = writer.GetIndexCount(),
+          .index_type = IndexTypeFor<IndexT>(),
+      };
+    };
+
+    if (supports_triangle_fan) {
+      FanPathVertexWriter<IndexT> writer(points_ptr, indices_ptr);
+      return tessellate_path(writer);
+    } else {
+      StripPathVertexWriter<IndexT> writer(points_ptr, indices_ptr);
+      return tessellate_path(writer);
+    }
+  }
+
+  void TessellateConvexIntoVectors(const PathSource& path,
+                                   Scalar tolerance,
+                                   bool supports_triangle_fan) {
+    const auto [point_count, contour_count] =
+        PathTessellator::CountFillStorage(path, tolerance);
+    point_buffer_.clear();
+    index_buffer_.clear();
+    point_buffer_.resize(point_count);
+    index_buffer_.resize(point_count + contour_count);
+
+    auto tessellate_into = [&](auto& writer) {
+      PathTessellator::PathToFilledVertices(path, writer, tolerance);
+      FML_DCHECK(writer.GetPointCount() <= point_count);
+      FML_DCHECK(writer.GetIndexCount() <= (point_count + contour_count));
+      point_buffer_.resize(writer.GetPointCount());
+      index_buffer_.resize(writer.GetIndexCount());
+    };
+
+    if (supports_triangle_fan) {
+      FanPathVertexWriter<IndexT> writer(point_buffer_.data(),
+                                         index_buffer_.data());
+      tessellate_into(writer);
+    } else {
+      StripPathVertexWriter<IndexT> writer(point_buffer_.data(),
+                                           index_buffer_.data());
+      tessellate_into(writer);
+    }
+  }
+
+  struct CacheKey {
+    const void* identity = nullptr;
+    Scalar tolerance = 0.0f;
+    bool restart = false;
+    bool fan = false;
+
+    bool operator==(const CacheKey& other) const {
+      return identity == other.identity && tolerance == other.tolerance &&
+             restart == other.restart && fan == other.fan;
+    }
+  };
+
+  struct CacheKeyHash {
+    size_t operator()(const CacheKey& key) const {
+      return fml::HashCombine(key.identity, key.tolerance, key.restart,
+                              key.fan);
+    }
+  };
+
+  struct CacheEntry {
+    // Keeps the source alive so its address cannot be reused by a different
+    // path while this entry is retained.
+    std::shared_ptr<const void> identity;
+    std::vector<Point> points;
+    std::vector<IndexT> indices;
+  };
+
+  VertexBuffer Upload(const std::vector<Point>& points,
+                      const std::vector<IndexT>& indices,
+                      HostBuffer& data_host_buffer,
+                      HostBuffer& indexes_host_buffer) {
+    if (points.empty() || indices.empty()) {
       return VertexBuffer{
           .vertex_buffer = {},
           .index_buffer = {},
@@ -387,24 +525,58 @@ class ConvexTessellatorImpl : public Tessellator::ConvexTessellator {
     }
 
     BufferView vertex_buffer = data_host_buffer.Emplace(
-        point_buffer_.data(), sizeof(Point) * point_buffer_.size(),
-        alignof(Point));
+        points.data(), sizeof(Point) * points.size(), alignof(Point));
 
     BufferView index_buffer = indexes_host_buffer.Emplace(
-        index_buffer_.data(), sizeof(IndexT) * index_buffer_.size(),
-        alignof(IndexT));
+        indices.data(), sizeof(IndexT) * indices.size(), alignof(IndexT));
 
     return VertexBuffer{
         .vertex_buffer = std::move(vertex_buffer),
         .index_buffer = std::move(index_buffer),
-        .vertex_count = index_buffer_.size(),
+        .vertex_count = indices.size(),
         .index_type = IndexTypeFor<IndexT>(),
     };
   }
 
- private:
+  void InsertCacheEntry(CacheKey key, CacheEntry entry) {
+    // Keep this eviction loop in sync with the stroke tessellation cache.
+    auto [it, inserted] = cache_.emplace(key, std::move(entry));
+    if (!inserted) {
+      return;
+    }
+    cached_points_ += it->second.points.size();
+    cache_order_.push_back(key);
+
+    while (!cache_order_.empty() && (cache_.size() > kMaxCacheEntries ||
+                                     cached_points_ > kMaxCachedPoints)) {
+      const CacheKey oldest = cache_order_.front();
+      cache_order_.pop_front();
+      auto found = cache_.find(oldest);
+      if (found != cache_.end()) {
+        cached_points_ -= found->second.points.size();
+        cache_.erase(found);
+      }
+    }
+  }
+
+  void RecordSeen(const CacheKey& key) {
+    if (!seen_.insert(key).second) {
+      return;
+    }
+    seen_order_.push_back(key);
+    while (seen_.size() > kMaxCacheEntries && !seen_order_.empty()) {
+      seen_.erase(seen_order_.front());
+      seen_order_.pop_front();
+    }
+  }
+
   std::vector<Point> point_buffer_;
   std::vector<IndexT> index_buffer_;
+  std::unordered_map<CacheKey, CacheEntry, CacheKeyHash> cache_;
+  std::deque<CacheKey> cache_order_;
+  std::unordered_set<CacheKey, CacheKeyHash> seen_;
+  std::deque<CacheKey> seen_order_;
+  size_t cached_points_ = 0u;
 };
 
 Tessellator::Tessellator(bool supports_32bit_primitive_indices)
@@ -420,6 +592,10 @@ Tessellator::~Tessellator() = default;
 
 std::vector<Point>& Tessellator::GetStrokePointCache() {
   return stroke_points_;
+}
+
+size_t Tessellator::GetFillTessellationCacheSizeForTesting() const {
+  return convex_tessellator_->GetCacheSizeForTesting();
 }
 
 Tessellator::Trigs Tessellator::GetTrigsForDeviceRadius(Scalar pixel_radius) {

--- a/engine/src/flutter/impeller/tessellator/tessellator.h
+++ b/engine/src/flutter/impeller/tessellator/tessellator.h
@@ -387,6 +387,9 @@ class Tessellator {
   /// Retrieve a pre-allocated arena of kPointArenaSize points.
   std::vector<Point>& GetStrokePointCache();
 
+  /// Visible for testing.
+  size_t GetFillTessellationCacheSizeForTesting() const;
+
   /// Return a vector of Trig (cos, sin pairs) structs for a 90 degree
   /// circle quadrant of the specified pixel radius
   Trigs GetTrigsForDeviceRadius(Scalar pixel_radius);
@@ -401,6 +404,7 @@ class Tessellator {
                                           Scalar tolerance,
                                           bool supports_primitive_restart,
                                           bool supports_triangle_fan) = 0;
+    virtual size_t GetCacheSizeForTesting() const = 0;
   };
   template <typename IndexT>
   friend class ConvexTessellatorImpl;

--- a/engine/src/flutter/impeller/tessellator/tessellator_playground_unittests.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator_playground_unittests.cc
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 
 #include "flutter/display_list/geometry/dl_path_builder.h"
+#include "impeller/geometry/path_source.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/tessellator/tessellator.h"
 
@@ -21,6 +22,16 @@ std::vector<T> CopyBufferView(const BufferView& vertex_buffer) {
   uint8_t* base_ptr = vertex_buffer.GetBuffer()->OnGetContents() + range.offset;
   return std::vector<T>(reinterpret_cast<T*>(base_ptr),
                         reinterpret_cast<T*>(base_ptr + range.length));
+}
+
+flutter::DlPath MakeCurvedPath() {
+  flutter::DlPathBuilder builder;
+  builder.MoveTo({0, 0});
+  builder.LineTo({40, 0});
+  builder.QuadraticCurveTo({50, 5}, {40, 40});
+  builder.LineTo({0, 40});
+  builder.Close();
+  return builder.TakePath();
 }
 
 TEST_P(TessellatorPlaygroundTest, TessellateConvex16or32Bit) {
@@ -55,6 +66,113 @@ TEST_P(TessellatorPlaygroundTest, TessellateConvex16or32Bit) {
   EXPECT_EQ(
       std::vector<uint32_t>(expected_indices.begin(), expected_indices.end()),
       CopyBufferView<uint32_t>(vertex_buffer32.index_buffer));
+}
+
+TEST_P(TessellatorPlaygroundTest, TessellateConvexCacheInsertsOnSecondUse) {
+  auto tessellator = std::make_shared<Tessellator>(false);
+
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  auto indexes_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+
+  auto path = MakeCurvedPath();
+
+  VertexBuffer first = tessellator->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 0u);
+
+  VertexBuffer second = tessellator->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  EXPECT_EQ(CopyBufferView<Point>(first.vertex_buffer),
+            CopyBufferView<Point>(second.vertex_buffer));
+  EXPECT_EQ(CopyBufferView<uint16_t>(first.index_buffer),
+            CopyBufferView<uint16_t>(second.index_buffer));
+
+  VertexBuffer third = tessellator->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  EXPECT_EQ(CopyBufferView<Point>(first.vertex_buffer),
+            CopyBufferView<Point>(third.vertex_buffer));
+
+  // Copies share identity, so a copy of a path that has already been
+  // tessellated once is a cache hit.
+  VertexBuffer from_copy =
+      tessellator->TessellateConvex(flutter::DlPath(path), *data_host_buffer,
+                                    *indexes_host_buffer, 1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  EXPECT_EQ(CopyBufferView<Point>(first.vertex_buffer),
+            CopyBufferView<Point>(from_copy.vertex_buffer));
+
+  auto path2 = MakeCurvedPath();
+  VertexBuffer other_first = tessellator->TessellateConvex(
+      path2, *data_host_buffer, *indexes_host_buffer, 1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  EXPECT_EQ(CopyBufferView<Point>(first.vertex_buffer),
+            CopyBufferView<Point>(other_first.vertex_buffer));
+  tessellator->TessellateConvex(path2, *data_host_buffer, *indexes_host_buffer,
+                                1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 2u);
+
+  tessellator->TessellateConvex(path, *data_host_buffer, *indexes_host_buffer,
+                                2.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 2u);
+  tessellator->TessellateConvex(path, *data_host_buffer, *indexes_host_buffer,
+                                2.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 3u);
+}
+
+TEST_P(TessellatorPlaygroundTest, TessellateConvexCacheMissesOnRestartAndFan) {
+  auto tessellator = std::make_shared<Tessellator>(true);
+
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  auto indexes_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+
+  auto path = MakeCurvedPath();
+
+  VertexBuffer first = tessellator->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, true, true);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 0u);
+  VertexBuffer second = tessellator->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, true, true);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  EXPECT_EQ(CopyBufferView<Point>(first.vertex_buffer),
+            CopyBufferView<Point>(second.vertex_buffer));
+  EXPECT_EQ(CopyBufferView<uint32_t>(first.index_buffer),
+            CopyBufferView<uint32_t>(second.index_buffer));
+
+  tessellator->TessellateConvex(path, *data_host_buffer, *indexes_host_buffer,
+                                1.0, true, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  tessellator->TessellateConvex(path, *data_host_buffer, *indexes_host_buffer,
+                                1.0, true, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 2u);
+}
+
+TEST_P(TessellatorPlaygroundTest, UncacheablePathSourceNeverEntersFillCache) {
+  auto tessellator = std::make_shared<Tessellator>(true);
+
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  auto indexes_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+
+  RectPathSource rect(Rect::MakeLTRB(0, 0, 10, 10));
+  ASSERT_EQ(rect.GetCacheIdentity(), nullptr);
+  for (int i = 0; i < 3; i++) {
+    tessellator->TessellateConvex(rect, *data_host_buffer, *indexes_host_buffer,
+                                  1.0, true, true);
+  }
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 0u);
 }
 
 }  // namespace testing


### PR DESCRIPTION
Tessellating the same convex path is repeated work for every fill draw that uses it. Add a bounded cache in the convex tessellator keyed on the source identity, the tolerance, and the device primitive capabilities.

The first draw of a cacheable DlPath stays on the existing zero-copy primitive-restart upload. The cache stores vertices only after the same key is seen again (insert-on-second-use), and retains the identity so a freed path's address cannot be reused while an entry is live (pin-after-second-use). Uncacheable sources never enter the cache. A recycled identity address may cache on first use of a new path; that is accepted for this bounded seen set.

Playground tests cover insert-on-second-use and pin-after-second-use.

Fixes #192675
Related to #164607

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

Made with [Cursor](https://cursor.com)