### PR TITLE
Fix AnimatedList disposing an item controller twice after unmount

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -1396,6 +1396,11 @@ abstract class _SliverAnimatedMultiBoxAdaptorState<T extends _SliverAnimatedMult
     });
 
     controller.forward().then<void>((_) {
+      // The state may be disposed before this runs, in which case the
+      // controller was already disposed in dispose().
+      if (!mounted) {
+        return;
+      }
       _removeActiveItemAt(_incomingItems, incomingItem.itemIndex)!.controller!.dispose();
     });
   }
@@ -1440,6 +1445,11 @@ abstract class _SliverAnimatedMultiBoxAdaptorState<T extends _SliverAnimatedMult
     });
 
     controller.reverse().then<void>((void value) {
+      // The state may be disposed before this runs, in which case the
+      // controller was already disposed in dispose().
+      if (!mounted) {
+        return;
+      }
       _removeActiveItemAt(_outgoingItems, outgoingItem.itemIndex)!.controller!.dispose();
 
       // Decrement the incoming and outgoing item indices to account

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -1300,6 +1300,92 @@ void main() {
     );
     await tester.pump();
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/192533
+  testWidgets('AnimatedList unmounted in the frame that completes removeItem', (
+    WidgetTester tester,
+  ) async {
+    final listKey = GlobalKey<AnimatedListState>();
+    late StateSetter setHostState;
+    var showList = true;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            setHostState = setState;
+            return showList
+                ? AnimatedList(
+                    key: listKey,
+                    initialItemCount: 1,
+                    itemBuilder: (_, _, _) => const SizedBox(height: 40),
+                  )
+                : const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    listKey.currentState!.removeItem(
+      0,
+      (_, Animation<double> animation) =>
+          SizeTransition(sizeFactor: animation, child: const SizedBox(height: 40)),
+      duration: const Duration(milliseconds: 100),
+    );
+    await tester.pump();
+
+    // Time passes without frames, then the list is unmounted.
+    await tester.binding.delayed(const Duration(milliseconds: 150));
+    setHostState(() => showList = false);
+    await _pumpWebStyleFrame(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(AnimatedList), findsNothing);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/192533
+  testWidgets('AnimatedList unmounted in the frame that completes insertItem', (
+    WidgetTester tester,
+  ) async {
+    final listKey = GlobalKey<AnimatedListState>();
+    late StateSetter setHostState;
+    var showList = true;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            setHostState = setState;
+            return showList
+                ? AnimatedList(key: listKey, itemBuilder: (_, _, _) => const SizedBox(height: 40))
+                : const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    listKey.currentState!.insertItem(0, duration: const Duration(milliseconds: 100));
+    await tester.pump();
+
+    // Time passes without frames, then the list is unmounted.
+    await tester.binding.delayed(const Duration(milliseconds: 150));
+    setHostState(() => showList = false);
+    await _pumpWebStyleFrame(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(AnimatedList), findsNothing);
+  });
+}
+
+// Pumps one frame the way the web engine does: handleBeginFrame and
+// handleDrawFrame run in the same task and microtasks are flushed only after
+// both. A plain pump() flushes microtasks between the two, like the mobile
+// engines do, which hides the bug in #192533.
+Future<void> _pumpWebStyleFrame(WidgetTester tester) async {
+  final TestWidgetsFlutterBinding binding = tester.binding;
+  binding.handleBeginFrame(Duration(microseconds: binding.clock.now().microsecondsSinceEpoch));
+  binding.handleDrawFrame();
+  await tester.pump();
 }
 
 class _StatefulListItem extends StatefulWidget {


### PR DESCRIPTION
When an `AnimatedList` (or `AnimatedGrid`) is unmounted in the same frame that completes an `insertItem` or `removeItem` animation, the item's `AnimationController` is disposed twice:

1. `_SliverAnimatedMultiBoxAdaptorState.dispose` disposes every controller still in `_incomingItems` and `_outgoingItems`.
2. The `.then` callback of `controller.forward()` / `controller.reverse()`, queued as a microtask by the completing tick, then runs and disposes the same controller again.

In debug this throws `AnimationController.dispose() called more than once`. In release it is a null check error from `AnimationController.dispose`.

This shows up on the web, where microtasks are not flushed between `onBeginFrame` and `onDrawFrame`, so the callback runs after the frame that tore the list down. On mobile the flush between the two phases runs the callback while the list is still mounted.

The fix returns early from both callbacks when the state is no longer mounted. At that point `dispose()` has already disposed the controller and there is nothing left to do. This is the same guard `Expansible` uses in its `reverse().then` callback.

Added two regression tests in `animated_list_test.dart`, one for `removeItem` and one for `insertItem`. They call `handleBeginFrame` and `handleDrawFrame` directly to run one frame the way the web engine does, since a plain `pump()` flushes microtasks between the two phases and does not hit the bug. Both tests fail on master and pass with the fix. The existing `animated_list_test.dart` and `animated_grid_test.dart` suites still pass.

Fixes https://github.com/flutter/flutter/issues/192533

Thanks to @Khorus888 for the detailed report and the test that reproduces the web frame order on the VM. It also reproduces on the latest stable (3.47.3).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

If this change needs to override an active code freeze, provide a comment explaining why. The code freeze workflow can be overridden by code reviewers. See pinned issues for any active code freezes with guidance.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[flutter/website]: https://github.com/flutter/website
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
