### PR TITLE
[Impeller] Cache stroke path tessellations on second use

### DIFF
--- a/engine/src/flutter/display_list/geometry/dl_path.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path.cc
@@ -256,6 +256,10 @@ bool DlPath::IsConvex() const {
   return data_->sk_path.isConvex();
 }
 
+std::shared_ptr<const void> DlPath::GetCacheIdentity() const {
+  return data_;
+}
+
 DlPath DlPath::operator+(const DlPath& other) const {
   SkPathBuilder path = SkPathBuilder(GetSkPath());
   path.addPath(other.GetSkPath());

--- a/engine/src/flutter/display_list/geometry/dl_path.h
+++ b/engine/src/flutter/display_list/geometry/dl_path.h
@@ -96,6 +96,9 @@ class DlPath : public impeller::PathSource {
   bool IsVolatile() const;
   bool IsConvex() const override;
 
+  // |impeller::PathSource|
+  std::shared_ptr<const void> GetCacheIdentity() const override;
+
   DlPath operator+(const DlPath& other) const;
 
  private:

--- a/engine/src/flutter/display_list/geometry/dl_path_unittests.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path_unittests.cc
@@ -843,5 +843,22 @@ TEST(DisplayListPath, CannotConstructFromSkiaInverseEvenOdd) {
 }
 #endif
 
+TEST(DisplayListPath, CacheIdentityIsSharedForCopies) {
+  DlPath path = DlPath::MakeRect(DlRect::MakeWH(10, 10));
+  ASSERT_NE(path.GetCacheIdentity(), nullptr);
+  // Copies share the same cache identity.
+  EXPECT_EQ(path.GetCacheIdentity(), DlPath(path).GetCacheIdentity());
+
+  DlPath other = DlPath::MakeRect(DlRect::MakeWH(20, 20));
+  ASSERT_NE(other.GetCacheIdentity(), nullptr);
+  EXPECT_NE(path.GetCacheIdentity(), other.GetCacheIdentity());
+
+  // A separately created path with identical geometry has a distinct
+  // identity so cached data is never shared between unrelated paths.
+  DlPath recreated = DlPath::MakeRect(DlRect::MakeWH(10, 10));
+  ASSERT_NE(recreated.GetCacheIdentity(), nullptr);
+  EXPECT_NE(path.GetCacheIdentity(), recreated.GetCacheIdentity());
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/impeller/entity/entity_unittests.cc
+++ b/engine/src/flutter/impeller/entity/entity_unittests.cc
@@ -57,6 +57,7 @@
 #include "impeller/renderer/render_target.h"
 #include "impeller/renderer/testing/mocks.h"
 #include "impeller/renderer/vertex_buffer_builder.h"
+#include "impeller/tessellator/tessellator.h"
 #include "third_party/abseil-cpp/absl/status/status_matchers.h"
 #include "third_party/imgui/imgui.h"
 
@@ -2353,6 +2354,100 @@ TEST_P(EntityTest, FillPathGeometryGetPositionBufferReturnsExpectedMode) {
     GeometryResult result = get_result(path);
     EXPECT_EQ(result.mode, GeometryResult::Mode::kNonZero);
   }
+}
+
+TEST_P(EntityTest, StrokePathGeometryCachesTessellationOnSecondUse) {
+  RenderTarget target;
+  testing::MockRenderPass mock_pass(GetContext(), target);
+  Tessellator& tessellator = GetContentContext().GetTessellator();
+  const size_t cache_before =
+      tessellator.GetStrokeTessellationCacheSizeForTesting();
+
+  flutter::DlPath path = flutter::DlPathBuilder{}
+                             .MoveTo({0, 0})
+                             .LineTo({40, 0})
+                             .QuadraticCurveTo({50, 5}, {40, 40})
+                             .LineTo({0, 40})
+                             .Close()
+                             .TakePath();
+  StrokeParameters stroke{.width = 2.0f};
+  auto geometry = Geometry::MakeStrokePath(path, stroke);
+  Entity entity;
+
+  auto copy_points = [](const GeometryResult& result) {
+    const BufferView& view = result.vertex_buffer.vertex_buffer;
+    const Point* ptr = reinterpret_cast<const Point*>(
+        view.GetBuffer()->OnGetContents() + view.GetRange().offset);
+    return std::vector<Point>(ptr, ptr + result.vertex_buffer.vertex_count);
+  };
+
+  GeometryResult first =
+      geometry->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before);
+  std::vector<Point> first_points = copy_points(first);
+
+  GeometryResult second =
+      geometry->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before + 1);
+  EXPECT_EQ(first_points, copy_points(second));
+
+  GeometryResult third =
+      geometry->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before + 1);
+  EXPECT_EQ(first_points, copy_points(third));
+
+  StrokeParameters round = stroke;
+  round.cap = Cap::kRound;
+  auto round_geom = Geometry::MakeStrokePath(path, round);
+  round_geom->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before + 1);
+  round_geom->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before + 2);
+
+  StrokeParameters join = stroke;
+  join.join = Join::kRound;
+  auto join_geom = Geometry::MakeStrokePath(path, join);
+  join_geom->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  join_geom->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before + 3);
+
+  StrokeParameters miter = stroke;
+  miter.miter_limit = 8.0f;
+  auto miter_geom = Geometry::MakeStrokePath(path, miter);
+  miter_geom->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  miter_geom->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before + 4);
+
+  StrokeParameters wide = stroke;
+  wide.width = 6.0f;
+  auto wide_geom = Geometry::MakeStrokePath(path, wide);
+  wide_geom->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  wide_geom->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before + 5);
+
+  StrokeParameters hairline{.width = 0.0f};
+  auto hairline_geom = Geometry::MakeStrokePath(path, hairline);
+  hairline_geom->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  hairline_geom->GetPositionBuffer(GetContentContext(), entity, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before + 6);
+
+  Entity scaled;
+  scaled.SetTransform(Matrix::MakeScale({2.0f, 2.0f, 1.0f}));
+  hairline_geom->GetPositionBuffer(GetContentContext(), scaled, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before + 6);
+  hairline_geom->GetPositionBuffer(GetContentContext(), scaled, mock_pass);
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(),
+            cache_before + 7);
 }
 
 TEST_P(EntityTest, StrokeArcGeometryGetPositionBufferReturnsExpectedMode) {

--- a/engine/src/flutter/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/stroke_path_geometry.cc
@@ -14,6 +14,7 @@
 #include "impeller/geometry/separated_vector.h"
 #include "impeller/geometry/wangs_formula.h"
 #include "impeller/tessellator/path_tessellator.h"
+#include "impeller/tessellator/tessellator.h"
 
 namespace impeller {
 
@@ -767,8 +768,28 @@ GeometryResult StrokeSegmentsGeometry::GetPositionBuffer(
   adjusted_stroke.width = std::max(stroke_.width, min_size);
 
   auto& data_host_buffer = renderer.GetTransientsDataBuffer();
-  auto scale = entity.GetTransform().GetMaxBasisLengthXY();
+  const Scalar scale = max_basis;
   auto& tessellator = renderer.GetTessellator();
+
+  const std::shared_ptr<const void> cache_identity = GetCacheIdentity();
+  if (cache_identity != nullptr) {
+    const std::vector<Point>* cached = tessellator.FindCachedStrokeTessellation(
+        cache_identity.get(), adjusted_stroke, scale);
+    if (cached != nullptr) {
+      BufferView buffer_view = data_host_buffer.Emplace(
+          cached->data(), cached->size() * sizeof(Point), alignof(Point));
+
+      return GeometryResult{.type = PrimitiveType::kTriangleStrip,
+                            .vertex_buffer =
+                                {
+                                    .vertex_buffer = buffer_view,
+                                    .vertex_count = cached->size(),
+                                    .index_type = IndexType::kNone,
+                                },
+                            .transform = entity.GetShaderTransform(pass),
+                            .mode = GeometryResult::Mode::kPreventOverdraw};
+    }
+  }
 
   PositionWriter position_writer(tessellator.GetStrokePointCache());
   StrokePathSegmentReceiver receiver(tessellator, position_writer,
@@ -776,6 +797,32 @@ GeometryResult StrokeSegmentsGeometry::GetPositionBuffer(
   Dispatch(receiver, tessellator, scale);
 
   const auto [arena_length, oversized_length] = position_writer.GetUsedSize();
+  const size_t point_count = arena_length + oversized_length;
+
+  if (cache_identity != nullptr) {
+    if (tessellator.HasSeenStrokeTessellation(cache_identity.get(),
+                                              adjusted_stroke, scale)) {
+      if (point_count > 0u && point_count <= kMaxCachedStrokePointsPerEntry) {
+        std::vector<Point> combined;
+        combined.reserve(point_count);
+        const std::vector<Point>& arena = tessellator.GetStrokePointCache();
+        combined.insert(combined.end(), arena.begin(),
+                        arena.begin() + arena_length);
+        if (oversized_length > 0u) {
+          const std::vector<Point>& oversized_data =
+              position_writer.GetOversizedBuffer();
+          combined.insert(combined.end(), oversized_data.begin(),
+                          oversized_data.end());
+        }
+        tessellator.StoreCachedStrokeTessellation(
+            cache_identity, adjusted_stroke, scale, std::move(combined));
+      }
+    } else {
+      tessellator.RecordSeenStrokeTessellation(cache_identity.get(),
+                                               adjusted_stroke, scale);
+    }
+  }
+
   if (!position_writer.HasOversizedBuffer()) {
     BufferView buffer_view =
         data_host_buffer.Emplace(tessellator.GetStrokePointCache().data(),
@@ -862,6 +909,10 @@ void StrokePathSourceGeometry::Dispatch(PathAndArcSegmentReceiver& receiver,
                                         Tessellator& tessellator,
                                         Scalar scale) const {
   PathTessellator::PathToStrokedSegments(GetSource(), receiver);
+}
+
+std::shared_ptr<const void> StrokePathSourceGeometry::GetCacheIdentity() const {
+  return GetSource().GetCacheIdentity();
 }
 
 StrokePathGeometry::StrokePathGeometry(const flutter::DlPath& path,

--- a/engine/src/flutter/impeller/entity/geometry/stroke_path_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/stroke_path_geometry.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_IMPELLER_ENTITY_GEOMETRY_STROKE_PATH_GEOMETRY_H_
 #define FLUTTER_IMPELLER_ENTITY_GEOMETRY_STROKE_PATH_GEOMETRY_H_
 
+#include <memory>
+
 #include "impeller/entity/geometry/geometry.h"
 #include "impeller/geometry/dashed_line_path_source.h"
 #include "impeller/geometry/matrix.h"
@@ -60,6 +62,12 @@ class StrokeSegmentsGeometry : public Geometry {
   std::optional<Rect> GetStrokeCoverage(const Matrix& transform,
                                         const Rect& segment_bounds) const;
 
+  /// @brief An opaque, stable identity for this geometry's tessellated stroke
+  ///        output, or nullptr when caching is not possible.
+  virtual std::shared_ptr<const void> GetCacheIdentity() const {
+    return nullptr;
+  }
+
  private:
   // |Geometry|
   GeometryResult GetPositionBuffer(const ContentContext& renderer,
@@ -106,6 +114,9 @@ class StrokePathSourceGeometry : public StrokeSegmentsGeometry {
   void Dispatch(PathAndArcSegmentReceiver& receiver,
                 Tessellator& tessellator,
                 Scalar scale) const override;
+
+  // |StrokeSegmentsGeometry|
+  std::shared_ptr<const void> GetCacheIdentity() const override;
 };
 
 /// @brief A Geometry that produces fillable vertices representing the

--- a/engine/src/flutter/impeller/geometry/path_source.h
+++ b/engine/src/flutter/impeller/geometry/path_source.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_IMPELLER_GEOMETRY_PATH_SOURCE_H_
 #define FLUTTER_IMPELLER_GEOMETRY_PATH_SOURCE_H_
 
+#include <memory>
+
 #include "impeller/geometry/point.h"
 #include "impeller/geometry/rect.h"
 
@@ -59,6 +61,19 @@ class PathSource {
   virtual Rect GetBounds() const = 0;
   virtual bool IsConvex() const = 0;
   virtual void Dispatch(PathReceiver& receiver) const = 0;
+
+  /// @brief  An opaque, stable identity for this source that can be used to
+  ///         cache derived data such as tessellations.
+  ///
+  /// Returns nullptr when the source has no stable identity and therefore
+  /// cannot be cached. The returned shared pointer keeps the identity alive
+  /// for as long as the caller retains it, which prevents address reuse by
+  /// newly created sources. Tessellation caches insert on second use of a
+  /// key; a recycled address with no live cache entry may cache on first
+  /// use of the new path.
+  virtual std::shared_ptr<const void> GetCacheIdentity() const {
+    return nullptr;
+  }
 };
 
 /// @brief A PathSource object that provides path iteration for any TRect.

--- a/engine/src/flutter/impeller/tessellator/tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator.cc
@@ -5,7 +5,14 @@
 #include "impeller/tessellator/tessellator.h"
 #include <cstdint>
 #include <cstring>
+#include <deque>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
+#include "flutter/fml/hash_combine.h"
 #include "flutter/impeller/core/device_buffer.h"
 #include "flutter/impeller/tessellator/path_tessellator.h"
 
@@ -334,50 +341,181 @@ class ConvexTessellatorImpl : public Tessellator::ConvexTessellator {
                                 Scalar tolerance,
                                 bool supports_primitive_restart,
                                 bool supports_triangle_fan) override {
-    if (supports_primitive_restart) {
-      // Primitive Restart.
-      const auto [point_count, contour_count] =
-          PathTessellator::CountFillStorage(path, tolerance);
-      BufferView point_buffer = data_host_buffer.Emplace(
-          nullptr, sizeof(Point) * point_count, alignof(Point));
-      BufferView index_buffer = indexes_host_buffer.Emplace(
-          nullptr, sizeof(IndexT) * (point_count + contour_count),
-          alignof(IndexT));
+    std::shared_ptr<const void> identity = path.GetCacheIdentity();
+    const CacheKey key = {
+        /*identity=*/identity.get(),
+        /*tolerance=*/tolerance,
+        /*restart=*/supports_primitive_restart,
+        /*fan=*/supports_triangle_fan,
+    };
 
-      auto* points_ptr =
-          reinterpret_cast<Point*>(point_buffer.GetBuffer()->OnGetContents() +
-                                   point_buffer.GetRange().offset);
-      auto* indices_ptr =
-          reinterpret_cast<IndexT*>(index_buffer.GetBuffer()->OnGetContents() +
-                                    index_buffer.GetRange().offset);
-
-      auto tessellate_path = [&](auto& writer) {
-        PathTessellator::PathToFilledVertices(path, writer, tolerance);
-        FML_DCHECK(writer.GetPointCount() <= point_count);
-        FML_DCHECK(writer.GetIndexCount() <= (point_count + contour_count));
-        point_buffer.GetBuffer()->Flush(point_buffer.GetRange());
-        index_buffer.GetBuffer()->Flush(index_buffer.GetRange());
-
-        return VertexBuffer{
-            .vertex_buffer = std::move(point_buffer),
-            .index_buffer = std::move(index_buffer),
-            .vertex_count = writer.GetIndexCount(),
-            .index_type = IndexTypeFor<IndexT>(),
-        };
-      };
-
-      if (supports_triangle_fan) {
-        FanPathVertexWriter writer(points_ptr, indices_ptr);
-        return tessellate_path(writer);
-      } else {
-        StripPathVertexWriter writer(points_ptr, indices_ptr);
-        return tessellate_path(writer);
+    if (identity != nullptr) {
+      auto found = cache_.find(key);
+      if (found != cache_.end()) {
+        return Upload(found->second.points, found->second.indices,
+                      data_host_buffer, indexes_host_buffer);
       }
     }
 
-    DoTessellateConvexInternal(path, point_buffer_, index_buffer_, tolerance);
+    // Unique paths stay on the existing direct / GLES path. Cache only after
+    // the same key is seen a second time so one-shot DlPaths keep zero-copy
+    // uploads. The seen set stores raw keys (no shared_ptr); a recycled
+    // address may therefore cache on first use of a new path.
+    const bool cacheable = identity != nullptr;
+    const bool second_use = cacheable && seen_.find(key) != seen_.end();
+    if (!second_use) {
+      if (cacheable) {
+        RecordSeen(key);
+      }
+      if (supports_primitive_restart) {
+        return TessellateConvexDirect(
+            path, data_host_buffer, indexes_host_buffer, tolerance,
+            supports_primitive_restart, supports_triangle_fan);
+      }
+      DoTessellateConvexInternal(path, point_buffer_, index_buffer_, tolerance);
+      return Upload(point_buffer_, index_buffer_, data_host_buffer,
+                    indexes_host_buffer);
+    }
 
-    if (point_buffer_.empty()) {
+    if (supports_primitive_restart) {
+      TessellateConvexIntoVectors(path, tolerance, supports_triangle_fan);
+    } else {
+      DoTessellateConvexInternal(path, point_buffer_, index_buffer_, tolerance);
+    }
+
+    VertexBuffer result = Upload(point_buffer_, index_buffer_, data_host_buffer,
+                                 indexes_host_buffer);
+    if (!point_buffer_.empty() && point_buffer_.size() <= kMaxPointsPerEntry) {
+      CacheEntry entry;
+      entry.identity = std::move(identity);
+      entry.points.swap(point_buffer_);
+      entry.indices.swap(index_buffer_);
+      point_buffer_.reserve(2048);
+      index_buffer_.reserve(2048);
+      InsertCacheEntry(key, std::move(entry));
+    }
+    return result;
+  }
+
+  size_t GetCacheSizeForTesting() const override { return cache_.size(); }
+
+ private:
+  // The maximum number of tessellations retained per tessellator, and the
+  // total number of points across all retained tessellations. These bounds
+  // keep the memory used by the cache predictable for applications that draw
+  // many distinct paths. Keep these eviction bounds in sync with the stroke
+  // tessellation cache.
+  static constexpr size_t kMaxCacheEntries = 256u;
+  static constexpr size_t kMaxCachedPoints = 1u << 18;
+  static constexpr size_t kMaxPointsPerEntry = 1u << 14;
+
+  VertexBuffer TessellateConvexDirect(const PathSource& path,
+                                      HostBuffer& data_host_buffer,
+                                      HostBuffer& indexes_host_buffer,
+                                      Scalar tolerance,
+                                      bool supports_primitive_restart,
+                                      bool supports_triangle_fan) {
+    FML_DCHECK(supports_primitive_restart);
+    const auto [point_count, contour_count] =
+        PathTessellator::CountFillStorage(path, tolerance);
+    BufferView point_buffer = data_host_buffer.Emplace(
+        nullptr, sizeof(Point) * point_count, alignof(Point));
+    BufferView index_buffer = indexes_host_buffer.Emplace(
+        nullptr, sizeof(IndexT) * (point_count + contour_count),
+        alignof(IndexT));
+
+    auto* points_ptr =
+        reinterpret_cast<Point*>(point_buffer.GetBuffer()->OnGetContents() +
+                                 point_buffer.GetRange().offset);
+    auto* indices_ptr =
+        reinterpret_cast<IndexT*>(index_buffer.GetBuffer()->OnGetContents() +
+                                  index_buffer.GetRange().offset);
+
+    auto tessellate_path = [&](auto& writer) {
+      PathTessellator::PathToFilledVertices(path, writer, tolerance);
+      FML_DCHECK(writer.GetPointCount() <= point_count);
+      FML_DCHECK(writer.GetIndexCount() <= (point_count + contour_count));
+      point_buffer.GetBuffer()->Flush(point_buffer.GetRange());
+      index_buffer.GetBuffer()->Flush(index_buffer.GetRange());
+
+      return VertexBuffer{
+          .vertex_buffer = std::move(point_buffer),
+          .index_buffer = std::move(index_buffer),
+          .vertex_count = writer.GetIndexCount(),
+          .index_type = IndexTypeFor<IndexT>(),
+      };
+    };
+
+    if (supports_triangle_fan) {
+      FanPathVertexWriter<IndexT> writer(points_ptr, indices_ptr);
+      return tessellate_path(writer);
+    } else {
+      StripPathVertexWriter<IndexT> writer(points_ptr, indices_ptr);
+      return tessellate_path(writer);
+    }
+  }
+
+  void TessellateConvexIntoVectors(const PathSource& path,
+                                   Scalar tolerance,
+                                   bool supports_triangle_fan) {
+    const auto [point_count, contour_count] =
+        PathTessellator::CountFillStorage(path, tolerance);
+    point_buffer_.clear();
+    index_buffer_.clear();
+    point_buffer_.resize(point_count);
+    index_buffer_.resize(point_count + contour_count);
+
+    auto tessellate_into = [&](auto& writer) {
+      PathTessellator::PathToFilledVertices(path, writer, tolerance);
+      FML_DCHECK(writer.GetPointCount() <= point_count);
+      FML_DCHECK(writer.GetIndexCount() <= (point_count + contour_count));
+      point_buffer_.resize(writer.GetPointCount());
+      index_buffer_.resize(writer.GetIndexCount());
+    };
+
+    if (supports_triangle_fan) {
+      FanPathVertexWriter<IndexT> writer(point_buffer_.data(),
+                                         index_buffer_.data());
+      tessellate_into(writer);
+    } else {
+      StripPathVertexWriter<IndexT> writer(point_buffer_.data(),
+                                           index_buffer_.data());
+      tessellate_into(writer);
+    }
+  }
+
+  struct CacheKey {
+    const void* identity = nullptr;
+    Scalar tolerance = 0.0f;
+    bool restart = false;
+    bool fan = false;
+
+    bool operator==(const CacheKey& other) const {
+      return identity == other.identity && tolerance == other.tolerance &&
+             restart == other.restart && fan == other.fan;
+    }
+  };
+
+  struct CacheKeyHash {
+    size_t operator()(const CacheKey& key) const {
+      return fml::HashCombine(key.identity, key.tolerance, key.restart,
+                              key.fan);
+    }
+  };
+
+  struct CacheEntry {
+    // Keeps the source alive so its address cannot be reused by a different
+    // path while this entry is retained.
+    std::shared_ptr<const void> identity;
+    std::vector<Point> points;
+    std::vector<IndexT> indices;
+  };
+
+  VertexBuffer Upload(const std::vector<Point>& points,
+                      const std::vector<IndexT>& indices,
+                      HostBuffer& data_host_buffer,
+                      HostBuffer& indexes_host_buffer) {
+    if (points.empty() || indices.empty()) {
       return VertexBuffer{
           .vertex_buffer = {},
           .index_buffer = {},
@@ -387,24 +525,58 @@ class ConvexTessellatorImpl : public Tessellator::ConvexTessellator {
     }
 
     BufferView vertex_buffer = data_host_buffer.Emplace(
-        point_buffer_.data(), sizeof(Point) * point_buffer_.size(),
-        alignof(Point));
+        points.data(), sizeof(Point) * points.size(), alignof(Point));
 
     BufferView index_buffer = indexes_host_buffer.Emplace(
-        index_buffer_.data(), sizeof(IndexT) * index_buffer_.size(),
-        alignof(IndexT));
+        indices.data(), sizeof(IndexT) * indices.size(), alignof(IndexT));
 
     return VertexBuffer{
         .vertex_buffer = std::move(vertex_buffer),
         .index_buffer = std::move(index_buffer),
-        .vertex_count = index_buffer_.size(),
+        .vertex_count = indices.size(),
         .index_type = IndexTypeFor<IndexT>(),
     };
   }
 
- private:
+  void InsertCacheEntry(CacheKey key, CacheEntry entry) {
+    // Keep this eviction loop in sync with the stroke tessellation cache.
+    auto [it, inserted] = cache_.emplace(key, std::move(entry));
+    if (!inserted) {
+      return;
+    }
+    cached_points_ += it->second.points.size();
+    cache_order_.push_back(key);
+
+    while (!cache_order_.empty() && (cache_.size() > kMaxCacheEntries ||
+                                     cached_points_ > kMaxCachedPoints)) {
+      const CacheKey oldest = cache_order_.front();
+      cache_order_.pop_front();
+      auto found = cache_.find(oldest);
+      if (found != cache_.end()) {
+        cached_points_ -= found->second.points.size();
+        cache_.erase(found);
+      }
+    }
+  }
+
+  void RecordSeen(const CacheKey& key) {
+    if (!seen_.insert(key).second) {
+      return;
+    }
+    seen_order_.push_back(key);
+    while (seen_.size() > kMaxCacheEntries && !seen_order_.empty()) {
+      seen_.erase(seen_order_.front());
+      seen_order_.pop_front();
+    }
+  }
+
   std::vector<Point> point_buffer_;
   std::vector<IndexT> index_buffer_;
+  std::unordered_map<CacheKey, CacheEntry, CacheKeyHash> cache_;
+  std::deque<CacheKey> cache_order_;
+  std::unordered_set<CacheKey, CacheKeyHash> seen_;
+  std::deque<CacheKey> seen_order_;
+  size_t cached_points_ = 0u;
 };
 
 Tessellator::Tessellator(bool supports_32bit_primitive_indices)
@@ -420,6 +592,10 @@ Tessellator::~Tessellator() = default;
 
 std::vector<Point>& Tessellator::GetStrokePointCache() {
   return stroke_points_;
+}
+
+size_t Tessellator::GetFillTessellationCacheSizeForTesting() const {
+  return convex_tessellator_->GetCacheSizeForTesting();
 }
 
 Tessellator::Trigs Tessellator::GetTrigsForDeviceRadius(Scalar pixel_radius) {

--- a/engine/src/flutter/impeller/tessellator/tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator.cc
@@ -579,8 +579,114 @@ class ConvexTessellatorImpl : public Tessellator::ConvexTessellator {
   size_t cached_points_ = 0u;
 };
 
+class Tessellator::StrokeTessellationCache {
+ public:
+  const std::vector<Point>* Find(const void* identity,
+                                 const StrokeParameters& stroke,
+                                 Scalar scale) const {
+    auto found = cache_.find(Key{identity, stroke, scale});
+    if (found == cache_.end()) {
+      return nullptr;
+    }
+    return &found->second.points;
+  }
+
+  void Store(std::shared_ptr<const void> identity,
+             const StrokeParameters& stroke,
+             Scalar scale,
+             std::vector<Point> points) {
+    // Keep in sync with ConvexTessellatorImpl::InsertCacheEntry.
+    const size_t point_count = points.size();
+    if (point_count == 0u || point_count > kMaxCachedStrokePointsPerEntry) {
+      return;
+    }
+    const Key key{identity.get(), stroke, scale};
+    auto found = cache_.find(key);
+    if (found != cache_.end()) {
+      cached_points_ -= found->second.points.size();
+      cached_points_ += point_count;
+      found->second = Entry{std::move(identity), std::move(points)};
+      return;
+    }
+
+    cache_.emplace(key, Entry{std::move(identity), std::move(points)});
+    cached_points_ += point_count;
+    cache_order_.push_back(key);
+
+    while (!cache_order_.empty() &&
+           (cache_.size() > kMaxEntries || cached_points_ > kMaxPoints)) {
+      const Key oldest = cache_order_.front();
+      cache_order_.pop_front();
+      auto oldest_found = cache_.find(oldest);
+      if (oldest_found != cache_.end()) {
+        cached_points_ -= oldest_found->second.points.size();
+        cache_.erase(oldest_found);
+      }
+    }
+  }
+
+  bool HasSeen(const void* identity,
+               const StrokeParameters& stroke,
+               Scalar scale) const {
+    return seen_.find(Key{identity, stroke, scale}) != seen_.end();
+  }
+
+  void RecordSeen(const void* identity,
+                  const StrokeParameters& stroke,
+                  Scalar scale) {
+    const Key key{identity, stroke, scale};
+    if (!seen_.insert(key).second) {
+      return;
+    }
+    seen_order_.push_back(key);
+    while (seen_.size() > kMaxEntries && !seen_order_.empty()) {
+      seen_.erase(seen_order_.front());
+      seen_order_.pop_front();
+    }
+  }
+
+  size_t GetSize() const { return cache_.size(); }
+
+ private:
+  static constexpr size_t kMaxEntries = 256u;
+  static constexpr size_t kMaxPoints = 1u << 18;
+
+  struct Key {
+    const void* identity = nullptr;
+    StrokeParameters stroke;
+    Scalar scale = 0.0f;
+
+    bool operator==(const Key& other) const {
+      return identity == other.identity && stroke == other.stroke &&
+             scale == other.scale;
+    }
+  };
+
+  struct KeyHash {
+    size_t operator()(const Key& key) const {
+      return fml::HashCombine(
+          key.identity, key.stroke.width, static_cast<int>(key.stroke.cap),
+          static_cast<int>(key.stroke.join), key.stroke.miter_limit, key.scale);
+    }
+  };
+
+  struct Entry {
+    // Keeps the source alive so its address cannot be reused by a different
+    // path while this entry is retained.
+    std::shared_ptr<const void> identity;
+    std::vector<Point> points;
+  };
+
+  std::unordered_map<Key, Entry, KeyHash> cache_;
+  std::deque<Key> cache_order_;
+  std::unordered_set<Key, KeyHash> seen_;
+  std::deque<Key> seen_order_;
+  size_t cached_points_ = 0u;
+};
+
 Tessellator::Tessellator(bool supports_32bit_primitive_indices)
-    : stroke_points_(kPointArenaSize) {
+    : stroke_points_(kPointArenaSize),
+      stroke_tessellation_cache_(std::make_unique<StrokeTessellationCache>()) {
   if (supports_32bit_primitive_indices) {
     convex_tessellator_ = std::make_unique<ConvexTessellatorImpl<uint32_t>>();
   } else {
@@ -596,6 +702,38 @@ std::vector<Point>& Tessellator::GetStrokePointCache() {
 
 size_t Tessellator::GetFillTessellationCacheSizeForTesting() const {
   return convex_tessellator_->GetCacheSizeForTesting();
+}
+
+size_t Tessellator::GetStrokeTessellationCacheSizeForTesting() const {
+  return stroke_tessellation_cache_->GetSize();
+}
+
+const std::vector<Point>* Tessellator::FindCachedStrokeTessellation(
+    const void* identity,
+    const StrokeParameters& stroke,
+    Scalar scale) const {
+  return stroke_tessellation_cache_->Find(identity, stroke, scale);
+}
+
+void Tessellator::StoreCachedStrokeTessellation(
+    std::shared_ptr<const void> identity,
+    const StrokeParameters& stroke,
+    Scalar scale,
+    std::vector<Point> points) {
+  stroke_tessellation_cache_->Store(std::move(identity), stroke, scale,
+                                    std::move(points));
+}
+
+bool Tessellator::HasSeenStrokeTessellation(const void* identity,
+                                            const StrokeParameters& stroke,
+                                            Scalar scale) const {
+  return stroke_tessellation_cache_->HasSeen(identity, stroke, scale);
+}
+
+void Tessellator::RecordSeenStrokeTessellation(const void* identity,
+                                               const StrokeParameters& stroke,
+                                               Scalar scale) {
+  stroke_tessellation_cache_->RecordSeen(identity, stroke, scale);
 }
 
 Tessellator::Trigs Tessellator::GetTrigsForDeviceRadius(Scalar pixel_radius) {

--- a/engine/src/flutter/impeller/tessellator/tessellator.h
+++ b/engine/src/flutter/impeller/tessellator/tessellator.h
@@ -387,6 +387,9 @@ class Tessellator {
   /// Retrieve a pre-allocated arena of kPointArenaSize points.
   std::vector<Point>& GetStrokePointCache();
 
+  /// Visible for testing.
+  size_t GetFillTessellationCacheSizeForTesting() const;
+
   /// Return a vector of Trig (cos, sin pairs) structs for a 90 degree
   /// circle quadrant of the specified pixel radius
   Trigs GetTrigsForDeviceRadius(Scalar pixel_radius);
@@ -401,6 +404,7 @@ class Tessellator {
                                           Scalar tolerance,
                                           bool supports_primitive_restart,
                                           bool supports_triangle_fan) = 0;
+    virtual size_t GetCacheSizeForTesting() const = 0;
   };
   template <typename IndexT>
   friend class ConvexTessellatorImpl;

--- a/engine/src/flutter/impeller/tessellator/tessellator.h
+++ b/engine/src/flutter/impeller/tessellator/tessellator.h
@@ -20,9 +20,15 @@
 
 namespace impeller {
 
+class StrokeSegmentsGeometry;
+class TessellatorTestAccess;
+
 /// The size of the point arena buffer stored on the tessellator.
 [[maybe_unused]]
 static constexpr size_t kPointArenaSize = 4096u;
+
+/// Maximum tessellated stroke points stored in a single cache entry.
+static constexpr size_t kMaxCachedStrokePointsPerEntry = 1u << 14;
 
 //------------------------------------------------------------------------------
 /// @brief      A utility that generates triangles of the specified fill type
@@ -390,6 +396,9 @@ class Tessellator {
   /// Visible for testing.
   size_t GetFillTessellationCacheSizeForTesting() const;
 
+  /// Visible for testing.
+  size_t GetStrokeTessellationCacheSizeForTesting() const;
+
   /// Return a vector of Trig (cos, sin pairs) structs for a 90 degree
   /// circle quadrant of the specified pixel radius
   Trigs GetTrigsForDeviceRadius(Scalar pixel_radius);
@@ -408,12 +417,35 @@ class Tessellator {
   };
   template <typename IndexT>
   friend class ConvexTessellatorImpl;
+  friend class StrokeSegmentsGeometry;
+  friend class TessellatorTestAccess;
+
+  const std::vector<Point>* FindCachedStrokeTessellation(
+      const void* identity,
+      const StrokeParameters& stroke,
+      Scalar scale) const;
+
+  void StoreCachedStrokeTessellation(std::shared_ptr<const void> identity,
+                                     const StrokeParameters& stroke,
+                                     Scalar scale,
+                                     std::vector<Point> points);
+
+  bool HasSeenStrokeTessellation(const void* identity,
+                                 const StrokeParameters& stroke,
+                                 Scalar scale) const;
+
+  void RecordSeenStrokeTessellation(const void* identity,
+                                    const StrokeParameters& stroke,
+                                    Scalar scale);
 
   /// Used for polyline generation.
   std::unique_ptr<ConvexTessellator> convex_tessellator_;
 
   /// Used for stroke path generation.
   std::vector<Point> stroke_points_;
+
+  class StrokeTessellationCache;
+  std::unique_ptr<StrokeTessellationCache> stroke_tessellation_cache_;
 
   // Data for various Circle/EllipseGenerator classes, cached per
   // Tessellator instance which is usually the foreground life of an app

--- a/engine/src/flutter/impeller/tessellator/tessellator_playground_unittests.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator_playground_unittests.cc
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 
 #include "flutter/display_list/geometry/dl_path_builder.h"
+#include "impeller/geometry/path_source.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/tessellator/tessellator.h"
 
@@ -21,6 +22,16 @@ std::vector<T> CopyBufferView(const BufferView& vertex_buffer) {
   uint8_t* base_ptr = vertex_buffer.GetBuffer()->OnGetContents() + range.offset;
   return std::vector<T>(reinterpret_cast<T*>(base_ptr),
                         reinterpret_cast<T*>(base_ptr + range.length));
+}
+
+flutter::DlPath MakeCurvedPath() {
+  flutter::DlPathBuilder builder;
+  builder.MoveTo({0, 0});
+  builder.LineTo({40, 0});
+  builder.QuadraticCurveTo({50, 5}, {40, 40});
+  builder.LineTo({0, 40});
+  builder.Close();
+  return builder.TakePath();
 }
 
 TEST_P(TessellatorPlaygroundTest, TessellateConvex16or32Bit) {
@@ -55,6 +66,113 @@ TEST_P(TessellatorPlaygroundTest, TessellateConvex16or32Bit) {
   EXPECT_EQ(
       std::vector<uint32_t>(expected_indices.begin(), expected_indices.end()),
       CopyBufferView<uint32_t>(vertex_buffer32.index_buffer));
+}
+
+TEST_P(TessellatorPlaygroundTest, TessellateConvexCacheInsertsOnSecondUse) {
+  auto tessellator = std::make_shared<Tessellator>(false);
+
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  auto indexes_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+
+  auto path = MakeCurvedPath();
+
+  VertexBuffer first = tessellator->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 0u);
+
+  VertexBuffer second = tessellator->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  EXPECT_EQ(CopyBufferView<Point>(first.vertex_buffer),
+            CopyBufferView<Point>(second.vertex_buffer));
+  EXPECT_EQ(CopyBufferView<uint16_t>(first.index_buffer),
+            CopyBufferView<uint16_t>(second.index_buffer));
+
+  VertexBuffer third = tessellator->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  EXPECT_EQ(CopyBufferView<Point>(first.vertex_buffer),
+            CopyBufferView<Point>(third.vertex_buffer));
+
+  // Copies share identity, so a copy of a path that has already been
+  // tessellated once is a cache hit.
+  VertexBuffer from_copy =
+      tessellator->TessellateConvex(flutter::DlPath(path), *data_host_buffer,
+                                    *indexes_host_buffer, 1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  EXPECT_EQ(CopyBufferView<Point>(first.vertex_buffer),
+            CopyBufferView<Point>(from_copy.vertex_buffer));
+
+  auto path2 = MakeCurvedPath();
+  VertexBuffer other_first = tessellator->TessellateConvex(
+      path2, *data_host_buffer, *indexes_host_buffer, 1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  EXPECT_EQ(CopyBufferView<Point>(first.vertex_buffer),
+            CopyBufferView<Point>(other_first.vertex_buffer));
+  tessellator->TessellateConvex(path2, *data_host_buffer, *indexes_host_buffer,
+                                1.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 2u);
+
+  tessellator->TessellateConvex(path, *data_host_buffer, *indexes_host_buffer,
+                                2.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 2u);
+  tessellator->TessellateConvex(path, *data_host_buffer, *indexes_host_buffer,
+                                2.0, false, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 3u);
+}
+
+TEST_P(TessellatorPlaygroundTest, TessellateConvexCacheMissesOnRestartAndFan) {
+  auto tessellator = std::make_shared<Tessellator>(true);
+
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  auto indexes_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+
+  auto path = MakeCurvedPath();
+
+  VertexBuffer first = tessellator->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, true, true);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 0u);
+  VertexBuffer second = tessellator->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, true, true);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  EXPECT_EQ(CopyBufferView<Point>(first.vertex_buffer),
+            CopyBufferView<Point>(second.vertex_buffer));
+  EXPECT_EQ(CopyBufferView<uint32_t>(first.index_buffer),
+            CopyBufferView<uint32_t>(second.index_buffer));
+
+  tessellator->TessellateConvex(path, *data_host_buffer, *indexes_host_buffer,
+                                1.0, true, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 1u);
+  tessellator->TessellateConvex(path, *data_host_buffer, *indexes_host_buffer,
+                                1.0, true, false);
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 2u);
+}
+
+TEST_P(TessellatorPlaygroundTest, UncacheablePathSourceNeverEntersFillCache) {
+  auto tessellator = std::make_shared<Tessellator>(true);
+
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  auto indexes_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+
+  RectPathSource rect(Rect::MakeLTRB(0, 0, 10, 10));
+  ASSERT_EQ(rect.GetCacheIdentity(), nullptr);
+  for (int i = 0; i < 3; i++) {
+    tessellator->TessellateConvex(rect, *data_host_buffer, *indexes_host_buffer,
+                                  1.0, true, true);
+  }
+  EXPECT_EQ(tessellator->GetFillTessellationCacheSizeForTesting(), 0u);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/tessellator/tessellator_unittests.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator_unittests.cc
@@ -12,6 +12,26 @@
 #include "impeller/tessellator/tessellator_libtess.h"
 
 namespace impeller {
+
+class TessellatorTestAccess {
+ public:
+  static const std::vector<Point>* Find(const Tessellator& tessellator,
+                                        const void* identity,
+                                        const StrokeParameters& stroke,
+                                        Scalar scale) {
+    return tessellator.FindCachedStrokeTessellation(identity, stroke, scale);
+  }
+
+  static void Store(Tessellator& tessellator,
+                    std::shared_ptr<const void> identity,
+                    const StrokeParameters& stroke,
+                    Scalar scale,
+                    std::vector<Point> points) {
+    tessellator.StoreCachedStrokeTessellation(std::move(identity), stroke,
+                                              scale, std::move(points));
+  }
+};
+
 namespace testing {
 
 TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
@@ -706,6 +726,78 @@ TEST(TessellatorTest, EarlyReturnEmptyConvexShape) {
 
   EXPECT_TRUE(points.empty());
   EXPECT_TRUE(indices.empty());
+}
+
+TEST(TessellatorTest, StrokeTessellationCacheFindStoreAndEvict) {
+  Tessellator tessellator(/*supports_32bit_primitive_indices=*/true);
+  const StrokeParameters stroke{.width = 2.0f};
+
+  const auto identity = std::make_shared<int>(0);
+  TessellatorTestAccess::Store(tessellator, identity, stroke, 1.0f,
+                               {Point(1, 2), Point(3, 4)});
+  const std::vector<Point>* found =
+      TessellatorTestAccess::Find(tessellator, identity.get(), stroke, 1.0f);
+  ASSERT_TRUE(found);
+  EXPECT_EQ((std::vector<Point>{Point(1, 2), Point(3, 4)}), *found);
+
+  // Different identity, scale, or stroke parameters must miss.
+  const auto other_identity = std::make_shared<int>(1);
+  EXPECT_EQ(nullptr, TessellatorTestAccess::Find(
+                         tessellator, other_identity.get(), stroke, 1.0f));
+  EXPECT_EQ(nullptr, TessellatorTestAccess::Find(tessellator, identity.get(),
+                                                 stroke, 2.0f));
+  StrokeParameters wide = stroke;
+  wide.width = 4.0f;
+  EXPECT_EQ(nullptr, TessellatorTestAccess::Find(tessellator, identity.get(),
+                                                 wide, 1.0f));
+}
+
+TEST(TessellatorTest, StrokeTessellationCacheReinsertUpdatesInPlace) {
+  Tessellator tessellator(/*supports_32bit_primitive_indices=*/true);
+  const StrokeParameters stroke{.width = 2.0f};
+  const auto identity = std::make_shared<int>(0);
+
+  TessellatorTestAccess::Store(tessellator, identity, stroke, 1.0f,
+                               {Point(1, 2)});
+  TessellatorTestAccess::Store(tessellator, identity, stroke, 1.0f,
+                               {Point(3, 4), Point(5, 6)});
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(), 1u);
+  const std::vector<Point>* found =
+      TessellatorTestAccess::Find(tessellator, identity.get(), stroke, 1.0f);
+  ASSERT_TRUE(found);
+  EXPECT_EQ((std::vector<Point>{Point(3, 4), Point(5, 6)}), *found);
+}
+
+TEST(TessellatorTest, StrokeTessellationCacheRejectsOversizedEntries) {
+  Tessellator tessellator(/*supports_32bit_primitive_indices=*/true);
+  const StrokeParameters stroke{.width = 1.0f};
+  const auto identity = std::make_shared<int>(0);
+  std::vector<Point> oversized(kMaxCachedStrokePointsPerEntry + 1u);
+  TessellatorTestAccess::Store(tessellator, identity, stroke, 1.0f,
+                               std::move(oversized));
+  EXPECT_EQ(tessellator.GetStrokeTessellationCacheSizeForTesting(), 0u);
+}
+
+TEST(TessellatorTest, StrokeTessellationCacheEvictsOldestEntry) {
+  Tessellator tessellator(/*supports_32bit_primitive_indices=*/true);
+  const StrokeParameters stroke{.width = 1.0f};
+
+  // The cache retains at most 256 entries.
+  constexpr size_t kEntries = 256;
+  std::vector<std::shared_ptr<int>> identities;
+  for (size_t i = 0; i < kEntries + 2; i++) {
+    auto identity = std::make_shared<int>(static_cast<int>(i));
+    TessellatorTestAccess::Store(tessellator, identity, stroke, 1.0f,
+                                 {Point(static_cast<Scalar>(i), 0)});
+    identities.push_back(std::move(identity));
+  }
+  // The first two entries have been evicted; the newest remains.
+  EXPECT_EQ(nullptr, TessellatorTestAccess::Find(
+                         tessellator, identities[0].get(), stroke, 1.0f));
+  EXPECT_EQ(nullptr, TessellatorTestAccess::Find(
+                         tessellator, identities[1].get(), stroke, 1.0f));
+  EXPECT_TRUE(TessellatorTestAccess::Find(tessellator, identities.back().get(),
+                                          stroke, 1.0f));
 }
 
 }  // namespace testing


### PR DESCRIPTION
Stroke tessellation walks every path segment and generates joins and caps on the CPU for each draw. Add a bounded cache keyed on the source identity, the adjusted stroke parameters, and the transform scale.

The first draw of a cacheable path stays on the existing arena upload. The cache stores vertices only after the same key is seen again. Uncacheable sources keep the direct path.

This PR is stacked on https://github.com/flutter/flutter/pull/192681. Until that lands, GitHub shows two commits versus master. The unique work is the top commit; the fill-cache commit is that other PR. After the fill cache lands, this branch should be rebased to one commit.

Do not review the fill-cache commit here. Caching strokes depends on the PathSource cache identity added for fill tessellations.

Fixes #192676
Related to #164607

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md