### PR TITLE
Animate the child between sub-screens when the fold changes

### DIFF
--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -11,10 +11,17 @@ library;
 import 'dart:math' as math;
 import 'dart:ui' show DisplayFeature, DisplayFeatureState;
 
+import 'package:flutter/animation.dart';
+
 import 'basic.dart';
 import 'debug.dart';
 import 'framework.dart';
+import 'implicit_animations.dart';
 import 'media_query.dart';
+
+/// How long [DisplayFeatureSubScreen] takes to move its child between
+/// sub-screens by default.
+const Duration _defaultDuration = Duration(milliseconds: 200);
 
 /// Positions [child] such that it avoids overlapping any [DisplayFeature] that
 /// splits the screen into sub-screens.
@@ -54,7 +61,13 @@ import 'media_query.dart';
 class DisplayFeatureSubScreen extends StatelessWidget {
   /// Creates a widget that positions its child so that it avoids display
   /// features.
-  const DisplayFeatureSubScreen({super.key, this.anchorPoint, required this.child});
+  const DisplayFeatureSubScreen({
+    super.key,
+    this.anchorPoint,
+    this.duration = _defaultDuration,
+    this.curve = Curves.easeInOut,
+    required this.child,
+  });
 
   /// {@template flutter.widgets.DisplayFeatureSubScreen.anchorPoint}
   /// The anchor point used to pick the closest sub-screen.
@@ -76,6 +89,21 @@ class DisplayFeatureSubScreen extends StatelessWidget {
   ///     sub-screen to be picked.
   /// {@endtemplate}
   final Offset? anchorPoint;
+
+  /// How long the [child] takes to move when the sub-screen it belongs to
+  /// changes.
+  ///
+  /// A fold that opens or closes changes which sub-screen holds the [child],
+  /// and the child moves there. Without a duration it arrives in the frame the
+  /// change is reported, which for a fold down the middle of the screen is a
+  /// jump of close to half the screen width.
+  ///
+  /// The first position is never animated; only later changes are. Pass
+  /// [Duration.zero] for the child to move in a single frame.
+  final Duration duration;
+
+  /// The curve the [child] follows while it moves between sub-screens.
+  final Curve curve;
 
   /// The widget below this widget in the tree.
   ///
@@ -107,7 +135,9 @@ class DisplayFeatureSubScreen extends StatelessWidget {
     final Iterable<Rect> subScreens = subScreensInBounds(wantedBounds, avoidBounds(mediaQuery));
     final Rect closestSubScreen = _closestToAnchorPoint(subScreens, resolvedAnchorPoint);
 
-    return Padding(
+    return AnimatedPadding(
+      duration: duration,
+      curve: curve,
       padding: EdgeInsets.only(
         left: closestSubScreen.left,
         top: closestSubScreen.top,

--- a/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
+++ b/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
@@ -222,6 +222,97 @@ void main() {
       expect(renderBox.size.height, equals(300.0));
       expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(0, 300)));
     });
+    testWidgets('moves to the new sub-screen over the duration', (WidgetTester tester) async {
+      const childKey = Key('childKey');
+      final MediaQueryData flat = MediaQueryData.fromView(tester.view);
+      final MediaQueryData folded = flat.copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(390, 0, 410, 600),
+            type: DisplayFeatureType.fold,
+            state: DisplayFeatureState.postureHalfOpened,
+          ),
+        ],
+      );
+
+      Widget build(MediaQueryData data) => MediaQuery(
+        data: data,
+        child: const DisplayFeatureSubScreen(
+          anchorPoint: Offset.zero,
+          child: SizedBox.expand(key: childKey),
+        ),
+      );
+
+      await tester.pumpWidget(build(flat));
+      expect(tester.renderObject<RenderBox>(find.byKey(childKey)).size.width, 800.0);
+
+      // The fold opens. The child belongs to the left sub-screen now, and gets
+      // there over the duration rather than in the next frame.
+      await tester.pumpWidget(build(folded));
+      await tester.pump(const Duration(milliseconds: 100));
+      final double midway = tester.renderObject<RenderBox>(find.byKey(childKey)).size.width;
+      expect(midway, greaterThan(390.0));
+      expect(midway, lessThan(800.0));
+
+      await tester.pumpAndSettle();
+      expect(tester.renderObject<RenderBox>(find.byKey(childKey)).size.width, 390.0);
+    });
+
+    testWidgets('Duration.zero moves the child in a single frame', (WidgetTester tester) async {
+      const childKey = Key('childKey');
+      final MediaQueryData flat = MediaQueryData.fromView(tester.view);
+      final MediaQueryData folded = flat.copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(390, 0, 410, 600),
+            type: DisplayFeatureType.fold,
+            state: DisplayFeatureState.postureHalfOpened,
+          ),
+        ],
+      );
+
+      Widget build(MediaQueryData data) => MediaQuery(
+        data: data,
+        child: const DisplayFeatureSubScreen(
+          anchorPoint: Offset.zero,
+          duration: Duration.zero,
+          child: SizedBox.expand(key: childKey),
+        ),
+      );
+
+      await tester.pumpWidget(build(flat));
+      await tester.pumpWidget(build(folded));
+      await tester.pump();
+
+      expect(tester.renderObject<RenderBox>(find.byKey(childKey)).size.width, 390.0);
+    });
+
+    testWidgets('the first position is not animated', (WidgetTester tester) async {
+      const childKey = Key('childKey');
+      final MediaQueryData folded = MediaQueryData.fromView(tester.view).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(390, 0, 410, 600),
+            type: DisplayFeatureType.fold,
+            state: DisplayFeatureState.postureHalfOpened,
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: folded,
+          child: const DisplayFeatureSubScreen(
+            anchorPoint: Offset.zero,
+            child: SizedBox.expand(key: childKey),
+          ),
+        ),
+      );
+
+      // A widget built into an already folded device starts where it belongs,
+      // so a test that sets up a fold and pumps once sees what it saw before.
+      expect(tester.renderObject<RenderBox>(find.byKey(childKey)).size.width, 390.0);
+    });
   });
 
   testWidgets('DisplayFeatureSubScreen does not crash at zero area', (WidgetTester tester) async {


### PR DESCRIPTION
When a device folds or unfolds, `DisplayFeatureSubScreen` moves its child to a different sub-screen, and the child got there in the frame the change was reported. On an 800 logical pixel screen with a 40 pixel fold, that is a jump of 420 pixels in one frame. Every dialog, bottom sheet, popup menu and picker inherits it, because the three things that build a `DisplayFeatureSubScreen` are `DialogRoute`, `ModalBottomSheetRoute` and the Cupertino sheet route.

Measured with a widget test that samples every frame instead of settling, dialog width per frame:

```
before   f0 380  f1 380  f2 380  f3 380  f4 380  f5 380  f6 380  f7 380
after    f0 800  f1 795  f2 779  f3 750  f4 710  f5 660  f6 605  f7 547   (settles at 380)
```

Apple's guidance for the iPhone Duo, which ships on 23 October, asks for exactly this: *"Avoid extreme layout changes as people fold the device."* The same page says *"Components like alerts, context menus, and sheets automatically move to account for the fold"* — which is what `DisplayFeatureSubScreen` already does, so this makes the move look the way the platform's own components do. ([Designing for iPhone Duo](https://developer.apple.com/design/human-interface-guidelines/designing-for-iphone-duo))

The `Padding` becomes an `AnimatedPadding`, and `duration` and `curve` are exposed so an app can lengthen, shorten or turn it off with `Duration.zero`. The default is 200ms on `Curves.easeInOut`. All three properties, `anchorPoint` included, are reported through `debugFillProperties`, with defaults filtered out. The default has to animate: `showDialog` and friends build the widget themselves and don't expose these, so a zero default would leave the animation unreachable for almost everyone.

The first position is not animated, because an implicitly animated widget only animates later changes — a widget built into an already folded device starts where it belongs. That's what keeps this from disturbing existing tests, which set a fold up before pumping rather than changing it midway. There's a test for it so the property can't quietly regress.

Addresses the animation part of #171448, which the reporter confirmed an `AnimatedPadding` improves. The other part of that issue, a bottom sheet spanning both sub-screens, is an API question and isn't touched here. The reporter also mentioned residual jank from the `SafeArea` inside the bottom sheet; that's separate too.

Related, not fixed here: #192667, `MediaQuery.sizeOf` reporting the whole screen inside a sub-screen.

Tests run locally: the 13 in `display_feature_sub_screen_test.dart` (5 new), and the 1,169 in every suite that sets display features or builds one of the three routes — `cupertino/dialog_test`, `cupertino/menu_anchor_test`, `cupertino/route_test`, `material/about_test`, `material/bottom_sheet_test`, `material/dialog_test`, `material/popup_menu_test`, `material/date_picker_test`, `material/date_range_picker_test`, `material/time_picker_test`, `widgets/media_query_test` and `widgets/routes_test`. Formatted with the repo's own `bin/dart`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant in-code documentation (doc comments with `///`).
- [x] If this PR introduces a new feature or capability, I created and linked a website documentation issue or PR in [flutter/website] (or verified none is needed).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
[flutter/website]: https://github.com/flutter/website

