### PR TITLE
Ignore sibling ScrollView notifications in RawScrollbar

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1953,8 +1953,32 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
         scrollController.position.axis == notificationAxis;
   }
 
+  // Whether the notification was sent by the ScrollView this scrollbar is
+  // attached to.
+  //
+  // Sibling ScrollViews share a scrollbar's notification scope, so without this
+  // check the metrics of an unrelated ScrollView can be applied to this
+  // scrollbar. Returns true when there is not enough information to tell the
+  // scroll views apart, preserving the behavior of the ScrollController-less
+  // and multiple-position cases.
+  bool _isOwnNotification(BuildContext? notificationContext) {
+    final ScrollController? scrollController = _effectiveScrollController;
+    if (scrollController == null ||
+        !scrollController.hasClients ||
+        scrollController.positions.length > 1) {
+      return true;
+    }
+    final BuildContext? positionContext = scrollController.position.context.notificationContext;
+    return notificationContext == null ||
+        positionContext == null ||
+        notificationContext == positionContext;
+  }
+
   bool _handleScrollMetricsNotification(ScrollMetricsNotification notification) {
     if (!widget.notificationPredicate(notification.asScrollUpdate())) {
+      return false;
+    }
+    if (!_isOwnNotification(notification.context)) {
       return false;
     }
 
@@ -1983,6 +2007,9 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
 
   bool _handleScrollNotification(ScrollNotification notification) {
     if (!widget.notificationPredicate(notification)) {
+      return false;
+    }
+    if (!_isOwnNotification(notification.context)) {
       return false;
     }
 

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -4399,4 +4399,62 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     await tester.pump();
     expect(scrollbarCursor(), SystemMouseCursors.grab);
   });
+
+  testWidgets('RawScrollbar ignores metrics from a sibling ScrollView', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/175012
+    // A sibling ScrollView shares the scrollbar's notification scope. Its
+    // metrics must not be applied to a scrollbar that is attached to a
+    // different ScrollView, which would otherwise leave the thumb unpainted
+    // until the user scrolled.
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: RawScrollbar(
+            thumbVisibility: true,
+            controller: scrollController,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                SizedBox(
+                  height: 300.0,
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    controller: scrollController,
+                    child: const SizedBox(width: 1600.0),
+                  ),
+                ),
+                // Scrolls along the same axis, is not attached to the
+                // scrollbar's controller, and has nothing to scroll. This is
+                // the PaginatedDataTable footer scenario.
+                const SizedBox(
+                  height: 300.0,
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: SizedBox(width: 100.0),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The thumb is painted without any user interaction, and its extent is
+    // derived from the scrollable child rather than from the sibling.
+    expect(scrollController.offset, 0.0);
+    expect(
+      find.byType(RawScrollbar),
+      paints
+        ..rect(rect: const Rect.fromLTRB(0.0, 594.0, 800.0, 600.0))
+        ..rect(rect: const Rect.fromLTRB(0.0, 594.0, 400.0, 600.0)),
+    );
+  });
 }


### PR DESCRIPTION
A `Scrollbar` with `thumbVisibility: true` is supposed to always show its thumb. But when it wraps a `PaginatedDataTable`, the thumb is missing at first. It only shows up after you scroll the table once, and then it stays.

The reason is that `PaginatedDataTable` has two horizontal scroll views inside it: the table, and the footer with the page buttons. Both of them report their scroll size up to the `Scrollbar`, and the scrollbar just used whichever report came last. On the first frame that is the footer. The footer usually has nothing to scroll, so the scrollbar thought there was nothing to draw and stayed empty.

Now the scrollbar only listens to the scroll view that its own controller is attached to, and ignores reports from any other scroll view next to it.

Fix: #175012

before:
<img width="1206" height="1200" alt="before" src="https://raw.githubusercontent.com/RootHex200/flutter/assets-175012/issue-175012/before.png" />

after:
<img width="1206" height="1200" alt="after" src="https://raw.githubusercontent.com/RootHex200/flutter/assets-175012/issue-175012/after.png" />

I added a test in `packages/flutter/test/widgets/scrollbar_test.dart`. It puts two horizontal scroll views under one scrollbar, like `PaginatedDataTable` does, and checks that the thumb is drawn before the user touches anything.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
